### PR TITLE
[ios][android][docs] "custom development build" -> "development build"

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -53,7 +53,7 @@ class ManifestException : ExponentException {
                   "This project uses SDK " + sdkVersionRequired + " , but this version of Expo Go only supports the following SDKs: " + Constants.SDK_VERSIONS_LIST.joinToString() + ". To load the project, it must be updated to a supported SDK version or an older version of Expo Go must be used."
               }
               "NO_SDK_VERSION_SPECIFIED" -> {
-                formattedMessage = "Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): " + Constants.SDK_VERSIONS_LIST.joinToString() + ". A custom development build must be used to load other runtimes."
+                formattedMessage = "Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): " + Constants.SDK_VERSIONS_LIST.joinToString() + ". A development build must be used to load other runtimes."
               }
               "EXPERIENCE_SDK_VERSION_TOO_NEW" ->
                 formattedMessage =

--- a/docs/pages/guides/color-schemes.mdx
+++ b/docs/pages/guides/color-schemes.mdx
@@ -29,7 +29,7 @@ Example **app.json** configuration:
 }
 ```
 
-In EAS Build and custom development builds you'll need to install the native module `expo-system-ui` otherwise the `userInterfaceStyle` property will be ignored. Running `expo config --type introspect` will warn if the project is misconfigured:
+In EAS Build and development builds you'll need to install the native module `expo-system-ui` otherwise the `userInterfaceStyle` property will be ignored. Running `expo config --type introspect` will warn if the project is misconfigured:
 
 ```
 » android: userInterfaceStyle: Install expo-system-ui in your project to enable this feature.

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -423,7 +423,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     formattedMessage = [NSString stringWithFormat:@"This project uses SDK %@, but this version of Expo Go only supports the following SDKs: %@. To load the project, it must be updated to a supported SDK version or an older version of Expo Go must be used.", sdkVersionRequired, supportedSDKVersions];
   } else if ([errorCode isEqualToString:@"NO_SDK_VERSION_SPECIFIED"]) {
     NSString *supportedSDKVersions = [[EXVersions sharedInstance].versions[@"sdkVersions"] componentsJoinedByString:@", "];
-    formattedMessage = [NSString stringWithFormat:@"Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): %@. A custom development build must be used to load other runtimes.", supportedSDKVersions];
+    formattedMessage = [NSString stringWithFormat:@"Incompatible SDK version or no SDK version specified. This version of Expo Go only supports the following SDKs (runtimes): %@. A development build must be used to load other runtimes.", supportedSDKVersions];
   } else if ([errorCode isEqualToString:@"EXPERIENCE_SDK_VERSION_TOO_NEW"]) {
     formattedMessage = @"The project you requested requires a newer version of Expo Go. Please download the latest version from the App Store.";
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){


### PR DESCRIPTION
# Why

Fixes ENG-6469

This change will likely be short-lived as we plan to try to load custom runtimes in Expo Go in the future.

# How

Find and replace

# Test Plan

Run Expo Go (I did not do this because the change is so simple). So, CI passing is sufficient.
