### PR TITLE
[docs] Remove preview from EAS Update known issues

### DIFF
--- a/docs/pages/eas-update/known-issues.mdx
+++ b/docs/pages/eas-update/known-issues.mdx
@@ -2,9 +2,7 @@
 title: Known issues
 ---
 
-EAS Update is in "preview" meaning we may still make breaking developer-facing changes. With that, EAS Update is ready for production apps.
-
-With our initial release of EAS Update, there are several known issues you may encounter. As we continue to iterate on EAS Update, we will address these issues.
+With EAS Update, there are some known issues you may encounter. As we continue to iterate on it, we will address these issues.
 
 ### Known issues
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While working on updating limitations doc, EAS update known issues were brought up and it seems the doc still refers to them in the preview.


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes the outdated context that EAS update are in preview.

# Test Plan

<img width="956" alt="CleanShot 2022-11-07 at 15 00 08@2x" src="https://user-images.githubusercontent.com/10234615/200275597-e557ec0f-9bf6-49c2-a9bb-def55de699d0.png">

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
