### PR TITLE
[core][ios] Allow to skip trailing optional arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🎉 New features
 
 - Added a new `executeOnJavaScriptThread` method to `appContext` to allow for running code blocks on the JS thread. ([#20161](https://github.com/expo/expo/pull/20161) by [@aleqsio](https://github.com/aleqsio))
-- Added the `Exception.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
+- Added the `Exceptions.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
+- Trailing optional arguments can be skipped when calling native functions from JavaScript on iOS. ([#20234](https://github.com/expo/expo/pull/20234) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -24,6 +24,11 @@ internal protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder {
   var argumentsCount: Int { get }
 
   /**
+   A minimum number of arguments the functions needs which equals to `argumentsCount` reduced by the number of trailing optional arguments.
+   */
+  var requiredArgumentsCount: Int { get }
+
+  /**
    Indicates whether the function's arguments starts from the owner that calls this function.
    */
   var takesOwner: Bool { get set }
@@ -42,6 +47,19 @@ internal protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder {
 }
 
 extension AnyFunction {
+  var requiredArgumentsCount: Int {
+    var trailingOptionalArgumentsCount: Int = 0
+
+    for dynamicArgumentType in dynamicArgumentTypes.reversed() {
+      if dynamicArgumentType is DynamicOptionalType {
+        trailingOptionalArgumentsCount += 1
+      } else {
+        break
+      }
+    }
+    return argumentsCount - trailingOptionalArgumentsCount
+  }
+
   /**
    Calls the function just like `call(by:withArguments:callback:)`, but without an owner
    and with an empty callback. Might be useful when you only want to call the function,

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -61,7 +61,7 @@ internal func concat(arguments: [Any], withOwner owner: AnyObject?, forFunction 
     result = [owner] + arguments
   }
   if arguments.count < function.argumentsCount {
-    result = result + Array(repeating: nil, count: function.argumentsCount - arguments.count) as [Any]
+    result += Array(repeating: Any?.none as Any, count: function.argumentsCount - arguments.count)
   }
   return result
 }

--- a/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptUtils.swift
@@ -28,10 +28,16 @@ internal func cast(_ value: Any, toType type: AnyDynamicType) throws -> Any {
  of function's arguments (without an owner and promise). Rethrows exceptions thrown by `cast(_:toType:)`.
  */
 internal func cast(arguments: [Any], forFunction function: AnyFunction) throws -> [Any] {
-  if arguments.count != function.argumentsCount {
-    throw InvalidArgsNumberException((received: arguments.count, expected: function.argumentsCount))
-  }
+  let requiredArgumentsCount = function.requiredArgumentsCount
   let argumentTypeOffset = function.takesOwner ? 1 : 0
+
+  if arguments.count < requiredArgumentsCount || arguments.count > function.argumentsCount {
+    throw InvalidArgsNumberException((
+      received: arguments.count,
+      expected: function.argumentsCount,
+      required: requiredArgumentsCount
+    ))
+  }
   return try arguments.enumerated().map { index, argument in
     let argumentType = function.dynamicArgumentTypes[index + argumentTypeOffset]
 
@@ -44,20 +50,31 @@ internal func cast(arguments: [Any], forFunction function: AnyFunction) throws -
 }
 
 /**
- Prepends the owner to the array of arguments if the given function can take it.
+ Ensures the provided array of arguments matches the number of arguments expected by the function.
+ - If the function takes the owner, it's added to the beginning.
+ - If the array is still too small, missing arguments are very likely to be optional so it puts `nil` in their place.
  */
 internal func concat(arguments: [Any], withOwner owner: AnyObject?, forFunction function: AnyFunction) -> [Any] {
+  var result = arguments
+
   if function.takesOwner, let owner = try? function.dynamicArgumentTypes.first?.cast(owner) {
-    return [owner] + arguments
+    result = [owner] + arguments
   }
-  return arguments
+  if arguments.count < function.argumentsCount {
+    result = result + Array(repeating: nil, count: function.argumentsCount - arguments.count) as [Any]
+  }
+  return result
 }
 
 // MARK: - Exceptions
 
-internal class InvalidArgsNumberException: GenericException<(received: Int, expected: Int)> {
+internal class InvalidArgsNumberException: GenericException<(received: Int, expected: Int, required: Int)> {
   override var reason: String {
-    "Received \(param.received) arguments, but \(param.expected) was expected"
+    if param.required < param.expected {
+      return "Received \(param.received) arguments, but \(param.expected) was expected and at least \(param.required) is required"
+    } else {
+      return "Received \(param.received) arguments, but \(param.expected) was expected"
+    }
   }
 }
 


### PR DESCRIPTION
# Why

So far we were very strict in terms of the number of arguments passed to the native function. However, there are some cases where we may want to have trailing optional arguments and let them be skipped when called from JS.

Imagine we have a native function that expects an optional string:

```swift
// Swift
Function("foo") { (a: String?) in
  return a ?? "bar"
}
```

```javascript
// JavaScript
foo(null)      // works, returns "bar"
foo(undefined) // works, returns "bar"
foo()          // throws "ERR_INVALID_ARGS_NUMBER"
```

Since `foo(undefined)` and `foo()` are logically the same, I think we should make it possible to skip trailing optional arguments without throwing that exception.

# How

- Added `requiredArgumentsCount` property to functions
- Throw `InvalidArgsNumberException` only when the number is less than the required count or greater than total count
- Improved the exception reason to note how many arguments are required
- Added new unit tests

# Test Plan

Unit tests are passing