### PR TITLE
[@expo/cli] tweak warning about metro config

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Fix ngrok error message format. ([#19822](https://github.com/expo/expo/pull/19822) by [@EvanBacon](https://github.com/EvanBacon))
+- Tweak warning about metro config. ([#20066](https://github.com/expo/expo/pull/20066) by [@kbrandwijk](https://github.com/kbrandwijk))
 
 ## 0.4.8 - 2022-11-08
 

--- a/packages/@expo/cli/src/prebuild/writeMetroConfig.ts
+++ b/packages/@expo/cli/src/prebuild/writeMetroConfig.ts
@@ -42,7 +42,7 @@ export function writeMetroConfig(
     });
     // Log.log(`\u203A ${e.message}`);
     Log.log(
-      chalk`\u203A Ensure the project uses {bold @expo/metro-config}.\n  {dim ${learnMore(
+      chalk`\u203A Ensure the project uses {bold expo/metro-config}.\n  {dim ${learnMore(
         'https://docs.expo.dev/guides/customizing-metro'
       )}}`
     );


### PR DESCRIPTION
# Why

We have updated our docs to advise people to use `expo/metro-config` instead of `@expo/metro-config` as part of the versioned package export initiative. This PR updates the informational message in the CLI to match that idea.

# How

Adjusted the message to refer to `expo/metro-config` instead of `@expo/metro-config`

# Test Plan

None

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
