### PR TITLE
[docs] Update component import statement in the Readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -234,7 +234,7 @@ The `Tabs` plugin is really useful for this, and this is how you'd use it in a m
 
 <!-- prettier-ignore -->
 ```jsx
-import { Tab, Tabs } from '~/components/plugins/Tabs';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 <Tabs>
 <Tab label="Add 1 One Way">


### PR DESCRIPTION
# Why

Currently, the import statement to import `<Tabs>` component in the `expo/docs/` is outdated. This PR fixes that.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
