### PR TITLE
[docs] fix typos in Expo modules docs, add Objective-C to dict

### DIFF
--- a/docs/expo-dict.json
+++ b/docs/expo-dict.json
@@ -11,6 +11,7 @@
   "expo sdk": "Expo SDK",
   "ios simulator": "iOS Simulator",
   "mac os": "macOS",
+  "objective c": "Objective-C",
   "play store": "Play Store",
   "react navigation": "React Navigation",
   "turtle cli": "Turtle CLI",

--- a/docs/pages/modules/appdelegate-subscribers.mdx
+++ b/docs/pages/modules/appdelegate-subscribers.mdx
@@ -18,7 +18,7 @@ First, you need to have created an Expo module or integrated the Expo modules AP
 
 Create a new public Swift class that extends `ExpoAppDelegateSubscriber` from `ExpoModulesCore` and add its name to the `ios.appDelegateSubscribers` array in the [module config](./module-config.mdx). Run `pod install`, and the subscriber will be generated in the **ExpoModulesProvider.swift** file within the application project.
 
-Now you can subscribe to events by adding delegate functions to your subscriber class. For the full list of functions that you can subscribe to, see the functions that are overriden in [`ExpoAppDelegate.swift`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift). App delegate functions that may cause side effects when provided are not supported yet (e.g. [`application(_:viewControllerWithRestorationIdentifierPath:coder:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623062-application)).
+Now you can subscribe to events by adding delegate functions to your subscriber class. For the full list of functions that you can subscribe to, see the functions that are overridden in [`ExpoAppDelegate.swift`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift). App delegate functions that may cause side effects when provided are not supported yet (e.g. [`application(_:viewControllerWithRestorationIdentifierPath:coder:)`](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623062-application)).
 
 > Objective-C classes are not supported.
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -9,7 +9,7 @@ import { APIMethod } from '~/components/plugins/api/APISectionMethods';
 
 > **warning** Expo Modules APIs are in beta and subject to breaking changes.
 
-The native modules API is an abstraction layer on top of [JSI](https://reactnative.dev/architecture/glossary#javascript-interfaces-jsi) and other low-level primities that React Native is built upon. It is built with modern languages (Swift and Kotlin) and provides an easy to use and convenient API that is consistent across platforms where possible.
+The native modules API is an abstraction layer on top of [JSI](https://reactnative.dev/architecture/glossary#javascript-interfaces-jsi) and other low-level primitives that React Native is built upon. It is built with modern languages (Swift and Kotlin) and provides an easy to use and convenient API that is consistent across platforms where possible.
 
 ## Definition Components
 
@@ -580,7 +580,7 @@ On iOS, `ExpoView` extends the `RCTView` which handles some styles (e.g. borders
 
 #### Extending `ExpoView`
 
-To export your view using the [`View`](#view) component, your custom class must inherit from the `ExpoView`. By doing that you will get access to the [`AppContext`](#appcontext) object. It's the only way of communicating with other modules and the JavaScript runtime. Also, you can't change constructor parameters, becuase provided view will be initialized by `expo-modules-core`.
+To export your view using the [`View`](#view) component, your custom class must inherit from the `ExpoView`. By doing that you will get access to the [`AppContext`](#appcontext) object. It's the only way of communicating with other modules and the JavaScript runtime. Also, you can't change constructor parameters, because provided view will be initialized by `expo-modules-core`.
 
 <CodeBlocksTable>
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -53,7 +53,7 @@ This is one of the reasons why the Expo Modules ecosystem was designed from the 
 ### Passing data between runtimes
 
 Another big pain point we have encountered is the validation of arguments passed from JavaScript to native functions.
-This is especially error prone, time consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime, and each property needs to be validated separately by the developer.
+This is especially error-prone, time-consuming, and difficult to maintain when it comes to `NSDictionary` or `ReadableMap`, where the type of values is unknown in runtime, and each property needs to be validated separately by the developer.
 A valuable feature of the Expo native modules API is its full knowledge of the argument types the native function expects. It can pre-validate and convert the arguments for you! The dictionaries can be represented as native structs that we call [Records](./module-api.md#records).
 Knowing the argument types, it is also possible to [automatically convert arguments](./module-api.md#convertibles) to some platform-specific types (for example, `{ x: number, y: number }` or `[number, number]` can be translated to CoreGraphics's `CGPoint` for your convenience).
 


### PR DESCRIPTION
# Why

Was testing the new dict addition and found those typos while ready the content for the other potential dict additions.

# How

Fix found typos in Expo modules docs, add "Objective-C" spelling check to the dict.

# Test Plan

The changes have been tested by running website app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
