### PR TITLE
[docs] Update ImagePicker Snack example for SDK 47

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -108,8 +108,8 @@ export default function ImagePickerExample() {
 
     console.log(result);
 
-    if (!result.cancelled) {
-      setImage(result.uri);
+    if (!result.canceled) {
+      setImage(result.assets[0].uri);
     }
   };
 
@@ -124,24 +124,36 @@ export default function ImagePickerExample() {
 
 </SnackInline>
 
-When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
+When you run this example and pick an image, you will see the image that you picked show up in your app, and a similar log will be shown in the console:
 
-```javascript
+```json
 {
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+  "assets": [
+    {
+      "assetId": "C166F9F5-B5FE-4501-9531",
+      "base64": null,
+      "duration": null,
+      "exif": null,
+      "fileName": "IMG.HEIC",
+      "fileSize": 6018901,
+      "height": 3025,
+      "type": "image",
+      "uri": "file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+      "width": 3024
+    }
+  ],
+  "canceled": false,
+  "cancelled": false
 }
 ```
 
 ### Using with AWS S3
 
-Please refer to the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
 
 ### Using with Firebase
 
-Please refer to the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the ["Using Firebase"](/guides/using-firebase/) docs to set your project up correctly.
+Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/imagepicker.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -138,22 +138,22 @@ export default function ImagePickerExample() {
 
 When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
 
-```javascript
+```json
 {
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+  "cancelled": false,
+  "height": 1611,
+  "width": 2148,
+  "uri": "file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
 }
 ```
 
-### Using ImagePicker with AWS S3
+### Using with AWS S3
 
-Please refer to the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
 
-### Using ImagePicker with Firebase
+### Using with Firebase
 
-Please refer to the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the ["Using Firebase"](/guides/using-firebase/) docs to set your project up correctly.
+Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -126,22 +126,22 @@ export default function ImagePickerExample() {
 
 When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
 
-```javascript
+```json
 {
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+  "cancelled": false,
+  "height": 1611,
+  "width": 2148,
+  "uri": "file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
 }
 ```
 
 ### Using with AWS S3
 
-Please refer to the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
 
 ### Using with Firebase
 
-Please refer to the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the ["Using Firebase"](/guides/using-firebase/) docs to set your project up correctly.
+Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -15,7 +15,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -108,8 +108,8 @@ export default function ImagePickerExample() {
 
     console.log(result);
 
-    if (!result.cancelled) {
-      setImage(result.uri);
+    if (!result.canceled) {
+      setImage(result.assets[0].uri);
     }
   };
 
@@ -124,24 +124,36 @@ export default function ImagePickerExample() {
 
 </SnackInline>
 
-When you run this example and pick an image, you will see the image that you picked show up in your app, and something similar to the following logged to your console:
+When you run this example and pick an image, you will see the image that you picked show up in your app, and a similar log will be shown in the console:
 
-```javascript
+```json
 {
-  "cancelled":false,
-  "height":1611,
-  "width":2148,
-  "uri":"file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+  "assets": [
+    {
+      "assetId": "C166F9F5-B5FE-4501-9531",
+      "base64": null,
+      "duration": null,
+      "exif": null,
+      "fileName": "IMG.HEIC",
+      "fileSize": 6018901,
+      "height": 3025,
+      "type": "image",
+      "uri": "file:///data/user/0/host.exp.exponent/cache/cropped1814158652.jpg"
+      "width": 3024
+    }
+  ],
+  "canceled": false,
+  "cancelled": false
 }
 ```
 
 ### Using with AWS S3
 
-Please refer to the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
 
 ### Using with Firebase
 
-Please refer to the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the ["Using Firebase"](/guides/using-firebase/) docs to set your project up correctly.
+Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

With SDK 47 release, the image picker snack example needs an update as it is currently outdated and uses deprecated API.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Updates the inline snack example for SDK 47 and unversioned docs
- It also updates the output logged when selecting an image for SDK 47 and unversioned docs
- Updates the verbiage to follow our writing style guide in two other sections (these changes are also backported to SDK 46, 45).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Updated example:
<img width="1512" alt="CleanShot 2022-11-10 at 20 53 27@2x" src="https://user-images.githubusercontent.com/10234615/201135670-8651517d-ecbe-43fc-9cde-d896b7154637.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
