### PR TITLE
[RTL][Expo Go] Add description on Expo Go RTL support

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -179,7 +179,7 @@ Now, iOS knows to set the display name of your app to `こんにちは` whenever
 
 Several regions around the world write text from right to left. If you want to localize your app, so it looks as expected in RTL languages, you need to make sure your app handles these layout and text direction changes accordingly.
 
-To enable RTL support in your application using SDK 48 or later, install the `expo-localization` package and add the following properties in the **app.json**: 
+To enable RTL support in your application using SDK 48 or later, install the `expo-localization` package and add the following properties in Expo config: 
 
 <Terminal cmd={['$ npx expo install expo-localization']} />
 
@@ -196,13 +196,11 @@ To enable RTL support in your application using SDK 48 or later, install the `ex
 
 This enables RTL when your app is loaded in Expo Go, in Expo dev Client, and in applications built using EAS Build or `expo prebuild`.
 
-When an application starts, Expo checks if the current device locale should render in RTL layout to look correctly. For example, an app marked as supporting RTL in the Expo config file will render in RTL mode in Hebrew or Arabic locale.
+When an application starts, Expo checks if the current device locale should render in RTL layout to look correctly. For example, an app marked to support RTL in the Expo config file will render in RTL mode in Hebrew or Arabic locale.
 
 <Collapsible summary="Dynamically overriding RTL settings">
 
-If you want to override the default RTL detection from your application code dynamically, you cannot use the static configuration in **app.json**. 
-
-Instead, apply these changes dynamically from your application code.
+If you want to override the default RTL detection from your application code dynamically, you cannot use the static configuration in Expo config. Instead, apply these changes dynamically from your application code.
 
 This does not work in Expo Go, as Expo Go resets RTL preferences when opening the launcher or individual projects.
 

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -179,7 +179,7 @@ Now, iOS knows to set the display name of your app to `こんにちは` whenever
 
 Several regions around the world write text from right to left. If you want to localize your app, so it looks as expected in RTL languages, you need to make sure your app handles these layout and text direction changes accordingly.
 
-To enable RTL support in your application, install the `expo-localization` package and add the following properties in the **app.json**: 
+To enable RTL support in your application using SDK 48 or later, install the `expo-localization` package and add the following properties in the **app.json**: 
 
 <Terminal cmd={['$ npx expo install expo-localization']} />
 

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -179,13 +179,32 @@ Now, iOS knows to set the display name of your app to `こんにちは` whenever
 
 Several regions around the world write text from right to left. If you want to localize your app, so it looks as expected in RTL languages, you need to make sure your app handles these layout and text direction changes accordingly.
 
-Expo will have full support for RTL applications in SDK 48.
+To enable RTL support in your application, install the `expo-localization` package and add the following properties in the **app.json**: 
 
-For now, you can enable RTL dynamically from your application code.
+<Terminal cmd={['$ npx expo install expo-localization']} />
 
-This does not work in Expo Go, as Expo Go resets RTL preferences when opening the launcher or individual projects.
+```json app.json
+{
+  "expo": {
+    "extra": {
+      "supportsRTL": true
+    },
+    "plugins": ["expo-localization"],
+  }
+}
+```
+
+This enables RTL when your app is loaded in Expo Go, in Expo dev Client, and in applications built using EAS Build or `expo prebuild`.
+
+When an application starts, Expo checks if the current device locale should render in RTL layout to look correctly. For example, an app marked as supporting RTL in the Expo config file will render in RTL mode in Hebrew or Arabic locale.
 
 <Collapsible summary="Dynamically overriding RTL settings">
+
+If you want to override the default RTL detection from your application code dynamically, you cannot use the static configuration in **app.json**. 
+
+Instead, apply these changes dynamically from your application code.
+
+This does not work in Expo Go, as Expo Go resets RTL preferences when opening the launcher or individual projects.
 
 <SnackInline
 label="Overriding RTL settings"


### PR DESCRIPTION
# Why

I removed some guide copy for features that are not yet released in SDK 48