### PR TITLE
[ENG-6892][docs] add Xcode 14.1 image

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -167,7 +167,23 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-monterey-12.6-xcode-14.0` (alias `latest`)
+#### `macos-monterey-12.6-xcode-14.1` (alias `latest`)
+
+<Collapsible summary="Details">
+
+- macOS Monterey 12.6
+- Xcode 14.1 (14B47b)
+- Node.js 16.13.2
+- Yarn 1.22.17
+- pnpm 7.15.0
+- npm 8.1.2
+- fastlane 2.210.1
+- CocoaPods 1.11.3
+- Ruby 2.7
+
+</Collapsible>
+
+#### `macos-monterey-12.6-xcode-14.0` (alias `default`)
 
 <Collapsible summary="Details">
 
@@ -183,7 +199,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.4-xcode-13.4` (alias `default`)
+#### `macos-monterey-12.4-xcode-13.4`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/turtle-v2/pull/1142

# How

Update iOS EAS Build images docs.

# Test Plan

Test manually

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
