### PR TITLE
[docs] update Expo Config schema render, fix search issues

### DIFF
--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.test.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.test.tsx
@@ -3,7 +3,6 @@ import { screen } from '@testing-library/react';
 import AppConfigSchemaPropertiesTable, {
   formatSchema,
   createDescription,
-  _getType,
   Property,
 } from './AppConfigSchemaPropertiesTable';
 
@@ -107,7 +106,7 @@ describe('AppConfigSchemaPropertiesTable', () => {
       <AppConfigSchemaPropertiesTable schema={{ entry: testSchema.androidNavigationBar }} />
     );
 
-    expect(screen.getByText('- Specifies the background color of the navigation bar.'));
+    expect(screen.getByText('Specifies the background color of the navigation bar.'));
     expect(screen.getByText('6 character long hex color string, eg:'));
     expect(screen.getByText('Set this property using just Xcode'));
     expect(screen.getByText('Set this property using AppConstants.java.'));
@@ -116,32 +115,32 @@ describe('AppConfigSchemaPropertiesTable', () => {
 
 describe('formatSchema', () => {
   const formattedSchema = formatSchema(Object.entries(testSchema));
-  test('name is property nestingLevel 0', () => {
-    expect(formattedSchema[0].nestingLevel).toBe(0);
+  test('name is property at toot level', () => {
+    expect(formattedSchema[0].name).toBe('name');
   });
-  test('androidNavigationBar is property nestingLevel 0', () => {
-    expect(formattedSchema[1].nestingLevel).toBe(0);
+  test('androidNavigationBar has two subproperties', () => {
+    expect(formattedSchema[1].subproperties.length).toBe(2);
   });
-  test('visible is subproperty nestingLevel 1', () => {
-    expect(formattedSchema[2].nestingLevel).toBe(1);
+  test('visible is androidNavigationBar subproperty', () => {
+    expect(formattedSchema[1].subproperties[0].name).toBe('visible');
   });
-  test('always is subproperty nestingLevel 2', () => {
-    expect(formattedSchema[3].nestingLevel).toBe(2);
+  test('always is visible subproperty', () => {
+    expect(formattedSchema[1].subproperties[0].subproperties[0].name).toBe('always');
   });
-  test('backgroundColor is subproperty nestingLevel 1', () => {
-    expect(formattedSchema[4].nestingLevel).toBe(1);
+  test('backgroundColor is androidNavigationBar subproperty', () => {
+    expect(formattedSchema[1].subproperties[1].name).toBe('backgroundColor');
   });
-  test('intentFilters is property nestingLevel 0', () => {
-    expect(formattedSchema[5].nestingLevel).toBe(0);
+  test('intentFilters is property at root level', () => {
+    expect(formattedSchema[2].name).toBe('intentFilters');
   });
-  test('autoVerify is subproperty nestingLevel 1', () => {
-    expect(formattedSchema[6].nestingLevel).toBe(1);
+  test('autoVerify is intentFilters subproperty', () => {
+    expect(formattedSchema[2].subproperties[0].name).toBe('autoVerify');
   });
-  test('data is subproperty nestingLevel 1', () => {
-    expect(formattedSchema[7].nestingLevel).toBe(1);
+  test('data is intentFilters subproperty', () => {
+    expect(formattedSchema[2].subproperties[1].name).toBe('data');
   });
-  test('host is subproperty nestingLevel 2', () => {
-    expect(formattedSchema[8].nestingLevel).toBe(2);
+  test('host is data subproperty', () => {
+    expect(formattedSchema[2].subproperties[1].subproperties[0].name).toBe('host');
   });
 });
 
@@ -151,9 +150,7 @@ describe('createDescription', () => {
     const intentFiltersObjectValue = intentFiltersObject[1] as any;
     const result = createDescription(intentFiltersObject);
 
-    expect(result).toBe(
-      `**(${_getType(intentFiltersObjectValue)})** - ${intentFiltersObjectValue.description}`
-    );
+    expect(result).toBe(`${intentFiltersObjectValue.description}`);
   });
 
   test('regexHuman is added correctly', () => {
@@ -163,9 +160,7 @@ describe('createDescription', () => {
     const result = createDescription(backgroundColorObject);
 
     expect(result).toBe(
-      `**(${_getType(backgroundColorObjectValue)})** - ${
-        backgroundColorObjectValue.description
-      }\n\n${backgroundColorObjectValue.meta!.regexHuman}`
+      `${backgroundColorObjectValue.description}\n\n${backgroundColorObjectValue.meta!.regexHuman}`
     );
   });
 });

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.test.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.test.tsx
@@ -115,7 +115,7 @@ describe('AppConfigSchemaPropertiesTable', () => {
 
 describe('formatSchema', () => {
   const formattedSchema = formatSchema(Object.entries(testSchema));
-  test('name is property at toot level', () => {
+  test('name is property at root level', () => {
     expect(formattedSchema[0].name).toBe('name');
   });
   test('androidNavigationBar has two subproperties', () => {

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -197,7 +197,6 @@ const AppConfigProperty = ({
 
 const boxStyle = css({
   [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
-    fontSize: '90%',
     paddingTop: spacing[4],
   },
 });

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -122,14 +122,14 @@ export function _getType({ enum: enm, type }: Partial<Property>) {
 }
 
 export function createDescription(propertyEntry: [string, Property]) {
-  const propertyValue = propertyEntry[1];
+  const { description, meta } = propertyEntry[1];
 
   let propertyDescription = ``;
-  if (propertyValue.description) {
-    propertyDescription += propertyValue.description;
+  if (description) {
+    propertyDescription += description;
   }
-  if (propertyValue.meta && propertyValue.meta.regexHuman) {
-    propertyDescription += `\n\n` + propertyValue.meta.regexHuman;
+  if (meta && meta.regexHuman) {
+    propertyDescription += `\n\n` + meta.regexHuman;
   }
 
   return propertyDescription;
@@ -142,7 +142,11 @@ const AppConfigSchemaPropertiesTable = ({ schema }: AppConfigSchemaProps) => {
   return (
     <div>
       {formattedSchema.map((formattedProperty, index) => (
-        <AppConfigProperty {...formattedProperty} index={index} nestingLevel={0} />
+        <AppConfigProperty
+          {...formattedProperty}
+          key={`${formattedProperty.name}-${index}`}
+          nestingLevel={0}
+        />
       ))}
     </div>
   );
@@ -158,9 +162,8 @@ const AppConfigProperty = ({
   nestingLevel,
   subproperties,
   parent,
-  index,
-}: FormattedProperty & { index: number; nestingLevel: number }) => (
-  <APIBox key={`${name}-${index}`} css={[boxStyle, nestedBoxStyle]}>
+}: FormattedProperty & { nestingLevel: number }) => (
+  <APIBox css={[boxStyle, nestedBoxStyle]}>
     <PropertyName name={name} nestingLevel={nestingLevel} />
     <CALLOUT theme="secondary">
       Type: <InlineCode>{type || 'undefined'}</InlineCode>
@@ -189,7 +192,11 @@ const AppConfigProperty = ({
     <div>
       {subproperties.length > 0 &&
         subproperties.map((formattedProperty, index) => (
-          <AppConfigProperty {...formattedProperty} index={index} nestingLevel={nestingLevel + 1} />
+          <AppConfigProperty
+            {...formattedProperty}
+            key={`${name}-${index}`}
+            nestingLevel={nestingLevel + 1}
+          />
         ))}
     </div>
   </APIBox>

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { css } from '@emotion/react';
+import { borderRadius, breakpoints, spacing, theme, typography } from '@expo/styleguide';
 import ReactMarkdown from 'react-markdown';
 
 import { InlineCode } from '../base/code';
@@ -6,9 +7,10 @@ import { InlineCode } from '../base/code';
 import { createPermalinkedComponent } from '~/common/create-permalinked-component';
 import { HeadingType } from '~/common/headingManager';
 import { PDIV } from '~/components/base/paragraph';
+import { APIBox } from '~/components/plugins/APIBox';
 import { mdComponents, mdInlineComponents } from '~/components/plugins/api/APISectionUtils';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
+import { CALLOUT } from '~/ui/components/Text';
 
 type PropertyMeta = {
   regexHuman?: string;
@@ -39,11 +41,12 @@ export type Property = {
 type FormattedProperty = {
   name: string;
   description: string;
-  nestingLevel: number;
   type?: string;
   example?: string;
   expoKit?: string;
   bareWorkflow?: string;
+  subproperties: FormattedProperty[];
+  parent?: string;
 };
 
 type AppConfigSchemaProps = {
@@ -55,9 +58,9 @@ const Anchor = createPermalinkedComponent(PDIV, {
   sidebarType: HeadingType.InlineCode,
 });
 
-const PropertyName = ({ name, nestingLevel }: Pick<FormattedProperty, 'name' | 'nestingLevel'>) => (
-  <Anchor level={nestingLevel}>
-    <InlineCode>{name}</InlineCode>
+const PropertyName = ({ name, nestingLevel }: { name: string; nestingLevel: number }) => (
+  <Anchor level={nestingLevel} data-testid={name}>
+    <InlineCode css={typography.fontSizes[16]}>{name}</InlineCode>
   </Anchor>
 );
 
@@ -65,64 +68,65 @@ export function formatSchema(rawSchema: [string, Property][]) {
   const formattedSchema: FormattedProperty[] = [];
 
   rawSchema.map(property => {
-    appendProperty(formattedSchema, property, 0);
+    appendProperty(formattedSchema, property);
   });
 
   return formattedSchema;
 }
 
-// Appends a property and recursively appends sub-properties
-function appendProperty(
-  formattedSchema: FormattedProperty[],
-  property: [string, Property],
-  _nestingLevel: number
-) {
-  let nestingLevel = _nestingLevel;
-  const propertyKey = property[0];
+function appendProperty(formattedSchema: FormattedProperty[], property: [string, Property]) {
   const propertyValue = property[1];
 
   if (propertyValue.meta && (propertyValue.meta.deprecated || propertyValue.meta.hidden)) {
     return;
   }
 
-  formattedSchema.push({
-    name: propertyKey,
-    description: createDescription(property),
-    nestingLevel,
-    type: _getType(propertyValue),
-    example: propertyValue.exampleString,
-    expoKit: propertyValue?.meta?.expoKit,
-    bareWorkflow: propertyValue?.meta?.bareWorkflow,
-  });
+  formattedSchema.push(formatProperty(property));
+}
 
-  nestingLevel++;
+function formatProperty(property: [string, Property], parent?: string): FormattedProperty {
+  const propertyKey = property[0];
+  const propertyValue = property[1];
+
+  const subproperties: FormattedProperty[] = [];
 
   if (propertyValue.properties) {
     Object.entries(propertyValue.properties).forEach(subproperty => {
-      appendProperty(formattedSchema, subproperty, nestingLevel);
+      subproperties.push(
+        formatProperty(subproperty, parent ? `${parent}.${propertyKey}` : propertyKey)
+      );
     });
-  } //Note: sub-properties are sometimes nested within "items"
+  } // note: sub-properties are sometimes nested within "items"
   else if (propertyValue.items && propertyValue.items.properties) {
     Object.entries(propertyValue.items.properties).forEach(subproperty => {
-      appendProperty(formattedSchema, subproperty, nestingLevel);
+      subproperties.push(
+        formatProperty(subproperty, parent ? `${parent}.${propertyKey}` : propertyKey)
+      );
     });
   }
+
+  return {
+    name: propertyKey,
+    description: createDescription(property),
+    type: _getType(propertyValue),
+    example: propertyValue.exampleString?.replaceAll('\n', ''),
+    expoKit: propertyValue?.meta?.expoKit,
+    bareWorkflow: propertyValue?.meta?.bareWorkflow,
+    subproperties,
+    parent,
+  };
 }
 
-export function _getType(propertyValue: Property) {
-  if (propertyValue.enum) {
-    return 'enum';
-  } else {
-    return propertyValue.type?.toString().replace(',', ' || ');
-  }
+export function _getType({ enum: enm, type }: Partial<Property>) {
+  return enm ? 'enum' : type?.toString().replace(',', ' || ');
 }
 
 export function createDescription(propertyEntry: [string, Property]) {
   const propertyValue = propertyEntry[1];
 
-  let propertyDescription = `**(${_getType(propertyValue)})**`;
+  let propertyDescription = ``;
   if (propertyValue.description) {
-    propertyDescription += ` - ` + propertyValue.description;
+    propertyDescription += propertyValue.description;
   }
   if (propertyValue.meta && propertyValue.meta.regexHuman) {
     propertyDescription += `\n\n` + propertyValue.meta.regexHuman;
@@ -136,53 +140,90 @@ const AppConfigSchemaPropertiesTable = ({ schema }: AppConfigSchemaProps) => {
   const formattedSchema = formatSchema(rawSchema);
 
   return (
-    <Table>
-      <TableHead>
-        <Row>
-          <HeaderCell>Property</HeaderCell>
-          <HeaderCell>Description</HeaderCell>
-        </Row>
-      </TableHead>
-      <tbody>
-        {formattedSchema.map(
-          ({ name, description, nestingLevel, type, example, expoKit, bareWorkflow }, index) => (
-            <Row key={index}>
-              <Cell fitContent>
-                <div
-                  data-testid={name}
-                  style={{
-                    marginLeft: `${nestingLevel * 32}px`,
-                    display: nestingLevel ? 'list-item' : 'block',
-                    listStyleType: nestingLevel % 2 ? 'default' : 'circle',
-                    overflowX: 'visible',
-                  }}>
-                  <PropertyName name={name} nestingLevel={nestingLevel} />
-                </div>
-              </Cell>
-              <Cell>
-                <ReactMarkdown components={mdComponents}>{description}</ReactMarkdown>
-                {expoKit && (
-                  <Collapsible summary="ExpoKit">
-                    <ReactMarkdown components={mdComponents}>{expoKit}</ReactMarkdown>
-                  </Collapsible>
-                )}
-                {bareWorkflow && (
-                  <Collapsible summary="Bare Workflow">
-                    <ReactMarkdown components={mdComponents}>{bareWorkflow}</ReactMarkdown>
-                  </Collapsible>
-                )}
-                {example && (
-                  <ReactMarkdown components={mdInlineComponents}>
-                    {`> ${example.replaceAll('\n', '')}`}
-                  </ReactMarkdown>
-                )}
-              </Cell>
-            </Row>
-          )
-        )}
-      </tbody>
-    </Table>
+    <div>
+      {formattedSchema.map((formattedProperty, index) => (
+        <AppConfigProperty {...formattedProperty} index={index} nestingLevel={0} />
+      ))}
+    </div>
   );
 };
+
+const AppConfigProperty = ({
+  name,
+  description,
+  example,
+  expoKit,
+  bareWorkflow,
+  type,
+  nestingLevel,
+  subproperties,
+  parent,
+  index,
+}: FormattedProperty & { index: number; nestingLevel: number }) => (
+  <APIBox key={`${name}-${index}`} css={[boxStyle, nestedBoxStyle]}>
+    <PropertyName name={name} nestingLevel={nestingLevel} />
+    <CALLOUT theme="secondary">
+      Type: <InlineCode>{type || 'undefined'}</InlineCode>
+      {nestingLevel > 0 && (
+        <>
+          &emsp;&bull;&emsp;Path:{' '}
+          <InlineCode css={secondaryCodeLineStyle}>
+            {parent}.{name}
+          </InlineCode>
+        </>
+      )}
+    </CALLOUT>
+    <br />
+    <ReactMarkdown components={mdComponents}>{description}</ReactMarkdown>
+    {expoKit && (
+      <Collapsible summary="ExpoKit">
+        <ReactMarkdown components={mdComponents}>{expoKit}</ReactMarkdown>
+      </Collapsible>
+    )}
+    {bareWorkflow && (
+      <Collapsible summary="Bare Workflow">
+        <ReactMarkdown components={mdComponents}>{bareWorkflow}</ReactMarkdown>
+      </Collapsible>
+    )}
+    {example && <ReactMarkdown components={mdInlineComponents}>{`> ${example}`}</ReactMarkdown>}
+    <div>
+      {subproperties.length > 0 &&
+        subproperties.map((formattedProperty, index) => (
+          <AppConfigProperty {...formattedProperty} index={index} nestingLevel={nestingLevel + 1} />
+        ))}
+    </div>
+  </APIBox>
+);
+
+const boxStyle = css({
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    fontSize: '90%',
+    paddingTop: spacing[4],
+  },
+});
+
+const nestedBoxStyle = css({
+  boxShadow: 'none',
+  marginBottom: 0,
+  borderRadius: 0,
+  borderBottomWidth: 0,
+
+  '&:first-of-type': {
+    borderTopLeftRadius: borderRadius.medium,
+    borderTopRightRadius: borderRadius.medium,
+  },
+
+  '&:last-of-type': {
+    borderBottomLeftRadius: borderRadius.medium,
+    borderBottomRightRadius: borderRadius.medium,
+    marginBottom: spacing[4],
+    borderBottomWidth: 1,
+  },
+});
+
+const secondaryCodeLineStyle = css({
+  color: theme.text.secondary,
+  background: 'none',
+});
 
 export default AppConfigSchemaPropertiesTable;

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -163,16 +163,16 @@ const AppConfigProperty = ({
   subproperties,
   parent,
 }: FormattedProperty & { nestingLevel: number }) => (
-  <APIBox css={[boxStyle, nestedBoxStyle]}>
+  <APIBox css={boxStyle}>
     <PropertyName name={name} nestingLevel={nestingLevel} />
     <CALLOUT theme="secondary">
       Type: <InlineCode>{type || 'undefined'}</InlineCode>
       {nestingLevel > 0 && (
         <>
           &emsp;&bull;&emsp;Path:{' '}
-          <InlineCode css={secondaryCodeLineStyle}>
+          <code css={secondaryCodeLineStyle}>
             {parent}.{name}
-          </InlineCode>
+          </code>
         </>
       )}
     </CALLOUT>
@@ -203,12 +203,6 @@ const AppConfigProperty = ({
 );
 
 const boxStyle = css({
-  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
-    paddingTop: spacing[4],
-  },
-});
-
-const nestedBoxStyle = css({
   boxShadow: 'none',
   marginBottom: 0,
   borderRadius: 0,
@@ -225,11 +219,17 @@ const nestedBoxStyle = css({
     marginBottom: spacing[4],
     borderBottomWidth: 1,
   },
+
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    paddingTop: spacing[4],
+  },
 });
 
 const secondaryCodeLineStyle = css({
+  fontFamily: typography.fontStacks.mono,
   color: theme.text.secondary,
-  background: 'none',
+  padding: `0 ${spacing[1]}px`,
+  wordBreak: 'break-word',
 });
 
 export default AppConfigSchemaPropertiesTable;

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -2,453 +2,411 @@
 
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
-  <div
-    class="css-rufzkc-Table"
-  >
-    <table
-      class="css-1goywt6-Table"
+  <div>
+    <div
+      class="css-gmoeog-AppConfigProperty"
     >
-      <thead
-        class="css-3b8qij-TableHead"
+      <div
+        class=" css-19f55nd-PDIV"
+        data-text="true"
       >
-        <tr
-          class="css-29opv4-Row"
+        <a
+          class="css-ah3byb"
+          href="/#name"
         >
-          <th
-            class="css-1p6k6di-HeaderCell"
+          <span
+            class="css-s3qkfm"
+            id="name"
+          />
+          <span
+            class="css-6n7j50"
           >
-            Property
-          </th>
-          <th
-            class="css-1p6k6di-HeaderCell"
+            <code
+              class="inline css-1cjswoo-PropertyName"
+            >
+              name
+            </code>
+          </span>
+          <span
+            class="css-1eysgws"
           >
-            Description
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class="css-29opv4-Row"
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </div>
+      <p
+        class="css-6kj7vp-TextComponent"
+      >
+        Type: 
+        <code
+          class="inline css-ov7own-InlineCode"
         >
-          <td
-            class="css-1i3ovdz-Cell"
+          string
+        </code>
+      </p>
+      <br />
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        Name of your app.
+      </p>
+      <details
+        class="css-1nmf69-Collapsible"
+      >
+        <summary
+          class="css-15fupqd-Collapsible"
+        >
+          <div
+            class="css-166ujkg-Collapsible"
           >
-            <div
-              data-testid="name"
-              style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
+            <svg
+              class="css-1wgpnk4-Collapsible"
+              fill="none"
+              height="16"
+              role="img"
+              size="16"
+              viewBox="0 0 20 20"
+              width="16"
+            >
+              <title>
+                Triangle-down-icon
+              </title>
+              <path
+                d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
+                fill="var(--expo-theme-icon-default)"
+              />
+            </svg>
+          </div>
+          <span
+            class="css-x1nydd-TextComponent"
+          >
+            Bare Workflow
+          </span>
+        </summary>
+        <div
+          class="css-1gk6nru-Collapsible"
+        >
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            Edit the 'Display Name' field in Xcode
+          </p>
+        </div>
+      </details>
+      <div />
+    </div>
+    <div
+      class="css-gmoeog-AppConfigProperty"
+    >
+      <div
+        class=" css-19f55nd-PDIV"
+        data-text="true"
+      >
+        <a
+          class="css-ah3byb"
+          href="/#androidnavigationbar"
+        >
+          <span
+            class="css-s3qkfm"
+            id="androidnavigationbar"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="inline css-1cjswoo-PropertyName"
+            >
+              androidNavigationBar
+            </code>
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </div>
+      <p
+        class="css-6kj7vp-TextComponent"
+      >
+        Type: 
+        <code
+          class="inline css-ov7own-InlineCode"
+        >
+          object
+        </code>
+      </p>
+      <br />
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        Configuration for the bottom navigation bar on Android.
+      </p>
+      <details
+        class="css-1nmf69-Collapsible"
+      >
+        <summary
+          class="css-15fupqd-Collapsible"
+        >
+          <div
+            class="css-166ujkg-Collapsible"
+          >
+            <svg
+              class="css-1wgpnk4-Collapsible"
+              fill="none"
+              height="16"
+              role="img"
+              size="16"
+              viewBox="0 0 20 20"
+              width="16"
+            >
+              <title>
+                Triangle-down-icon
+              </title>
+              <path
+                d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
+                fill="var(--expo-theme-icon-default)"
+              />
+            </svg>
+          </div>
+          <span
+            class="css-x1nydd-TextComponent"
+          >
+            ExpoKit
+          </span>
+        </summary>
+        <div
+          class="css-1gk6nru-Collapsible"
+        >
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            Set this property using AppConstants.java.
+          </p>
+        </div>
+      </details>
+      <details
+        class="css-1nmf69-Collapsible"
+      >
+        <summary
+          class="css-15fupqd-Collapsible"
+        >
+          <div
+            class="css-166ujkg-Collapsible"
+          >
+            <svg
+              class="css-1wgpnk4-Collapsible"
+              fill="none"
+              height="16"
+              role="img"
+              size="16"
+              viewBox="0 0 20 20"
+              width="16"
+            >
+              <title>
+                Triangle-down-icon
+              </title>
+              <path
+                d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
+                fill="var(--expo-theme-icon-default)"
+              />
+            </svg>
+          </div>
+          <span
+            class="css-x1nydd-TextComponent"
+          >
+            Bare Workflow
+          </span>
+        </summary>
+        <div
+          class="css-1gk6nru-Collapsible"
+        >
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            Set this property using just Xcode
+          </p>
+        </div>
+      </details>
+      <div>
+        <div
+          class="css-gmoeog-AppConfigProperty"
+        >
+          <div
+            class=" css-19f55nd-PDIV"
+            data-text="true"
+          >
+            <a
+              class="css-ah3byb"
+              href="/#visible"
+            >
+              <span
+                class="css-s3qkfm"
+                id="visible"
+              />
+              <span
+                class="css-6n7j50"
+              >
+                <code
+                  class="inline css-1cjswoo-PropertyName"
+                >
+                  visible
+                </code>
+              </span>
+              <span
+                class="css-1eysgws"
+              >
+                <svg
+                  aria-label="permalink"
+                  class="anchor-icon"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+            </a>
+          </div>
+          <p
+            class="css-6kj7vp-TextComponent"
+          >
+            Type: 
+            <code
+              class="inline css-ov7own-InlineCode"
+            >
+              enum
+            </code>
+             • Path:
+             
+            <code
+              class="inline css-1esaweg-AppConfigProperty"
+            >
+              androidNavigationBar
+              .
+              visible
+            </code>
+          </p>
+          <br />
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            Determines how and when the navigation bar is shown.
+          </p>
+          <details
+            class="css-1nmf69-Collapsible"
+          >
+            <summary
+              class="css-15fupqd-Collapsible"
             >
               <div
-                class=" css-19f55nd-PDIV"
+                class="css-166ujkg-Collapsible"
+              >
+                <svg
+                  class="css-1wgpnk4-Collapsible"
+                  fill="none"
+                  height="16"
+                  role="img"
+                  size="16"
+                  viewBox="0 0 20 20"
+                  width="16"
+                >
+                  <title>
+                    Triangle-down-icon
+                  </title>
+                  <path
+                    d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
+                    fill="var(--expo-theme-icon-default)"
+                  />
+                </svg>
+              </div>
+              <span
+                class="css-x1nydd-TextComponent"
+              >
+                ExpoKit
+              </span>
+            </summary>
+            <div
+              class="css-1gk6nru-Collapsible"
+            >
+              <p
+                class="css-6jxvia-P"
                 data-text="true"
               >
-                <a
-                  class="css-ah3byb"
-                  href="/#name"
-                >
-                  <span
-                    class="css-s3qkfm"
-                    id="name"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      name
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
+                Set this property using Xcode.
+              </p>
             </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (string)
-              </strong>
-               - Name of your app.
-            </p>
-            <details
-              class="css-1nmf69-Collapsible"
-            >
-              <summary
-                class="css-15fupqd-Collapsible"
-              >
-                <div
-                  class="css-166ujkg-Collapsible"
-                >
-                  <svg
-                    class="css-1wgpnk4-Collapsible"
-                    fill="none"
-                    height="16"
-                    role="img"
-                    size="16"
-                    viewBox="0 0 20 20"
-                    width="16"
-                  >
-                    <title>
-                      Triangle-down-icon
-                    </title>
-                    <path
-                      d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
-                      fill="var(--expo-theme-icon-default)"
-                    />
-                  </svg>
-                </div>
-                <span
-                  class="css-x1nydd-TextComponent"
-                >
-                  Bare Workflow
-                </span>
-              </summary>
-              <div
-                class="css-1gk6nru-Collapsible"
-              >
-                <p
-                  class="css-6jxvia-P"
-                  data-text="true"
-                >
-                  Edit the 'Display Name' field in Xcode
-                </p>
-              </div>
-            </details>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
-          >
+          </details>
+          <div>
             <div
-              data-testid="androidNavigationBar"
-              style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
-            >
-              <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
-              >
-                <a
-                  class="css-ah3byb"
-                  href="/#androidnavigationbar"
-                >
-                  <span
-                    class="css-s3qkfm"
-                    id="androidnavigationbar"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      androidNavigationBar
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (object)
-              </strong>
-               - Configuration for the bottom navigation bar on Android.
-            </p>
-            <details
-              class="css-1nmf69-Collapsible"
-            >
-              <summary
-                class="css-15fupqd-Collapsible"
-              >
-                <div
-                  class="css-166ujkg-Collapsible"
-                >
-                  <svg
-                    class="css-1wgpnk4-Collapsible"
-                    fill="none"
-                    height="16"
-                    role="img"
-                    size="16"
-                    viewBox="0 0 20 20"
-                    width="16"
-                  >
-                    <title>
-                      Triangle-down-icon
-                    </title>
-                    <path
-                      d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
-                      fill="var(--expo-theme-icon-default)"
-                    />
-                  </svg>
-                </div>
-                <span
-                  class="css-x1nydd-TextComponent"
-                >
-                  ExpoKit
-                </span>
-              </summary>
-              <div
-                class="css-1gk6nru-Collapsible"
-              >
-                <p
-                  class="css-6jxvia-P"
-                  data-text="true"
-                >
-                  Set this property using AppConstants.java.
-                </p>
-              </div>
-            </details>
-            <details
-              class="css-1nmf69-Collapsible"
-            >
-              <summary
-                class="css-15fupqd-Collapsible"
-              >
-                <div
-                  class="css-166ujkg-Collapsible"
-                >
-                  <svg
-                    class="css-1wgpnk4-Collapsible"
-                    fill="none"
-                    height="16"
-                    role="img"
-                    size="16"
-                    viewBox="0 0 20 20"
-                    width="16"
-                  >
-                    <title>
-                      Triangle-down-icon
-                    </title>
-                    <path
-                      d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
-                      fill="var(--expo-theme-icon-default)"
-                    />
-                  </svg>
-                </div>
-                <span
-                  class="css-x1nydd-TextComponent"
-                >
-                  Bare Workflow
-                </span>
-              </summary>
-              <div
-                class="css-1gk6nru-Collapsible"
-              >
-                <p
-                  class="css-6jxvia-P"
-                  data-text="true"
-                >
-                  Set this property using just Xcode
-                </p>
-              </div>
-            </details>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
-          >
-            <div
-              data-testid="visible"
-              style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
-            >
-              <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
-              >
-                <a
-                  class="css-ah3byb"
-                  href="/#visible"
-                >
-                  <span
-                    class="css-s3qkfm"
-                    id="visible"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      visible
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (enum)
-              </strong>
-               - Determines how and when the navigation bar is shown.
-            </p>
-            <details
-              class="css-1nmf69-Collapsible"
-            >
-              <summary
-                class="css-15fupqd-Collapsible"
-              >
-                <div
-                  class="css-166ujkg-Collapsible"
-                >
-                  <svg
-                    class="css-1wgpnk4-Collapsible"
-                    fill="none"
-                    height="16"
-                    role="img"
-                    size="16"
-                    viewBox="0 0 20 20"
-                    width="16"
-                  >
-                    <title>
-                      Triangle-down-icon
-                    </title>
-                    <path
-                      d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
-                      fill="var(--expo-theme-icon-default)"
-                    />
-                  </svg>
-                </div>
-                <span
-                  class="css-x1nydd-TextComponent"
-                >
-                  ExpoKit
-                </span>
-              </summary>
-              <div
-                class="css-1gk6nru-Collapsible"
-              >
-                <p
-                  class="css-6jxvia-P"
-                  data-text="true"
-                >
-                  Set this property using Xcode.
-                </p>
-              </div>
-            </details>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
-          >
-            <div
-              data-testid="always"
-              style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
+              class="css-gmoeog-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"
@@ -466,7 +424,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-6n7j50"
                   >
                     <code
-                      class="inline css-ov7own-InlineCode"
+                      class="inline css-1cjswoo-PropertyName"
                     >
                       always
                     </code>
@@ -501,442 +459,445 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   </span>
                 </a>
               </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
+              <p
+                class="css-6kj7vp-TextComponent"
               >
-                (boolean)
-              </strong>
-               - Test sub-sub-property
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
-          >
-            <div
-              data-testid="backgroundColor"
-              style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
-            >
-              <div
-                class=" css-19f55nd-PDIV"
+                Type: 
+                <code
+                  class="inline css-ov7own-InlineCode"
+                >
+                  boolean
+                </code>
+                 • Path:
+                 
+                <code
+                  class="inline css-1esaweg-AppConfigProperty"
+                >
+                  androidNavigationBar.visible
+                  .
+                  always
+                </code>
+              </p>
+              <br />
+              <p
+                class="css-6jxvia-P"
                 data-text="true"
               >
-                <a
-                  class="css-ah3byb"
-                  href="/#backgroundcolor"
-                >
-                  <span
-                    class="css-s3qkfm"
-                    id="backgroundcolor"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      backgroundColor
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
+                Test sub-sub-property
+              </p>
+              <div />
             </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (string)
-              </strong>
-               - Specifies the background color of the navigation bar.
-            </p>
-            
-
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              6 character long hex color string, eg: 
-              <code
-                class="inline css-ov7own-InlineCode"
-              >
-                '#000000'
-              </code>
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
+          </div>
+        </div>
+        <div
+          class="css-gmoeog-AppConfigProperty"
         >
-          <td
-            class="css-1i3ovdz-Cell"
+          <div
+            class=" css-19f55nd-PDIV"
+            data-text="true"
           >
-            <div
-              data-testid="intentFilters"
-              style="margin-left: 0px; display: block; list-style-type: circle; overflow-x: visible;"
+            <a
+              class="css-ah3byb"
+              href="/#backgroundcolor"
             >
-              <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
+              <span
+                class="css-s3qkfm"
+                id="backgroundcolor"
+              />
+              <span
+                class="css-6n7j50"
               >
-                <a
-                  class="css-ah3byb"
-                  href="/#intentfilters"
+                <code
+                  class="inline css-1cjswoo-PropertyName"
                 >
-                  <span
-                    class="css-s3qkfm"
-                    id="intentfilters"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      intentFilters
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (array)
-              </strong>
-               - Configuration for setting an array of custom intent filters in Android manifest.
-            </p>
-            <details
-              class="css-1nmf69-Collapsible"
-            >
-              <summary
-                class="css-15fupqd-Collapsible"
-              >
-                <div
-                  class="css-166ujkg-Collapsible"
-                >
-                  <svg
-                    class="css-1wgpnk4-Collapsible"
-                    fill="none"
-                    height="16"
-                    role="img"
-                    size="16"
-                    viewBox="0 0 20 20"
-                    width="16"
-                  >
-                    <title>
-                      Triangle-down-icon
-                    </title>
-                    <path
-                      d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
-                      fill="var(--expo-theme-icon-default)"
-                    />
-                  </svg>
-                </div>
-                <span
-                  class="css-x1nydd-TextComponent"
-                >
-                  Bare Workflow
-                </span>
-              </summary>
-              <div
-                class="css-1gk6nru-Collapsible"
-              >
-                <p
-                  class="css-6jxvia-P"
-                  data-text="true"
-                >
-                  This is set in AndroidManifest.xml directly.
-                </p>
-              </div>
-            </details>
-            <blockquote
-              class="css-1xjn6jt-Callout"
-              data-testid="callout-container"
-            >
-              <div
-                class="css-ks2t0-Callout"
+                  backgroundColor
+                </code>
+              </span>
+              <span
+                class="css-1eysgws"
               >
                 <svg
-                  color="var(--expo-theme-icon-default)"
+                  aria-label="permalink"
+                  class="anchor-icon"
                   fill="none"
-                  height="16"
-                  role="img"
-                  size="16"
-                  viewBox="0 0 20 20"
-                  width="16"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <title>
-                    Info-icon
-                  </title>
                   <path
-                    d="M10 1a9 9 0 100 18 9 9 0 000-18zm-.01 4.064a.962.962 0 01.73-.33c.229 0 .43.082.582.238.152.155.23.354.23.59 0 .295-.104.558-.308.78-.209.23-.453.347-.726.347a.777.777 0 01-.576-.244.844.844 0 01-.227-.607c0-.3.099-.561.295-.774zm1.499 8.48c-.746.7-1.279 1.138-1.628 1.337-.372.213-.679.317-.937.317a.814.814 0 01-.622-.254c-.152-.162-.23-.382-.23-.652 0-.69.392-2.293 1.197-4.9.013-.044.024-.086.031-.125a.814.814 0 00-.105.056c-.066.042-.267.2-.854.773a.25.25 0 01-.329.02l-.347-.27a.25.25 0 01-.033-.367c.542-.596 1.047-1.029 1.502-1.286.477-.269.88-.4 1.232-.4.227 0 .411.057.547.17a.621.621 0 01.225.492c0 .132-.063.474-.522 2.015-.657 2.203-.814 3.003-.825 3.28.125-.074.419-.283 1.046-.873a.25.25 0 01.347.003l.308.3a.25.25 0 01-.003.363z"
-                    fill="var(--expo-theme-icon-default)"
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
                   />
                 </svg>
-              </div>
-              <div
-                class="css-19syq17-Callout"
-              >
-                
+              </span>
+            </a>
+          </div>
+          <p
+            class="css-6kj7vp-TextComponent"
+          >
+            Type: 
+            <code
+              class="inline css-ov7own-InlineCode"
+            >
+              string
+            </code>
+             • Path:
+             
+            <code
+              class="inline css-1esaweg-AppConfigProperty"
+            >
+              androidNavigationBar
+              .
+              backgroundColor
+            </code>
+          </p>
+          <br />
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            Specifies the background color of the navigation bar.
+          </p>
+          
 
-                <span>
-                  [{  "autoVerify": true,  "data": {"host": "*.example.com"  }  }]
-                </span>
-                
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            6 character long hex color string, eg: 
+            <code
+              class="inline css-ov7own-InlineCode"
+            >
+              '#000000'
+            </code>
+          </p>
+          <div />
+        </div>
+      </div>
+    </div>
+    <div
+      class="css-gmoeog-AppConfigProperty"
+    >
+      <div
+        class=" css-19f55nd-PDIV"
+        data-text="true"
+      >
+        <a
+          class="css-ah3byb"
+          href="/#intentfilters"
+        >
+          <span
+            class="css-s3qkfm"
+            id="intentfilters"
+          />
+          <span
+            class="css-6n7j50"
+          >
+            <code
+              class="inline css-1cjswoo-PropertyName"
+            >
+              intentFilters
+            </code>
+          </span>
+          <span
+            class="css-1eysgws"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
+      </div>
+      <p
+        class="css-6kj7vp-TextComponent"
+      >
+        Type: 
+        <code
+          class="inline css-ov7own-InlineCode"
+        >
+          array
+        </code>
+      </p>
+      <br />
+      <p
+        class="css-6jxvia-P"
+        data-text="true"
+      >
+        Configuration for setting an array of custom intent filters in Android manifest.
+      </p>
+      <details
+        class="css-1nmf69-Collapsible"
+      >
+        <summary
+          class="css-15fupqd-Collapsible"
+        >
+          <div
+            class="css-166ujkg-Collapsible"
+          >
+            <svg
+              class="css-1wgpnk4-Collapsible"
+              fill="none"
+              height="16"
+              role="img"
+              size="16"
+              viewBox="0 0 20 20"
+              width="16"
+            >
+              <title>
+                Triangle-down-icon
+              </title>
+              <path
+                d="M16.883 7.43H3.117L10 14.313l6.883-6.883z"
+                fill="var(--expo-theme-icon-default)"
+              />
+            </svg>
+          </div>
+          <span
+            class="css-x1nydd-TextComponent"
+          >
+            Bare Workflow
+          </span>
+        </summary>
+        <div
+          class="css-1gk6nru-Collapsible"
+        >
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
+          >
+            This is set in AndroidManifest.xml directly.
+          </p>
+        </div>
+      </details>
+      <blockquote
+        class="css-1xjn6jt-Callout"
+        data-testid="callout-container"
+      >
+        <div
+          class="css-ks2t0-Callout"
+        >
+          <svg
+            color="var(--expo-theme-icon-default)"
+            fill="none"
+            height="16"
+            role="img"
+            size="16"
+            viewBox="0 0 20 20"
+            width="16"
+          >
+            <title>
+              Info-icon
+            </title>
+            <path
+              d="M10 1a9 9 0 100 18 9 9 0 000-18zm-.01 4.064a.962.962 0 01.73-.33c.229 0 .43.082.582.238.152.155.23.354.23.59 0 .295-.104.558-.308.78-.209.23-.453.347-.726.347a.777.777 0 01-.576-.244.844.844 0 01-.227-.607c0-.3.099-.561.295-.774zm1.499 8.48c-.746.7-1.279 1.138-1.628 1.337-.372.213-.679.317-.937.317a.814.814 0 01-.622-.254c-.152-.162-.23-.382-.23-.652 0-.69.392-2.293 1.197-4.9.013-.044.024-.086.031-.125a.814.814 0 00-.105.056c-.066.042-.267.2-.854.773a.25.25 0 01-.329.02l-.347-.27a.25.25 0 01-.033-.367c.542-.596 1.047-1.029 1.502-1.286.477-.269.88-.4 1.232-.4.227 0 .411.057.547.17a.621.621 0 01.225.492c0 .132-.063.474-.522 2.015-.657 2.203-.814 3.003-.825 3.28.125-.074.419-.283 1.046-.873a.25.25 0 01.347.003l.308.3a.25.25 0 01-.003.363z"
+              fill="var(--expo-theme-icon-default)"
+            />
+          </svg>
+        </div>
+        <div
+          class="css-19syq17-Callout"
+        >
+          
 
-              </div>
-            </blockquote>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
+          <span>
+            [{  "autoVerify": true,  "data": {"host": "*.example.com"  }  }]
+          </span>
+          
+
+        </div>
+      </blockquote>
+      <div>
+        <div
+          class="css-gmoeog-AppConfigProperty"
         >
-          <td
-            class="css-1i3ovdz-Cell"
+          <div
+            class=" css-19f55nd-PDIV"
+            data-text="true"
           >
-            <div
-              data-testid="autoVerify"
-              style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
+            <a
+              class="css-ah3byb"
+              href="/#autoverify"
             >
-              <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
+              <span
+                class="css-s3qkfm"
+                id="autoverify"
+              />
+              <span
+                class="css-6n7j50"
               >
-                <a
-                  class="css-ah3byb"
-                  href="/#autoverify"
+                <code
+                  class="inline css-1cjswoo-PropertyName"
                 >
-                  <span
-                    class="css-s3qkfm"
-                    id="autoverify"
-                  />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      autoVerify
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
+                  autoVerify
+                </code>
+              </span>
+              <span
+                class="css-1eysgws"
               >
-                (boolean)
-              </strong>
-               - You may also use an intent filter to set your app as the default handler for links
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
-          >
-            <div
-              data-testid="data"
-              style="margin-left: 32px; display: list-item; list-style-type: default; overflow-x: visible;"
-            >
-              <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
-              >
-                <a
-                  class="css-ah3byb"
-                  href="/#data"
+                <svg
+                  aria-label="permalink"
+                  class="anchor-icon"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
-                  <span
-                    class="css-s3qkfm"
-                    id="data"
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
                   />
-                  <span
-                    class="css-6n7j50"
-                  >
-                    <code
-                      class="inline css-ov7own-InlineCode"
-                    >
-                      data
-                    </code>
-                  </span>
-                  <span
-                    class="css-1eysgws"
-                  >
-                    <svg
-                      aria-label="permalink"
-                      class="anchor-icon"
-                      fill="none"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      width="24"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                      <path
-                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                        stroke="#9B9B9B"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                      />
-                    </svg>
-                  </span>
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+            </a>
+          </div>
+          <p
+            class="css-6kj7vp-TextComponent"
           >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
+            Type: 
+            <code
+              class="inline css-ov7own-InlineCode"
             >
-              <strong
-                class="css-1qx481h-B"
-              >
-                (array || object)
-              </strong>
-            </p>
-          </td>
-        </tr>
-        <tr
-          class="css-29opv4-Row"
-        >
-          <td
-            class="css-1i3ovdz-Cell"
+              boolean
+            </code>
+             • Path:
+             
+            <code
+              class="inline css-1esaweg-AppConfigProperty"
+            >
+              intentFilters
+              .
+              autoVerify
+            </code>
+          </p>
+          <br />
+          <p
+            class="css-6jxvia-P"
+            data-text="true"
           >
+            You may also use an intent filter to set your app as the default handler for links
+          </p>
+          <div />
+        </div>
+        <div
+          class="css-gmoeog-AppConfigProperty"
+        >
+          <div
+            class=" css-19f55nd-PDIV"
+            data-text="true"
+          >
+            <a
+              class="css-ah3byb"
+              href="/#data"
+            >
+              <span
+                class="css-s3qkfm"
+                id="data"
+              />
+              <span
+                class="css-6n7j50"
+              >
+                <code
+                  class="inline css-1cjswoo-PropertyName"
+                >
+                  data
+                </code>
+              </span>
+              <span
+                class="css-1eysgws"
+              >
+                <svg
+                  aria-label="permalink"
+                  class="anchor-icon"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+            </a>
+          </div>
+          <p
+            class="css-6kj7vp-TextComponent"
+          >
+            Type: 
+            <code
+              class="inline css-ov7own-InlineCode"
+            >
+              array || object
+            </code>
+             • Path:
+             
+            <code
+              class="inline css-1esaweg-AppConfigProperty"
+            >
+              intentFilters
+              .
+              data
+            </code>
+          </p>
+          <br />
+          <div>
             <div
-              data-testid="host"
-              style="margin-left: 64px; display: list-item; list-style-type: circle; overflow-x: visible;"
+              class="css-gmoeog-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"
@@ -954,7 +915,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                     class="css-6n7j50"
                   >
                     <code
-                      class="inline css-ov7own-InlineCode"
+                      class="inline css-1cjswoo-PropertyName"
                     >
                       host
                     </code>
@@ -989,25 +950,32 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   </span>
                 </a>
               </div>
-            </div>
-          </td>
-          <td
-            class="css-4ul8tm-Cell"
-          >
-            <p
-              class="css-6jxvia-P"
-              data-text="true"
-            >
-              <strong
-                class="css-1qx481h-B"
+              <p
+                class="css-6kj7vp-TextComponent"
               >
-                (string)
-              </strong>
-            </p>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+                Type: 
+                <code
+                  class="inline css-ov7own-InlineCode"
+                >
+                  string
+                </code>
+                 • Path:
+                 
+                <code
+                  class="inline css-1esaweg-AppConfigProperty"
+                >
+                  intentFilters.data
+                  .
+                  host
+                </code>
+              </p>
+              <br />
+              <div />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="css-8h8p3u-AppConfigProperty"
+      class="css-1lzbq05-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -121,7 +121,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       <div />
     </div>
     <div
-      class="css-8h8p3u-AppConfigProperty"
+      class="css-1lzbq05-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -281,7 +281,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
       <div>
         <div
-          class="css-8h8p3u-AppConfigProperty"
+          class="css-1lzbq05-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -346,7 +346,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="inline css-1esaweg-AppConfigProperty"
+              class="css-1c83t10-AppConfigProperty"
             >
               androidNavigationBar
               .
@@ -406,7 +406,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </details>
           <div>
             <div
-              class="css-8h8p3u-AppConfigProperty"
+              class="css-1lzbq05-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"
@@ -471,7 +471,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                  • Path:
                  
                 <code
-                  class="inline css-1esaweg-AppConfigProperty"
+                  class="css-1c83t10-AppConfigProperty"
                 >
                   androidNavigationBar.visible
                   .
@@ -490,7 +490,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="css-8h8p3u-AppConfigProperty"
+          class="css-1lzbq05-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -555,7 +555,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="inline css-1esaweg-AppConfigProperty"
+              class="css-1c83t10-AppConfigProperty"
             >
               androidNavigationBar
               .
@@ -587,7 +587,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="css-8h8p3u-AppConfigProperty"
+      class="css-1lzbq05-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -740,7 +740,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </blockquote>
       <div>
         <div
-          class="css-8h8p3u-AppConfigProperty"
+          class="css-1lzbq05-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -805,7 +805,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="inline css-1esaweg-AppConfigProperty"
+              class="css-1c83t10-AppConfigProperty"
             >
               intentFilters
               .
@@ -822,7 +822,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </div>
         <div
-          class="css-8h8p3u-AppConfigProperty"
+          class="css-1lzbq05-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -887,7 +887,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
              • Path:
              
             <code
-              class="inline css-1esaweg-AppConfigProperty"
+              class="css-1c83t10-AppConfigProperty"
             >
               intentFilters
               .
@@ -897,7 +897,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <br />
           <div>
             <div
-              class="css-8h8p3u-AppConfigProperty"
+              class="css-1lzbq05-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"
@@ -962,7 +962,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                  • Path:
                  
                 <code
-                  class="inline css-1esaweg-AppConfigProperty"
+                  class="css-1c83t10-AppConfigProperty"
                 >
                   intentFilters.data
                   .

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div>
     <div
-      class="css-gmoeog-AppConfigProperty"
+      class="css-8h8p3u-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -121,7 +121,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       <div />
     </div>
     <div
-      class="css-gmoeog-AppConfigProperty"
+      class="css-8h8p3u-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -281,7 +281,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </details>
       <div>
         <div
-          class="css-gmoeog-AppConfigProperty"
+          class="css-8h8p3u-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -406,7 +406,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </details>
           <div>
             <div
-              class="css-gmoeog-AppConfigProperty"
+              class="css-8h8p3u-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"
@@ -490,7 +490,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
         </div>
         <div
-          class="css-gmoeog-AppConfigProperty"
+          class="css-8h8p3u-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -587,7 +587,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </div>
     <div
-      class="css-gmoeog-AppConfigProperty"
+      class="css-8h8p3u-AppConfigProperty"
     >
       <div
         class=" css-19f55nd-PDIV"
@@ -740,7 +740,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </blockquote>
       <div>
         <div
-          class="css-gmoeog-AppConfigProperty"
+          class="css-8h8p3u-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -822,7 +822,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <div />
         </div>
         <div
-          class="css-gmoeog-AppConfigProperty"
+          class="css-8h8p3u-AppConfigProperty"
         >
           <div
             class=" css-19f55nd-PDIV"
@@ -897,7 +897,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           <br />
           <div>
             <div
-              class="css-gmoeog-AppConfigProperty"
+              class="css-8h8p3u-AppConfigProperty"
             >
               <div
                 class=" css-19f55nd-PDIV"


### PR DESCRIPTION
# Why

Fix ENG-6232 + readability improvement (especially on mobile).

# How

This PR converts the Expo config schema reference component to render modified APIBoxes instead of the table. This should fix the search/indexing issue and also improve the page readability, and links position in certain cases.

# Test Plan

The changes have ben tested by running docs website locally.

Additionally I have refactored the current nesting level test to match to new formatted structure.

# Preview
<img width="1136" alt="Screenshot 2022-10-30 at 17 06 43" src="https://user-images.githubusercontent.com/719641/198888966-c6c50753-115f-4499-aa9c-f7fec728e735.png">

<img width="1136" alt="Screenshot 2022-10-30 at 16 35 14" src="https://user-images.githubusercontent.com/719641/198888867-5398ef0b-2cb9-4719-b286-4a00a359e927.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
