### PR TITLE
fix: [expo-barcode-scanner] import wrong on case-sensitive file systems

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed case-sensitive import in expo-barcode-scanner ([#20142](https://github.com/expo/expo/pull/20142) by [@hirbod] 
+
 ### 💡 Others
 
 ## 12.0.0 — 2022-10-25

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.h
@@ -2,7 +2,7 @@
 
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
-#import <ExpoModulesCore/EXBarCodeScannerInterface.h>
+#import <ExpoModulesCore/EXBarcodeScannerInterface.h>
 
 @interface EXBarCodeScanner : NSObject <EXBarCodeScannerInterface>
 


### PR DESCRIPTION
# Why

Compiling failed on case sensitive file systems

# How

Fixed spelling

# Test Plan

Untested

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
