### PR TITLE
[docs] Fix typo in `create-a-modal` tutorial page

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -13,7 +13,7 @@ In this chapter, we'll create a modal that shows an emoji picker list.
 
 ## Step 1: Declare a state variable to show buttons
 
-Before implementing the modal, we are going to add three new buttons. These buttons will only be visible when the user picks an image from the media library or decides to use the placeholder image. One of these buttons will trigger the emoji picer modal.
+Before implementing the modal, we are going to add three new buttons. These buttons will only be visible when the user picks an image from the media library or decides to use the placeholder image. One of these buttons will trigger the emoji picker modal.
 
 Declare a state variable called `showAppOptions` in **App.js**. We'll use this variable to show or hide buttons that open the modal alongside a few other options.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While going through the tutorial, I found a typo in [Create a modal](https://docs.expo.dev/tutorial/create-a-modal/) page.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Replaced the typo `picer` with `picker`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I don't think the test plan is needed for this minor fix. If needed, let me know :)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
