### PR TITLE
[modules][Android] Fix `should_throw_if_js_value_cannot_be_passed`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -198,8 +198,8 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(exception.message).contains("java.lang.IllegalStateException")
   }
 
-  @Test(expected = JavaScriptEvaluateException::class)
-  fun should_throw_if_js_value_cannot_be_passed() = withJSIInterop(
+  @Test(expected = PromiseException::class)
+  fun should_reject_if_js_value_cannot_be_passed() = withJSIInterop(
     inlineModule {
       Name("TestModule")
       AsyncFunction("f") { _: Int -> }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -4,7 +4,6 @@ package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
 import expo.modules.kotlin.exception.CodedException
-import expo.modules.kotlin.exception.JavaScriptEvaluateException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable


### PR DESCRIPTION
# Why

Fixes:
```
expo.modules.kotlin.jni.JSIAsyncFunctionsTest > should_throw_if_js_value_cannot_be_passed[avd-31(AVD) - 12] FAILED 
	java.lang.Exception: Unexpected exception, expected<expo.modules.kotlin.exception.JavaScriptEvaluateException> but was<expo.modules.kotlin.jni.PromiseException>
	at org.junit.internal.runners.statements.ExpectException.evaluate(ExpectException.java:30)
Tests on avd-31(AVD) - 12 failed: There was 1 failure(s).
```

# How

I can confirm that `PromiseException` is the correct exception here. The underlying code is working correctly - the test code wasn't changed correctly after https://github.com/expo/expo/pull/19611.

# Test Plan

- run unit tests ✅