### PR TITLE
[gh] Use M1 workers on EAS Build

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -14,9 +14,6 @@ inputs:
   expoToken:
     description: 'Expo token'
     required: true
-  resourceClass:
-    description: 'EAS instance resource class'
-    required: true
   noWait:
     description: 'Exit immediately after build is scheduled'
     required: false
@@ -40,7 +37,7 @@ runs:
           COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -c1000)
         fi
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
-        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --resource-class ${{ inputs.resourceClass }} --non-interactive --json --no-wait | jq -r ".[0].id")
+        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
         echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.projectRoot }}
       env:

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -113,7 +113,6 @@ jobs:
           profile: ${{ steps.profile.outputs.profile  }}
           projectRoot: './apps/eas-expo-go'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          resourceClass: large
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On workflow canceled

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -113,7 +113,7 @@ jobs:
           profile: ${{ steps.profile.outputs.profile  }}
           projectRoot: './apps/eas-expo-go'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          resourceClass: default
+          resourceClass: m1-experimental
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On workflow canceled

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -113,7 +113,6 @@ jobs:
           profile: ${{ steps.profile.outputs.profile  }}
           projectRoot: './apps/eas-expo-go'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          resourceClass: m1-experimental
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On workflow canceled

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -13,6 +13,7 @@
             "../../android/prebuiltHermes"
           ]
         },
+        "resourceClass": "large",
         "env": {
           "EAS_BUILD_PLATFORM": "android",
           "EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID": "host.exp.exponent",
@@ -26,6 +27,7 @@
             "../../ios/Pods"
           ]
         },
+        "resourceClass": "m1-medium",
         "env": {
           "EAS_BUILD_PLATFORM": "ios",
           "EXPO_ROOT_DIR": "/Users/expo/workingdir/build"


### PR DESCRIPTION
# Why

Switch to M1 builders

# How


# Test Plan

Build time improved from 22 - 24 minutes to 15 minutes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
