### PR TITLE
Use optional JSON access

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/TextDirectionController.kt
@@ -24,7 +24,7 @@ class ExperienceRTLManager {
     fun setSupportsRTLFromManifest(context: Context, manifest: Manifest) {
       setSupportsRTL(
         context,
-        (manifest.getExpoClientConfigRootObject()?.getJSONObject("extra")?.getBoolean("supportsRTL") ?: false)
+        (manifest.getExpoClientConfigRootObject()?.optJSONObject("extra")?.optBoolean("supportsRTL") ?: false)
       )
     }
   }


### PR DESCRIPTION
# Why

Missused the non-optional JSON getters and that causes a crash if the field is missing.