### PR TITLE
[updates] Fix app.manifest occasionally missing on android

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the _app.manifest_ occasionally missing from build outputs on Android. ([#19731](https://github.com/expo/expo/pull/19731) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.15.0 — 2022-10-25

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -95,7 +95,7 @@ def setupClosure = {
       enabled(currentBundleTask.enabled)
     }
 
-    Task dependentTask = appProject.tasks.findByPath("process${targetName}Resources");
+    Task dependentTask = appProject.tasks.findByPath("merge${targetName}Resources");
     if (dependentTask != null) {
       dependentTask.dependsOn currentAssetsCopyTask
     }


### PR DESCRIPTION
# Why

there are some reported issues that the _app.manifest_ is missing from output builds.
close ENG-2610

# How

i cannot reliably reproduce the problem and the hypothesis is about building task sequence. the pr tries changing the task dependency to `mergeReleaseResources` which would be earlier than `processReleaseResources`. this is also aligned with [react-native implementation](https://github.com/facebook/react-native/blob/475310dbbaec8048411edefc6cdddab330df7966/react.gradle#L421).

# Test Plan

updates e2e ci passed (based on #19730)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
