### PR TITLE
[config-plugins] Ability to replace content

### DIFF
--- a/packages/@expo/config-plugins/src/utils/__tests__/generateCode-test.ts
+++ b/packages/@expo/config-plugins/src/utils/__tests__/generateCode-test.ts
@@ -1,0 +1,73 @@
+import { mergeContents } from '../generateCode';
+
+const src = `
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeDelegate.h>
+#import <UIKit/UIKit.h>
+
+#import <Expo/Expo.h>
+
+@interface AppDelegate : EXAppDelegateWrapper <RCTBridgeDelegate>
+
+@end
+`;
+
+const defaultValuesForTest = {
+  src,
+  newSrc: 'NEW_SRC',
+  tag: 'MY_TAG',
+  anchor: '#import <Expo/Expo.h>',
+  comment: '//',
+};
+
+describe(mergeContents, () => {
+  it('should throw if anchor is not found', () => {
+    function willThrow() {
+      mergeContents({
+        ...defaultValuesForTest,
+        anchor: 'NOT_FOUND_ANCHOR',
+        offset: 0,
+      });
+    }
+    expect(willThrow).toThrow();
+  });
+
+  it('should insert before the found anchor', () => {
+    const result = mergeContents({
+      ...defaultValuesForTest,
+      offset: 0,
+    });
+    // ensure the merge went ok
+    expect(result.didMerge).toBe(true);
+    expect(result.didClear).toBe(false);
+    const tagIndex = result.contents.indexOf(defaultValuesForTest.tag);
+    const anchorIndex = result.contents.indexOf(defaultValuesForTest.anchor);
+    // ensure tag and anchor has been found in the result content
+    expect(tagIndex).not.toBe(-1);
+    expect(anchorIndex).not.toBe(-1);
+    // ensure the first occurence of the tag is before the anchor
+    expect(tagIndex < anchorIndex).toBe(true);
+  });
+
+  it('should insert after the found anchor', () => {
+    const result = mergeContents({
+      ...defaultValuesForTest,
+      offset: 1,
+    });
+    const tagIndex = result.contents.indexOf(defaultValuesForTest.tag);
+    const anchorIndex = result.contents.indexOf(defaultValuesForTest.anchor);
+    // ensure the first occurence of the tag is after the anchor
+    expect(tagIndex > anchorIndex).toBe(true);
+  });
+
+  it('should replace the found anchor', () => {
+    const result = mergeContents({
+      ...defaultValuesForTest,
+      offset: 0,
+      deleteCount: 1,
+    });
+    const anchorIndex = result.contents.indexOf(defaultValuesForTest.anchor);
+    // ensure anchor is not found anymore
+    expect(anchorIndex).toBe(-1);
+  });
+});

--- a/packages/@expo/config-plugins/src/utils/generateCode.ts
+++ b/packages/@expo/config-plugins/src/utils/generateCode.ts
@@ -27,9 +27,10 @@ export type MergeResults = {
  *
  * @param src contents of the original file
  * @param newSrc new contents to merge into the original file
- * @param identifier used to update and remove merges
+ * @param tag used to update and remove merges
  * @param anchor regex to where the merge should begin
  * @param offset line offset to start merging at (<1 for behind the anchor)
+ * @param deleteCount lines to remove at the start of merging (defaults to 0)
  * @param comment comment style `//` or `#`
  */
 export function mergeContents({
@@ -38,6 +39,7 @@ export function mergeContents({
   tag,
   anchor,
   offset,
+  deleteCount,
   comment,
 }: {
   src: string;
@@ -45,6 +47,7 @@ export function mergeContents({
   tag: string;
   anchor: string | RegExp;
   offset: number;
+  deleteCount?: number;
   comment: string;
 }): MergeResults {
   const header = createGeneratedHeaderComment(newSrc, tag, comment);
@@ -52,7 +55,7 @@ export function mergeContents({
     // Ensure the old generated contents are removed.
     const sanitizedTarget = removeGeneratedContents(src, tag);
     return {
-      contents: addLines(sanitizedTarget ?? src, anchor, offset, [
+      contents: addLines(sanitizedTarget ?? src, anchor, offset, deleteCount ?? 0, [
         header,
         ...newSrc.split('\n'),
         `${comment} @generated end ${tag}`,
@@ -74,7 +77,7 @@ export function removeContents({ src, tag }: { src: string; tag: string }): Merg
   };
 }
 
-function addLines(content: string, find: string | RegExp, offset: number, toAdd: string[]) {
+function addLines(content: string, find: string | RegExp, offset: number, deleteCount: number, toAdd: string[]) {
   const lines = content.split('\n');
 
   let lineIndex = lines.findIndex((line) => line.match(find));
@@ -85,7 +88,7 @@ function addLines(content: string, find: string | RegExp, offset: number, toAdd:
     throw error;
   }
   for (const newLine of toAdd) {
-    lines.splice(lineIndex + offset, 0, newLine);
+    lines.splice(lineIndex + offset, deleteCount, newLine);
     lineIndex++;
   }
 

--- a/packages/@expo/config-plugins/src/utils/generateCode.ts
+++ b/packages/@expo/config-plugins/src/utils/generateCode.ts
@@ -80,17 +80,14 @@ export function removeContents({ src, tag }: { src: string; tag: string }): Merg
 function addLines(content: string, find: string | RegExp, offset: number, deleteCount: number, toAdd: string[]) {
   const lines = content.split('\n');
 
-  let lineIndex = lines.findIndex((line) => line.match(find));
+  const lineIndex = lines.findIndex((line) => line.match(find));
   if (lineIndex < 0) {
     const error = new Error(`Failed to match "${find}" in contents:\n${content}`);
     // @ts-ignore
     error.code = 'ERR_NO_MATCH';
     throw error;
   }
-  for (const newLine of toAdd) {
-    lines.splice(lineIndex + offset, deleteCount, newLine);
-    lineIndex++;
-  }
+  lines.splice(lineIndex + offset, deleteCount, ...toAdd);
 
   return lines.join('\n');
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When writing `config-plugins` it happens we need to replace content instead of merging it.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Adds an optional param to `mergeContent` to indicate how many lines we want to delete at the start of the merge

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Added few unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
