### PR TITLE
[android] backport fix for sdk47 to versioned code

### DIFF
--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -118,7 +118,6 @@ public class ModuleRegistryAdapter implements ReactPackage {
   ) {
     if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
       mModulesProxy = null;
-      mWrapperDelegateHolders = null;
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -43,6 +43,18 @@ open class ObjectDefinitionBuilder {
   internal var properties = mutableMapOf<String, PropertyComponentBuilder>()
 
   fun buildObject(): ObjectDefinitionData {
+    // Register stub functions to bypass react-native `NativeEventEmitter` warnings
+    // WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.
+    // WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.
+    eventsDefinition?.run {
+      if (!containsFunction("addListener")) {
+        Function("addListener") { _: String -> { } }
+      }
+      if (!containsFunction("removeListeners")) {
+        Function("removeListeners") { _: Int -> { } }
+      }
+    }
+
     return ObjectDefinitionData(
       constantsProvider,
       syncFunctions,
@@ -50,6 +62,12 @@ open class ObjectDefinitionBuilder {
       eventsDefinition,
       properties.mapValues { (_, value) -> value.build() }
     )
+  }
+
+  private fun containsFunction(functionName: String): Boolean {
+    return syncFunctions.containsKey(functionName) ||
+      asyncFunctions.containsKey(functionName) ||
+      functionBuilders.containsKey(functionName)
   }
 
   /**

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -145,7 +145,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       isOptional, ExpectedType(CppType.BOOLEAN)
     ) { it.asBoolean() }
 
-    return mapOf(
+    val converters = mapOf(
       Int::class.createType(nullable = isOptional) to intTypeConverter,
       java.lang.Integer::class.createType(nullable = isOptional) to intTypeConverter,
 
@@ -229,9 +229,16 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       URI::class.createType(nullable = isOptional) to JavaURITypeConverter(isOptional),
 
       File::class.createType(nullable = isOptional) to FileTypeConverter(isOptional),
-      Path::class.createType(nullable = isOptional) to PathTypeConverter(isOptional),
 
       Any::class.createType(nullable = isOptional) to AnyTypeConverter(isOptional),
     )
+
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+      return converters + mapOf(
+        Path::class.createType(nullable = isOptional) to PathTypeConverter(isOptional),
+      )
+    }
+
+    return converters
   }
 }


### PR DESCRIPTION
# Why

backport fix for sdk47 to versioned code

# How

- backport #19920 
- backport #20037
- backport #20063

# Test Plan

ci passed but android client is broken because of HomeActivity 😞

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
