### PR TITLE
[docs] LightSensor: backport the latest docs to SDK 47

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/light-sensor.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/light-sensor.mdx
@@ -4,13 +4,12 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-47/packages/expo-sensors'
 packageName: 'expo-sensors'
 ---
 
+import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
-import { InlineCode } from '~/components/base/code';
-
-`LightSensor` from `expo-sensors` provides access to the device's light sensor to respond to illuminance changes. `illuminance` is measured in lux (`lx`).
+`LightSensor` from `expo-sensors` provides access to the device's light sensor to respond to illuminance changes.
 
 <PlatformsSection android emulator />
 
@@ -20,7 +19,7 @@ import { InlineCode } from '~/components/base/code';
 
 ## Usage
 
-<SnackInline label='Basic Light Sensor usage' dependencies={['expo-sensors']}>
+<SnackInline label='Basic Light Sensor usage' dependencies={['expo-sensors']} platforms={['android']}>
 
 ```jsx
 import React, { useState, useEffect } from 'react';
@@ -28,13 +27,11 @@ import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native
 import { LightSensor } from 'expo-sensors';
 
 export default function App() {
-  const [illuminance, setIlluminance] = useState(null);
+  const [{ illuminance }, setData] = useState({ illuminance: 0 });
 
   useEffect(() => {
     _toggle();
-  }, []);
 
-  useEffect(() => {
     return () => {
       _unsubscribe();
     };
@@ -49,9 +46,7 @@ export default function App() {
   };
 
   const _subscribe = () => {
-    this._subscription = LightSensor.addListener(lightSensorData => {
-      setIlluminance(lightSensorData.illuminance);
-    });
+    this._subscription = LightSensor.addListener(setData);
   };
 
   const _unsubscribe = () => {
@@ -104,64 +99,4 @@ const styles = StyleSheet.create({
 import { LightSensor } from 'expo-sensors';
 ```
 
-## Methods
-
-### `LightSensor.isAvailableAsync()`
-
-> You should always check the sensor availability before attempting to use it.
-
-Returns a promise which resolves into a boolean denoting the availability of the device light sensor.
-
-| OS      | Availability                |
-| ------- | --------------------------- |
-| iOS     | `N/A`                       |
-| Android | Android 2.3+ (API Level 9+) |
-| Web     | `N/A`                       |
-
-#### Returns
-
-- A promise that resolves to a `boolean` denoting the availability of the sensor.
-
-### `LightSensor.addListener((data: LightSensorMeasurement) => void)`
-
-Subscribe for updates to the light sensor.
-
-```js
-const subscription = LightSensor.addListener(lightSensorData => {
-  console.log(lightSensorData.illuminance);
-});
-```
-
-#### Arguments
-
-- **listener (_function_)** -- A callback that is invoked when a LightSensor update is available. When invoked, the listener is provided a single argument that is the illuminance value.
-
-#### Returns
-
-- A subscription that you can call `remove()` on when you would like to unsubscribe the listener.
-
-### `LightSensor.removeAllListeners()`
-
-Removes all listeners.
-
-## Types
-
-### `LightSensorMeasurement`
-
-```typescript
-type LightSensorMeasurement = {
-  illuminance: number;
-};
-```
-
-| Name        | Type     | Format | iOS | Android | Web |
-| ----------- | -------- | ------ | --- | ------- | --- |
-| illuminance | `number` | `lx`   | ❌  | ✅      | ❌  |
-
-## Units and Providers
-
-| OS      | Units  | Provider                                                                                          | Description          |
-| ------- | ------ | ------------------------------------------------------------------------------------------------- | -------------------- |
-| iOS     | `N/A`  | Not implemented... see([here](https://github.com/expo/expo/discussions/18101))                    |
-| Android | _`lx`_ | [`Sensor.TYPE_LIGHT`](https://developer.android.com/reference/android/hardware/Sensor#TYPE_LIGHT) | illuminance changes. |
-| Web     | `N/A`  | Not implemented... see([here](https://github.com/expo/expo/discussions/18101))                    |
+<APISection packageName="expo-light-sensor" />


### PR DESCRIPTION
# Why

For some reason, when finishing the sensors migration I have missed that page in backport PR, the data file is already there:
* https://github.com/expo/expo/blob/main/docs/public/static/data/v47.0.0/expo-light-sensor.json

# How

Backport unversioned docs for LightSensor to SDK 47.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1549" alt="Screenshot 2022-11-09 at 20 32 54" src="https://user-images.githubusercontent.com/719641/200924070-1282a187-fee0-4287-b070-cb9a54d5d3a3.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
