### PR TITLE
fix: Backport broken webview url in versioned docs

### DIFF
--- a/docs/pages/versions/v43.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/webview.mdx
@@ -15,12 +15,12 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <InstallSection
   packageName="react-native-webview"
-  href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.mdx#react-native-webview-getting-started-guide"
+  href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide"
 />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/v44.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/webview.mdx
@@ -15,12 +15,12 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <InstallSection
   packageName="react-native-webview"
-  href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.mdx#react-native-webview-getting-started-guide"
+  href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide"
 />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/v45.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/webview.mdx
@@ -14,7 +14,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.mdx#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 

--- a/docs/pages/versions/v45.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/webview.mdx
@@ -18,7 +18,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 

--- a/docs/pages/versions/v46.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/webview.mdx
@@ -14,11 +14,11 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Installation
 
-<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.mdx#react-native-webview-getting-started-guide" />
+<APIInstallSection href="https://github.com/react-native-community/react-native-webview/blob/master/docs/Getting-Started.md#react-native-webview-getting-started-guide" />
 
 ## Usage
 
-You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
+You should refer to the [react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get up and running!
 
 <SnackInline label="Basic Webview usage" dependencies={["react-native-webview", "expo-constants"]}>
 


### PR DESCRIPTION
# Why

Continuation of [expo#19684](https://github.com/expo/expo/pull/19684), backporting the fix for the versioned docs as well

The links to some `react-native-webview` mdx pages in the following section of the Expo docs are broken:
https://docs.expo.dev/versions/latest/sdk/webview/#usage

<img width="796" alt="Screenshot 2022-10-25 at 16 25 53" src="https://user-images.githubusercontent.com/5967956/197800643-6a1451d2-0974-4b19-b285-fb87bd124504.png">

# How

Replace the link url's `Guide.mdx` reference with `Guide.md` instead

```suggestion
https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.mdx#react-native-webview-guide
https://github.com/react-native-webview/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide
```

# Test Plan

Preview change in (vscode) Markdown preview, click on `[react-native-webview docs](https://github.com/react-native-community/react-native-webview/blob/master/docs/Guide.md#react-native-webview-guide)` to see that the link is no longer broken

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
