### PR TITLE
[modules][template] Start using `ExpoView` instead of Android's`View`

### DIFF
--- a/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}View.kt
+++ b/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}View.kt
@@ -1,6 +1,7 @@
 package <%- project.package %>
 
 import android.content.Context
-import android.view.View
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.ExpoView
 
-class <%- project.name %>View(context: Context) : View(context)
+class <%- project.name %>View(context: Context, appContext: AppContext) : ExpoView(context, appContext)


### PR DESCRIPTION
# Why

Start using `ExpoView` instead of Android's`View`.

