### PR TITLE
feat!(jest-expo): Drop support for .expo extension

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Drop support for `.expo.*` extensions (deprecated in SDK 41).
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Drop support for `.expo.*` extensions (deprecated in SDK 41).
+- Drop support for `.expo.*` extensions (deprecated in SDK 41). ([#19910](https://github.com/expo/expo/pull/19910) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -1,11 +1,11 @@
 'use strict';
-const { getManagedExtensions } = require('@expo/config/paths');
+const { getBareExtensions } = require('@expo/config/paths');
 
 const expoPreset = require('../jest-preset');
 const { withWatchPlugins } = require('./withWatchPlugins');
 
 function getPlatformPreset(displayOptions, extensions) {
-  const moduleFileExtensions = getManagedExtensions(extensions, {
+  const moduleFileExtensions = getBareExtensions(extensions, {
     isTS: true,
     isReact: true,
     isModern: false,

--- a/packages/jest-expo/tests/__tests__/workflow-test.ios.js
+++ b/packages/jest-expo/tests/__tests__/workflow-test.ios.js
@@ -1,3 +1,3 @@
 it(`resolves a workflow extension`, () => {
-  expect(require('../workflow').default).toContain('workflow.ios.expo');
+  expect(require('../workflow').default).toContain('workflow.ios');
 });


### PR DESCRIPTION
# Why

We stopped supporting `.expo.*` extensions in SDK 41.