### PR TITLE
Updates uuid/v4 import to new format & upgrades package where necessary

### DIFF
--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-assets.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { setTimeout } from 'timers/promises';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 import * as Server from './utils/server';
 import * as Simulator from './utils/simulator';

--- a/packages/expo-updates/e2e/__tests__/Updates-e2e-basic.test.ts
+++ b/packages/expo-updates/e2e/__tests__/Updates-e2e-basic.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { setTimeout } from 'timers/promises';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from 'uuid';
 
 import * as Server from './utils/server';
 import * as Simulator from './utils/simulator';

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -50,7 +50,7 @@
     "expo-updates-interface": "~0.8.0",
     "fbemitter": "^3.0.0",
     "resolve-from": "^5.0.0",
-    "uuid": "^3.4.0"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -79,7 +79,7 @@
     "md5-file": "^3.2.3",
     "node-fetch": "^2.6.7",
     "pretty-format": "^26.5.2",
-    "uuid": "^3.4.0"
+    "uuid": "^9.0.0"
   },
   "optionalDependencies": {
     "expo-error-recovery": "~4.0.1"
@@ -90,7 +90,7 @@
     "@types/react": "~18.0.14",
     "@types/react-native": "~0.69.1",
     "@types/react-test-renderer": "^18.0.0",
-    "@types/uuid": "^3.4.7",
+    "@types/uuid": "^8.3.4",
     "expo-module-scripts": "^3.0.3",
     "react": "18.1.0",
     "react-dom": "18.0.0",

--- a/packages/expo/src/environment/getInstallationIdAsync.ts
+++ b/packages/expo/src/environment/getInstallationIdAsync.ts
@@ -1,5 +1,5 @@
 import * as Application from 'expo-application';
-import uuidv5 from 'uuid/v5';
+import { v5 as uuidv5 } from 'uuid';
 
 let installationId: string | null;
 const UUID_NAMESPACE = '29cc8a0d-747c-5f85-9ff9-f2f16636d963'; // uuidv5(0, "expo")

--- a/yarn.lock
+++ b/yarn.lock
@@ -4595,6 +4595,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.10.tgz#637d3c8431f112edf6728ac9bdfadfe029540f48"
   integrity sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/victory@^31.0.14":
   version "31.0.22"
   resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.22.tgz#b1c0f87261af7bc264207e3864acfe75d0abf605"
@@ -20732,6 +20737,11 @@ uuid@^8.0.0, uuid@^8.3.0, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
# Why

After reading the [Expo Monorepo docs ](https://docs.expo.dev/guides/monorepos/)and setting `config.resolver.disableHierarchicalLookup = true;`, I wasn't able to successfully build our app anymore.

The error was `uuid/v5 not found`. I'm using a newer version of `uuid` which metro was resolving.

using a default export, ie: `require("uuid/v5")` [has been removed in v7](https://github.com/uuidjs/uuid#default-export-removed)

The file I need working is `packages/expo/src/environment/getInstallationIdAsync.ts` but after searching your codebase, there were only 3 places where `uuid/v4` or `uuid/v5` were being used, so I updated those as well.

# How

- Updates import
- Upgrades package (where necessary)
- Read [uuid changelog](https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md)

# Test Plan

- Updated the import directly in node_modules
- Restarted Expo server
- Success

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

Thank you!