### PR TITLE
[image][android] Add missing `Enumerable` class

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
@@ -2,8 +2,9 @@ package expo.modules.image.enums
 
 import android.widget.ImageView
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
+import expo.modules.kotlin.types.Enumerable
 
-enum class ImageResizeMode(val stringValue: String) {
+enum class ImageResizeMode(val stringValue: String) : Enumerable {
   CONTAIN("contain"),
   COVER("cover"),
   STRETCH("stretch"),


### PR DESCRIPTION
# Why

All enums should inherit from the `Enumerable` interface.
