### PR TITLE
[docs] fix url to "Use development builds"

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -152,6 +152,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/development/troubleshooting/': '/development/introduction/',
   '/development/upgrading/': '/development/introduction/',
   '/development/extensions/': '/development/development-workflows/',
+  '/development/develop-your-project': '/development/use-development-builds',
 
   // Consolidate workflow page
   '/bare/customizing/': '/workflow/customizing/',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -128,6 +128,7 @@ redirects[development/getting-started]=development/create-development-builds/
 redirects[development/troubleshooting]=development/introduction/
 redirects[development/upgrading]=development/introduction/
 redirects[development/extensions]=development/development-workflows/
+redirects[development/develop-your-project]=development/use-development-builds/
 
 # Guides that have been deleted
 redirects[guides/using-gatsby]=guides/

--- a/docs/pages/development/create-development-builds.mdx
+++ b/docs/pages/development/create-development-builds.mdx
@@ -171,5 +171,5 @@ To share the build with your team, direct them to the build page in the Expo das
 <BoxLink
   title="Use a development build"
   description="Learn about how to use the development build that you have just installed."
-  href="/development/develop-your-project"
+  href="/development/use-development-builds"
 />

--- a/docs/pages/development/installation.mdx
+++ b/docs/pages/development/installation.mdx
@@ -120,7 +120,7 @@ import 'expo-dev-client';
 import App from "./App";
 ```
 
-For more information, see [Error handling](/development/develop-your-project/#add-error-handling).
+For more information, see [Error handling](/development/use-development-builds/#add-error-handling).
 
 ### Loading published updates
 


### PR DESCRIPTION
Fix incorrect link.