### PR TITLE
[docs] simplify Permalinks, fix scroll shift

### DIFF
--- a/docs/common/create-permalinked-component.tsx
+++ b/docs/common/create-permalinked-component.tsx
@@ -4,7 +4,6 @@ import { AdditionalProps, HeadingType } from '~/common/headingManager';
 import Permalink from '~/components/Permalink';
 
 type Options = {
-  customIconStyle?: React.CSSProperties;
   baseNestingLevel?: number;
   sidebarType?: HeadingType;
 };
@@ -17,7 +16,7 @@ export const createPermalinkedComponent = (
   BaseComponent: React.ComponentType<React.PropsWithChildren<object>>,
   options?: Options
 ) => {
-  const { customIconStyle, baseNestingLevel, sidebarType = HeadingType.Text } = options || {};
+  const { baseNestingLevel, sidebarType = HeadingType.Text } = options || {};
   return ({ children, level, ...props }: PermalinkedComponentProps) => {
     const cleanChildren = React.Children.map(children, child => {
       if (React.isValidElement(child) && child?.props?.href) {
@@ -32,10 +31,7 @@ export const createPermalinkedComponent = (
     });
     const nestingLevel = baseNestingLevel != null ? (level ?? 0) + baseNestingLevel : undefined;
     return (
-      <Permalink
-        nestingLevel={nestingLevel}
-        customIconStyle={customIconStyle}
-        additionalProps={{ ...props, sidebarType }}>
+      <Permalink nestingLevel={nestingLevel} additionalProps={{ ...props, sidebarType }}>
         <BaseComponent>{cleanChildren}</BaseComponent>
       </Permalink>
     );

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { breakpoints } from '@expo/styleguide';
+import { breakpoints, spacing } from '@expo/styleguide';
 import * as React from 'react';
 
 import DocumentationSidebarRightLink from './DocumentationSidebarRightLink';
@@ -8,20 +8,26 @@ import { BASE_HEADING_LEVEL, Heading, HeadingManager } from '~/common/headingMan
 import withHeadingManager, {
   HeadingManagerProps,
 } from '~/components/page-higher-order/withHeadingManager';
+import { CALLOUT } from '~/ui/components/Text';
 
-const STYLES_SIDEBAR = css`
-  padding: 20px 24px 24px 24px;
-  width: 280px;
+const sidebarStyle = css({
+  padding: spacing[6],
+  width: 280,
 
-  @media screen and (max-width: ${breakpoints.medium + 124}px) {
-    width: 100%;
-  }
-`;
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    width: '100%',
+  },
+});
+
+const sidebarTitleStyle = css({
+  marginBottom: spacing[2],
+  userSelect: 'none',
+});
 
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
 const LOWER_SCROLL_LIMIT_FACTOR = 3 / 4;
 
-const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 6;
+const ACTIVE_ITEM_OFFSET_FACTOR = 1 / 10;
 
 const isDynamicScrollAvailable = () => {
   if (!history?.replaceState) {
@@ -94,7 +100,10 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     );
 
     return (
-      <nav css={STYLES_SIDEBAR} data-sidebar>
+      <nav css={sidebarStyle} data-sidebar>
+        <CALLOUT weight="medium" css={sidebarTitleStyle}>
+          On this page
+        </CALLOUT>
         {displayedHeadings.map(heading => {
           const isActive = heading.slug === this.state.activeSlug;
           return (

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -15,22 +15,18 @@ type BaseProps = React.PropsWithChildren<{
 type EnhancedProps = React.PropsWithChildren<{
   nestingLevel?: number;
   additionalProps?: AdditionalProps;
-  customIconStyle?: React.CSSProperties;
   id?: string;
 }>;
-
-const STYLES_PERMALINK = css`
-  position: relative;
-`;
 
 const STYLES_PERMALINK_TARGET = css`
   display: block;
   position: absolute;
-  top: -100px;
+  top: -46px;
   visibility: hidden;
 `;
 
 const STYLES_PERMALINK_LINK = css`
+  position: relative;
   color: inherit;
   text-decoration: inherit;
 
@@ -86,33 +82,25 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(
     const component = props.children as JSX.Element;
     const children = component.props.children || '';
 
-    let permalinkKey = props.id;
-    let heading;
-
-    if (props.nestingLevel) {
-      heading = props.headingManager.addHeading(
-        children,
-        props.nestingLevel,
-        props.additionalProps,
-        permalinkKey
-      );
-    }
-
-    if (!permalinkKey && heading?.slug) {
-      permalinkKey = heading.slug;
-    }
+    const heading = props.nestingLevel
+      ? props.headingManager.addHeading(
+          children,
+          props.nestingLevel,
+          props.additionalProps,
+          props.id
+        )
+      : undefined;
+    const permalinkKey = props.id ?? heading?.slug;
 
     return (
       <PermalinkBase component={component} data-components-heading>
-        <div css={STYLES_PERMALINK} ref={heading?.ref}>
+        <a css={STYLES_PERMALINK_LINK} href={'#' + permalinkKey} ref={heading?.ref}>
           <span css={STYLES_PERMALINK_TARGET} id={permalinkKey} />
-          <a css={STYLES_PERMALINK_LINK} href={'#' + permalinkKey}>
-            <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
-            <span css={STYLES_PERMALINK_ICON} style={props.customIconStyle}>
-              <PermalinkIcon />
-            </span>
-          </a>
-        </div>
+          <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
+          <span css={STYLES_PERMALINK_ICON}>
+            <PermalinkIcon />
+          </span>
+        </a>
       </PermalinkBase>
     );
   }

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,9 +3,14 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="css-1u2eykn"
+    class="css-133zsmp"
     data-sidebar="true"
   >
+    <p
+      class="css-xqbzh-TextComponent"
+    >
+      On this page
+    </p>
     <a
       class="css-1fc6p3j"
       href="#base-level-heading"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -6,21 +6,72 @@ exports[`APISection expo-apple-authentication 1`] = `
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#component"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="component"
       />
-      <a
-        class="css-8y2kaf"
-        href="#component"
+      <span
+        class="css-6n7j50"
       >
+        Component
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationbutton"
+      >
+        <span
+          class="css-s3qkfm"
+          id="appleauthenticationbutton"
+        />
         <span
           class="css-6n7j50"
         >
-          Component
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            AppleAuthenticationButton
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -51,65 +102,6 @@ exports[`APISection expo-apple-authentication 1`] = `
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="appleauthenticationbutton"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationbutton"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationButton
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -285,52 +277,48 @@ for more details.
       class="css-1ck3d9a-H2"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#props"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="props"
         />
-        <a
-          class="css-8y2kaf"
-          href="#props"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          Props
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Props
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h2>
     <div>
       <div
@@ -340,56 +328,52 @@ for more details.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#buttonstyle"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="buttonstyle"
             />
-            <a
-              class="css-8y2kaf"
-              href="#buttonstyle"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  buttonStyle
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                buttonStyle
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -426,56 +410,52 @@ for more details.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#buttontype"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="buttontype"
             />
-            <a
-              class="css-8y2kaf"
-              href="#buttontype"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  buttonType
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                buttonType
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -512,56 +492,52 @@ for more details.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#cornerradius"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="cornerradius"
             />
-            <a
-              class="css-8y2kaf"
-              href="#cornerradius"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  cornerRadius
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                cornerRadius
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -605,56 +581,52 @@ for more details.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#style"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="style"
             />
-            <a
-              class="css-8y2kaf"
-              href="#style"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  style
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                style
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -735,56 +707,52 @@ properties.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#onpress"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="onpress"
             />
-            <a
-              class="css-8y2kaf"
-              href="#onpress"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  onPress
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                onPress
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -828,151 +796,18 @@ in here.
         class="css-m417je-H3"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#inherited-props"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="inherited-props"
           />
-          <a
-            class="css-8y2kaf"
-            href="#inherited-props"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Inherited Props
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
-      </h3>
-      <ul
-        class="css-ftstf7-UL"
-        data-text="true"
-      >
-        <li
-          class="docs-list-item css-1vg85kg-LI"
-        >
-          <code
-            class="inline css-ov7own-InlineCode"
-          >
-            <a
-              class="css-153g748-InternalLink"
-              href="/versions/latest/react-native/view#props"
-            >
-              ViewProps
-            </a>
-          </code>
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="css-1ck3d9a-H2"
-    data-heading="true"
-  >
-    <div
-      class="css-79elbk"
-    >
-      <span
-        class="css-120d683"
-        id="methods"
-      />
-      <a
-        class="css-8y2kaf"
-        href="#methods"
-      >
-        <span
-          class="css-6n7j50"
-        >
-          Methods
-        </span>
-        <span
-          class="css-1eysgws"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </div>
-  </h2>
-  <div
-    class="css-18dzyrv"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="getcredentialstateasyncuser"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#getcredentialstateasyncuser"
-        >
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              getCredentialStateAsync(user)
-            </code>
+            Inherited Props
           </span>
           <span
             class="css-1eysgws"
@@ -1003,7 +838,128 @@ in here.
             </svg>
           </span>
         </a>
-      </div>
+      </h3>
+      <ul
+        class="css-ftstf7-UL"
+        data-text="true"
+      >
+        <li
+          class="docs-list-item css-1vg85kg-LI"
+        >
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            <a
+              class="css-153g748-InternalLink"
+              href="/versions/latest/react-native/view#props"
+            >
+              ViewProps
+            </a>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <h2
+    class="css-1ck3d9a-H2"
+    data-heading="true"
+  >
+    <a
+      class="css-1y1hc0n"
+      href="#methods"
+    >
+      <span
+        class="css-s3qkfm"
+        id="methods"
+      />
+      <span
+        class="css-6n7j50"
+      >
+        Methods
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-18dzyrv"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#getcredentialstateasyncuser"
+      >
+        <span
+          class="css-s3qkfm"
+          id="getcredentialstateasyncuser"
+        />
+        <span
+          class="css-6n7j50"
+        >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            getCredentialStateAsync(user)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -1143,52 +1099,48 @@ This should come from the user field of an
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -1265,25 +1217,79 @@ value depending on the state of the credential.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#isavailableasync"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="isavailableasync"
         />
-        <a
-          class="css-8y2kaf"
-          href="#isavailableasync"
+        <span
+          class="css-6n7j50"
         >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            isAvailableAsync()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
+    </h3>
+    <p
+      class="css-6jxvia-P"
+      data-text="true"
+    >
+      Determine if the current device's operating system supports Apple authentication.
+    </p>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
+      >
+        <a
+          class="css-1y1hc0n"
+          href="#returns-1"
+        >
+          <span
+            class="css-s3qkfm"
+            id="returns-1"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              isAvailableAsync()
-            </code>
+            Returns
           </span>
           <span
             class="css-1eysgws"
@@ -1314,68 +1320,6 @@ value depending on the state of the credential.
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <p
-      class="css-6jxvia-P"
-      data-text="true"
-    >
-      Determine if the current device's operating system supports Apple authentication.
-    </p>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="returns-1"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#returns-1"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <ul
@@ -1447,56 +1391,52 @@ value depending on the state of the credential.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#refreshasyncoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="refreshasyncoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#refreshasyncoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              refreshAsync(options)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            refreshAsync(options)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -1594,52 +1534,48 @@ Calling this method will show the sign in modal before actually refreshing the u
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-2"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-2"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-2"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -1723,56 +1659,52 @@ refresh operation.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#signinasyncoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="signinasyncoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#signinasyncoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              signInAsync(options)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            signInAsync(options)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -1914,52 +1846,48 @@ the user, since this remains the same for apps released by the same developer.
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-3"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-3"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-3"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -2043,56 +1971,52 @@ sign-in operation.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#signoutasyncoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="signoutasyncoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#signoutasyncoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              signOutAsync(options)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            signOutAsync(options)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -2220,52 +2144,48 @@ from using
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-4"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-4"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-4"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -2346,21 +2266,72 @@ sign-out operation.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#event-subscriptions"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="event-subscriptions"
       />
-      <a
-        class="css-8y2kaf"
-        href="#event-subscriptions"
+      <span
+        class="css-6n7j50"
       >
+        Event Subscriptions
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-18dzyrv"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#addrevokelistenerlistener"
+      >
+        <span
+          class="css-s3qkfm"
+          id="addrevokelistenerlistener"
+        />
         <span
           class="css-6n7j50"
         >
-          Event Subscriptions
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            addRevokeListener(listener)
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -2391,65 +2362,6 @@ sign-out operation.
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-18dzyrv"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="addrevokelistenerlistener"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#addrevokelistenerlistener"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              addRevokeListener(listener)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -2521,52 +2433,48 @@ sign-out operation.
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-5"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-5"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-5"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -2611,21 +2519,72 @@ sign-out operation.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#types"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="types"
       />
-      <a
-        class="css-8y2kaf"
-        href="#types"
+      <span
+        class="css-6n7j50"
       >
+        Types
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationcredential"
+      >
+        <span
+          class="css-s3qkfm"
+          id="appleauthenticationcredential"
+        />
         <span
           class="css-6n7j50"
         >
-          Types
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            AppleAuthenticationCredential
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -2656,65 +2615,6 @@ sign-out operation.
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="appleauthenticationcredential"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationcredential"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationCredential
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -3148,56 +3048,52 @@ developers.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationfullname"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationfullname"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationfullname"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationFullName
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationFullName
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -3451,56 +3347,52 @@ may be
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationrefreshoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationrefreshoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationrefreshoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationRefreshOptions
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationRefreshOptions
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -3744,56 +3636,52 @@ OAuth 2.0 protocol
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationsigninoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationsigninoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationsigninoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationSignInOptions
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationSignInOptions
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -4054,56 +3942,52 @@ OAuth 2.0 protocol
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationsignoutoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationsignoutoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationsignoutoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationSignOutOptions
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationSignOutOptions
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -4284,56 +4168,52 @@ OAuth 2.0 protocol
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#subscription"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="subscription"
         />
-        <a
-          class="css-8y2kaf"
-          href="#subscription"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              Subscription
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            Subscription
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -4405,21 +4285,72 @@ OAuth 2.0 protocol
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#enums"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="enums"
       />
-      <a
-        class="css-8y2kaf"
-        href="#enums"
+      <span
+        class="css-6n7j50"
       >
+        Enums
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-k1r7bq"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationbuttonstyle"
+      >
+        <span
+          class="css-s3qkfm"
+          id="appleauthenticationbuttonstyle"
+        />
         <span
           class="css-6n7j50"
         >
-          Enums
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            AppleAuthenticationButtonStyle
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -4450,65 +4381,6 @@ OAuth 2.0 protocol
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-k1r7bq"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="appleauthenticationbuttonstyle"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationbuttonstyle"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationButtonStyle
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -4538,56 +4410,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#white"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="white"
             />
-            <a
-              class="css-8y2kaf"
-              href="#white"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  WHITE
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                WHITE
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -4616,56 +4484,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#white_outline"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="white_outline"
             />
-            <a
-              class="css-8y2kaf"
-              href="#white_outline"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  WHITE_OUTLINE
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                WHITE_OUTLINE
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -4694,56 +4558,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#black"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="black"
             />
-            <a
-              class="css-8y2kaf"
-              href="#black"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  BLACK
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                BLACK
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -4769,56 +4629,52 @@ OAuth 2.0 protocol
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationbuttontype"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationbuttontype"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationbuttontype"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationButtonType
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationButtonType
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -4848,56 +4704,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#sign_in"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="sign_in"
             />
-            <a
-              class="css-8y2kaf"
-              href="#sign_in"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  SIGN_IN
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                SIGN_IN
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -4926,56 +4778,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#continue"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="continue"
             />
-            <a
-              class="css-8y2kaf"
-              href="#continue"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  CONTINUE
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                CONTINUE
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5037,56 +4885,52 @@ OAuth 2.0 protocol
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#sign_up"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="sign_up"
             />
-            <a
-              class="css-8y2kaf"
-              href="#sign_up"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  SIGN_UP
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                SIGN_UP
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5112,56 +4956,52 @@ OAuth 2.0 protocol
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationcredentialstate"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationcredentialstate"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationcredentialstate"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationCredentialState
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationCredentialState
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -5238,56 +5078,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#revoked"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="revoked"
             />
-            <a
-              class="css-8y2kaf"
-              href="#revoked"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  REVOKED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                REVOKED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5310,56 +5146,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#authorized"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="authorized"
             />
-            <a
-              class="css-8y2kaf"
-              href="#authorized"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  AUTHORIZED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                AUTHORIZED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5382,56 +5214,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#not_found"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="not_found"
             />
-            <a
-              class="css-8y2kaf"
-              href="#not_found"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  NOT_FOUND
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                NOT_FOUND
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5454,56 +5282,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#transferred"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="transferred"
             />
-            <a
-              class="css-8y2kaf"
-              href="#transferred"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  TRANSFERRED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                TRANSFERRED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5523,56 +5347,52 @@ for more details.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationoperation"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationoperation"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationoperation"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationOperation
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationOperation
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-181x4m0"
@@ -5585,56 +5405,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#implicit"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="implicit"
             />
-            <a
-              class="css-8y2kaf"
-              href="#implicit"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  IMPLICIT
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                IMPLICIT
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5663,56 +5479,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#login"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="login"
             />
-            <a
-              class="css-8y2kaf"
-              href="#login"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  LOGIN
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                LOGIN
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5735,56 +5547,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#refresh"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="refresh"
             />
-            <a
-              class="css-8y2kaf"
-              href="#refresh"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  REFRESH
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                REFRESH
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5807,56 +5615,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#logout"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="logout"
             />
-            <a
-              class="css-8y2kaf"
-              href="#logout"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  LOGOUT
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                LOGOUT
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -5876,56 +5680,52 @@ for more details.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationscope"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationscope"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationscope"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationScope
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationScope
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -6043,56 +5843,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#full_name"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="full_name"
             />
-            <a
-              class="css-8y2kaf"
-              href="#full_name"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  FULL_NAME
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                FULL_NAME
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -6115,56 +5911,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#email"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="email"
             />
-            <a
-              class="css-8y2kaf"
-              href="#email"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  EMAIL
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                EMAIL
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -6184,56 +5976,52 @@ for more details.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#appleauthenticationuserdetectionstatus"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="appleauthenticationuserdetectionstatus"
         />
-        <a
-          class="css-8y2kaf"
-          href="#appleauthenticationuserdetectionstatus"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              AppleAuthenticationUserDetectionStatus
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            AppleAuthenticationUserDetectionStatus
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -6299,56 +6087,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#unsupported"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="unsupported"
             />
-            <a
-              class="css-8y2kaf"
-              href="#unsupported"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  UNSUPPORTED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                UNSUPPORTED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -6377,56 +6161,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#unknown"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="unknown"
             />
-            <a
-              class="css-8y2kaf"
-              href="#unknown"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  UNKNOWN
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                UNKNOWN
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -6455,56 +6235,52 @@ for more details.
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#likely_real"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="likely_real"
             />
-            <a
-              class="css-8y2kaf"
-              href="#likely_real"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  LIKELY_REAL
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                LIKELY_REAL
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -6532,21 +6308,72 @@ exports[`APISection expo-barcode-scanner 1`] = `
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#component"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="component"
       />
-      <a
-        class="css-8y2kaf"
-        href="#component"
+      <span
+        class="css-6n7j50"
       >
+        Component
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescanner"
+      >
+        <span
+          class="css-s3qkfm"
+          id="barcodescanner"
+        />
         <span
           class="css-6n7j50"
         >
-          Component
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            BarCodeScanner
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -6577,65 +6404,6 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="barcodescanner"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#barcodescanner"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeScanner
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -6667,52 +6435,48 @@ exports[`APISection expo-barcode-scanner 1`] = `
       class="css-1ck3d9a-H2"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#props"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="props"
         />
-        <a
-          class="css-8y2kaf"
-          href="#props"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          Props
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            Props
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h2>
     <div>
       <div
@@ -6722,56 +6486,52 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#barcodetypes"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="barcodetypes"
             />
-            <a
-              class="css-8y2kaf"
-              href="#barcodetypes"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  barCodeTypes
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                barCodeTypes
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -6842,56 +6602,52 @@ minimize battery usage.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#onbarcodescanned"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="onbarcodescanned"
             />
-            <a
-              class="css-8y2kaf"
-              href="#onbarcodescanned"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  onBarCodeScanned
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                onBarCodeScanned
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -7002,56 +6758,52 @@ data has been retrieved.
           class="css-m417je-H3"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#type"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="type"
             />
-            <a
-              class="css-8y2kaf"
-              href="#type"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-1pk617c-InlineCode"
               >
-                <code
-                  class="inline css-1pk617c-InlineCode"
-                >
-                  type
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                type
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h3>
         <p
           class="css-6jxvia-P"
@@ -7134,151 +6886,18 @@ Same as
         class="css-m417je-H3"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#inherited-props"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="inherited-props"
           />
-          <a
-            class="css-8y2kaf"
-            href="#inherited-props"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Inherited Props
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
-      </h3>
-      <ul
-        class="css-ftstf7-UL"
-        data-text="true"
-      >
-        <li
-          class="docs-list-item css-1vg85kg-LI"
-        >
-          <code
-            class="inline css-ov7own-InlineCode"
-          >
-            <a
-              class="css-153g748-InternalLink"
-              href="/versions/latest/react-native/view#props"
-            >
-              ViewProps
-            </a>
-          </code>
-        </li>
-      </ul>
-    </div>
-  </div>
-  <h2
-    class="css-1ck3d9a-H2"
-    data-heading="true"
-  >
-    <div
-      class="css-79elbk"
-    >
-      <span
-        class="css-120d683"
-        id="hooks"
-      />
-      <a
-        class="css-8y2kaf"
-        href="#hooks"
-      >
-        <span
-          class="css-6n7j50"
-        >
-          Hooks
-        </span>
-        <span
-          class="css-1eysgws"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </div>
-  </h2>
-  <div
-    class="css-18dzyrv"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="usepermissionsoptions"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#usepermissionsoptions"
-        >
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              usePermissions(options)
-            </code>
+            Inherited Props
           </span>
           <span
             class="css-1eysgws"
@@ -7309,7 +6928,128 @@ Same as
             </svg>
           </span>
         </a>
-      </div>
+      </h3>
+      <ul
+        class="css-ftstf7-UL"
+        data-text="true"
+      >
+        <li
+          class="docs-list-item css-1vg85kg-LI"
+        >
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            <a
+              class="css-153g748-InternalLink"
+              href="/versions/latest/react-native/view#props"
+            >
+              ViewProps
+            </a>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <h2
+    class="css-1ck3d9a-H2"
+    data-heading="true"
+  >
+    <a
+      class="css-1y1hc0n"
+      href="#hooks"
+    >
+      <span
+        class="css-s3qkfm"
+        id="hooks"
+      />
+      <span
+        class="css-6n7j50"
+      >
+        Hooks
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-18dzyrv"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#usepermissionsoptions"
+      >
+        <span
+          class="css-s3qkfm"
+          id="usepermissionsoptions"
+        />
+        <span
+          class="css-6n7j50"
+        >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            usePermissions(options)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -7485,52 +7225,48 @@ This can be used to quickly create specific permission hooks in every module.
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -7613,21 +7349,73 @@ This can be used to quickly create specific permission hooks in every module.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#methods"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="methods"
       />
-      <a
-        class="css-8y2kaf"
-        href="#methods"
+      <span
+        class="css-6n7j50"
       >
+        Methods
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-18dzyrv"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescannergetpermissionsasync"
+      >
+        <span
+          class="css-s3qkfm"
+          id="barcodescannergetpermissionsasync"
+        />
         <span
           class="css-6n7j50"
         >
-          Methods
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            BarCodeScanner.
+            getPermissionsAsync()
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -7658,35 +7446,33 @@ This can be used to quickly create specific permission hooks in every module.
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-18dzyrv"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
+    </h3>
+    <p
+      class="css-6jxvia-P"
+      data-text="true"
     >
-      <div
-        class="css-79elbk"
+      Checks user's permissions for accessing the camera.
+    </p>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
       >
-        <span
-          class="css-120d683"
-          id="barcodescannergetpermissionsasync"
-        />
         <a
-          class="css-8y2kaf"
-          href="#barcodescannergetpermissionsasync"
+          class="css-1y1hc0n"
+          href="#returns-1"
         >
+          <span
+            class="css-s3qkfm"
+            id="returns-1"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              BarCodeScanner.
-              getPermissionsAsync()
-            </code>
+            Returns
           </span>
           <span
             class="css-1eysgws"
@@ -7717,68 +7503,6 @@ This can be used to quickly create specific permission hooks in every module.
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <p
-      class="css-6jxvia-P"
-      data-text="true"
-    >
-      Checks user's permissions for accessing the camera.
-    </p>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="returns-1"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#returns-1"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <ul
@@ -7854,57 +7578,53 @@ This can be used to quickly create specific permission hooks in every module.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescannerrequestpermissionsasync"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodescannerrequestpermissionsasync"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodescannerrequestpermissionsasync"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              BarCodeScanner.
-              requestPermissionsAsync()
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeScanner.
+            requestPermissionsAsync()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -7938,52 +7658,48 @@ This can be used to quickly create specific permission hooks in every module.
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-2"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-2"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-2"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -8059,57 +7775,53 @@ This can be used to quickly create specific permission hooks in every module.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescannerscanfromurlasyncurl-barcodetypes"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodescannerscanfromurlasyncurl-barcodetypes"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodescannerscanfromurlasyncurl-barcodetypes"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              BarCodeScanner.
-              scanFromURLAsync(url, barCodeTypes)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeScanner.
+            scanFromURLAsync(url, barCodeTypes)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -8276,52 +7988,48 @@ the platform.
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-3"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-3"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-3"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -8392,21 +8100,72 @@ code.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#interfaces"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="interfaces"
       />
-      <a
-        class="css-8y2kaf"
-        href="#interfaces"
+      <span
+        class="css-6n7j50"
       >
+        Interfaces
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#permissionresponse"
+      >
+        <span
+          class="css-s3qkfm"
+          id="permissionresponse"
+        />
         <span
           class="css-6n7j50"
         >
-          Interfaces
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            PermissionResponse
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -8437,34 +8196,34 @@ code.
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
+    </h3>
+    <p
+      class="css-6jxvia-P"
+      data-text="true"
     >
-      <div
-        class="css-79elbk"
+      An object obtained by permissions get and request functions.
+    </p>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
       >
-        <span
-          class="css-120d683"
-          id="permissionresponse"
-        />
         <a
-          class="css-8y2kaf"
-          href="#permissionresponse"
+          class="css-1y1hc0n"
+          href="#permissionresponse--properties"
         >
+          <span
+            class="css-s3qkfm"
+            id="permissionresponse--properties"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionResponse
-            </code>
+            PermissionResponse
+             Properties
           </span>
           <span
             class="css-1eysgws"
@@ -8495,69 +8254,6 @@ code.
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <p
-      class="css-6jxvia-P"
-      data-text="true"
-    >
-      An object obtained by permissions get and request functions.
-    </p>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="permissionresponse--properties"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#permissionresponse--properties"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              PermissionResponse
-               Properties
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <div
@@ -8726,21 +8422,72 @@ in order to enable/disable the permission.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#types"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="types"
       />
-      <a
-        class="css-8y2kaf"
-        href="#types"
+      <span
+        class="css-6n7j50"
       >
+        Types
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#barcodebounds"
+      >
+        <span
+          class="css-s3qkfm"
+          id="barcodebounds"
+        />
         <span
           class="css-6n7j50"
         >
-          Types
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            BarCodeBounds
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -8771,65 +8518,6 @@ in order to enable/disable the permission.
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="barcodebounds"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#barcodebounds"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeBounds
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -8940,56 +8628,52 @@ in order to enable/disable the permission.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodeevent"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodeevent"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodeevent"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeEvent
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeEvent
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -9082,56 +8766,52 @@ in order to enable/disable the permission.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodeeventcallbackarguments"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodeeventcallbackarguments"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodeeventcallbackarguments"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeEventCallbackArguments
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeEventCallbackArguments
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -9206,56 +8886,52 @@ in order to enable/disable the permission.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodepoint"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodepoint"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodepoint"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodePoint
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodePoint
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -9375,57 +9051,53 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescannedcallback"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodescannedcallback"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodescannedcallback"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeScannedCallback
-              ()
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeScannedCallback
+            ()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div>
       <div
@@ -9502,56 +9174,52 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodescannerresult"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodescannerresult"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodescannerresult"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeScannerResult
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeScannerResult
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <blockquote
       class="css-1xjn6jt-Callout"
@@ -9811,56 +9479,52 @@ For some types, they will represent the area used by the scanner.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#barcodesize"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="barcodesize"
         />
-        <a
-          class="css-8y2kaf"
-          href="#barcodesize"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              BarCodeSize
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            BarCodeSize
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -9961,56 +9625,52 @@ For some types, they will represent the area used by the scanner.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#permissionhookoptions"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="permissionhookoptions"
         />
-        <a
-          class="css-8y2kaf"
-          href="#permissionhookoptions"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionHookOptions
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            PermissionHookOptions
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -10040,52 +9700,48 @@ For some types, they will represent the area used by the scanner.
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#enums"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="enums"
       />
-      <a
-        class="css-8y2kaf"
-        href="#enums"
+      <span
+        class="css-6n7j50"
       >
-        <span
-          class="css-6n7j50"
+        Enums
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          Enums
-        </span>
-        <span
-          class="css-1eysgws"
-        >
-          <svg
-            aria-label="permalink"
-            class="anchor-icon"
-            fill="none"
-            height="24"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-            <path
-              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-              stroke="#9B9B9B"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-            />
-          </svg>
-        </span>
-      </a>
-    </div>
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
   </h2>
   <div
     class="css-k1r7bq"
@@ -10094,316 +9750,22 @@ For some types, they will represent the area used by the scanner.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#permissionstatus"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="permissionstatus"
         />
-        <a
-          class="css-8y2kaf"
-          href="#permissionstatus"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionStatus
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
-    </h3>
-    <div
-      class="css-181x4m0"
-    >
-      <div
-        class="css-1ow0rw3"
-      >
-        <h4
-          class="  css-uucypz-H4"
-          data-components-heading="true"
-          data-heading="true"
-        >
-          <div
-            class="css-79elbk"
-          >
-            <span
-              class="css-120d683"
-              id="denied"
-            />
-            <a
-              class="css-8y2kaf"
-              href="#denied"
-            >
-              <span
-                class="css-6n7j50"
-              >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  DENIED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
-              >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
-        </h4>
-      </div>
-      <code
-        class="inline css-1v964ss-InlineCode"
-      >
-        PermissionStatus
-        .
-        DENIED
-         ＝ "denied"
-      </code>
-      <p
-        class="css-6jxvia-P"
-        data-text="true"
-      >
-        User has denied the permission.
-      </p>
-    </div>
-    <div
-      class="css-181x4m0"
-    >
-      <div
-        class="css-1ow0rw3"
-      >
-        <h4
-          class="  css-uucypz-H4"
-          data-components-heading="true"
-          data-heading="true"
-        >
-          <div
-            class="css-79elbk"
-          >
-            <span
-              class="css-120d683"
-              id="granted"
-            />
-            <a
-              class="css-8y2kaf"
-              href="#granted"
-            >
-              <span
-                class="css-6n7j50"
-              >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  GRANTED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
-              >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
-        </h4>
-      </div>
-      <code
-        class="inline css-1v964ss-InlineCode"
-      >
-        PermissionStatus
-        .
-        GRANTED
-         ＝ "granted"
-      </code>
-      <p
-        class="css-6jxvia-P"
-        data-text="true"
-      >
-        User has granted the permission.
-      </p>
-    </div>
-    <div
-      class="css-181x4m0"
-    >
-      <div
-        class="css-1ow0rw3"
-      >
-        <h4
-          class="  css-uucypz-H4"
-          data-components-heading="true"
-          data-heading="true"
-        >
-          <div
-            class="css-79elbk"
-          >
-            <span
-              class="css-120d683"
-              id="undetermined"
-            />
-            <a
-              class="css-8y2kaf"
-              href="#undetermined"
-            >
-              <span
-                class="css-6n7j50"
-              >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  UNDETERMINED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
-              >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
-        </h4>
-      </div>
-      <code
-        class="inline css-1v964ss-InlineCode"
-      >
-        PermissionStatus
-        .
-        UNDETERMINED
-         ＝ "undetermined"
-      </code>
-      <p
-        class="css-6jxvia-P"
-        data-text="true"
-      >
-        User hasn't granted or denied the permission yet.
-      </p>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`APISection expo-pedometer 1`] = `
-<div>
-  <h2
-    class="css-1ck3d9a-H2"
-    data-heading="true"
-  >
-    <div
-      class="css-79elbk"
-    >
-      <span
-        class="css-120d683"
-        id="methods"
-      />
-      <a
-        class="css-8y2kaf"
-        href="#methods"
-      >
         <span
           class="css-6n7j50"
         >
-          Methods
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            PermissionStatus
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -10434,89 +9796,34 @@ exports[`APISection expo-pedometer 1`] = `
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-18dzyrv"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="getpermissionsasync"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#getpermissionsasync"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              getPermissionsAsync()
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <div
-      class="css-1wdnwk5"
+      class="css-181x4m0"
     >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
+      <div
+        class="css-1ow0rw3"
       >
-        <div
-          class="css-79elbk"
+        <h4
+          class="  css-uucypz-H4"
+          data-components-heading="true"
+          data-heading="true"
         >
-          <span
-            class="css-120d683"
-            id="returns"
-          />
           <a
-            class="css-8y2kaf"
-            href="#returns"
+            class="css-1y1hc0n"
+            href="#denied"
           >
+            <span
+              class="css-s3qkfm"
+              id="denied"
+            />
             <span
               class="css-6n7j50"
             >
-              Returns
+              <code
+                class="inline css-ov7own-InlineCode"
+              >
+                DENIED
+              </code>
             </span>
             <span
               class="css-1eysgws"
@@ -10547,7 +9854,328 @@ exports[`APISection expo-pedometer 1`] = `
               </svg>
             </span>
           </a>
-        </div>
+        </h4>
+      </div>
+      <code
+        class="inline css-1v964ss-InlineCode"
+      >
+        PermissionStatus
+        .
+        DENIED
+         ＝ "denied"
+      </code>
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        User has denied the permission.
+      </p>
+    </div>
+    <div
+      class="css-181x4m0"
+    >
+      <div
+        class="css-1ow0rw3"
+      >
+        <h4
+          class="  css-uucypz-H4"
+          data-components-heading="true"
+          data-heading="true"
+        >
+          <a
+            class="css-1y1hc0n"
+            href="#granted"
+          >
+            <span
+              class="css-s3qkfm"
+              id="granted"
+            />
+            <span
+              class="css-6n7j50"
+            >
+              <code
+                class="inline css-ov7own-InlineCode"
+              >
+                GRANTED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
+      <code
+        class="inline css-1v964ss-InlineCode"
+      >
+        PermissionStatus
+        .
+        GRANTED
+         ＝ "granted"
+      </code>
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        User has granted the permission.
+      </p>
+    </div>
+    <div
+      class="css-181x4m0"
+    >
+      <div
+        class="css-1ow0rw3"
+      >
+        <h4
+          class="  css-uucypz-H4"
+          data-components-heading="true"
+          data-heading="true"
+        >
+          <a
+            class="css-1y1hc0n"
+            href="#undetermined"
+          >
+            <span
+              class="css-s3qkfm"
+              id="undetermined"
+            />
+            <span
+              class="css-6n7j50"
+            >
+              <code
+                class="inline css-ov7own-InlineCode"
+              >
+                UNDETERMINED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
+        </h4>
+      </div>
+      <code
+        class="inline css-1v964ss-InlineCode"
+      >
+        PermissionStatus
+        .
+        UNDETERMINED
+         ＝ "undetermined"
+      </code>
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        User hasn't granted or denied the permission yet.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`APISection expo-pedometer 1`] = `
+<div>
+  <h2
+    class="css-1ck3d9a-H2"
+    data-heading="true"
+  >
+    <a
+      class="css-1y1hc0n"
+      href="#methods"
+    >
+      <span
+        class="css-s3qkfm"
+        id="methods"
+      />
+      <span
+        class="css-6n7j50"
+      >
+        Methods
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-18dzyrv"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#getpermissionsasync"
+      >
+        <span
+          class="css-s3qkfm"
+          id="getpermissionsasync"
+        />
+        <span
+          class="css-6n7j50"
+        >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            getPermissionsAsync()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
+    </h3>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
+      >
+        <a
+          class="css-1y1hc0n"
+          href="#returns"
+        >
+          <span
+            class="css-s3qkfm"
+            id="returns"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -10606,56 +10234,52 @@ exports[`APISection expo-pedometer 1`] = `
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#getstepcountasyncstart-end"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="getstepcountasyncstart-end"
         />
-        <a
-          class="css-8y2kaf"
-          href="#getstepcountasyncstart-end"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              getStepCountAsync(start, end)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            getStepCountAsync(start, end)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -10780,52 +10404,48 @@ exports[`APISection expo-pedometer 1`] = `
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-1"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-1"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-1"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -10960,25 +10580,79 @@ a start date that is more than seven days in the past returns only the available
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#isavailableasync"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="isavailableasync"
         />
-        <a
-          class="css-8y2kaf"
-          href="#isavailableasync"
+        <span
+          class="css-6n7j50"
         >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            isAvailableAsync()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
+    </h3>
+    <p
+      class="css-6jxvia-P"
+      data-text="true"
+    >
+      Returns whether the pedometer is enabled on the device.
+    </p>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
+      >
+        <a
+          class="css-1y1hc0n"
+          href="#returns-2"
+        >
+          <span
+            class="css-s3qkfm"
+            id="returns-2"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              isAvailableAsync()
-            </code>
+            Returns
           </span>
           <span
             class="css-1eysgws"
@@ -11009,68 +10683,6 @@ a start date that is more than seven days in the past returns only the available
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <p
-      class="css-6jxvia-P"
-      data-text="true"
-    >
-      Returns whether the pedometer is enabled on the device.
-    </p>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="returns-2"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#returns-2"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <ul
@@ -11137,25 +10749,73 @@ available on this device.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#requestpermissionsasync"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="requestpermissionsasync"
         />
-        <a
-          class="css-8y2kaf"
-          href="#requestpermissionsasync"
+        <span
+          class="css-6n7j50"
         >
+          <code
+            class="inline css-1pk617c-InlineCode"
+          >
+            requestPermissionsAsync()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
+    </h3>
+    <div
+      class="css-1wdnwk5"
+    >
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
+      >
+        <a
+          class="css-1y1hc0n"
+          href="#returns-3"
+        >
+          <span
+            class="css-s3qkfm"
+            id="returns-3"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              requestPermissionsAsync()
-            </code>
+            Returns
           </span>
           <span
             class="css-1eysgws"
@@ -11186,62 +10846,6 @@ available on this device.
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="returns-3"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#returns-3"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <ul
@@ -11300,56 +10904,52 @@ available on this device.
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#watchstepcountcallback"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="watchstepcountcallback"
         />
-        <a
-          class="css-8y2kaf"
-          href="#watchstepcountcallback"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-1pk617c-InlineCode"
           >
-            <code
-              class="inline css-1pk617c-InlineCode"
-            >
-              watchStepCount(callback)
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            watchStepCount(callback)
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -11447,52 +11047,48 @@ provided with a single argument that is
         data-components-heading="true"
         data-heading="true"
       >
-        <div
-          class="css-79elbk"
+        <a
+          class="css-1y1hc0n"
+          href="#returns-4"
         >
           <span
-            class="css-120d683"
+            class="css-s3qkfm"
             id="returns-4"
           />
-          <a
-            class="css-8y2kaf"
-            href="#returns-4"
+          <span
+            class="css-6n7j50"
           >
-            <span
-              class="css-6n7j50"
+            Returns
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Returns
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </h4>
     </div>
     <ul
@@ -11561,21 +11157,72 @@ provided with a single argument that is
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#interfaces"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="interfaces"
       />
-      <a
-        class="css-8y2kaf"
-        href="#interfaces"
+      <span
+        class="css-6n7j50"
       >
+        Interfaces
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#permissionresponse"
+      >
+        <span
+          class="css-s3qkfm"
+          id="permissionresponse"
+        />
         <span
           class="css-6n7j50"
         >
-          Interfaces
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            PermissionResponse
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -11606,34 +11253,28 @@ provided with a single argument that is
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
+    </h3>
+    <div
+      class="css-1wdnwk5"
     >
-      <div
-        class="css-79elbk"
+      <h4
+        class="  css-uucypz-H4"
+        data-components-heading="true"
+        data-heading="true"
       >
-        <span
-          class="css-120d683"
-          id="permissionresponse"
-        />
         <a
-          class="css-8y2kaf"
-          href="#permissionresponse"
+          class="css-1y1hc0n"
+          href="#permissionresponse--properties"
         >
+          <span
+            class="css-s3qkfm"
+            id="permissionresponse--properties"
+          />
           <span
             class="css-6n7j50"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionResponse
-            </code>
+            PermissionResponse
+             Properties
           </span>
           <span
             class="css-1eysgws"
@@ -11664,63 +11305,6 @@ provided with a single argument that is
             </svg>
           </span>
         </a>
-      </div>
-    </h3>
-    <div
-      class="css-1wdnwk5"
-    >
-      <h4
-        class="  css-uucypz-H4"
-        data-components-heading="true"
-        data-heading="true"
-      >
-        <div
-          class="css-79elbk"
-        >
-          <span
-            class="css-120d683"
-            id="permissionresponse--properties"
-          />
-          <a
-            class="css-8y2kaf"
-            href="#permissionresponse--properties"
-          >
-            <span
-              class="css-6n7j50"
-            >
-              PermissionResponse
-               Properties
-            </span>
-            <span
-              class="css-1eysgws"
-            >
-              <svg
-                aria-label="permalink"
-                class="anchor-icon"
-                fill="none"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-                <path
-                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                  stroke="#9B9B9B"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                />
-              </svg>
-            </span>
-          </a>
-        </div>
       </h4>
     </div>
     <div
@@ -11879,21 +11463,72 @@ provided with a single argument that is
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#types"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="types"
       />
-      <a
-        class="css-8y2kaf"
-        href="#types"
+      <span
+        class="css-6n7j50"
       >
+        Types
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-kyhipd"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#pedometerresult"
+      >
+        <span
+          class="css-s3qkfm"
+          id="pedometerresult"
+        />
         <span
           class="css-6n7j50"
         >
-          Types
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            PedometerResult
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -11924,65 +11559,6 @@ provided with a single argument that is
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-kyhipd"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="pedometerresult"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#pedometerresult"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PedometerResult
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -12054,57 +11630,53 @@ provided with a single argument that is
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#pedometerupdatecallback"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="pedometerupdatecallback"
         />
-        <a
-          class="css-8y2kaf"
-          href="#pedometerupdatecallback"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PedometerUpdateCallback
-              ()
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            PedometerUpdateCallback
+            ()
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div>
       <div
@@ -12181,56 +11753,52 @@ provided with a single argument that is
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#permissionexpiration"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="permissionexpiration"
         />
-        <a
-          class="css-8y2kaf"
-          href="#permissionexpiration"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionExpiration
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            PermissionExpiration
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <p
       class="css-6jxvia-P"
@@ -12263,56 +11831,52 @@ provided with a single argument that is
       class="css-m417je-H3"
       data-heading="true"
     >
-      <div
-        class="css-79elbk"
+      <a
+        class="css-1y1hc0n"
+        href="#subscription"
       >
         <span
-          class="css-120d683"
+          class="css-s3qkfm"
           id="subscription"
         />
-        <a
-          class="css-8y2kaf"
-          href="#subscription"
+        <span
+          class="css-6n7j50"
         >
-          <span
-            class="css-6n7j50"
+          <code
+            class="inline css-ov7own-InlineCode"
           >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              Subscription
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
+            Subscription
+          </code>
+        </span>
+        <span
+          class="css-1eysgws"
+        >
+          <svg
+            aria-label="permalink"
+            class="anchor-icon"
+            fill="none"
+            height="24"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
+            <path
+              d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+            <path
+              d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+              stroke="#9B9B9B"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+            />
+          </svg>
+        </span>
+      </a>
     </h3>
     <div
       class="css-rufzkc-Table"
@@ -12384,21 +11948,72 @@ provided with a single argument that is
     class="css-1ck3d9a-H2"
     data-heading="true"
   >
-    <div
-      class="css-79elbk"
+    <a
+      class="css-1y1hc0n"
+      href="#enums"
     >
       <span
-        class="css-120d683"
+        class="css-s3qkfm"
         id="enums"
       />
-      <a
-        class="css-8y2kaf"
-        href="#enums"
+      <span
+        class="css-6n7j50"
       >
+        Enums
+      </span>
+      <span
+        class="css-1eysgws"
+      >
+        <svg
+          aria-label="permalink"
+          class="anchor-icon"
+          fill="none"
+          height="24"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+            stroke="#9B9B9B"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </svg>
+      </span>
+    </a>
+  </h2>
+  <div
+    class="css-k1r7bq"
+  >
+    <h3
+      class="css-m417je-H3"
+      data-heading="true"
+    >
+      <a
+        class="css-1y1hc0n"
+        href="#permissionstatus"
+      >
+        <span
+          class="css-s3qkfm"
+          id="permissionstatus"
+        />
         <span
           class="css-6n7j50"
         >
-          Enums
+          <code
+            class="inline css-ov7own-InlineCode"
+          >
+            PermissionStatus
+          </code>
         </span>
         <span
           class="css-1eysgws"
@@ -12429,65 +12044,6 @@ provided with a single argument that is
           </svg>
         </span>
       </a>
-    </div>
-  </h2>
-  <div
-    class="css-k1r7bq"
-  >
-    <h3
-      class="css-m417je-H3"
-      data-heading="true"
-    >
-      <div
-        class="css-79elbk"
-      >
-        <span
-          class="css-120d683"
-          id="permissionstatus"
-        />
-        <a
-          class="css-8y2kaf"
-          href="#permissionstatus"
-        >
-          <span
-            class="css-6n7j50"
-          >
-            <code
-              class="inline css-ov7own-InlineCode"
-            >
-              PermissionStatus
-            </code>
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </div>
     </h3>
     <div
       class="css-181x4m0"
@@ -12500,56 +12056,52 @@ provided with a single argument that is
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#denied"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="denied"
             />
-            <a
-              class="css-8y2kaf"
-              href="#denied"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  DENIED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                DENIED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -12572,56 +12124,52 @@ provided with a single argument that is
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#granted"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="granted"
             />
-            <a
-              class="css-8y2kaf"
-              href="#granted"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  GRANTED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                GRANTED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code
@@ -12644,56 +12192,52 @@ provided with a single argument that is
           data-components-heading="true"
           data-heading="true"
         >
-          <div
-            class="css-79elbk"
+          <a
+            class="css-1y1hc0n"
+            href="#undetermined"
           >
             <span
-              class="css-120d683"
+              class="css-s3qkfm"
               id="undetermined"
             />
-            <a
-              class="css-8y2kaf"
-              href="#undetermined"
+            <span
+              class="css-6n7j50"
             >
-              <span
-                class="css-6n7j50"
+              <code
+                class="inline css-ov7own-InlineCode"
               >
-                <code
-                  class="inline css-ov7own-InlineCode"
-                >
-                  UNDETERMINED
-                </code>
-              </span>
-              <span
-                class="css-1eysgws"
+                UNDETERMINED
+              </code>
+            </span>
+            <span
+              class="css-1eysgws"
+            >
+              <svg
+                aria-label="permalink"
+                class="anchor-icon"
+                fill="none"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-label="permalink"
-                  class="anchor-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                  <path
-                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                    stroke="#9B9B9B"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                  />
-                </svg>
-              </span>
-            </a>
-          </div>
+                <path
+                  d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+                <path
+                  d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                  stroke="#9B9B9B"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                />
+              </svg>
+            </span>
+          </a>
         </h4>
       </div>
       <code

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -41,56 +41,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#name"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="name"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#name"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        name
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      name
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -168,56 +164,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#androidnavigationbar"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="androidnavigationbar"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#androidnavigationbar"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        androidNavigationBar
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      androidNavigationBar
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -339,56 +331,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#visible"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="visible"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#visible"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        visible
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      visible
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -466,56 +454,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#always"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="always"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#always"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        always
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      always
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -549,56 +533,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#backgroundcolor"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="backgroundcolor"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#backgroundcolor"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        backgroundColor
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      backgroundColor
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -645,56 +625,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#intentfilters"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="intentfilters"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#intentfilters"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        intentFilters
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      intentFilters
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -809,56 +785,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#autoverify"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="autoverify"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#autoverify"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        autoVerify
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      autoVerify
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -892,56 +864,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#data"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="data"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#data"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        data
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      data
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>
@@ -974,56 +942,52 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 class=" css-19f55nd-PDIV"
                 data-text="true"
               >
-                <div
-                  class="css-79elbk"
+                <a
+                  class="css-1y1hc0n"
+                  href="#host"
                 >
                   <span
-                    class="css-120d683"
+                    class="css-s3qkfm"
                     id="host"
                   />
-                  <a
-                    class="css-8y2kaf"
-                    href="#host"
+                  <span
+                    class="css-6n7j50"
                   >
-                    <span
-                      class="css-6n7j50"
+                    <code
+                      class="inline css-ov7own-InlineCode"
                     >
-                      <code
-                        class="inline css-ov7own-InlineCode"
-                      >
-                        host
-                      </code>
-                    </span>
-                    <span
-                      class="css-1eysgws"
+                      host
+                    </code>
+                  </span>
+                  <span
+                    class="css-1eysgws"
+                  >
+                    <svg
+                      aria-label="permalink"
+                      class="anchor-icon"
+                      fill="none"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
+                      xmlns="http://www.w3.org/2000/svg"
                     >
-                      <svg
-                        aria-label="permalink"
-                        class="anchor-icon"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                        <path
-                          d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                          stroke="#9B9B9B"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                        />
-                      </svg>
-                    </span>
-                  </a>
-                </div>
+                      <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                      <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                        stroke="#9B9B9B"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                      />
+                    </svg>
+                  </span>
+                </a>
               </div>
             </div>
           </td>


### PR DESCRIPTION
# Why

We are not ready yet to switch to the new heading and ToC components, but at least we can simplify the current ones to reduce the DOM complexity.

# How

Reduce the amount of nested elements in `Permalink`,  remove no longer used `customIconStyle` prop, tweak styles accordingly.

Additionally I have fixed the scroll shift when clicking heading and table of contents entry. Also a title has been added to the ToC as visible on latest mocks.

# Test Plan

The changes have been tested by running docs locally. Test snapshots have been regenerated.

# Preview

https://user-images.githubusercontent.com/719641/197866492-2abdbdf0-1bc0-4b3b-8a1c-92c016417489.mp4

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
