### PR TITLE
[android] Fix unstable jitpack error from ci tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,9 +84,7 @@ allprojects {
       dirs 'libs'
       // dirs project(':expoview').file('libs')
     }
-    // Using www.jitpack.io instead of plain jitpack.io due to
-    // https://github.com/jitpack/jitpack.io/issues/4002
-    maven { url "https://www.jitpack.io" }
+    maven { url "https://jitpack.io" }
 
     // Want this last so that we never end up with a stale cache
     mavenLocal()

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -53,14 +53,9 @@ buildscript {
   }
 
   repositories {
-    // If you have maven { url "https://jitpack.io" } as your resolving url,
-    // then Jitpack will only return the POM for the Android dependency causing the Gradle sync to fail.
-    // However, when you change url to "https://www.jitpack.io", Jitpack returns POM, AAR, and sources.jar.
-    // That is why we were adding www even though jitpacks docs don't say so.
-    // See https://github.com/jitpack/jitpack.io/issues/4002.
-    maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
+    maven { url "https://jitpack.io" }
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -68,8 +63,8 @@ buildscript {
 }
 
 repositories {
-  maven { url "https://www.jitpack.io" }
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 android {

--- a/android/versioned-abis/expoview-abi45_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi45_0_0/build.gradle
@@ -14,14 +14,9 @@ buildscript {
   }
 
   repositories {
-    // If you have maven { url "https://jitpack.io" } as your resolving url,
-    // then Jitpack will only return the POM for the Android dependency causing the Gradle sync to fail.
-    // However, when you change url to "https://www.jitpack.io", Jitpack returns POM, AAR, and sources.jar.
-    // That is why we were adding www even though jitpacks docs don't say so.
-    // See https://github.com/jitpack/jitpack.io/issues/4002.
-    maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
+    maven { url "https://jitpack.io" }
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -29,8 +24,8 @@ buildscript {
 }
 
 repositories {
-  maven { url "https://www.jitpack.io" }
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 android {

--- a/android/versioned-abis/expoview-abi46_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi46_0_0/build.gradle
@@ -15,14 +15,9 @@ buildscript {
   }
 
   repositories {
-    // If you have maven { url "https://jitpack.io" } as your resolving url,
-    // then Jitpack will only return the POM for the Android dependency causing the Gradle sync to fail.
-    // However, when you change url to "https://www.jitpack.io", Jitpack returns POM, AAR, and sources.jar.
-    // That is why we were adding www even though jitpacks docs don't say so.
-    // See https://github.com/jitpack/jitpack.io/issues/4002.
-    maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
+    maven { url "https://jitpack.io" }
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -30,8 +25,8 @@ buildscript {
 }
 
 repositories {
-  maven { url "https://www.jitpack.io" }
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 android {

--- a/android/versioned-abis/expoview-abi47_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi47_0_0/build.gradle
@@ -24,14 +24,9 @@ buildscript {
   }
 
   repositories {
-    // If you have maven { url "https://jitpack.io" } as your resolving url,
-    // then Jitpack will only return the POM for the Android dependency causing the Gradle sync to fail.
-    // However, when you change url to "https://www.jitpack.io", Jitpack returns POM, AAR, and sources.jar.
-    // That is why we were adding www even though jitpacks docs don't say so.
-    // See https://github.com/jitpack/jitpack.io/issues/4002.
-    maven { url "https://www.jitpack.io" }
     mavenCentral()
     google()
+    maven { url "https://jitpack.io" }
   }
   dependencies {
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.6.10')}")
@@ -39,8 +34,8 @@ buildscript {
 }
 
 repositories {
-  maven { url "https://www.jitpack.io" }
   mavenCentral()
+  maven { url "https://jitpack.io" }
 }
 
 android {


### PR DESCRIPTION
# Why

fix ci failures: https://github.com/expo/expo/actions/runs/3333667338/jobs/5515831993

```
Could not determine the dependencies of task ':app:compileUnversionedDebugJavaWithJavac'.
> Could not resolve all dependencies for configuration ':app:unversionedDebugRuntimeClasspath'.
   > A problem occurred configuring project ':expoview'.
      > Could not resolve all files for configuration ':expoview:classpath'.
         > Could not find semver4j-0.16.4-nodeps.jar (com.github.gundy:semver4j:0.16.4).
           Searched in the following locations:
               https://www.jitpack.io/com/github/gundy/semver4j/0.16.4/semver4j-0.16.4-nodeps.jar
```

# How

- change `www.jitpack.io` back to `jitpack.io`
- use maven central whenever possible than jitpack

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
