### PR TITLE
[docs] Add section about view callbacks

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -157,7 +157,7 @@ async function getMessageAsync() {
 
 Defines event names that the module can send to JavaScript.
 
-> Note: This component can be used inside of the [`View`](#view) block to define callback names. See [`View callbacks`](#view-callbacks)
+> **Note**: This component can be used inside of the [`View`](#view) block to define callback names. See [`View callbacks`](#view-callbacks)
 
 <CodeBlocksTable>
 
@@ -593,9 +593,9 @@ export function addClipboardListener(listener: (event) => void): Subscription {
 
 Some events are connected to a certain view. For example, the touch event should be sent only to the underlying JavaScript view which was pressed. In that case, you can't use `sendEvent` described in [`Sending events`](#sending-events). The `expo-modules-core` introduces a view callbacks mechanism to handle view-bound events.
 
-To use it, in the view definition, you need to provide the event names that the view can send using the [Events](#events) definition component. After that, you need to declare a property of type `EventDispatcher` in your view class. The name of the declared property has to be the same as the name exported in the `Events` component. Later, you can just call it as a function and pass a payload of type `[String: Any?]` on iOS and `Map<String, Any?>` on Android.
+To use it, in the view definition, you need to provide the event names that the view can send using the [Events](#events) definition component. After that, you need to declare a property of type `EventDispatcher` in your view class. The name of the declared property has to be the same as the name exported in the `Events` component. Later, you can call it as a function and pass a payload of type `[String: Any?]` on iOS and `Map<String, Any?>` on Android.
 
-> Note: On Android, it's possible to specify the payload type. In case of types that don't convert into objects, the payload will be encapsulated and stored under the `payload` key: `{payload: <provided value>}`.
+> **Note**: On Android, it's possible to specify the payload type. In case of types that don't convert into objects, the payload will be encapsulated and stored under the `payload` key: `{payload: <provided value>}`.
 
 <CodeBlocksTable>
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -157,6 +157,8 @@ async function getMessageAsync() {
 
 Defines event names that the module can send to JavaScript.
 
+> Note: This component can be used inside of the [`View`](#view) block to define callback names. See [`View callbacks`](#view-callbacks)
+
 <CodeBlocksTable>
 
 ```swift
@@ -584,6 +586,90 @@ export function addClipboardListener(listener: (event) => void): Subscription {
   return emitter.addListener('onClipboardChanged', listener);
 }
 ```
+
+</APIBox>
+
+<APIBox header="View callbacks">
+
+Some events are connected to a certain view. For example, the touch event should be sent only to the underlying JavaScript view which was pressed. In that case, you can't use `sendEvent` described in [`Sending events`](#sending-events). The `expo-modules-core` introduces a view callbacks mechanism to handle view-bound events.
+
+To use it, in the view definition, you need to provide the event names that the view can send using the [Events](#events) definition component. After that, you can have to declare a member property on the custom view class using an `EventDispatcher` decorator. The name of the declared property has to be the same as the name exported in the `Events` component. Later, you can just call it as a function and pass a payload of type `[String: Any?]` on iOS and `Map<String, Any?>` on Android.
+
+> Note: On Android, it's possible to specify the payload type. In case of types that don't convert into objects, the payload will be encapsulated and stored under the `payload` key: `{payload: <provided value>}`.
+
+<CodeBlocksTable>
+
+```swift
+class CameraViewModule: Module {
+  public func definition() -> ModuleDefinition {
+    View(CamerView.self) {
+      Events(
+        "onCameraReady"
+      )
+
+      // ...
+    }
+  }
+}
+
+class CamerView: ExpoView {
+  let onCameraReady = EventDispatcher()
+
+  func callOnCameraReady() {
+    onCameraReady([
+      "message": "Camera was mounted"
+    ]);
+  }
+}
+
+```
+
+```kotlin
+class CameraViewModule : Module() {
+  override fun definition() = ModuleDefinition {
+    View(ExpoCameraView::class) {
+      Events(
+        "onCameraReady"
+      )
+
+      // ...
+    }
+  }
+}
+
+class CameraView(
+  context: Context,
+  appContext: AppContext
+) : ExpoView(context, appContext) {
+  val onCameraReady by EventDispatcher()
+
+  fun callOnCameraReady() {
+    onCameraReady(mapOf(
+      "message" to "Camera was mounted"
+    ));
+  }
+}
+```
+
+</CodeBlocksTable>
+
+To subscribe to these events in JavaScript/TypeScript, you need to pass a function to the native view as shown:
+
+```ts TypeScript
+import { requireNativeViewManager } from 'expo-modules-core';
+
+const CameraView = requireNativeViewManager('CameraView');
+
+export default fucntion MainView() {
+  const onCameraReady = (event) => {
+    console.log(even.nativeEvent);
+  }
+
+  return <CameraView onCameraReady={onCameraReady}/>
+}
+```
+
+Provided payload is available under the `nativeEvent` key.
 
 </APIBox>
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -593,7 +593,7 @@ export function addClipboardListener(listener: (event) => void): Subscription {
 
 Some events are connected to a certain view. For example, the touch event should be sent only to the underlying JavaScript view which was pressed. In that case, you can't use `sendEvent` described in [`Sending events`](#sending-events). The `expo-modules-core` introduces a view callbacks mechanism to handle view-bound events.
 
-To use it, in the view definition, you need to provide the event names that the view can send using the [Events](#events) definition component. After that, you can have to declare a member property on the custom view class using an `EventDispatcher` decorator. The name of the declared property has to be the same as the name exported in the `Events` component. Later, you can just call it as a function and pass a payload of type `[String: Any?]` on iOS and `Map<String, Any?>` on Android.
+To use it, in the view definition, you need to provide the event names that the view can send using the [Events](#events) definition component. After that, you need to declare a property of type `EventDispatcher` in your view class. The name of the declared property has to be the same as the name exported in the `Events` component. Later, you can just call it as a function and pass a payload of type `[String: Any?]` on iOS and `Map<String, Any?>` on Android.
 
 > Note: On Android, it's possible to specify the payload type. In case of types that don't convert into objects, the payload will be encapsulated and stored under the `payload` key: `{payload: <provided value>}`.
 
@@ -612,7 +612,7 @@ class CameraViewModule: Module {
   }
 }
 
-class CamerView: ExpoView {
+class CameraView: ExpoView {
   let onCameraReady = EventDispatcher()
 
   func callOnCameraReady() {
@@ -621,7 +621,6 @@ class CamerView: ExpoView {
     ]);
   }
 }
-
 ```
 
 ```kotlin
@@ -660,12 +659,12 @@ import { requireNativeViewManager } from 'expo-modules-core';
 
 const CameraView = requireNativeViewManager('CameraView');
 
-export default fucntion MainView() {
-  const onCameraReady = (event) => {
-    console.log(even.nativeEvent);
-  }
+export default function MainView() {
+  const onCameraReady = event => {
+    console.log(event.nativeEvent);
+  };
 
-  return <CameraView onCameraReady={onCameraReady}/>
+  return <CameraView onCameraReady={onCameraReady} />;
 }
 ```
 


### PR DESCRIPTION
# Why

Closes ENG-6605.
Adds a section about view callbacks.

# Test Plan

![image](https://user-images.githubusercontent.com/9578601/199710789-e3132682-089c-40f6-886f-fa1ba5cd2652.png)
