### PR TITLE
[docs] add RNW version to the SDK reference table

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version |
-| ---------------- | -------------------- |
-| 47.0.0           | 0.70.5               |
-| 46.0.0           | 0.69.6               |
-| 45.0.0           | 0.68.2               |
-| 44.0.0           | 0.64.3               |
+| Expo SDK version | React Native version | React Native Web version |
+| ---------------- | -------------------- | ------------------------ |
+| 47.0.0           | 0.70.5               | 0.18.9                   |
+| 46.0.0           | 0.69.6               | 0.18.7                   |
+| 45.0.0           | 0.68.2               | 0.17.7                   |
+| 44.0.0           | 0.64.3               | 0.17.1                   |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -52,7 +52,7 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 ## Each Expo SDK version depends on a React Native version
 
-Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
+Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version |
-| ---------------- | -------------------- |
-| 47.0.0           | 0.70.5               |
-| 46.0.0           | 0.69.6               |
-| 45.0.0           | 0.68.2               |
-| 44.0.0           | 0.64.3               |
+| Expo SDK version | React Native version | React Native Web version |
+| ---------------- | -------------------- | ------------------------ |
+| 47.0.0           | 0.70.5               | 0.18.9                   |
+| 46.0.0           | 0.69.6               | 0.18.7                   |
+| 45.0.0           | 0.68.2               | 0.17.7                   |
+| 44.0.0           | 0.64.3               | 0.17.1                   |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -52,7 +52,7 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 ## Each Expo SDK version depends on a React Native version
 
-Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
+Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |


### PR DESCRIPTION
# Why

Fixes ENG-6187

# How

Add React Native Web version to the SDK reference table. Data have been taken from `bundledNativeModules.json` for a given SDK version.

# Test Plan

The changes have been tested by running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
