### PR TITLE
[modules][Android] Add list of the acceptable enum values

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
+- Added a list of the acceptable enum values to the conversion error on Android.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
-- Added a list of the acceptable enum values to the conversion error on Android.
+- Added a list of the acceptable enum values to the conversion error on Android. ([#19895](https://github.com/expo/expo/pull/19895) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -76,7 +76,7 @@ internal class EnumNoSuchValueException(
   enumConstants: Array<out Enum<*>>,
   value: Any?
 ) : CodedException(
-  message = "'$value' is not present in '${enumType.simpleName}' enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}"
+  message = "'$value' is not present in ${enumType.simpleName} enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}"
 )
 
 internal class MissingTypeConverter(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -76,7 +76,7 @@ internal class EnumNoSuchValueException(
   enumConstants: Array<out Enum<*>>,
   value: Any?
 ) : CodedException(
-  message = "'$value' is not present in '${enumType.simpleName}' enum, it must be one of: '${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}'"
+  message = "'$value' is not present in '${enumType.simpleName}' enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}"
 )
 
 internal class MissingTypeConverter(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -71,6 +71,14 @@ internal class IncompatibleArgTypeException(
   cause = cause
 )
 
+internal class EnumNoSuchValueException(
+  enumType: KClass<Enum<*>>,
+  enumConstants: Array<out Enum<*>>,
+  value: Any?
+) : CodedException(
+  message = "'$value' is not present in '${enumType.simpleName}' enum, it must be one of: '${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}'"
+)
+
 internal class MissingTypeConverter(
   forType: KType
 ) : CodedException(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.logger
@@ -73,9 +74,8 @@ class EnumTypeConverter(
     stringRepresentation: String,
     enumConstants: Array<out Enum<*>>
   ): Enum<*> {
-    return requireNotNull(
-      enumConstants.find { it.name == stringRepresentation }
-    ) { "Couldn't convert '$stringRepresentation' to ${enumClass.simpleName}" }
+    return enumConstants.find { it.name == stringRepresentation }
+      ?: throw EnumNoSuchValueException(enumClass, enumConstants, stringRepresentation)
   }
 
   /**

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/EnumTypeConverterTest.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.DynamicFromObject
 import com.google.common.truth.Truth
+import expo.modules.kotlin.exception.EnumNoSuchValueException
 import org.junit.Test
 
 class EnumTypeConverterTest {
@@ -51,5 +52,13 @@ class EnumTypeConverterTest {
     Truth.assertThat(converter.convert(v1)).isSameInstanceAs(EnumWithString.VALUE1)
     Truth.assertThat(converter.convert(v2)).isSameInstanceAs(EnumWithString.VALUE2)
     Truth.assertThat(converter.convert(v3)).isSameInstanceAs(EnumWithString.VALUE3)
+  }
+
+  @Test(expected = EnumNoSuchValueException::class)
+  fun `should throw when value is invalid`() {
+    val value = DynamicFromObject("INVALID")
+    val converter = obtainTypeConverter<EnumWithoutParameter>()
+
+    converter.convert(value)
   }
 }


### PR DESCRIPTION
# Why

Fixes ENG-6881.

# How

In the case of the simple enum (with the default constructor), we can provide more descriptive errors when we can't convert a provided value to the enum class. 

# Test Plan

- unit test:
New error:
```
'INVALID' is not present in 'EnumWithoutParameter' enum, it must be one of: 'VALUE1', 'VALUE2', 'VALUE3'
```

