### PR TITLE
[core] Fix reload crash from accessing callback dangling pointers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `~CallbackWrapper()` dangling pointer crashes when reloading the app on Android. ([#19699](https://github.com/expo/expo/pull/19699) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.13.0 — 2022-10-25

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -72,6 +72,7 @@ void JavaScriptModuleObject::registerSyncFunction(
 
   methodsMetadata.try_emplace(
     cName,
+    longLivedObjectCollection_,
     cName,
     args,
     false,
@@ -90,6 +91,7 @@ void JavaScriptModuleObject::registerAsyncFunction(
 
   methodsMetadata.try_emplace(
     cName,
+    longLivedObjectCollection_,
     cName,
     args,
     true,
@@ -107,6 +109,7 @@ void JavaScriptModuleObject::registerProperty(
   auto cName = name->toStdString();
 
   auto getterMetadata = MethodMetadata(
+    longLivedObjectCollection_,
     cName,
     0,
     false,
@@ -117,6 +120,7 @@ void JavaScriptModuleObject::registerProperty(
   auto types = std::vector<std::unique_ptr<AnyType>>();
   types.push_back(std::make_unique<AnyType>(jni::make_local(expectedArgType)));
   auto setterMetadata = MethodMetadata(
+    longLivedObjectCollection_,
     cName,
     1,
     false,
@@ -145,6 +149,7 @@ JavaScriptModuleObject::HostObject::~HostObject() {
   jsModule->methodsMetadata.clear();
   jsModule->constants.clear();
   jsModule->properties.clear();
+  jsModule->longLivedObjectCollection_->clear();
 }
 
 jsi::Value JavaScriptModuleObject::HostObject::get(jsi::Runtime &runtime,
@@ -226,4 +231,10 @@ std::vector<jsi::PropNameID> JavaScriptModuleObject::HostObject::getPropertyName
 
   return result;
 }
+
+JavaScriptModuleObject::JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
+  : javaPart_(jni::make_global(jThis)) {
+  longLivedObjectCollection_ = std::make_shared<react::LongLivedObjectCollection>();
+}
+
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -4,6 +4,7 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
+#include <react/bridging/LongLivedObject.h>
 #include <react/jni/ReadableNativeArray.h>
 #include <jni/JCallback.h>
 
@@ -117,6 +118,9 @@ public:
   };
 
 private:
+  explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis);
+
+private:
   friend HybridBase;
   /**
    * A reference to the `JavaScriptModuleObject::HostObject`.
@@ -141,7 +145,10 @@ private:
    */
   std::map<std::string, std::pair<MethodMetadata, MethodMetadata>> properties;
 
-  explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
-    : javaPart_(jni::make_global(jThis)) {}
+  /**
+   * The `LongLivedObjectCollection` to hold `LongLivedObject` (callbacks or promises) for this module.
+   */
+  std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
+
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -25,12 +25,18 @@ namespace expo {
 // https://github.com/facebook/react-native/blob/7dceb9b63c0bfd5b13bf6d26f9530729506e9097/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp#L57
 jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
   jsi::Function &&function,
+  std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
   jsi::Runtime &rt,
   JSIInteropModuleRegistry *moduleRegistry,
   bool isRejectCallback = false
 ) {
   std::shared_ptr<react::CallInvoker> jsInvoker = moduleRegistry->runtimeHolder->jsInvoker;
-  auto weakWrapper = react::CallbackWrapper::createWeak(std::move(function), rt,
+  auto strongLongLiveObjectCollection = longLivedObjectCollection.lock();
+  if (!strongLongLiveObjectCollection) {
+    throw std::runtime_error("The LongLivedObjectCollection for MethodMetadata is not alive.");
+  }
+  auto weakWrapper = react::CallbackWrapper::createWeak(strongLongLiveObjectCollection,
+                                                        std::move(function), rt,
                                                         std::move(jsInvoker));
 
   // This needs to be a shared_ptr because:
@@ -148,12 +154,14 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
 }
 
 MethodMetadata::MethodMetadata(
+  std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
   std::string name,
   int args,
   bool isAsync,
   jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
-) : name(std::move(name)),
+) : longLivedObjectCollection_(longLivedObjectCollection),
+    name(std::move(name)),
     args(args),
     isAsync(isAsync),
     jBodyReference(std::move(jBodyReference)) {
@@ -167,12 +175,14 @@ MethodMetadata::MethodMetadata(
 }
 
 MethodMetadata::MethodMetadata(
+  std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
   std::string name,
   int args,
   bool isAsync,
   std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
-) : name(std::move(name)),
+) : longLivedObjectCollection_(longLivedObjectCollection),
+    name(std::move(name)),
     args(args),
     isAsync(isAsync),
     argTypes(std::move(expectedArgTypes)),
@@ -402,12 +412,14 @@ jsi::Function MethodMetadata::createPromiseBody(
 
       jobject resolve = createJavaCallbackFromJSIFunction(
         std::move(resolveJSIFn),
+        longLivedObjectCollection_,
         rt,
         moduleRegistry
       ).release();
 
       jobject reject = createJavaCallbackFromJSIFunction(
         std::move(rejectJSIFn),
+        longLivedObjectCollection_,
         rt,
         moduleRegistry,
         true

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -160,11 +160,11 @@ MethodMetadata::MethodMetadata(
   bool isAsync,
   jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
-) : longLivedObjectCollection_(longLivedObjectCollection),
-    name(std::move(name)),
+) : name(std::move(name)),
     args(args),
     isAsync(isAsync),
-    jBodyReference(std::move(jBodyReference)) {
+    jBodyReference(std::move(jBodyReference)),
+    longLivedObjectCollection_(longLivedObjectCollection) {
   argTypes.reserve(args);
   for (size_t i = 0; i < args; i++) {
     auto expectedType = expectedArgTypes->getElement(i);
@@ -181,13 +181,13 @@ MethodMetadata::MethodMetadata(
   bool isAsync,
   std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
-) : longLivedObjectCollection_(longLivedObjectCollection),
-    name(std::move(name)),
+) : name(std::move(name)),
     args(args),
     isAsync(isAsync),
     argTypes(std::move(expectedArgTypes)),
-    jBodyReference(std::move(jBodyReference)
-    ) {}
+    jBodyReference(std::move(jBodyReference)),
+    longLivedObjectCollection_(longLivedObjectCollection) {
+}
 
 std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(
   jsi::Runtime &runtime,

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -9,6 +9,7 @@
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
 #include <ReactCommon/TurboModuleUtils.h>
+#include <react/bridging/LongLivedObject.h>
 #include <react/jni/ReadableNativeArray.h>
 #include <memory>
 #include <vector>
@@ -45,6 +46,7 @@ public:
   std::vector<std::unique_ptr<AnyType>> argTypes;
 
   MethodMetadata(
+    std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
     int args,
     bool isAsync,
@@ -53,6 +55,7 @@ public:
   );
 
   MethodMetadata(
+    std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
     int args,
     bool isAsync,
@@ -110,6 +113,8 @@ private:
    * To not create a jsi::Function always when we need it, we cached that value.
    */
   std::shared_ptr<jsi::Function> body = nullptr;
+
+  std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
 
   jsi::Function toSyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
 


### PR DESCRIPTION
# Why

fix crash from accessing callback dangling pointers when reloading. this issue is found from sdk 47 versioned qa and possibly relates to https://github.com/expo/expo/issues/19167#issuecomment-1280747562
close ENG-6811

```
DEBUG  F  #00 pc 00000000004bb794  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libjsc.so (BuildId: dad225e5c5aafb43e3fcbfcd576772a6a0f8c19a)
                         F  #01 pc 00000000000d60e8  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libjsc.so (JSValueUnprotect+20) (BuildId: dad225e5c5aafb43e3fcbfcd576772a6a0f8c19a)
                         F  #02 pc 0000000000020dd4  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libjscexecutor_abi47_0_0.so (facebook::jsc::JSCRuntime::JSCObjectValue::invalidate()+36) (BuildId: 099921d0601c6be0c790876dcb59e17e18239b96)
                         F  #03 pc 000000000006a868  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (facebook::react::CallbackWrapper::~CallbackWrapper()+100) (BuildId: 4ae7dadfafca105897c93329e28754dcc16428d7)
                         F  #04 pc 000000000006a954  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (std::__ndk1::__shared_ptr_pointer<facebook::react::CallbackWrapper*, std::__ndk1::default_delete<facebook::react::CallbackWrapper>, std::__ndk1::allocator<facebook::react::CallbackWrapper> >::__on_zero_s
                            hared()+44) (BuildId: 4ae7dadfafca105897c93329e28754dcc16428d7)
                         F  #05 pc 000000000006ae80  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (facebook::react::RAIICallbackWrapperDestroyer::~RAIICallbackWrapperDestroyer()+172) (BuildId: 4ae7dadfafca105897c93329e28754dcc16428d7)
                         F  #06 pc 000000000006ad68  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (std::__ndk1::__shared_ptr_emplace<facebook::react::RAIICallbackWrapperDestroyer, std::__ndk1::allocator<facebook::react::RAIICallbackWrapperDestroyer> >::__on_zero_shared()+32) (BuildId: 4ae7dadfafca1058
                            97c93329e28754dcc16428d7)
                         F  #07 pc 000000000006b248  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (BuildId: 4ae7dadfafca105897c93329e28754dcc16428d7)
                         F  #08 pc 000000000004df4c  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libexpo-modules-core_abi47_0_0.so (expo::JavaCallback::~JavaCallback()+88) (BuildId: 4ae7dadfafca105897c93329e28754dcc16428d7)
                         F  #09 pc 000000000001eaa0  /data/app/~~T3HmXfSlw3opSwxrTB2pxA==/host.exp.exponent-eoMeNuc3GrHVhGHe2nrtRA==/lib/arm64/libfbjni.so (BuildId: 27496b9e5551bff5c79496b936b663bf8868c68b)
                         F  #10 pc 0000000000440554  /apex/com.android.art/lib64/libart.so (art_quick_generic_jni_trampoline+148) (BuildId: 56e704c544e6c624201be2ab4933e853)
                         F  #11 pc 0000000002066108  /memfd:jit-cache (deleted) (com.facebook.jni.HybridData$Destructor.destruct+104)
                         F  #12 pc 000000000020a2b0  /apex/com.android.art/lib64/libart.so (nterp_helper+4016) (BuildId: 56e704c544e6c624201be2ab4933e853) 
```

# How

the `RAIICallbackWrapperDestroyer` is designed to collect callbacks even they are not called. it will collect callbacks when the std::function is destroyed. from our MethodMetadata design, the std::function is collected by java GC. my hypothesis is that when reloading if js runtime is destroyed before java GC, the underlying jsi::Function will be a dangling pointer when the `RAIICallbackWrapperDestroyer` trying to collect the callback.

the pr tries to use a dedicated `LongLivedObjectCollection` for each module, and we can reset the collection when reloading.

# Test Plan

- tested on bare-expo
1. set `USE_DEV_CLIENT = true` in MainApplication
2. update App.js with [the content](https://github.com/Kudo/demo-expo-auth-session/blob/master/App.js)
3. keep reloading the app

- android unversioned expo go + NCL AsyncStorage reload

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
