### PR TITLE
[bug fix] Only show USB attached Apple devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))
+- Only show physical USB devices in the Apple device list, suppress bogus Network devices. ([#20188](https://github.com/expo/expo/pull/20188) by [@shreeve](https://github.com/shreeve))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -45,7 +45,7 @@ export async function getConnectedDevicesAsync(): Promise<ConnectedDevice[]> {
 export async function getConnectedDeviceValuesAsync(): Promise<DeviceValues[]> {
   const client = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
   const devices = (await client.getDevices()).filter(
-    device => device.Properties?.ConnectionType === "USB" // only USB devices
+    (device) => device.Properties?.ConnectionType === "USB" // only USB devices
   );
   client.socket.end();
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -45,7 +45,7 @@ export async function getConnectedDevicesAsync(): Promise<ConnectedDevice[]> {
 export async function getConnectedDeviceValuesAsync(): Promise<DeviceValues[]> {
   const client = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
   const devices = (await client.getDevices()).filter(
-    (device) => device.Properties?.ConnectionType === "USB" // only USB devices
+    (device) => device.Properties?.ConnectionType === 'USB' // only USB devices
   );
   client.socket.end();
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -44,7 +44,9 @@ export async function getConnectedDevicesAsync(): Promise<ConnectedDevice[]> {
 /** @returns a list of physically connected Apple devices. */
 export async function getConnectedDeviceValuesAsync(): Promise<DeviceValues[]> {
   const client = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
-  const devices = await client.getDevices();
+  const devices = (await client.getDevices()).filter(
+    device => device.Properties?.ConnectionType === "USB" // only USB devices
+  );
   client.socket.end();
 
   return Promise.all(


### PR DESCRIPTION
# Why

It is common on macOS, for a physical iOS device (like an iPhone) to have both a `Network` and a `USB` entry in the device list. When running `expo`, both of these entries look same and show the little plug emoji (🔌 ). However, the `Network` version is not usable and, if selected, will crash with `TypeError: Cannot read properties of undefined (reading 'udid')`. This PR will only preserve true `USB` devices from the list of physical Apple devices, thus avoiding the annoying error of picking the `Network` device (since they look the same) and bombing out.

# How

I had to find out where the Apple device list was being built and then had to find the latest stage where the distinction between `USB` and `Network` devices could be used to filter out the `Network` devices. This code just lets the `USB` Apple devices through.

# Test Plan

Run the code and see that the list no longer includes spurious and non-working Apple device entries. Only `USB` physical Apple devices are shown now.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
