### PR TITLE
[iOS][expo-constants] add missing platform keys to module config

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the list of platform keys in expo-module.config.json
+
 ### 💡 Others
 
 ## 14.0.2 — 2022-10-30

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix the list of platform keys in expo-module.config.json
+- Fix the list of platform keys in expo-module.config.json ([#20017](https://github.com/expo/expo/pull/20017) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-constants/expo-module.config.json
+++ b/packages/expo-constants/expo-module.config.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-constants",
-  "platforms": ["ios"],
+  "platforms": ["ios", "android", "web"],
   "ios": {
     "modules": ["ConstantsModule"]
   }


### PR DESCRIPTION
# Why
Recently migrated the expo-constant module to the new modules API and left out some of the required platform keys from the module config file. 

# How
Add required keys

# Test Plan
The test app will not run without this. Once added it works again. 
 I also have a [PR](https://github.com/expo/expo/pull/19974) to migrate the android implementation of expo-constants that completes the migration of this module

