### PR TITLE
fix: fix firebase recaptcha for web

### DIFF
--- a/packages/expo-firebase-recaptcha/src/FirebaseRecaptchaVerifierModal.web.tsx
+++ b/packages/expo-firebase-recaptcha/src/FirebaseRecaptchaVerifierModal.web.tsx
@@ -1,5 +1,5 @@
-import firebase from 'firebase/compat/app';
-import 'firebase/compat/auth';
+import { getApp } from 'firebase/app';
+import { getAuth, RecaptchaVerifier } from "firebase/auth";
 import * as React from 'react';
 
 import { FirebaseAuthApplicationVerifier } from './FirebaseRecaptcha.types';
@@ -13,19 +13,20 @@ interface Props {
 
 class FirebaseRecaptchaVerifierModal extends React.Component<Props> {
   private verifier: FirebaseAuthApplicationVerifier | null = null;
+  private auth = getAuth(getApp())
 
   private setRef = (ref: any) => {
     if (ref) {
       if (this.props.appVerificationDisabledForTesting !== undefined) {
-        firebase.auth().settings.appVerificationDisabledForTesting =
+       this.auth.settings.appVerificationDisabledForTesting =
           !!this.props.appVerificationDisabledForTesting;
       }
       if (this.props.languageCode) {
-        firebase.auth().languageCode = this.props.languageCode;
+        this.auth.languageCode = this.props.languageCode;
       }
-      this.verifier = new firebase.auth.RecaptchaVerifier(ref, {
+      this.verifier = new RecaptchaVerifier(ref, {
         size: this.props.attemptInvisibleVerification ? 'invisible' : 'normal',
-      });
+      }, this.auth);
     } else {
       this.verifier = null;
     }


### PR DESCRIPTION
# Why
I understand that expo-firebase-recaptcha is getting deprecated in the coming SDK, however my team would like to continue using it in our existing project. I also notice, some user are also facing the same issue that we had with this package. Hence, I would like to fix this. I would open an issue for this soon, but for now, you may refer this [comment](https://github.com/expo/expo/pull/11695#issuecomment-1145626388).
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
