### PR TITLE
fix(cli): resolve `metadata.json` file path absolutely for `npx expo export`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolve `metadata.json` file path absolutely for `npx expo export`.
+- Resolve `metadata.json` file path absolutely for `npx expo export`. ([#19802](https://github.com/expo/expo/pull/19802) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve `metadata.json` file path absolutely for `npx expo export`.
+
 ### 💡 Others
 
 ## 0.4.5 — 2022-10-30

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -146,7 +146,7 @@ export async function exportAppAsync(
   }
 
   // Generate a `metadata.json` and the export is complete.
-  await writeMetadataJsonAsync({ outputDir, bundles, fileNames });
+  await writeMetadataJsonAsync({ outputDir: outputPath, bundles, fileNames });
 }
 
 /**

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -119,7 +119,9 @@ export async function writeMetadataJsonAsync({
     bundles,
     fileNames,
   });
-  await fs.writeFile(path.join(outputDir, 'metadata.json'), JSON.stringify(contents));
+  const metadataPath = path.join(outputDir, 'metadata.json');
+  debug(`Writing metadata.json to ${metadataPath}`);
+  await fs.writeFile(metadataPath, JSON.stringify(contents));
   return contents;
 }
 


### PR DESCRIPTION
# Why

- Possible solution to bug report [from partner-coinbase](https://exponent-internal.slack.com/archives/C0238THKESC/p1667331749499469).
- Appears the output directory is not being resolved correctly, meaning the `metadata.json` has the potential to write to a nonexistent location.


# Test Plan

- In an Expo project existing in a monorepo: `cd ..` (`/apps`)
- Run `yarn expo export ./path/to/app/root`
- Project should export as expected.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
