### PR TITLE
[docs] Update Netlify deployment docs to include redirect instructions

### DIFF
--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -86,23 +86,19 @@ Learn more about [Netlify](https://www.netlify.com/).
 
 ### Manual deployment with the Netlify CDN
 
-1. Install the Netlify CLI by running `npm install netlify-cli -g`
+1. Install the Netlify CLI by running `npm install netlify-cli -g`.
 
-2. Build your Expo web app with `npx expo export:web` (SDK 45 and lower should use `expo build:web` via the legacy global Expo CLI).
+2. If your app uses routes, add a **\_redirects** file inside the **web-build** directory so the client has complete control over the routing logic. This file should contain the `/* /index.html 200` rule.
 
-3. If your app uses routes you must configure `redirects` so the client has full control over the routing logic:
+   2.1. Run `cd web-build` to navigate inside the directory.
 
-   3.1. Run `cd web-build`
+   2.2. Run the command `echo "/* /index.html 200" > "_redirects"` to create **\_redirects** file with rule.
 
-   3.2. Create a `_redirects` file by running `echo "/* /index.html 200" > "\_redirects"`
+3. To deploy:
 
-4. To deploy:
+   3.1. Run the `netlify deploy` command and choose **web-build** as the publish directory.
 
-   4.1. Run `netlify deploy`
-
-   4.2. Choose `web-build` as the publish directory
-
-   4.3. You should see a URL that you can use to view your project online.
+   3.2. You should see a URL that you can use to view your project online.
 
 ### Continuous delivery
 

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -86,12 +86,23 @@ Learn more about [Netlify](https://www.netlify.com/).
 
 ### Manual deployment with the Netlify CDN
 
-```sh
-npm install netlify-cli -g
-netlify deploy
-```
+1. Install the Netlify CLI by running `npm install netlify-cli -g`
 
-Choose `web-build` as the path to deploy.
+2. Build your Expo web app with `npx expo export:web` (SDK 45 and lower should use `expo build:web` via the legacy global Expo CLI).
+
+3. If your app uses routes you must configure `redirects` so the client has full control over the routing logic:
+
+   3.1. Run `cd web-build`
+
+   3.2. Create a `_redirects` file by running `echo "/* /index.html 200" > "\_redirects"`
+
+4. To deploy:
+
+   4.1. Run `netlify deploy`
+
+   4.2. Choose `web-build` as the publish directory
+
+   4.3. You should see a URL that you can use to view your project online.
 
 ### Continuous delivery
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/19351

# How

This PR updates the Netlify deployment section inside the Publishing Websites documentation to include instructions about the configuration of a `_redirects` file inside `web-build` if your app uses multiple routes.

# Test Plan

Changes have been tested by running docs repo locally and visiting: http://localhost:3002/distribution/publishing-websites/

# Checklist
 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
