### PR TITLE
[updates] Fix updates e2e test

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the _app.manifest_ occasionally missing from build outputs on Android. ([#19731](https://github.com/expo/expo/pull/19731) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.15.0 — 2022-10-25

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -87,6 +87,7 @@ async function initAsync(workingDir, repoRoot, runtimeVersion) {
       'expo-manifests': 'file:../expo/packages/expo-manifests',
       'expo-modules-autolinking': 'file:../expo/packages/expo-modules-autolinking',
       'expo-modules-core': 'file:../expo/packages/expo-modules-core',
+      'expo-splash-screen': 'file:../expo/packages/expo-splash-screen',
       'expo-structured-headers': 'file:../expo/packages/expo-structured-headers',
       'expo-updates-interface': 'file:../expo/packages/expo-updates-interface',
     },

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -95,7 +95,7 @@ def setupClosure = {
       enabled(currentBundleTask.enabled)
     }
 
-    Task dependentTask = appProject.tasks.findByPath("process${targetName}Resources");
+    Task dependentTask = appProject.tasks.findByPath("merge${targetName}Resources");
     if (dependentTask != null) {
       dependentTask.dependsOn currentAssetsCopyTask
     }


### PR DESCRIPTION
# Why

fix update e2e ci failure: https://github.com/expo/expo/actions/runs/3337392070/jobs/5523675403

# How

the prebuilt expo-splash-screen xcframework is incompatible. we should symlink it and build from source.

# Test Plan

update e2e ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
