### PR TITLE
Expose buildmenu to appDelegate subscribers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Exposing buildMenu to AppDelegate subscribers. ([#20192](https://github.com/expo/expo/pull/20192))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.m
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.m
@@ -27,6 +27,10 @@
   return self;
 }
 
+- (void)buildMenuWithBuilder:(id<UIMenuBuilder>)builder{
+    [_expoAppDelegate buildMenuWithBuilder:builder];
+}
+
 // This needs to be implemented, otherwise forwarding won't be called.
 // When the app starts, `UIApplication` uses it to check beforehand
 // which `UIApplicationDelegate` selectors are implemented.

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -36,7 +36,7 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-      let parsedSubscribers = subscribers.filter {
+    let parsedSubscribers = subscribers.filter {
       $0.responds(to: #selector(application(_:willFinishLaunchingWithOptions:)))
     }
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegate.swift
@@ -25,14 +25,14 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if parsedSubscribers.isEmpty {
-            return;
+            return
         }
-        
+
         parsedSubscribers.forEach {
             $0.buildMenu(with: builder)
         }
     }
-    
+
   // MARK: - Initializing the App
 
   open func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -121,8 +121,8 @@ open class ExpoAppDelegate: UIResponder, UIApplicationDelegate {
   open func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
     subscribers.forEach { $0.application?(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken) }
   }
-    
-  
+
+
 
   open func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
     subscribers.forEach { $0.application?(application, didFailToRegisterForRemoteNotificationsWithError: error) }


### PR DESCRIPTION
# Why

Expose buildmenu UIResponder callback to appDelegate subscribers in expo-modules-core. This enables expo-modules to modify the system menu on macOS.

Two things worth noting:
- The subscribers array is now using `ExpoAppDelegateSubscriber` instead of `ExpoAppDelegateSubscriberProtocol` which exposes the UIResponder callbacks (and not only the AppDelegate callbacks)
- It seems I need to add `buildMenuWithBuilder` in `EXAppDelegateWrapper.m`. All other callbacks seems to be handled seamlessly. I'm not quite sure why - maybe this can be done in a cleaner way?

And another question - wouldn't it be nice to have SwiftLint integrated in the development flow? Getting warnings on PR level is not optimal, or maybe I'm missing something in my setup.. :)

# How

By adding the buildMenu callback listener.

# Test Plan

I've tried it with the `react-native-hotkeys` package, [working (patched) example available here](https://github.com/kingstinct/react-native-hotkeys/tree/expo-module-patch-for-adding-menu-items)

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).