### PR TITLE
[go] Dont register commands on text connected views

### DIFF
--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -128,6 +128,9 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (NSArray<UIKeyCommand *> *)EX_keyCommands
 {
+  if ([self isKindOfClass:[UITextView class]] || [self isKindOfClass:[UITextField class]]) {
+    return @[];
+  }
   NSSet<EXKeyCommand *> *commands = [EXKernelDevKeyCommands sharedInstance].commands;
   return [[commands valueForKeyPath:@"keyCommand"] allObjects];
 }


### PR DESCRIPTION
# Why

Don't register commands on text-connected views.

# Test Plan

Expo Go 
- checks if key commands work outside of the text box ✅
- checks if key commands don't work inside of the box ✅