### PR TITLE
[android][expo-haptics] migrate expo-haptics to new modules api on an…

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Migrated Android codebase to use the new Expo modules API. ([#20016](https://github.com/expo/expo/pull/20016) by [@alanhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
@@ -4,42 +4,45 @@ import android.content.Context
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
-import expo.modules.core.ExportedModule
-import expo.modules.core.Promise
-import expo.modules.core.interfaces.ExpoMethod
-import expo.modules.haptics.arguments.HapticsInvalidArgumentException
 import expo.modules.haptics.arguments.HapticsImpactType
+import expo.modules.haptics.arguments.HapticsInvalidArgumentException
 import expo.modules.haptics.arguments.HapticsNotificationType
 import expo.modules.haptics.arguments.HapticsSelectionType
 import expo.modules.haptics.arguments.HapticsVibrationType
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
 
-class HapticsModule internal constructor(context: Context) : ExportedModule(context) {
-  private val mVibrator = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-  override fun getName() = "ExpoHaptics"
+class HapticsModule : Module() {
+  private val context: Context
+    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
+  private val mVibrator get() = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
 
-  @ExpoMethod
-  fun notificationAsync(type: String, promise: Promise) {
-    try {
-      vibrate(HapticsNotificationType.fromString(type))
-      promise.resolve(null)
-    } catch (e: HapticsInvalidArgumentException) {
-      promise.reject(e)
+  override fun definition() = ModuleDefinition {
+    Name("ExpoHaptics")
+
+    AsyncFunction("notificationAsync") { type: String, promise: Promise ->
+      try {
+        vibrate(HapticsNotificationType.fromString(type))
+        promise.resolve(null)
+      } catch (e: HapticsInvalidArgumentException) {
+        throw HapticsInvalidArgumentException(e.message)
+      }
     }
-  }
 
-  @ExpoMethod
-  fun selectionAsync(promise: Promise) {
-    vibrate(HapticsSelectionType)
-    promise.resolve(null)
-  }
-
-  @ExpoMethod
-  fun impactAsync(style: String, promise: Promise) {
-    try {
-      vibrate(HapticsImpactType.fromString(style))
+    AsyncFunction("selectionAsync") { promise: Promise ->
+      vibrate(HapticsSelectionType)
       promise.resolve(null)
-    } catch (e: HapticsInvalidArgumentException) {
-      promise.reject(e)
+    }
+
+    AsyncFunction("impactAsync") { style: String, promise: Promise ->
+      try {
+        vibrate(HapticsImpactType.fromString(style))
+        promise.resolve(null)
+      } catch (e: HapticsInvalidArgumentException) {
+        throw HapticsInvalidArgumentException(e.message)
+      }
     }
   }
 

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
@@ -17,40 +17,30 @@ import expo.modules.kotlin.modules.ModuleDefinition
 class HapticsModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-  private val mVibrator get() = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+  private val vibrator
+    get() = context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
 
   override fun definition() = ModuleDefinition {
     Name("ExpoHaptics")
 
-    AsyncFunction("notificationAsync") { type: String, promise: Promise ->
-      try {
-        vibrate(HapticsNotificationType.fromString(type))
-        promise.resolve(null)
-      } catch (e: HapticsInvalidArgumentException) {
-        throw HapticsInvalidArgumentException(e.message)
-      }
+    AsyncFunction("notificationAsync") { type: String ->
+      vibrate(HapticsNotificationType.fromString(type))
     }
 
-    AsyncFunction("selectionAsync") { promise: Promise ->
+    AsyncFunction("selectionAsync") {
       vibrate(HapticsSelectionType)
-      promise.resolve(null)
     }
 
-    AsyncFunction("impactAsync") { style: String, promise: Promise ->
-      try {
-        vibrate(HapticsImpactType.fromString(style))
-        promise.resolve(null)
-      } catch (e: HapticsInvalidArgumentException) {
-        throw HapticsInvalidArgumentException(e.message)
-      }
+    AsyncFunction("impactAsync") { style: String ->
+      vibrate(HapticsImpactType.fromString(style))
     }
   }
 
   private fun vibrate(type: HapticsVibrationType) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      mVibrator.vibrate(VibrationEffect.createWaveform(type.timings, type.amplitudes, -1))
+      vibrator.vibrate(VibrationEffect.createWaveform(type.timings, type.amplitudes, -1))
     } else {
-      mVibrator.vibrate(type.oldSDKPattern, -1)
+      vibrator.vibrate(type.oldSDKPattern, -1)
     }
   }
 }

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
@@ -5,11 +5,9 @@ import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
 import expo.modules.haptics.arguments.HapticsImpactType
-import expo.modules.haptics.arguments.HapticsInvalidArgumentException
 import expo.modules.haptics.arguments.HapticsNotificationType
 import expo.modules.haptics.arguments.HapticsSelectionType
 import expo.modules.haptics.arguments.HapticsVibrationType
-import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsPackage.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsPackage.kt
@@ -1,9 +1,0 @@
-package expo.modules.haptics
-
-import android.content.Context
-import expo.modules.core.BasePackage
-
-class HapticsPackage : BasePackage() {
-  override fun createExportedModules(context: Context) =
-    listOf(HapticsModule(context))
-}

--- a/packages/expo-haptics/expo-module.config.json
+++ b/packages/expo-haptics/expo-module.config.json
@@ -2,6 +2,9 @@
   "name": "expo-haptics",
   "platforms": ["ios", "android"],
   "ios": {
-    "modulesClassNames": ["HapticsModule"]
+    "modules": ["HapticsModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.haptics.HapticsModule"]
   }
 }


### PR DESCRIPTION
# Why
Continue migration of expo modules to the new API

# How
Followed the usual steps involved in migrating a module

# Test Plan
All original tests pass as before and confirmed in the bare-expo app
