### PR TITLE
[prebuild-config] build image-utils dependency

### DIFF
--- a/packages/@expo/CHANGELOG.md
+++ b/packages/@expo/CHANGELOG.md
@@ -13,6 +13,6 @@
 
 - Fix incorrect hermesc path on SDK 46. ([#18548](https://github.com/expo/expo/pull/18548) by [@thespacemanatee](https://github.com/thespacemanatee))
 
-- [prebuild-config] bump image-utils version.
+- [prebuild-config] bump image-utils version. ([#19711]([https://github.com/expo/expo/pull/19711) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ### 💡 Others

--- a/packages/@expo/CHANGELOG.md
+++ b/packages/@expo/CHANGELOG.md
@@ -13,4 +13,6 @@
 
 - Fix incorrect hermesc path on SDK 46. ([#18548](https://github.com/expo/expo/pull/18548) by [@thespacemanatee](https://github.com/thespacemanatee))
 
+- [prebuild-config] bump image-utils version.
+
 ### 💡 Others

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -38,7 +38,7 @@
     "@expo/config": "7.0.2",
     "@expo/config-plugins": "~5.0.1",
     "@expo/config-types": "^47.0.0",
-    "@expo/image-utils": "0.3.20",
+    "@expo/image-utils": "0.3.22",
     "@expo/json-file": "8.2.36",
     "debug": "^4.3.1",
     "fs-extra": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,10 +1366,10 @@
     semver "7.3.2"
     tempy "0.3.0"
 
-"@expo/image-utils@^0.3.18":
-  version "0.3.21"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.21.tgz#dabe772135a66671939f87389e11f23e54341e1e"
-  integrity sha512-Ha7pNcpl52RJIeYz3gR1ajOgPPl7WLZWiLqtLi94s9J0a7FvmNBMqd/VKrfHNj8QmtZxXcmXr7y7tPhZbVFg7w==
+"@expo/image-utils@0.3.22", "@expo/image-utils@^0.3.18":
+  version "0.3.22"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.22.tgz#3a45fb2e268d20fcc761c87bca3aca7fd8e24260"
+  integrity sha512-uzq+RERAtkWypOFOLssFnXXqEqKjNj9eXN7e97d/EXUAojNcLDoXc0sL+F5B1I4qtlsnhX01kcpoIBBZD8wZNQ==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     chalk "^4.0.0"


### PR DESCRIPTION
# Why

`@expo/prebuild-config` missed the dependency bump for `image-utils` that happened in `expo/expo-cli` around the same time these packages were migrated over.

# How

Bumped the dependency version to latest

# Test Plan

None

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
