### PR TITLE
[docs] improve Expo Config reference searchability

### DIFF
--- a/docs/components/base/paragraph.tsx
+++ b/docs/components/base/paragraph.tsx
@@ -4,9 +4,9 @@ import { PropsWithChildren } from 'react';
 
 import { paragraph } from './typography';
 
-const attributes = {
-  'data-text': true,
-};
+const getAttributes = (isHeading = false) => ({
+  [`data-${isHeading ? 'heading' : 'text'}`]: true,
+});
 
 const STYLES_PARAGRAPH = css`
   ${paragraph}
@@ -14,7 +14,7 @@ const STYLES_PARAGRAPH = css`
 `;
 
 export const P = ({ children }: PropsWithChildren<object>) => (
-  <p {...attributes} css={STYLES_PARAGRAPH}>
+  <p {...getAttributes()} css={STYLES_PARAGRAPH}>
     {children}
   </p>
 );
@@ -48,7 +48,15 @@ const STYLES_PARAGRAPH_DIV = css`
 export const PDIV = ({ children }: PropsWithChildren<object>) => {
   const isWider = (children as JSX.Element)?.props?.snackId;
   return (
-    <div {...attributes} css={STYLES_PARAGRAPH_DIV} className={isWider ? 'is-wider' : ''}>
+    <div {...getAttributes()} css={STYLES_PARAGRAPH_DIV} className={isWider ? 'is-wider' : ''}>
+      {children}
+    </div>
+  );
+};
+
+export const PDIVHEADER = ({ children }: PropsWithChildren<object>) => {
+  return (
+    <div {...getAttributes(true)} css={STYLES_PARAGRAPH_DIV}>
       {children}
     </div>
   );

--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -6,7 +6,7 @@ import { InlineCode } from '../base/code';
 
 import { createPermalinkedComponent } from '~/common/create-permalinked-component';
 import { HeadingType } from '~/common/headingManager';
-import { PDIV } from '~/components/base/paragraph';
+import { PDIVHEADER } from '~/components/base/paragraph';
 import { APIBox } from '~/components/plugins/APIBox';
 import { mdComponents, mdInlineComponents } from '~/components/plugins/api/APISectionUtils';
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -53,13 +53,13 @@ type AppConfigSchemaProps = {
   schema: Record<string, Property>;
 };
 
-const Anchor = createPermalinkedComponent(PDIV, {
+const Anchor = createPermalinkedComponent(PDIVHEADER, {
   baseNestingLevel: 3,
   sidebarType: HeadingType.InlineCode,
 });
 
 const PropertyName = ({ name, nestingLevel }: { name: string; nestingLevel: number }) => (
-  <Anchor level={nestingLevel} data-testid={name}>
+  <Anchor level={nestingLevel} data-testid={name} data-heading="true">
     <InlineCode css={typography.fontSizes[16]}>{name}</InlineCode>
   </Anchor>
 );
@@ -165,7 +165,7 @@ const AppConfigProperty = ({
 }: FormattedProperty & { nestingLevel: number }) => (
   <APIBox css={boxStyle}>
     <PropertyName name={name} nestingLevel={nestingLevel} />
-    <CALLOUT theme="secondary">
+    <CALLOUT theme="secondary" data-text="true">
       Type: <InlineCode>{type || 'undefined'}</InlineCode>
       {nestingLevel > 0 && (
         <>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -7,8 +7,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1lzbq05-AppConfigProperty"
     >
       <div
-        class=" css-19f55nd-PDIV"
-        data-text="true"
+        class="css-1xvbpdy-PDIVHEADER"
+        data-heading="true"
       >
         <a
           class="css-ah3byb"
@@ -59,6 +59,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
       <p
         class="css-6kj7vp-TextComponent"
+        data-text="true"
       >
         Type: 
         <code
@@ -124,8 +125,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1lzbq05-AppConfigProperty"
     >
       <div
-        class=" css-19f55nd-PDIV"
-        data-text="true"
+        class="css-1xvbpdy-PDIVHEADER"
+        data-heading="true"
       >
         <a
           class="css-ah3byb"
@@ -176,6 +177,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
       <p
         class="css-6kj7vp-TextComponent"
+        data-text="true"
       >
         Type: 
         <code
@@ -284,8 +286,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1lzbq05-AppConfigProperty"
         >
           <div
-            class=" css-19f55nd-PDIV"
-            data-text="true"
+            class="css-1xvbpdy-PDIVHEADER"
+            data-heading="true"
           >
             <a
               class="css-ah3byb"
@@ -336,6 +338,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
           <p
             class="css-6kj7vp-TextComponent"
+            data-text="true"
           >
             Type: 
             <code
@@ -409,8 +412,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-1lzbq05-AppConfigProperty"
             >
               <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
+                class="css-1xvbpdy-PDIVHEADER"
+                data-heading="true"
               >
                 <a
                   class="css-ah3byb"
@@ -461,6 +464,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
               <p
                 class="css-6kj7vp-TextComponent"
+                data-text="true"
               >
                 Type: 
                 <code
@@ -493,8 +497,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1lzbq05-AppConfigProperty"
         >
           <div
-            class=" css-19f55nd-PDIV"
-            data-text="true"
+            class="css-1xvbpdy-PDIVHEADER"
+            data-heading="true"
           >
             <a
               class="css-ah3byb"
@@ -545,6 +549,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
           <p
             class="css-6kj7vp-TextComponent"
+            data-text="true"
           >
             Type: 
             <code
@@ -590,8 +595,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1lzbq05-AppConfigProperty"
     >
       <div
-        class=" css-19f55nd-PDIV"
-        data-text="true"
+        class="css-1xvbpdy-PDIVHEADER"
+        data-heading="true"
       >
         <a
           class="css-ah3byb"
@@ -642,6 +647,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
       <p
         class="css-6kj7vp-TextComponent"
+        data-text="true"
       >
         Type: 
         <code
@@ -743,8 +749,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1lzbq05-AppConfigProperty"
         >
           <div
-            class=" css-19f55nd-PDIV"
-            data-text="true"
+            class="css-1xvbpdy-PDIVHEADER"
+            data-heading="true"
           >
             <a
               class="css-ah3byb"
@@ -795,6 +801,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
           <p
             class="css-6kj7vp-TextComponent"
+            data-text="true"
           >
             Type: 
             <code
@@ -825,8 +832,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1lzbq05-AppConfigProperty"
         >
           <div
-            class=" css-19f55nd-PDIV"
-            data-text="true"
+            class="css-1xvbpdy-PDIVHEADER"
+            data-heading="true"
           >
             <a
               class="css-ah3byb"
@@ -877,6 +884,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </div>
           <p
             class="css-6kj7vp-TextComponent"
+            data-text="true"
           >
             Type: 
             <code
@@ -900,8 +908,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-1lzbq05-AppConfigProperty"
             >
               <div
-                class=" css-19f55nd-PDIV"
-                data-text="true"
+                class="css-1xvbpdy-PDIVHEADER"
+                data-heading="true"
               >
                 <a
                   class="css-ah3byb"
@@ -952,6 +960,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </div>
               <p
                 class="css-6kj7vp-TextComponent"
+                data-text="true"
               >
                 Type: 
                 <code


### PR DESCRIPTION
# Why

Follow up to #19781

# How

This PR aims to improve the searchability of Expo Config reference. 

The previous changeset addressed main issue, but after deploy and recrawl I have spotted that search still is not yield the correct result in every case, this should fix that issue.

# Test Plan

We need to deploy the PR and trigger manual recrawl to see if this is working as intended.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
