### PR TITLE
[android] Align fbjni version to 0.2.2

### DIFF
--- a/android/vendored/sdk47/react-native-reanimated/android/build.gradle
+++ b/android/vendored/sdk47/react-native-reanimated/android/build.gradle
@@ -193,7 +193,7 @@ def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
 def GLOG_VERSION = reactProperties.getProperty("GLOG_VERSION")
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
-def FBJNI_VERSION = "0.3.0"
+def FBJNI_VERSION = "0.2.2"
 def REANIMATED_PACKAGE_BUILD = System.getenv("REANIMATED_PACKAGE_BUILD")
 
 // We download various C++ open-source dependencies into downloads.

--- a/android/vendored/unversioned/react-native-reanimated/android/build.gradle
+++ b/android/vendored/unversioned/react-native-reanimated/android/build.gradle
@@ -199,7 +199,7 @@ def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
 def GLOG_VERSION = reactProperties.getProperty("GLOG_VERSION")
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
-def FBJNI_VERSION = "0.3.0"
+def FBJNI_VERSION = "0.2.2"
 def REANIMATED_PACKAGE_BUILD = System.getenv("REANIMATED_PACKAGE_BUILD")
 def REANIMATED_MAJOR_VERSION = 2
 


### PR DESCRIPTION
# Why

try to fix the android expo go 2.26.4 crash 

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 0 >>> host.exp.exponent <<<

backtrace:
  #00  pc 0x00000000000b2bdc  /data/app/host.exp.exponent-7YRLiOv6bTg4h8glrIL41g==/split_config.arm64_v8a.apk!libc++_shared.so
  #01  pc 0x00000000000aec8c  /data/app/host.exp.exponent-7YRLiOv6bTg4h8glrIL41g==/split_config.arm64_v8a.apk!libc++_shared.so (__gxx_personality_v0+348)
  #02  pc 0x00000000000224e8  /data/app/host.exp.exponent-7YRLiOv6bTg4h8glrIL41g==/split_config.arm64_v8a.apk!libfbjni.so
```

related to #20019

# How

just noticed the fbjni is built by ndk r23 and it is fbjni@0.3.0. the file is overwritten by reanimated because reanimated extracts fbjni to `react-native/ReactAndroid/src/main/jni/first-party/fbjni`, which is also the fbjni extraction path from ReactAndroid.

i'm not 100% sure this is the root cause for the crash, but inconsistent ndk versions would cause crashes for sure. this pr tries to downgrade reanimated fbjni to 0.2.2. i don't update the vendoring tool because react-native 0.71 would have fbjni@0.3.0. 

# Test Plan

`./gradlew :app:assembleVersionedDebug`, unzip the apk and check the fbjni ndk version by [parse_elfnote.py](https://android.googlesource.com/platform/ndk/+/master/parse_elfnote.py)

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
