### PR TITLE
chore(cli): drop CLI unit tests in favor of check packages

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -47,9 +47,6 @@ jobs:
       - name: 🛠 Build CLI
         run: yarn prepare
         working-directory: packages/@expo/cli
-      - name: 🧪 Unit Test CLI
-        run: yarn test
-        working-directory: packages/@expo/cli
       - name: E2E Test CLI
         run: yarn test:e2e
         working-directory: packages/@expo/cli

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,16 +14,12 @@ on:
       - tools/**
       - packages/**
       - yarn.lock
-      # Ignore Expo CLI for now...
-      - '!packages/@expo/cli/**'
   pull_request:
     paths:
       - .github/workflows/sdk.yml
       - tools/**
       - packages/**
       - yarn.lock
-      # Ignore Expo CLI for now...
-      - '!packages/@expo/cli/**'
   schedule:
     - cron: 0 14 * * *
 


### PR DESCRIPTION
# Why

- drop unit tests in CLI workflow in favor of check packages
