### PR TITLE
[docs] Update Reanimated doc structure Web support section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with react-native-reanimated, you will need to use the [Hermes JavaScript engine](/guides/using-hermes.mdx) and the [JavaScript Inspector for Hermes](/guides/using-hermes.mdx#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -17,7 +17,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-**In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
+After the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -29,7 +29,13 @@ module.exports = function (api) {
 };
 ```
 
-**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js**:
+After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+
+> If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
+
+### Web support
+
+**For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js** to load it:
 
 {/* prettier-ignore */}
 ```js babel.config.js
@@ -39,9 +45,7 @@ plugins: [
 ],
 ```
 
-After you add the Babel plugins, restart your development server and clear the bundler cache: `npx expo start --clear`.
-
-> Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
+After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
 
 ## Usage
 

--- a/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
@@ -9,7 +9,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 `react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
-> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with react-native-reanimated, you will need to use the [Hermes JavaScript engine](/guides/using-hermes.mdx) and the [JavaScript Inspector for Hermes](/guides/using-hermes.mdx#javascript-inspector-for-hermes).
+> **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
 
 <PlatformsSection android emulator ios simulator web />
 
@@ -17,7 +17,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation" />
 
-**In all cases,** after the installation completes, you must also add the Babel plugin to **babel.config.js**:
+After the installation completes, you must also add the Babel plugin to **babel.config.js**:
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -29,6 +29,12 @@ module.exports = function (api) {
 };
 ```
 
+After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
+
+> If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
+
+### Web support
+
 **For web,** you'll have to install the [`@babel/plugin-proposal-export-namespace-from`](https://babeljs.io/docs/en/babel-plugin-proposal-export-namespace-from#installation) Babel plugin and update the **babel.config.js**:
 
 {/* prettier-ignore */}
@@ -39,9 +45,7 @@ plugins: [
 ],
 ```
 
-After you add the Babel plugins, restart your development server and clear the bundler cache: `npx expo start --clear`.
-
-> Note: If you load other Babel plugins, the Reanimated plugin has to be the last item in the plugins array.
+After you add the Babel plugin, restart your development server and clear the bundler cache: `npx expo start --clear`.
 
 ## Usage
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

To highlight web support.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the page structure by adding a "Web support" section. Changes backported to `unversioned` and `SDK 47` docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1512" alt="CleanShot 2022-11-18 at 01 29 44@2x" src="https://user-images.githubusercontent.com/10234615/202546941-01214161-0211-4a03-9c34-58da3ad084d5.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
