### PR TITLE
[docs] Fix typo on internal distribution page

### DIFF
--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -4,9 +4,8 @@ title: Internal distribution
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
-import { theme } from '@expo/styleguide';
 
-Uploading your app to TestFlight and Google Play beta can be time-consuming (or example, waiting for the build to run through static analysis before becoming available to testers) and limiting (for example, TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
+Uploading your app to TestFlight and Google Play beta can be time-consuming (for example, waiting for the build to run through static analysis before becoming available to testers) and limiting (for example, TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
 
 EAS Build can help you with this by providing shareable URLs for your builds with instructions on how to get them running, so you can share a single URL with a teammate that'll include all of the information they need to test the app.
 


### PR DESCRIPTION
# Why & how

Follow up for #20116.
This PR fixes a small typo and cleans up to remove unused import statement.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="862" alt="CleanShot 2022-11-20 at 12 15 42@2x" src="https://user-images.githubusercontent.com/10234615/202889591-43e2c0a9-143b-456a-b8b9-dba7e1bdf12e.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
