### PR TITLE
[emc] Rephrase ArgumentCastException to use ordinal numbers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Rephrased the message of `ArgumentCastException` to use ordinal numbers. ([#19912](https://github.com/expo/expo/pull/19912) by [@tsapeta](https://github.com/tsapeta))
+
 ## 1.0.1 - 2022-11-07
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -145,9 +145,19 @@ internal class ArgumentCastException(
   providedType: ReadableType,
   cause: CodedException,
 ) : DecoratedException(
-  message = "Argument at index '$argIndex' couldn't be casted to type '$argDesiredType' (received '$providedType').",
+  message = "The ${formatOrdinalNumber(argIndex + 1)} argument cannot be cast to type $argDesiredType (received $providedType)",
   cause,
-)
+) {
+  companion object {
+    fun formatOrdinalNumber(number: Int) = "$number" + when {
+      (number % 100 in 11..13) -> "th"
+      (number % 10) == 1 -> "st"
+      (number % 10) == 2 -> "nd"
+      (number % 10) == 3 -> "rd"
+      else -> "th"
+    }
+  }
+}
 
 internal class FieldCastException(
   fieldName: String,

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -150,7 +150,7 @@ class KotlinInteropModuleRegistryTest {
         JavaOnlyArray().apply { pushString("string") }
       ) to """
         Call to function 'test-2.f2' has been rejected.
-        → Caused by: Argument at index '0' couldn't be casted to type 'kotlin.Int' (received 'String').
+        → Caused by: The 1st argument cannot be cast to type kotlin.Int (received String)
         → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
       """.trimIndent(),
       Triple(
@@ -167,7 +167,7 @@ class KotlinInteropModuleRegistryTest {
         JavaOnlyArray().apply { pushMap(JavaOnlyMap().apply { putInt("string", 10) }) }
       ) to """
         Call to function 'test-1.f2' has been rejected.
-        → Caused by: Argument at index '0' couldn't be casted to type 'expo.modules.kotlin.TestRecord' (received 'Map').
+        → Caused by: The 1st argument cannot be cast to type expo.modules.kotlin.TestRecord (received Map)
         → Caused by: Cannot create a record of the type: 'expo.modules.kotlin.TestRecord'.
         → Caused by: Cannot cast 'Number' for field 'string' ('kotlin.String').
         → Caused by: java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.String (java.lang.Double and java.lang.String are in module java.base of loader 'bootstrap')

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -75,7 +75,7 @@ class AnyFunctionTest {
 
     assertThrows<ArgumentCastException>(
       """
-      Argument at index '0' couldn't be casted to type 'kotlin.Int' (received 'String').
+      The 1st argument cannot be cast to type kotlin.Int (received String)
       → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
       """.trimIndent()
     ) {

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -63,7 +63,14 @@ internal class InvalidArgsNumberException: GenericException<(received: Int, expe
 
 internal class ArgumentCastException: GenericException<(index: Int, type: AnyDynamicType)> {
   override var reason: String {
-    "Argument at index '\(param.index)' couldn't be cast to type \(param.type.description)"
+    "The \(formatOrdinalNumber(param.index + 1)) argument cannot be cast to type \(param.type.description)"
+  }
+
+  func formatOrdinalNumber(_ number: Int) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .ordinal
+    formatter.locale = Locale(identifier: "en_US")
+    return formatter.string(from: NSNumber(value: number)) ?? ""
   }
 }
 


### PR DESCRIPTION
# Why

The reason message of `ArgumentCastException` is a bit awkward:

```
Argument at index '0' couldn't be cast to type Enum<NotificationType>
```

# How

Now it returns a message like this:

```
The 1st argument cannot be cast to type Enum<NotificationType>
```

# Test Plan

Called some Haptics method with a value that cannot be cast to the expected enum value and confirmed the error message is correct