### PR TITLE
[android] Fix sdk 45/46 crash from reanimated and gesture-handler

### DIFF
--- a/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/host/exp/exponent/modules/api/reanimated/NativeProxy.java
+++ b/android/versioned-abis/expoview-abi45_0_0/src/main/java/abi45_0_0/host/exp/exponent/modules/api/reanimated/NativeProxy.java
@@ -116,7 +116,7 @@ public class NativeProxy {
     try {
       Class<NativeModule> gestureHandlerModuleClass =
           (Class<NativeModule>)
-              Class.forName("com.swmansion.gesturehandler.react.RNGestureHandlerModule");
+              Class.forName("abi45_0_0.com.swmansion.gesturehandler.react.RNGestureHandlerModule");
       tempHandlerStateManager =
           (GestureHandlerStateManager) context.getNativeModule(gestureHandlerModuleClass);
     } catch (ClassCastException | ClassNotFoundException e) {

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/reanimated/NativeProxy.java
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/reanimated/NativeProxy.java
@@ -116,7 +116,7 @@ public class NativeProxy {
     try {
       Class<NativeModule> gestureHandlerModuleClass =
           (Class<NativeModule>)
-              Class.forName("com.swmansion.gesturehandler.react.RNGestureHandlerModule");
+              Class.forName("abi46_0_0.com.swmansion.gesturehandler.react.RNGestureHandlerModule");
       tempHandlerStateManager =
           (GestureHandlerStateManager) context.getNativeModule(gestureHandlerModuleClass);
     } catch (ClassCastException | ClassNotFoundException e) {


### PR DESCRIPTION
# Why

fix reanimated and gesture-handler integration crashed on sdk 45/46 android expo go
fixes #19862

# How

from sdk 47, we changed reanimated and gesture-handler to new style vendoring. the `com.swmansion.gesturehandler.react.RNGestureHandlerModule` now exists in unversioned code. the crash is actually from sdk45/46 + unversioned gesture-handler integration. the pr adds the abi prefix to the versioned code. as sdk45/46 we turned off the reanimated and gesture-handler integration, the class finding is expected to fail. 

# Test Plan

- test local build android versioned expo go + https://github.com/brunohkbx/expo-sdk-47-issue-repro
- test local build android versioned expo go + https://github.com/brunohkbx/expo-sdk-47-issue-repro (downgrade to sdk 45)
- test local build android versioned expo go + https://github.com/brunohkbx/expo-sdk-47-issue-repro (upgrade to sdk 47)

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
