### PR TITLE
[emt] Migrate the module template to use View instead of ViewManager

### DIFF
--- a/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
+++ b/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
@@ -35,15 +35,9 @@ class <%- project.name %>Module : Module() {
       ))
     }
 
-    // Enables the module to be used as a view manager. The view manager definition is built from
-    // the definition components used in the closure passed to viewManager.
-    // Definition components that are accepted as part of the view manager definition: `View`, `Prop`.
-    ViewManager {
-      // Defines the factory creating a native view when the module is used as a view.
-      View { context -> 
-        <%- project.name %>View(context) 
-      }
-
+    // Enables the module to be used as a native view.
+    // Definition components that are accepted as part of the view definition: `Prop`, `Events`.
+    View(<%- project.name %>View::class) {
       // Defines a setter for the `name` prop.
       Prop("name") { view: <%- project.name %>View, prop: String ->
         println(prop)

--- a/packages/expo-module-template/ios/{%- project.name %}Module.swift
+++ b/packages/expo-module-template/ios/{%- project.name %}Module.swift
@@ -32,15 +32,9 @@ public class <%- project.name %>Module: Module {
       ])
     }
 
-    // Enables the module to be used as a view manager. The view manager definition is built from
-    // the definition components used in the closure passed to viewManager.
-    // Definition components that are accepted as part of the view manager definition: `View`, `Prop`.
-    ViewManager {
-      // Defines the factory creating a native view when the module is used as a view.
-      View {
-        <%- project.name %>View()
-      }
-
+    // Enables the module to be used as a native view.
+    // Definition components that are accepted as part of the view definition: `Prop`, `Events`.
+    View(<%- project.name %>View.self) {
       // Defines a setter for the `name` prop.
       Prop("name") { (view: <%- project.name %>View, prop: String) in
         print(prop)


### PR DESCRIPTION
# Why

We've deprecated `ViewManager` definition component in favor of just `View` that takes the view class. It's been changed to better integrate with the view recycling mechanism in Fabric, for which we cannot let the library author to customize the initialization of the view.

# How

This PR migrates the modules template to use the new recommended component

# Test Plan

Successfully created and compiled a new module from the template