### PR TITLE
[android][task-manager] Do not load the application JS if it's already loading

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Do not load the application JS if it's already loading on Android. ([#19873](https://github.com/expo/expo/pull/19873) by [@mdmitry01](https://github.com/mdmitry01))
+
 ### 💡 Others
 
 ## 11.0.1 — 2022-10-28

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -88,6 +88,9 @@ dependencies {
   api "androidx.core:core:1.0.0"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+
+  //noinspection GradleDynamicVersion
+  implementation 'com.facebook.react:react-native:+'
 }
 repositories {
   mavenCentral()


### PR DESCRIPTION
# Why

I'm developing an app which uses the bare workflow. My Expo version is 46.0.7. Also, the app uses the `expo-location` package to listen to the location updates (`startLocationUpdatesAsync`). The issue is that when the app cold boots on Android (for example after the user force stopped it) it crashes almost every time. In the logs, I can see two errors:

1. `Error: Cannot find native module 'ExpoLocalization'`
2. `JSCRuntime destroyed with a dangling API object` (the app crashes on this error)

As far as I can tell, the issue is coming from the `expo-modules-core` package. The package implements something similar to the [Turbo Native Modules](https://reactnative.dev/docs/next/the-new-architecture/pillars-turbomodules). 

The crash happens each when the JS runtime is being destroyed. For example, when a developer reloads the app using the terminal. Or when the JS runtime is started in the background (see [Headless JS](https://reactnative.dev/docs/headless-js-android)) to handle some event (for example, location updates) and then destroyed. To prevent the second scenario, I've started preloading the JS runtime in our app, meaning I've added a call of `createReactContextInBackground()` to `MainApplication.java`. The idea is that if there is a JS runtime running, there is no need to run another one and destroy it afterwards. When an even comes, the already running runtime should be used. But it doesn't work properly because it seems that `expo-task-manager` may try to start a JS runtime anyway even if one is already starting. To fix it, I've opened this PR.

So, when the app is cold booting (after a forced stop, for example) and the app uses `startLocationUpdatesAsync`, the JS runtime is started twice almost at the same time. First time to handle a location update in the background, but in the next moment, the JS runtime is started again for the `ReactRootView`. I'm not sure if there are two JS runtimes running in parallel or the first one is immediately destroyed once the second one tries to start. But the JS runtime which is started to handle the location update cannot import the `expo-localization` package: `Error: Cannot find native module 'ExpoLocalization'`. And then the app eventually crashes with the `JSCRuntime destroyed with a dangling API object` error.

# How

The fix prevents loading of the JS runtime in the background if there is a `ReactRootView` attached to the `ReactInstanceManager`. It should prevent the situation when the JS runtime is started twice during a cold boot.

# Test Plan

See this [minimal reproducible example](https://github.com/mdmitry01/expo-crash-demo).

Call the `startLocationUpdatesAsync` function to start listening to the location updates in your app on Android. Force stop the app and launch it again. The app should not load, but crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
