### PR TITLE
[image][NCL] Exclude `icns` on Android

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
@@ -85,21 +85,15 @@ const data: SectionListData<ImageSource>[] = [
       },
     ],
   },
-];
-
-const iOSData =
-  Platform.OS === 'ios'
-    ? [
-        {
-          title: 'ICNS',
-          data: [
-            {
-              uri: 'https://icon-icons.com/downloadimage.php?id=214748&root=3398/ICNS/512/&file=react_logo_icon_214748.icns',
-            },
-          ],
-        },
-      ]
-    : [];
+  Platform.OS === 'ios' && {
+    title: 'ICNS',
+    data: [
+      {
+        uri: 'https://icon-icons.com/downloadimage.php?id=214748&root=3398/ICNS/512/&file=react_logo_icon_214748.icns',
+      },
+    ],
+  },
+].filter(Boolean);
 
 function keyExtractor(item: any, index: number) {
   return '' + index;
@@ -120,7 +114,7 @@ function renderSectionHeader({ section }: { section: SectionListData<ImageSource
 export default function ImageFormatsScreen() {
   return (
     <SectionList
-      sections={[...data, ...iOSData]}
+      sections={data}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
       renderSectionHeader={renderSectionHeader}

--- a/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
@@ -6,6 +6,7 @@ import {
   SectionListRenderItemInfo,
   StyleSheet,
   View,
+  Platform,
 } from 'react-native';
 
 import HeadingText from '../../components/HeadingText';
@@ -84,15 +85,21 @@ const data: SectionListData<ImageSource>[] = [
       },
     ],
   },
-  {
-    title: 'ICNS',
-    data: [
-      {
-        uri: 'https://icon-icons.com/downloadimage.php?id=214748&root=3398/ICNS/512/&file=react_logo_icon_214748.icns',
-      },
-    ],
-  },
 ];
+
+const iOSData =
+  Platform.OS === 'ios'
+    ? [
+        {
+          title: 'ICNS',
+          data: [
+            {
+              uri: 'https://icon-icons.com/downloadimage.php?id=214748&root=3398/ICNS/512/&file=react_logo_icon_214748.icns',
+            },
+          ],
+        },
+      ]
+    : [];
 
 function keyExtractor(item: any, index: number) {
   return '' + index;
@@ -113,7 +120,7 @@ function renderSectionHeader({ section }: { section: SectionListData<ImageSource
 export default function ImageFormatsScreen() {
   return (
     <SectionList
-      sections={data}
+      sections={[...data, ...iOSData]}
       keyExtractor={keyExtractor}
       renderItem={renderItem}
       renderSectionHeader={renderSectionHeader}

--- a/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageFormatsScreen.tsx
@@ -93,7 +93,7 @@ const data: SectionListData<ImageSource>[] = [
       },
     ],
   },
-].filter(Boolean);
+].filter(Boolean) as SectionListData<ImageSource>[];
 
 function keyExtractor(item: any, index: number) {
   return '' + index;


### PR DESCRIPTION
# Why

`icns` is Apple specific icon format, which won't be available on Android. I think we should remove it on Android from our example in the NCL 