### PR TITLE
[modules][Android] Add a component that declares a prop group

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -67,6 +67,52 @@ class ViewManagerDefinitionBuilder {
   }
 
   /**
+   * Creates a view prop group that defines its name and setter.
+   */
+  inline fun <reified ViewType : View, reified PropType> Prop(
+    vararg names: String,
+    noinline body: (name: String, view: ViewType, prop: PropType) -> Unit
+  ) {
+    for (name in names) {
+      props[name] = ConcreteViewProp<ViewType, PropType>(
+        name,
+        typeOf<PropType>().toAnyType()
+      ) { view, prop -> body(name, view, prop) }
+    }
+  }
+
+  /**
+   * Creates a view prop group that defines its name and setter with the custom mapping.
+   */
+  inline fun <reified ViewType : View, reified PropType, reified CustomValue> Prop(
+    vararg propInfo: Pair<String, CustomValue>,
+    noinline body: (value: CustomValue, view: ViewType, prop: PropType) -> Unit
+  ) {
+    for ((name, value) in propInfo) {
+      props[name] = ConcreteViewProp<ViewType, PropType>(
+        name,
+        typeOf<PropType>().toAnyType()
+      ) { view, prop -> body(value, view, prop) }
+    }
+  }
+
+  /**
+   * Creates a view prop group that defines its name and setter with the index mapping.
+   */
+  @JvmName("PropGroup")
+  inline fun <reified ViewType : View, reified PropType> Prop(
+    vararg names: String,
+    noinline body: (value: Int, view: ViewType, prop: PropType) -> Unit
+  ) {
+    names.forEachIndexed { index, name ->
+      props[name] = ConcreteViewProp<ViewType, PropType>(
+        name,
+        typeOf<PropType>().toAnyType()
+      ) { view, prop -> body(index, view, prop) }
+    }
+  }
+
+  /**
    * Defines prop names that should be treated as callbacks.
    */
   fun Events(vararg callbacks: String) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -69,46 +69,46 @@ class ViewManagerDefinitionBuilder {
   /**
    * Creates a view prop group that defines its name and setter.
    */
-  inline fun <reified ViewType : View, reified PropType> Prop(
+  inline fun <reified ViewType : View, reified PropType> PropGroup(
     vararg names: String,
-    noinline body: (name: String, view: ViewType, prop: PropType) -> Unit
+    noinline body: (view: ViewType, name: String, prop: PropType) -> Unit
   ) {
     for (name in names) {
       props[name] = ConcreteViewProp<ViewType, PropType>(
         name,
         typeOf<PropType>().toAnyType()
-      ) { view, prop -> body(name, view, prop) }
+      ) { view, prop -> body(view, name, prop) }
     }
   }
 
   /**
    * Creates a view prop group that defines its name and setter with the custom mapping.
    */
-  inline fun <reified ViewType : View, reified PropType, reified CustomValue> Prop(
+  inline fun <reified ViewType : View, reified PropType, reified CustomValue> PropGroup(
     vararg propInfo: Pair<String, CustomValue>,
-    noinline body: (value: CustomValue, view: ViewType, prop: PropType) -> Unit
+    noinline body: (view: ViewType, value: CustomValue, prop: PropType) -> Unit
   ) {
     for ((name, value) in propInfo) {
       props[name] = ConcreteViewProp<ViewType, PropType>(
         name,
         typeOf<PropType>().toAnyType()
-      ) { view, prop -> body(value, view, prop) }
+      ) { view, prop -> body(view, value, prop) }
     }
   }
 
   /**
    * Creates a view prop group that defines its name and setter with the index mapping.
    */
-  @JvmName("PropGroup")
-  inline fun <reified ViewType : View, reified PropType> Prop(
+  @JvmName("PropGroupIndexed")
+  inline fun <reified ViewType : View, reified PropType> PropGroup(
     vararg names: String,
-    noinline body: (value: Int, view: ViewType, prop: PropType) -> Unit
+    noinline body: (view: ViewType, value: Int, prop: PropType) -> Unit
   ) {
     names.forEachIndexed { index, name ->
       props[name] = ConcreteViewProp<ViewType, PropType>(
         name,
         typeOf<PropType>().toAnyType()
-      ) { view, prop -> body(index, view, prop) }
+      ) { view, prop -> body(view, index, prop) }
     }
   }
 


### PR DESCRIPTION
# Why

Adds a way to declare a group of properties. Similar to the `@ReactPropGroup`. 

# How

Adds 3 new versions of the prop group. The first one can receive multiple prop names and then you can distinguish which one was called based on the additional parameter in the prop setter. The second version maps props to their indexes. Finally, the third one uses custom mapping. 

# Test Plan

Usage:
```
PropGroup("p1", "p2") { view: ViewType, name: String, prop: String ->

}

PropGroup("p1", "p2") { view: ViewType, index: Int, prop: String ->

}

PropGroup("p1" to 1, "p2" to 2) { view: ViewType, value: Int, prop: String ->

}
```