### PR TITLE
[Android] Remove deprecated android-extensions plugin

### DIFF
--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### 🛠 Breaking changes
 
-- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes
 
 ### 💡 Others
+
+- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
 
 ## 0.4.0 — 2022-10-25
 

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Removed deprecated Android `kotlin-android-extensions` plugin
+- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🎉 New features
 

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Removed deprecated Android `kotlin-android-extensions` plugin
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 group = 'host.exp.exponent'

--- a/packages/expo-module-template/$CHANGELOG.md
+++ b/packages/expo-module-template/$CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Removed deprecated Android `kotlin-android-extensions` plugin
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-module-template/$CHANGELOG.md
+++ b/packages/expo-module-template/$CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unpublished
 
-- Removed deprecated Android `kotlin-android-extensions` plugin
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 group = '<%- project.package %>'

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Removed deprecated Android `kotlin-android-extensions` plugin
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unpublished
 
-- Removed deprecated Android `kotlin-android-extensions` plugin
+- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unpublished
 
-- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
-
 ### 🛠 Breaking changes
 
 ### 🎉 New features
@@ -11,6 +9,8 @@
 ### 🐛 Bug fixes
 
 ### 💡 Others
+
+- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
 
 ## 3.0.0 — 2022-10-25
 

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 group = 'host.exp.exponent'

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Removed deprecated Android `kotlin-android-extensions` plugin
+- Removed deprecated Android `kotlin-android-extensions` plugin ([#19732](https://github.com/expo/expo/pull/19732) by [@josephyanks](https://github.com/josephyanks))
 
 ## 0.8.0 — 2022-10-25
 

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Removed deprecated Android `kotlin-android-extensions` plugin
+
 ## 0.8.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 
 group = 'host.exp.exponent'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `kotlin-android-extensions` plugin is deprecated with Kotlin 1.4, and should be removed / replaced from the expo modules that still use it.

This affects the following modules:
* eas-client
* module-template
* structured-headers
* updates-interface

# How

<!--
How did you build this feature or fix this bug and why?
-->

None of the expo modules are using functionality that the `kotlin-android-extension` distinctly enabled (view binding or parcelize), so removing the plugin is simple since the functionality has been replaced by the Kotlin compiler and AGP.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

We have tested these changes in our production application as local patches. It's unclear to me how to go about testing these (especially expo-updates) without doing it on a real application.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
