### PR TITLE
[docs] tweaks and fixes for the Expo modules guide

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -2,40 +2,55 @@
 title: Get started
 ---
 
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-There are two ways to get started with the Expo Module API: you can either initialize a new module from scratch or add the Expo Module API to an existing module. This guide will walk you through creating a new module from scratch, and the ["Integrating in an existing library" guide](/modules/existing-library) covers the latter case.
+There are two ways to get started with the Expo Module API: you can either initialize a new module from scratch or add the Expo Module API to an existing module.
+This guide will walk you through creating a new module from scratch, and the ["Integrating in an existing library" guide](/modules/existing-library) covers the latter case.
 
 ## 1. Creating a new module
 
-To create a new Expo module from scratch, run the `create-expo-module` script as shown below. The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
+To create a new Expo module from scratch, run the `create-expo-module` script as shown below.
+The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
 
 <Terminal cmd={[`$ npx create-expo-module my-module`]} />
 
 ## 2. Running the example project
 
-> **Note:** If you're using Windows, you can open the example project by opening the `android` and/or `ios` directory in Android Studio and Xcode respectively,
-
-Navigate to the module directory and then open the iOS and/or Android example project by running the following commands:
+Navigate to the module directory and then open the Android and/or iOS example project by running the following commands:
 
 <Terminal cmd={[`$ cd my-module`, `$ npm run open:android`, `$ npm run open:ios`]} />
 
 Now, you can run the example project on your device or simulator/emulator. When the project compiles and runs, you will see "Hello world! 👋" on the screen.
 
+> **Note:** If you're using Windows, you can open the example project by opening the `android` directory in Android Studio, but you cannot open the iOS project files.
+
 ## 3. Making a change
-
-### iOS
-
-Open up `MyModuleModule.swift` in Xcode (<kbd>⌘</kbd> + <kbd>O</kbd> or <kbd>Ctrl</kbd> + <kbd>O</kbd> and search for `MyModuleModule.swift`) and change the `hello` method to return a different string. For example, you can change it to return `"Hello world! 🌎🍎"`. Rebuild the app and you should see your change.
 
 ### Android
 
-Open up `MyModuleModule.kt` in Android Studio (<kbd>⌘+o</kbd> or <kbd>ctrl+o</kbd> and search for `MyModuleModule.kt`) and change the `hello` method to return a different string. For example, you can change it to return `"Hello world! 🌎🤖"`. Rebuild the app and you should see your change.
+Open up **MyModuleModule.kt** in Android Studio (<kbd>⌘ Cmd</kbd> + <kbd>O</kbd> or <kbd>Ctrl</kbd> + <kbd>O</kbd> and search for **MyModuleModule.kt**).
+Change the `hello` method to return a different string.
+For example, you can change it to return `"Hello world! 🌎🤖"`. Rebuild the app and you should see your change.
+
+### iOS
+
+Open up **MyModuleModule.swift** in Xcode (<kbd>⌘ Cmd</kbd> + <kbd>O</kbd> or <kbd>Ctrl</kbd> + <kbd>O</kbd> and search for **MyModuleModule.swift**).
+Change the `hello` method to return a different string.
+For example, you can change it to return `"Hello world! 🌎🍎"`. Rebuild the app and you should see your change.
 
 ## Next steps
 
 Now that you've learned how to initialize a module and make simple changes to it, you can continue to a tutorial or dive right into the API reference.
 
-- ["Creating your first native module"](/modules/native-module-tutorial) walks you through creating a simple but complete native module to interact with iOS and Android preferences APIs.
-- ["Module API Reference"](/modules/module-api/) outlines the Expo Module API and provides information for common patterns like sending events from native to JavaScript. You will refer to this page often when building a module.
+<BoxLink
+  title="Creating your first native module"
+  description="Create a simple, but complete, native module to interact with Android and iOS preferences APIs."
+  href="/modules/native-module-tutorial"
+/>
+
+<BoxLink
+  title="Module API Reference"
+  description="Outline for the Expo Module API and common patterns like sending events from native code to JavaScript."
+  href="/modules/native-module-tutorial"
+/>

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -11,7 +11,7 @@ This guide will walk you through creating a new module from scratch, and the ["I
 ## 1. Creating a new module
 
 To create a new Expo module from scratch, run the `create-expo-module` script as shown below.
-The script will ask you a few questions and then generate the native Expo module along with the example app for iOS and Android that uses your new module.
+The script will ask you a few questions and then generate the native Expo module along with the example app for Android and iOS that uses your new module.
 
 <Terminal cmd={[`$ npx create-expo-module my-module`]} />
 


### PR DESCRIPTION
# Why

During the pass on latest Expo modules docs changes I have spotted that the Get Started guide could receive few tweaks and updates.

# How

the following changes have been made:
* replace Next Steps links with BoxLink components
* correct the note for Windows users 😅 
* correct the mentioned key strokes
* order Android before iOS where possible

# Test Plan

The changes have been tested by running the docs website locally.

# Preview

<img width="1187" alt="Screenshot 2022-11-09 at 14 46 10" src="https://user-images.githubusercontent.com/719641/200846418-63fb0e07-f33e-4bb9-89e3-39b6e4522464.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
