### PR TITLE
[docs] fixed broken links in api docs

### DIFF
--- a/docs/pages/versions/unversioned/react-native/animated.mdx
+++ b/docs/pages/versions/unversioned/react-native/animated.mdx
@@ -97,7 +97,7 @@ There are two value types you can use with `Animated`:
 
 - [`Animated.decay()`](#decay) starts with an initial velocity and gradually slows to a stop.
 - [`Animated.spring()`](#spring) provides a basic spring physics model.
-- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.md).
+- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.mdx).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -214,7 +214,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.mdx) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -473,7 +473,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.mdx).
 
 ---
 
@@ -481,7 +481,7 @@ You can read more about `Animated.Value` API on the separate [page](animatedvalu
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.mdx).
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/animatedvaluexy.mdx
+++ b/docs/pages/versions/unversioned/react-native/animatedvaluexy.mdx
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.mdx), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/unversioned/react-native/appearance.mdx
+++ b/docs/pages/versions/unversioned/react-native/appearance.mdx
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.mdx) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/unversioned/react-native/button.mdx
+++ b/docs/pages/versions/unversioned/react-native/button.mdx
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.mdx) or [TouchableWithoutFeedback](touchablewithoutfeedback.mdx). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button
@@ -100,7 +100,7 @@ export default App;
 
 | Type                                  |
 | ------------------------------------- |
-| function([PressEvent](pressevent.md)) |
+| function([PressEvent](pressevent.mdx)) |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/dimensions.mdx
+++ b/docs/pages/versions/unversioned/react-native/dimensions.mdx
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.mdx) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/unversioned/react-native/flatlist.mdx
+++ b/docs/pages/versions/unversioned/react-native/flatlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](sectionlist.md).
+If you need section support, use [`<SectionList>`](sectionlist.mdx).
 
 ## Example
 
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -227,7 +227,7 @@ Example usage:
 
 ### `data`
 
-**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
+**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.mdx) directly.
 
 | Type  |
 | ----- |
@@ -271,7 +271,7 @@ Styling for internal View for `ListFooterComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -291,7 +291,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -301,7 +301,7 @@ Optional custom style for multi-item rows generated when `numColumns > 1`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -445,7 +445,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/image.mdx
+++ b/docs/pages/versions/unversioned/react-native/image.mdx
@@ -153,7 +153,7 @@ When the image is resized, the corners of the size specified by `capInsets` will
 
 | Type            |
 | --------------- |
-| [Rect](rect.md) |
+| [Rect](rect.mdx) |
 
 ---
 
@@ -205,7 +205,7 @@ Invoked on mount and on layout changes.
 
 | Type                                            |
 | ----------------------------------------------- |
-| function([LayoutEvent](layoutevent.md)) => void |
+| function([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -327,7 +327,7 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, 
 
 | Type                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.md) |
+| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.mdx) |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/imagebackground.mdx
+++ b/docs/pages/versions/unversioned/react-native/imagebackground.mdx
@@ -62,7 +62,7 @@ Inherits [Image Props](image.md#props).
 
 | Type                                |
 | ----------------------------------- |
-| [Image Style](image-style-props.md) |
+| [Image Style](image-style-props.mdx) |
 
 ---
 
@@ -80,4 +80,4 @@ Allows to set a reference to the inner `Image` component
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |

--- a/docs/pages/versions/unversioned/react-native/inputaccessoryview.mdx
+++ b/docs/pages/versions/unversioned/react-native/inputaccessoryview.mdx
@@ -68,7 +68,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 # Known issues
 

--- a/docs/pages/versions/unversioned/react-native/keyboardavoidingview.mdx
+++ b/docs/pages/versions/unversioned/react-native/keyboardavoidingview.mdx
@@ -97,7 +97,7 @@ The style of the content container (View) when behavior is `'position'`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/layoutevent.mdx
+++ b/docs/pages/versions/unversioned/react-native/layoutevent.mdx
@@ -3,7 +3,7 @@ id: layoutevent
 title: LayoutEvent Object Type
 ---
 
-`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.md) component.
+`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.mdx) component.
 
 ## Example
 
@@ -63,10 +63,10 @@ The node id of the element receiving the PressEvent.
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/unversioned/react-native/panresponder.mdx
+++ b/docs/pages/versions/unversioned/react-native/panresponder.mdx
@@ -13,7 +13,7 @@ It provides a predictable wrapper of the responder handlers provided by the [ges
 onPanResponderMove: (event, gestureState) => {};
 ```
 
-A native event is a synthetic touch event with form of [PressEvent](pressevent.md).
+A native event is a synthetic touch event with form of [PressEvent](pressevent.mdx).
 
 A `gestureState` object has the following:
 
@@ -154,7 +154,7 @@ static create(config)
 | --------------------- | ------ | ----------- |
 | config **(Required)** | object | Refer below |
 
-The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.mdx), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/unversioned/react-native/pressable.mdx
+++ b/docs/pages/versions/unversioned/react-native/pressable.mdx
@@ -125,7 +125,7 @@ Either children or a function that receives a boolean reflecting whether the com
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [React Node](react-node.md) | No       |
+| [React Node](react-node.mdx) | No       |
 
 ### `unstable_pressDelay`
 
@@ -157,7 +157,7 @@ Sets additional distance outside of element in which a press can be detected.
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onLongPress`
 
@@ -165,7 +165,7 @@ Called if the time after `onPressIn` lasts longer than 500 milliseconds. This ti
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPress`
 
@@ -173,7 +173,7 @@ Called after `onPressOut`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressIn`
 
@@ -181,7 +181,7 @@ Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressOut`
 
@@ -189,7 +189,7 @@ Called when a touch is released.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `pressRetentionOffset`
 
@@ -197,7 +197,7 @@ Additional distance outside of this view in which a touch is considered a press 
 
 | Type                      | Required | Default                                        |
 | ------------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect.md) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| [Rect](rect.mdx) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
@@ -205,7 +205,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/unversioned/react-native/pressevent.mdx
+++ b/docs/pages/versions/unversioned/react-native/pressevent.mdx
@@ -3,7 +3,7 @@ id: pressevent
 title: PressEvent Object Type
 ---
 
-`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.md) component.
+`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.mdx) component.
 
 ## Example
 
@@ -105,14 +105,14 @@ Array of all current PressEvents on the screen.
 
 ## Used by
 
-- [`Button`](button.md)
-- [`PanResponder`](panresponder.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableHighlight`](touchablenativefeedback.md)
-- [`TouchableOpacity`](touchablewithoutfeedback.md)
-- [`TouchableNativeFeedback`](touchablenativefeedback.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Button`](button.mdx)
+- [`PanResponder`](panresponder.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableHighlight`](touchablenativefeedback.mdx)
+- [`TouchableOpacity`](touchablewithoutfeedback.mdx)
+- [`TouchableNativeFeedback`](touchablenativefeedback.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/unversioned/react-native/rect.mdx
+++ b/docs/pages/versions/unversioned/react-native/rect.mdx
@@ -44,7 +44,7 @@ title: Rect Object Type
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`Text`](text.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`Text`](text.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)

--- a/docs/pages/versions/unversioned/react-native/scrollview.mdx
+++ b/docs/pages/versions/unversioned/react-native/scrollview.mdx
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.mdx) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -170,7 +170,7 @@ const styles = StyleSheet.create({
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -520,7 +520,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out.
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](refreshcontrol.md).
+See [RefreshControl](refreshcontrol.mdx).
 
 | Type    |
 | ------- |

--- a/docs/pages/versions/unversioned/react-native/sectionlist.mdx
+++ b/docs/pages/versions/unversioned/react-native/sectionlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.mdx).
 
 ## Example
 
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -126,7 +126,7 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
+**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.mdx).
 
 | Type                                        |
 | ------------------------------------------- |
@@ -250,7 +250,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/text.mdx
+++ b/docs/pages/versions/unversioned/react-native/text.mdx
@@ -371,7 +371,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -381,7 +381,7 @@ This function is called on long press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -391,7 +391,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -401,7 +401,7 @@ This function is called on press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -411,7 +411,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -421,7 +421,7 @@ The user is moving their finger.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -431,7 +431,7 @@ Fired at the end of the touch.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -441,7 +441,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -451,7 +451,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -461,7 +461,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -481,7 +481,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                    |
 | ----------------------- |
-| [Rect](rect.md), number |
+| [Rect](rect.mdx), number |
 
 ---
 
@@ -509,7 +509,7 @@ The highlight color of the text.
 
 | Type                                                                       |
 | -------------------------------------------------------------------------- |
-| [Text Style](text-style-props.md), [View Style Props](view-style-props.md) |
+| [Text Style](text-style-props.mdx), [View Style Props](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/textinput.mdx
+++ b/docs/pages/versions/unversioned/react-native/textinput.mdx
@@ -325,7 +325,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID` **(iOS)**
 
-An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.mdx) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   |
 | ------ |
@@ -485,7 +485,7 @@ Callback that is called when a touch is engaged.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -495,7 +495,7 @@ Callback that is called when a touch is released.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -505,7 +505,7 @@ Callback that is called when the text input is focused. This is called with `{ n
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/touchablehighlight.mdx
+++ b/docs/pages/versions/unversioned/react-native/touchablehighlight.mdx
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 

--- a/docs/pages/versions/unversioned/react-native/touchablenativefeedback.mdx
+++ b/docs/pages/versions/unversioned/react-native/touchablenativefeedback.mdx
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 

--- a/docs/pages/versions/unversioned/react-native/touchableopacity.mdx
+++ b/docs/pages/versions/unversioned/react-native/touchableopacity.mdx
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 

--- a/docs/pages/versions/unversioned/react-native/touchablewithoutfeedback.mdx
+++ b/docs/pages/versions/unversioned/react-native/touchablewithoutfeedback.mdx
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 
@@ -255,7 +255,7 @@ This defines how far your touch can start away from the button. This is added to
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onBlur`
 
@@ -283,7 +283,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -299,7 +299,7 @@ Called if the time after `onPressIn` lasts longer than 370 milliseconds. This ti
 
 ### `onPress`
 
-Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.md).
+Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -309,7 +309,7 @@ Called when the touch is released, but not if cancelled (e.g. by a scroll that s
 
 ### `onPressIn`
 
-Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -319,7 +319,7 @@ Called as soon as the touchable element is pressed and invoked even before onPre
 
 ### `onPressOut`
 
-Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -333,7 +333,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/view.mdx
+++ b/docs/pages/versions/unversioned/react-native/view.mdx
@@ -35,7 +35,7 @@ export default ViewBoxesWithColorAndText;
 
 ### Synthetic Touch Events
 
-For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.md).
+For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.mdx).
 
 ---
 
@@ -47,7 +47,7 @@ For `View` responder props (e.g., `onResponderMove`), the synthetic touch event 
 
 Does this view want to become responder on the start of a touch?
 
-`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -308,7 +308,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -316,7 +316,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -328,7 +328,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -340,7 +340,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -352,7 +352,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -364,7 +364,7 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -376,7 +376,7 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -388,7 +388,7 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -400,7 +400,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -412,7 +412,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -470,7 +470,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ---
 

--- a/docs/pages/versions/unversioned/react-native/viewtoken.mdx
+++ b/docs/pages/versions/unversioned/react-native/viewtoken.mdx
@@ -3,7 +3,7 @@ id: viewtoken
 title: ViewToken Object Type
 ---
 
-`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.md) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
+`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.mdx) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
 
 ## Example
 
@@ -60,6 +60,6 @@ Item section data when used with `SectionList`.
 
 ## Used by
 
-- [`FlatList`](flatlist.md)
-- [`SectionList`](sectionlist.md)
-- [`VirtualizedList`](virtualizedlist.md)
+- [`FlatList`](flatlist.mdx)
+- [`SectionList`](sectionlist.mdx)
+- [`VirtualizedList`](virtualizedlist.mdx)

--- a/docs/pages/versions/unversioned/react-native/virtualizedlist.mdx
+++ b/docs/pages/versions/unversioned/react-native/virtualizedlist.mdx
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.mdx) and [`<SectionList>`](sectionlist.mdx) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.mdx) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -139,7 +139,7 @@ Inherits [ScrollView Props](scrollview.md#props).
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.md).
+Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.mdx).
 
 | Type                |
 | ------------------- |
@@ -213,7 +213,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -398,7 +398,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/unversioned/sdk/shared-element.mdx
+++ b/docs/pages/versions/unversioned/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.mdx) for API and usage information.

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -55,7 +55,7 @@ On iOS, these properties are set as keys in **Expo.plist** file. You can also se
 | `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
 | `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
 
-For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
+For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.mdx) repository.
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/react-native/animated.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/animated.mdx
@@ -97,7 +97,7 @@ There are two value types you can use with `Animated`:
 
 - [`Animated.decay()`](#decay) starts with an initial velocity and gradually slows to a stop.
 - [`Animated.spring()`](#spring) provides a basic spring physics model.
-- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.md).
+- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.mdx).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -214,7 +214,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.mdx) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -473,7 +473,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.mdx).
 
 ---
 
@@ -481,7 +481,7 @@ You can read more about `Animated.Value` API on the separate [page](animatedvalu
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.mdx).
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/animatedvaluexy.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/animatedvaluexy.mdx
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.mdx), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v45.0.0/react-native/appearance.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/appearance.mdx
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.mdx) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/v45.0.0/react-native/button.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/button.mdx
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.mdx) or [TouchableWithoutFeedback](touchablewithoutfeedback.mdx). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button
@@ -100,7 +100,7 @@ export default App;
 
 | Type                                  |
 | ------------------------------------- |
-| function([PressEvent](pressevent.md)) |
+| function([PressEvent](pressevent.mdx)) |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/dimensions.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/dimensions.mdx
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.mdx) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v45.0.0/react-native/flatlist.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/flatlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](sectionlist.md).
+If you need section support, use [`<SectionList>`](sectionlist.mdx).
 
 ## Example
 
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -227,7 +227,7 @@ Example usage:
 
 ### `data`
 
-**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
+**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.mdx) directly.
 
 | Type  |
 | ----- |
@@ -271,7 +271,7 @@ Styling for internal View for `ListFooterComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -291,7 +291,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -301,7 +301,7 @@ Optional custom style for multi-item rows generated when `numColumns > 1`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -445,7 +445,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/image.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/image.mdx
@@ -153,7 +153,7 @@ When the image is resized, the corners of the size specified by `capInsets` will
 
 | Type            |
 | --------------- |
-| [Rect](rect.md) |
+| [Rect](rect.mdx) |
 
 ---
 
@@ -205,7 +205,7 @@ Invoked on mount and on layout changes.
 
 | Type                                            |
 | ----------------------------------------------- |
-| function([LayoutEvent](layoutevent.md)) => void |
+| function([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -327,7 +327,7 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, 
 
 | Type                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.md) |
+| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.mdx) |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/imagebackground.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/imagebackground.mdx
@@ -62,7 +62,7 @@ Inherits [Image Props](image.md#props).
 
 | Type                                |
 | ----------------------------------- |
-| [Image Style](image-style-props.md) |
+| [Image Style](image-style-props.mdx) |
 
 ---
 
@@ -80,4 +80,4 @@ Allows to set a reference to the inner `Image` component
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |

--- a/docs/pages/versions/v45.0.0/react-native/inputaccessoryview.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/inputaccessoryview.mdx
@@ -68,7 +68,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 # Known issues
 

--- a/docs/pages/versions/v45.0.0/react-native/keyboardavoidingview.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/keyboardavoidingview.mdx
@@ -97,7 +97,7 @@ The style of the content container (View) when behavior is `'position'`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/layoutevent.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/layoutevent.mdx
@@ -3,7 +3,7 @@ id: layoutevent
 title: LayoutEvent Object Type
 ---
 
-`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.md) component.
+`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.mdx) component.
 
 ## Example
 
@@ -63,10 +63,10 @@ The node id of the element receiving the PressEvent.
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v45.0.0/react-native/panresponder.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/panresponder.mdx
@@ -13,7 +13,7 @@ It provides a predictable wrapper of the responder handlers provided by the [ges
 onPanResponderMove: (event, gestureState) => {};
 ```
 
-A native event is a synthetic touch event with form of [PressEvent](pressevent.md).
+A native event is a synthetic touch event with form of [PressEvent](pressevent.mdx).
 
 A `gestureState` object has the following:
 
@@ -154,7 +154,7 @@ static create(config)
 | --------------------- | ------ | ----------- |
 | config **(Required)** | object | Refer below |
 
-The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.mdx), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/v45.0.0/react-native/pressable.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/pressable.mdx
@@ -125,7 +125,7 @@ Either children or a function that receives a boolean reflecting whether the com
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [React Node](react-node.md) | No       |
+| [React Node](react-node.mdx) | No       |
 
 ### `unstable_pressDelay`
 
@@ -157,7 +157,7 @@ Sets additional distance outside of element in which a press can be detected.
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onLongPress`
 
@@ -165,7 +165,7 @@ Called if the time after `onPressIn` lasts longer than 500 milliseconds. This ti
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPress`
 
@@ -173,7 +173,7 @@ Called after `onPressOut`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressIn`
 
@@ -181,7 +181,7 @@ Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressOut`
 
@@ -189,7 +189,7 @@ Called when a touch is released.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `pressRetentionOffset`
 
@@ -197,7 +197,7 @@ Additional distance outside of this view in which a touch is considered a press 
 
 | Type                      | Required | Default                                        |
 | ------------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect.md) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| [Rect](rect.mdx) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
@@ -205,7 +205,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/v45.0.0/react-native/pressevent.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/pressevent.mdx
@@ -3,7 +3,7 @@ id: pressevent
 title: PressEvent Object Type
 ---
 
-`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.md) component.
+`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.mdx) component.
 
 ## Example
 
@@ -105,14 +105,14 @@ Array of all current PressEvents on the screen.
 
 ## Used by
 
-- [`Button`](button.md)
-- [`PanResponder`](panresponder.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableHighlight`](touchablenativefeedback.md)
-- [`TouchableOpacity`](touchablewithoutfeedback.md)
-- [`TouchableNativeFeedback`](touchablenativefeedback.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Button`](button.mdx)
+- [`PanResponder`](panresponder.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableHighlight`](touchablenativefeedback.mdx)
+- [`TouchableOpacity`](touchablewithoutfeedback.mdx)
+- [`TouchableNativeFeedback`](touchablenativefeedback.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v45.0.0/react-native/rect.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/rect.mdx
@@ -44,7 +44,7 @@ title: Rect Object Type
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`Text`](text.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`Text`](text.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)

--- a/docs/pages/versions/v45.0.0/react-native/scrollview.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/scrollview.mdx
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.mdx) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -170,7 +170,7 @@ const styles = StyleSheet.create({
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -520,7 +520,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out.
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](refreshcontrol.md).
+See [RefreshControl](refreshcontrol.mdx).
 
 | Type    |
 | ------- |

--- a/docs/pages/versions/v45.0.0/react-native/sectionlist.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/sectionlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.mdx).
 
 ## Example
 
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -126,7 +126,7 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
+**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.mdx).
 
 | Type                                        |
 | ------------------------------------------- |
@@ -250,7 +250,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/text.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/text.mdx
@@ -371,7 +371,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -381,7 +381,7 @@ This function is called on long press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -391,7 +391,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -401,7 +401,7 @@ This function is called on press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -411,7 +411,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -421,7 +421,7 @@ The user is moving their finger.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -431,7 +431,7 @@ Fired at the end of the touch.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -441,7 +441,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -451,7 +451,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -461,7 +461,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -481,7 +481,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                    |
 | ----------------------- |
-| [Rect](rect.md), number |
+| [Rect](rect.mdx), number |
 
 ---
 
@@ -509,7 +509,7 @@ The highlight color of the text.
 
 | Type                                                                       |
 | -------------------------------------------------------------------------- |
-| [Text Style](text-style-props.md), [View Style Props](view-style-props.md) |
+| [Text Style](text-style-props.mdx), [View Style Props](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/textinput.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/textinput.mdx
@@ -325,7 +325,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID` **(iOS)**
 
-An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.mdx) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   |
 | ------ |
@@ -485,7 +485,7 @@ Callback that is called when a touch is engaged.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -495,7 +495,7 @@ Callback that is called when a touch is released.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -505,7 +505,7 @@ Callback that is called when the text input is focused. This is called with `{ n
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/touchablehighlight.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/touchablehighlight.mdx
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 

--- a/docs/pages/versions/v45.0.0/react-native/touchablenativefeedback.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/touchablenativefeedback.mdx
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 

--- a/docs/pages/versions/v45.0.0/react-native/touchableopacity.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/touchableopacity.mdx
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 

--- a/docs/pages/versions/v45.0.0/react-native/touchablewithoutfeedback.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/touchablewithoutfeedback.mdx
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 
@@ -255,7 +255,7 @@ This defines how far your touch can start away from the button. This is added to
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onBlur`
 
@@ -283,7 +283,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -299,7 +299,7 @@ Called if the time after `onPressIn` lasts longer than 370 milliseconds. This ti
 
 ### `onPress`
 
-Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.md).
+Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -309,7 +309,7 @@ Called when the touch is released, but not if cancelled (e.g. by a scroll that s
 
 ### `onPressIn`
 
-Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -319,7 +319,7 @@ Called as soon as the touchable element is pressed and invoked even before onPre
 
 ### `onPressOut`
 
-Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -333,7 +333,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/view.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/view.mdx
@@ -35,7 +35,7 @@ export default ViewBoxesWithColorAndText;
 
 ### Synthetic Touch Events
 
-For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.md).
+For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.mdx).
 
 ---
 
@@ -47,7 +47,7 @@ For `View` responder props (e.g., `onResponderMove`), the synthetic touch event 
 
 Does this view want to become responder on the start of a touch?
 
-`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -308,7 +308,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -316,7 +316,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -328,7 +328,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -340,7 +340,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -352,7 +352,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -364,7 +364,7 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -376,7 +376,7 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -388,7 +388,7 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -400,7 +400,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -412,7 +412,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -470,7 +470,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/react-native/viewtoken.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/viewtoken.mdx
@@ -3,7 +3,7 @@ id: viewtoken
 title: ViewToken Object Type
 ---
 
-`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.md) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
+`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.mdx) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
 
 ## Example
 
@@ -60,6 +60,6 @@ Item section data when used with `SectionList`.
 
 ## Used by
 
-- [`FlatList`](flatlist.md)
-- [`SectionList`](sectionlist.md)
-- [`VirtualizedList`](virtualizedlist.md)
+- [`FlatList`](flatlist.mdx)
+- [`SectionList`](sectionlist.mdx)
+- [`VirtualizedList`](virtualizedlist.mdx)

--- a/docs/pages/versions/v45.0.0/react-native/virtualizedlist.mdx
+++ b/docs/pages/versions/v45.0.0/react-native/virtualizedlist.mdx
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.mdx) and [`<SectionList>`](sectionlist.mdx) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.mdx) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -139,7 +139,7 @@ Inherits [ScrollView Props](scrollview.md#props).
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.md).
+Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.mdx).
 
 | Type                |
 | ------------------- |
@@ -213,7 +213,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -398,7 +398,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v45.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.mdx) for API and usage information.

--- a/docs/pages/versions/v46.0.0/react-native/animated.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/animated.mdx
@@ -97,7 +97,7 @@ There are two value types you can use with `Animated`:
 
 - [`Animated.decay()`](#decay) starts with an initial velocity and gradually slows to a stop.
 - [`Animated.spring()`](#spring) provides a basic spring physics model.
-- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.md).
+- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.mdx).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -214,7 +214,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.mdx) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -473,7 +473,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.mdx).
 
 ---
 
@@ -481,7 +481,7 @@ You can read more about `Animated.Value` API on the separate [page](animatedvalu
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.mdx).
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/animatedvaluexy.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/animatedvaluexy.mdx
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.mdx), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v46.0.0/react-native/appearance.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/appearance.mdx
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.mdx) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/v46.0.0/react-native/button.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/button.mdx
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.mdx) or [TouchableWithoutFeedback](touchablewithoutfeedback.mdx). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button
@@ -100,7 +100,7 @@ export default App;
 
 | Type                                  |
 | ------------------------------------- |
-| function([PressEvent](pressevent.md)) |
+| function([PressEvent](pressevent.mdx)) |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/dimensions.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/dimensions.mdx
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.mdx) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v46.0.0/react-native/flatlist.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/flatlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](sectionlist.md).
+If you need section support, use [`<SectionList>`](sectionlist.mdx).
 
 ## Example
 
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -227,7 +227,7 @@ Example usage:
 
 ### `data`
 
-**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
+**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.mdx) directly.
 
 | Type  |
 | ----- |
@@ -271,7 +271,7 @@ Styling for internal View for `ListFooterComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -291,7 +291,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -301,7 +301,7 @@ Optional custom style for multi-item rows generated when `numColumns > 1`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -445,7 +445,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/image.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/image.mdx
@@ -153,7 +153,7 @@ When the image is resized, the corners of the size specified by `capInsets` will
 
 | Type            |
 | --------------- |
-| [Rect](rect.md) |
+| [Rect](rect.mdx) |
 
 ---
 
@@ -205,7 +205,7 @@ Invoked on mount and on layout changes.
 
 | Type                                            |
 | ----------------------------------------------- |
-| function([LayoutEvent](layoutevent.md)) => void |
+| function([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -327,7 +327,7 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, 
 
 | Type                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.md) |
+| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.mdx) |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/imagebackground.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/imagebackground.mdx
@@ -62,7 +62,7 @@ Inherits [Image Props](image.md#props).
 
 | Type                                |
 | ----------------------------------- |
-| [Image Style](image-style-props.md) |
+| [Image Style](image-style-props.mdx) |
 
 ---
 
@@ -80,4 +80,4 @@ Allows to set a reference to the inner `Image` component
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |

--- a/docs/pages/versions/v46.0.0/react-native/inputaccessoryview.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/inputaccessoryview.mdx
@@ -68,7 +68,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 # Known issues
 

--- a/docs/pages/versions/v46.0.0/react-native/keyboardavoidingview.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/keyboardavoidingview.mdx
@@ -97,7 +97,7 @@ The style of the content container (View) when behavior is `'position'`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/layoutevent.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/layoutevent.mdx
@@ -3,7 +3,7 @@ id: layoutevent
 title: LayoutEvent Object Type
 ---
 
-`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.md) component.
+`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.mdx) component.
 
 ## Example
 
@@ -63,10 +63,10 @@ The node id of the element receiving the PressEvent.
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v46.0.0/react-native/panresponder.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/panresponder.mdx
@@ -13,7 +13,7 @@ It provides a predictable wrapper of the responder handlers provided by the [ges
 onPanResponderMove: (event, gestureState) => {};
 ```
 
-A native event is a synthetic touch event with form of [PressEvent](pressevent.md).
+A native event is a synthetic touch event with form of [PressEvent](pressevent.mdx).
 
 A `gestureState` object has the following:
 
@@ -154,7 +154,7 @@ static create(config)
 | --------------------- | ------ | ----------- |
 | config **(Required)** | object | Refer below |
 
-The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.mdx), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/v46.0.0/react-native/pressable.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/pressable.mdx
@@ -125,7 +125,7 @@ Either children or a function that receives a boolean reflecting whether the com
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [React Node](react-node.md) | No       |
+| [React Node](react-node.mdx) | No       |
 
 ### `unstable_pressDelay`
 
@@ -157,7 +157,7 @@ Sets additional distance outside of element in which a press can be detected.
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onLongPress`
 
@@ -165,7 +165,7 @@ Called if the time after `onPressIn` lasts longer than 500 milliseconds. This ti
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPress`
 
@@ -173,7 +173,7 @@ Called after `onPressOut`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressIn`
 
@@ -181,7 +181,7 @@ Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressOut`
 
@@ -189,7 +189,7 @@ Called when a touch is released.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `pressRetentionOffset`
 
@@ -197,7 +197,7 @@ Additional distance outside of this view in which a touch is considered a press 
 
 | Type                      | Required | Default                                        |
 | ------------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect.md) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| [Rect](rect.mdx) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
@@ -205,7 +205,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/v46.0.0/react-native/pressevent.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/pressevent.mdx
@@ -3,7 +3,7 @@ id: pressevent
 title: PressEvent Object Type
 ---
 
-`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.md) component.
+`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.mdx) component.
 
 ## Example
 
@@ -105,14 +105,14 @@ Array of all current PressEvents on the screen.
 
 ## Used by
 
-- [`Button`](button.md)
-- [`PanResponder`](panresponder.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableHighlight`](touchablenativefeedback.md)
-- [`TouchableOpacity`](touchablewithoutfeedback.md)
-- [`TouchableNativeFeedback`](touchablenativefeedback.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Button`](button.mdx)
+- [`PanResponder`](panresponder.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableHighlight`](touchablenativefeedback.mdx)
+- [`TouchableOpacity`](touchablewithoutfeedback.mdx)
+- [`TouchableNativeFeedback`](touchablenativefeedback.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v46.0.0/react-native/rect.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/rect.mdx
@@ -44,7 +44,7 @@ title: Rect Object Type
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`Text`](text.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`Text`](text.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)

--- a/docs/pages/versions/v46.0.0/react-native/scrollview.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/scrollview.mdx
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.mdx) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -170,7 +170,7 @@ const styles = StyleSheet.create({
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -520,7 +520,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out.
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](refreshcontrol.md).
+See [RefreshControl](refreshcontrol.mdx).
 
 | Type    |
 | ------- |

--- a/docs/pages/versions/v46.0.0/react-native/sectionlist.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/sectionlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.mdx).
 
 ## Example
 
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -126,7 +126,7 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
+**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.mdx).
 
 | Type                                        |
 | ------------------------------------------- |
@@ -250,7 +250,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/text.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/text.mdx
@@ -371,7 +371,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -381,7 +381,7 @@ This function is called on long press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -391,7 +391,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -401,7 +401,7 @@ This function is called on press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -411,7 +411,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -421,7 +421,7 @@ The user is moving their finger.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -431,7 +431,7 @@ Fired at the end of the touch.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -441,7 +441,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -451,7 +451,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -461,7 +461,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -481,7 +481,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                    |
 | ----------------------- |
-| [Rect](rect.md), number |
+| [Rect](rect.mdx), number |
 
 ---
 
@@ -509,7 +509,7 @@ The highlight color of the text.
 
 | Type                                                                       |
 | -------------------------------------------------------------------------- |
-| [Text Style](text-style-props.md), [View Style Props](view-style-props.md) |
+| [Text Style](text-style-props.mdx), [View Style Props](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/textinput.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/textinput.mdx
@@ -325,7 +325,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID` **(iOS)**
 
-An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.mdx) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   |
 | ------ |
@@ -485,7 +485,7 @@ Callback that is called when a touch is engaged.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -495,7 +495,7 @@ Callback that is called when a touch is released.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -505,7 +505,7 @@ Callback that is called when the text input is focused. This is called with `{ n
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/touchablehighlight.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/touchablehighlight.mdx
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 

--- a/docs/pages/versions/v46.0.0/react-native/touchablenativefeedback.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/touchablenativefeedback.mdx
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 

--- a/docs/pages/versions/v46.0.0/react-native/touchableopacity.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/touchableopacity.mdx
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 

--- a/docs/pages/versions/v46.0.0/react-native/touchablewithoutfeedback.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/touchablewithoutfeedback.mdx
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 
@@ -255,7 +255,7 @@ This defines how far your touch can start away from the button. This is added to
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onBlur`
 
@@ -283,7 +283,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -299,7 +299,7 @@ Called if the time after `onPressIn` lasts longer than 370 milliseconds. This ti
 
 ### `onPress`
 
-Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.md).
+Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -309,7 +309,7 @@ Called when the touch is released, but not if cancelled (e.g. by a scroll that s
 
 ### `onPressIn`
 
-Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -319,7 +319,7 @@ Called as soon as the touchable element is pressed and invoked even before onPre
 
 ### `onPressOut`
 
-Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -333,7 +333,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/view.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/view.mdx
@@ -35,7 +35,7 @@ export default ViewBoxesWithColorAndText;
 
 ### Synthetic Touch Events
 
-For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.md).
+For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.mdx).
 
 ---
 
@@ -47,7 +47,7 @@ For `View` responder props (e.g., `onResponderMove`), the synthetic touch event 
 
 Does this view want to become responder on the start of a touch?
 
-`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -308,7 +308,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -316,7 +316,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -328,7 +328,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -340,7 +340,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -352,7 +352,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -364,7 +364,7 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -376,7 +376,7 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -388,7 +388,7 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -400,7 +400,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -412,7 +412,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -470,7 +470,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/react-native/viewtoken.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/viewtoken.mdx
@@ -3,7 +3,7 @@ id: viewtoken
 title: ViewToken Object Type
 ---
 
-`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.md) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
+`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.mdx) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
 
 ## Example
 
@@ -60,6 +60,6 @@ Item section data when used with `SectionList`.
 
 ## Used by
 
-- [`FlatList`](flatlist.md)
-- [`SectionList`](sectionlist.md)
-- [`VirtualizedList`](virtualizedlist.md)
+- [`FlatList`](flatlist.mdx)
+- [`SectionList`](sectionlist.mdx)
+- [`VirtualizedList`](virtualizedlist.mdx)

--- a/docs/pages/versions/v46.0.0/react-native/virtualizedlist.mdx
+++ b/docs/pages/versions/v46.0.0/react-native/virtualizedlist.mdx
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.mdx) and [`<SectionList>`](sectionlist.mdx) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.mdx) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -139,7 +139,7 @@ Inherits [ScrollView Props](scrollview.md#props).
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.md).
+Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.mdx).
 
 | Type                |
 | ------------------- |
@@ -213,7 +213,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -398,7 +398,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.mdx) for API and usage information.

--- a/docs/pages/versions/v47.0.0/react-native/animated.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/animated.mdx
@@ -97,7 +97,7 @@ There are two value types you can use with `Animated`:
 
 - [`Animated.decay()`](#decay) starts with an initial velocity and gradually slows to a stop.
 - [`Animated.spring()`](#spring) provides a basic spring physics model.
-- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.md).
+- [`Animated.timing()`](#timing) animates a value over time using [easing functions](easing.mdx).
 
 In most cases, you will be using `timing()`. By default, it uses a symmetric easeInOut curve that conveys the gradual acceleration of an object to full speed and concludes by gradually decelerating to a stop.
 
@@ -214,7 +214,7 @@ Config is an object that may have the following options:
 static timing(value, config)
 ```
 
-Animates a value along a timed easing curve. The [`Easing`](easing.md) module has tons of predefined curves, or you can use your own function.
+Animates a value along a timed easing curve. The [`Easing`](easing.mdx) module has tons of predefined curves, or you can use your own function.
 
 Config is an object that may have the following options:
 
@@ -473,7 +473,7 @@ Stops any running animation and resets the value to its original.
 
 Standard value class for driving animations. Typically initialized with `new Animated.Value(0);`
 
-You can read more about `Animated.Value` API on the separate [page](animatedvalue.md).
+You can read more about `Animated.Value` API on the separate [page](animatedvalue.mdx).
 
 ---
 
@@ -481,7 +481,7 @@ You can read more about `Animated.Value` API on the separate [page](animatedvalu
 
 2D value class for driving 2D animations, such as pan gestures.
 
-You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.md).
+You can read more about `Animated.ValueXY` API on the separate [page](animatedvaluexy.mdx).
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/animatedvaluexy.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/animatedvaluexy.mdx
@@ -3,7 +3,7 @@ id: animatedvaluexy
 title: Animated.ValueXY
 ---
 
-2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.md), but multiplexed. Contains two regular `Animated.Value`s under the hood.
+2D Value for driving 2D animations, such as pan gestures. Almost identical API to normal [`Animated.Value`](animatedvalue.mdx), but multiplexed. Contains two regular `Animated.Value`s under the hood.
 
 ## Example
 

--- a/docs/pages/versions/v47.0.0/react-native/appearance.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/appearance.mdx
@@ -28,7 +28,7 @@ if (colorScheme === 'dark') {
 }
 ```
 
-Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.md) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
+Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value. For example, you may use the [`useColorScheme`](usecolorscheme.mdx) React hook as it provides and subscribes to color scheme updates, or you may use inline styles rather than setting a value in a `StyleSheet`.
 
 # Reference
 

--- a/docs/pages/versions/v47.0.0/react-native/button.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/button.mdx
@@ -5,7 +5,7 @@ title: Button
 
 A basic button component that should render nicely on any platform. Supports a minimal level of customization.
 
-If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.md) or [TouchableWithoutFeedback](touchablewithoutfeedback.md). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
+If this button doesn't look right for your app, you can build your own button using [TouchableOpacity](touchableopacity.mdx) or [TouchableWithoutFeedback](touchablewithoutfeedback.mdx). For inspiration, look at the [source code for this button component](https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js). Or, take a look at the [wide variety of button components built by the community](https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button).
 
 ```js
 <Button
@@ -100,7 +100,7 @@ export default App;
 
 | Type                                  |
 | ------------------------------------- |
-| function([PressEvent](pressevent.md)) |
+| function([PressEvent](pressevent.mdx)) |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/dimensions.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/dimensions.mdx
@@ -3,7 +3,7 @@ id: dimensions
 title: Dimensions
 ---
 
-> [`useWindowDimensions`](usewindowdimensions.md) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
+> [`useWindowDimensions`](usewindowdimensions.mdx) is the preferred API for React components. Unlike `Dimensions`, it updates as the window's dimensions update. This works nicely with the React paradigm.
 
 ```js
 import { Dimensions } from 'react-native';

--- a/docs/pages/versions/v47.0.0/react-native/flatlist.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/flatlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering basic, flat lists, supporting the most hand
 - ScrollToIndex support.
 - Multiple column support.
 
-If you need section support, use [`<SectionList>`](sectionlist.md).
+If you need section support, use [`<SectionList>`](sectionlist.mdx).
 
 ## Example
 
@@ -160,7 +160,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -227,7 +227,7 @@ Example usage:
 
 ### `data`
 
-**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.md) directly.
+**Required** For simplicity, data is a plain array. If you want to use something else, like an immutable list, use the underlying [`VirtualizedList`](virtualizedlist.mdx) directly.
 
 | Type  |
 | ----- |
@@ -271,7 +271,7 @@ Styling for internal View for `ListFooterComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -291,7 +291,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -301,7 +301,7 @@ Optional custom style for multi-item rows generated when `numColumns > 1`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -445,7 +445,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/image.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/image.mdx
@@ -153,7 +153,7 @@ When the image is resized, the corners of the size specified by `capInsets` will
 
 | Type            |
 | --------------- |
-| [Rect](rect.md) |
+| [Rect](rect.mdx) |
 
 ---
 
@@ -205,7 +205,7 @@ Invoked on mount and on layout changes.
 
 | Type                                            |
 | ----------------------------------------------- |
-| function([LayoutEvent](layoutevent.md)) => void |
+| function([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -327,7 +327,7 @@ The currently supported formats are `png`, `jpg`, `jpeg`, `bmp`, `gif`, `webp`, 
 
 | Type                                                                                                                                                       |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.md) |
+| [Image Style Props](image-style-props.md#props), [Layout Props](layout-props.md#props), [Shadow Props](shadow-props.md#props), [Transforms](transforms.mdx) |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/imagebackground.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/imagebackground.mdx
@@ -62,7 +62,7 @@ Inherits [Image Props](image.md#props).
 
 | Type                                |
 | ----------------------------------- |
-| [Image Style](image-style-props.md) |
+| [Image Style](image-style-props.mdx) |
 
 ---
 
@@ -80,4 +80,4 @@ Allows to set a reference to the inner `Image` component
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |

--- a/docs/pages/versions/v47.0.0/react-native/inputaccessoryview.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/inputaccessoryview.mdx
@@ -68,7 +68,7 @@ An ID which is used to associate this `InputAccessoryView` to specified TextInpu
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 # Known issues
 

--- a/docs/pages/versions/v47.0.0/react-native/keyboardavoidingview.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/keyboardavoidingview.mdx
@@ -97,7 +97,7 @@ The style of the content container (View) when behavior is `'position'`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/layoutevent.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/layoutevent.mdx
@@ -3,7 +3,7 @@ id: layoutevent
 title: LayoutEvent Object Type
 ---
 
-`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.md) component.
+`LayoutEvent` object is returned in the callback as a result of component layout change, for example `onLayout` in [View](view.mdx) component.
 
 ## Example
 
@@ -63,10 +63,10 @@ The node id of the element receiving the PressEvent.
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v47.0.0/react-native/panresponder.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/panresponder.mdx
@@ -13,7 +13,7 @@ It provides a predictable wrapper of the responder handlers provided by the [ges
 onPanResponderMove: (event, gestureState) => {};
 ```
 
-A native event is a synthetic touch event with form of [PressEvent](pressevent.md).
+A native event is a synthetic touch event with form of [PressEvent](pressevent.mdx).
 
 A `gestureState` object has the following:
 
@@ -154,7 +154,7 @@ static create(config)
 | --------------------- | ------ | ----------- |
 | config **(Required)** | object | Refer below |
 
-The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.md), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
+The `config` object provides enhanced versions of all of the responder callbacks that provide not only the [`PressEvent`](pressevent.mdx), but also the `PanResponder` gesture state, by replacing the word `Responder` with `PanResponder` in each of the typical `onResponder*` callbacks. For example, the `config` object would look like:
 
 - `onMoveShouldSetPanResponder: (e, gestureState) => {...}`
 - `onMoveShouldSetPanResponderCapture: (e, gestureState) => {...}`

--- a/docs/pages/versions/v47.0.0/react-native/pressable.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/pressable.mdx
@@ -125,7 +125,7 @@ Either children or a function that receives a boolean reflecting whether the com
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [React Node](react-node.md) | No       |
+| [React Node](react-node.mdx) | No       |
 
 ### `unstable_pressDelay`
 
@@ -157,7 +157,7 @@ Sets additional distance outside of element in which a press can be detected.
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onLongPress`
 
@@ -165,7 +165,7 @@ Called if the time after `onPressIn` lasts longer than 500 milliseconds. This ti
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPress`
 
@@ -173,7 +173,7 @@ Called after `onPressOut`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressIn`
 
@@ -181,7 +181,7 @@ Called immediately when a touch is engaged, before `onPressOut` and `onPress`.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `onPressOut`
 
@@ -189,7 +189,7 @@ Called when a touch is released.
 
 | Type                        | Required |
 | --------------------------- | -------- |
-| [PressEvent](pressevent.md) | No       |
+| [PressEvent](pressevent.mdx) | No       |
 
 ### `pressRetentionOffset`
 
@@ -197,7 +197,7 @@ Additional distance outside of this view in which a touch is considered a press 
 
 | Type                      | Required | Default                                        |
 | ------------------------- | -------- | ---------------------------------------------- |
-| [Rect](rect.md) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
+| [Rect](rect.mdx) or number | No       | `{ bottom: 30, left: 20, right: 20, top: 20 }` |
 
 ### `style`
 
@@ -205,7 +205,7 @@ Either view styles or a function that receives a boolean reflecting whether the 
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ### `testOnly_pressed`
 

--- a/docs/pages/versions/v47.0.0/react-native/pressevent.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/pressevent.mdx
@@ -3,7 +3,7 @@ id: pressevent
 title: PressEvent Object Type
 ---
 
-`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.md) component.
+`PressEvent` object is returned in the callback as a result of user press interaction, for example `onPress` in [Button](button.mdx) component.
 
 ## Example
 
@@ -105,14 +105,14 @@ Array of all current PressEvents on the screen.
 
 ## Used by
 
-- [`Button`](button.md)
-- [`PanResponder`](panresponder.md)
-- [`Pressable`](pressable.md)
-- [`ScrollView`](scrollview.md)
-- [`Text`](text.md)
-- [`TextInput`](textinput.md)
-- [`TouchableHighlight`](touchablenativefeedback.md)
-- [`TouchableOpacity`](touchablewithoutfeedback.md)
-- [`TouchableNativeFeedback`](touchablenativefeedback.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
-- [`View`](view.md)
+- [`Button`](button.mdx)
+- [`PanResponder`](panresponder.mdx)
+- [`Pressable`](pressable.mdx)
+- [`ScrollView`](scrollview.mdx)
+- [`Text`](text.mdx)
+- [`TextInput`](textinput.mdx)
+- [`TouchableHighlight`](touchablenativefeedback.mdx)
+- [`TouchableOpacity`](touchablewithoutfeedback.mdx)
+- [`TouchableNativeFeedback`](touchablenativefeedback.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)
+- [`View`](view.mdx)

--- a/docs/pages/versions/v47.0.0/react-native/rect.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/rect.mdx
@@ -44,7 +44,7 @@ title: Rect Object Type
 
 ## Used by
 
-- [`Image`](image.md)
-- [`Pressable`](pressable.md)
-- [`Text`](text.md)
-- [`TouchableWithoutFeedback`](touchablewithoutfeedback.md)
+- [`Image`](image.mdx)
+- [`Pressable`](pressable.mdx)
+- [`Text`](text.mdx)
+- [`TouchableWithoutFeedback`](touchablewithoutfeedback.mdx)

--- a/docs/pages/versions/v47.0.0/react-native/scrollview.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/scrollview.mdx
@@ -9,7 +9,7 @@ Keep in mind that ScrollViews must have a bounded height in order to work, since
 
 Doesn't yet support other contained responders from blocking this scroll view from becoming the responder.
 
-`<ScrollView>` vs [`<FlatList>`](flatlist.md) - which one to use?
+`<ScrollView>` vs [`<FlatList>`](flatlist.mdx) - which one to use?
 
 `ScrollView` renders all its react child components at once, but this has a performance downside.
 
@@ -170,7 +170,7 @@ const styles = StyleSheet.create({
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -520,7 +520,7 @@ When true, ScrollView allows use of pinch gestures to zoom in and out.
 
 A RefreshControl component, used to provide pull-to-refresh functionality for the ScrollView. Only works for vertical ScrollViews (`horizontal` prop must be `false`).
 
-See [RefreshControl](refreshcontrol.md).
+See [RefreshControl](refreshcontrol.mdx).
 
 | Type    |
 | ------- |

--- a/docs/pages/versions/v47.0.0/react-native/sectionlist.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/sectionlist.mdx
@@ -16,7 +16,7 @@ A performant interface for rendering sectioned lists, supporting the most handy 
 - Pull to Refresh.
 - Scroll loading.
 
-If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.md).
+If you don't need section support and want a simpler interface, use [`<FlatList>`](flatlist.mdx).
 
 ## Example
 
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 export default App;
 ```
 
-This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.md), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.md)) that aren't explicitly listed here, along with the following caveats:
+This is a convenience wrapper around [`<VirtualizedList>`](virtualizedlist.mdx), and thus inherits its props (as well as those of [`<ScrollView>`](scrollview.mdx)) that aren't explicitly listed here, along with the following caveats:
 
 - Internal state is not preserved when content scrolls out of the render window. Make sure all your data is captured in the item data or external stores like Flux, Redux, or Relay.
 - This is a `PureComponent` which means that it will not re-render if `props` remain shallow-equal. Make sure that everything your `renderItem` function depends on is passed as a prop (e.g. `extraData`) that is not `===` after updates, otherwise your UI may not update on changes. This includes the `data` prop and parent component state.
@@ -126,7 +126,7 @@ The render function will be passed an object with the following keys:
 
 ### `sections`
 
-**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.md).
+**Required** The actual data to render, akin to the `data` prop in [`FlatList`](flatlist.mdx).
 
 | Type                                        |
 | ------------------------------------------- |
@@ -250,7 +250,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/text.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/text.mdx
@@ -371,7 +371,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 
@@ -381,7 +381,7 @@ This function is called on long press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -391,7 +391,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -401,7 +401,7 @@ This function is called on press.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -411,7 +411,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -421,7 +421,7 @@ The user is moving their finger.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -431,7 +431,7 @@ Fired at the end of the touch.
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -441,7 +441,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 | Type                                  |
 | ------------------------------------- |
-| ([PressEvent](pressevent.md)) => void |
+| ([PressEvent](pressevent.mdx)) => void |
 
 ---
 
@@ -451,7 +451,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -461,7 +461,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 | Type                                     |
 | ---------------------------------------- |
-| ([PressEvent](pressevent.md)) => boolean |
+| ([PressEvent](pressevent.mdx)) => boolean |
 
 ---
 
@@ -481,7 +481,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                    |
 | ----------------------- |
-| [Rect](rect.md), number |
+| [Rect](rect.mdx), number |
 
 ---
 
@@ -509,7 +509,7 @@ The highlight color of the text.
 
 | Type                                                                       |
 | -------------------------------------------------------------------------- |
-| [Text Style](text-style-props.md), [View Style Props](view-style-props.md) |
+| [Text Style](text-style-props.mdx), [View Style Props](view-style-props.mdx) |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/textinput.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/textinput.mdx
@@ -325,7 +325,7 @@ Padding between the inline image, if any, and the text input itself.
 
 ### `inputAccessoryViewID` **(iOS)**
 
-An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.md) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
+An optional identifier which links a custom [InputAccessoryView](inputaccessoryview.mdx) to this text input. The InputAccessoryView is rendered above the keyboard when this text input is focused.
 
 | Type   |
 | ------ |
@@ -485,7 +485,7 @@ Callback that is called when a touch is engaged.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -495,7 +495,7 @@ Callback that is called when a touch is released.
 
 | Type                        |
 | --------------------------- |
-| [PressEvent](pressevent.md) |
+| [PressEvent](pressevent.mdx) |
 
 ---
 
@@ -505,7 +505,7 @@ Callback that is called when the text input is focused. This is called with `{ n
 
 | Type                                    |
 | --------------------------------------- |
-| ([LayoutEvent](layoutevent.md)) => void |
+| ([LayoutEvent](layoutevent.mdx)) => void |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/touchablehighlight.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/touchablehighlight.mdx
@@ -3,7 +3,7 @@ id: touchablehighlight
 title: TouchableHighlight
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, which allows the underlay color to show through, darkening or tinting the view.
 

--- a/docs/pages/versions/v47.0.0/react-native/touchablenativefeedback.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/touchablenativefeedback.mdx
@@ -3,7 +3,7 @@ id: touchablenativefeedback
 title: TouchableNativeFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches (Android only). On Android this component uses native state drawable to display touch feedback.
 

--- a/docs/pages/versions/v47.0.0/react-native/touchableopacity.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/touchableopacity.mdx
@@ -3,7 +3,7 @@ id: touchableopacity
 title: TouchableOpacity
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
 

--- a/docs/pages/versions/v47.0.0/react-native/touchablewithoutfeedback.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/touchablewithoutfeedback.mdx
@@ -3,7 +3,7 @@ id: touchablewithoutfeedback
 title: TouchableWithoutFeedback
 ---
 
-> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.md) API.
+> If you're looking for a more extensive and future-proof way to handle touch-based input, check out the [Pressable](pressable.mdx) API.
 
 Do not use unless you have a very good reason. All elements that respond to press should have a visual feedback when touched.
 
@@ -255,7 +255,7 @@ This defines how far your touch can start away from the button. This is added to
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ### `onBlur`
 
@@ -283,7 +283,7 @@ Invoked on mount and on layout changes.
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -299,7 +299,7 @@ Called if the time after `onPressIn` lasts longer than 370 milliseconds. This ti
 
 ### `onPress`
 
-Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.md).
+Called when the touch is released, but not if cancelled (e.g. by a scroll that steals the responder lock). The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -309,7 +309,7 @@ Called when the touch is released, but not if cancelled (e.g. by a scroll that s
 
 ### `onPressIn`
 
-Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touchable element is pressed and invoked even before onPress. This can be useful when making network requests. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -319,7 +319,7 @@ Called as soon as the touchable element is pressed and invoked even before onPre
 
 ### `onPressOut`
 
-Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.md).
+Called as soon as the touch is released even before onPress. The first function argument is an event in form of [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -333,7 +333,7 @@ When the scroll view is disabled, this defines how far your touch may move off o
 
 | Type                      | Required |
 | ------------------------- | -------- |
-| [Rect](rect.md) or number | No       |
+| [Rect](rect.mdx) or number | No       |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/view.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/view.mdx
@@ -35,7 +35,7 @@ export default ViewBoxesWithColorAndText;
 
 ### Synthetic Touch Events
 
-For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.md).
+For `View` responder props (e.g., `onResponderMove`), the synthetic touch event passed to them are in form of [PressEvent](pressevent.mdx).
 
 ---
 
@@ -47,7 +47,7 @@ For `View` responder props (e.g., `onResponderMove`), the synthetic touch event 
 
 Does this view want to become responder on the start of a touch?
 
-`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -308,7 +308,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 | Type                                    | Required |
 | --------------------------------------- | -------- |
-| ([LayoutEvent](layoutevent.md)) => void | No       |
+| ([LayoutEvent](layoutevent.mdx)) => void | No       |
 
 ---
 
@@ -316,7 +316,7 @@ This event is fired immediately once the layout has been calculated, but the new
 
 Does this view want to "claim" touch responsiveness? This is called for every touch move on the `View` when it is not the responder.
 
-`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponder: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -328,7 +328,7 @@ Does this view want to "claim" touch responsiveness? This is called for every to
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a move, it should have this handler which returns `true`.
 
-`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onMoveShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -340,7 +340,7 @@ If a parent `View` wants to prevent a child `View` from becoming responder on a 
 
 The View is now responding for touch events. This is the time to highlight and show the user what is happening.
 
-`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderGrant: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -352,7 +352,7 @@ The View is now responding for touch events. This is the time to highlight and s
 
 The user is moving their finger.
 
-`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderMove: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -364,7 +364,7 @@ The user is moving their finger.
 
 Another responder is already active and will not release it to that `View` asking to be the responder.
 
-`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderReject: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -376,7 +376,7 @@ Another responder is already active and will not release it to that `View` askin
 
 Fired at the end of the touch.
 
-`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderRelease: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -388,7 +388,7 @@ Fired at the end of the touch.
 
 The responder has been taken from the `View`. Might be taken by other views after a call to `onResponderTerminationRequest`, or might be taken by the OS without asking (e.g., happens with control center/ notification center on iOS)
 
-`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminate: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -400,7 +400,7 @@ The responder has been taken from the `View`. Might be taken by other views afte
 
 Some other `View` wants to become responder and is asking this `View` to release its responder. Returning `true` allows its release.
 
-`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onResponderTerminationRequest: (event) => {}`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -412,7 +412,7 @@ Some other `View` wants to become responder and is asking this `View` to release
 
 If a parent `View` wants to prevent a child `View` from becoming responder on a touch start, it should have this handler which returns `true`.
 
-`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.md).
+`View.props.onStartShouldSetResponderCapture: (event) => [true | false]`, where `event` is a [PressEvent](pressevent.mdx).
 
 | Type     | Required |
 | -------- | -------- |
@@ -470,7 +470,7 @@ This is a reserved performance property exposed by `RCTView` and is useful for s
 
 | Type                              | Required |
 | --------------------------------- | -------- |
-| [View Style](view-style-props.md) | No       |
+| [View Style](view-style-props.mdx) | No       |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/react-native/viewtoken.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/viewtoken.mdx
@@ -3,7 +3,7 @@ id: viewtoken
 title: ViewToken Object Type
 ---
 
-`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.md) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
+`ViewToken` object is returned as one of properties in the `onViewableItemsChanged` callback, for example in [FlatList](flatlist.mdx) component. It is exported by [**ViewabilityHelper.js**](https://github.com/facebook/react-native/blob/master/Libraries/Lists/ViewabilityHelper.js).
 
 ## Example
 
@@ -60,6 +60,6 @@ Item section data when used with `SectionList`.
 
 ## Used by
 
-- [`FlatList`](flatlist.md)
-- [`SectionList`](sectionlist.md)
-- [`VirtualizedList`](virtualizedlist.md)
+- [`FlatList`](flatlist.mdx)
+- [`SectionList`](sectionlist.mdx)
+- [`VirtualizedList`](virtualizedlist.mdx)

--- a/docs/pages/versions/v47.0.0/react-native/virtualizedlist.mdx
+++ b/docs/pages/versions/v47.0.0/react-native/virtualizedlist.mdx
@@ -3,7 +3,7 @@ id: virtualizedlist
 title: VirtualizedList
 ---
 
-Base implementation for the more convenient [`<FlatList>`](flatlist.md) and [`<SectionList>`](sectionlist.md) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.md) provides, e.g. for use with immutable data instead of plain arrays.
+Base implementation for the more convenient [`<FlatList>`](flatlist.mdx) and [`<SectionList>`](sectionlist.mdx) components, which are also better documented. In general, this should only really be used if you need more flexibility than [`FlatList`](flatlist.mdx) provides, e.g. for use with immutable data instead of plain arrays.
 
 Virtualization massively improves memory consumption and performance of large lists by maintaining a finite render window of active items and replacing all items outside of the render window with appropriately sized blank space. The window adapts to scrolling behavior, and items are rendered incrementally with low-pri (after any running interactions) if they are far from the visible area, or with hi-pri otherwise to minimize the potential of seeing blank space.
 
@@ -139,7 +139,7 @@ Inherits [ScrollView Props](scrollview.md#props).
 
 ### `CellRendererComponent`
 
-Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.md).
+Each cell is rendered using this element. Can be a React Component Class, or a render function. Defaults to using [`View`](view.mdx).
 
 | Type                |
 | ------------------- |
@@ -213,7 +213,7 @@ Styling for internal View for `ListHeaderComponent`.
 
 | Type                              |
 | --------------------------------- |
-| [View Style](view-style-props.md) |
+| [View Style](view-style-props.mdx) |
 
 ---
 
@@ -398,7 +398,7 @@ Called when the viewability of rows changes, as defined by the `viewabilityConfi
 
 | Type                                                                                                                                   |
 |----------------------------------------------------------------------------------------------------------------------------------------|
-| (callback: &lbrace; changed: array of [ViewToken](viewtoken.md)s, viewableItems: array of [ViewToken](viewtoken.md)s &rbrace;) => void |
+| (callback: &lbrace; changed: array of [ViewToken](viewtoken.mdx)s, viewableItems: array of [ViewToken](viewtoken.mdx)s &rbrace;) => void |
 
 ---
 

--- a/docs/pages/versions/v47.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/shared-element.mdx
@@ -22,4 +22,4 @@ import Video from '~/components/plugins/Video';
 
 ## API
 
-See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.md) for API and usage information.
+See the [react-native-shared-element README](https://github.com/IjzerenHein/react-native-shared-element/blob/main/README.mdx) for API and usage information.

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -55,7 +55,7 @@ On iOS, these properties are set as keys in **Expo.plist** file. You can also se
 | `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
 | `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
 
-For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
+For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.mdx) repository.
 
 ## API
 


### PR DESCRIPTION
# Why

I found the broken links when I was reading the api docs. (e.g. https://docs.expo.dev/versions/v47.0.0/react-native/flatlist/)
Their links are not found in this repository and redirected to `https://reactnative.dev/~` because they converted to `.mdx` by https://github.com/expo/expo/pull/19255

# How

I ran the following commands to replace `.md` with `.mdx`.
```sh
$ cd docs/pages/versions/
$ grep -l -r '.md)' | xargs sed -i '' -e "s#.md)#.mdx)#g"
```

# Test Plan

There were many changed files, so I confirmed that the only some links properly worked.
