### PR TITLE
[docs] Add Prebuild doc back into navigation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -80,6 +80,7 @@ const general = [
     makePage('workflow/using-libraries.mdx'),
     makePage('workflow/logging.mdx'),
     makePage('workflow/development-mode.mdx'),
+    makePage('workflow/prebuild.mdx'),
     makePage('workflow/ios-simulator.mdx'),
     makePage('workflow/android-studio-emulator.mdx'),
     makePage('workflow/run-on-device.mdx'),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1666967395167679

# How

<!--
How did you build this feature or fix this bug and why?
-->

Prebuild doc was missing in the sidebar navigation under "Fundamentals". This PR adds it back.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes are tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
