### PR TITLE
[docs] Update expo-document-picker for using with expo-file-system

### DIFF
--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -15,7 +15,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -58,7 +58,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in your Expo config (**app.json**, **app.config.js**) as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [Expo config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
@@ -90,6 +90,12 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
   ]}
 />
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ## API
 

--- a/docs/pages/versions/v43.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v43.0.0/sdk/document-picker.mdx
@@ -8,7 +8,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -37,6 +37,12 @@ For iOS bare projects, the `DocumentPicker` module requires the iCloud entitleme
 - In the project, go to the `Capabilities` tab
 - Set the iCloud switch to `on`
 - Check the `iCloud Documents` checkbox
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ## API
 

--- a/docs/pages/versions/v44.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v44.0.0/sdk/document-picker.mdx
@@ -8,7 +8,7 @@ import InstallSection from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -37,6 +37,12 @@ For iOS bare projects, the `DocumentPicker` module requires the iCloud entitleme
 - In the project, go to the `Capabilities` tab
 - Set the iCloud switch to `on`
 - Check the `iCloud Documents` checkbox
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/document-picker.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -38,6 +38,12 @@ For iOS bare projects, the `DocumentPicker` module requires the iCloud entitleme
 - In the project, go to the `Capabilities` tab
 - Set the iCloud switch to `on`
 - Check the `iCloud Documents` checkbox
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/document-picker.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -38,6 +38,12 @@ For iOS bare projects, the `DocumentPicker` module requires the iCloud entitleme
 - In the project, go to the `Capabilities` tab
 - Set the iCloud switch to `on`
 - Check the `iCloud Documents` checkbox
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -15,7 +15,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
-Provides access to the system's UI for selecting documents from the available providers on the user's device.
+`expo-document-picker` provides access to the system's UI for selecting documents from the available providers on the user's device.
 
 <Video file={'sdk/documentpicker.mp4'} loop={false} />
 
@@ -58,7 +58,7 @@ Apple Developer Console also requires an **iCloud Container** to be created. Whe
 
 <ConfigPluginExample>
 
-If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in your Expo config (**app.json**, **app.config.js**) as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
+If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [Expo config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
@@ -92,6 +92,12 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
 />
 
 ## API
+
+## Using with expo-file-system
+
+When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
+
+To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
 
 ```js
 import * as DocumentPicker from 'expo-document-picker';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-5969

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a new section that explicitly mentions that `copyToCacheDirectory` need to be set to true for the file to be available for immediate usage with other Expo APIs such as `expo-file-system` when picked by the `expo-document-picker`.

Other changes:
- relevant changes backported to SDK 47, 46, 45, 44, 43
- updated overall verbiage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="920" alt="CleanShot 2022-11-09 at 16 15 51@2x" src="https://user-images.githubusercontent.com/10234615/200810154-cc72caa6-f2e8-4811-844c-0dea16e9a270.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
