### PR TITLE
Fix web assets not loading in Metro for web on Windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix web assets not loading in Metro for web on Windows.
+- Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Hermes debugger `TypeError: Only HTTP(S) protocols are supported` error when starting server with `--dev-client` parameter. ([#19919](https://github.com/expo/expo/pull/19919) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix web assets not loading in Metro for web on Windows.
 - Fix Hermes debugger `TypeError: Only HTTP(S) protocols are supported` error when starting server with `--dev-client` parameter. ([#19919](https://github.com/expo/expo/pull/19919) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1,0 +1,45 @@
+import { shouldAliasAssetRegistryForWeb } from '../withMetroMultiPlatform';
+
+describe(shouldAliasAssetRegistryForWeb, () => {
+  it(`should return true if the incoming resolution is for the web platform and the AssetRegistry`, () => {
+    [
+      'node_modules/react-native-web/dist/modules/AssetRegistry/index.js',
+      // Monorepo
+      '../../react-native-web/dist/modules/AssetRegistry/index.js',
+      // Windows
+      'node_modules\\react-native-web\\dist\\modules\\AssetRegistry\\index.js',
+    ].forEach((filePath) => {
+      expect(
+        shouldAliasAssetRegistryForWeb('web', {
+          type: 'sourceFile',
+          filePath,
+        })
+      ).toBe(true);
+    });
+  });
+  it(`should return false if the path is wrong`, () => {
+    ['modules/AssetRegistry/index.js', 'invalid'].forEach((filePath) => {
+      expect(
+        shouldAliasAssetRegistryForWeb('web', {
+          type: 'sourceFile',
+          filePath,
+        })
+      ).toBe(false);
+    });
+  });
+  it(`should return false if the incoming resolution is for non-web platforms`, () => {
+    [
+      'invalid.js',
+
+      // valid
+      'node_modules/react-native-web/dist/modules/AssetRegistry/index.js',
+    ].forEach((filePath) => {
+      expect(
+        shouldAliasAssetRegistryForWeb('ios', {
+          type: 'sourceFile',
+          filePath,
+        })
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Why

- fix https://github.com/expo/router/issues/120

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Normalize slashes on Windows to ensure they match the replacement key.

# Test Plan

- Added tests.
- Need @byCedric to validate that the following renders an image on web when using Windows:

```tsx
// Set `expo.web.bundler: 'metro'`

import { Image } from 'react-native';

// Requires an image file: ./icon.png
const icon = require('./icon.png');

export default function App() {
  return (
      <Image source={icon} style={{ width: 100, height: 100 }} />
  );
}
```



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
