### PR TITLE
[modules] Fix `failed resolution of: Ljava/nio/file/Path;`

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -385,13 +385,13 @@ Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are alre
 
 Similarly, some common Android types from packages like `java.io`, `java.net`, or `android.graphics` are also made convertible.
 
-| Native Android Type                     | TypeScript                                                                                                                                                                        |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `java.net.URL`                          | `string` with a URL. Note that the scheme has to be provided                                                                                                                      |
-| `android.net.Uri`<br/>`java.net.URI`    | `string` with a URI. Note that the scheme has to be provided                                                                                                                      |
-| `java.io.File`<br/>`java.nio.file.Path` | `string` with a path to the file                                                                                                                                                  |
-| `android.graphics.Color`                | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
-| `kotlin.Pair<A, B>`                     | Array with two values, where the first one is of type _A_ and the second is of type _B_                                                                                           |
+| Native Android Type                                                           | TypeScript                                                                                                                                                                        |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `java.net.URL`                                                                | `string` with a URL. Note that the scheme has to be provided                                                                                                                      |
+| `android.net.Uri`<br/>`java.net.URI`                                          | `string` with a URI. Note that the scheme has to be provided                                                                                                                      |
+| `java.io.File`<br/>`java.nio.file.Path` (is only available on Android API 26) | `string` with a path to the file                                                                                                                                                  |
+| `android.graphics.Color`                                                      | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
+| `kotlin.Pair<A, B>`                                                           | Array with two values, where the first one is of type _A_ and the second is of type _B_                                                                                           |
 
 </APIBox>
 <APIBox header="Records">

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
+- Fixed failed resolution of 'java.nio.file.Path' on Android.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -145,7 +145,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       isOptional, ExpectedType(CppType.BOOLEAN)
     ) { it.asBoolean() }
 
-    return mapOf(
+    val converters = mapOf(
       Int::class.createType(nullable = isOptional) to intTypeConverter,
       java.lang.Integer::class.createType(nullable = isOptional) to intTypeConverter,
 
@@ -229,9 +229,16 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       URI::class.createType(nullable = isOptional) to JavaURITypeConverter(isOptional),
 
       File::class.createType(nullable = isOptional) to FileTypeConverter(isOptional),
-      Path::class.createType(nullable = isOptional) to PathTypeConverter(isOptional),
 
       Any::class.createType(nullable = isOptional) to AnyTypeConverter(isOptional),
     )
+
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+      return converters + mapOf(
+        Path::class.createType(nullable = isOptional) to PathTypeConverter(isOptional),
+      )
+    }
+
+    return converters
   }
 }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/19510.

# How

Removed usages of Path API on Android 25 or below. 

# Test Plan

- start bare app using API 25 and 31.