### PR TITLE
[image-picker] Fix incorrect asset type for videos on iOS

### DIFF
--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -11,28 +11,25 @@ export const name = 'ImagePicker';
 export async function test({ it, beforeAll, expect, jasmine, describe, afterAll }) {
   function testMediaObjectShape(shape, type) {
     expect(shape).toBeDefined();
-    expect(typeof shape.cancelled).toBe('boolean');
 
-    if (!shape.cancelled) {
-      expect(typeof shape.uri).toBe('string');
-      expect(typeof shape.width).toBe('number');
-      expect(typeof shape.height).toBe('number');
-      expect(typeof shape.type).toBe('string');
+    expect(typeof shape.uri).toBe('string');
+    expect(typeof shape.width).toBe('number');
+    expect(typeof shape.height).toBe('number');
+    expect(typeof shape.type).toBe('string');
 
-      expect(shape.uri).not.toBe('');
-      expect(shape.width).toBeGreaterThan(0);
-      expect(shape.height).toBeGreaterThan(0);
+    expect(shape.uri).not.toBe('');
+    expect(shape.width).toBeGreaterThan(0);
+    expect(shape.height).toBeGreaterThan(0);
 
-      expect(typeof shape.type).toBe('string');
+    expect(typeof shape.type).toBe('string');
 
-      if (type) {
-        expect(shape.type).toBe(type);
-      }
+    if (type) {
+      expect(shape.type).toBe(type);
+    }
 
-      if (shape.type === 'video') {
-        expect(typeof shape.duration).toBe('number');
-        expect(shape.duration).toBeGreaterThan(0);
-      }
+    if (shape.type === 'video') {
+      expect(typeof shape.duration).toBe('number');
+      expect(shape.duration).toBeGreaterThan(0);
     }
   }
   function testResultShape(result, type) {
@@ -141,8 +138,8 @@ export async function test({ it, beforeAll, expect, jasmine, describe, afterAll 
           testResultShape(result, 'video');
 
           for (const video of result.assets) {
-            expect(video.width).toBeLessThanOrEqual(640);
-            expect(video.height).toBeLessThanOrEqual(480);
+            expect(Math.max(video.width, video.height)).toBeLessThanOrEqual(640);
+            expect(Math.min(video.width, video.height)).toBeLessThanOrEqual(480);
           }
         });
       }

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix incorrect asset type for videos on iOS. ([#19932](https://github.com/expo/expo/pull/19932) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 14.0.0 — 2022-10-25

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -186,6 +186,7 @@ internal struct MediaHandler {
       let fileName = asset?.value(forKey: "filename") as? String
       let fileSize = getFileSize(from: targetUrl)
       let videoInfo = AssetInfo(assetId: asset?.localIdentifier,
+                                type: "video",
                                 uri: targetUrl.absoluteString,
                                 width: dimensions.width,
                                 height: dimensions.height,
@@ -269,6 +270,7 @@ internal struct MediaHandler {
     let fileSize = getFileSize(from: videoUrl)
 
     let result = AssetInfo(assetId: assetId,
+                           type: "video",
                            uri: videoUrl.absoluteString,
                            width: size.width,
                            height: size.height,


### PR DESCRIPTION
# Why

#19570 introduced a regression that causes all videos to have the default type (`image`).
Fixes #19883

# How

- Set type to `video` for video assets
- Ensured that all tests are passing (some were broken, not sure why that passed QA before the SDK release?)

# Test Plan

Tested with test-suite and NCL