### PR TITLE
[docs] update jest command to use main instead of master

### DIFF
--- a/docs/pages/guides/testing-with-jest.mdx
+++ b/docs/pages/guides/testing-with-jest.mdx
@@ -170,7 +170,7 @@ This is optional, but wanted to talk about different Jest test flows. Currently 
 "scripts": {
   ...
   // active development of tests, watch files for changes and re-runs all tests
-  "test": "jest --watch --coverage=false --changedSince=origin/master",
+  "test": "jest --watch --coverage=false --changedSince=origin/main",
 
   // debug, console.logs and only re-runs the file that was changed
   "testDebug": "jest -o --watch --coverage=false",


### PR DESCRIPTION
# Why
Tiny docs change.  I received an error like this running the command out of the docs:
```
  ● Test suite failed to run

    fatal: ambiguous argument 'origin/master...HEAD': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
```

Since new GitHub repos and git initialization use `main` as the default branch name instead of `master`, I think it makes sense to update the docs to use origin/main as well.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
n/a docs update
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
👀
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
