### PR TITLE
[gh] Replace deprecated ::set-output

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -40,7 +40,7 @@ runs:
         COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -c1000)
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
         BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --resource-class ${{ inputs.resourceClass }} --non-interactive --json --no-wait | jq -r ".[0].id")
-        echo ::set-output name=build_id::"$BUILD_ID"
+        echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.projectRoot }}
       env:
         EXPO_TOKEN: ${{ inputs.expoToken }}

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -85,7 +85,7 @@ runs:
   steps:
     - name: 🔍️ Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
     - name: ♻️ Restore workspace node modules
       if: inputs.yarn-workspace == 'true'
@@ -190,7 +190,7 @@ runs:
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'
       id: git-lfs
-      run: echo "::set-output name=sha256::$(git lfs ls-files | openssl dgst -sha256)"
+      run: echo "sha256=$(git lfs ls-files | openssl dgst -sha256)" >> $GITHUB_OUTPUT
       shell: bash
     - name: ♻️ Restore Git LFS cache
       uses: actions/cache@v2
@@ -212,7 +212,11 @@ runs:
       run: |
         CURRENT_VERSION=$(test -f android/prebuiltHermes/.hermesversion && cat android/prebuiltHermes/.hermesversion) || true
         TARGET_VERSION=$(test -f react-native-lab/react-native/sdks/.hermesversion && cat react-native-lab/react-native/sdks/.hermesversion) || true
-        if [[ $CURRENT_VERSION == $TARGET_VERSION ]]; then echo '::set-output name=cache-hit::true'; else echo '::set-output name=cache-hit::false'; fi
+        if [[ $CURRENT_VERSION == $TARGET_VERSION ]]; then
+          echo "cache-hit=true" >> $GITHUB_OUTPUT
+        else
+          echo "cache-hit=false" >> $GITHUB_OUTPUT
+        fi
     - name: 🛠 Rebuild hermes-engine AAR when cache missed
       if: inputs.hermes-engine-aar == 'true' && inputs.rebuild-hermes-engine-aar-if-needed == 'true' && steps.cache-hermes-engine-aar.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -74,15 +74,15 @@ jobs:
           DISPATCH_PROFILE="${{ github.event.inputs.buildType }}"
           IS_VERSIONED="${{ steps.flavor.outputs.versioned }}"
           if [[ ! -z "$DISPATCH_PROFILE" ]]; then
-            echo ::set-output name=profile::"$DISPATCH_PROFILE"
+            echo "profile=$DISPATCH_PROFILE" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event.schedule }}" == "20 5 * * 1,3,5" ]]; then
-            echo ::set-output name=profile::"versioned-client"
+            echo "profile=versioned-client" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event.schedule }}" == "20 5 * * 1" ]]; then
-            echo ::set-output name=profile::"versioned-client-add-sdk"
+            echo "profile=versioned-client-add-sdk" >> $GITHUB_OUTPUT
           elif [[ "$IS_VERSIONED" == "true" ]]; then
-            echo ::set-output name=profile::"versioned-client"
+            echo "profile=versioned-client" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=profile::"unversioned-client"
+            echo "profile=unversioned-client" >> $GITHUB_OUTPUT
           fi
       - name: Generate local credentials.json
         working-directory: ./apps/eas-expo-go

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -94,15 +94,15 @@ jobs:
           DISPATCH_PROFILE="${{ github.event.inputs.buildType }}"
           IS_VERSIONED="${{ steps.flavor.outputs.versioned }}"
           if [[ ! -z "$DISPATCH_PROFILE" ]]; then
-            echo ::set-output name=profile::"$DISPATCH_PROFILE"
+            echo "profile=$DISPATCH_PROFILE" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event.schedule }}" == "20 5 * * 1,3,5" ]]; then
-            echo ::set-output name=profile::"versioned-client"
+            echo "profile=versioned-client" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event.schedule }}" == "20 5 * * 1" ]]; then
-            echo ::set-output name=profile::"versioned-client-add-sdk"
+            echo "profile=versioned-client-add-sdk" >> $GITHUB_OUTPUT
           elif [[ "$IS_VERSIONED" == "true" ]]; then
-            echo ::set-output name=profile::"versioned-client"
+            echo "profile=versioned-client" >> $GITHUB_OUTPUT
           else
-            echo ::set-output name=profile::"unversioned-client"
+            echo "profile=unversioned-client" >> $GITHUB_OUTPUT
           fi
       - name: Build
         uses: ./.github/actions/eas-build

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -54,7 +54,7 @@ jobs:
       # # Get Expo link for the comment
       # - name: Get expo link
       #   id: expo
-      #   run: echo "::set-output name=path::@community/native-component-list?release-channel=pr-${{ github.event.number }}"
+      #   run: echo "path=@community/native-component-list?release-channel=pr-${{ github.event.number }}" >> $GITHUB_OUTPUT
       # Build the Expo website
       - name: Build Website
         working-directory: ./apps/native-component-list


### PR DESCRIPTION
# Why

`::set-output` was deprecated
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
# How

Replace 

```
echo "::set-output name={name}::{value}"
```

with

```
echo "{name}={value}" >> $GITHUB_OUTPUT
```

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
