### PR TITLE
[image] Add support for `apng` and `avif`

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -100,6 +100,9 @@ dependencies {
   kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
   api 'com.caverock:androidsvg-aar:1.4'
 
+  implementation "com.github.penfeizhou.android.animation:glide-plugin:2.24.0"
+  implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
+
   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'
   api "com.squareup.okhttp3:okhttp:${safeExtGet("okHttpVersion", '4.9.2')}"
 


### PR DESCRIPTION
# Why

Closes ENG-6954.
Closes ENG-6955.

# How

Adds two libraries that provide support for `apng` and `avif` files. 
Unfortunately, I didn't find a library that supports animated `avif` files. 
 
# Test Plan

![image](https://user-images.githubusercontent.com/9578601/203326516-9507bbce-0bad-4560-9ebb-7b0139a690d0.png)
![image](https://user-images.githubusercontent.com/9578601/203326572-2ab8f030-d680-4797-87c1-1c0db6ac8d52.png)