### PR TITLE
[android] Fix cancelScheduledNotificationAsync double promise resolving

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedNotificationScheduler.kt
@@ -1,6 +1,7 @@
 package versioned.host.exp.exponent.modules.universal.notifications
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.os.ResultReceiver
 import expo.modules.core.Promise
@@ -53,9 +54,13 @@ class ScopedNotificationScheduler(context: Context, private val experienceKey: E
           super.onReceiveResult(resultCode, resultData)
 
           if (resultCode == NotificationsService.SUCCESS_CODE) {
-            val request = resultData?.getParcelable<NotificationRequest>(NotificationsService.NOTIFICATION_REQUESTS_KEY)
+            val request = when {
+              Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> resultData?.getParcelable(NotificationsService.NOTIFICATION_REQUEST_KEY, ScopedNotificationRequest::class.java)
+              else -> resultData?.getParcelable(NotificationsService.NOTIFICATION_REQUEST_KEY)
+            }
             if (request == null || !scopedNotificationsUtils.shouldHandleNotification(request, experienceKey)) {
               promise.resolve(null)
+              return
             }
             doCancelScheduledNotificationAsync(identifier, promise)
           } else {


### PR DESCRIPTION
# Why

Fix cancelScheduledNotificationAsync double promise resolving crash

# How

there are several issues in the `ScopedNotificationScheduler.cancelScheduledNotificationAsync`:
- if `shouldHandleNotification` returns false and resolving the promise. the call should return. otherwise, calling `doCancelScheduledNotificationAsync` will cause the promise resolving again and crash from JSI interop.
- the key to get the request from `resultData?.getParcelable` is `NOTIFICATION_REQUEST_KEY` not `NOTIFICATION_REQUESTS_KEY`
- support android sdk 33 type-safe [`getParcelable`](https://developer.android.com/reference/android/os/Bundle#getParcelable(java.lang.String,%20java.lang.Class%3CT%3E))

# Test Plan

android unversioned expo go + test-suite Notifications

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
