### PR TITLE
[emt] Pass in appContext to view

### DIFF
--- a/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
+++ b/packages/expo-module-template/android/src/main/java/{%= project.package %}/{%- project.name %}Module.kt
@@ -41,7 +41,7 @@ class <%- project.name %>Module : Module() {
     ViewManager {
       // Defines the factory creating a native view when the module is used as a view.
       View { context -> 
-        <%- project.name %>View(context) 
+        <%- project.name %>View(context, appContext)
       }
 
       // Defines a setter for the `name` prop.


### PR DESCRIPTION
# Why

Required after https://github.com/expo/expo/commit/6cdcf6514c85e7aacc5fc9167d11b678228eb3bb

# How

Pass in `appContext`

# Test Plan

Tried it out in a new module