### PR TITLE
[tools] Enable inspector in libhermes-executor-release.so

### DIFF
--- a/tools/src/versioning/android/reactNativeTransforms.ts
+++ b/tools/src/versioning/android/reactNativeTransforms.ts
@@ -88,6 +88,30 @@ export function reactNativeTransforms(
         find: new RegExp(`SoLoader.loadLibrary\\\("${escapeRegExp(libName)}"\\\)`),
         replaceWith: `SoLoader.loadLibrary("${libName}_${abiVersion}")`,
       })),
+      // add HERMES_ENABLE_DEBUGGER for libhermes-executor-release.so
+      {
+        paths: './ReactAndroid/hermes-engine/build.gradle',
+        find: /-DHERMES_ENABLE_DEBUGGER=False/,
+        replaceWith: '-DHERMES_ENABLE_DEBUGGER=True',
+      },
+      {
+        paths: './ReactCommon/hermes/executor/CMakeLists.txt',
+        find: /\bdebug (hermes-inspector_)/g,
+        replaceWith: '$1',
+      },
+      {
+        paths: './ReactCommon/hermes/executor/CMakeLists.txt',
+        find: /if\(\${CMAKE_BUILD_TYPE} MATCHES Debug\)(\n\s*target_compile_options)/g,
+        replaceWith: 'if(true)$1',
+      },
+      {
+        paths: [
+          './ReactAndroid/src/main/java/com/facebook/hermes/reactexecutor/CMakeLists.txt', // remove this when we drop sdk 45 for sdk 48
+          './ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt',
+        ],
+        find: '$<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>',
+        replaceWith: '-DHERMES_ENABLE_DEBUGGER=1',
+      },
     ],
   };
 }


### PR DESCRIPTION
# Why

we use libhermes-executor-release.so in expo go and it doesn't support inspector by default. to support the inspector feature, we should patch react-native to enable this feature even in the release build.

# How

add transform rules to enable inspector in libhermes-executor-release.so

# Test Plan

versioned expo go + hermes NCL + open js debugger

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
