### PR TITLE
[github] expo-caches: bump cache action

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
     - name: ♻️ Restore workspace node modules
       if: inputs.yarn-workspace == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: workspace-modules-cache
       with:
         # See "workspaces" → "packages" in the root package.json for the source of truth of
@@ -107,7 +107,7 @@ runs:
 
     - name: ♻️ Restore /tools node modules and bins
       if: inputs.yarn-tools == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: tools-modules-cache
       with:
         path: |
@@ -116,21 +116,21 @@ runs:
 
     - name: ♻️ Restore /docs node modules
       if: inputs.yarn-docs == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: docs-modules-cache
       with:
         path: docs/node_modules
         key: ${{ runner.os }}-docs-modules-${{ hashFiles('docs/yarn.lock') }}
     - name: ♻️ Restore Docs Next cache
       if: inputs.yarn-docs == 'true' && steps.docs-modules-cache.outputs.cache-hit == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: docs/.next/cache
         key: ${{ runner.os }}-docs-next-${{ hashFiles('docs/yarn.lock') }}-${{ hashFiles('docs/next.config.js') }}
 
     - name: ♻️ Restore ios/Pods from cache
       if: inputs.ios-pods == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: ios-pods-cache
       with:
         path: ios/Pods
@@ -138,7 +138,7 @@ runs:
 
     - name: ♻️ Restore apps/bare-expo/ios/Pods from cache
       if: inputs.bare-expo-pods == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: bare-expo-pods-cache
       with:
         path: apps/bare-expo/ios/Pods
@@ -146,7 +146,7 @@ runs:
 
     - name: ♻️ Restore apps/native-tests/ios/Pods from cache
       if: inputs.native-tests-pods == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: native-tests-pods-cache
       with:
         path: apps/native-tests/ios/Pods
@@ -158,7 +158,7 @@ runs:
 
     - name: ♻️ Restore AVD cache
       if: inputs.avd == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: avd-cache
       with:
         path: |
@@ -177,7 +177,7 @@ runs:
 
     - name: ♻️ Restore Android NDK from cache
       if: inputs.ndk == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-android-ndk
       with:
         path: /usr/local/lib/android/sdk/ndk/${{ inputs.ndk-version }}/
@@ -193,7 +193,7 @@ runs:
       run: echo "sha256=$(git lfs ls-files | openssl dgst -sha256)" >> $GITHUB_OUTPUT
       shell: bash
     - name: ♻️ Restore Git LFS cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       if: inputs.git-lfs == 'true'
       with:
         path: .git/lfs
@@ -201,7 +201,7 @@ runs:
 
     - name: ♻️ Restore hermes-engine AAR cache
       if: inputs.hermes-engine-aar == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: android/prebuiltHermes
         key: hermes-engine-aar-v2-${{ hashFiles('react-native-lab/react-native/sdks/.hermesversion') }}
@@ -240,7 +240,7 @@ runs:
       run: echo "REACT_NATIVE_DOWNLOADS_DIR=$HOME/.gradle/react-native-downloads" >> $GITHUB_ENV
     - name: ♻️ Restore Gradle downloads cache for React Native libraries
       if: inputs.react-native-gradle-downloads == 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ env.REACT_NATIVE_DOWNLOADS_DIR }}
         key: gradle-downloads-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
# Why

Fixes:

<img width="1540" alt="Screenshot 2022-11-17 at 22 31 59" src="https://user-images.githubusercontent.com/719641/202564201-52aefc03-7f1d-4d20-b816-a7c2b15e2166.png">

# How

Update `actions/cache` to v3, like other actions (`checkout`, `setup-node` etc.), so it runs by default using Node 16.

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
