### PR TITLE
[docs] Remove web from platforms in BarCodeScanner

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -11,7 +11,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v43.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/bar-code-scanner.mdx
@@ -10,7 +10,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v44.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/bar-code-scanner.mdx
@@ -10,7 +10,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v45.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/bar-code-scanner.mdx
@@ -11,7 +11,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
@@ -11,7 +11,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
@@ -11,7 +11,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator web />
+<PlatformsSection android emulator ios simulator />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 


### PR DESCRIPTION
BarCodeScanner Component not supported on the web
See: https://github.com/expo/expo/blob/168ee43f71f005baa11edf98e518593443e1807a/packages/expo-barcode-scanner/src/ExpoBarCodeScannerView.web.tsx