### PR TITLE
[docs] squash several typos, gramma fixes

### DIFF
--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -75,7 +75,7 @@ The example below is Step 3 in the conversion process on a Personal Account with
   style={{ maxWidth: 720 }}
 />
 
-After completing the conversion process, you will no longer be able to log in as the your old user. To continue using Expo services, log into [expo.dev](https://expo.dev/) with the user you selected or created during the conversion process. Then, select the organization from the top left dropdown to access the organization.
+After completing the conversion process, you will no longer be able to log in as your old user. To continue using Expo services, log into [expo.dev](https://expo.dev/) with the user you selected or created during the conversion process. Then, select the organization from the top left dropdown to access the organization.
 
 ### Inviting members
 
@@ -126,7 +126,7 @@ Projects can be transferred a limited number of times. A user must be an Owner o
 
 Before transferring a project, make sure that it is on Expo SDK 43 or above. If not, you must upgrade it and rebuild it for OTA updates to continue to work on that project.
 
-> If you want to transfer the ownership of a project from your Personal or Organization Account (source) to another person or company (destination), and you cannot be given "Owner or "Admin" permissions on the destination account, you can create an escrow account (a new Organization Account). This solves the problem that a user must be an "Owner" on the source account and either an "Owner" or "Admin" on the destination account to transfer projects between them. Once the escrow account is created, you can grant the ultimate destination account member the Owner role on the escrow account and safely transfer the project to the escrow account. The receiving person or company can then transfer it to their destination account from the escrow account without having had access to the destination account itself.
+> If you want to transfer the ownership of a project from your Personal or Organization Account (source) to another person or company (destination), and you cannot be given "Owner" or "Admin" permissions on the destination account, you can create an escrow account (a new Organization Account). This solves the problem that a user must be an "Owner" on the source account and either an "Owner" or "Admin" on the destination account to transfer projects between them. Once the escrow account is created, you can grant the ultimate destination account member the Owner role on the escrow account and safely transfer the project to the escrow account. The receiving person or company can then transfer it to their destination account from the escrow account without having had access to the destination account itself.
 
 ## Teams
 

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -121,7 +121,7 @@ Let's say that your project consists of a main application target (named `multit
   style={{ maxWidth: 360 }}
 />
 
-In this case your **credentials.json** should like like this:
+In this case your **credentials.json** should look like this:
 
 {/* prettier-ignore */}
 ```json

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -121,7 +121,7 @@ Let's say that your project consists of a main application target (named `multit
   style={{ maxWidth: 360 }}
 />
 
-In this case your **credentials.json** should look like this:
+In this case, your **credentials.json** should look like below:
 
 {/* prettier-ignore */}
 ```json

--- a/docs/pages/archived/adhoc-builds.mdx
+++ b/docs/pages/archived/adhoc-builds.mdx
@@ -129,7 +129,7 @@ On iOS versions earlier than 12.2, if you aren't taken to the `Installing Profil
 
 #### iOS 12.2+
 
-On iOS versions 12.2 or later, a window will popup saying `Profile Downloaded`. Close the popup, go to the `Settings` app and navigate to the `Profile Downloaded` option to download the device enrollment challenge.
+On iOS versions 12.2 or later, a window will pop up saying `Profile Downloaded`. Close the popup, go to the `Settings` app and navigate to the `Profile Downloaded` option to download the device enrollment challenge.
 
 ![UDID Workflow](/static/images/adhoc-builds-udid2.png)
 
@@ -197,7 +197,7 @@ Revoking an existing distribution certificate associated with an app is safe if:
 Revoking an existing distribution certificate associated with an app is **NOT** safe if:
 
 - Your app is distributed through the App Store and you are on an Apple Enterprise account.
-- Your app is distributed ad hoc (distributed outside of the App Store for testing purposes).
+- Your app is distributed ad hoc (distributed outside the App Store for testing purposes).
 
 An App Store app gets re-signed with an Apple certificate when it goes on the store with non-Enterprise accounts. Revoking the certificate therefore won't affect it. Enterprise apps and apps distributed ad hoc use the original certificate, which means revoking it will cause the app to stop functioning on all devices it is installed on.
 

--- a/docs/pages/archived/expo-cli.mdx
+++ b/docs/pages/archived/expo-cli.mdx
@@ -770,7 +770,7 @@ In Expo SDK 46, we migrated to a new suite of tooling that is versioned in the `
 
 ### Other Notes
 
-- Dev Tools UI has been deprecated in favor of the the CLI's Terminal UI, Flipper, and Remote Debugging.
+- Dev Tools UI has been deprecated in favor of the CLI's Terminal UI, Flipper, and Remote Debugging.
 - `npx expo install` now supports installing the correct version of `react-native`, `react`, `react-dom` automatically.
 - Tooling now supports `pnpm` along with Yarn and npm, the default is still Yarn.
 - Dropped the deprecated `--config` argument across all commands. Use `app.config.js` instead.

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -4,7 +4,7 @@ title: Using private npm packages
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-EAS Build comes with full support for using private npm packages in your project. These can either be published to npm (if you have [the Pro/Teams plan](https://www.npmjs.com/products)) or to a private registry (for example, using self-hosted [verdaccio](https://verdaccio.org/)).
+EAS Build comes with full support for using private npm packages in your project. These can either be published to npm (if you have [the Pro/Teams plan](https://www.npmjs.com/products)) or to a private registry (for example, using self-hosted [Verdaccio](https://verdaccio.org/)).
 
 You will need to configure your project and/or provide EAS Build with your npm token before you start the build.
 
@@ -50,7 +50,7 @@ You can verify it worked by viewing build logs and looking for the `Prepare proj
 
 ## Using packages published to a private registry
 
-If you're using a private npm registry like self-hosted [verdaccio](https://verdaccio.org/), you will need to configure the `.npmrc` file manually.
+If you're using a private npm registry like self-hosted [Verdaccio](https://verdaccio.org/), you will need to configure the `.npmrc` file manually.
 
 Create an `.npmrc` file in your project's root directory with the following contents:
 

--- a/docs/pages/build-reference/simulators.mdx
+++ b/docs/pages/build-reference/simulators.mdx
@@ -21,7 +21,7 @@ To build your app for installation into an iOS simulator, you can create a new p
 }
 ```
 
-Now, to run your build run `eas build -p ios --profile preview`. Remember that you can name the profile whatever you like; we named the profile "preview", but you could call it "simulator", "local", or "simulador" &mdash; whatever makes most sense for you.
+Now, to run your build run `eas build -p ios --profile preview`. Remember that you can name the profile whatever you like; we named the profile "preview", but you could call it "simulator", "local", or "simulator" &mdash; whatever makes most sense for you.
 
 ## Installing your build on the simulator
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -142,7 +142,7 @@ If you're using a **.env** file for storing your secrets locally, you can use th
 
 Beware that EAS CLI will fail if some of the secrets defined in the dotenv file already exist on the server. To force overriding those secrets, pass the `--force` flag to the command.
 
-#### Doppler intergration
+#### Doppler integration
 
 You can use the `eas secret:push` command to integrate EAS with your [Doppler](https://doppler.com/) project:
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -36,7 +36,7 @@ Learn how to [build standalone apps on your CI with our classic build service](/
 
 {/* The latter is the easiest way, but may increase the installation time. */}
 
-{/* For vendors that charge you per minute, it might we worth creating a prebuilt environment. */}
+{/* For vendors that charge you per minute, it might be worth creating a prebuilt environment. */}
 
 {/* To install EAS CLI in your project, run: */}
 

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -6,7 +6,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { theme } from '@expo/styleguide';
 
-Uploading your app to TestFlight and Google Play beta can be time consuming (e.g. waiting for the build to run through static analysis before becoming available to testers) and limiting (e.g. TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
+Uploading your app to TestFlight and Google Play beta can be time-consuming (e.g. waiting for the build to run through static analysis before becoming available to testers) and limiting (e.g. TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
 
 EAS Build can help you with this by providing shareable URLs for your builds with instructions on how to get them running, so you can share a single URL with a teammate that'll include all of the information they need to test the app.
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -26,7 +26,7 @@ The following example demonstrates how you might use the `"production"` channel 
 
 ## Binary compatibility and runtime versions
 
-Your native runtime may change on each build, depending on whether you modify the code in a way that changes the API contract with JavaScript. If you publish a JavaScript bundle to a binary with an incompatible native runtime (for example, a function that the JavaScript bundle expects to exist does not exist) then your app may not work as expected or it may crash.
+Your native runtime may change on each build, depending on whether you modify the code in a way that changes the API contract with JavaScript. If you publish a JavaScript bundle to a binary with an incompatible native runtime (for example, a function that the JavaScript bundle expects to exist does not exist) then your app may not work as expected, or it may crash.
 
 We recommend using a different [runtime version](/distribution/runtime-versions.mdx) for each binary version of your app. Any time you change the native runtime (in managed apps, this happens when you add or remove a native library, or modify **app.json**), you should increment the runtime version.
 

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -66,7 +66,7 @@ The changes above affect the native code layer inside builds, which means you'll
 
 ## Publishing an update
 
-After making a change to your poject locally, you're ready to publish an update, run:
+After making a change to your project locally, you're ready to publish an update, run:
 
 ```bash
 eas update --branch [branch-name] --message [message]

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -6,13 +6,9 @@ sidebar_depth: 4
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { markdownComponents as MD } from '~/ui/components/Markdown';
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import {
   MetadataTable,
   MetadataSubcategories,
-  MetadataNameCell,
-  MetadataTypeCell,
-  MetadataDescriptionCell,
 } from '~/components/plugins/EasMetadataTable';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.

--- a/docs/pages/guides/config-plugins.mdx
+++ b/docs/pages/guides/config-plugins.mdx
@@ -749,7 +749,7 @@ interface StaticObject {
 
 Static properties are required because the Expo config must be serializable to JSON for use as the app manifest. Static properties can also enable tooling that generates JSON schema type checking for autocomplete and IntelliSense.
 
-If possible, attempt to make your plugin work without props, this will help resolution tooling like [`expo install`][#expo-install] or [vscode expo][vscode-expo] work better. Remember that every property you add increases complexity, making it harder to change in the future and increase the amount of features you'll need to test. Good default values are preferred over mandatory configuration when feasible.
+If possible, attempt to make your plugin work without props, this will help resolution tooling like [`expo install`](#expo-install) or [vscode expo][vscode-expo] work better. Remember that every property you add increases complexity, making it harder to change in the future and increase the amount of features you'll need to test. Good default values are preferred over mandatory configuration when feasible.
 
 ### Configuring Android App Startup
 

--- a/docs/pages/guides/splash-screens.mdx
+++ b/docs/pages/guides/splash-screens.mdx
@@ -110,7 +110,7 @@ We recommend displaying a `SplashScreen` when [pre-loading and caching assets](/
 Your app can be opened from the [Expo Go][expo-go] app or in a standalone app, and it can be either published or in development. There are slight differences in the splash screen behavior between these environments.
 
 <ImageSpotlight
-  alt="iOS splash screen bechaviour"
+  alt="iOS splash screen behaviour"
   src="https://media.giphy.com/media/l378l98EI0VQdwRzy/giphy.gif"
 />
 

--- a/docs/pages/guides/troubleshooting-proxies.mdx
+++ b/docs/pages/guides/troubleshooting-proxies.mdx
@@ -34,14 +34,12 @@ In order to run this in the local iOS Simulator while on your corporate wi-fi ne
    Username: YOUR USERNAME
    Password: YOUR PASSWORD
 7. Same for Secure Web Proxy (HTTPS). _Be sure to fill in the same proxy, username, and password address_ fields.
-8. In the text area for `Bypass external proxies for the following hosts:` enter
-
-```
-localhost
-*.local
-```
-
-You may need to include your mail server, or other corporate network addresses.
+8. In the text area for `Bypass external proxies for the following hosts:` enter:
+   ```
+   localhost
+   *.local
+   ```
+   You may need to include your mail server, or other corporate network addresses.
 
 9. Check "Always bypass external proxies for localhost"
 

--- a/docs/pages/next-steps/additional-resources.mdx
+++ b/docs/pages/next-steps/additional-resources.mdx
@@ -11,7 +11,7 @@ The following resources are useful for learning about Expo tooling and services.
 ## GitHub
 
 - [expo/expo](https://github.com/expo/expo) - Expo Go, SDK, Docs, and the Expo CLI.
-- [expo/eas-cli](https://github.com/expo/eas-cli) - Fastest way to build, submit, and update iOS and Android apps.
+- [expo/eas-cli](https://github.com/expo/eas-cli) - The fastest way to build, submit, and update Android and iOS apps.
 - [expo/examples](https://github.com/expo/examples) - Integrations and other examples.
 - [expo/config-plugins](https://github.com/expo/config-plugins) - Expo Config Plugins for working with third-party packages.
 - [expo/snack](https://github.com/expo/snack) - Build apps from the browser.

--- a/docs/pages/push-notifications/faq.mdx
+++ b/docs/pages/push-notifications/faq.mdx
@@ -75,7 +75,7 @@ Expo abstracts the majority of credential management away so that you can focus 
 
 ### Push notifications _occasionally_ stop coming through on Android
 
-This is likely due to the `priority` level of the notifications you're sending. You can learn more about Android priority [here](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json), but as for how it relates to Expo- [Expo accepts four priorities](/push-notifications/sending-notifications/#message-request-format):
+This is likely due to the `priority` level of the notifications you're sending. You can learn more about Android priority [here](https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json), but as for how it relates to Expo - [Expo accepts four priorities](/push-notifications/sending-notifications/#message-request-format):
 
 - `default`: manually mapped to the default priority documented by Apple and Google
 - `high`: mapped to the high priority level documented by Apple and Google

--- a/docs/pages/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/technical-specs/expo-updates-0.mdx
@@ -183,7 +183,7 @@ type ExpoAssetHeaderDictionary = {
 }
 ```
 
-- `assetRequestHeaders`: MAY contain an dictionary of header (key, value) pairs to include with asset requests. Key and value MUST both be strings.
+- `assetRequestHeaders`: MAY contain a dictionary of header (key, value) pairs to include with asset requests. Key and value MUST both be strings.
 
 ## Asset Request
 

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -29,7 +29,7 @@ If you're in this situation, the error message you're seeing is a [red herring](
 
 Look at your logs prior to this error message to see what may have caused it. A frequent cause is multiple versions of a native module dependency that registers itself as a view &mdash; for example [this StackOverflow thread](https://stackoverflow.com/questions/67543844/invariant-violation-main-has-not-been-registered-while-running-react-native-a/67550379) where the poster has multiple versions of `react-native-safe-area-context` in their dependencies.
 
-### Your app root component may not registered
+### Your app root component may not be registered
 
 Another possibility is that there is a mismatch between the `AppKey` being provided to [`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent), and the `AppKey` being registered on the native iOS or Android side.
 

--- a/docs/pages/tutorial/button.mdx
+++ b/docs/pages/tutorial/button.mdx
@@ -77,7 +77,7 @@ export default function App() {
       <Text style={styles.instructions}>
         To share a photo from your phone with a friend, just press the button below!
       </Text>
-      <TouchableOpacity onPress={() => alert('Hello, world!')} /* @info We moved our our style down to the StyleSheet, keep scrolling! */ style={styles.button}/* @end */>
+      <TouchableOpacity onPress={() => alert('Hello, world!')} /* @info We moved our style down to the StyleSheet, keep scrolling! */ style={styles.button}/* @end */>
         <Text /* @info See StyleSheet */style={styles.buttonText}/* @end */>Pick a photo</Text>
       </TouchableOpacity>
     </View>

--- a/docs/pages/workflow/already-used-react-native.mdx
+++ b/docs/pages/workflow/already-used-react-native.mdx
@@ -25,9 +25,9 @@ Managed Expo projects also offer updates and a push notification service.
 
 Expo offers a shared configuration file we call a _manifest_.
 
-- Configuration that you would typically do inside of your Xcode / plist files or Android studio / xml files is handled through **app.json**. For example, if you want to lock the orientation, change your icon, customize your splash screen, add/remove permissions and entitlements (in standalone apps), configure keys for Google Maps and other services, you set this in **app.json** and it will apply to both iOS and Android. [See the guide here](/workflow/configuration.mdx).
+- Configuration that you would typically do inside your Xcode / plist files or Android studio / xml files is handled through **app.json**. For example, if you want to lock the orientation, change your icon, customize your splash screen, add/remove permissions and entitlements (in standalone apps), configure keys for Google Maps and other services, you set this in **app.json** and it will apply to both iOS and Android. [See the guide here](/workflow/configuration.mdx).
 
-In the managed workflow, you can share your app with anyone, anywhere in the world while you're working through the Expo Go app [(available on the App / Play Store)](https://expo.dev). Scan a QR code, or enter in a phone number and we'll send you a link that will instantly load your app on your device.
+In the managed workflow, you can share your app with anyone, anywhere in the world while you're working through the Expo Go app [(available on the App / Play Store)](https://expo.dev). Scan a QR code, or enter a phone number and we'll send you a link that will instantly load your app on your device.
 
 - Instead of having to sign up several external testers through App Store Connect, you can easily have them download the Expo Go app and immediately have a working version on their phone.
 

--- a/docs/pages/workflow/debugging.mdx
+++ b/docs/pages/workflow/debugging.mdx
@@ -50,7 +50,7 @@ When you're done, simply delete the native folder with `rm -rf ios` to continue 
 1. Generate the native code for your project with: `npx expo prebuild -p android`
    1. You can delete the `/android` folder when you're done to ensure your project remains managed by Expo CLI. Keeping the folder and manually modifying it outside of `npx expo prebuild` means you'll need to manually upgrade and configure native libraries (Bare Workflow).
 2. Open the project in Android Studio: `open -a /Applications/Android\ Studio.app ./android`
-3. Build the app from Android Studio and connect the debugger. Refer to the [Google docs for more information](https://developer.android.com/studio/debug#startdebug).
+3. Build the app from Android Studio and connect the debugger. Refer to the [Google documentation for more information](https://developer.android.com/studio/debug#startdebug).
 
 When you're done, simply delete the native folder with `rm -rf android` to continue having your code managed by Expo.
 
@@ -64,7 +64,7 @@ Using an automated error logging system like [Sentry](../guides/using-sentry.mdx
 
 ### My production app is crashing
 
-This can be a really frustrating scenario, since it gives you very little information to go off of on first glance. It's important now to reproduce the issue, and, even if you can't do that, to find any related crash reports.
+This can be a really frustrating scenario, since it gives you very little information to go off of at first glance. It's important now to reproduce the issue, and, even if you can't do that, to find any related crash reports.
 
 - Reproduce the crash (either using your production app, or the Expo Go app)
 - **Find an associated JavaScript crash report**: Check your JavaScript error reporting service (such as Sentry).
@@ -207,11 +207,11 @@ React DevTools can also be paired with remote debugging, allowing you to inspect
 
 ### Remote debugging with Chrome Developer Tools
 
-You can debug React Native apps using the Chrome debugger tools. Rather than running your app's JavaScript on your phone, it will instead run it inside of a webworker in Chrome. You can then set breakpoints, inspect variables, execute code, etc, as you would when debugging a web app.
+You can debug React Native apps using the Chrome debugger tools. Rather than running your app's JavaScript on your phone, it will instead run it inside of a webworker in Chrome. You can then set breakpoints, inspect variables, execute code, etc., as you would when debugging a web app.
 
 - To ensure the best debugging experience, first, change your host type to `npx expo start --lan` or `npx expo start --localhost`. If you use `npx expo start --tunnel` with debugging enabled, you are likely to experience so much latency that your app is unusable.
 
-- If you are using `npx expo start --lan`, make sure your device is on the same wifi network as your development machine. This may not work on some public networks. `npx expo start --localhost` will not work for iOS unless you are in the simulator, and it only works on Android if your device is connected to your machine via USB.
+- If you are using `npx expo start --lan`, make sure your device is on the same Wi-Fi network as your development machine. This may not work on some public networks. `npx expo start --localhost` will not work for iOS unless you are in the simulator, and it only works on Android if your device is connected to your machine via USB.
 
 - Open the app on your device, reveal the developer menu then tap on `Debug JS Remotely`. This should open up a Chrome tab with the URL `http://localhost:19000/debugger-ui`. From there, you can set breakpoints and interact through the JavaScript console. Shake the device and stop Chrome debugging when you're done.
 

--- a/docs/pages/workflow/expo-cli.mdx
+++ b/docs/pages/workflow/expo-cli.mdx
@@ -133,7 +133,7 @@ You can compile your app locally with the `run` commands:
 
 **Highlights**
 
-- Build directly on connected devices with no global side-effects using the `--device` flag. Supports locked devices, letting you retry instantly instead of needing to rebuild.
+- Build directly on connected devices with no global side effects using the `--device` flag. Supports locked devices, letting you retry instantly instead of needing to rebuild.
 - Automatically codesign iOS apps for development from the CLI without having to open Xcode.
 - Smart log parsing show you warnings and errors from your project source code, unlike Xcode which surfaces hundreds of benign warnings from your node modules.
 - Fatal errors causing your app to crash will be surfaced to the terminal preventing the need to reproduce in Xcode.
@@ -146,7 +146,7 @@ Building locally is useful for developing native modules and [debugging complex 
 
 If your project does not have the corresponding native directories, the `npx expo prebuild` command will run once to generate the respective directory before building.
 
-For example, if your project does not have a root `ios/` directory, then `npx expo run:ios` will first run `npx expo prebuild -p ios` before compiling your app. Learn more about about this process in the [Expo Prebuild](/workflow/prebuild) doc.
+For example, if your project does not have a root `ios/` directory, then `npx expo run:ios` will first run `npx expo prebuild -p ios` before compiling your app. Learn more about this process in the [Expo Prebuild](/workflow/prebuild) doc.
 
 **Cross-Platform Arguments**
 

--- a/docs/pages/workflow/glossary-of-terms.mdx
+++ b/docs/pages/workflow/glossary-of-terms.mdx
@@ -129,7 +129,7 @@ The term "eject" was popularized by [create-react-app](https://github.com/facebo
 
 ### Emulator
 
-Emulator is used to describe software emulators of Android devices on your computers. Typically iOS emulators are referred to as [Simulators](#simulator).
+Emulator is used to describe software emulators of Android devices on your computers. Typically, iOS emulators are referred to as [Simulators](#simulator).
 
 ### Entry Point
 


### PR DESCRIPTION
# Why

After fixing few typos in Expo modules docs I have decided to run static code and language analysis in IDEA, which reported bunch of the typos and grammar issues.

# How

This PR fixes most of the valid typos reported and applies some of the grammar suggestions, which fells for me correct.

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
