### PR TITLE
[docs] Clarify that splash screen must be PNG

### DIFF
--- a/docs/pages/guides/splash-screens.mdx
+++ b/docs/pages/guides/splash-screens.mdx
@@ -30,7 +30,7 @@ You can work off of [this Sketch template](https://github.com/expo/files/blob/b2
 
 Export the image as a PNG and put it in your project directory. I'll assume it's in the **assets** directory and named **splash.png**.
 
-**Note:** Currently only PNG images are supported. If you use another image format, making a production build of your app will fail.
+> **warning:** Currently only PNG images are supported. If you use another image format, making a production build of your app will fail.
 
 ### `splash.image`
 

--- a/docs/pages/guides/splash-screens.mdx
+++ b/docs/pages/guides/splash-screens.mdx
@@ -30,6 +30,8 @@ You can work off of [this Sketch template](https://github.com/expo/files/blob/b2
 
 Export the image as a PNG and put it in your project directory. I'll assume it's in the **assets** directory and named **splash.png**.
 
+**Note:** Currently only PNG images are supported. If you use another image format, making a production build of your app will fail.
+
 ### `splash.image`
 
 Open the [Expo config][expo-config] (**app.json**, **app.config.js**) and add the following:


### PR DESCRIPTION
Fixes #1654

# Why

Some background is already in #1654. I ran into this today and reading the documentation (or googling for that matter) didn't make it explicitly clear that JPEG images won't work...

# How

Added a note in the documentation.

# Test Plan

Read the updated documentation.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
