### PR TITLE
[docs] Backport expo-localization changes to SDK 47

### DIFF
--- a/docs/pages/versions/unversioned/sdk/localization.mdx
+++ b/docs/pages/versions/unversioned/sdk/localization.mdx
@@ -7,10 +7,8 @@ packageName: 'expo-localization'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-localization`** allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
+`expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
 Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
 
 <PlatformsSection android emulator ios simulator web />
@@ -21,17 +19,17 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-You can find more info about using `expo-localization` in the [Localization](/guides/localization) guide.
+Find more information about using `expo-localization` in the [Localization](/guides/localization) guide.
 
 ## API
 
-```ts
+```jsx
 import { getLocales, getCalendars } from 'expo-localization';
 ```
 
 ### Behavior
 
-You can use synchronous `getLocales()` and `getCalendars()` methods to get the locale settings of the user device. On iOS, the results will remain the same while the app is running. 
+You can use synchronous `getLocales()` and `getCalendars()` methods to get the locale settings of the user device. On iOS, the results will remain the same while the app is running.
 
 On Android, the user can change locale preferences in Settings without restarting apps. To keep the localization current, you can rerun the `getLocales()` and `getCalendars()` methods every time the app returns to the foreground. Use `AppState` to detect this.
 

--- a/docs/pages/versions/v47.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/localization.mdx
@@ -7,10 +7,8 @@ packageName: 'expo-localization'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { Terminal } from '~/ui/components/Snippet';
 
-**`expo-localization`** allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
+`expo-localization` allows you to Localize your app, customizing the experience for specific regions, languages, or cultures. It also provides access to the locale data on the native device.
 Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `expo-localization` will enable you to create a very accessible experience for users.
 
 <PlatformsSection android emulator ios simulator web />
@@ -21,96 +19,17 @@ Using the popular library [`i18n-js`](https://github.com/fnando/i18n-js) with `e
 
 ## Usage
 
-Let's make our app support English and Japanese. To achieve this install the i18n package `i18n-js`:
-
-<Terminal cmd={['$ npx expo install i18n-js']} />
-
-Then, configure the languages for your app.
-
-```tsx
-import * as Localization from 'expo-localization';
-import { I18n } from 'i18n-js';
-
-// Set the key-value pairs for the different languages you want to support.
-const i18n = new I18n({
-  en: { welcome: 'Hello' },
-  ja: { welcome: 'こんにちは' },
-});
-
-// Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
-```
-
-### API Design Tips
-
-- You may want to refrain from localizing text for certain things, like names. In this case you can define them _once_ in your default language and reuse them with `i18n.enableFallback = true;`.
-- When a user changes the device's language, your app will reset. This means you can set the language once, and don't need to update any of your React components to account for the language changes.
-- On iOS, you can add `"CFBundleAllowMixedLocalizations": true` to your `ios.infoPlist` property [in your app.json](/workflow/configuration/#ios) so that your app supports the retrieval of localized strings from frameworks.
-  - This will allow you to translate app metadata, including the homescreen display name! Read [here](/distribution/app-stores#localizing-your-ios-app) for details.
-
-### Full Demo
-
-<SnackInline label="Localization" dependencies={['expo-localization', 'i18n-js']}>
-
-```tsx
-import { View, StyleSheet, Text } from 'react-native';
-import * as Localization from 'expo-localization';
-import { I18n } from 'i18n-js';
-
-// Set the key-value pairs for the different languages you want to support.
-const translations = {
-  en: { welcome: 'Hello', name: 'Charlie' },
-  ja: { welcome: 'こんにちは' },
-};
-const i18n = new I18n(translations);
-
-// Set the locale once at the beginning of your app.
-i18n.locale = Localization.locale;
-
-// When a value is missing from a language it'll fallback to another language with the key present.
-i18n.enableFallback = true;
-// To see the fallback mechanism uncomment line below to force app to use Japanese language.
-// i18n.locale = 'ja';
-
-export default function App() {
-  return (
-    <View style={styles.container}>
-      <Text style={styles.text}>
-        {i18n.t('welcome')} {i18n.t('name')}
-      </Text>
-      <Text>Current locale: {i18n.locale}</Text>
-      <Text>Device locale: {Localization.locale}</Text>
-    </View>
-  );
-}
-
-/* @hide const styles = StyleSheet.create({ ... }); */
-const styles = StyleSheet.create({
-  container: {
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flex: 1,
-  },
-  text: {
-    fontSize: 20,
-    marginBottom: 16,
-  },
-});
-/* @end */
-```
-
-</SnackInline>
+Find more information about using `expo-localization` in the [Localization](/guides/localization) guide.
 
 ## API
 
-```ts
-import * as Localization from 'expo-localization';
+```jsx
+import { getLocales, getCalendars } from 'expo-localization';
 ```
 
 ### Behavior
 
-You can use synchronous `getLocales()` and `getCalendars()` methods to get the locale settings of the user device. On iOS, the results will remain the same while the app is running. 
+You can use synchronous `getLocales()` and `getCalendars()` methods to get the locale settings of the user device. On iOS, the results will remain the same while the app is running.
 
 On Android, the user can change locale preferences in Settings without restarting apps. To keep the localization current, you can rerun the `getLocales()` and `getCalendars()` methods every time the app returns to the foreground. Use `AppState` to detect this.
 


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Recently, a new guide on using `expo-localization` (#19905) and removed the example from the usage section of the API reference. 

This PR backports those changes to SDK 47 with a few minor tweaks and cleanup to both `unversioned` and SDK 47 docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
