### PR TITLE
[expo-module-template] Enable inlineRequires option in example metro config

### DIFF
--- a/packages/expo-module-template/example/metro.config.js
+++ b/packages/expo-module-template/example/metro.config.js
@@ -11,4 +11,11 @@ config.resolver.nodeModulesPaths = [
 
 config.watchFolders = [path.resolve(__dirname, '..')];
 
+config.transformer.getTransformOptions = async () => ({
+  transform: {
+    experimentalImportSupport: false,
+    inlineRequires: true,
+  },
+});
+
 module.exports = config;


### PR DESCRIPTION
# Why

This fixes the example project on npm 7+

# How

I referred to https://github.com/th3rdwave/react-native-safe-area-context/blob/9dbb0864591220870a4cbc4a1667a6a2c78bd4e3/example/metro.config.js and saw that this is what @janicduplessis is doing in his project, and I'm not very clear on why this fixes our issue but it does.

Without this fix, `npx create-expo-module my-module` and `cd my-module` and `npx expo run:ios` will silently error (nothing in logs, just a white screen):

<img width="489" alt="image" src="https://user-images.githubusercontent.com/90494/198861735-97d2e789-d27a-4ac4-8b0d-b2ac047e7c87.png">

I tried debugging this a bit and found that it came from trying to access a property on `NativeModules` in our `NativeModuleProxy`. I'm not quite sure what it is about the way npm 7+ builds the dep tree that causes this (maybe someone else knows? if not it'd be an interesting thing to investigate), but the change in this PR fixes it.

# Test Plan

```
npx create-expo-module my-module
cd my-module
npx expo run:ios
```

This won't work. Apply the diff from this PR to `my-module/example/metro.config.js` and run the build again, it'll work.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
