### PR TITLE
[docs] formatting and style tweaks for various pages

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -28,7 +28,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [VS Code Editor](https://code.visualstudio.com/download)
-  - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for **app.json** or **app.config.js** debugging and autocomplete.
+  - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for Expo config debugging and autocomplete.
 
 For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal.
 
@@ -67,7 +67,7 @@ Open the Expo Go app after it has finished installing. If you have created an ac
 Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the "Projects" section on the Home tab of the app.
 
 > It's often useful to be able to run your app directly on your computer instead of on a separate physical device.
-> If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator) .
+> If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator).
 
 ## Up next
 

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -4,13 +4,16 @@ title: Installation
 
 import { Terminal } from '~/ui/components/Snippet';
 
-To develop applications with Expo, you need two tools. A command-line tool called [Expo CLI](#1-expo-cli) to serve your project, and a mobile client app called [Expo Go](#2-expo-go-app-for-ios-and) to open the project on iOS and Android platforms. Additionally, you can use any web browser to run the project on the web.
+To develop applications with Expo, you need two tools. A command-line tool called [Expo CLI](#1-expo-cli) to serve your project,
+and a mobile client app called [Expo Go](#2-expo-go-app-for-ios-and) to open the project on iOS and Android platforms.
+Additionally, you can use any web browser to run the project on the web.
 
 > **info** You don't need macOS to build an iOS app with Expo. You only need an iOS device to run the Expo Go app. Windows, Linux, and macOS are all supported for your development machine.
 
 ## 1. Expo CLI
 
-[Expo CLI](/workflow/expo-cli) is a command-line tool that is the primary interface between a developer and other Expo tools. You are going to use it for different tasks in the development life cycle of your project such as serving the project in development, viewing logs, opening the app on an emulator or a physical device, and so on.
+[Expo CLI](/workflow/expo-cli) is a command-line tool that is the primary interface between a developer and other Expo tools.
+You are going to use it for different tasks in the development life cycle of your project such as serving the project in development, viewing logs, opening the app on an emulator or a physical device, and so on.
 
 ### Requirements
 
@@ -27,7 +30,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 - [VS Code Editor](https://code.visualstudio.com/download)
   - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for **app.json** or **app.config.js** debugging and autocomplete.
 
-For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal
+For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal.
 
 ### Using Expo CLI
 
@@ -41,7 +44,8 @@ Now, run the following command:
 
 <Terminal cmd={['$ npx expo whoami']} />
 
-This command checks which Expo account is currently authenticated on your machine. You will see a **Not logged in** message since you are not logged in to an Expo account. You do not need an account to start and can proceed further with your project. However, if you want to register a new Expo account, run the following command to register a new account:
+This command checks which Expo account is currently authenticated on your machine. You will see a **Not logged in** message since you are not logged in to an Expo account.
+You do not need an account to start and can proceed further with your project. However, if you want to register a new Expo account, run the following command to register a new account:
 
 <Terminal cmd={['$ npx expo register']} />
 
@@ -51,16 +55,19 @@ If you already have an Expo account, you can log in to it by running the command
 
 > **Need help?** Try searching the [forums](https://forums.expo.dev) &mdash; which are great resources for troubleshooting.
 
-## 2. Expo Go app for iOS and Android
+## 2. Expo Go app for Android and iOS
 
-The fastest way to get up and running is to use the [Expo Go](https://expo.dev/client) client app on your iOS or Android device. It allows you to open up apps served through Expo CLI and run your projects faster when developing them. It is available on both the iOS App Store and Android Play Store.
+The fastest way to get up and running is to use the [Expo Go](https://expo.dev/client) client app on your iOS or Android device.
+It allows you to open up apps served through Expo CLI and run your projects faster when developing them. It is available on both the iOS App Store and Android Play Store.
 
 - [Android Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent) - Android Lollipop (5) and greater
 - [iOS App Store](https://apps.apple.com/app/expo-go/id982107779) - iOS 11 and greater
 
-Open the Expo Go app after it has finished installing. If you have created an account with Expo CLI, you can sign in by clicking the "Login" button in the top header on the "Home" tab. Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the "Projects" section on the Home tab of the app.
+Open the Expo Go app after it has finished installing. If you have created an account with Expo CLI, you can sign in by clicking the "Login" button in the top header on the "Home" tab.
+Signing in will make it easier for you to open projects in the Expo Go app while developing them &mdash; they will appear automatically under the "Projects" section on the Home tab of the app.
 
-> It's often useful to be able to run your app directly on your computer instead of on a separate physical device. If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator) .
+> It's often useful to be able to run your app directly on your computer instead of on a separate physical device.
+> If you would like to set this up, you can learn more about [installing an Android Emulator](/workflow/android-studio-emulator) and [installing the iOS Simulator (macOS only)](/workflow/ios-simulator) .
 
 ## Up next
 

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -19,8 +19,8 @@ You are going to use it for different tasks in the development life cycle of you
 
 To use Expo CLI, you need to have the following tools installed on your developer machine:
 
-- [Node.js LTS release](https://nodejs.org/en/)
-  > Only Node.js LTS releases (even-numbered) are recommended. As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases.".
+- [Node.js LTS release](https://nodejs.org/en/) - Only Node.js LTS releases (even-numbered) are recommended.
+  As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases".
 - [Git](https://git-scm.com)
 - For macOS or Linux users: [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall)
 

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -6,7 +6,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 To develop applications with Expo, you need two tools. A command-line tool called [Expo CLI](#1-expo-cli) to serve your project, and a mobile client app called [Expo Go](#2-expo-go-app-for-ios-and) to open the project on iOS and Android platforms. Additionally, you can use any web browser to run the project on the web.
 
-> You don't need macOS to build an iOS app with Expo. You only need an iOS device to run the Expo Go app. Windows, Linux, and macOS are all supported for your development machine.
+> **info** You don't need macOS to build an iOS app with Expo. You only need an iOS device to run the Expo Go app. Windows, Linux, and macOS are all supported for your development machine.
 
 ## 1. Expo CLI
 
@@ -17,21 +17,23 @@ To develop applications with Expo, you need two tools. A command-line tool calle
 To use Expo CLI, you need to have the following tools installed on your developer machine:
 
 - [Node.js LTS release](https://nodejs.org/en/)
+  > Only Node.js LTS releases (even-numbered) are recommended. As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases.".
 - [Git](https://git-scm.com)
-- [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall) required only for macOS or Linux users
-
-> Only Node.js LTS releases (even-numbered) are recommended. As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases."
+- For macOS or Linux users: [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall)
 
 ### Recommended tools
 
-- [VS Code Editor](https://code.visualstudio.com/download)
-  - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for **app.json** debugging and autocomplete
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
-- Windows users: [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal
+- [VS Code Editor](https://code.visualstudio.com/download)
+  - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for **app.json** or **app.config.js** debugging and autocomplete.
+
+For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal
 
 ### Using Expo CLI
 
-You can use Expo CLI without installation by leveraging `npx` &mdash; a Node.js package runner. For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
+You can use Expo CLI without installation by leveraging `npx` &mdash; a Node.js package runner.
+
+For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
 
 <Terminal cmd={['# See a list of available commands in Expo CLI', '$ npx expo -h']} />
 

--- a/docs/pages/introduction/expo.mdx
+++ b/docs/pages/introduction/expo.mdx
@@ -2,26 +2,28 @@
 title: What is Expo
 ---
 
-import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { PlanEnterpriseIcon, ExpoGoLogo, DocsLogo } from '@expo/styleguide';
 
-Expo is an npm package that enables a suite of incredible features for React Native apps. The `expo` package can be installed in nearly **any React Native project**.
+Expo is a npm package that enables a suite of incredible features for React Native apps. The `expo` package can be installed in nearly **any React Native project**.
 
-## Features
+## Tools and Features
 
 <BoxLink
   title="Expo Go"
   description="Share your development app instantly with your team from anywhere in the world."
   href="/workflow/expo-go"
+  Icon={ExpoGoLogo}
 />
 <BoxLink
   title="Expo SDK"
-  description="Comprehensive suite of well tested React Native modules that run on iOS, Android, and web."
+  description="Comprehensive suite of well tested React Native modules that run on Android, iOS, and web."
   href="/versions/latest"
+  Icon={DocsLogo}
 />
 <BoxLink
-  title="Native API"
+  title="Expo Modules API"
   description="Write highly performant native code with modern Swift & Kotlin API."
   href="/modules/overview"
 />
@@ -36,32 +38,32 @@ Expo is an npm package that enables a suite of incredible features for React Nat
   href="/workflow/expo-cli"
 />
 
-> All features are free, optional, and can be used independently of each other. Unused features add no additional bloat to your app.
+> **info** All features are free, optional, and can be used independently of each other. Unused features add no additional bloat to your app.
 
-| Feature                                                           | <YesIcon /> With `expo` | <NoIcon /> Without `expo` (bare React Native) |
-| ----------------------------------------------------------------- | ----------------------- | --------------------------------------------- |
-| Instantly share and test your app with your team from anywhere.   | <YesIcon />             | <NoIcon />                                    |
-| Develop complex apps **entirely** in JavaScript.                  | <YesIcon />             | <NoIcon />                                    |
-| Write JSI native modules with Swift & Kotlin.                     | <YesIcon />             | <NoIcon />                                    |
-| Develop apps without Xcode or Android Studio.                     | <YesIcon />             | <NoIcon />                                    |
-| Create and share example apps in the browser with [Snack][snack]. | <YesIcon />             | <NoIcon />                                    |
-| Major upgrades without native changes.                            | <YesIcon />             | <NoIcon />                                    |
-| First-class TypeScript support.                                   | <YesIcon />             | <NoIcon />                                    |
-| Install natively compatible libraries from the command line.      | <YesIcon />             | <NoIcon />                                    |
-| Develop performant websites with the same codebase.               | <YesIcon />             | <NoIcon />                                    |
-| [Tunnel][tunnel] your dev server to any device.                   | <YesIcon />             | <NoIcon />                                    |
+| Feature                                                           | With `expo` | Without `expo` (bare React Native) |
+|-------------------------------------------------------------------|-------------|------------------------------------|
+| Instantly share and test your app with your team from anywhere.   | <YesIcon /> | <NoIcon />                         |
+| Develop complex apps **entirely** in JavaScript.                  | <YesIcon /> | <NoIcon />                         |
+| Write JSI native modules with Swift & Kotlin.                     | <YesIcon /> | <NoIcon />                         |
+| Develop apps without Xcode or Android Studio.                     | <YesIcon /> | <NoIcon />                         |
+| Create and share example apps in the browser with [Snack][snack]. | <YesIcon /> | <NoIcon />                         |
+| Major upgrades without native changes.                            | <YesIcon /> | <NoIcon />                         |
+| First-class TypeScript support.                                   | <YesIcon /> | <NoIcon />                         |
+| Install natively compatible libraries from the command line.      | <YesIcon /> | <NoIcon />                         |
+| Develop performant websites with the same codebase.               | <YesIcon /> | <NoIcon />                         |
+| [Tunnel][tunnel] your dev server to any device.                   | <YesIcon /> | <NoIcon />                         |
 
 ## Services
 
 The team behind Expo also provides **Expo Application Services**, deeply integrated cloud services for building, submitting, and updating your React Native app.
+Expo Application Services (EAS) can be used with **any React Native app**, regardless of whether it uses `expo` or not.
 
 <BoxLink
   title="Expo Application Services"
   description="The easiest way to build, deploy, and update native apps."
   href="/eas"
+  Icon={PlanEnterpriseIcon}
 />
-
-> Expo Application Services (EAS) can be used with **any React Native app**, regardless of whether it uses `expo` or not.
 
 [snack]: https://snack.expo.dev
 [tunnel]: /workflow/expo-cli/#tunneling

--- a/docs/pages/workflow/expo-cli.mdx
+++ b/docs/pages/workflow/expo-cli.mdx
@@ -3,11 +3,13 @@ title: Expo CLI
 maxHeadingDepth: 4
 ---
 
+> **info** This documentation refers to the Local Expo CLI (SDK 46 and greater). For information on legacy Expo CLI, see [Global Expo CLI](/archived/expo-cli/).
+
 import { Terminal } from '~/ui/components/Snippet';
 
 The `expo` package provides a small and powerful CLI tool `npx expo` which is designed to keep you moving fast during app development.
 
-**Highlights**
+## Highlights
 
 - [Start a server](#develop) for developing your app: `npx expo start`.
 - [Generate the native iOS and Android directories](#prebuild) for your project: `npx expo prebuild`.
@@ -15,9 +17,6 @@ The `expo` package provides a small and powerful CLI tool `npx expo` which is de
 - [Install and update packages](#install) that work with the version of `react-native` in your project: `npx expo install package-name`.
 - `npx expo` can be used with `npx react-native` simultaneously.
 
-> This documentation refers to the Local Expo CLI (SDK 46 and greater). For information on legacy Expo CLI, see [Global Expo CLI](/archived/expo-cli/).
-
-<hr />
 
 To view a list of available commands in Expo CLI, run the following in your project:
 
@@ -28,18 +27,18 @@ To view a list of available commands in Expo CLI, run the following in your proj
 The output should look something like below:
 
 ```
-  Usage
-    $ npx expo <command>
+Usage
+  $ npx expo <command>
 
-  Commands
-    start, export, export:web
-    run:ios, run:android, prebuild
-    install, customize, config
-    login, logout, whoami, register
+Commands
+  start, export, export:web
+  run:ios, run:android, prebuild
+  install, customize, config
+  login, logout, whoami, register
 
-  Options
-    --version, -v   Version number
-    --help, -h      Usage info
+Options
+  --version, -v   Version number
+  --help, -h      Usage info
 ```
 
 You can run any command with the `--help` or `-h` flag to learn more about it:
@@ -56,24 +55,22 @@ Start a development server to work on your project by running:
 
 This command starts a server on `http://localhost:19000` which a client can use to interact with the bundler. The default bundler is [Metro](https://facebook.github.io/metro/).
 
-The UI that shows up in the process is referred to as the **Terminal UI**.
+The UI that shows up in the process is referred to as the **Terminal UI**. It contains a QR code (for the dev server URL) and a list of keyboard shortcuts you can press:
 
-The Terminal UI has a QR code (for the dev server URL) and a list of keyboard shortcuts you can press:
-
-- `a`: Open the project in Expo Go on Android.
-- `shift` + `a`: Select an Android device or emulator to open.
-
-- `i`: Open the project in Expo Go on iOS.
-- `shift` + `i`: Select an iOS Simulator to open.
-- `w`: Open the project in a web browser. This may require Webpack to be installed in your project.
-
-- `r`: Reload the app on any connected device.
-- `m`: Open the dev menu on any connected native device (web not supported).
-- `shift` + `m`: Choose more commands to trigger on connected devices. This includes toggling the performance monitor, opening the element inspector, reloading the device, and opening the dev menu.
-- `j`: Open Chrome Dev Tools for any connected device that is using Hermes as the JavaScript engine. [Learn more](/guides/using-hermes#javascript-inspector-for-hermes).
-- `o`: Open project code in your editor. This can be configured with the `EXPO_EDITOR` and `EDITOR` [environment variables](#environment-variables).
-- `c`: Show development server URL as a QR code in the terminal.
-- `?`: Show all Terminal UI commands.
+| Keyboard shortcut               | Description                                                                                                                                                                              |
+|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <kbd>A</kbd>                    | Open the project in Expo Go on Android.                                                                                                                                                  |
+| <kbd>Shift</kbd> + <kbd>A</kbd> | Select an Android device or emulator to open.                                                                                                                                            |
+| <kbd>I</kbd>                    | Open the project in Expo Go on iOS.                                                                                                                                                      |
+| <kbd>Shift</kbd> + <kbd>I</kbd> | Select an iOS Simulator to open.                                                                                                                                                         |
+| <kbd>W</kbd>                    | Open the project in a web browser. This may require Webpack to be installed in your project.                                                                                             |
+| <kbd>R</kbd>                    | Reload the app on any connected device.                                                                                                                                                  |
+| <kbd>M</kbd>                    | Open the dev menu on any connected native device (web not supported).                                                                                                                    |
+| <kbd>Shift</kbd> + <kbd>M</kbd> | Choose more commands to trigger on connected devices.<br/>This includes toggling the performance monitor, opening the element inspector, reloading the device, and opening the dev menu. |
+| <kbd>J</kbd>                    | Open Chrome Dev Tools for any connected device that is using Hermes as the JavaScript engine. [Learn more](/guides/using-hermes#javascript-inspector-for-hermes).                        |
+| <kbd>O</kbd>                    | Open project code in your editor. This can be configured with the `EXPO_EDITOR` and `EDITOR` [environment variables](#environment-variables).                                            |
+| <kbd>E</kbd>                    | Show development server URL as a QR code in the terminal.                                                                                                                                |
+| <kbd>?</kbd>                    | Show all Terminal UI commands.                                                                                                                                                           |
 
 ### Server URL
 

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -30,7 +30,7 @@ export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps
       <div css={tileContentWrapperStyle}>
         {Icon && (
           <div css={tileIconBackgroundStyle}>
-            <Icon />
+            <Icon width={iconSize.regular} />
           </div>
         )}
         <div>


### PR DESCRIPTION
# Why

Update formatting and phrasing on few pages.

# How

The following change have been made:
* emphasize and move certain callouts
* convert shortcuts list on Expo CLI page to table for readability
* add icons to the few `BoxLink`s on What is Expo page
* rephrase and reformat of requirements on Installation page

Additionally, I have made a change in `BoxLink` to support properly logo icons.

# Test Plan

The changes have bben tested by running docs website locally.

# Preview

<img width="1152" alt="Screenshot 2022-10-28 at 16 19 51" src="https://user-images.githubusercontent.com/719641/198646671-0d7319b3-fd17-4c08-96ca-2a71201d279c.png">
<img width="1152" alt="Screenshot 2022-10-28 at 16 26 05" src="https://user-images.githubusercontent.com/719641/198646645-0c39d8b8-c5d5-41b1-aca3-0aaf479cc5f7.png">
<img width="1152" alt="Screenshot 2022-10-28 at 16 20 24" src="https://user-images.githubusercontent.com/719641/198646664-20b3a839-477b-4024-a001-55f0a0172e8d.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
