### PR TITLE
[docs] Fix typo in deep linking with dev client example

### DIFF
--- a/docs/pages/development/development-workflows.mdx
+++ b/docs/pages/development/development-workflows.mdx
@@ -45,7 +45,7 @@ You can load your app on a device that has a compatible build of your custom cli
 Example:
 
 ```
-exp+app-slug://expo-development=client/?url=https%3A%2F%2Fu.expo.dev%2F767ADF57-B487-4D8F-9522-85549C39F43F%2F%3Fchannel-name%3Dmain
+exp+app-slug://expo-development-client/?url=https%3A%2F%2Fu.expo.dev%2F767ADF57-B487-4D8F-9522-85549C39F43F%2F%3Fchannel-name%3Dmain
 ```
 
 In the example above, the `scheme` is `exp+app-slug`, and the `url` is a project with an ID of `F767ADF57-B487-4D8F-9522-85549C39F43F` and a channel of `main`.


### PR DESCRIPTION
# Why

Fixes a small typo in docs for an example of deep linking with dev client

# How

N/A

# Test Plan

N/A

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
