### PR TITLE
[ios] Experimental support for embedding SwiftUI views

### DIFF
--- a/apps/native-component-list/src/screens/LinearGradientScreen.tsx
+++ b/apps/native-component-list/src/screens/LinearGradientScreen.tsx
@@ -31,7 +31,8 @@ export default function LinearGradientScreen() {
   }, []);
 
   const location = Math.sin(count / 100) * 0.5;
-  const position = Math.sin(count / 100);
+  const position = Math.abs(Math.sin(count / 100));
+
   return (
     <ScrollView
       style={{ flex: 1 }}

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Support implementing `customizeRootView` in `ExpoAppDelegateSubscriber`. ([#30550](https://github.com/expo/expo/pull/30550) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Added support for primitive arrays in functions. ([#30657](https://github.com/expo/expo/pull/30657) by [@lukmccall](https://github.com/lukmccall))
 - Implemented `toJSON` function on shared objects that includes dynamic properties defined in their prototype chain. ([#30813](https://github.com/expo/expo/pull/30813) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added experimental support for rendering SwiftUI views. ([#19888](https://github.com/expo/expo/pull/19888) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/ViewFactories.swift
@@ -10,6 +10,15 @@ public func View<ViewType: UIView>(
   return ViewDefinition(viewType, elements: elements())
 }
 
+/**
+ Creates a view definition describing the native SwiftUI view exported to React.
+ */
+public func View<Props: ExpoSwiftUI.ViewProps, ViewType: ExpoSwiftUI.View<Props>>(
+  _ viewType: ViewType.Type
+) -> ExpoSwiftUI.ViewDefinition<Props, ViewType> {
+  return ExpoSwiftUI.ViewDefinition(ViewType.self)
+}
+
 // MARK: Props
 
 /**

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyViewDefinition.swift
@@ -23,6 +23,11 @@ public protocol AnyViewDefinition {
   func propsDict() -> [String: AnyViewProp]
 
   /**
+   Returns a list of prop names supported by the view.
+   */
+  func getSupportedPropNames() -> [String]
+
+  /**
    Calls defined lifecycle methods with the given type.
    */
   func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: UIView)

--- a/packages/expo-modules-core/ios/Core/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Record.swift
@@ -36,7 +36,10 @@ public extension Record {
 
   init(from dict: Dict, appContext: AppContext) throws {
     self.init()
+    try update(withDict: dict, appContext: appContext)
+  }
 
+  func update(withDict dict: Dict, appContext: AppContext) throws {
     let dictKeys = dict.keys
 
     try fieldsOf(self).forEach { field in
@@ -61,7 +64,7 @@ public extension Record {
  Returns an array of fields found in record's mirror. If the field is missing the `key`,
  it gets assigned to the property label, so after all it's safe to enforce unwrapping it (using `key!`).
  */
-private func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
+internal func fieldsOf(_ record: Record) -> [AnyFieldInternal] {
   return Mirror(reflecting: record).children.compactMap { (label: String?, value: Any) in
     guard var field = value as? AnyFieldInternal, let key = field.key ?? convertLabelToKey(label) else {
       return nil

--- a/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ComponentData.swift
@@ -56,6 +56,17 @@ public final class ComponentData: RCTComponentDataSwiftAdapter {
       log.warn("App context has been lost")
       return
     }
+
+    // Props are set differently in SwiftUI hosting views – delegate the work to `ExpoSwiftUI.HostingView`.
+    if let hostingView = view as? ExpoSwiftUI.AnyHostingView {
+      hostingView.updateRawProps(props, appContext: appContext)
+
+      // Pass props to React too, to apply layout and styles for the hosting view.
+      super.setProps(props, forView: view)
+
+      return
+    }
+
     let propsDict = viewDefinition.propsDict()
     var remainingProps = props
 
@@ -88,9 +99,9 @@ public final class ComponentData: RCTComponentDataSwiftAdapter {
     let superClass: AnyClass? = managerClass.superclass()
 
     if let viewDefinition = moduleHolder?.definition.view {
-      for prop in viewDefinition.props {
+      for propName in viewDefinition.getSupportedPropNames() {
         // `id` allows every type to be passed in
-        propTypes[prop.name] = "id"
+        propTypes[propName] = "id"
       }
       for eventName in viewDefinition.eventNames {
         directEvents.append(RCTNormalizeInputEventName(eventName))

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/Convertibles+SwiftUI.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/Convertibles+SwiftUI.swift
@@ -1,0 +1,23 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+extension Color: Convertible {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> Color {
+    // Simply reuse the logic from UIColor
+    if let uiColor = try? UIColor.convert(from: value, appContext: appContext) {
+      return Color(uiColor)
+    }
+    throw Conversions.ConvertingException<Color>(value)
+  }
+}
+
+extension UnitPoint: Convertible {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> UnitPoint {
+    // Simply reuse the logic from CGPoint
+    if let cgPoint = try? CGPoint.convert(from: value, appContext: appContext) {
+      return UnitPoint(x: cgPoint.x, y: cgPoint.y)
+    }
+    throw Conversions.ConvertingException<UnitPoint>(value)
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSwiftUI.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/ExpoSwiftUI.swift
@@ -1,0 +1,6 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+/**
+ A namespace for Expo APIs that deal with SwiftUI.
+ */
+public struct ExpoSwiftUI {}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -1,0 +1,91 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+/**
+ A type-erased protocol that hosting views must conform to.
+ */
+internal protocol AnyExpoSwiftUIHostingView {
+  func updateRawProps(_ rawProps: [String: Any], appContext: AppContext)
+}
+
+extension ExpoSwiftUI {
+  typealias AnyHostingView = AnyExpoSwiftUIHostingView
+
+  /**
+   A hosting view that renders a SwiftUI view inside the UIKit view hierarchy.
+   */
+  public final class HostingView<Props: ViewProps, ContentView: View<Props>>: UIView, AnyExpoSwiftUIHostingView {
+    /**
+     Props object that stores all the props for this particular view.
+     It's an environment object that is observed by the content view.
+     */
+    private let props: Props
+
+    /**
+     View controller that embeds the content view into the UIKit view hierarchy.
+     */
+    private let hostingController: UIViewController
+
+    /**
+     Initializes a SwiftUI hosting view with the given SwiftUI view type.
+     */
+    init(viewType: ContentView.Type, props: Props) {
+      let rootView = ContentView().environmentObject(props)
+
+      self.props = props
+      self.hostingController = UIHostingController(rootView: rootView)
+
+      super.init(frame: .zero)
+
+      // Hosting controller has white background by default,
+      // but we always want it to be transparent.
+      hostingController.view.backgroundColor = .clear
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    /**
+     Updates the environment object with props, based on the given dictionary with raw props.
+     */
+    internal func updateRawProps(_ rawProps: [String: Any], appContext: AppContext) {
+      try? props.updateRawProps(rawProps, appContext: appContext)
+    }
+
+    /**
+     Setups layout constraints of the hosting controller view to match the layout set by React.
+     */
+    private func setupHostingViewConstraints() {
+      guard let view = hostingController.view else {
+        return
+      }
+      view.translatesAutoresizingMaskIntoConstraints = false
+
+      NSLayoutConstraint.activate([
+        view.topAnchor.constraint(equalTo: topAnchor),
+        view.bottomAnchor.constraint(equalTo: bottomAnchor),
+        view.leftAnchor.constraint(equalTo: leftAnchor),
+        view.rightAnchor.constraint(equalTo: rightAnchor)
+      ])
+    }
+
+    // MARK: - UIView lifecycle
+
+    public override func didMoveToWindow() {
+      super.didMoveToWindow()
+
+      if window != nil, let parentController = reactViewController() {
+        parentController.addChild(hostingController)
+        addSubview(hostingController.view)
+        hostingController.didMove(toParent: parentController)
+        setupHostingViewConstraints()
+      } else {
+        hostingController.view.removeFromSuperview()
+        hostingController.removeFromParent()
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -1,0 +1,41 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import Combine
+
+/**
+ A protocol for SwiftUI views that need to access props.
+ */
+public protocol ExpoSwiftUIView<Props>: SwiftUI.View {
+  associatedtype Props: ExpoSwiftUI.ViewProps
+
+  var props: Props { get }
+
+  init()
+}
+
+extension ExpoSwiftUI {
+  public typealias View = ExpoSwiftUIView
+
+  /**
+   A definition representing the native SwiftUI view to export to React.
+   */
+  public final class ViewDefinition<Props: ViewProps, ViewType: View<Props>>: ExpoModulesCore.ViewDefinition<HostingView<Props, ViewType>> {
+    init(_ viewType: ViewType.Type) {
+      super.init(HostingView<Props, ViewType>.self, elements: [])
+    }
+
+    public override func createView(appContext: AppContext) -> UIView? {
+      let props = Props()
+      return HostingView(viewType: ViewType.self, props: props)
+    }
+
+    public override func getSupportedPropNames() -> [String] {
+      // To obtain field names from the props object we need to create a dummy instance first.
+      // This is not ideal, but RN requires us to provide all prop names before the view is created
+      // and there doesn't seem to be a better way to do this right now.
+      let props = Props()
+      return fieldsOf(props).compactMap(\.key)
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewProps.swift
@@ -1,0 +1,21 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+extension ExpoSwiftUI {
+  /**
+   Base implementation of the view props object for SwiftUI views.
+   It's a record that can be observed by SwiftUI to re-render on its changes.
+   */
+  open class ViewProps: ObservableObject, Record {
+    public required init() {}
+
+    internal func updateRawProps(_ rawProps: [String: Any], appContext: AppContext) throws {
+      // Update the props just like the records
+      try update(withDict: rawProps, appContext: appContext)
+
+      // Notify subscribed views about the change to re-render them.
+      objectWillChange.send()
+    }
+  }
+}

--- a/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/ViewDefinition.swift
@@ -3,7 +3,7 @@
 /**
  A definition representing the native view to export to React.
  */
-public final class ViewDefinition<ViewType: UIView>: ObjectDefinition, AnyViewDefinition {
+public class ViewDefinition<ViewType: UIView>: ObjectDefinition, AnyViewDefinition {
   /**
    An array of view props definitions.
    */
@@ -59,6 +59,10 @@ public final class ViewDefinition<ViewType: UIView>: ObjectDefinition, AnyViewDe
     return props.reduce(into: [String: AnyViewProp]()) { acc, prop in
       acc[prop.name] = prop
     }
+  }
+
+  public func getSupportedPropNames() -> [String] {
+    return props.map(\.name)
   }
 
   public func callLifecycleMethods(withType type: ViewLifecycleMethodType, forView view: UIView) {


### PR DESCRIPTION
# Why

Closes ENG-5248

# How

Added a mechanism that can embed SwiftUI views inside the UIKit view hierarchy using the `UIHostingController`. There is a new `View(...)` definition component that takes the SwiftUI struct type as the argument. As opposed to UIKit view definitions, it cannot have a nested definition with `Prop` components inside. Instead, the view is associated with a type that extends a Record-like class `ExpoSwiftUI.ViewProps` where each view prop is defined as a `Field`.
The view props type is then used for the `props` property inside the view. Since the base class for view props implements `ObservableObject` protocol, the user can use `@EnvironmentObject` property wrapper to re-render the view on each view prop change. Alternatively, also `@StateObject` could be used, but it's available as of iOS 14.

For clarity, all types specific to SwiftUI are in the `ExpoSwiftUI` namespace (except the `View` component). We may consider removing the namespace in the future, when the support for SwiftUI is stable.

Note that it **doesn't** (yet?) allow rendering children views.

An example of a SwiftUI view may look like this:

```swift
public class LinearGradientModule: Module {
  public func definition() -> ModuleDefinition {
    Name("ExpoLinearGradient")
    View(LinearGradientSwiftUIView.self)
  }
}

class LinearGradientProps: ExpoSwiftUI.ViewProps {
  @Field var colors: [Color] = []
  @Field var startPoint: UnitPoint = UnitPoint(x: 0.5, y: 0.0)
  @Field var endPoint: UnitPoint = UnitPoint(x: 0.5, y: 1.0)
  @Field var locations: [Double] = []
}

struct LinearGradientSwiftUIView: ExpoSwiftUI.View {
  @EnvironmentObject var props: LinearGradientProps

  var body: some View {
    LinearGradient(
      colors: props.colors,
      startPoint: props.startPoint,
      endPoint: props.endPoint
    )
  }
}
```

# Test Plan

I tested `expo-linear-gradient` with the above example. I'm going to create a module that showcases more capabilities of this feature.