### PR TITLE
 [docs] Fix onDestroy typo in android modules

### DIFF
--- a/docs/pages/modules/android-lifecycle-listeners.mdx
+++ b/docs/pages/modules/android-lifecycle-listeners.mdx
@@ -25,7 +25,7 @@ The following `Activity` lifecycle callbacks are currently supported:
 - `onCreate`
 - `onResume`
 - `onPause`
-- `onDestrory`
+- `onDestroy`
 - `onNewIntent`
 - `onBackPressed`
 


### PR DESCRIPTION
# Why

Fixes a typo in the Modules documentation for Android Lifecycle Listeners.

# How

Updated the spelling

# Test Plan

N/A

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
~- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).~
