### PR TITLE
[docs] Update reanimated doc to add web installation step

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -7,7 +7,7 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`react-native-reanimated`** provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
+`react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with react-native-reanimated, you will need to use the [Hermes JavaScript engine](/guides/using-hermes.mdx) and the [JavaScript Inspector for Hermes](/guides/using-hermes.mdx#javascript-inspector-for-hermes).
 
@@ -19,7 +19,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
-```jsx
+```js babel.config.js
 module.exports = function (api) {
   api.cache(true);
   return {
@@ -29,7 +29,17 @@ module.exports = function (api) {
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js**:
+
+{/* prettier-ignore */}
+```js babel.config.js
+plugins: [    
+  '@babel/plugin-proposal-export-namespace-from',
+  'react-native-reanimated/plugin',
+],
+```
+
+After you add the Babel plugins, restart your development server and clear the bundler cache: `npx expo start --clear`.
 
 > Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 

--- a/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
@@ -7,7 +7,7 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-**`react-native-reanimated`** provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
+`react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with react-native-reanimated, you will need to use the [Hermes JavaScript engine](/guides/using-hermes.mdx) and the [JavaScript Inspector for Hermes](/guides/using-hermes.mdx#javascript-inspector-for-hermes).
 
@@ -19,7 +19,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 **In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
-```jsx
+```js babel.config.js
 module.exports = function (api) {
   api.cache(true);
   return {
@@ -29,7 +29,17 @@ module.exports = function (api) {
 };
 ```
 
-After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js**:
+
+{/* prettier-ignore */}
+```js babel.config.js
+plugins: [    
+  '@babel/plugin-proposal-export-namespace-from',
+  'react-native-reanimated/plugin',
+],
+```
+
+After you add the Babel plugins, restart your development server and clear the bundler cache: `npx expo start --clear`.
 
 > Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
 


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The installation step for web with `react-native-reanimated` requires an extra step on the latest version (which is used by the SDK 47). This PR adds that installation step for SDK 47.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1228" alt="CleanShot 2022-11-09 at 17 46 10@2x" src="https://user-images.githubusercontent.com/10234615/200828151-e3d52c88-f58c-4f60-9b31-540ef62dbefc.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
