### PR TITLE
[camera] Fixed barCodeTypes typing

### DIFF
--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -476,7 +476,7 @@ export type CameraNativeProps = {
 };
 
 export type BarCodeSettings = {
-  barCodeTypes: string[];
+  barCodeTypes: number[];
   interval?: number;
 };
 


### PR DESCRIPTION
# Why

Looking [at the docs](https://docs.expo.dev/versions/latest/sdk/camera/#barcodescannersettings) we should be able to use a constant from `BarCodeScanner.Constants.BarCodeType` for the `barCodeTypes` array. These are all numbers, not strings: 

```{"aztec": 4096, "codabar": 8, "code128": 1, "code39": 2, "code93": 4, "datamatrix": 16, "ean13": 32, "ean8": 64, "itf14": 128, "pdf417": 2048, "qr": 256, "upc_a": 512, "upc_e": 1024}```

I noticed this when I manually added ```<Camera barCodeScannerSettings={{ barCodeTypes: ["256"]}} />``` as the typing suggests and it didn't work. You need to use `barCodeTypes: [256]`


# How

Switched the type from `string[]` to `number[]`