### PR TITLE
[cli] Add extra param required for latest cli-plugin-metro

### DIFF
--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -108,7 +108,8 @@ export async function exportAppAsync(
           // @ts-expect-error: tolerable type mismatches: unused `readonly` (common in Metro) and `undefined` instead of `null`.
           bundle.assets,
           platform,
-          outputPath
+          outputPath,
+          undefined
         );
       })
     );


### PR DESCRIPTION
# Why

https://github.com/react-native-community/cli/commit/b15a96417ced348370552fcd8d0ebec59f12c3f3 added a 4th required param, and this commit was pulled in when bumping to react-native@0.70.4

# How

Add undefined as 4th param, because we don't want to use the iOS asset catalog in export.