### PR TITLE
[expotools] fix publish-dev-home

### DIFF
--- a/tools/src/ExpoCLI.ts
+++ b/tools/src/ExpoCLI.ts
@@ -27,6 +27,29 @@ export async function runExpoCliAsync(
   });
 }
 
+/**
+ * Added to support tools that require the `expo publish` command
+ * that is only available in the old global expo-cli
+ */
+export async function runLegacyExpoCliAsync(
+  command: string,
+  args: string[] = [],
+  options: Options = {}
+): Promise<void> {
+  // Don't handle SIGINT/SIGTERM in this process...defer to expo-cli
+  process.on('SIGINT', () => {});
+  process.on('SIGTERM', () => {});
+
+  await spawnAsync('expo', [command, ...args], {
+    cwd: options.cwd || EXPO_DIR,
+    stdio: options.stdio || 'inherit',
+    env: {
+      ...process.env,
+      EXPO_NO_DOCTOR: 'true',
+    },
+  });
+}
+
 export async function runCreateExpoAppAsync(
   name: string,
   args: string[] = [],

--- a/tools/src/XDL.ts
+++ b/tools/src/XDL.ts
@@ -29,7 +29,8 @@ export async function publishProjectWithExpoCliAsync(
 
     if (username && password) {
       Log.collapsed('Logging in...');
-      await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password]);
+      // TODO: rework this to use EAS update instead of expo publish
+      await ExpoCLI.runLegacyExpoCliAsync('login', ['-u', username, '-p', password]);
     } else {
       Log.collapsed('Expo username and password not specified. Using currently logged-in account.');
     }
@@ -42,7 +43,8 @@ export async function publishProjectWithExpoCliAsync(
     publishArgs.push('--max-workers', '1');
   }
 
-  await ExpoCLI.runExpoCliAsync('publish', publishArgs, {
+  // TODO: rework this to use EAS update instead of expo publish
+  await ExpoCLI.runLegacyExpoCliAsync('publish', publishArgs, {
     cwd: projectRoot,
   });
 }

--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -182,7 +182,8 @@ async function action(options: ActionOptions): Promise<void> {
 
   if (cliUsername) {
     console.log(`Logging out from ${chalk.green(cliUsername)} account...`);
-    await ExpoCLI.runExpoCliAsync('logout', [], {
+    // TODO: rework this to use EAS update instead of expo publish
+    await ExpoCLI.runLegacyExpoCliAsync('logout', [], {
       stdio: 'ignore',
     });
   }


### PR DESCRIPTION
# Why

Temporary fix for the `publish-dev-home` tool, after it was broken by #19657

# How

Add a new method in `ExpoCLI.ts` to call the legacy global expo-cli.

# Test Plan

- Test this locally
- Come up with a plan to migrate this tool to use EAS Update.

