### PR TITLE
[ios][image] Optimize rerendering on props change, use OnViewDidUpdateProps

### DIFF
--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -28,6 +28,10 @@ public final class ImageModule: Module {
       Prop("transition") { (view, transition: ImageTransition?) in
         view.transition = transition
       }
+
+      OnViewDidUpdateProps { view in
+        view.reload()
+      }
     }
 
     Function("clearMemoryCache") {

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -9,16 +9,11 @@ public final class ImageView: ExpoView {
   let sdImageView = SDAnimatedImageView(frame: .zero)
   let imageManager = SDWebImageManager()
 
-  var source: ImageSource? {
-    didSet {
-      loadFromSource(source)
-    }
-  }
+  var source: ImageSource?
 
   var resizeMode: ImageResizeMode = .cover {
     didSet {
       sdImageView.contentMode = resizeMode.toContentMode()
-      loadFromSource(source)
     }
   }
 
@@ -49,7 +44,7 @@ public final class ImageView: ExpoView {
 
   // MARK: - Implementation
 
-  func loadFromSource(_ source: ImageSource?) {
+  func reload() {
     guard let source = source else {
       renderImage(nil)
       return


### PR DESCRIPTION
# Why

We don't want to rerender the image for each prop change — this may lead to flickering and slowing down. `OnViewDidUpdateProps` component was designed just for that, to reload the view only when all props are finished updating.

# How

Used `OnViewDidUpdateProps` to reload the image

# Test Plan

The image still renders correctly and reloads only once if both `source` and `resizeMode` are changed