### PR TITLE
[modules][Android] Expose coroutines related packages

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Exposed coroutines related packages on Android.
+
 ## 1.0.0 — 2022-11-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Exposed coroutines related packages on Android.
+- Exposed coroutines related packages on Android. ([#19896](https://github.com/expo/expo/pull/19896) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.0.0 — 2022-11-03
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -286,7 +286,11 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
   implementation 'androidx.annotation:annotation:1.3.0'
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
+
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0"
+  api "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.0"
+  api "androidx.core:core-ktx:1.6.0"
+
   /**
    * ReactActivity (the base activity for every React Native application) is subclassing AndroidX classes.
    * Unfortunately until https://github.com/facebook/react-native/pull/33072 is released React Native uses "androidx.appcompat:appcompat:1.0.2".


### PR DESCRIPTION
# Why

A different approach to expose commonly required dependencies than https://github.com/expo/expo/pull/19889.

# How

Exposed coroutines-related packages as an API from the `build.gradle` of `expo-modules-core`.

# Test Plan

- bare-expo ✅