### PR TITLE
[dev-menu] fix r reloads in webviews

### DIFF
--- a/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
+++ b/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift
@@ -40,7 +40,7 @@ extension UIResponder: DevMenuUIResponderExtensionProtocol {
 
   @objc
   var EXDevMenu_keyCommands: [UIKeyCommand] {
-    if self is UITextField || self is UITextView {
+    if self is UITextField || self is UITextView || String(describing: type(of: self)) == "WKContentView" {
       return []
     }
     let actions = DevMenuManager.shared.devMenuCallable.filter { $0 is DevMenuExportedAction } as! [DevMenuExportedAction]


### PR DESCRIPTION
# Why
Pressing 'r' in webview input fields forces dev-client to reload

# How

Do not register key commands on UIResponders that happen inside a WKContentView.
The solution is equivalent to the one proposed in the previous non-swift version described here:  https://github.com/expo/expo/pull/14887/files

# Test Plan
To reproduce the bug open a dev-client in a bare app and open webview with an input field. Try writing the 'r' letter and the app will reload

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
