### PR TITLE
[test-suite] Fix notification custom channel properties error

### DIFF
--- a/apps/test-suite/tests/Notifications.js
+++ b/apps/test-suite/tests/Notifications.js
@@ -397,7 +397,7 @@ export async function test(t) {
               showBadge: false,
               sound: null,
               audioAttributes: {
-                usage: Notifications.AndroidAudioUsage.NOTIFICATION_COMMUNICATION_INSTANT,
+                usage: Notifications.AndroidAudioUsage.NOTIFICATION,
                 contentType: Notifications.AndroidAudioContentType.SONIFICATION,
                 flags: {
                   enforceAudibility: true,


### PR DESCRIPTION
# Why

the `USAGE_NOTIFICATION_COMMUNICATION_INSTANT` is deprecated in android sdk 33. the system will return `USAGE_NOTIFICATION` instead

# How

https://developer.android.com/reference/android/media/AudioAttributes#USAGE_NOTIFICATION_COMMUNICATION_INSTANT
update the test case to use the supported `USAGE_NOTIFICATION`

# Test Plan

unversioned expo go + notifications test-suite

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
