### PR TITLE
[emt] Add commonly required dependencies for Android Expo Modules

### DIFF
--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -88,4 +88,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2"
+  implementation "androidx.core:core-ktx:1.6.0"
 }


### PR DESCRIPTION
# Why

In our [Native Modules API reference](https://docs.expo.dev/modules/module-api/) we use both `Coroutine` and `bundleOf` - I think including the require deps for these in our template makes this a bit easier, and developers can remove them if they don't need them.
 
# How

Copy the versions from expo-clipboard

# Test Plan

I used this in a test project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
