### PR TITLE
[ios] Fix Reanimated requiring main queue setup on the old architecture

### DIFF
--- a/ios/vendored/sdk47/react-native-reanimated/ios/ABI47_0_0REAModule.mm
+++ b/ios/vendored/sdk47/react-native-reanimated/ios/ABI47_0_0REAModule.mm
@@ -19,10 +19,12 @@ typedef void (^AnimatedOperation)(ABI47_0_0REANodesManager *nodesManager);
 
 ABI47_0_0RCT_EXPORT_MODULE(ReanimatedModule);
 
+#ifdef ABI47_0_0RCT_NEW_ARCH_ENABLED
 + (BOOL)requiresMainQueueSetup
 {
   return YES;
 }
+#endif // ABI47_0_0RCT_NEW_ARCH_ENABLED
 
 - (void)invalidate
 {

--- a/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/REAModule.mm
@@ -19,10 +19,12 @@ typedef void (^AnimatedOperation)(REANodesManager *nodesManager);
 
 RCT_EXPORT_MODULE(ReanimatedModule);
 
+#ifdef RCT_NEW_ARCH_ENABLED
 + (BOOL)requiresMainQueueSetup
 {
   return YES;
 }
+#endif // RCT_NEW_ARCH_ENABLED
 
 - (void)invalidate
 {


### PR DESCRIPTION
# Why

Fixes ENG-6821

# How

- Applied the fix from https://github.com/software-mansion/react-native-reanimated/pull/3698
- Backported to SDK 47 code

# Test Plan

Running NCL no longer shows a warning about the bridge needing to dispatch_sync the setup for REAModule