### PR TITLE
[docs] Fix command to use npx expo install

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -1145,7 +1145,7 @@ export default function App() {
 
 [c-google]: https://console.developers.google.com/apis/credentials
 
-> Be sure to install the peerDependency `yarn add expo-application`
+> Be sure to install the peerDependency `npx expo install expo-application`
 
 There are 4 different types of client IDs you can provide:
 


### PR DESCRIPTION
# Why & how

Currently the command suggested is to use `yarn add` for an Expo module. This PR changes that to use `npx expo install` for version compatibility an SDK version.

## Test
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="916" alt="CleanShot 2022-11-15 at 17 06 30@2x" src="https://user-images.githubusercontent.com/10234615/201910436-90713d78-f05f-4c3f-a5f3-9ad60c4bd721.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
