### PR TITLE
[modules][ios] Fix: Repeated requests for iOS notification permissions #20072

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
 - Fixed failed resolution of 'java.nio.file.Path' on Android. ([#20037](https://github.com/expo/expo/pull/20037) by [@lukmccall](https://github.com/lukmccall))
 - Fixed views are not correctly initialized after reloading on Android. ([#20063](https://github.com/expo/expo/pull/20063) by [@lukmccall](https://github.com/lukmccall))
+- Fixed supression of repeated calls to requestPermissionsAsync on iOS with new options ([#20086](https://github.com/expo/expo/pull/20086) by [@below](https://github.com/below))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Services/Permissions/EXPermissionsService.h
+++ b/packages/expo-modules-core/ios/Services/Permissions/EXPermissionsService.h
@@ -10,10 +10,6 @@
 
 + (NSString *)permissionStringForStatus:(EXPermissionStatus)status;
 
-- (void)askForGlobalPermissionUsingRequesterClass:(Class)requesterClass
-                                    withResolver:(EXPromiseResolveBlock)resolver
-                                    withRejecter:(EXPromiseRejectBlock)reject;
-
 - (NSDictionary *)getPermissionUsingRequesterClass:(Class)requesterClass;
 
 @end

--- a/packages/expo-modules-core/ios/Services/Permissions/EXPermissionsService.m
+++ b/packages/expo-modules-core/ios/Services/Permissions/EXPermissionsService.m
@@ -94,30 +94,10 @@ EX_EXPORT_MODULE();
   return [permissions[EXStatusKey] isEqualToString:@"granted"];
 }
 
-- (void)askForPermissionUsingRequesterClass:(Class)requesterClass
-                                    resolve:(EXPromiseResolveBlock)onResult
-                                     reject:(EXPromiseRejectBlock)reject
-{
-  NSMutableDictionary *permission = [[self getPermissionUsingRequesterClass:requesterClass] mutableCopy];
-  
-  // permission type not found - reject immediately
-  if (permission == nil) {
-    return reject(@"E_PERMISSIONS_UNKNOWN", [NSString stringWithFormat:@"Unrecognized requester: %@", NSStringFromClass(requesterClass)], nil);
-  }
-  
-  BOOL isGranted = [EXPermissionsService statusForPermission:permission] == EXPermissionStatusGranted;
-  permission[@"granted"] = @(isGranted);
-  
-  if (isGranted) {
-    return onResult(permission);
-  }
-  
-  [self askForGlobalPermissionUsingRequesterClass:requesterClass withResolver:onResult withRejecter:reject];
-}
    
-- (void)askForGlobalPermissionUsingRequesterClass:(Class)requesterClass
-                                     withResolver:(EXPromiseResolveBlock)resolver
-                                     withRejecter:(EXPromiseRejectBlock)reject
+- (void)askForPermissionUsingRequesterClass:(Class)requesterClass
+                               resolve:(EXPromiseResolveBlock)onResult
+                               reject:(EXPromiseRejectBlock)reject
 {
   id<EXPermissionsRequester> requester = [self getPermissionRequesterForClass:requesterClass];
   if (requester == nil) {
@@ -125,7 +105,7 @@ EX_EXPORT_MODULE();
   }
   
   void (^permissionParser)(NSDictionary *) = ^(NSDictionary * permission){
-    resolver([EXPermissionsService parsePermissionFromRequester:permission]);
+    onResult([EXPermissionsService parsePermissionFromRequester:permission]);
   };
   
   [requester requestPermissionsWithResolver:permissionParser rejecter:reject];


### PR DESCRIPTION
# Why

On iOS, the permissions for Notification can be requested with a set of [options](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions). The most common ones are to display alerts or play sounds, but they can also enable notifications on CarPlay displays, or enable critical alerts. Over the course of its lifetime, an app may introduce aditional capabilities, such as critical alerts or other, newly introduced iOS features and thus, must call `requestAuthorization(options:completionHandler:)` again with a new set of options. Expo Notifications supports all these [options](https://docs.expo.dev/versions/latest/sdk/notifications/#requestpermissionsasyncrequest-notificationpermissionsrequest-promisenotificationpermissionsstatus) for  `requestPermissionsAsync`.

The issue is, that after an app is newly installed on a device, the first call to `Notification.requestPermissionsAsync` will prompt the user, and set the given options. **However, subsequent calls will have no effect.** This means, for the user to take advantage of new features, they will have to de-install and re-install the app, which is completely unacceptable.

The root of the problem can be found in [EXPermissionsService.m:111](https://github.com/expo/expo/blob/168ee43f71f005baa11edf98e518593443e1807a/packages/expo-modules-core/ios/Services/Permissions/EXPermissionsService.m#L111):

```objc
  BOOL isGranted = [EXPermissionsService statusForPermission:permission] == EXPermissionStatusGranted;
  permission[@"granted"] = @(isGranted);

  if (isGranted) {
    return onResult(permission);
  }

  [self askForGlobalPermissionUsingRequesterClass:requesterClass
                                     withResolver:onResult
                                     withRejecter:reject];
```

This means that permissions are only ever requested again if permission has not previously been granted. This however **does not consider different options**, but only if any sort of notification permissions have been granted. This means that if previously only Alerts have been requested, a new request for Alerts and Sounds will be ignored.

# How

On iOS, it is perfectly acceptable to call `requestAuthorization(options:completionHandler:)` repeatedly:
> subsequent calls to this method (even with different options do not prompt the user again.

It is best practice on iOS to call this method liberally (e.g. at every startup), and the performance hit should not be different from getting the permission status.

Also not that several tutorials suggest to check the permission status first, and then requesting it. This is — at least for iOS — not advisable.

Therefore the method `askForPermissionUsingRequesterClass` was removed entirely, and instead the name and signature for the method `askForGlobalPermissionUsingRequesterClass` was changed appropriately.

# Test Plan

This was tested with my [test app](https://github.com/below/ExpoNotificationIssue).

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
