### PR TITLE
[docs] make eas update intro page consistent with the other ones

### DIFF
--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -1,5 +1,7 @@
 ---
-title: Introduction
+title: EAS Update
+sidebar_title: Introduction
+hideTOC: true
 ---
 
 import Head from '~/components/Head';


### PR DESCRIPTION
# Why

![image](https://user-images.githubusercontent.com/852069/201409667-b893c791-0bf2-4947-835d-a98f588fcfd4.png)
![image](https://user-images.githubusercontent.com/852069/201409684-79c05e24-3495-4b5c-8052-59db102c7701.png)

# How

Added distinct title/sidebar_title and updated toc visibility config. 

# Test Plan

Mk. I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
