### PR TITLE
[clipboard][Android] Fixes clipboard listener is called twice

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Fixed clipboard listener is called twice on Android.
+- Fixed clipboard listener can crash the application during initialization on Android.
+
 ### 💡 Others
 
 ## 4.0.0 — 2022-10-25

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Fixed clipboard listener is called twice on Android.
-- Fixed clipboard listener can crash the application during initialization on Android.
+- Fixed clipboard listener is called twice on Android. ([#19723](https://github.com/expo/expo/pull/19723) by [@lukmccall](https://github.com/lukmccall))
+- Fixed clipboard listener can crash the application during initialization on Android. ([#19723](https://github.com/expo/expo/pull/19723) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -147,19 +147,35 @@ class ClipboardModule : Module() {
 
   private inner class ClipboardEventEmitter {
     private var isListening = true
+    private var timestamp = -1L
+    fun resumeListening() {
+      isListening = true
+    }
 
-    fun resumeListening() { isListening = true }
-    fun pauseListening() { isListening = false }
+    fun pauseListening() {
+      isListening = false
+    }
 
     fun attachListener() = maybeClipboardManager?.addPrimaryClipChangedListener(listener).ifNull {
       Log.e(TAG, "'CLIPBOARD_SERVICE' unavailable. Events won't be received")
     }
+
     fun detachListener() = maybeClipboardManager?.removePrimaryClipChangedListener(listener)
 
     private val listener = ClipboardManager.OnPrimaryClipChangedListener {
+      if (!appContext.hasActiveReactInstance) {
+        return@OnPrimaryClipChangedListener
+      }
+
       maybeClipboardManager.takeIf { isListening }
         ?.primaryClipDescription
         ?.let { clip ->
+          if (timestamp == clip.timestamp) {
+            return@OnPrimaryClipChangedListener
+          }
+          timestamp = clip.timestamp
+
+
           this@ClipboardModule.sendEvent(
             CLIPBOARD_CHANGED_EVENT_NAME,
             bundleOf(

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -175,7 +175,6 @@ class ClipboardModule : Module() {
           }
           timestamp = clip.timestamp
 
-
           this@ClipboardModule.sendEvent(
             CLIPBOARD_CHANGED_EVENT_NAME,
             bundleOf(

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added `AppContext.hasActiveReactInstance` on Android.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added `AppContext.hasActiveReactInstance` on Android.
+- Added `AppContext.hasActiveReactInstance` on Android. ([#19723](https://github.com/expo/expo/pull/19723) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -164,13 +164,15 @@ class AppContext(
    * A directory for storing user documents and other permanent files.
    */
   val persistentFilesDirectory: File
-    get() = appDirectories?.persistentFilesDirectory ?: throw ModuleNotFoundException("expo.modules.interfaces.filesystem.AppDirectories")
+    get() = appDirectories?.persistentFilesDirectory
+      ?: throw ModuleNotFoundException("expo.modules.interfaces.filesystem.AppDirectories")
 
   /**
    * A directory for storing temporary files that can be removed at any time by the device's operating system.
    */
   val cacheDirectory: File
-    get() = appDirectories?.cacheDirectory ?: throw ModuleNotFoundException("expo.modules.interfaces.filesystem.AppDirectories")
+    get() = appDirectories?.cacheDirectory
+      ?: throw ModuleNotFoundException("expo.modules.interfaces.filesystem.AppDirectories")
 
   /**
    * Provides access to the permissions manager from the legacy module registry
@@ -225,6 +227,12 @@ class AppContext(
    */
   val reactContext: Context?
     get() = reactContextHolder.get()
+
+  /**
+   * @return true if there is an non-null, alive react native instance
+   */
+  val hasActiveReactInstance: Boolean
+    get() = reactContextHolder.get()?.hasActiveReactInstance() ?: false
 
   /**
    * Provides access to the event emitter

--- a/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
+++ b/packages/expo-modules-test-core/android/src/main/java/expo/modules/test/core/ModuleMock.kt
@@ -127,7 +127,7 @@ private fun prepareMockAppContext(customAppContext: AppContext?): AppContext {
   // we need to override it to return actual strong reference (held by mockk internals)
   val appContextSpy = convertToSpy(appContext)
   every { appContextSpy getProperty "reactContext" } returns reactContext
-
+  every { appContextSpy getProperty "hasActiveReactInstance" } returns true
   return appContextSpy
 }
 


### PR DESCRIPTION
# Why

Fixes clipboard listener is called twice on Android.
Fixes clipboard listener crashing the application on Android during the initialization phase. 

# How

During the `dev-client` QA, I faced two issues with a clipboard. First of all, the listener's called twice for a single event. It was fixed by checking the timestamp. Moreover, the clipboard code may break the application, when the same listener is called in the initialization phase when react modules aren't fully initiated. I've decided to add a function to the app context to check if the react native is alive.

# Test Plan

- bare-expo ✅