### PR TITLE
[updates] yet another fix for missing app.manifest on android

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed another _app.manifest_ occasionally missing from build outputs on Android. ([#19809](https://github.com/expo/expo/pull/19809) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.15.3 — 2022-10-30

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -95,10 +95,8 @@ def setupClosure = {
       enabled(currentBundleTask.enabled)
     }
 
-    Task dependentTask = appProject.tasks.findByPath("merge${targetName}Resources");
-    if (dependentTask != null) {
-      dependentTask.dependsOn currentAssetsCopyTask
-    }
+    appProject.tasks.findByName("merge${targetName}Resources")?.dependsOn(currentAssetsCopyTask)
+    appProject.tasks.findByName("compress${targetName}Assets")?.dependsOn(currentAssetsCopyTask)
   }
 }
 


### PR DESCRIPTION
# Why

follow up with the findings from https://github.com/expo/expo/issues/19693#issuecomment-1300109166 to have another fix for missing `app.manifest` on android

# How

the copy task should also depend on `compressReleaseAssets` based on https://github.com/expo/expo/issues/19693#issuecomment-1300346121

Co-authored-by: Chung Xa <baochungit@gmail.com>

# Test Plan

- updates e2e ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
