### PR TITLE
[docs] Add links for limitations/faqs for other services

### DIFF
--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -29,7 +29,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 <BoxLink
   title="EAS Metadata"
-  description="EAS Metadata aims to make creating or maintaining an app in the stores as easy as possible by using one configuration file. In some situations, not be the right fit for a project. Learn more."
+  description="EAS Metadata helps creating or maintaining an app in the stores as easy as possible by using one configuration file. In some situations, not be the right fit for a project. Learn more."
   href="/eas/metadata/faq/#anti-pitch"
   Icon={EasMetadataIcon}
 />
@@ -43,7 +43,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 ### Bare workflow
 
-Similar to [development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild/).
+Similar to [development builds](/development/introduction), bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android/** and **ios/** directories rather than continuously generating them on demand using the [Expo config and prebuild](/workflow/prebuild).
 
 EAS Build is compatible with bare workflow projects if you check in the native directories, but no longer runs prebuild, as that could overwrite any manual customizations you've made to the native project files. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
 
@@ -56,7 +56,7 @@ Like any other tool, it too has its own limitations:
 - Using a third-party library that requires native code
 - Using a third-party push notification service
 
-**We strongly recommend any projects that require additional libraries with native code to migrate to [development builds](/development/introduction/). It's like creating a version of Expo Go that is specifically customized to your app's needs.**
+**We strongly recommend any projects that require additional libraries with native code to migrate to [development builds](/development/introduction). It's like creating a version of Expo Go that is specifically customized to your app's needs.**
 
 ## Up next
 

--- a/docs/pages/introduction/why-not-expo.mdx
+++ b/docs/pages/introduction/why-not-expo.mdx
@@ -5,7 +5,7 @@ sidebar_title: Limitations
 
 import { InlineCode } from '~/components/base/code';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasMetadataIcon } from '@expo/styleguide';
+import { BuildIcon, EasMetadataIcon, UpdateIcon, BellIcon } from '@expo/styleguide';
 
 We believe Expo tools are a great option for anyone looking to create amazing cross-platform apps quickly. Nonetheless, everyone's project is unique, and there may be reasons Expo is not the right choice for what you're building. Read on for some reasons why you may **not** want to use certain Expo tools with your project.
 
@@ -16,8 +16,15 @@ For more information on what current limitations exist with EAS, see the followi
 <BoxLink
   title="EAS Build"
   description="EAS Build is designed to work for any React Native project, whether or not you also use Expo Prebuild or manage your own native files. In some situations, you may need to change your project configuration, or it may be incompatible with your app. Learn more."
-  href="/build-reference/limitations/"
+  href="/build-reference/limitations"
   Icon={BuildIcon}
+/>
+
+<BoxLink
+  title="EAS Update"
+  description="EAS Update is a hosted service that serves updates for projects using the expo-updates library. You can use it to fix small bugs and push quick fixes a snap in between app store submissions. In some situations, not be the right fit for a project. Learn more."
+  href="/eas-update/known-issues"
+  Icon={UpdateIcon}
 />
 
 <BoxLink
@@ -25,6 +32,13 @@ For more information on what current limitations exist with EAS, see the followi
   description="EAS Metadata aims to make creating or maintaining an app in the stores as easy as possible by using one configuration file. In some situations, not be the right fit for a project. Learn more."
   href="/eas/metadata/faq/#anti-pitch"
   Icon={EasMetadataIcon}
+/>
+
+<BoxLink
+  title="Notifications"
+  description="Push Notifications are an important feature, no matter what kind of app you're building. In some situations, you might want to know about common issues when setting up push notifications with Expo. Learn more."
+  href="/push-notifications/faq"
+  Icon={BellIcon}
 />
 
 ### Bare workflow


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6849

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR add links to other EAS Services and notification common issues/FAQ pages to Expo Limitations page (/why-not-expo).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="913" alt="CleanShot 2022-11-28 at 13 30 01@2x" src="https://user-images.githubusercontent.com/10234615/204224283-ad865b2e-45d1-4a69-926f-a4f9270acd83.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
