### PR TITLE
Update SwiftLint to 0.50.1 in code review CI action

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,19 +30,19 @@ jobs:
       ### This job is run on Ubuntu which doesn't have SwiftLint installed, so we need to build it from sources.
       ### Building it on each run may take too much time, so we bundle the binary in `@expo/swiftlint` package.
       ### To update SwiftLint, uncomment steps below, download the artifact and update that package.
-      # - name: 👷 Build and install SwiftLint
-      #   run: |
-      #     git clone https://github.com/realm/SwiftLint.git --branch 0.45.1 --depth 1
-      #     cd SwiftLint
-      #     make build
-      #     cp .build/x86_64-unknown-linux-gnu/release/swiftlint /usr/local/bin/
-      # - name: 📦 Make an artifact
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: swiftlint
-      #     path: SwiftLint/.build
+      - name: 👷 Build and install SwiftLint
+        run: |
+          git clone https://github.com/realm/SwiftLint.git --branch 0.50.1 --depth 1
+          cd SwiftLint
+          swift build -c release
+          cp .build/release/swiftlint /usr/local/bin/
+      - name: 📦 Make an artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: swiftlint
+          path: SwiftLint/.build
 
-      - name: 🔬 Reviewing a pull request
-        run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+      # - name: 🔬 Reviewing a pull request
+      #   run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -30,19 +30,19 @@ jobs:
       ### This job is run on Ubuntu which doesn't have SwiftLint installed, so we need to build it from sources.
       ### Building it on each run may take too much time, so we bundle the binary in `@expo/swiftlint` package.
       ### To update SwiftLint, uncomment steps below, download the artifact and update that package.
-      - name: 👷 Build and install SwiftLint
-        run: |
-          git clone https://github.com/realm/SwiftLint.git --branch 0.50.1 --depth 1
-          cd SwiftLint
-          swift build -c release
-          cp .build/release/swiftlint /usr/local/bin/
-      - name: 📦 Make an artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: swiftlint
-          path: SwiftLint/.build
+      # - name: 👷 Build and install SwiftLint
+      #   run: |
+      #     git clone https://github.com/realm/SwiftLint.git --branch 0.50.1 --depth 1
+      #     cd SwiftLint
+      #     swift build -c release
+      #     cp .build/release/swiftlint /usr/local/bin/
+      # - name: 📦 Make an artifact
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: swiftlint
+      #     path: SwiftLint/.build
 
-      # - name: 🔬 Reviewing a pull request
-      #   run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+      - name: 🔬 Reviewing a pull request
+        run: expotools code-review --pr ${{ github.event.inputs.pullNumber || github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,19 +31,43 @@ excluded:
 # Enable rules that are turned off by default. Run `swiftlint rules` to see what's available to opt-in.
 opt_in_rules:
   - anyobject_protocol
+  - array_init
+  - capture_variable
+  - closure_body_length
   - closure_end_indentation
   - closure_spacing
   - collection_alignment
+  - comma_inheritance
   - conditional_returns_on_newline
+  - discouraged_object_literal
   - empty_collection_literal
   - empty_count
   - empty_string
+  - enum_case_associated_values_count
+  - fatal_error_message
+  - file_name_no_space
+  - force_unwrapping
+  - identical_operands
+  - implicitly_unwrapped_optional
+  - indentation_width
+  - legacy_objc_type
+  - literal_expression_end_indentation
+  - local_doc_comment
+  - lower_acl_than_parent
+  - multiline_arguments
+  - multiline_function_chains
   - multiline_literal_brackets
   - multiline_parameters
   - multiline_parameters_brackets
+  - no_grouping_extension
   - number_separator
+  - operator_usage_whitespace
+  - overridden_super_call
   - prefer_zero_over_explicit_init
+  - prohibited_super_call
   - redundant_nil_coalescing
+  - static_operator
+  - unavailable_function
   - unneeded_parentheses_in_closure_argument
   - unowned_variable_capture
   - unused_declaration
@@ -62,6 +86,18 @@ disabled_rules:
 # Prefer using AnyObject over class for class-only protocols.
 anyobject_protocol: warning
 
+# Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array.
+array_init: warning
+
+# Non-constant variables should not be listed in a closure’s capture list
+# to avoid confusion about closures capturing variables at creation time.
+capture_variable: warning
+
+# Closure bodies should not span too many lines.
+closure_body_length:
+  warning: 30
+  error: 50
+
 # Closure end should have the same indentation as the line that started it.
 closure_end_indentation: warning
 
@@ -73,6 +109,9 @@ collection_alignment:
   severity: warning
   align_colons: false
 
+# Use commas to separate types in inheritance lists.
+comma_inheritance: warning
+
 # if, for, guard, switch, while, and catch statements shouldn’t unnecessarily wrap their conditionals or arguments in parentheses.
 control_statement: warning
 
@@ -81,6 +120,12 @@ cyclomatic_complexity:
   warning: 12
   error: 20
   ignores_case_statements: true
+
+# Prefer initializers over object literals.
+discouraged_object_literal:
+  severity: error
+  image_literal: true
+  color_literal: true
 
 # Prefer checking `isEmpty` over comparing collection to an empty array or dictionary literal.
 empty_collection_literal: warning
@@ -96,10 +141,34 @@ empty_parentheses_with_trailing_closure: warning
 # Prefer checking `isEmpty` over comparing string to an empty string literal.
 empty_string: warning
 
+# Number of associated values in an enum case should be low.
+enum_case_associated_values_count:
+  warning: 5
+  error: 6
+
+# A `fatalError` call should have a message.
+fatal_error_message: error
+
+# File name should not contain any whitespace.
+file_name_no_space:
+  severity: error
+
+# Force casts should be avoided.
+force_cast: error
+
+# Force tries should be avoided.
+force_try: error
+
+# Force unwrapping should be avoided.
+force_unwrapping: error
+
 # Functions bodies should not span too many lines.
 function_body_length:
   warning: 80
   error: 100
+
+# Comparing two identical operands is likely a mistake.
+identical_operands: error
 
 # Identifier names should only contain alphanumeric characters and start with a lowercase character or should only
 # contain capital letters. In an exception to the above, variable names may start with a capital letter when they are
@@ -135,6 +204,22 @@ identifier_name:
       'ViewManager',
     ]
 
+# Implicitly unwrapped optionals should be avoided when possible.
+implicitly_unwrapped_optional:
+  severity: error
+
+# Indent code using either one tab or the configured amount of spaces,
+# unindent to match previous indentations. Don’t indent the first line.
+indentation_width:
+  severity: warning
+  indentation_width: 2
+  include_comments: false
+
+# Tuples shouldn’t have too many members. Create a custom type instead.
+large_tuple:
+  warning: 10
+  error: 10
+
 # Files should not contain leading whitespace.
 leading_whitespace: warning
 
@@ -143,6 +228,9 @@ legacy_constant: warning
 
 # Swift constructors are preferred over legacy convenience functions.
 legacy_constructor: warning
+
+# Prefer Swift value types to bridged Objective-C reference types.
+legacy_objc_type: warning
 
 # Lines should not span too many characters.
 line_length:
@@ -153,8 +241,24 @@ line_length:
   ignores_comments: false
   ignores_interpolated_strings: true
 
+# Array and dictionary literal end should have the same indentation as the line that started it.
+literal_expression_end_indentation: warning
+
+# Doc comments shouldn’t be used in local scopes. Use regular comments.
+local_doc_comment: warning
+
+# Ensure declarations have a lower access control level than their enclosing parent.
+lower_acl_than_parent: warning
+
 # MARK comment should be in valid format. e.g. `// MARK: ...` or `// MARK: - ...`
 mark: warning
+
+# Arguments should be either on the same line, or one per line.
+multiline_arguments:
+  severity: warning
+
+# Chained function calls should be either on the same line, or one per line.
+multiline_function_chains: warning
 
 # Multiline literals should have their surrounding brackets in a new line.
 multiline_literal_brackets: warning
@@ -171,16 +275,31 @@ nesting:
 # Multiline parameters should have their surrounding brackets in a new line.
 multiline_parameters_brackets: warning
 
+# Extensions shouldn’t be used to group code within the same source file.
+no_grouping_extension: warning
+
 # Underscores should be used as thousand separator in large decimal numbers.
 number_separator:
   severity: warning
   minimum_length: 5
 
+# Operators should be surrounded by a single whitespace when they are being used.
+operator_usage_whitespace:
+  severity: warning
+
 # A doc comment should be attached to a declaration.
 orphaned_doc_comment: warning
 
+# Some overridden methods should always call super.
+overridden_super_call:
+  severity: warning
+
 # Prefer `.zero` over explicit init with zero parameters (e.g. `CGPoint(x: 0, y: 0)`).
 prefer_zero_over_explicit_init: warning
+
+# Some methods should not call super.
+prohibited_super_call:
+  severity: warning
 
 # When declaring properties in protocols, the order of accessors should be `get set`.
 protocol_property_accessors_order: warning
@@ -190,6 +309,9 @@ redundant_nil_coalescing: warning
 
 # Initializing an optional variable with nil is redundant.
 redundant_optional_initialization: warning
+
+# Operators should be declared as static functions, not free functions.
+static_operator: warning
 
 # Files should have a single trailing newline.
 trailing_newline: warning
@@ -214,6 +336,9 @@ type_name:
   max_length:
     warning: 40
     error: 50
+
+# Unimplemented functions should be marked as unavailable.
+unavailable_function: warning
 
 # Parentheses are not needed when declaring closure arguments.
 unneeded_parentheses_in_closure_argument: warning
@@ -256,7 +381,9 @@ vertical_whitespace:
   max_empty_lines: 1
 
 # Don’t include vertical whitespace (empty line) before closing braces.
-vertical_whitespace_closing_braces: warning
+vertical_whitespace_closing_braces:
+  severity: warning
+  only_enforce_before_trivial_lines: false
 
 # Don’t include vertical whitespace (empty line) after opening braces.
 vertical_whitespace_opening_braces: warning

--- a/tools/package.json
+++ b/tools/package.json
@@ -22,7 +22,7 @@
     "@expo/commander": "2.21.1",
     "@expo/json-file": "^8.2.36",
     "@expo/spawn-async": "^1.7.0",
-    "@expo/swiftlint": "^0.1.1",
+    "@expo/swiftlint": "^0.2.0",
     "@expo/xcodegen": "2.18.0-patch.1",
     "@expo/xdl": "^59.2.1",
     "@octokit/rest": "^19.0.4",

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -1209,10 +1209,10 @@
   dependencies:
     cross-spawn "^7.0.3"
 
-"@expo/swiftlint@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/swiftlint/-/swiftlint-0.1.1.tgz#9dd8062879111718eb804e288f3aa5d67f722ed7"
-  integrity sha512-tCoNwDm2TyTePMdpe0pIRs6Dg+ZhoLGpZZ0JYEPuPQh4R4Wqq5RQhsz88fCK0H19US3mgpgvibq/vto8vWbMuA==
+"@expo/swiftlint@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@expo/swiftlint/-/swiftlint-0.2.0.tgz#ad371837aac602b8f9cb9b93982f315ac72f1f68"
+  integrity sha512-kEKIuLaGSf5CfCIpjv1K+iEbuXFphiuel6LTIUzO59rLa7jM4HRot4N5SH3JsTLNFQJspjuHKiHfRrtfAf6Ywg==
   dependencies:
     "@expo/spawn-async" "^1.5.0"
 


### PR DESCRIPTION
# Why

It's time to upgrade. From 0.45.1 to 0.50.1 🎉 

# How

- Built the new version of SwiftLint from sources on the CI machine and downloaded the artifact
- Published `@expo/swiftlint@0.2.0` with the new binaries (for Linux x64 and macOS arm64)
- Updated `.swiftlint.yml` with some new rules that I think are right
- Updated dependency in expotools

# Test Plan

Manually dispatched code review workflow, see bot's review: https://github.com/expo/expo/pull/19888#pullrequestreview-1195053389
