### PR TITLE
[docs] Add note to Skia docs about web installation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -15,6 +15,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
+If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+
 ## Usage
 
 See full documentation at [https://shopify.github.io/react-native-skia/](https://shopify.github.io/react-native-skia/).

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
-If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+> **Additional setup required for web**: if you want to use Skia on web, you will need to follow [web installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to load CanvasKit.
 
 ## Usage
 

--- a/docs/pages/versions/v46.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/skia.mdx
@@ -15,6 +15,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
+If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+
 ## Usage
 
 See full documentation at [https://shopify.github.io/react-native-skia/](https://shopify.github.io/react-native-skia/).

--- a/docs/pages/versions/v46.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/skia.mdx
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
-If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+> **Additional setup required for web**: if you want to use Skia on web, you will need to follow [web installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to load CanvasKit.
 
 ## Usage
 

--- a/docs/pages/versions/v47.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/skia.mdx
@@ -15,6 +15,8 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
+If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+
 ## Usage
 
 See full documentation at [https://shopify.github.io/react-native-skia/](https://shopify.github.io/react-native-skia/).

--- a/docs/pages/versions/v47.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/skia.mdx
@@ -15,7 +15,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://shopify.github.io/react-native-skia/docs/getting-started/installation/" />
 
-If you want to use this on web you will need to follow these [additional installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to properly load CanvasKit.
+> **Additional setup required for web**: if you want to use Skia on web, you will need to follow [web installation instructions](https://shopify.github.io/react-native-skia/docs/getting-started/web/#expo) to load CanvasKit.
 
 ## Usage
 


### PR DESCRIPTION
# Why

Currently the Skia instructions on the Expo documentation website can be a bit misleading as they don't mention any extra steps necessary in order to use Skia with Expo web. Related to https://github.com/expo/expo/pull/19717

# How

This PR updates the Skia documentation to include instructions about the additional steps that need to be followed to use Skia on web 

# Test Plan

Changes have been tested by running docs repo locally and visiting: http://localhost:3002/versions/latest/sdk/skia/

# Checklist
 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
