### PR TITLE
[expo] Swallow stdout while resolving entry point

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Swallow stdout while resolving entry point ([#20212](https://github.com/expo/expo/pull/20212) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 - Upgrade uuid package and update uuid/v4 import to new format. ([#20211](https://github.com/expo/expo/pull/20211) by [@peterpme](https://github.com/peterpme))

--- a/packages/expo/scripts/resolveAppEntry.js
+++ b/packages/expo/scripts/resolveAppEntry.js
@@ -29,12 +29,18 @@ if (!platform || !projectRoot) {
   process.exit(1);
 }
 
+// Prevent any logs from the app.config.js
+// from being used in the output of this command.
+const originalWrite = process.stdout.write;
+process.stdout.write = () => {};
+
+// Resolve the entry point
 const entry = resolveEntryPoint(projectRoot, { platform });
 
+// Restore stdout
+process.stdout.write = originalWrite;
+
 if (entry) {
-  // Prevent any logs from the app.config.js
-  // from being used in the output of this command.
-  console.clear();
   // React Native's `PROJECT_ROOT` could be using a different root on MacOS (`/var` vs `/private/var`)
   // We need to make sure to get the real path, `resolveEntryPoint` is using this too
   console.log(


### PR DESCRIPTION
# Why

Fixes #19997

# How

The `console.clear()` approach worked fine for IOS but does not work within Gradle, it seems. `console.clear()` is known to behave differently depending on the terminal, and TTY or not, so we can't really depend on it here I think.

Is swallowing stdout entirely the best approach here? Possibly not, but I'd be curious what people think the downsides are. Another alternative suggested by @ide was to use a sentinel value and parse the output with that in mind.

# Test Plan

- Clone repro from #19997: https://github.com/phryneas/reproduction-expo-19997
- Install deps and run `npx expo run:android --variant release`, notice the build failure
- Apply the diff from this PR, build again, success
- Try `npx expo ios --configuration Release` - notice that works as well

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
