### PR TITLE
[docs] Update React Native version in API reference

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -56,10 +56,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
+| 47.0.0           | 0.70.5               |
 | 46.0.0           | 0.69.6               |
 | 45.0.0           | 0.68.2               |
 | 44.0.0           | 0.64.3               |
-| 43.0.0           | 0.64.3               |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -56,10 +56,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK Version | React Native Version |
 | ---------------- | -------------------- |
+| 47.0.0           | 0.70.5               |
 | 46.0.0           | 0.69.6               |
 | 45.0.0           | 0.68.2               |
 | 44.0.0           | 0.64.3               |
-| 43.0.0           | 0.64.3               |
 
 ### Support for other React Native versions
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the latest API reference index doc doesn't mention SDK 47.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the React Native version table for SDK 47 and unversioned and removes SDK 43 reference from both of them.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1506" alt="CleanShot 2022-11-09 at 15 19 59@2x" src="https://user-images.githubusercontent.com/10234615/200798148-d715b31b-69f0-425a-b613-a5e2783ddf7c.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
