### PR TITLE
[ios][haptics] Feedback Generators in HapticModule now operate on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,8 @@ Package-specific changes not released in any SDK will be added here just before 
   - Added missing permissions requester. ([#19633](https://github.com/expo/expo/pull/19633) by [@lukmccall](https://github.com/lukmccall))
 - **`expo-device`**
   - Fixed `<bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31` error when the `targetSdkVersion` is set to 33. ([#19666](https://github.com/expo/expo/pull/19666) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
+- **`expo-haptics`**
+  - Fixed rare crash on iOS when using Feedback Generator's API not on the main thread. ([#19819](https://github.com/expo/expo/pull/19819) by [@AntonGolikov](https://github.com/AntonGolikov))
 - **`expo-image-picker`**
   - Fix images taken with `launchCameraAsync` being translated incorrectly on some camera orientations. ([#19185](https://github.com/expo/expo/pull/19185) by [@jacobjaffe](https://github.com/JacobJaffe) and [@reececox](https://github.com/reececox)) ([#19185](https://github.com/expo/expo/pull/19185) by [@JacobJaffe](https://github.com/JacobJaffe), [@reececox](https://github.com/reececox))
   - Fix error where `launchImageLibraryAsync()` saved the photo to a global cache directory that was inaccessible in Expo Go. ([#19205](https://github.com/expo/expo/pull/19205) by [@aleqsio](https://github.com/aleqsio))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,8 +204,6 @@ Package-specific changes not released in any SDK will be added here just before 
   - Added missing permissions requester. ([#19633](https://github.com/expo/expo/pull/19633) by [@lukmccall](https://github.com/lukmccall))
 - **`expo-device`**
   - Fixed `<bluetooth_name> is only readable to apps with targetSdkVersion lower than or equal to: 31` error when the `targetSdkVersion` is set to 33. ([#19666](https://github.com/expo/expo/pull/19666) by [@kudo](https://github.com/kudo), [@kudo](https://github.com/kudo))
-- **`expo-haptics`**
-  - Fixed rare crash on iOS when using Feedback Generator's API not on the main thread. ([#19819](https://github.com/expo/expo/pull/19819) by [@AntonGolikov](https://github.com/AntonGolikov))
 - **`expo-image-picker`**
   - Fix images taken with `launchCameraAsync` being translated incorrectly on some camera orientations. ([#19185](https://github.com/expo/expo/pull/19185) by [@jacobjaffe](https://github.com/JacobJaffe) and [@reececox](https://github.com/reececox)) ([#19185](https://github.com/expo/expo/pull/19185) by [@JacobJaffe](https://github.com/JacobJaffe), [@reececox](https://github.com/reececox))
   - Fix error where `launchImageLibraryAsync()` saved the photo to a global cache directory that was inaccessible in Expo Go. ([#19205](https://github.com/expo/expo/pull/19205) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed rare crash on iOS when using Feedback Generator's API not on the main thread. ([#19819](https://github.com/expo/expo/pull/19819) by [@AntonGolikov](https://github.com/AntonGolikov))
+
 ### 💡 Others
 
 ## 12.0.0 — 2022-10-25

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -5,21 +5,27 @@ public class HapticsModule: Module {
     Name("ExpoHaptics")
 
     AsyncFunction("notificationAsync") { (notificationType: NotificationType) in
-      let generator = UINotificationFeedbackGenerator()
-      generator.prepare()
-      generator.notificationOccurred(notificationType.toFeedbackType())
+      DispatchQueue.main.async {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(notificationType.toFeedbackType())
+      }
     }
 
     AsyncFunction("impactAsync") { (style: ImpactStyle) in
-      let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
-      generator.prepare()
-      generator.impactOccurred()
+      DispatchQueue.main.async {
+        let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
+        generator.prepare()
+        generator.impactOccurred()
+      }
     }
 
     AsyncFunction("selectionAsync") {
-      let generator = UISelectionFeedbackGenerator()
-      generator.prepare()
-      generator.selectionChanged()
+      DispatchQueue.main.async {
+        let generator = UISelectionFeedbackGenerator()
+        generator.prepare()
+        generator.selectionChanged()
+      }
     }
   }
 

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -5,28 +5,22 @@ public class HapticsModule: Module {
     Name("ExpoHaptics")
 
     AsyncFunction("notificationAsync") { (notificationType: NotificationType) in
-      DispatchQueue.main.async {
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(notificationType.toFeedbackType())
-      }
-    }
+      let generator = UINotificationFeedbackGenerator()
+      generator.prepare()
+      generator.notificationOccurred(notificationType.toFeedbackType())
+    }.runOnQueue(.main)
 
     AsyncFunction("impactAsync") { (style: ImpactStyle) in
-      DispatchQueue.main.async {
-        let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
-        generator.prepare()
-        generator.impactOccurred()
-      }
-    }
+      let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
+      generator.prepare()
+      generator.impactOccurred()
+    }.runOnQueue(.main)
 
     AsyncFunction("selectionAsync") {
-      DispatchQueue.main.async {
-        let generator = UISelectionFeedbackGenerator()
-        generator.prepare()
-        generator.selectionChanged()
-      }
-    }
+      let generator = UISelectionFeedbackGenerator()
+      generator.prepare()
+      generator.selectionChanged()
+    }.runOnQueue(.main)
   }
 
   enum NotificationType: String, EnumArgument {

--- a/packages/expo-haptics/ios/HapticsModule.swift
+++ b/packages/expo-haptics/ios/HapticsModule.swift
@@ -8,19 +8,22 @@ public class HapticsModule: Module {
       let generator = UINotificationFeedbackGenerator()
       generator.prepare()
       generator.notificationOccurred(notificationType.toFeedbackType())
-    }.runOnQueue(.main)
+    }
+    .runOnQueue(.main)
 
     AsyncFunction("impactAsync") { (style: ImpactStyle) in
       let generator = UIImpactFeedbackGenerator(style: style.toFeedbackStyle())
       generator.prepare()
       generator.impactOccurred()
-    }.runOnQueue(.main)
+    }
+    .runOnQueue(.main)
 
     AsyncFunction("selectionAsync") {
       let generator = UISelectionFeedbackGenerator()
       generator.prepare()
       generator.selectionChanged()
-    }.runOnQueue(.main)
+    }
+    .runOnQueue(.main)
   }
 
   enum NotificationType: String, EnumArgument {


### PR DESCRIPTION
# Why

Feedback Generator APIs for iOS are not thread-safe and should only be called on the main thread. Current implementation uses default QoS thread. It leads to occasional crashes whenever apps using `expo-haptics` APIs. This PR changes it and moves usage of the Feedback Generator API to the main thread.

# How

<!--
How did you build this feature or fix this bug and why?
-->
According to the code, `AsyncFunction` uses `default` QoS thread if not specified. To ensure the main thread execution, we just need to set it with `runOnQueue(_:)` method

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
The expo's API didn't change, the changes are straightforward and only for iOS, so just triggering `Haptics.selectionAsync()` on iOS device should be enough. We've tested it as local patch in our project.  The crash happens at low volume over thousands of user sessions, so I'm not sure how to reliably reproduce the issue in order to test it properly.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
