### PR TITLE
[docs] Sentry setup tweaks

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -20,6 +20,9 @@ Sentry.init({
   dsn: 'https://1a2f5c8cec574bcea3971b74f91504d6@o30871.ingest.sentry.io/1526800',
   beforeSend: preprocessSentryError,
   environment: isDev ? 'development' : 'production',
+  denyUrls: isDev
+    ? undefined
+    : [/https:\/\/docs-expo-dev\.translate\.goog/, /https:\/\/translated\.turbopages\.org/],
   integrations: [new BrowserTracing()],
   tracesSampleRate: 1.0,
 });

--- a/docs/pages/_error.tsx
+++ b/docs/pages/_error.tsx
@@ -81,7 +81,11 @@ const Error = () => {
 
     // We are confident now that we can render a not found error
     setNotFound(true);
-    Sentry.captureMessage(`Page not found (404)`);
+    Sentry.captureMessage(`Page not found (404)`, {
+      extra: {
+        '404': pathname,
+      },
+    });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
# Why

To reduce the noise in the reports, let's start with some safe tweaks for the Sentry config.

# How

This PR adds `denyUrls` for Prod for website translate services, which often throw errors on which we cannot have a control. Ideally we should use `allowUrls` but at least for now, to ensure that we don't break the setup relay on `denyUrls`.

Additionally I have added an extra field for the 404 reports which hopefully allow us to better filter and group 404 events in Sentry dashboard.

# Test Plan

I have tried to induce an error report locally, after performing the changes, and everything seems to be working fine.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
