### PR TITLE
[modules][Android] Add `MissingActivity` exception

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added the `Exception.MissingActivity` on Android.
+- Added the `Exception.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added the `Exception.MissingActivity` on Android.
+
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
@@ -38,4 +38,9 @@ class Exceptions {
    * An exception to throw when Android permissions haven't been granted.
    */
   class MissingPermissions(vararg permissions: String) : CodedException(message = "Missing permissions: ${permissions.joinToString(separator = ", ")}")
+
+  /**
+   * An exception to throw when the current Android activity is not longer available.
+   */
+  class MissingActivity : CodedException(message = "The current activity is no longer available")
 }


### PR DESCRIPTION
# Why

Adds a `MissingActivity` exception. That exception should be thrown when the current activity is no longer available.