### PR TITLE
Bump react-native patch version

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -111,7 +111,7 @@
     "native-component-list": "*",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-reanimated": "~2.11.0",
     "react-native-safe-area-context": "4.4.1",

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -17,7 +17,7 @@
     "expo-splash-screen": "~0.17.0",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-web": "~0.18.9"
   },
   "devDependencies": {

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -11,7 +11,7 @@
     "@expo/mux": "^1.0.7",
     "expo": "~47.0.0-alpha.1",
     "react": "18.1.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "uuid": "^3.4.0"
   }
 }

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -144,7 +144,7 @@
     "processing-js": "^1.6.6",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-iphone-x-helper": "^1.3.0",
     "react-native-maps": "1.3.2",

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -22,7 +22,7 @@
     "native-component-list": "*",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3"
+    "react-native": "0.70.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "expo": "~47.0.0-alpha.1",
     "react": "18.1.0",
-    "react-native": "0.70.3"
+    "react-native": "0.70.4"
   },
   "devDependencies": {
     "babel-preset-expo": "~9.2.0",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -52,7 +52,7 @@
     "jasmine-core": "^2.4.1",
     "lodash": "^4.17.19",
     "react": "18.1.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-safe-area-view": "^0.14.8",
     "sinon": "^7.1.1"

--- a/home/package.json
+++ b/home/package.json
@@ -54,7 +54,7 @@
     "prop-types": "^15.7.2",
     "querystring": "^0.2.0",
     "react": "18.1.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-fade-in-image": "^1.6.1",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-infinite-scroll-view": "^0.4.5",

--- a/ios/versioned-react-native/ABI47_0_0/ReactNative/package.json
+++ b/ios/versioned-react-native/ABI47_0_0/ReactNative/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.70.3",
+  "version": "0.70.4",
   "bin": "./cli.js",
   "description": "A framework for building native apps using React",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     ]
   },
   "resolutions": {
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "**/util": "~0.12.4"
   },
   "dependencies": {

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -49,7 +49,7 @@
     "graphql": "^16.0.1",
     "graphql-request": "^3.6.1",
     "react": "18.1.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-query": "^3.34.16",
     "url": "^0.11.0"
   },

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -65,7 +65,7 @@
     "graphql": "^15.3.0",
     "graphql-tag": "^2.10.1",
     "react": "18.1.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "use-subscription": "^1.8.0",
     "url": "^0.11.0"
   },

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -87,7 +87,7 @@
   "lottie-react-native": "5.1.4",
   "react": "18.1.0",
   "react-dom": "18.0.0",
-  "react-native": "0.70.3",
+  "react-native": "0.70.4",
   "react-native-web": "~0.18.9",
   "react-native-branch": "^5.4.0",
   "react-native-gesture-handler": "~2.8.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -92,6 +92,6 @@
     "expo-module-scripts": "^3.0.0",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3"
+    "react-native": "0.70.4"
   }
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,7 +14,7 @@
     "expo-splash-screen": "~0.17.0",
     "expo-status-bar": "~1.4.1",
     "react": "18.1.0",
-    "react-native": "0.70.3"
+    "react-native": "0.70.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo-status-bar": "~1.4.1",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-web": "~0.18.9"
   },
   "devDependencies": {

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -13,7 +13,7 @@
     "expo": "~47.0.0-beta.1",
     "expo-status-bar": "~1.4.1",
     "react": "18.1.0",
-    "react-native": "0.70.3"
+    "react-native": "0.70.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -29,7 +29,7 @@
     "expo-web-browser": "~12.0.0",
     "react": "18.1.0",
     "react-dom": "18.0.0",
-    "react-native": "0.70.3",
+    "react-native": "0.70.4",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",
     "react-native-web": "~0.18.9"


### PR DESCRIPTION
# Why

Bump to 0.70.4. No need to update Expo Go code here.

# How

- Find all occurrences of react-native dep and update them
- Bring in missing commits to our fork (although not actually needed)

# Test Plan

CI

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
