### PR TITLE
[cli] Upgrade @expo/code-signing-certificates dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
+- Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/cli",
   "dependencies": {
     "@babel/runtime": "^7.14.0",
-    "@expo/code-signing-certificates": "0.0.4",
+    "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "~7.0.2",
     "@expo/config-plugins": "~5.0.3",
     "@expo/dev-server": "0.1.122",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/cli",
   "dependencies": {
     "@babel/runtime": "^7.14.0",
-    "@expo/code-signing-certificates": "^0.0.2",
+    "@expo/code-signing-certificates": "0.0.4",
     "@expo/config": "~7.0.2",
     "@expo/config-plugins": "~5.0.3",
     "@expo/dev-server": "0.1.122",

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -6,7 +6,7 @@ import {
   generateCSR,
   convertPrivateKeyPEMToPrivateKey,
   validateSelfSignedCertificate,
-  signStringRSASHA256AndVerify,
+  signBufferRSASHA256AndVerify,
 } from '@expo/code-signing-certificates';
 import { ExpoConfig } from '@expo/config';
 import { getExpoHomeDirectory } from '@expo/config/build/getUserState';
@@ -373,5 +373,9 @@ export function signManifestString(
 ): string {
   const privateKey = convertPrivateKeyPEMToPrivateKey(codeSigningInfo.privateKey);
   const certificate = convertCertificatePEMToCertificate(codeSigningInfo.certificateForPrivateKey);
-  return signStringRSASHA256AndVerify(privateKey, certificate, stringifiedManifest, 'utf8');
+  return signBufferRSASHA256AndVerify(
+    privateKey,
+    certificate,
+    Buffer.from(stringifiedManifest, 'utf8')
+  );
 }

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -373,5 +373,5 @@ export function signManifestString(
 ): string {
   const privateKey = convertPrivateKeyPEMToPrivateKey(codeSigningInfo.privateKey);
   const certificate = convertCertificatePEMToCertificate(codeSigningInfo.certificateForPrivateKey);
-  return signStringRSASHA256AndVerify(privateKey, certificate, stringifiedManifest);
+  return signStringRSASHA256AndVerify(privateKey, certificate, stringifiedManifest, 'utf8');
 }

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -39,7 +39,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/code-signing-certificates": "0.0.4",
+    "@expo/code-signing-certificates": "0.0.5",
     "@expo/config": "~7.0.2",
     "@expo/config-plugins": "~5.0.3",
     "@expo/metro-config": "~0.5.0",

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -39,7 +39,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/code-signing-certificates": "0.0.2",
+    "@expo/code-signing-certificates": "0.0.4",
     "@expo/config": "~7.0.2",
     "@expo/config-plugins": "~5.0.3",
     "@expo/metro-config": "~0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/code-signing-certificates@0.0.2", "@expo/code-signing-certificates@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@expo/code-signing-certificates/-/code-signing-certificates-0.0.2.tgz#65cd615800e6724b54831c966dd1a90145017246"
-  integrity sha512-vnPHFjwOqxQ1VLztktY+fYCfwvLzjqpzKn09rchcQE7Sdf0wtW5fFtIZBEFOOY5wasp8tXSnp627zrAwazPHzg==
+"@expo/code-signing-certificates@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@expo/code-signing-certificates/-/code-signing-certificates-0.0.4.tgz#f12e110bacb4c64914bdf34bb90900b711cdadb9"
+  integrity sha512-BuAW9UN1+Dr3ocFNNiQ+C9MscYGrjQoL6l+qLXnPCQdFWglRyj24c+rJTOdZyoTeHCXubCkS1esKcadksSnvwg==
   dependencies:
     node-forge "^1.2.1"
     nullthrows "^1.1.1"
@@ -21880,8 +21880,10 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,10 +1251,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/code-signing-certificates@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@expo/code-signing-certificates/-/code-signing-certificates-0.0.4.tgz#f12e110bacb4c64914bdf34bb90900b711cdadb9"
-  integrity sha512-BuAW9UN1+Dr3ocFNNiQ+C9MscYGrjQoL6l+qLXnPCQdFWglRyj24c+rJTOdZyoTeHCXubCkS1esKcadksSnvwg==
+"@expo/code-signing-certificates@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz#a693ff684fb20c4725dade4b88a6a9f96b02496c"
+  integrity sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==
   dependencies:
     node-forge "^1.2.1"
     nullthrows "^1.1.1"


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/19431.

# How

https://github.com/expo/code-signing-certificates/pull/10 allows us to specify that this should use `utf-8` encoding instead of the default `raw` encoding. Because what we serve in the devserver is encoded as utf-8, this needs to match. This only affects manifests with accented characters because I'm assuming `utf-8` and `raw` overlap for the base characters.

# Test Plan

1. `npx create-expo-app my-app`
2. `cd my-app`
3. Modify app.json to put `öäå` in a description field.
4. `eas init`
5. `eas update:configure`
6. `npx expo start --ios`, open on both android and ios

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
