### PR TITLE
[docs] Update verbiage on expo-splash-screen page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -7,7 +7,7 @@ packageName: 'expo-font'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-font` allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Fonts](/guides/using-custom-fonts) guide.
 
@@ -19,29 +19,22 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Example: hook
-
-<SnackInline label="Minimal Example of Using Custom Font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
+<SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
 ```jsx
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 /* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
 /* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+
+/* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
+SplashScreen.preventAutoHideAsync();
+/* @end */
 
 export default function App() {
   const [fontsLoaded] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
-
-  useEffect(() => {
-    /* @info This asynchronous function prevents SplashScreen from auto hiding while the fonts are loaded. */
-    async function prepare() {
-      await SplashScreen.preventAutoHideAsync();
-    }
-    /* @end */
-    prepare();
-  }, []);
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -8,9 +8,9 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-The `SplashScreen` module tells the splash screen to remain visible until it has been explicitly told to hide. This is useful to do some work behind the scenes before displaying your app (eg: make API calls) and to animate your splash screen (eg: fade out or slide away, or switch from a static splash screen to an animated splash screen).
+The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
-Read more about [creating a splash screen image](../../../guides/splash-screens.mdx), or [quickly generate an icon and splash screen on the web](https://buildicon.netlify.app/)
+Also, see the guide on [creating a splash screen image](/guides/splash-screens.mdx), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -82,7 +82,7 @@ export default function App() {
 
 ### Animating the splash screen
 
-Refer to the [with-splash-screen example](https://github.com/expo/examples/tree/master/with-splash-screen) to see how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/font.mdx
@@ -7,7 +7,7 @@ packageName: 'expo-font'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-font` allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Fonts](/guides/using-custom-fonts) guide.
 
@@ -19,33 +19,22 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Example: hook
-
-<SnackInline label="Minimal Example of Using Custom Font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
+<SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
 ```jsx
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
-/* @info Import useFonts hook from 'expo-font'. */
-import { useFonts } from 'expo-font';
-/* @end */
-/* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */
-import * as SplashScreen from 'expo-splash-screen';
+/* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
+/* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+
+/* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
+SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
   const [fontsLoaded] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
-
-  useEffect(() => {
-    /* @info This asynchronous function prevents SplashScreen from auto hiding while the fonts are loaded. */
-    async function prepare() {
-      await SplashScreen.preventAutoHideAsync();
-    }
-    /* @end */
-    prepare();
-  }, []);
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {

--- a/docs/pages/versions/v45.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/splash-screen.mdx
@@ -8,9 +8,9 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-The `SplashScreen` module tells the splash screen to remain visible until it has been explicitly told to hide. This is useful to do some work behind the scenes before displaying your app (eg: make API calls) and to animate your splash screen (eg: fade out or slide away, or switch from a static splash screen to an animated splash screen).
+The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
-Read more about [creating a splash screen image](../../../guides/splash-screens.mdx), or [quickly generate an icon and splash screen on the web](https://buildicon.netlify.app/)
+Also, see the guide on [creating a splash screen image](/guides/splash-screens.mdx), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -82,7 +82,7 @@ export default function App() {
 
 ### Animating the splash screen
 
-Refer to the [with-splash-screen example](https://github.com/expo/examples/tree/master/with-splash-screen) to see how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/font.mdx
@@ -7,7 +7,7 @@ packageName: 'expo-font'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-font` allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Fonts](/guides/using-custom-fonts) guide.
 
@@ -19,33 +19,22 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Example: hook
-
-<SnackInline label="Minimal Example of Using Custom Font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
+<SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
 ```jsx
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
-/* @info Import useFonts hook from 'expo-font'. */
-import { useFonts } from 'expo-font';
-/* @end */
-/* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */
-import * as SplashScreen from 'expo-splash-screen';
+/* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
+/* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+
+/* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
+SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
   const [fontsLoaded] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
-
-  useEffect(() => {
-    /* @info This asynchronous function prevents SplashScreen from auto hiding while the fonts are loaded. */
-    async function prepare() {
-      await SplashScreen.preventAutoHideAsync();
-    }
-    /* @end */
-    prepare();
-  }, []);
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {

--- a/docs/pages/versions/v46.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/splash-screen.mdx
@@ -8,9 +8,9 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-The `SplashScreen` module tells the splash screen to remain visible until it has been explicitly told to hide. This is useful to do some work behind the scenes before displaying your app (eg: make API calls) and to animate your splash screen (eg: fade out or slide away, or switch from a static splash screen to an animated splash screen).
+The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
-Read more about [creating a splash screen image](../../../guides/splash-screens.mdx), or [quickly generate an icon and splash screen on the web](https://buildicon.netlify.app/)
+Also, see the guide on [creating a splash screen image](/guides/splash-screens.mdx), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -82,7 +82,7 @@ export default function App() {
 
 ### Animating the splash screen
 
-Refer to the [with-splash-screen example](https://github.com/expo/examples/tree/master/with-splash-screen) to see how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/font.mdx
@@ -7,7 +7,7 @@ packageName: 'expo-font'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-font` allows loading fonts from the web and using them in React Native components. See more detailed usage information in the [Fonts](/guides/using-custom-fonts) guide.
 
@@ -19,29 +19,22 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Example: hook
-
-<SnackInline label="Minimal Example of Using Custom Font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
+<SnackInline label="Minimal example of using a custom font" dependencies={['expo-font', 'expo-splash-screen']} files={{ 'assets/fonts/Inter-Black.otf': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/44b1541a96341780b29112665c66ac67' }}>
 
 ```jsx
-import { useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 /* @info Import useFonts hook from 'expo-font'. */ import { useFonts } from 'expo-font'; /* @end */
 /* @info Also, import SplashScreen so that when the fonts are not loaded, we can continue to show SplashScreen. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+
+/* @info This prevents SplashScreen from auto hiding while the fonts are loaded. */
+SplashScreen.preventAutoHideAsync();
+/* @end */
 
 export default function App() {
   const [fontsLoaded] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
-
-  useEffect(() => {
-    /* @info This asynchronous function prevents SplashScreen from auto hiding while the fonts are loaded. */
-    async function prepare() {
-      await SplashScreen.preventAutoHideAsync();
-    }
-    /* @end */
-    prepare();
-  }, []);
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {

--- a/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
@@ -8,9 +8,9 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-The `SplashScreen` module tells the splash screen to remain visible until it has been explicitly told to hide. This is useful to do some work behind the scenes before displaying your app (eg: make API calls) and to animate your splash screen (eg: fade out or slide away, or switch from a static splash screen to an animated splash screen).
+The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
-Read more about [creating a splash screen image](../../../guides/splash-screens.mdx), or [quickly generate an icon and splash screen on the web](https://buildicon.netlify.app/)
+Also, see the guide on [creating a splash screen image](/guides/splash-screens.mdx), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -82,7 +82,7 @@ export default function App() {
 
 ### Animating the splash screen
 
-Refer to the [with-splash-screen example](https://github.com/expo/examples/tree/master/with-splash-screen) to see how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6501

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates verbiage on `expo-splash-screen` page.

It also fixes the example on `expo-font` page which was using `SplashScreen.preventAutoHideAsync()` method in a React Hook (`useEffect`) but `expo-splash-screen` docs [recommend using the method globally](https://docs.expo.dev/versions/latest/sdk/splash-screen/#splashscreenpreventautohideasync).

All changes have been backported to SDK 47, 46, and 45.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
