### PR TITLE
[docs] separate development Sentry errors from the production ones

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -16,6 +16,7 @@ import 'tippy.js/dist/tippy.css';
 Sentry.init({
   dsn: 'https://1a2f5c8cec574bcea3971b74f91504d6@o30871.ingest.sentry.io/1526800',
   beforeSend: preprocessSentryError,
+  environment: process.env.NODE_ENV === 'development' ? 'development' : 'production',
 });
 
 const rootMarkdownComponents = {


### PR DESCRIPTION
# Why

Currently we track the error induced during the development as production ones, let's correct this.

# How

Change the Sentry environment when running in dev mode.

# Test Plan

Test if development induced errors are correctly tracked on Sentry:

<img width="478" alt="Screenshot 2022-11-08 095510" src="https://user-images.githubusercontent.com/719641/200519571-e69da39b-ec98-4caa-818d-34b9f4289269.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
