### PR TITLE
[expo] update `sentry-expo` and `@sentry/react-native` versions

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,10 +100,10 @@
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.4.0",
   "react-native-webview": "11.23.1",
-  "sentry-expo": "~5.0.0",
+  "sentry-expo": "~6.0.0",
   "unimodules-app-loader": "~4.0.0",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.157",
   "@shopify/flash-list": "1.3.1",
-  "@sentry/react-native": "4.2.2"
+  "@sentry/react-native": "4.9.0"
 }


### PR DESCRIPTION
# Why

`sentry-expo@6.0.0` is released to support EAS Update and SDK 47. This version, along with its bumped `@sentry/react-native` version, should be the default version moving forward.

# How

Update version numbers in json.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
