### PR TITLE
[docs] Clarify behavior of pre-install/post-install hooks

### DIFF
--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -6,8 +6,8 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 
 - `eas-build-pre-install` - executed before EAS Build runs `npm install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
-  - Android - runs after the following scripts have all completed: `npm install` and `npx expo prebuild` (if needed)
-  - iOS - runs after the following scripts have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
+  - Android - runs once after the following scripts have all completed: `npm install` and `npx expo prebuild` (if needed)
+  - iOS - runs once after the following scripts have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
 - `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -6,8 +6,8 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 
 - `eas-build-pre-install` - executed before EAS Build runs `npm install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
-  - Android - runs after `npm install` and `npx expo prebuild` (if needed)
-  - iOS - runs after `npm install`, `npx expo prebuild` (if needed), and `pod install`.
+  - Android - runs after the following scripts have all completed: `npm install` and `npx expo prebuild` (if needed)
+  - iOS - runs after the following scripts have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
 - `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -7,7 +7,7 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 - `eas-build-pre-install` - executed before EAS Build runs `npm install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
   - Android - runs once after the following commands have all completed: `npm install` and `npx expo prebuild` (if needed)
-  - iOS - runs once after the following scripts have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
+  - iOS - runs once after the following commands have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
 - `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -6,7 +6,7 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 
 - `eas-build-pre-install` - executed before EAS Build runs `npm install`.
 - `eas-build-post-install` - the behavior depends on the platform and project type:
-  - Android - runs once after the following scripts have all completed: `npm install` and `npx expo prebuild` (if needed)
+  - Android - runs once after the following commands have all completed: `npm install` and `npx expo prebuild` (if needed)
   - iOS - runs once after the following scripts have all completed: `npm install`, `npx expo prebuild` (if needed), and `pod install`.
 - `eas-build-on-success` - this hook is triggered at the end of the build process if the build was successful.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.


### PR DESCRIPTION
The old wording implied the hooks would run after each of these scripts, rather than at the completion of all of them

# Why

I spent a lot of time today down the wrong paths because I misinterpreted the old wording.