### PR TITLE
[expo] Resolve path inconsistencies with monorepos when resolving entrypoint

### DIFF
--- a/packages/expo/scripts/resolveAppEntry.js
+++ b/packages/expo/scripts/resolveAppEntry.js
@@ -37,7 +37,11 @@ if (entry) {
   console.clear();
   // React Native's `PROJECT_ROOT` could be using a different root on MacOS (`/var` vs `/private/var`)
   // We need to make sure to get the real path, `resolveEntryPoint` is using this too
-  console.log(absolute ? path.resolve(entry) : path.relative(fs.realpathSync(projectRoot), entry));
+  console.log(
+    absolute
+      ? path.resolve(entry)
+      : path.relative(fs.realpathSync(projectRoot), fs.realpathSync(entry))
+  );
 } else {
   console.error(`Error: Could not find entry file for project at: ${projectRoot}`);
   process.exit(1);


### PR DESCRIPTION
# Why

Fixes #20129

# How

As demonstrated by #20129, it seems that `resolveEntryPath` is returning the symlink reference when using monorepos. While the previous fix #20056 focused on a plain setup, this should fix relative project paths inconsistencies (e.g. with monorepos).

# Test Plan

```
$ git clone git@github.com:byCedric/expo-issue-20129.git
$ yarn
$ EAS_LOCAL_BUILD_SKIP_CLEANUP=1 eas build -p ios --local

  <fails when building with expo@47.0.6>

$ cd <temporary build path>
$ <apply the change in this PR to `expo/scripts/resolveAppEntry`>
$ xed ios

  <build with xcode, should succeed>
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
