### PR TITLE
[ENG-6620][docs] add example on uploading google-services.json to EAS secrets

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -290,3 +290,28 @@ Environment variables set in your build profile that impact **app.config.js** wi
 ### Can I just set my environment variables on a CI provider?
 
 Environment variables must be defined in **eas.json** in order to be made available to EAS Build workers. If you are [triggering builds from CI](/build/building-on-ci.mdx) this same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets in **eas.json**.
+
+### How to upload a secret file and use it in my app config?
+
+A common use case for uploading file secrets to EAS is when you want to supply your build with the **google-services.json** and **GoogleService-Info.plist** files. Usually, those files should not be checked in to the repository.
+
+Here's an example how to upload **google-services.json** to EAS and use it in your app config:
+
+1. Upload the file to EAS.
+   <Terminal
+     cmd={[
+       '$ eas secret:create --scope project --name GOOGLE_SERVICES_JSON --type file --value ./path/to/google-services.json',
+       '✔ ️Created a new secret GOOGLE_SERVICES_JSON on project @user/myproject.',
+     ]}
+   />
+2. Use **app.config.js** to read the path to **google-services.json**.
+
+```js app.config.js
+export default {
+  // ...
+  android: {
+    googleServicesFile: process.env.GOOGLE_SERVICES_JSON,
+    // ...
+  },
+};
+```


### PR DESCRIPTION
Part of https://linear.app/expo/issue/ENG-6620/point-to-file-secrets-guide-from-google-servicesjson-error

This PR adds an example of uploading google-services.json to EAS secrets and using it in app.config.js