### PR TITLE
[guides] add hermes inspector qa flow

### DIFF
--- a/guides/releasing/Quality Assurance.md
+++ b/guides/releasing/Quality Assurance.md
@@ -17,7 +17,13 @@ Unversioned QA: Test in native-component-list.
   - Disable Fast Refresh, make and save a change, it shouldn't show up
   - Reload manually, your change should appear
   - Make and save another change, reenable Fast Refresh, your change should show up automatically
-- Debug Remote JS
+- Debug JS in-place (Hermes)
+  - Add `jsEngine` as `hermes` in _apps/native-component-list/app.json_
+  - Open JS debugger either pressing `j` by `expo-cli` terminal UI hotkey or from the dev-menu in Expo Go
+  - Add a breakpoint (maybe add a button to your app), ensure the breakpoint works
+  - Click Reload on the webpage, make sure it reloads the app
+- Debug Remote JS (JSC)
+  - Add `jsEngine` as `jsc` in _apps/native-component-list/app.json_
   - Start Remote JS debugging
   - Add a breakpoint (maybe add a button to your app), ensure the breakpoint works
   - Click Reload on the webpage, make sure it reloads the app


### PR DESCRIPTION
# Why

now expo go create js runtime based on the `jsEngine` in app.json and the js debugging experience is also different between hermes and jsc. we should cover these in qa phase.

# How

update qa guide to cover both hermes and jsc debugging tests.

# Test Plan

n/a

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
