### PR TITLE
[image][Android] Fix resize mode center

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -11,11 +11,12 @@ import android.graphics.drawable.Drawable
 import androidx.appcompat.widget.AppCompatImageView
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestManager
-import com.bumptech.glide.integration.webp.decoder.WebpDrawable
-import com.bumptech.glide.integration.webp.decoder.WebpDrawableTransformation
 import com.bumptech.glide.load.model.GlideUrl
-import com.bumptech.glide.load.resource.bitmap.FitCenter
+import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.RequestOptions
+import com.bumptech.glide.request.target.DrawableImageViewTarget
+import com.bumptech.glide.request.target.SizeReadyCallback
+import com.bumptech.glide.request.target.Target
 import com.facebook.react.modules.i18nmanager.I18nUtil
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.views.view.ReactViewBackgroundDrawable
@@ -146,6 +147,7 @@ class ExpoImageView(
     set(value) {
       field = value
       scaleType = value.getScaleType()
+      propsChanged = true
     }
 
   internal fun setBorderRadius(position: Int, borderRadius: Float) {
@@ -212,14 +214,14 @@ class ExpoImageView(
         .load(sourceToLoad)
         .apply { if (defaultSourceToLoad != null) thumbnail(requestManager.load(defaultSourceToLoad)) }
         .apply(options)
+        .downsample(DownsampleStrategy.NONE)
         .addListener(eventsManager)
-        .run {
-          val fitCenter = FitCenter()
-          optionalTransform(fitCenter)
-          optionalTransform(WebpDrawable::class.java, WebpDrawableTransformation(fitCenter))
-        }
         .apply(propOptions)
-        .into(this)
+        .into(object : DrawableImageViewTarget(this) {
+          override fun getSize(cb: SizeReadyCallback) {
+            cb.onSizeReady(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL)
+          }
+        })
 
       requestManager
         .`as`(BitmapFactory.Options::class.java)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
@@ -15,13 +15,7 @@ enum class ImageResizeMode(val stringValue: String) : Enumerable {
     CONTAIN -> ImageView.ScaleType.FIT_CENTER
     COVER -> ImageView.ScaleType.CENTER_CROP
     STRETCH -> ImageView.ScaleType.FIT_XY
-    CENTER -> ImageView.ScaleType.CENTER
+    CENTER -> ImageView.ScaleType.CENTER_INSIDE
     REPEAT -> ImageView.ScaleType.FIT_XY
-  }
-
-  companion object {
-    fun fromStringValue(value: String): ImageResizeMode =
-      values().firstOrNull { it.stringValue == value }
-        ?: throw JSApplicationIllegalArgumentException("Invalid resizeMode: $value")
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageResizeMode.kt
@@ -1,10 +1,9 @@
 package expo.modules.image.enums
 
 import android.widget.ImageView
-import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import expo.modules.kotlin.types.Enumerable
 
-enum class ImageResizeMode(val stringValue: String) : Enumerable {
+enum class ImageResizeMode(val value: String) : Enumerable {
   CONTAIN("contain"),
   COVER("cover"),
   STRETCH("stretch"),


### PR DESCRIPTION
# Why

Fixes `ResizeMode.center`.

# How

The `ResizeMode.center` was upscaling the image which wasn't the correct behavior. To fix that I have to:
- remove the `FitCenter` transformation, which wasn't needed. 
- disable downsampling
- change the scale mode from `ImageView.ScaleType.CENTER` to `ImageView.ScaleType.CENTER_INSIDE`
- replace glide target to override image size

# Test Plan

- NCL ✅