### PR TITLE
[docs] Fix inconsistent use of the term development builds

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -653,7 +653,7 @@ You must use the proxy service in the Expo Go app because `exp://` cannot be add
 
 #### Custom Apps
 
-For SDK 46 and above, we recommend using [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next#expo-installation) module with [Development Builds](https://docs.expo.dev/development/introduction/).
+For SDK 46 and above, we recommend using [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next#expo-installation) module with [development builds](https://docs.expo.dev/development/introduction/).
 
 You'll have to rebuild after adding the `react-native-fbsdk-next` as a config plugin to **app.json** or **app.config.js**:
 

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -60,7 +60,7 @@ Please note that the Hermes bytecode format may change between different Hermes 
 
 ## JavaScript debugger
 
-To debug JavaScript code running with Hermes, you can start your project with `npx expo start` then press <kbd>j</kbd> to open the debugger in Google Chrome or Microsoft Edge. The developer menu of Expo Go or Development builds also has the **Open JS Debugger** option to do the same.
+To debug JavaScript code running with Hermes, you can start your project with `npx expo start` then press <kbd>j</kbd> to open the debugger in Google Chrome or Microsoft Edge. The developer menu of Expo Go or development builds also has the **Open JS Debugger** option to do the same.
 
 Alternatively, you can use the JavaScript inspector from the following tools:
 
@@ -105,6 +105,6 @@ Alternatively, you can use the JavaScript inspector from the following tools:
 
 ### Can I use Remote Debugging with Hermes?
 
-One of the many limitations of [remote debugging](/workflow/glossary-of-terms/#remote-debugging) is that it does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). For example, if your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2 or higher, [remote debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations). 
+One of the many limitations of [remote debugging](/workflow/glossary-of-terms/#remote-debugging) is that it does not work with modules built on top of [JSI](https://github.com/react-native-community/discussions-and-proposals/issues/91). For example, if your app uses [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) version 2 or higher, [remote debugging will not work](https://docs.swmansion.com/react-native-reanimated/docs/#known-problems-and-limitations).
 
 Hermes supports [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/v8/) to debug JavaScript in place by connecting to the running engine on the device. This enables you to debug your app even when using JSI modules. This debugging technique is superior to remote debugging and replaces it for apps using Hermes.

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -29,7 +29,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 ### Bare workflow
 
-Similar to [Development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild/).
+Similar to [development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild/).
 
 EAS Build is compatible with bare workflow projects if you check in the native directories, but no longer runs prebuild, as that could overwrite any manual customizations you've made to the native project files. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
 
@@ -45,7 +45,6 @@ Like any other tool, it too has its own limitations:
 **We strongly recommend any projects that require additional libraries with native code to migrate to [development builds](/development/introduction/). It's like creating a version of Expo Go that is specifically customized to your app's needs.**
 
 ## Up next
-
 
 - If you have heard enough and want to get to coding, see [Installation](/get-started/installation).
 - If you have some unanswered questions, continue to the [Common Questions](/introduction/faq) page.

--- a/docs/pages/versions/v45.0.0/sdk/admob.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/admob.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [Development Builds](/development/introduction.mdx), you should use [react-native-google-mobile-ads](https://github.com/invertase/react-native-google-mobile-ads) instead.
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [development builds](/development/introduction.mdx), you should use [react-native-google-mobile-ads](https://github.com/invertase/react-native-google-mobile-ads) instead.
 
 Expo includes support for the [Google AdMob SDK](https://www.google.com/admob/) for mobile advertising, including components for banner ads and imperative APIs for interstitial and rewarded video ads. **`expo-ads-admob`** is largely based of the [react-native-admob](https://github.com/sbugert/react-native-admob) module, as the documentation and questions surrounding that module may prove helpful. A simple example implementing AdMob SDK can be found [here](https://github.com/deadcoder0904/expo-google-admob).
 

--- a/docs/pages/versions/v45.0.0/sdk/amplitude.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/amplitude.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [Development Builds](/development/introduction.mdx), you should use the official [@amplitude/react-native](https://github.com/amplitude/Amplitude-ReactNative) instead.
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [development builds](/development/introduction.mdx), you should use the official [@amplitude/react-native](https://github.com/amplitude/Amplitude-ReactNative) instead.
 
 **`expo-analytics-amplitude`** provides access to [Amplitude](https://amplitude.com/) mobile analytics which allows you track and log various events and data. This module wraps Amplitude's [iOS](https://github.com/amplitude/Amplitude-iOS) and [Android](https://github.com/amplitude/Amplitude-Android) SDKs. For a great example of usage, see the [Expo app source code](https://github.com/expo/expo/tree/main/home/api/Analytics.ts).
 

--- a/docs/pages/versions/v45.0.0/sdk/facebook-ads.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/facebook-ads.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [Development Builds](/development/introduction.mdx), you should use [react-native-fbads](https://github.com/callstack/react-native-fbads) instead.
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [development builds](/development/introduction.mdx), you should use [react-native-fbads](https://github.com/callstack/react-native-fbads) instead.
 
 **`expo-ads-facebook`** provides access to the Facebook Audience SDK, allowing you to monetize your app with targeted ads.
 

--- a/docs/pages/versions/v45.0.0/sdk/facebook.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/facebook.mdx
@@ -16,7 +16,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 
-> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [Development Builds](/development/introduction.mdx), you should use [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next/#expo-installation) instead.
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build** and [development builds](/development/introduction.mdx), you should use [react-native-fbsdk-next](https://github.com/thebergamo/react-native-fbsdk-next/#expo-installation) instead.
 
 **`expo-facebook`** provides Facebook integration, such as logging in through Facebook, for React Native apps. Expo exposes a minimal native API since you can access Facebook's [Graph API](https://developers.facebook.com/docs/graph-api) directly through HTTP (using [fetch](https://reactnative.dev/docs/network.html#fetch), for example).
 

--- a/docs/pages/versions/v45.0.0/sdk/google-sign-in.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/google-sign-in.mdx
@@ -6,7 +6,7 @@ packageName: 'expo-google-sign-in'
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **Deprecated.** This package has been deprecated in favor of [`expo-auth-session`](auth-session.mdx)'s Google provider (for web-browser based authentication) and [@react-native-google-signin/google-signin](https://github.com/react-native-google-signin/google-signin#expo-installation) for authentication using Google's native APIs, which you can use with **EAS Build** and [Development Builds](/development/introduction.mdx).
+> **Deprecated.** This package has been deprecated in favor of [`expo-auth-session`](auth-session.mdx)'s Google provider (for web-browser based authentication) and [@react-native-google-signin/google-signin](https://github.com/react-native-google-signin/google-signin#expo-installation) for authentication using Google's native APIs, which you can use with **EAS Build** and [development builds](/development/introduction.mdx).
 
 `expo-google-sign-in` provides native Google authentication for **standalone** Expo apps or bare React Native apps. It cannot be used in Expo Go as the native `GoogleSignIn` library expects your `REVERSED_CLIENT_ID` in the **Info.plist** at build-time. To use Google authentication in the Expo Go, and on web, check out [`expo-auth-session`](/guides/authentication#google).
 

--- a/docs/pages/versions/v45.0.0/sdk/segment.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/segment.mdx
@@ -8,7 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build\*** and [Development Builds](/development/introduction.mdx), you should use official [@segment/analytics-react-native](https://github.com/segmentio/analytics-react-native) instead.
+> **Deprecated.** This module will be removed in SDK 46. There will be no replacement that works with the classic build service (`expo build`) because [the classic build service has been superseded by **EAS Build**](https://blog.expo.dev/turtle-goes-out-to-sea-d334db2a6b60). With **EAS Build\*** and [development builds](/development/introduction.mdx), you should use official [@segment/analytics-react-native](https://github.com/segmentio/analytics-react-native) instead.
 
 **`expo-analytics-segment`** provides access to `https://segment.com/` mobile analytics. Wraps Segment's [iOS](https://segment.com/docs/sources/mobile/ios/) and [Android](https://segment.com/docs/sources/mobile/android/) sources.
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -6,13 +6,13 @@ import { Terminal } from '~/ui/components/Snippet';
 
 The Expo Go app is a great tool to get started — it exists to help developers quickly get projects off the ground, to experiment with ideas (such as on [Snack](https://snack.expo.dev/)) and share their work with minimal friction. Expo Go makes this possible by including a feature-rich native runtime made up of every module in the [Expo SDK](/versions/latest/), so all you need to do to use a module is install the package and reload your app.
 
-The tradeoff is that Expo Go does not allow you to add custom native code, you can only use native modules built into the Expo SDK. There are many great libraries available outside of the Expo SDK, and you may even want to build your own native library. You can leverage these libraries with "development builds", or by using prebuild to generate the native projects, or both. You can also continue using [EAS Build](/build/introduction) to release your app, no changes are required.
+The tradeoff is that Expo Go does not allow you to add custom native code, you can only use native modules built into the Expo SDK. There are many great libraries available outside of the Expo SDK, and you may even want to build your own native library. You can leverage these libraries with development builds, or by using prebuild to generate the native projects, or both. You can also continue using [EAS Build](/build/introduction) to release your app, no changes are required.
 
 ## Adding custom native code with development builds
 
-To make use of third party libraries with custom native code and continue with the same developer experience of Expo Go, you can migrate to using ["development builds"](/development/introduction). Development builds are like your own personal version of Expo Go — they include the native runtime that powers your app, and you control what is included in that native runtime by adding or removing packages in your **package.json**. Development builds allow you to continue to build your app in JavaScript while taking advantage of the full ecosystem of native packages available for Expo and React Native projects.
+To make use of third party libraries with custom native code and continue with the same developer experience of Expo Go, you can migrate to using [development builds](/development/introduction). Development builds are like your own personal version of Expo Go — they include the native runtime that powers your app, and you control what is included in that native runtime by adding or removing packages in your **package.json**. Development builds allow you to continue to build your app in JavaScript while taking advantage of the full ecosystem of native packages available for Expo and React Native projects.
 
-Learn how to start using custom native code in your app by switching from Expo Go to development builds in the ["Getting Started" guide for development builds](/development/getting-started).
+Learn how to start using custom native code in your app by switching from Expo Go to development builds in the [Getting Started guide for development builds](/development/getting-started).
 
 ## Generate native projects with prebuild
 
@@ -60,7 +60,6 @@ When you're ready to ship your app, you can [build it with EAS Build](/build/int
   cmd={['# Install the CLI', '$ npm i -g eas-cli', '', '# Build your app!', '$ eas build -p all']}
   cmdCopy="npm i -g eas-cli && eas build -p all"
 />
-
 
 ## Creating native modules
 

--- a/docs/pages/workflow/expo-go.mdx
+++ b/docs/pages/workflow/expo-go.mdx
@@ -54,7 +54,7 @@ We release a new SDK version approximately every quarter. Find out which [versio
 
 ## Custom native code
 
-Each version of the Expo Go app contains 3-4 versions of React Native and the Expo SDK. This enables you to get up and running fast without performing a native build. However, if you need to use custom native code, you will need to use a custom client. For more information, see [Development builds](/development/introduction).
+Each version of the Expo Go app contains 3-4 versions of React Native and the Expo SDK. This enables you to get up and running fast without performing a native build. However, if you need to use custom native code, you will need to use a custom client. For more information, see [development builds](/development/introduction).
 
 Projects with custom native code can still partially use Expo Go by [following this guide](/bare/using-expo-client).
 

--- a/docs/pages/workflow/run-on-device.mdx
+++ b/docs/pages/workflow/run-on-device.mdx
@@ -34,7 +34,7 @@ If it still doesn't work, it may be due to the router configuration &mdash; this
 
 When you have hit the limitations of Expo Go and need to move on to development builds (for example, to [add custom native code](/workflow/customizing/)), the process for loading the project remains mostly the same but the mechanism to get the build on your device is different. Development builds can be created locally with [`npx expo run:[ios|android] --device`](/workflow/expo-cli/), with Xcode or Android Studio, or [remotely with EAS Build](/build/introduction/).
 
-Refer to the ["Getting Started" guide for development builds](/development/getting-started/) to learn how to create a development build and run it on your device.
+Refer to the [Getting Started guide for development builds](/development/getting-started/) to learn how to create and run it on your device.
 
 ## Running a project as a standalone app
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6566

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the inconsistent use of the terms "Development builds", "development builds" and "Development Builds" across various docs.

Left out Development build docs from this PR since #19703 is already up for review to improve/update those docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs repo locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
