### PR TITLE
[docs] Video: fix hydration issue reported in Sentry

### DIFF
--- a/docs/components/plugins/Video.tsx
+++ b/docs/components/plugins/Video.tsx
@@ -1,29 +1,65 @@
+import { css } from '@emotion/react';
+import { borderRadius, breakpoints } from '@expo/styleguide';
 import React, { useState } from 'react';
 import ReactPlayer from 'react-player';
 import VisibilitySensor from 'react-visibility-sensor';
 
-// lol: https://stackoverflow.com/a/11381730/659988
-function mobileAndTabletCheck() {
-  if (typeof window === 'undefined') {
-    return false;
-  }
+const PLAYER_WIDTH = '100%' as const;
+const PLAYER_HEIGHT = 400 as const;
+const YOUTUBE_DOMAINS = ['youtube.com', 'youtu.be'] as const;
 
-  let check = false;
-  (function (a) {
-    if (
-      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(
-        a
-      ) ||
-      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(
-        a.substr(0, 4)
-      )
-    )
-      check = true;
-  })(navigator.userAgent || navigator.vendor || window.opera);
-  return check;
-}
+type VideoProps = React.PropsWithChildren<{
+  controls?: any;
+  spaceAfter?: boolean | number;
+  url?: string;
+  file?: string;
+  loop?: boolean;
+}>;
 
-const isMobileOrTablet = mobileAndTabletCheck();
+const Video = ({ controls, spaceAfter, url, file, loop = true }: VideoProps) => {
+  const [hover, setHover] = useState(false);
+  const [forceShowControls, setForceShowControls] = useState(isYouTubeDomain(url));
+
+  return (
+    <div
+      onClick={() => {
+        if (typeof controls === 'undefined' && !forceShowControls) {
+          setForceShowControls(true);
+        }
+      }}
+      style={hover ? { cursor: 'pointer' } : undefined}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}>
+      <VisibilitySensor partialVisibility>
+        {({ isVisible }: { isVisible: boolean }) => (
+          <div css={[videoWrapperStyle, { marginBottom: getInitialMarginBottom(spaceAfter) }]}>
+            <ReactPlayer
+              url={isVisible ? url || `/static/videos/${file}` : undefined}
+              className="react-player"
+              width={PLAYER_WIDTH}
+              height={PLAYER_HEIGHT}
+              style={playerStyle}
+              muted
+              playing={isVisible}
+              controls={typeof controls === 'undefined' ? forceShowControls : controls}
+              playsinline
+              loop={loop}
+            />
+            <div
+              css={[
+                videoWrapperStyle,
+                dimmerStyle,
+                {
+                  opacity: isVisible ? 0 : 0.7,
+                },
+              ]}
+            />
+          </div>
+        )}
+      </VisibilitySensor>
+    </div>
+  );
+};
 
 const getInitialMarginBottom = (spaceAfter: VideoProps['spaceAfter']) => {
   if (typeof spaceAfter === 'undefined') {
@@ -36,80 +72,35 @@ const getInitialMarginBottom = (spaceAfter: VideoProps['spaceAfter']) => {
   return 0;
 };
 
-type VideoProps = React.PropsWithChildren<{
-  controls?: any;
-  spaceAfter?: boolean | number;
-  url?: string;
-  file?: string;
-  loop?: boolean;
-}>;
-
-const Video = ({ controls, spaceAfter, url, file, loop = true }: VideoProps) => {
-  const [hover, setHover] = useState(false);
-  const ytDomains = ['youtube.com', 'youtu.be'];
-  const [forceShowControls, setForceShowControls] = useState(
-    ytDomains.some(domain => url?.includes(domain))
-  );
-  const marginBottom = getInitialMarginBottom(spaceAfter);
-
-  return (
-    <div
-      onClick={() => {
-        if (typeof controls === 'undefined' && !forceShowControls) {
-          setForceShowControls(true);
-        }
-      }}
-      style={hover ? { cursor: 'pointer' } : undefined}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}>
-      <VisibilitySensor partialVisibility={isMobileOrTablet}>
-        {({ isVisible }: { isVisible: boolean }) => (
-          <div
-            style={{
-              position: 'relative',
-              width: '100%',
-              height: 400,
-              backgroundColor: '#000',
-              marginBottom,
-            }}>
-            <ReactPlayer
-              url={isVisible || !isMobileOrTablet ? url || `/static/videos/${file}` : undefined}
-              className="react-player"
-              width="100%"
-              height="400px"
-              style={{
-                outline: 'none',
-                backgroundColor: '#000',
-                borderRadius: 5,
-              }}
-              muted
-              playing={isVisible}
-              controls={typeof controls === 'undefined' ? forceShowControls : controls}
-              playsinline
-              loop={loop}
-            />
-            {isMobileOrTablet ? null : (
-              <div
-                style={{
-                  pointerEvents: 'none',
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  bottom: 0,
-                  right: 0,
-                  backgroundColor: '#000',
-                  width: '100%',
-                  height: 400,
-                  opacity: isVisible ? 0 : 0.7,
-                  transition: 'opacity 0.5s ease-out',
-                }}
-              />
-            )}
-          </div>
-        )}
-      </VisibilitySensor>
-    </div>
-  );
+const isYouTubeDomain = (url?: string) => {
+  return url ? YOUTUBE_DOMAINS.some(domain => url.includes(domain)) : false;
 };
+
+const videoWrapperStyle = css({
+  position: 'relative',
+  width: PLAYER_WIDTH,
+  height: PLAYER_HEIGHT,
+  backgroundColor: '#000',
+});
+
+const playerStyle = css({
+  outline: 'none',
+  backgroundColor: '#000',
+  borderRadius: borderRadius.medium,
+});
+
+const dimmerStyle = css({
+  pointerEvents: 'none',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  transition: 'opacity 0.5s ease-out',
+
+  [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
+    display: 'none',
+  },
+});
 
 export default Video;


### PR DESCRIPTION
# Why

I have spotted in Sentry reports that Video component causes some hydration errors on mobile devices.

This have a major role in contributing to the overall docs errors count, so let's fix that.

# How

Remove the client side, user agent based code for mobile devices detection. 

Instead Video now will always start playing even when partially visible on desktop (earlier we only use this behaviour on mobile). The conditional video dimmer has been replaced with static DOM, and visibility is controlled via media queries.

Additionally, I have made a small refactor of the code, so the component is up to date with our current code patterns.

# Test Plan

The changes have been tested by running docs app locally.

I was able to reproduce the issue in development mode, and after the component update the errors stop appearing in the browser console.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
