### PR TITLE
[expo] Fix missing disable-missing-native-module-errors.js on npm

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo))
+- Fixed missing _disable-missing-native-module-errors.js_ in the package. ([#19815](https://github.com/expo/expo/pull/19815) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -22,6 +22,7 @@
     "AppEntry.js",
     "Expo.podspec",
     "bundledNativeModules.json",
+    "disable-missing-native-module-errors.js",
     "expo-module.config.json",
     "metro-config.js",
     "config.js",


### PR DESCRIPTION
# Why

the `disable-missing-native-module-errors.js` is missing in the expo package on npm.
this pr will fix the problem mentioned in https://github.com/expo/expo/issues/19811#issuecomment-1300695458

# How

should include `disable-missing-native-module-errors.js` in publishing files

# Test Plan

n/a

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
