### PR TITLE
[docs] Fix broken link in Expo's SharedElement docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/shared-element.mdx
+++ b/docs/pages/versions/unversioned/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.mdx) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.md) for API and usage information.

--- a/docs/pages/versions/unversioned/sdk/shared-element.mdx
+++ b/docs/pages/versions/unversioned/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.md) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.

--- a/docs/pages/versions/v43.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/shared-element.mdx
@@ -24,4 +24,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.mdx) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.

--- a/docs/pages/versions/v44.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/shared-element.mdx
@@ -24,4 +24,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.mdx) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.

--- a/docs/pages/versions/v45.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.mdx) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.

--- a/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/master/README.mdx) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.


### PR DESCRIPTION
# Why

react-native-shared-element document link is broke

https://docs.expo.dev/versions/latest/sdk/shared-element/#api

<img width="790" alt="2022-10-26 오후 8 25 08" src="https://user-images.githubusercontent.com/40460655/198014315-64fa1599-5cc0-4fc0-a9f9-8290c2e965a2.png">
<img width="820" alt="2022-10-26 오후 8 23 52" src="https://user-images.githubusercontent.com/40460655/198014054-2cede6ce-633a-403c-82e5-d0943f416601.png">



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

Change link
https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.mdx
to
https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
