### PR TITLE
[docs] Improve SQLite docs to show usage after installation instructions

### DIFF
--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
@@ -20,7 +22,12 @@ import { Step } from '~/ui/components/Step';
 
 ## Usage
 
-An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
+<BoxLink
+  title="To-do list app"
+  description="An example to-do list app is available that uses this module for storage."
+  href="https://github.com/expo/examples/tree/master/with-sqlite"
+  Icon={GithubIcon}
+/>
 
 ### Importing an existing database
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -8,49 +8,64 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
-An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
-
 <PlatformsSection android emulator ios simulator />
 
-## Guides
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
 ### Importing an existing database
 
-To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, follow the steps below:
 
-- Install `expo-file-system` and `expo-asset` modules:
+<Step label="1">
+Install `expo-file-system` and `expo-asset` modules:
 
-  <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
+<Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-- Create a **metro.config.js** file at the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+</Step>
 
-  ```ts
-  const { getDefaultConfig } = require('expo/metro-config');
+<Step label="2">
+Create a **metro.config.js** file at the root of your project with the following contents to include [extra asset extensions](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts):
 
-  const defaultConfig = getDefaultConfig(__dirname);
+```js
+const { getDefaultConfig } = require('expo/metro-config');
 
-  defaultConfig.resolver.assetExts.push('db');
+const defaultConfig = getDefaultConfig(__dirname);
 
-  module.exports = defaultConfig;
-  ```
+defaultConfig.resolver.assetExts.push('db');
 
-- Use the following function (or similar) to open your database:
+module.exports = defaultConfig;
+```
 
-  ```ts
-  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
-    }
-    await FileSystem.downloadAsync(
-      Asset.fromModule(require(pathToDatabaseFile)).uri,
-      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-    );
-    return SQLite.openDatabase('myDatabaseName.db');
+</Step>
+
+<Step label="3">
+
+Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  ```
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+</Step>
 
 ### Executing statements outside of a transaction
 
@@ -63,10 +78,6 @@ db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
   console.log('Foreign keys turned on')
 );
 ```
-
-## Installation
-
-<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
@@ -20,7 +22,12 @@ import { Step } from '~/ui/components/Step';
 
 ## Usage
 
-An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
+<BoxLink
+  title="To-do list app"
+  description="An example to-do list app is available that uses this module for storage."
+  href="https://github.com/expo/examples/tree/master/with-sqlite"
+  Icon={GithubIcon}
+/>
 
 ### Importing an existing database
 

--- a/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
@@ -29,7 +29,7 @@ To open a new SQLite database using an existing `.db` file you already have, fol
 <Step label="1">
 Install `expo-file-system` and `expo-asset` modules:
 
-<Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
+<Terminal cmd={['$ expo install expo-file-system expo-asset']} />
 
 </Step>
 

--- a/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/sqlite.mdx
@@ -8,53 +8,68 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
-An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
-
 <PlatformsSection android emulator ios simulator />
 
-## Guides
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
 ### Importing an existing database
 
-To open a new SQLite database using an existing `.db` file you already have, you need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, follow the steps below:
 
-- Install `expo-file-system` and `expo-asset` modules:
+<Step label="1">
+Install `expo-file-system` and `expo-asset` modules:
 
-  <Terminal cmd={['$ expo install expo-file-system expo-asset']} />
+<Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-- Create a **metro.config.js** file in the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+</Step>
 
-  ```ts
-  const { getDefaultConfig } = require('expo/metro-config');
+<Step label="2">
+Create a **metro.config.js** file at the root of your project with the following contents to include [extra asset extensions](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts):
 
-  const defaultConfig = getDefaultConfig(__dirname);
+```js
+const { getDefaultConfig } = require('expo/metro-config');
 
-  defaultConfig.resolver.assetExts.push('db');
+const defaultConfig = getDefaultConfig(__dirname);
 
-  module.exports = defaultConfig;
-  ```
+defaultConfig.resolver.assetExts.push('db');
 
-- Use the following function (or similar) to open your database:
+module.exports = defaultConfig;
+```
 
-  ```ts
-  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
-    }
-    await FileSystem.downloadAsync(
-      Asset.fromModule(require(pathToDatabaseFile)).uri,
-      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-    );
-    return SQLite.openDatabase('myDatabaseName.db');
+</Step>
+
+<Step label="3">
+
+Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  ```
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+</Step>
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
+> You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);
@@ -63,10 +78,6 @@ db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
   console.log('Foreign keys turned on')
 );
 ```
-
-## Installation
-
-<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
@@ -20,7 +22,12 @@ import { Step } from '~/ui/components/Step';
 
 ## Usage
 
-An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
+<BoxLink
+  title="To-do list app"
+  description="An example to-do list app is available that uses this module for storage."
+  href="https://github.com/expo/examples/tree/master/with-sqlite"
+  Icon={GithubIcon}
+/>
 
 ### Importing an existing database
 

--- a/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/sqlite.mdx
@@ -8,53 +8,68 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
-An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
-
 <PlatformsSection android emulator ios simulator />
 
-## Guides
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
 ### Importing an existing database
 
-To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, follow the steps below:
 
-- Install `expo-file-system` and `expo-asset` modules:
+<Step label="1">
+Install `expo-file-system` and `expo-asset` modules:
 
-  <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
+<Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-- Create a **metro.config.js** file at the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+</Step>
 
-  ```ts
-  const { getDefaultConfig } = require('expo/metro-config');
+<Step label="2">
+Create a **metro.config.js** file at the root of your project with the following contents to include [extra asset extensions](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts):
 
-  const defaultConfig = getDefaultConfig(__dirname);
+```js
+const { getDefaultConfig } = require('expo/metro-config');
 
-  defaultConfig.resolver.assetExts.push('db');
+const defaultConfig = getDefaultConfig(__dirname);
 
-  module.exports = defaultConfig;
-  ```
+defaultConfig.resolver.assetExts.push('db');
 
-- Use the following function (or similar) to open your database:
+module.exports = defaultConfig;
+```
 
-  ```ts
-  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
-    }
-    await FileSystem.downloadAsync(
-      Asset.fromModule(require(pathToDatabaseFile)).uri,
-      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-    );
-    return SQLite.openDatabase('myDatabaseName.db');
+</Step>
+
+<Step label="3">
+
+Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  ```
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+</Step>
 
 ### Executing statements outside of a transaction
 
-> **info** You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
+> You should use this kind of execution only when it is necessary. For instance, when code is a no-op within transactions. Example: `PRAGMA foreign_keys = ON;`.
 
 ```js
 const db = SQLite.openDatabase('dbName', version);
@@ -63,10 +78,6 @@ db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
   console.log('Foreign keys turned on')
 );
 ```
-
-## Installation
-
-<APIInstallSection />
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
@@ -20,7 +22,12 @@ import { Step } from '~/ui/components/Step';
 
 ## Usage
 
-An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
+<BoxLink
+  title="To-do list app"
+  description="An example to-do list app is available that uses this module for storage."
+  href="https://github.com/expo/examples/tree/master/with-sqlite"
+  Icon={GithubIcon}
+/>
 
 ### Importing an existing database
 

--- a/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/sqlite.mdx
@@ -8,49 +8,64 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 `expo-sqlite` gives your app access to a database that can be queried through a [WebSQL](https://www.w3.org/TR/webdatabase/)-like API. The database is persisted across restarts of your app.
 
-An [example to do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
-
 <PlatformsSection android emulator ios simulator />
 
-## Guides
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+An [example to-do list app](https://github.com/expo/examples/tree/master/with-sqlite) is available that uses this module for storage.
 
 ### Importing an existing database
 
-To open a new SQLite database using an existing `.db` file you already have, you'll need to do three things:
+To open a new SQLite database using an existing `.db` file you already have, follow the steps below:
 
-- Install `expo-file-system` and `expo-asset` modules:
+<Step label="1">
+Install `expo-file-system` and `expo-asset` modules:
 
-  <Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
+<Terminal cmd={['$ npx expo install expo-file-system expo-asset']} />
 
-- Create a **metro.config.js** file at the root of your project with the following contents ([curious why? read here](/guides/customizing-metro.mdx#adding-more-file-extensions-to--assetexts)):
+</Step>
 
-  ```ts
-  const { getDefaultConfig } = require('expo/metro-config');
+<Step label="2">
+Create a **metro.config.js** file at the root of your project with the following contents to include [extra asset extensions](/guides/customizing-metro/#adding-more-file-extensions-to--assetexts):
 
-  const defaultConfig = getDefaultConfig(__dirname);
+```js
+const { getDefaultConfig } = require('expo/metro-config');
 
-  defaultConfig.resolver.assetExts.push('db');
+const defaultConfig = getDefaultConfig(__dirname);
 
-  module.exports = defaultConfig;
-  ```
+defaultConfig.resolver.assetExts.push('db');
 
-- Use the following function (or similar) to open your database:
+module.exports = defaultConfig;
+```
 
-  ```ts
-  async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
-    if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
-      await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
-    }
-    await FileSystem.downloadAsync(
-      Asset.fromModule(require(pathToDatabaseFile)).uri,
-      FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
-    );
-    return SQLite.openDatabase('myDatabaseName.db');
+</Step>
+
+<Step label="3">
+
+Use the following function (or similar) to open your database:
+
+```ts
+async function openDatabase(pathToDatabaseFile: string): Promise<SQLite.WebSQLDatabase> {
+  if (!(await FileSystem.getInfoAsync(FileSystem.documentDirectory + 'SQLite')).exists) {
+    await FileSystem.makeDirectoryAsync(FileSystem.documentDirectory + 'SQLite');
   }
-  ```
+  await FileSystem.downloadAsync(
+    Asset.fromModule(require(pathToDatabaseFile)).uri,
+    FileSystem.documentDirectory + 'SQLite/myDatabaseName.db'
+  );
+  return SQLite.openDatabase('myDatabaseName.db');
+}
+```
+
+</Step>
 
 ### Executing statements outside of a transaction
 
@@ -63,10 +78,6 @@ db.exec([{ sql: 'PRAGMA foreign_keys = ON;', args: [] }], false, () =>
   console.log('Foreign keys turned on')
 );
 ```
-
-## Installation
-
-<APIInstallSection />
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6974

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR improves the structure of `expo-sqlite` docs to
- place the short guides and example app link under Usage section
- replace Installation section before the Usage to follow the unified structure across all API reference docs
- changes backported to SDK 47, 46, 45

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1512" alt="CleanShot 2022-11-27 at 23 45 51@2x" src="https://user-images.githubusercontent.com/10234615/204152572-55fc4999-3486-446e-8e84-b8465c95ef66.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
