### PR TITLE
[docs] Footer: add npm registry link, correct issues url

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -40,6 +40,7 @@ type Props = React.PropsWithChildren<{
   title?: string;
   sourceCodeUrl?: string;
   tocVisible: boolean;
+  packageName?: string;
   /** If the page should not show up in the Algolia Docsearch results */
   hideFromSearch?: boolean;
   version: PageApiVersionContextType['version'];
@@ -193,7 +194,11 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
         {this.props.title && <H1>{this.props.title}</H1>}
         {this.props.children}
         {this.props.title && (
-          <Footer title={this.props.title} sourceCodeUrl={this.props.sourceCodeUrl} />
+          <Footer
+            title={this.props.title}
+            sourceCodeUrl={this.props.sourceCodeUrl}
+            packageName={this.props.packageName}
+          />
         )}
       </>
     );

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -33,7 +33,8 @@ export default function DocumentationElements(props: DocumentationElementsProps)
               title={props.meta.title || ''}
               sourceCodeUrl={props.meta.sourceCodeUrl}
               tocVisible={!props.meta.hideTOC}
-              hideFromSearch={props.meta.hideFromSearch}>
+              hideFromSearch={props.meta.hideFromSearch}
+              packageName={props.meta.packageName}>
               {props.children}
             </DocumentationPage>
           </PageApiVersionProvider>

--- a/docs/ui/components/Footer/Footer.test.tsx
+++ b/docs/ui/components/Footer/Footer.test.tsx
@@ -1,45 +1,79 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { NextRouter } from 'next/router';
-import * as React from 'react';
+import { ReactElement } from 'react';
 
 import { Footer } from './Footer';
 import { githubUrl } from './utils';
 
-const withTestRouter = (tree: React.ReactElement, router: Partial<NextRouter> = {}) => (
+const withTestRouter = (tree: ReactElement, router: Partial<NextRouter> = {}) => (
   <RouterContext.Provider value={router as NextRouter}>{tree}</RouterContext.Provider>
 );
 
-describe('DocumentationFooter', () => {
+describe('Footer', () => {
   test('displays default links', () => {
-    const router = { asPath: '/', pathname: '/example/' };
-    const { container } = render(withTestRouter(<Footer title="test-title" />, router));
+    const router = { pathname: '/example/' };
+    render(withTestRouter(<Footer title="test-title" />, router));
 
-    expect(container).toHaveTextContent('Ask a question on the forums');
-    expect(container).toHaveTextContent('Edit this page');
+    screen.getByText('Ask a question on the forums');
+    screen.getByText('Edit this page');
   });
 
   test('displays forums link with tag', () => {
-    const router = { asPath: '/sdk/', pathname: '' };
-    const { container } = render(withTestRouter(<Footer title="test-title" />, router));
+    const router = { pathname: '/sdk/' };
+    render(withTestRouter(<Footer title="test-title" />, router));
 
-    expect(container).toHaveTextContent('Ask a question on the forums about test-title');
+    screen.getByText('Ask a question on the forums about test-title');
   });
 
   test('displays issues link', () => {
-    const router = { asPath: '/sdk/', pathname: '' };
-    const { container } = render(withTestRouter(<Footer title="test-title" />, router));
+    const router = { pathname: '/sdk/' };
+    render(withTestRouter(<Footer title="test-title" />, router));
 
-    expect(container).toHaveTextContent('View open bug reports for test-title');
+    screen.getByText('View open bug reports for test-title');
+  });
+
+  test('displays correct issues link for 3rd-party package', () => {
+    const router = { pathname: '/sdk/' };
+    render(
+      withTestRouter(
+        <Footer
+          title="GestureHandler"
+          sourceCodeUrl="https://github.com/software-mansion/react-native-gesture-handler"
+          packageName="react-native-gesture-handler"
+        />,
+        router
+      )
+    );
+
+    const link = screen.getByRole('link', {
+      name: 'Github-icon View open bug reports for GestureHandler',
+    });
+    expect(link.getAttribute('href')).toBe(
+      'https://github.com/software-mansion/react-native-gesture-handler/issues'
+    );
   });
 
   test('displays source code link', () => {
-    const router = { asPath: '/sdk/', pathname: '' };
-    const { container } = render(
-      withTestRouter(<Footer title="test-title" sourceCodeUrl="/" />, router)
+    const router = { pathname: '/sdk/' };
+    render(
+      withTestRouter(
+        <Footer
+          title="test-title"
+          sourceCodeUrl="https://github.com/expo/expo/tree/main/packages/expo-av"
+        />,
+        router
+      )
     );
 
-    expect(container).toHaveTextContent('View source code for test-title');
+    screen.getByText('View source code for test-title');
+  });
+
+  test('displays npm registry link', () => {
+    const router = { pathname: '/sdk/' };
+    render(withTestRouter(<Footer title="test-title" packageName="expo-av" />, router));
+
+    screen.getByText('View package in npm Registry');
   });
 });
 

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { breakpoints, spacing, theme } from '@expo/styleguide';
 import { useRouter } from 'next/router';
 
-import { ForumsLink, GitHubLink, IssuesLink, SourceCodeLink } from './Links';
+import { ForumsLink, GitHubLink, IssuesLink, NpmLink, SourceCodeLink } from './Links';
 
 import { NewsletterSignUp } from '~/ui/components/Footer/NewsletterSignUp';
 import { PageVote } from '~/ui/components/Footer/PageVote';
@@ -13,22 +13,26 @@ const NEWSLETTER_DISABLED = true as const;
 type Props = {
   title: string;
   sourceCodeUrl?: string;
+  packageName?: string;
 };
 
-export const Footer = ({ title, sourceCodeUrl }: Props) => {
-  const router = useRouter();
-
-  const isAPIPage = router.asPath.includes('/sdk/');
+export const Footer = ({ title, sourceCodeUrl, packageName }: Props) => {
+  const { pathname } = useRouter();
+  const isAPIPage = pathname.includes('/sdk/');
+  const isExpoPackage = packageName && packageName.startsWith('expo-');
 
   return (
     <footer css={footerStyle}>
       <UL css={linksListStyle}>
         <ForumsLink isAPIPage={isAPIPage} title={title} />
-        {isAPIPage && <IssuesLink title={title} />}
+        {isAPIPage && (
+          <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
+        )}
         {isAPIPage && sourceCodeUrl && (
           <SourceCodeLink title={title} sourceCodeUrl={sourceCodeUrl} />
         )}
-        {router && <GitHubLink pathname={router.pathname} />}
+        {packageName && <NpmLink packageName={packageName} />}
+        <GitHubLink pathname={pathname} />
       </UL>
       <PageVote />
       {!NEWSLETTER_DISABLED && <NewsletterSignUp />}

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import {
+  BuildIcon,
   CodeIcon,
   EditIcon,
   GithubIcon,
@@ -13,9 +14,14 @@ import {
 import { A, LI } from '../Text';
 import { githubUrl } from './utils';
 
-export const IssuesLink = ({ title }: { title: string }) => (
+export const IssuesLink = ({ title, repositoryUrl }: { title: string; repositoryUrl?: string }) => (
   <LI>
-    <A css={linkStyle} openInNewTab href={`https://github.com/expo/expo/labels/${title}`}>
+    <A
+      css={linkStyle}
+      openInNewTab
+      href={
+        repositoryUrl ? `${repositoryUrl}/issues` : `https://github.com/expo/expo/labels/${title}`
+      }>
       <span css={iconStyle}>
         <GithubIcon size={iconSize.small} />
       </span>
@@ -69,6 +75,17 @@ export const GitHubLink = ({ pathname }: { pathname: string }) => (
         <EditIcon size={iconSize.small} />
       </span>
       Edit this page
+    </A>
+  </LI>
+);
+
+export const NpmLink = ({ packageName }: { packageName: string }) => (
+  <LI>
+    <A css={linkStyle} openInNewTab href={`https://www.npmjs.com/package/${packageName}`}>
+      <span css={iconStyle}>
+        <BuildIcon size={iconSize.small} />
+      </span>
+      View package in npm Registry
     </A>
   </LI>
 );


### PR DESCRIPTION
# Why

This is a first step to show more information about the package itself on API Reference pages. 

Additionally, I have fixed the incorrect "Open issue" link for 3rd-party packages listed under Expo SDK.

# How

Add generic link to the package in npm Registry to the API Reference pages footer, I was thinking about including package name in there, but this do not look good without `InlineCode` styling, but with that appearance entry was too emphasised.

I have also refactored the test to use global `screen` instead of returned container.

Unfortunately we cannot leverage the `@testing-library/jest-dom` matchers fully, since the extension code in distributed package do not work in ESM project right now (thus, I had to use `getAttribute` and not `toHaveAttribute`).

# Test Plan

The changes have been tested by running docs app locally.

Also, all tests are passing.

# Preview
<img width="900" alt="Screenshot 2022-11-22 at 12 42 29" src="https://user-images.githubusercontent.com/719641/203319746-0800adc3-3363-4b5a-ba56-a7f58191969f.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
