### PR TITLE
fix(cli): skip printing source maps when exporting

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Don't print source map size in `npx expo export` when the source maps are not written.
+- Don't print source map size in `npx expo export` when the source maps are not written. ([#19710](https://github.com/expo/expo/pull/19710) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Don't print source map size in `npx expo export` when the source maps are not written.
+
 ### 💡 Others
 
 ## 0.4.0 — 2022-10-25

--- a/packages/@expo/cli/src/export/__tests__/printBundleSizes-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/printBundleSizes-test.ts
@@ -1,4 +1,4 @@
-import { printBundleSizes } from '../printBundleSizes';
+import { printBundleSizes, createFilesTable } from '../printBundleSizes';
 
 jest.mock('../../log');
 jest.mock('chalk', () => {
@@ -9,6 +9,29 @@ jest.mock('chalk', () => {
   def.dim = (str) => str;
 
   return def;
+});
+
+describe(createFilesTable, () => {
+  it(`handles single-line output`, () => {
+    expect(createFilesTable([['foo', 'bar']])).toMatchInlineSnapshot(`
+      "Bundle  Size
+      ─ foo    3 B"
+    `);
+  });
+  it(`handles multi-line output`, () => {
+    expect(
+      createFilesTable([
+        ['alpha', '1'],
+        ['beta', '2'],
+        ['charlie', '3'],
+      ])
+    ).toMatchInlineSnapshot(`
+      "Bundle     Size
+      ┌ alpha     1 B
+      ├ beta      1 B
+      └ charlie   1 B"
+    `);
+  });
 });
 
 describe(printBundleSizes, () => {

--- a/packages/@expo/cli/src/export/__tests__/writeContents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/writeContents-test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { vol } from 'memfs';
 import path from 'path';
 
@@ -50,7 +51,7 @@ describe(writeBundlesAsync, () => {
       ios: expect.any(String),
       android: expect.any(String),
     });
-    expect(vol.readFileSync(path.join(projectRoot, results.fileNames.ios), 'utf8')).toBe(contents);
+    expect(vol.readFileSync(path.join(projectRoot, results.fileNames.ios!), 'utf8')).toBe(contents);
   });
   it(`writes hbc bundles to disk`, async () => {
     const projectRoot = '/';
@@ -70,7 +71,7 @@ describe(writeBundlesAsync, () => {
     expect(results.hashes).toStrictEqual({
       ios: expect.any(String),
     });
-    expect(vol.readFileSync(path.join(projectRoot, results.fileNames.ios))).toBeDefined();
+    expect(vol.readFileSync(path.join(projectRoot, results.fileNames.ios!))).toBeDefined();
   });
 });
 
@@ -135,6 +136,7 @@ describe(writeSourceMapsAsync, () => {
     });
 
     for (const item of results) {
+      assert(item);
       expect(vol.readFileSync(path.join(projectRoot, item.fileName), 'utf8')).toBe(item.map);
       expect(
         vol.readFileSync(path.join(projectRoot, `${item.platform}-${item.hash}.js`), 'utf8')
@@ -144,5 +146,39 @@ describe(writeSourceMapsAsync, () => {
       //   vol.readFileSync(path.join(projectRoot, `${item.platform}-${item.hash}.js`), 'utf8')
       // ).not.toMatch(/invalid-source-map-comment/);
     }
+  });
+
+  it(`skips writing when the map is not defined`, async () => {
+    const projectRoot = '/';
+
+    // User wrote this
+    const contents = `var foo = true;\ninvalid-source-map-comment`;
+
+    // Metro made this
+    const bundles = {
+      ios: {
+        code: contents,
+      },
+      android: {
+        code: contents,
+        map: 'android_map',
+      },
+    };
+
+    // Expo persists the code and returns info
+    const jsResults = await writeBundlesAsync({
+      outputDir: projectRoot,
+      bundles,
+    });
+
+    // Expo also modifies the source maps and persists
+    const results = await writeSourceMapsAsync({
+      outputDir: projectRoot,
+      hashes: jsResults.hashes,
+      fileNames: jsResults.fileNames,
+      bundles,
+    });
+
+    expect(results).toHaveLength(1);
   });
 });

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -1,5 +1,6 @@
-import type { BundleOutput } from '@expo/dev-server';
 import path from 'path';
+
+import { BundleOutput } from './fork-bundleAsync';
 
 export type BundlePlatform = 'android' | 'ios';
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -67,7 +67,24 @@ export async function exportAppAsync(
   );
 
   // Log bundle size info to the user
-  printBundleSizes(bundles);
+  printBundleSizes(
+    Object.fromEntries(
+      Object.entries(bundles).map(([key, value]) => {
+        if (!dumpSourcemap) {
+          return [
+            key,
+            {
+              ...value,
+              // Remove source maps from the bundles if they aren't going to be written.
+              map: undefined,
+            },
+          ];
+        }
+
+        return [key, value];
+      })
+    )
+  );
 
   // Write the JS bundles to disk, and get the bundle file names (this could change with async chunk loading support).
   const { hashes, fileNames } = await writeBundlesAsync({ bundles, outputDir: bundlesPath });

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -1,12 +1,12 @@
 import { ExpoAppManifest } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
-import { BundleOutput } from '@expo/dev-server';
 import minimatch from 'minimatch';
 import path from 'path';
 
 import * as Log from '../log';
 import { resolveGoogleServicesFile } from '../start/server/middleware/resolveAssets';
 import { uniqBy } from '../utils/array';
+import { BundleOutput } from './fork-bundleAsync';
 import { Asset, saveAssetsAsync } from './saveAssets';
 
 const debug = require('debug')('expo:export:exportAssets') as typeof console.log;

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -34,7 +34,7 @@ export type BundleAssetWithFileHashes = Metro.AssetData & {
 };
 export type BundleOutput = {
   code: string;
-  map: string;
+  map?: string;
   hermesBytecodeBundle?: Uint8Array;
   hermesSourcemap?: string;
   assets: readonly BundleAssetWithFileHashes[];
@@ -184,7 +184,7 @@ export async function bundleAsync(
       const hermesBundleOutput = await buildHermesBundleAsync(
         projectRoot,
         bundleOutput.code,
-        bundleOutput.map,
+        bundleOutput.map!,
         bundle.minify
       );
       bundleOutput.hermesBytecodeBundle = hermesBundleOutput.hbc;

--- a/packages/@expo/cli/src/export/printBundleSizes.ts
+++ b/packages/@expo/cli/src/export/printBundleSizes.ts
@@ -1,5 +1,4 @@
 import { Platform } from '@expo/config';
-import { BundleOutput } from '@expo/dev-server';
 import chalk from 'chalk';
 import prettyBytes from 'pretty-bytes';
 import table from 'text-table';
@@ -7,6 +6,7 @@ import table from 'text-table';
 import * as Log from '../log';
 import { stripAnsi } from '../utils/ansi';
 import { learnMore } from '../utils/link';
+import { BundleOutput } from './fork-bundleAsync';
 
 export function printBundleSizes(bundles: Partial<Record<Platform, BundleOutput>>) {
   const files: [string, string | Uint8Array][] = [];

--- a/packages/@expo/cli/src/export/printBundleSizes.ts
+++ b/packages/@expo/cli/src/export/printBundleSizes.ts
@@ -42,7 +42,8 @@ export function printBundleSizes(bundles: Partial<Record<Platform, BundleOutput>
 
 export function createFilesTable(files: [string, string | Uint8Array][]): string {
   const tableData = files.map((item, index) => {
-    const fileBranch = index === 0 ? '┌' : index === files.length - 1 ? '└' : '├';
+    const fileBranch =
+      index === 0 ? (files.length > 1 ? '┌' : '─') : index === files.length - 1 ? '└' : '├';
 
     return [`${fileBranch} ${item[0]}`, prettyBytes(Buffer.byteLength(item[1], 'utf8'))];
   });

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -1,11 +1,13 @@
 import { Platform } from '@expo/config';
-import { BundleOutput } from '@expo/dev-server';
 import crypto from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 
 import { createMetadataJson } from './createMetadataJson';
+import { BundleOutput } from './fork-bundleAsync';
 import { Asset } from './saveAssets';
+
+const debug = require('debug')('expo:export:write') as typeof console.log;
 
 /**
  * @param props.platform native platform for the bundle
@@ -50,6 +52,14 @@ export async function writeBundlesAsync({
   return { hashes, fileNames };
 }
 
+type SourceMapWriteResult = {
+  platform: string;
+  fileName: string;
+  hash: string;
+  map: string;
+  comment: string;
+};
+
 export async function writeSourceMapsAsync({
   bundles,
   hashes,
@@ -63,30 +73,37 @@ export async function writeSourceMapsAsync({
   hashes?: Record<string, string>;
   fileNames?: Record<string, string>;
   outputDir: string;
-}) {
-  return Promise.all(
-    Object.entries(bundles).map(async ([platform, bundle]) => {
-      const sourceMap = bundle.hermesSourcemap ?? bundle.map;
-      const hash =
-        hashes?.[platform] ?? createBundleHash(bundle.hermesBytecodeBundle ?? bundle.code);
-      const mapName = `${platform}-${hash}.map`;
-      await fs.writeFile(path.join(outputDir, mapName), sourceMap);
+}): Promise<SourceMapWriteResult[]> {
+  return (
+    await Promise.all(
+      Object.entries(bundles).map(async ([platform, bundle]) => {
+        const sourceMap = bundle.hermesSourcemap ?? bundle.map;
+        if (!sourceMap) {
+          debug(`Skip writing sourcemap (platform: ${platform})`);
+          return null;
+        }
 
-      const jsBundleFileName = fileNames?.[platform] ?? createBundleFileName({ platform, hash });
-      const jsPath = path.join(outputDir, jsBundleFileName);
+        const hash =
+          hashes?.[platform] ?? createBundleHash(bundle.hermesBytecodeBundle ?? bundle.code);
+        const mapName = `${platform}-${hash}.map`;
+        await fs.writeFile(path.join(outputDir, mapName), sourceMap);
 
-      // Add correct mapping to sourcemap paths
-      const mappingComment = `\n//# sourceMappingURL=${mapName}`;
-      await fs.appendFile(jsPath, mappingComment);
-      return {
-        platform,
-        fileName: mapName,
-        hash,
-        map: sourceMap,
-        comment: mappingComment,
-      };
-    })
-  );
+        const jsBundleFileName = fileNames?.[platform] ?? createBundleFileName({ platform, hash });
+        const jsPath = path.join(outputDir, jsBundleFileName);
+
+        // Add correct mapping to sourcemap paths
+        const mappingComment = `\n//# sourceMappingURL=${mapName}`;
+        await fs.appendFile(jsPath, mappingComment);
+        return {
+          platform,
+          fileName: mapName,
+          hash,
+          map: sourceMap,
+          comment: mappingComment,
+        };
+      })
+    )
+  ).filter(Boolean) as SourceMapWriteResult[];
 }
 
 export async function writeMetadataJsonAsync({


### PR DESCRIPTION
# Why

When the source maps aren't written to disk, we shouldn't print them in the console.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `npx expo export --dump-sourcemap` -> source maps are printed:
```
Bundle                     Size
┌ index.ios.js           867 kB
├ index.android.js       870 kB
├ index.ios.js.map      3.58 MB
└ index.android.js.map   3.6 MB
```
- `npx expo export` -> source maps are skipped:
```
Bundle                Size
┌ index.ios.js      867 kB
└ index.android.js  870 kB
```

- `npx expo export --platform android` -> formats a single-line output:
```
Bundle  Size
─ foo    3 B
```



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
