### PR TITLE
revert #18381

### DIFF
--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -67,8 +67,6 @@ Only the second purpose applies with the new build system. All assets referenced
 
 ### Custom `"main"` entry point in **package.json** is not yet supported
 
-> Support for custom entry points is available in SDK 47 and later.
-
 If your app depends on a custom `"main"` entry point, you will need to remove that field from **package.json** and then create **index.js** in the root of your project and use [registerRootComponent](/versions/latest/sdk/register-root-component/) to register your root component. For example, if your app root component lives in **src/App.tsx**, your **index.js** should look like the following:
 
 ```js
@@ -77,6 +75,8 @@ import App from './src/App';
 
 registerRootComponent(App);
 ```
+
+Support for custom entry points is in progress and is coming soon.
 
 ### Monorepos may require additional setup
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Revert [#18381](https://github.com/expo/expo/pull/18381) (custom entry support).
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -133,7 +133,7 @@ it(
     const pkg = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
 
     // Deleted
-    expect(pkg.main).toBe('node_modules/expo/AppEntry.js');
+    expect(pkg.main).not.toBeDefined();
 
     // Added new packages
     expect(Object.keys(pkg.dependencies).sort()).toStrictEqual([
@@ -201,6 +201,7 @@ it(
         "android/gradlew.bat",
         "android/settings.gradle",
         "app.json",
+        "index.js",
         "ios/.gitignore",
         "ios/.xcode.env",
         "ios/Podfile",

--- a/packages/@expo/cli/src/prebuild/__tests__/copyTemplateFiles-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/copyTemplateFiles-test.ts
@@ -1,0 +1,47 @@
+import { vol } from 'memfs';
+
+import { resolveBareEntryFile } from '../copyTemplateFiles';
+
+describe(resolveBareEntryFile, () => {
+  const projectRoot = '/alpha';
+  const projectRootBeta = '/beta';
+  beforeAll(() => {
+    vol.fromJSON(
+      {
+        'index.js': '',
+        'src/index.js': '',
+      },
+      projectRoot
+    );
+    vol.fromJSON(
+      {
+        'App.js': '',
+      },
+      projectRootBeta
+    );
+  });
+  afterAll(() => {
+    vol.reset();
+  });
+  it(`resolves null when the app entry is managed`, () => {
+    // managed entry points shouldn't even be searched in bare.
+    expect(resolveBareEntryFile('/noop', 'node_modules/expo/AppEntry.js')).toEqual(null);
+    expect(resolveBareEntryFile('/noop', 'expo/AppEntry.js')).toEqual(null);
+  });
+  it(`resolves to the provided main field`, () => {
+    expect(resolveBareEntryFile(projectRoot, './src/index')).toEqual('/alpha/src/index.js');
+    expect(resolveBareEntryFile(projectRoot, './index')).toEqual('/alpha/index.js');
+    // Test that the "node_modules" aren't searched.
+    expect(resolveBareEntryFile(projectRootBeta, 'App')).toEqual('/beta/App.js');
+  });
+  // Uses the default file if it exists and isn't defined in the package.json.
+  it(`resolves to the existing default main file when no field is defined`, () => {
+    expect(resolveBareEntryFile(projectRoot, null)).toEqual('/alpha/index.js');
+  });
+  // support crna blank template -- https://github.com/expo/expo-cli/issues/2873
+  // no package.json main, but has a file that expo managed would resolve as the entry.
+  // This tests that a valid managed entry isn't resolved in bare.
+  it(`resolves to null when the default file doesn't exist`, () => {
+    expect(resolveBareEntryFile(projectRootBeta, null)).toEqual(null);
+  });
+});

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -1,5 +1,10 @@
 import { isModuleSymlinked } from '../../utils/isModuleSymlinked';
-import { hashForDependencyMap, updatePkgDependencies } from '../updatePackageJson';
+import {
+  hashForDependencyMap,
+  isPkgMainExpoAppEntry,
+  shouldDeleteMainField,
+  updatePkgDependencies,
+} from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
 
@@ -8,6 +13,35 @@ describe(hashForDependencyMap, () => {
     expect(hashForDependencyMap({ a: '1.0.0', b: 2, c: '~3.0' })).toBe(
       hashForDependencyMap({ c: '~3.0', b: 2, a: '1.0.0' })
     );
+  });
+});
+
+describe(shouldDeleteMainField, () => {
+  it(`should delete non index field`, () => {
+    expect(shouldDeleteMainField(null)).toBe(false);
+    expect(shouldDeleteMainField()).toBe(false);
+    expect(shouldDeleteMainField('expo/AppEntry')).toBe(true);
+    // non-expo fields
+    expect(shouldDeleteMainField('.src/other.js')).toBe(false);
+    expect(shouldDeleteMainField('index.js')).toBe(false);
+    expect(shouldDeleteMainField('index.ios.js')).toBe(false);
+    expect(shouldDeleteMainField('index.ts')).toBe(false);
+    expect(shouldDeleteMainField('./index')).toBe(false);
+  });
+});
+
+describe(isPkgMainExpoAppEntry, () => {
+  it(`matches expo app entry`, () => {
+    expect(isPkgMainExpoAppEntry('./node_modules/expo/AppEntry.js')).toBe(true);
+    expect(isPkgMainExpoAppEntry('./node_modules/expo/AppEntry')).toBe(true);
+    expect(isPkgMainExpoAppEntry('expo/AppEntry.js')).toBe(true);
+    expect(isPkgMainExpoAppEntry('expo/AppEntry')).toBe(true);
+  });
+  it(`doesn't match expo app entry`, () => {
+    expect(isPkgMainExpoAppEntry()).toBe(false);
+    expect(isPkgMainExpoAppEntry(null)).toBe(false);
+    expect(isPkgMainExpoAppEntry('./expo/AppEntry')).toBe(false);
+    expect(isPkgMainExpoAppEntry('./expo/AppEntry.js')).toBe(false);
   });
 });
 

--- a/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
+++ b/packages/@expo/cli/src/prebuild/copyTemplateFiles.ts
@@ -1,11 +1,14 @@
+import { PackageJSONConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
 import { MergeResults } from '@expo/config-plugins/build/utils/generateCode';
+import { getBareExtensions, getFileWithExtensions } from '@expo/config/paths';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 
 import { copySync, directoryExistsAsync } from '../utils/dir';
 import { mergeGitIgnorePaths } from '../utils/mergeGitIgnorePaths';
+import { isPkgMainExpoAppEntry } from './updatePackageJson';
 
 const debug = require('debug')('expo:prebuild:copyTemplateFiles') as typeof console.log;
 
@@ -57,22 +60,23 @@ export function createCopyFilesSuccessMessage(
 export async function copyTemplateFilesAsync(
   projectRoot: string,
   {
+    pkg,
     templateDirectory,
     platforms,
   }: {
+    /** Project `package.json` as JSON. */
+    pkg: PackageJSONConfig;
     /** File path to the template directory. */
     templateDirectory: string;
     /** List of platforms to copy against. */
     platforms: ModPlatform[];
   }
 ): Promise<CopyFilesResults> {
+  const copyFilePaths = getFilePathsToCopy(projectRoot, pkg, platforms);
+
   const copyResults = await copyPathsFromTemplateAsync(projectRoot, {
     templateDirectory,
-    copyFilePaths: [
-      // Just copy over the native folders from the template
-      // we copy the metro file in a different way.
-      ...platforms,
-    ],
+    copyFilePaths,
   });
 
   const hasPlatformSpecificGitIgnores = hasAllPlatformSpecificGitIgnores(
@@ -117,4 +121,31 @@ async function copyPathsFromTemplateAsync(
   debug(`Copied files:`, copiedPaths);
   debug(`Skipped files:`, copiedPaths);
   return { copiedPaths, skippedPaths };
+}
+
+/** Get a list of relative file paths to copy from the template folder. Example: `['ios', 'android', 'index.js']` */
+function getFilePathsToCopy(projectRoot: string, pkg: PackageJSONConfig, platforms: ModPlatform[]) {
+  const targetPaths: string[] = [...platforms];
+
+  const bareEntryFile = resolveBareEntryFile(projectRoot, pkg.main);
+  // Only create index.js if we cannot resolve the existing entry point (after replacing the expo entry).
+  if (!bareEntryFile) {
+    targetPaths.push('index.js');
+  }
+
+  debug(`Files to copy:`, targetPaths);
+  return targetPaths;
+}
+
+export function resolveBareEntryFile(projectRoot: string, main: any) {
+  // expo app entry is not needed for bare projects.
+  if (isPkgMainExpoAppEntry(main)) {
+    return null;
+  }
+  // Look at the `package.json`s `main` field for the main file.
+  const resolvedMainField = main ?? './index';
+  // Get a list of possible extensions for the main file.
+  const extensions = getBareExtensions(['ios', 'android']);
+  // Testing the main field against all of the provided extensions - for legacy reasons we can't use node module resolution as the package.json allows you to pass in a file without a relative path and expect it as a relative path.
+  return getFileWithExtensions(projectRoot, resolvedMainField, extensions);
 }

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -57,6 +57,7 @@ export async function updateFromTemplateAsync(
     template,
     templateDirectory,
     exp,
+    pkg,
     platforms,
   });
 
@@ -89,12 +90,14 @@ async function cloneTemplateAndCopyToProjectAsync({
   templateDirectory,
   template,
   exp,
+  pkg,
   platforms,
 }: {
   projectRoot: string;
   templateDirectory: string;
   template?: string;
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
+  pkg: PackageJSONConfig;
   platforms: ModPlatform[];
 }): Promise<string[]> {
   const ora = logNewSection(
@@ -105,6 +108,7 @@ async function cloneTemplateAndCopyToProjectAsync({
     await cloneTemplateAsync({ templateDirectory, template, exp, ora });
 
     const results = await copyTemplateFilesAsync(projectRoot, {
+      pkg,
       templateDirectory,
       platforms,
     });

--- a/templates/expo-template-bare-minimum/index.js
+++ b/templates/expo-template-bare-minimum/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -2,6 +2,7 @@
   "name": "expo-template-bare-minimum",
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
   "version": "47.0.0",
+  "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client",
     "android": "expo run:android",


### PR DESCRIPTION
# Why

We cannot reliably make this feature work in bare apps that don't use `expo-dev-client` in development mode. `expo-dev-client` is also not ready to be installed by default. Therefore we have no reliable way to dynamically infer the main path in development mode.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
