### PR TITLE
[docs] Fixes and small tweaks in guides and development build docs

### DIFF
--- a/docs/pages/development/create-development-builds.mdx
+++ b/docs/pages/development/create-development-builds.mdx
@@ -23,7 +23,7 @@ To initialize a development build, you need to install the `expo-dev-client` lib
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-## Build with EAS
+## Create and install EAS Build
 
 We recommend EAS Build to manage your native projects. It allows a smooth experience, especially if you do not have experience with Xcode and Android studio builds or do not have them installed locally on your computer.
 
@@ -51,7 +51,7 @@ The `"development"` profile sets the following options:
 
 > iOS builds where `developmentClient` is set to `true` on the build profile should always be distributed as `"internal"`. If you are distributing for TestFlight, you have to set the distribution to `"store"`.
 
-### Create and install a build for emulator/simulator
+### On emulator/simulator
 
 Follow the steps below to create and install the development build on an Android Emulator or an iOS simulator.
 
@@ -122,7 +122,7 @@ You can now install the it on an iOS simulator:
 
 </Tabs>
 
-### Create and install a build on a device
+### On a device
 
 Follow the steps below to create and install the development build on an Android or an iOS device. Each platform has specific instructions you'll have to follow:
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -92,6 +92,7 @@ const app = initializeApp(firebaseConfig);
 You do not have to install other plugins or configurations to use Firebase JS SDK.
 
 Firebase version 9 provides a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
+
 </Step>
 
 <Step label="3">
@@ -115,6 +116,7 @@ defaultConfig.resolver.assetExts.push('cjs');
 
 module.exports = defaultConfig;
 ```
+
 </Step>
 
 ### Next steps
@@ -210,13 +212,14 @@ It also adds custom native code in your project using a config plugin. You can i
 **At this point, you must follow the instructions from [React Native Firebase documentation](https://rnfirebase.io/#managed-workflow)** as it covers all the steps required to configure your project with the library.
 
 Once you have configured the React Native Firebase library in your project, come back to this guide to learn how to run your project in the next step.
+
 </Step>
 
 <Step label="3">
 #### Run the project
 
 If you are using **[EAS Build](/build/introduction/), you can create and install a development build** on your devices. You do not need to run the project locally before creating a development build.
-For more information on creating a development build, see the section on [installing a development build](/development/getting-started/#creating-and-installing-your-first-development-build).
+For more information on creating a development build, see the section on [installing a development build](/development/create-development-builds/#create-and-install-eas-build).
 
 <Collapsible summary="Run project locally?">
 

--- a/docs/pages/guides/using-flipper.mdx
+++ b/docs/pages/guides/using-flipper.mdx
@@ -11,7 +11,7 @@ It offers various features such as a device log viewer, interactive native layou
 
 Debugging your Expo projects with Flipper requires the following:
 
-- Building your project into a [development build](/development/introduction/)
+- Creating a [development build](/development/introduction/) of your project
 - Installing the [`expo-community-flipper`](https://github.com/jakobo/expo-community-flipper) config plugin
 
 > The `expo-community-flipper` library is a [config plugin](/guides/config-plugins/) that adds native code to your project.
@@ -59,44 +59,18 @@ In the **app.json**, add `expo-community-flipper` to the `plugins` array:
 
 ## Step 5: Configure a development build
 
-To configure a development build for your project, run the following command:
+To configure and install a development build, follow the instructions below for:
 
-<Terminal cmd={['$ eas build:configure']} />
+- [Android Emulator or iOS simulator](/development/create-development-builds/#on-emulatorsimulator)
+- [Physical device](/development/create-development-builds/#on-a-device)
 
-This command will generate the **eas.json** file in your project, which will contain various build profiles.
-
-Inside the `"development"` build profile in **eas.json**, add the `android.buildType` property to generate a **.apk** for an Android device or emulator. To test your project on the iOS simulator, add the `ios.simulator` property to the build profile.
-
-An example of a build profile with the configuration mentioned above is shown below:
-
-```json eas.json
-{
-  "build": {
-    "development": {
-      "developmentClient": true,
-      "distribution": "internal",
-      "android": {
-        "buildType": "apk"
-      },
-      "ios": {
-        "simulator": true
-      }
-    }
-  }
-}
-```
-
-After you have configured the build profile, run the following command to build the project:
-
-<Terminal cmd={['$ eas build --profile development --platform all']} />
-
-Once the builds are complete, you can download them from [Expo's website](https://expo.dev/accounts/[account]/projects/[project]/builds). From there, you can install them on your devices or your emulator/simulator.
+Once the build is complete, you can download them from [Expo's website](https://expo.dev/accounts/[account]/projects/[project]/builds). From there, you can install them on your device or an emulator/simulator.
 
 ## Step 6: Run the development server
 
-Run the following command to start a development server:
+After installing the build, run the following command to start a development server:
 
-<Terminal cmd={['$ npx expo --dev-client']} />
+<Terminal cmd={['$ npx expo start --dev-client']} />
 
 Once the development server is running, open the Flipper desktop app and select your device or simulator under **App Inspect**:
 

--- a/docs/pages/guides/using-flipper.mdx
+++ b/docs/pages/guides/using-flipper.mdx
@@ -57,7 +57,7 @@ In the **app.json**, add `expo-community-flipper` to the `plugins` array:
 }
 ```
 
-## Step 5: Configure a development build
+## Step 5: Configure and install a development build
 
 To configure and install a development build, follow the instructions below for:
 


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR:
- Updates the link section heading in [Create Development Build](https://docs.expo.dev/development/create-development-builds) doc. Currently, the sub-section headers are too verbose and this PR improves that.
- Updates the Using Flipper guide to redirect the user to [Create development builds](https://docs.expo.dev/development/create-development-builds/) on the step 5.
- Update the link to redirect the user to create a development build in React Native Firebase section > Step 3.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Development builds:

<img width="1512" alt="CleanShot 2022-11-21 at 21 11 41@2x" src="https://user-images.githubusercontent.com/10234615/203097188-0cf58140-fbf2-49d9-84ca-346239416d2f.png">

Using Flipper:

<img width="1506" alt="CleanShot 2022-11-21 at 21 12 31@2x" src="https://user-images.githubusercontent.com/10234615/203097232-e6d78454-38bf-49fa-a807-efd93725d114.png">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
