### PR TITLE
[docs] remove code signing early beta message

### DIFF
--- a/docs/pages/eas-update/code-signing.mdx
+++ b/docs/pages/eas-update/code-signing.mdx
@@ -6,8 +6,6 @@ import Head from '~/components/Head';
 
 <Head title="EAS Update Code Signing" />
 
-> **warning** Expo Updates code signing is in early beta, meaning that it is not yet ready for use in production apps. We may still make breaking changes to the developer-facing portion and the end-user portion as well.
-
 > EAS Update Code Signing is only available to accounts subscribed to the EAS Enterprise plan. [Sign up](https://expo.dev/pricing).
 
 ## Introduction


### PR DESCRIPTION
We are releasing code signing, so I am removing the callout that this feature is in early beta