### PR TITLE
[docs] Improved the Azure example

### DIFF
--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -128,8 +128,13 @@ export default function App() {
 ```tsx Azure Example
 import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
-import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
-import { Button } from 'react-native';
+import {
+  exchangeCodeAsync,
+  makeRedirectUri,
+  useAuthRequest,
+  useAutoDiscovery,
+} from 'expo-auth-session';
+import { Button, Text, SafeAreaView } from 'react-native';
 
 /* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
@@ -137,33 +142,67 @@ WebBrowser.maybeCompleteAuthSession();
 
 export default function App() {
   // Endpoint
-  const discovery = useAutoDiscovery('https://login.microsoftonline.com/<TENANT_ID>/v2.0');
+  const discovery = useAutoDiscovery(
+    'https://login.microsoftonline.com/<TENANT_ID>/v2.0',
+  );
+  const redirectUri = makeRedirectUri({
+    /* @info The URI <code>[scheme]://</code> to be used in bare and standalone. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
+    scheme: undefined,
+    /* @end */
+    /* @info Azure requires there to be a path in your redirect URI. */
+    path: 'auth',
+    /* @end */
+  });
+  const clientId = '<CLIENT_ID>';
+
+  // We store the JWT in here
+  const [token, setToken] = React.useState<string | null>(null);
+
   // Request
-  const [request, response, promptAsync] = useAuthRequest(
+  const [request, , promptAsync] = useAuthRequest(
     {
-      clientId: 'CLIENT_ID',
+      clientId,
       scopes: ['openid', 'profile', 'email', 'offline_access'],
-      redirectUri: makeRedirectUri({
-        /* @info The URI <code>[scheme]://</code> to be used in bare and standalone. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
-        scheme: 'your.app'
-        /* @end */
-      }),
+      redirectUri,
     },
-    discovery
+    discovery,
   );
 
   return (
-    <Button
-      /* @info Disable the button until the request is loaded asynchronously. */
-      disabled={!request}
-      /* @end */
-      title="Login"
-      onPress={() => {
-        /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
-        promptAsync();
+    <SafeAreaView>
+      <Button
+        /* @info Disable the button until the request is loaded asynchronously. */
+        disabled={!request}
         /* @end */
-      }}
-    />
+        title="Login"
+        onPress={() => {
+          /* @info Prompt the user to authenticate in a user interaction or web browsers will block it. */
+          promptAsync().then((codeResponse) => {
+            /* @end */
+            if (request && codeResponse?.type === 'success' && discovery) {
+              /* @info Exchange the code to get the JWT. */
+              exchangeCodeAsync(
+                /* @end */
+                {
+                  clientId,
+                  code: codeResponse.params.code,
+                  /* @info Reuse the codeVerifier for PCKE */
+                  extraParams: request.codeVerifier
+                    ? { code_verifier: request.codeVerifier }
+                    : undefined,
+                  /* @end */
+                  redirectUri,
+                },
+                discovery,
+              ).then((res) => {
+                setToken(res.accessToken);
+              });
+            }
+          });
+        }}
+      />
+      <Text>{token}</Text>
+    </SafeAreaView>
   );
 }
 ```


### PR DESCRIPTION
Gave my criticism here #20183

# Why

Azure example only gives you the authentication code, added exchangeCodeAsync for the code exchange.

# How

Added exchangeCodeAsync for the code exchange to retrieve the JWT

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
