### PR TITLE
[home] poll for projects regardless of authentication state to support Snack Device ID flow

### DIFF
--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -236,7 +236,7 @@ export class HomeScreenView extends React.Component<Props, State> {
       const api = new APIV2Client();
 
       const [projects, graphQLResponse] = await Promise.all([
-        api.sendAuthenticatedApiV2Request<DevSession[]>('development-sessions', {
+        api.sendOptionallyAuthenticatedApiV2Request<DevSession[]>('development-sessions', {
           method: 'GET',
           searchParams: {
             deviceId: getSnackId(),

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -79,7 +79,7 @@ export class HomeScreenView extends React.Component<Props, State> {
 
     // @evanbacon: Without this setTimeout, the state doesn't update correctly and the "Recently in Development" items don't load for 10 seconds.
     setTimeout(() => {
-      if (this.props.isAuthenticated) this._startPollingForProjects();
+      this._startPollingForProjects();
     }, 1);
 
     // NOTE(brentvatne): if we add QR code button to the menu again, we'll need to
@@ -187,10 +187,6 @@ export class HomeScreenView extends React.Component<Props, State> {
       this._fetchProjectsAsync();
     }
 
-    if (!prevProps.isAuthenticated && this.props.isAuthenticated) {
-      this._startPollingForProjects();
-    }
-
     if (prevProps.isAuthenticated && !this.props.isAuthenticated) {
       // Remove all projects except Snack, because they are tied to device id
       // Fix this lint warning when converting to hooks
@@ -198,8 +194,6 @@ export class HomeScreenView extends React.Component<Props, State> {
       this.setState(({ projects }) => ({
         projects: projects.filter((p) => p.source === 'snack'),
       }));
-
-      this._stopPollingForProjects();
     }
   }
 
@@ -221,6 +215,8 @@ export class HomeScreenView extends React.Component<Props, State> {
     this.props.dispatch(HistoryActions.clearHistory());
   };
 
+  // NOTE(juwan): We should poll regardless of authentication state so that we can support the Snack
+  // device ID flow
   private _startPollingForProjects = async () => {
     await this._fetchProjectsAsync();
     this._projectPolling = setInterval(this._fetchProjectsAsync, PROJECT_UPDATE_INTERVAL);
@@ -234,8 +230,6 @@ export class HomeScreenView extends React.Component<Props, State> {
   };
 
   private _fetchProjectsAsync = async () => {
-    if (!this.props.isAuthenticated) return;
-
     const { accountName } = this.props;
 
     try {


### PR DESCRIPTION
# Why

In a [previous PR](https://github.com/expo/expo/pull/18074), we changed Expo Go such that it wouldn't poll for projects if the user wasn't authenticated. This broke the Device ID flow used by snack as shown in the linear issue.

# How

I reverted the code from that PR and added a comment about keeping this polling behavior around for Snack.

# Test Plan

Visit snack.expo.dev and open the Device ID prompt in the bottom right corner of the window:

![Screenshot 2022-11-08 at 19 28 53](https://user-images.githubusercontent.com/12488826/200706201-9c743bca-aa97-4cb8-a6d1-4a5f5b0edb60.png)
![Screenshot 2022-11-08 at 19 28 59](https://user-images.githubusercontent.com/12488826/200706203-107df174-ecbd-4f74-a33b-0873a5695c47.png)

Open Expo Go with a local `home` server and go to the Settings page to find the Device ID. Enter that value into the snack form and when you confirm the project should show up in your Expo Go app.
