### PR TITLE
[clipboard][Android] Add missing `Enumerable`

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the `ImageFormat` or the `StringFormat` not working in the release builds on Android.
+- Fixed the `ImageFormat` or the `StringFormat` not working in the release builds on Android. ([#20155](https://github.com/expo/expo/pull/20155) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the `ImageFormat` or the `StringFormat` not working in the release builds on Android.
+
 ### 💡 Others
 
 ## 4.0.1 — 2022-10-30

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardOptions.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardOptions.kt
@@ -3,6 +3,7 @@ package expo.modules.clipboard
 import android.graphics.Bitmap
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.Enumerable
 
 internal class GetImageOptions : Record {
   @Field(key = "format")
@@ -22,7 +23,7 @@ internal class SetStringOptions : Record {
   var inputFormat: StringFormat = StringFormat.PLAIN
 }
 
-internal enum class ImageFormat(val jsName: String) {
+internal enum class ImageFormat(val jsName: String) : Enumerable {
   JPG("jpeg"), PNG("png");
 
   val compressFormat: Bitmap.CompressFormat
@@ -38,7 +39,7 @@ internal enum class ImageFormat(val jsName: String) {
     }
 }
 
-internal enum class StringFormat(val jsValue: String) {
+internal enum class StringFormat(val jsValue: String) : Enumerable {
   PLAIN("plainText"),
   HTML("html")
 }


### PR DESCRIPTION
# Why

All enums should inherit from the Enumerable interface.