### PR TITLE
[image][Android] Add default value for the scale in the `SourceMap`

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
@@ -8,4 +8,6 @@ import com.bumptech.glide.module.AppGlideModule
  * to work.
  */
 @GlideModule
-class ExpoImageAppGlideModule : AppGlideModule()
+class ExpoImageAppGlideModule : AppGlideModule() {
+  override fun isManifestParsingEnabled() = false
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -9,7 +9,7 @@ data class SourceMap(
   @Field val uri: String? = null,
   @Field val width: Int? = null,
   @Field val height: Int? = null,
-  @Field val scale: Double? = null,
+  @Field val scale: Double = 1.0,
 ) : Record {
   internal fun createGlideUrl(): GlideUrl? = uri?.let { GlideUrl(it) }
 
@@ -18,7 +18,7 @@ data class SourceMap(
       .apply {
         // Override the size for local assets. This ensures that
         // resizeMode "center" displays the image in the correct size.
-        if (width != null && height != null && scale != null) {
+        if (width != null && height != null) {
           override((width * scale).toInt(), (height * scale).toInt())
         }
       }


### PR DESCRIPTION
# Why

Adds a default value for the scale parameter in the `SourceMap` record. 

Also, I've settled the `isManifestParsingEnabled` to be false in the `ExpoImageAppGlideModule`. Manifest parsing was used in previous versions of Glide and is not recommended anymore. We can safely set that to false in our case. 