### PR TITLE
[core][ios] Fixed Either types not supporting non-primitive types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed failed resolution of 'java.nio.file.Path' on Android. ([#20037](https://github.com/expo/expo/pull/20037) by [@lukmccall](https://github.com/lukmccall))
 - Fixed views are not correctly initialized after reloading on Android. ([#20063](https://github.com/expo/expo/pull/20063) by [@lukmccall](https://github.com/lukmccall))
 - Fixed libraries using the `ViewDefinitionBuilder` crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
-- Fixed Either types not supporting non-primitive types on iOS.
+- Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed failed resolution of 'java.nio.file.Path' on Android. ([#20037](https://github.com/expo/expo/pull/20037) by [@lukmccall](https://github.com/lukmccall))
 - Fixed views are not correctly initialized after reloading on Android. ([#20063](https://github.com/expo/expo/pull/20063) by [@lukmccall](https://github.com/lukmccall))
 - Fixed libraries using the `ViewDefinitionBuilder` crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
+- Fixed Either types not supporting non-primitive types on iOS.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
@@ -51,8 +51,11 @@ open class Either<FirstType, SecondType>: Convertible {
   // MARK: - Convertible
 
   public class func convert(from value: Any?) throws -> Self {
-    if value is FirstType || value is SecondType {
-      return Self(value)
+    for type in dynamicTypes() {
+      // Initialize the "either" when the current type can cast given value.
+      if let value = try? type.cast(value) {
+        return Self(value)
+      }
     }
     throw NeitherTypeException(Self.dynamicTypes())
   }
@@ -79,12 +82,6 @@ open class EitherOfThree<FirstType, SecondType, ThirdType>: Either<FirstType, Se
   public func get() -> ThirdType? {
     return value as? ThirdType
   }
-
-  // MARK: - Convertible
-
-  public override class func convert(from value: Any?) throws -> Self {
-    return value is ThirdType ? Self(value) : try super.convert(from: value)
-  }
 }
 
 /*
@@ -107,12 +104,6 @@ open class EitherOfFour<FirstType, SecondType, ThirdType, FourthType>: EitherOfT
    */
   public func get() -> FourthType? {
     return value as? FourthType
-  }
-
-  // MARK: - Convertible
-
-  public override class func convert(from value: Any?) throws -> Self {
-    return value is FourthType ? Self(value) : try super.convert(from: value)
   }
 }
 

--- a/packages/expo-modules-core/ios/Tests/EitherSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EitherSpec.swift
@@ -40,6 +40,34 @@ final class EitherSpec: ExpoSpec {
       it("throws when converting from neither type") {
         expect({ try Either<String, Int>.convert(from: true) }).to(throwError(errorType: NeitherTypeException.self))
       }
+
+      it("supports arrays") {
+        let either = try Either<String, [String]>.convert(from: ["foo"])
+        let value: [String]? = either.get()
+
+        expect(either.is([String].self)) == true
+        expect(value) == ["foo"]
+      }
+
+      it("supports convertibles (UIColor)") {
+        let either = try Either<Int, UIColor>.convert(from: "blue")
+        let color: UIColor? = either.get()
+
+        expect(either.is(UIColor.self)) == true
+        expect(color?.cgColor.components) == CGColor(red: 0, green: 0, blue: 1, alpha: 1).components
+      }
+
+      it("supports records") {
+        struct TestRecord: Record {
+          @Field
+          var foo: String
+        }
+        let either = try Either<String, TestRecord>.convert(from: ["foo": "bar"])
+        let record: TestRecord? = either.get()
+
+        expect(either.is(TestRecord.self)) == true
+        expect(record?.foo) == "bar"
+      }
     }
     describe("EitherOfThree") {
       it("is the third type") {


### PR DESCRIPTION
# Why

On iOS `Either` types supported only primitive types, especially Records (and convertibles in general) were not supported.

# How

Now instead of doing simple `is` on each type, it tries to cast the value using the dynamic types.

# Test Plan

Added new tests that should confirm that Either types support arrays, records and convertibles