### PR TITLE
[docs] Fix callback function

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -501,7 +501,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       /* rest of the code remains unchanged */
-      <EmojiPicker modalVisible={modalVisible} onClose={modalVisibilityHandler}>
+      <EmojiPicker modalVisible={modalVisible} onClose={onModalClose}>
         /* @info Render the EmojiList component inside the EmojiPicker component. */
         <EmojiList onSelect={setPickedEmoji} onCloseModal={onModalClose} />
         /* @end */


### PR DESCRIPTION
# Why

In `tutorial/create-a-modal/`, `modalVisibilityHandler()` is not defined. 
So, it causes error.
Using `onModalClose()` is correct.

# Test Plan

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
