### PR TITLE
[docs] Update MapView documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 - In the modal, click **Edit API key**.
 - Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
 - Under **Restrict usage to your Android apps**, click **Add an item**.
-- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Add your `android.package` from **app.json** (for example: `com.company.myapp`) to the package name field.
 - Then, add the **SHA-1 certificate fingerprint's** value from step 2.
 - Click **Done** and then click **Save**.
 

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -28,9 +28,9 @@ See full documentation at [react-native-maps/react-native-maps](https://github.c
 <SnackInline label='MapView' dependencies={['react-native-maps']}>
 
 ```jsx
-import * as React from 'react';
+import React from 'react';
 import MapView from 'react-native-maps';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 export default function App() {
   return (
@@ -43,13 +43,10 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   map: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
+    width: '100%',
+    height: '100%',
   },
 });
 ```
@@ -151,11 +148,11 @@ const styles = StyleSheet.create({
 
 ## Configuration for web
 
-> Web is experimental! We do not recommend using this library on the web yet.
+> **warning** Web support is experimental. We do not recommend using this library on the web yet.
 
 To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
-```html
+```html web/index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -6,10 +6,14 @@ packageName: 'react-native-maps'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-**`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-native-maps/react-native-maps](https://github.com/react-native-maps/react-native-maps). No setup required for use within the Expo Go app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
+`react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
+
+No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploying-app-with-google-maps).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -52,98 +56,104 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Configuration
+## Deploy app with Google Maps
 
-No additional configuration is necessary to use `react-native-maps` in Expo Go. However, once you want to deploy your standalone app you should follow instructions below.
-
-### Configuring for web
-
-> Web is experimental! We do not recommend using this library on web yet.
-
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- At the end of the <head/> element... -->
-
-    <script
-      async
-      defer
-      src="https://maps.googleapis.com/maps/api/js?key=API_KEY"
-      type="text/javascript"></script>
-
-    <!-- Use your web API Key in place of API_KEY: https://developers.google.com/maps/documentation/javascript/get-api-key -->
-  </head>
-
-  <!-- <body /> -->
-</html>
-```
-
-## Deploying app with Google Maps
-
-### Android standalone app
+### Android
 
 > If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
-#### 1. Register a Google Cloud API project and enable the Maps SDK for Android
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for Android
 
 - Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for Android**
+- Once it's created, go to the project and enable the **Maps SDK for Android**.
 
-#### 2. Have your app's SHA-1 certificate fingerprint ready
+</Step>
 
-- **If you are deploying your app to the Google Play Store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps) and [uploaded it to Google Play](/distribution/introduction) at least once in order to have Google generate your app signing credentials.
-  - Go to the [Google Play Console](https://play.google.com/console) → (your app) → Setup → App Integrity
-  - Copy the value of _SHA-1 certificate fingerprint_
-- **If you are sideloading your APK or deploying it to another store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps), then run `expo fetch:android:hashes` and copy the _Google Certificate Fingerprint_.
-- **If you are running a _debug_ build (development client or local debug build)**, your Android app will be signed using the debug keystore. See the instructions [below](#how-to-retrieve-your-debug-keystore-fingerprint) on how to retrieve your fingerprint.
+<Step label="2">
+#### Copy your app's SHA-1 certificate fingerprint
 
-#### 3. Create an API key
+<Tabs>
+<Tab label="For Google Play Store">
+
+- **If you are deploying your app to the Google Play Store**, you'll need to [upload your app binary to Google Play console](/submit/android/) at least once. This is required for Google to generate your app signing credentials.
+- Go to the **[Google Play Console](https://play.google.com/console) > (your app) > Release > Setup > App integrity > App Signing**.
+- Copy the value of **SHA-1 certificate fingerprint**.
+
+</Tab>
+
+<Tab label="For development builds">
+
+- If you have already created a [development build](/development/introduction/), your project will be signed using a debug keystore.
+- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
+- Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
+
+</Tab>
+
+</Tabs>
+
+</Step>
+
+<Step label="3">
+#### Create an API key
 
 - Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Under **Key restrictions** → **Application restrictions**, ensure that the **Android apps** radio button is chosen.
-- Click the **+ Add package name and fingerprint** button.
-- Add your Android package name from **app.json** to the package name field.
-- Add or replace the **SHA-1 certificate fingerprint** with the value from step 2.
-- Click **Done** and then click **Save**
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
+- Under **Restrict usage to your Android apps**, click **Add an item**.
+- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Then, add the **SHA-1 certificate fingerprint's** value from step 2.
+- Click **Done** and then click **Save**.
 
-#### 4. Add the API key to your project
+</Step>
+
+<Step label="4">
+#### Add the API key to your project
 
 - Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
-- Rebuild the app binary and re-submit to Google Play or sideload it (depending on how you configured your API key) to test that the configuration was successful.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
 
-### iOS standalone app
+</Step>
+
+### iOS
 
 > If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
-#### 1. Register a Google Cloud API project and enable the Maps SDK for iOS
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for iOS
 
 - Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for iOS**
+- Then, go to the project, click **Enable APIs and Services** and enable the **Maps SDK for iOS**.
 
-#### 2. Create an API key
+</Step>
+
+<Step label="2">
+#### Create an API key
 
 - Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Choose the **iOS apps** radio button under **Key restriction**.
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **iOS apps**.
 - Under **Accept requests from an iOS application with one of these bundle identifiers**, click the **Add an item** button.
-- Add your `ios.bundleIdentifier` from **app.json** eg: `com.company.myapp`) to the bundle ID field.
-- Click **Done** and then click **Save**
+- Add your `ios.bundleIdentifier` from **app.json** (for example: `com.company.myapp`) to the bundle ID field.
+- Click **Done** and then click **Save**.
 
-#### 3. Add the API key to your project
+</Step>
+
+<Step label="3">
+#### Add the API key to your project
 
 - Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both iOS and Android.
-- Rebuild the app binary. An easy way to test that the configuration was successful is to do a simulator build.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
 
-## Configuring for web
+</Step>
 
-> Web is experimental! We do not recommend using this library on web yet.
+## Configuration for web
 
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+> Web is experimental! We do not recommend using this library on the web yet.
+
+To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 ```html
 <!DOCTYPE html>
@@ -160,30 +170,4 @@ To use this in web, add the following script to your **web/index.html**. This sc
   </head>
   <body />
 </html>
-```
-
-## How to retrieve your debug keystore fingerprint (Android only)
-
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
-
-> All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
-
-The debug keystore location and password is defined in your `android/app/build.gradle` file like this:
-
-```groovy
-signingConfigs {
-    debug {
-        storeFile file('debug.keystore')
-        storePassword 'android'
-        keyAlias 'androiddebugkey'
-        keyPassword 'android'
-    }
-}
-```
-
-You can view the fingerprint for this keystore using the `keytool` command, and entering the storePassword. Copy the value shown after `SHA1:`
-
-```bash
-❯ keytool -list -v -keystore ./android/app/debug.keystore
-Enter keystore password:
 ```

--- a/docs/pages/versions/v45.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/map-view.mdx
@@ -6,7 +6,7 @@ packageName: 'react-native-maps'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
 
 **`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-community/react-native-maps](https://github.com/react-community/react-native-maps). No setup required for use within the Expo Go app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
@@ -24,9 +24,9 @@ See full documentation at [react-native-maps/react-native-maps](https://github.c
 <SnackInline label='MapView' dependencies={['react-native-maps']}>
 
 ```jsx
-import * as React from 'react';
+import React from 'react';
 import MapView from 'react-native-maps';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 export default function App() {
   return (
@@ -39,13 +39,10 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   map: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
+    width: '100%',
+    height: '100%',
   },
 });
 ```
@@ -54,15 +51,15 @@ const styles = StyleSheet.create({
 
 ## Configuration
 
-No additional configuration is necessary to use `react-native-maps` in Expo Go. However, once you want to deploy your standalone app you should follow instructions below.
+No additional configuration is necessary to use `react-native-maps` in Expo Go. However, once you want to deploy your standalone app you should follow the instructions below.
 
 ### Configuring for web
 
-> Web is experimental! We do not recommend using this library on web yet.
+> **warning** Web support is experimental! We do not recommend using this library on the web yet.
 
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
 
-```html
+```html web/index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 - In the modal, click **Edit API key**.
 - Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
 - Under **Restrict usage to your Android apps**, click **Add an item**.
-- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Add your `android.package` from **app.json** (for example: `com.company.myapp`) to the package name field.
 - Then, add the **SHA-1 certificate fingerprint's** value from step 2.
 - Click **Done** and then click **Save**.
 

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -6,10 +6,14 @@ packageName: 'react-native-maps'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-**`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-native-maps/react-native-maps](https://github.com/react-native-maps/react-native-maps). No setup required for use within the Expo Go app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
+`react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
+
+No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploying-app-with-google-maps).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -52,22 +56,110 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Configuration
+## Deploy app with Google Maps
 
-No additional configuration is necessary to use `react-native-maps` in Expo Go. However, once you want to deploy your standalone app you should follow instructions below.
+### Android
 
-### Configuring for web
+> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
-> Web is experimental! We do not recommend using this library on web yet.
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for Android
 
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
+- Once it's created, go to the project and enable the **Maps SDK for Android**.
+
+</Step>
+
+<Step label="2">
+#### Copy your app's SHA-1 certificate fingerprint
+
+<Tabs>
+<Tab label="For Google Play Store">
+
+- **If you are deploying your app to the Google Play Store**, you'll need to [upload your app binary to Google Play console](/submit/android/) at least once. This is required for Google to generate your app signing credentials.
+- Go to the **[Google Play Console](https://play.google.com/console) > (your app) > Release > Setup > App integrity > App Signing**.
+- Copy the value of **SHA-1 certificate fingerprint**.
+
+</Tab>
+
+<Tab label="For development builds">
+
+- If you have already created a [development build](/development/introduction/), your project will be signed using a debug keystore.
+- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
+- Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
+
+</Tab>
+
+</Tabs>
+
+</Step>
+
+<Step label="3">
+#### Create an API key
+
+- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
+- Under **Restrict usage to your Android apps**, click **Add an item**.
+- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Then, add the **SHA-1 certificate fingerprint's** value from step 2.
+- Click **Done** and then click **Save**.
+
+</Step>
+
+<Step label="4">
+#### Add the API key to your project
+
+- Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
+
+</Step>
+
+### iOS
+
+> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for iOS
+
+- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
+- Then, go to the project, click **Enable APIs and Services** and enable the **Maps SDK for iOS**.
+
+</Step>
+
+<Step label="2">
+#### Create an API key
+
+- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **iOS apps**.
+- Under **Accept requests from an iOS application with one of these bundle identifiers**, click the **Add an item** button.
+- Add your `ios.bundleIdentifier` from **app.json** (for example: `com.company.myapp`) to the bundle ID field.
+- Click **Done** and then click **Save**.
+
+</Step>
+
+<Step label="3">
+#### Add the API key to your project
+
+- Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
+
+</Step>
+
+## Configuration for web
+
+> Web is experimental! We do not recommend using this library on the web yet.
+
+To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 ```html
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <!-- At the end of the <head/> element... -->
-
     <script
       async
       defer
@@ -76,90 +168,6 @@ To use this in web, add the following script to your **web/index.html**. This sc
 
     <!-- Use your web API Key in place of API_KEY: https://developers.google.com/maps/documentation/javascript/get-api-key -->
   </head>
-
-  <!-- <body /> -->
+  <body />
 </html>
 ```
-
-## Deploying app with Google Maps
-
-### Android standalone app
-
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
-
-#### 1. Register a Google Cloud API project and enable the Maps SDK for Android
-
-- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for Android**
-
-#### 2. Have your app's SHA-1 certificate fingerprint ready
-
-- **If you are deploying your app to the Google Play Store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps) and [uploaded it to Google Play](../../../distribution/app-stores.mdx) at least once in order to have Google generate your app signing credentials.
-  - Go to the [Google Play Console](https://play.google.com/console) → (your app) → Setup → App Integrity
-  - Copy the value of _SHA-1 certificate fingerprint_
-- **If you are sideloading your APK or deploying it to another store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps.mdx), then run `expo fetch:android:hashes` and copy the _Google Certificate Fingerprint_.
-- **If you are running a _debug_ build (development client or local debug build)**, your Android app will be signed using the debug keystore. See the instructions [below](#how-to-retrieve-your-debug-keystore-fingerprint) on how to retrieve your fingerprint.
-
-#### 3. Create an API key
-
-- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Under **Key restrictions** → **Application restrictions**, ensure that the **Android apps** radio button is chosen.
-- Click the **+ Add package name and fingerprint** button.
-- Add your Android package name from **app.json** to the package name field.
-- Add or replace the **SHA-1 certificate fingerprint** with the value from step 2.
-- Click **Done** and then click **Save**
-
-#### 4. Add the API key to your project
-
-- Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
-- Rebuild the app binary and re-submit to Google Play or sideload it (depending on how you configured your API key) to test that the configuration was successful.
-
-### iOS standalone app
-
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
-
-#### 1. Register a Google Cloud API project and enable the Maps SDK for iOS
-
-- Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for iOS**
-
-#### 2. Create an API key
-
-- Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Choose the **iOS apps** radio button under **Key restriction**.
-- Under **Accept requests from an iOS application with one of these bundle identifiers**, click the **Add an item** button.
-- Add your `ios.bundleIdentifier` from **app.json** eg: `com.company.myapp`) to the bundle ID field.
-- Click **Done** and then click **Save**
-
-#### 3. Add the API key to your project
-
-- Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both iOS and Android.
-- Rebuild the app binary. An easy way to test that the configuration was successful is to do a simulator build.
-
-## How to retrieve your debug keystore fingerprint (Android only)
-
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
-
-> All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
-
-The debug keystore location and password is defined in your `android/app/build.gradle` file like this:
-
-```groovy
-signingConfigs {
-    debug {
-        storeFile file('debug.keystore')
-        storePassword 'android'
-        keyAlias 'androiddebugkey'
-        keyPassword 'android'
-    }
-}
-```
-
-You can view the fingerprint for this keystore using the `keytool` command, and entering the storePassword. Copy the value shown after `SHA1:`.
-
-<Terminal
-  cmd={['$ keytool -list -v -keystore ./android/app/debug.keystore', '# Enter keystore password:']}
-/>

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -28,9 +28,9 @@ See full documentation at [react-native-maps/react-native-maps](https://github.c
 <SnackInline label='MapView' dependencies={['react-native-maps']}>
 
 ```jsx
-import * as React from 'react';
+import React from 'react';
 import MapView from 'react-native-maps';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 export default function App() {
   return (
@@ -43,13 +43,10 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   map: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
+    width: '100%',
+    height: '100%',
   },
 });
 ```
@@ -151,11 +148,11 @@ const styles = StyleSheet.create({
 
 ## Configuration for web
 
-> Web is experimental! We do not recommend using this library on the web yet.
+> **warning** Web support is experimental. We do not recommend using this library on the web yet.
 
 To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
-```html
+```html web/index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/docs/pages/versions/v47.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/map-view.mdx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
 - In the modal, click **Edit API key**.
 - Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
 - Under **Restrict usage to your Android apps**, click **Add an item**.
-- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Add your `android.package` from **app.json** (for example: `com.company.myapp`) to the package name field.
 - Then, add the **SHA-1 certificate fingerprint's** value from step 2.
 - Click **Done** and then click **Save**.
 

--- a/docs/pages/versions/v47.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/map-view.mdx
@@ -28,9 +28,9 @@ See full documentation at [react-native-maps/react-native-maps](https://github.c
 <SnackInline label='MapView' dependencies={['react-native-maps']}>
 
 ```jsx
-import * as React from 'react';
+import React from 'react';
 import MapView from 'react-native-maps';
-import { StyleSheet, Text, View, Dimensions } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
 export default function App() {
   return (
@@ -43,13 +43,10 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   map: {
-    width: Dimensions.get('window').width,
-    height: Dimensions.get('window').height,
+    width: '100%',
+    height: '100%',
   },
 });
 ```
@@ -151,11 +148,11 @@ const styles = StyleSheet.create({
 
 ## Configuration for web
 
-> Web is experimental! We do not recommend using this library on the web yet.
+> **warning** Web support is experimental. We do not recommend using this library on the web yet.
 
 To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
-```html
+```html web/index.html
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/docs/pages/versions/v47.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/map-view.mdx
@@ -6,10 +6,14 @@ packageName: 'react-native-maps'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
-**`react-native-maps`** provides a Map component that uses Apple Maps or Google Maps on iOS and Google Maps on Android. Expo uses react-native-maps at [react-native-maps/react-native-maps](https://github.com/react-native-maps/react-native-maps). No setup required for use within the Expo Go app. See below for instructions on how to configure for deployment as a standalone app on Android and iOS.
+`react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
+
+No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploying-app-with-google-maps).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -52,98 +56,104 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Configuration
+## Deploy app with Google Maps
 
-No additional configuration is necessary to use `react-native-maps` in Expo Go. However, once you want to deploy your standalone app you should follow instructions below.
-
-### Configuring for web
-
-> Web is experimental! We do not recommend using this library on web yet.
-
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <!-- At the end of the <head/> element... -->
-
-    <script
-      async
-      defer
-      src="https://maps.googleapis.com/maps/api/js?key=API_KEY"
-      type="text/javascript"></script>
-
-    <!-- Use your web API Key in place of API_KEY: https://developers.google.com/maps/documentation/javascript/get-api-key -->
-  </head>
-
-  <!-- <body /> -->
-</html>
-```
-
-## Deploying app with Google Maps
-
-### Android standalone app
+### Android
 
 > If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
-#### 1. Register a Google Cloud API project and enable the Maps SDK for Android
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for Android
 
 - Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for Android**
+- Once it's created, go to the project and enable the **Maps SDK for Android**.
 
-#### 2. Have your app's SHA-1 certificate fingerprint ready
+</Step>
 
-- **If you are deploying your app to the Google Play Store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps) and [uploaded it to Google Play](/distribution/introduction) at least once in order to have Google generate your app signing credentials.
-  - Go to the [Google Play Console](https://play.google.com/console) → (your app) → Setup → App Integrity
-  - Copy the value of _SHA-1 certificate fingerprint_
-- **If you are sideloading your APK or deploying it to another store**, you will need to have [created a standalone app](/archive/classic-updates/building-standalone-apps), then run `expo fetch:android:hashes` and copy the _Google Certificate Fingerprint_.
-- **If you are running a _debug_ build (development client or local debug build)**, your Android app will be signed using the debug keystore. See the instructions [below](#how-to-retrieve-your-debug-keystore-fingerprint) on how to retrieve your fingerprint.
+<Step label="2">
+#### Copy your app's SHA-1 certificate fingerprint
 
-#### 3. Create an API key
+<Tabs>
+<Tab label="For Google Play Store">
+
+- **If you are deploying your app to the Google Play Store**, you'll need to [upload your app binary to Google Play console](/submit/android/) at least once. This is required for Google to generate your app signing credentials.
+- Go to the **[Google Play Console](https://play.google.com/console) > (your app) > Release > Setup > App integrity > App Signing**.
+- Copy the value of **SHA-1 certificate fingerprint**.
+
+</Tab>
+
+<Tab label="For development builds">
+
+- If you have already created a [development build](/development/introduction/), your project will be signed using a debug keystore.
+- After the build is complete, go to your [project's dashboard](https://expo.dev/accounts/[username]/projects/[project-name]), then, under **Configure** > click **Credentials**.
+- Under **Application Identifiers**, click your project's package name and under **Android Keystore** copy the value of **SHA-1 Certificate Fingerprint**.
+
+</Tab>
+
+</Tabs>
+
+</Step>
+
+<Step label="3">
+#### Create an API key
 
 - Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Under **Key restrictions** → **Application restrictions**, ensure that the **Android apps** radio button is chosen.
-- Click the **+ Add package name and fingerprint** button.
-- Add your Android package name from **app.json** to the package name field.
-- Add or replace the **SHA-1 certificate fingerprint** with the value from step 2.
-- Click **Done** and then click **Save**
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **Android apps**.
+- Under **Restrict usage to your Android apps**, click **Add an item**.
+- Add `android.package` name from **app.json** (for example: `com.company.myapp`) to the package name field.
+- Then, add the **SHA-1 certificate fingerprint's** value from step 2.
+- Click **Done** and then click **Save**.
 
-#### 4. Add the API key to your project
+</Step>
+
+<Step label="4">
+#### Add the API key to your project
 
 - Copy your **API Key** into your **app.json** under the `android.config.googleMaps.apiKey` field.
-- Rebuild the app binary and re-submit to Google Play or sideload it (depending on how you configured your API key) to test that the configuration was successful.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary (or re-submit to the Google Play Store in case your app is already uploaded). An easy way to test if the configuration was successful is to do an [emulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
 
-### iOS standalone app
+</Step>
+
+### iOS
 
 > If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
-#### 1. Register a Google Cloud API project and enable the Maps SDK for iOS
+<Step label="1">
+#### Register a Google Cloud API project and enable the Maps SDK for iOS
 
 - Open your browser to the [Google API Manager](https://console.developers.google.com/apis) and create a project.
-- Once it's created, go to the project and enable the **Maps SDK for iOS**
+- Then, go to the project, click **Enable APIs and Services** and enable the **Maps SDK for iOS**.
 
-#### 2. Create an API key
+</Step>
+
+<Step label="2">
+#### Create an API key
 
 - Go to [Google Cloud Credential manager](https://console.cloud.google.com/apis/credentials) and click **Create Credentials**, then **API Key**.
-- In the modal, click **Restrict Key**.
-- Choose the **iOS apps** radio button under **Key restriction**.
+- In the modal, click **Edit API key**.
+- Under **Key restrictions** > **Application restrictions**, choose **iOS apps**.
 - Under **Accept requests from an iOS application with one of these bundle identifiers**, click the **Add an item** button.
-- Add your `ios.bundleIdentifier` from **app.json** eg: `com.company.myapp`) to the bundle ID field.
-- Click **Done** and then click **Save**
+- Add your `ios.bundleIdentifier` from **app.json** (for example: `com.company.myapp`) to the bundle ID field.
+- Click **Done** and then click **Save**.
 
-#### 3. Add the API key to your project
+</Step>
+
+<Step label="3">
+#### Add the API key to your project
 
 - Copy your API key into **app.json** under the `ios.config.googleMapsApiKey` field.
-- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both iOS and Android.
-- Rebuild the app binary. An easy way to test that the configuration was successful is to do a simulator build.
+- In your code, import `{ PROVIDER_GOOGLE }` from `react-native-maps` and add the property `provider=PROVIDER_GOOGLE` to your `<MapView>`. This property works on both Android and iOS.
+- Rebuild the app binary. An easy way to test if the configuration was successful is to do a [simulator build](/development/create-development-builds/#create-and-install-a-build-for-emulatorsimulator).
 
-## Configuring for web
+</Step>
 
-> Web is experimental! We do not recommend using this library on web yet.
+## Configuration for web
 
-To use this in web, add the following script to your **web/index.html**. This script may already be present, if this is the case, just replace the `API_KEY` with your Google Maps API key which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key)
+> Web is experimental! We do not recommend using this library on the web yet.
+
+To use this on the web, add the following script to your **web/index.html**. This script may already be present. If this is the case, replace the `API_KEY` with your Google Maps API key, which you can obtain here: [Google Maps: Get API key](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
 ```html
 <!DOCTYPE html>
@@ -160,30 +170,4 @@ To use this in web, add the following script to your **web/index.html**. This sc
   </head>
   <body />
 </html>
-```
-
-## How to retrieve your debug keystore fingerprint (Android only)
-
-When building a debug version of your application outside of Expo Go (for example, when using a [development client](/development/introduction/) or a standalone debug build), your app will be signed with the debug keystore on Android.
-
-> All standard Expo templates use a debug keystore with fingerprint `5E:8F:16:06:2E:A3:CD:2C:4A:0D:54:78:76:BA:A6:F3:8C:AB:F6:25`, that you can enter directly in the Google Cloud Credential Manager. So if you are using one of the standard Expo templates, you don't need to perform the steps below.
-
-The debug keystore location and password is defined in your `android/app/build.gradle` file like this:
-
-```groovy
-signingConfigs {
-    debug {
-        storeFile file('debug.keystore')
-        storePassword 'android'
-        keyAlias 'androiddebugkey'
-        keyPassword 'android'
-    }
-}
-```
-
-You can view the fingerprint for this keystore using the `keytool` command, and entering the storePassword. Copy the value shown after `SHA1:`
-
-```bash
-❯ keytool -list -v -keystore ./android/app/debug.keystore
-Enter keystore password:
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Instructions in `react-native-naps` documentation currently is outdated on various levels. Working with development builds is also not highlighted and the text is confusing when following instructions to generate API key for Google Maps on Android.

Closes ENG-6618, ENG-6596, ENG-6216

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes the outdated references to standalone apps and replaces that with development builds. It also backport these changes to SDK 47 and 46.

Also, removes duplicated step for web configuration and removes [How to retrieve your debug keystore fingerprint (Android only)](https://docs.expo.dev/versions/latest/sdk/map-view/#how-to-retrieve-your-debug-keystore-fingerprint).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally and visiting: http://localhost:3002/versions/latest/sdk/map-view

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
