### PR TITLE
[docs] Fix typo in Create Development builds

### DIFF
--- a/docs/pages/development/create-development-builds.mdx
+++ b/docs/pages/development/create-development-builds.mdx
@@ -87,7 +87,7 @@ For example, the `"development-simulator"` profile below is only for creating a 
 
 ```json eas.json
 {
-  "builds": {
+  "build": {
     "development-simulator": {
       "developmentClient": true,
       "distribution": "internal",


### PR DESCRIPTION
# Why & how
This PR fixes the typo in **eas.json** example and changes `builds` to `build`.
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

Changes have been tested locally.

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
