### PR TITLE
[dev-client][splash-screen] Fix error when running with new arch mode on android

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo), [#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
+- Fixed Android `java.lang.AssertionError: TurboModules are enabled, but mTurboModuleRegistry hasn't been set.` error when running on new architecture mode. ([#19931](https://github.com/expo/expo/pull/19931) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -1,9 +1,12 @@
 package expo.modules.devlauncher.launcher
 
 import android.app.Application
+import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.shell.MainReactPackage
 import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
 import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
@@ -55,4 +58,14 @@ class DevLauncherClientHost(
   override fun getJSMainModuleName() = "index"
 
   override fun getBundleAssetName() = "expo_dev_launcher_android.bundle"
+
+  override fun getReactPackageTurboModuleManagerDelegateBuilder(): ReactPackageTurboModuleManagerDelegate.Builder? {
+    if (!ReactFeatureFlags.useTurboModules) {
+      return null
+    }
+    val appHost = (application as ReactApplication)?.reactNativeHost ?: return null
+    val method = ReactNativeHost::class.java.getDeclaredMethod("getReactPackageTurboModuleManagerDelegateBuilder")
+    method.isAccessible = true
+    return method.invoke(appHost) as ReactPackageTurboModuleManagerDelegate.Builder
+  }
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19369](https://github.com/expo/expo/pull/19369) by [@kudo](https://github.com/kudo), [#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
+- Fixed Android `java.lang.AssertionError: TurboModules are enabled, but mTurboModuleRegistry hasn't been set.` error when running on new architecture mode. ([#19931](https://github.com/expo/expo/pull/19931) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -3,10 +3,13 @@ package expo.modules.devmenu
 import android.app.Application
 import android.content.Context
 import android.util.Log
+import com.facebook.react.ReactApplication
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
+import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.JavaScriptExecutorFactory
+import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.shell.MainReactPackage
 import devmenu.com.swmansion.gesturehandler.react.RNGestureHandlerPackage
@@ -98,5 +101,15 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
     }
 
     return reactInstanceManager
+  }
+
+  override fun getReactPackageTurboModuleManagerDelegateBuilder(): ReactPackageTurboModuleManagerDelegate.Builder? {
+    if (!ReactFeatureFlags.useTurboModules) {
+      return null
+    }
+    val appHost = (application as ReactApplication)?.reactNativeHost ?: return null
+    val method = ReactNativeHost::class.java.getDeclaredMethod("getReactPackageTurboModuleManagerDelegateBuilder")
+    method.isAccessible = true
+    return method.invoke(appHost) as ReactPackageTurboModuleManagerDelegate.Builder
   }
 }

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android `NullPointerException` in `FrameLayout.onMeasure()` when running on new architecture mode with expo-dev-client. ([#19931](https://github.com/expo/expo/pull/19931) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.17.3 — 2022-10-30

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenViewController.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenViewController.kt
@@ -62,7 +62,7 @@ open class SplashScreenViewController(
       return failureCallback("Cannot hide native splash screen on activity that is already destroyed (application is already closed).")
     }
 
-    activity.runOnUiThread {
+    Handler(activity.mainLooper).post {
       contentView.removeView(splashScreenView)
       autoHideEnabled = true
       splashScreenShown = false


### PR DESCRIPTION
# Why

when turning on new architecture mode with dev-client, there is a runtime crash:
```
java.lang.AssertionError: TurboModules are enabled, but mTurboModuleRegistry hasn't been set.
```

fixes #19866

# How

- react-native has a singleton flag `ReactFeatureFlags.useTurboModules`. even though we have the `ReactNativeHost` with old architecture mode in dev-menu and dev-launcher, [the underlying `CatalystInstanceImpl` will still fail at the check](https://github.com/facebook/react-native/blob/dac6806559c49b267ce6eb2722c9ff3b9108ead1/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java#L473-L477). the `ReactPackageTurboModuleManagerDelegate.Builder` requires some c++ code, considering we don't support new architecture mode in dev-menu and dev-launcher, this pr uses a workaround to pass the `ReactPackageTurboModuleManagerDelegate.Builder` from MainApplication.

- when running on new architecture mode, there is a NPE in [`FrameLayout.onMeasure`](https://android.googlesource.com/platform/frameworks/base/+/4d07687915b39dd4c241f5d22e1f0bd02e41bff8/core/java/android/widget/FrameLayout.java#193). since splash screen view remove itself in `ViewGroup.OnHierarchyChangeListener`. the child iteration will get null from `getChildAt()`. the pr tries to remove the splash screen view from the next run loop.

# Test Plan

- https://github.com/evelant/test_fabric_eas_build + this pr's patch

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
