### PR TITLE
[expo] Fix path inconsistencies when resolving app entry point during build phase

### DIFF
--- a/packages/expo/scripts/resolveAppEntry.js
+++ b/packages/expo/scripts/resolveAppEntry.js
@@ -15,6 +15,7 @@
 //   Currently only supports android and ios.
 
 const { resolveEntryPoint } = require('@expo/config/paths');
+const fs = require('fs');
 const path = require('path');
 
 const projectRoot = process.argv[1];
@@ -34,7 +35,9 @@ if (entry) {
   // Prevent any logs from the app.config.js
   // from being used in the output of this command.
   console.clear();
-  console.log(absolute ? path.resolve(entry) : path.relative(projectRoot, entry));
+  // React Native's `PROJECT_ROOT` could be using a different root on MacOS (`/var` vs `/private/var`)
+  // We need to make sure to get the real path, `resolveEntryPoint` is using this too
+  console.log(absolute ? path.resolve(entry) : path.relative(fs.realpathSync(projectRoot), entry));
 } else {
   console.error(`Error: Could not find entry file for project at: ${projectRoot}`);
   process.exit(1);


### PR DESCRIPTION
# Why

Fixes #20001

# How

It seems that React Native might have an issue with `REACT_NATIVE_DIR` and/or `PROJECT_ROOT` environment variables. What's happening is that, in the logs, these variables are set:

<img width="1152" alt="image" src="https://user-images.githubusercontent.com/1203991/201915802-d3d9ea95-778d-411d-bd7d-fd6c264dde7f.png">

During the build phase, `expo/scripts/resolveAppEntry` is executed with this mismatched root path (`/var/...` vs `/private/var/...`). When using absolute paths, that shouldn't be an issue, but we are using relative paths. This relative mode runs `path.relative('/var', '/private/var')`, causing some weird `ENTRY_FILE` path to be generated.

<details><summary>Wrong entry path</summary>

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/1203991/201918827-d5f67569-11e4-45ba-87bd-c57957990c24.png">

<img width="1242" alt="image" src="https://user-images.githubusercontent.com/1203991/201918860-886ae8f5-351d-40e0-ac5b-41a9adffba00.png">

</details>

<details><summary>Correct entry path (with this fix)</summary>

<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1203991/201919009-d216883b-f04d-4bf3-95aa-2358c6a62a43.png">

<img width="81" alt="image" src="https://user-images.githubusercontent.com/1203991/201919033-1af2460a-bb5a-4c44-86eb-637d1b3eea0d.png">

</details>

This fix compensates for possible malformed project root paths originating from these two variables, using `fs.realpathSync`.

# Test Plan

To trigger this issue:

```bash
$ npx create-expo-app issue-20001
$ cd issue-20001
$ EAS_LOCAL_BUILD_SKIP_CLEANUP=1 eas build -p ios --local
```

To validate the fix:

```bash
$ npx create-expo-app issue-20001
$ cd issue-20001
$ npm i --save-dev patch-package

  <add patch-package to the postinstall hook>
  <replace `expo/scripts/resolveAppEntry.js` with the change from this PR>

$ npx patch-package expo
$ EAS_LOCAL_BUILD_SKIP_CLEANUP=1 eas build -p ios --local
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
