### PR TITLE
[ios][splash-screen] Fixed 'No native splash screen registered for given view controller.' warning being shown when app is started in the background (i.e. headless)

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.` warning being displayed on iOS when app is started in background. ([#20064](https://github.com/expo/expo/pull/20064) by [@grigorigoldman](https://github.com/grigorigoldman))
+
 ### 💡 Others
 
 ## 0.17.4 - 2022-11-08

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -114,7 +114,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 - (void)onAppContentDidAppear:(UIViewController *)viewController
 {
-  if (![self.splashScreenControllers objectForKey:viewController]) {
+  if ([self isAppActive] && ![self.splashScreenControllers objectForKey:viewController]) {
     EXLogWarn(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
   }
   BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
@@ -128,7 +128,7 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 - (void)onAppContentWillReload:(UIViewController *)viewController
 {
-  if (![self.splashScreenControllers objectForKey:viewController]) {
+  if ([self isAppActive] && ![self.splashScreenControllers objectForKey:viewController]) {
     EXLogWarn(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
   }
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
@@ -140,6 +140,10 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
               successCallback:^{}
               failureCallback:^(NSString *message){}];
   }
+}
+
+- (BOOL)isAppActive {
+    return UIApplication.sharedApplication.applicationState == UIApplicationStateActive;
 }
 
 # pragma mark - UIApplicationDelegate


### PR DESCRIPTION
# Why

Some times a React Native app maybe started in the background, i.e. headless. For example, when using a push notifications SDK such as `react-native-firebase/messaging`. When a message is received by the device and the app is not running, the app is launched in the background, registers a background message handler, which is then receives the message. 

In this scenario, a `No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.` is shown when the app is started (in background).

# How

This is an iOS specific issue. I added a conditional check, to ensure that the app is actually active (in foreground) before logging the warning.


# Test Plan

✅ Tested in `apps/bare-expo` to make sure no unexpected side effects are present
✅ Included the fix into custom app, which integrates with `react-native-firebase/messaging` to ensure that when the app is launched in the background, warning is not shown.

