### PR TITLE
[@expo/config-types] Add default update channel

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -191,6 +191,10 @@ export interface ExpoConfig {
          */
         checkAutomatically?: 'ON_ERROR_RECOVERY' | 'ON_LOAD';
         /**
+         * A default channel for updates. If this is defined, and if no channel is defined in a build profile, this channel will be the default one used for fetching update manifests.
+         */
+        defaultChannel?: string;
+        /**
          * How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 0. Must be between 0 and 300000 (5 minutes).
          */
         fallbackToCacheTimeout?: number;

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -191,6 +191,10 @@ export interface ExpoConfig {
      */
     checkAutomatically?: 'ON_ERROR_RECOVERY' | 'ON_LOAD';
     /**
+     * A default channel for updates. If this is defined, and if no channel is defined in a build profile, this channel will be the default one used for fetching update manifests.
+     */
+    defaultChannel?: string;
+    /**
      * How long (in ms) to allow for fetching OTA updates before falling back to a cached version of the app. Defaults to 0. Must be between 0 and 300000 (5 minutes).
      */
     fallbackToCacheTimeout?: number;


### PR DESCRIPTION
# Why

See discussion in ENG-6078

# How

Add a new optional property `defaultChannel` to the updates section of the Expo config (`app.json`).

# Test Plan

To be used in future changes to `eas-cli` to configure new apps so that there is a good flow for trying out updates.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
