### PR TITLE
[tools] fix versioning expo go ci error

### DIFF
--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -383,13 +383,16 @@ async function generateReactNativePodScriptAsync(
     // hermes
     { find: /^\s+prepare_hermes[.\s\S]*abort unless prep_status == 0\n$/gm, replaceWith: '' },
     {
-      find: new RegExp(`^\\s*pod '${versionName}hermes-engine', :podspec => "#\\{react_native_path\\}\\/sdks\\/hermes\\/hermes-engine.podspec"`, 'gm'),
+      find: new RegExp(
+        `^\\s*pod '${versionName}hermes-engine', :podspec => "#\\{react_native_path\\}\\/sdks\\/hermes\\/hermes-engine.podspec"`,
+        'gm'
+      ),
       replaceWith: `
     if File.exists?("#{react_native_path}/sdks/hermes-engine/destroot")
       pod '${versionName}hermes-engine', :path => "#{react_native_path}/sdks/hermes-engine", :project_name => '${versionName}'
     else
       pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/${versionName}hermes-engine.podspec", :project_name => '${versionName}'
-    end`
+    end`,
     },
     { find: new RegExp(`\\b${versionName}(libevent)\\b`, 'g'), replaceWith: '$1' },
   ];

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -383,8 +383,13 @@ async function generateReactNativePodScriptAsync(
     // hermes
     { find: /^\s+prepare_hermes[.\s\S]*abort unless prep_status == 0\n$/gm, replaceWith: '' },
     {
-      find: `pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes/hermes-engine.podspec"`,
-      replaceWith: `pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/${versionName}hermes-engine.podspec", :project_name => '${versionName}'`,
+      find: new RegExp(`^\\s*pod '${versionName}hermes-engine', :podspec => "#\\{react_native_path\\}\\/sdks\\/hermes\\/hermes-engine.podspec"`, 'gm'),
+      replaceWith: `
+    if File.exists?("#{react_native_path}/sdks/hermes-engine/destroot")
+      pod '${versionName}hermes-engine', :path => "#{react_native_path}/sdks/hermes-engine", :project_name => '${versionName}'
+    else
+      pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/${versionName}hermes-engine.podspec", :project_name => '${versionName}'
+    end`
     },
     { find: new RegExp(`\\b${versionName}(libevent)\\b`, 'g'), replaceWith: '$1' },
   ];


### PR DESCRIPTION
# Why

fix versioning expo go ci error when pod install `Unsupported download strategy {:path=>"."}.`
https://github.com/expo/expo/actions/runs/3325898368/jobs/5499064873
close ENG-6825

# How

when serving hermes locally, use `pod ...,  :path => ...`.
when serving hermes from remote, use `pod ..., :podspec => ...` 

# Test Plan

versioning expo go ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
