### PR TITLE
[github] workflows: don't run CLI lint twice

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -38,9 +38,6 @@ jobs:
       - name: 🧶 Install node modules in root dir
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
-      - name: 🚨 Lint CLI
-        run: yarn lint --max-warnings 0
-        working-directory: packages/@expo/cli
       - name: 🔎 Type Check CLI
         run: yarn typecheck
         working-directory: packages/@expo/cli


### PR DESCRIPTION
# Why

It looks like currently we run CLI lint twice, in two separate workflows (SDK and CLI):
* https://github.com/expo/expo/actions/runs/3536911456/jobs/5940006012
* https://github.com/expo/expo/actions/runs/3536911457/jobs/5940006009

# How

Since SDK checks run on changed packages I think there is no need to run it manually inside CLI workflow.

# Test Plan

Runt he CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
