### PR TITLE
[docs] Fix page document picker page structure

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -91,13 +91,13 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
   ]}
 />
 
-## API
-
 ## Using with expo-file-system
 
 When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 
 To allow the `expo-file-system` to read the file immediately after it is picked, you'll need to ensure that the [`copyToCacheDirectory`](#documentpickeroptions) option is set to `true`.
+
+## API
 
 ```js
 import * as DocumentPicker from 'expo-document-picker';


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is a follow up PR to #19946. While backporting changes to SDK 47 version docs, the current structure of the page was disrupted (by me 😅). This PR fixes that. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="1506" alt="CleanShot 2022-11-11 at 00 42 24@2x" src="https://user-images.githubusercontent.com/10234615/201185463-bb73c6b6-cd52-4e22-9fde-e4d9aa6b902a.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
