### PR TITLE
Updates 'uuid/v5' import to new format. Old format has been removed in the latest version.

### DIFF
--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { setTimeout } from 'timers/promises';
-import uuid from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as Server from './utils/server';
 import * as Simulator from './utils/simulator';

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-basic.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-basic.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { setTimeout } from 'timers/promises';
-import uuid from 'uuid/v4';
+import { v4 as uuidv4 } from 'uuid';
 
 import * as Server from './utils/server';
 import * as Simulator from './utils/simulator';

--- a/packages/expo/src/environment/getInstallationIdAsync.ts
+++ b/packages/expo/src/environment/getInstallationIdAsync.ts
@@ -1,5 +1,5 @@
 import * as Application from 'expo-application';
-import uuidv5 from 'uuid/v5';
+import { v5 as uuidv5 } from 'uuid';
 
 let installationId: string | null;
 const UUID_NAMESPACE = '29cc8a0d-747c-5f85-9ff9-f2f16636d963'; // uuidv5(0, "expo")


### PR DESCRIPTION
# Why

After reading the [Expo Monorepo docs ](https://docs.expo.dev/guides/monorepos/)and setting `config.resolver.disableHierarchicalLookup = true;`, I wasn't able to successfully build our app anymore.

The error was `uuid/v5` not found. I'm using a newer version of `uuid` which metro is resolving.

`require("uuid/v5")` [has been removed in v7](https://github.com/uuidjs/uuid#default-export-removed)

The file I need working is `packages/expo/src/environment/getInstallationIdAsync.ts` but after searching your codebase, there were only 3 places where `uuid/v4` or `uuid/v5` were being used, so I updated those as well.

`uuid@v3`, which Expo still uses in some places, supports this new format so the change is relatively easy.

# How

Updated the import

# Test Plan

- Updated the import directly in node_modules
- Restarted Expo server
- Success

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

Thank you!