### PR TITLE
[dev-menu] Fix writing 'r' into text input reloading the app on iOS

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed writing 'r' into text input reloading the app on iOS.
+
 ### 💡 Others
 
 ## 2.0.1 - 2022-11-08

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed writing 'r' into text input reloading the app on iOS.
+- Fixed writing 'r' into text input reloading the app on iOS. ([#20107](https://github.com/expo/expo/pull/20107) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -41,9 +41,8 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
   @objc
   var EXDevMenu_keyCommands: [UIKeyCommand] {
     if self is UITextField || self is UITextView {
-      return [];
+      return []
     }
-    
     let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction } as! [DevMenuExportedAction]
     let actionsWithKeyCommands = actions.filter { $0.keyCommand != nil }
     var keyCommands = actionsWithKeyCommands.map { $0.keyCommand! }

--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -40,6 +40,10 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   var EXDevMenu_keyCommands: [UIKeyCommand] {
+    if self is UITextField || self is UITextView {
+      return [];
+    }
+    
     let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction } as! [DevMenuExportedAction]
     let actionsWithKeyCommands = actions.filter { $0.keyCommand != nil }
     var keyCommands = actionsWithKeyCommands.map { $0.keyCommand! }


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/19911.

# How

Don't register key commands on the text inputs. 

# Test Plan

- bare-expo ✅