### PR TITLE
Fix importing barcode scanner interfaces on case-sensitive file systems

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix import issue on case-sensitive file systems ([#20141](https://github.com/expo/expo/pull/20141) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 ## 12.0.0 — 2022-10-25

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.h
@@ -2,7 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-#import <ExpoModulesCore/EXBarCodeScannerInterface.h>
+#import <ExpoModulesCore/EXBarcodeScannerInterface.h>
 
 @interface EXBarCodeScanner : NSObject <EXBarCodeScannerInterface>
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScannerProvider.h
@@ -2,7 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXInternalModule.h>
-#import <ExpoModulesCore/EXBarCodeScannerProviderInterface.h>
+#import <ExpoModulesCore/EXBarcodeScannerProviderInterface.h>
 
 @interface EXBarCodeScannerProvider : NSObject <EXInternalModule, EXBarCodeScannerProviderInterface>
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### 🛠 Breaking changes
 
-- Fix import issue on case-sensitive file systems ([#20141](https://github.com/expo/expo/pull/20141) by [@hirbod](https://github.com/hirbod))
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Fix import issue on case-sensitive file systems ([#20141](https://github.com/expo/expo/pull/20141) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Fix import issue on case-sensitive file systems ([#20141](https://github.com/expo/expo/pull/20141) by [@hirbod](https://github.com/hirbod))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -1,6 +1,6 @@
 #import <AVFoundation/AVFoundation.h>
 
-#import <ExpoModulesCore/EXBarCodeScannerProviderInterface.h>
+#import <ExpoModulesCore/EXBarcodeScannerProviderInterface.h>
 #import <EXCamera/EXCamera.h>
 #import <EXCamera/EXCameraUtils.h>
 #import <EXCamera/EXCameraCameraPermissionRequester.h>


### PR DESCRIPTION
# Why

fixes #20075

The import naming was wrong, which caused issues on case-sensitive file systems 

# How

Fixed the import in both expo-camera and expo-barcode-scanner

# Test Plan

Locally tested

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
