### PR TITLE
[docs] Add a section about removing expo-yarn-workspaces in Monorepo guide

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -13,7 +13,7 @@ Monorepos, or _"monolithic repositories"_, are single repositories containing mu
 
 Setting up a monorepo was difficult before SDK 43. You had to implement your tooling or use [expo-yarn-workspaces](https://github.com/expo/expo/tree/main/packages/expo-yarn-workspaces). The yarn workspaces package symlinks all required dependencies back to the app **node_modules** folder. Although this works for most apps, it has some flaws. For example, it doesn't work well with multiple versions of the same package.
 
-We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also look for packages in parent node_modules folders. None of our native files inside our template contain hardcoded paths to packages.
+We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also looks for packages in parent **node_modules** folders. None of our native files inside our template contain hardcoded paths to packages.
 
 </Collapsible>
 
@@ -29,7 +29,7 @@ In this example, we will set up a monorepo using yarn workspaces without the [no
 
 All yarn monorepos should have a "root" **package.json** file. It is the main configuration for our monorepo and may contain packages installed for all projects in the repository. You can run `yarn init`, or create the **package.json** manually. It should look something like this:
 
-```json
+```json package.json
 {
   "name": "monorepo",
   "version": "1.0.0"
@@ -38,9 +38,9 @@ All yarn monorepos should have a "root" **package.json** file. It is the main co
 
 ### Set up yarn workspaces
 
-Yarn and other tooling have a concept called _"workspaces"_. Every package and app in our repository has its own workspace. But, before we can use them, we have to instruct yarn where to find these workspaces. We can do that by setting the `workspaces` property using [glob patterns](https://classic.yarnpkg.com/lang/en/docs/workspaces/#toc-tips-tricks), in the **package.json**:
+Yarn and other tooling have a concept called _"workspaces"_. Every package and app in our repository has its own workspace. Before we can use them, we have to instruct yarn where to find these workspaces. We can do that by setting the `workspaces` property using [glob patterns](https://classic.yarnpkg.com/lang/en/docs/workspaces/#toc-tips-tricks), in the **package.json**:
 
-```json
+```json package.json
 {
   "private": true,
   "name": "monorepo",
@@ -53,12 +53,11 @@ Yarn and other tooling have a concept called _"workspaces"_. Every package and a
 
 ### Create our first app
 
-Now that we have the basic monorepo structure set up, let's add our first app. Before we can create our app, we have to create the **apps/** folder. This folder can contain all separate apps or websites that belong to this monorepo. Inside this **apps/** folder, we can create a subfolder that contains the React Native app.
+Now that we have the basic monorepo structure set up, let's add our first app.
 
-<Terminal
-  cmd={['$ yarn create expo-app apps/cool-app']}
-  cmdCopy="yarn create expo-app apps/cool-app"
-/>
+Before we can create our app, we have to create the **apps/** folder. This folder can contain all separate apps or websites that belong to this monorepo. Inside this **apps/** folder, we can create a subfolder that contains the React Native app.
+
+<Terminal cmd={['$ yarn create expo-app apps/cool-app']} />
 
 > If you have an existing app, you can copy all those files inside a subfolder.
 
@@ -66,17 +65,15 @@ After copying or creating the first app, run `yarn` to check for common warnings
 
 #### Modify the Metro config
 
-Metro doesn't come with monorepo support by default (yet). That's why we need to configure Metro and let it know where to find certain things. There are two main changes we need to make:
+Metro doesn't come with monorepo support by default (yet). That's why we need to configure Metro and tell it where to find certain things. There are three main changes we need to:
 
 1. Make sure Metro is watching the full monorepo, not just **apps/cool-app**.
 2. Tell Metro where it can resolve packages. They might be installed in **apps/cool-app/node_modules** or **node_modules**.
 3. Force Metro to only resolve (sub)packages from the `nodeModulesPaths`.
 
-We can configure that by creating a **metro.config.js** with the following content.
+We can configure this by creating a **metro.config.js** with the following content.
 
-> Learn more about [customizing Metro](/guides/customizing-metro).
-
-```js
+```js metro.config.js
 // Learn more https://docs.expo.dev/guides/monorepos
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
@@ -100,6 +97,8 @@ config.resolver.disableHierarchicalLookup = true;
 
 module.exports = config;
 ```
+
+> Learn more about [customizing Metro](/guides/customizing-metro).
 
 <Collapsible summary="1. Why do we need to watch all files with the monorepo?">
 
@@ -185,15 +184,13 @@ As long as the **apps/mobile/node_modules** path has the correct library version
 
 </Collapsible>
 
-<br />
-
 #### Change default entrypoint
 
-In monorepos, we can't hardcode paths to packages anymore. We can't be sure if they are installed in the root **node_modules** or the workspace **node_modules** folder. If you are using a managed project, we have to change our default entrypoint `node_modules/expo/AppEntry.js`.
+In monorepos, we can't hardcode paths to packages anymore since we can't be sure if they are installed in the root **node_modules** or the workspace **node_modules** folder. If you are using a managed project, we have to change our default entrypoint to `node_modules/expo/AppEntry.js`.
 
 Open our app's **package.json**, change the `main` property to `index.js`, and create this new **index.js** file in the app directory with the content below.
 
-```js
+```js index.js
 import { registerRootComponent } from 'expo';
 
 import App from './App';
@@ -226,7 +223,7 @@ Let's go back to the root and create the **packages/** folder. This folder can c
 
 We won't go into too much detail in creating a package. If you are not familiar with this, please consider using a simple app without monorepos. But, to make the example complete, let's add an **index.js** file with the following content:
 
-```js
+```js index.js
 export const greeting = 'Hello!';
 ```
 
@@ -234,7 +231,7 @@ export const greeting = 'Hello!';
 
 Like standard packages, we need to add our **cool-package** as a dependency to our **cool-app**. The main difference between a standard package, and one from the monorepo, is you'll always want to use the _"current state of the package"_ instead of a version. Let's add **cool-package** to our app by adding `"cool-package": "*"` to our app **package.json** file:
 
-```json
+```json package.json
 {
   "name": "cool-app",
   "version": "1.0.0",
@@ -261,9 +258,9 @@ Like standard packages, we need to add our **cool-package** as a dependency to o
 
 > After adding the package as a dependency, run `yarn install` to install or link the dependency to your app.
 
-Now you should be able to use the package inside your app! To test this, let's edit the `App.js` in our app and render the `greeting` text from our **cool-package**.
+Now you should be able to use the package inside your app! To test this, let's edit the **App.js** in our app and render the `greeting` text from our **cool-package**.
 
-```js
+```js App.js
 import { greeting } from 'cool-package';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
@@ -289,13 +286,13 @@ There are a lot of monorepo tools available, and each of these tools has its ben
 
 <Collapsible summary="1. All dependencies must be installed in a node_modules directory">
 
-React Native dependencies contain many other files besides JavaScript, like Gradle files such as `react-native/react.gradle`. These native files are referenced from different sources other than Node, and because of that, it makes it fundamentally incompatible with concepts like Plug'n'Play modules.
+React Native dependencies contain many other files besides JavaScript, like Gradle files such as **react-native/react.gradle**. These native files are referenced from different sources other than Node.js, and because of that, it makes it fundamentally incompatible with concepts like Plug'n'Play modules.
 
 </Collapsible>
 
 <Collapsible summary="2. Dependencies used in multiple workspaces can be installed in the root node_modules directory">
 
-Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to remove duplicate tasks, like installing the exact same dependency twice in different places. This rule isn't necessary but does set us up for rule #3.
+Whenever multiple workspaces use the same version of a single dependency, they can be installed in a root **node_modules** directory. Monorepo tools usually do this to remove duplicate tasks, like installing the same dependency twice in different places. This rule isn't necessary but does set us up for rule #3.
 
 </Collapsible>
 
@@ -308,13 +305,13 @@ In the [Modify the Metro config](#modify-the-metro-config) step, we instructed M
 
 If a workspace uses a different library version than the one installed in the root **/node_modules**, that different library version must be installed in the workspace **/apps/&lt;name&gt;/node_modules** directory.
 
-When Metro resolves a library, e.g. `react`, from the workspace, it should find that different version in **/apps/&lt;name&gt;/node_modules** and not look inside the root **/node_modules** directory.
+When Metro resolves a library, for example, `react`, from the workspace, it should find that different version in **/apps/&lt;name&gt;/node_modules** and not look inside the root **/node_modules** directory.
 
 When importing a dependency from the root **/node_modules** folder that also imports `react`, `react` should still resolve to the different version installed in **/apps/&lt;name&gt;/node_modules**. That's what the disabled hierarchical lookup option does for Metro. Without this, some libraries might import the wrong `react` version and cause "multiple React versions found" errors.
 
 </Collapsible>
 
-The default settings of tools like [pnpm](https://pnpm.io/) do not follow these rules. You can change that by adding an **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). That config option will change the behavior to match these rules.
+The default settings of tools like [pnpm](https://pnpm.io/) do not follow these rules. You can change that by adding a **.npmrc** file with `node-linker=hoisted` ([see docs](https://pnpm.io/npmrc#node-linker)). That config option will change the behavior to match these rules.
 
 ### Script '...' does not exist
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -9,14 +9,6 @@ Monorepos, or _"monolithic repositories"_, are single repositories containing mu
 
 > **warning** Monorepos are not for everyone. It requires in-depth knowledge of the used tooling, adds more complexity, and often requires specific tooling configuration. You can get far with just a single repository.
 
-<Collapsible summary="Using SDK older than 43?">
-
-Setting up a monorepo was difficult before SDK 43. You had to implement your tooling or use [expo-yarn-workspaces](https://github.com/expo/expo/tree/main/packages/expo-yarn-workspaces). The yarn workspaces package symlinks all required dependencies back to the app **node_modules** folder. Although this works for most apps, it has some flaws. For example, it doesn't work well with multiple versions of the same package.
-
-We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also looks for packages in parent **node_modules** folders. None of our native files inside our template contain hardcoded paths to packages.
-
-</Collapsible>
-
 ## Example monorepo
 
 In this example, we will set up a monorepo using yarn workspaces without the [nohoist](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/) option. We will assume some familiar names, but you can fully customize them. After this guide, our basic structure should look like this:
@@ -349,6 +341,8 @@ All Expo SDK modules and templates, starting from SDK 43, have these dynamic ref
 
 ### Remove expo-yarn-workspaces
 
-Before SDK 43, `expo-yarn-workspaces` was the recommended way to use Yarn workspaces with your Expo project. It was used to symlink all required dependencies back to the app's **node_modules** folder.
+Before SDK 43, `expo-yarn-workspaces` was the recommended way to use Yarn workspaces with your Expo project. It was used to symlink all required dependencies back to the app's **node_modules** folder. Although this works for most apps, it has some flaws. For example, it doesn't work well with multiple versions of the same package.
+
+We made some significant changes with Expo SDK 43 to improve support for monorepos. [The auto linker in the newer Expo modules](https://blog.expo.dev/whats-new-in-expo-modules-infrastructure-7a7cdda81ebc) now also looks for packages in parent **node_modules** folders. None of our native files inside our template contain hardcoded paths to packages.
 
 If you are following this guide, you should remove that package from your project's dependencies.

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -63,7 +63,7 @@ Metro doesn't come with monorepo support by default (yet). That's why we need to
 2. Tell Metro where it can resolve packages. They might be installed in **apps/cool-app/node_modules** or **node_modules**.
 3. Force Metro to only resolve (sub)packages from the `nodeModulesPaths`.
 
-We can configure this by creating a **metro.config.js** with the following content.
+We can configure this by [creating a **metro.config.js**](/guides/customizing-metro/#customizing) with the following content:
 
 ```js metro.config.js
 // Learn more https://docs.expo.dev/guides/monorepos

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -349,3 +349,9 @@ require File.join(File.dirname(`node --print "require.resolve('react-native/pack
 In the snippets above, you can see that we use Node's own [`require.resolve()`](https://nodejs.org/api/modules.html#requireresolverequest-options) method to find the package location. We explicitly refer to `package.json` because we want to find the root location of the package, not the location of the entry point. And with that root location, we can resolve to the expected relative path within the package. [Learn more about these references here](https://github.com/expo/expo/blob/4633ab2364e30ea87ca2da968f3adaf5cdde9d8b/packages/expo-modules-core/README.mdx#importing-native-dependencies---autolinking).
 
 All Expo SDK modules and templates, starting from SDK 43, have these dynamic references and work with monorepos. But, occasionally, you might run into packages that still use the hardcoded path. You can manually edit it with [patch-package](https://github.com/ds300/patch-package#readme) or mention this to the package maintainers.
+
+### Remove expo-yarn-workspaces
+
+Before SDK 43, `expo-yarn-workspaces` was the recommended way to use Yarn workspaces with your Expo project. It was used to symlink all required dependencies back to the app's **node_modules** folder.
+
+If you are following this guide, you should remove that package from your project's dependencies.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #19591, ENG-6248 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR added a new sub section that explicitly says to not use `expo-yarn-workspaces`. It also converts the note "Using SDK 43 or older". After adding this section, I don't think there is a requirement for that note since it is duplicating the information.

Also includes some verbiage updates to match our writing styleguide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1504" alt="CleanShot 2022-11-23 at 16 50 45@2x" src="https://user-images.githubusercontent.com/10234615/203534298-37b52bba-39c2-4183-96cb-009bd8c03a23.png">


Other changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
