### PR TITLE
[image][ios] Support multiple sources for responsive images

### DIFF
--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -24,8 +24,13 @@ public final class ImageModule: Module {
         "onLoad"
       )
 
-      Prop("source") { (view, source: ImageSource) in
-        view.source = source
+      Prop("source") { (view, sourceSet: Either<ImageSource, [ImageSource]>) in
+        if let source: ImageSource = sourceSet.get() {
+          view.sources = [source]
+        }
+        if let sources: [ImageSource] = sourceSet.get() {
+          view.sources = sources
+        }
       }
 
       Prop("resizeMode") { (view, resizeMode: ImageResizeMode) in

--- a/packages/expo-image/ios/ImageSource.swift
+++ b/packages/expo-image/ios/ImageSource.swift
@@ -4,17 +4,21 @@ import ExpoModulesCore
 
 struct ImageSource: Record {
   @Field
-  var width: Double?
+  var width: Double = 0.0
 
   @Field
-  var height: Double?
+  var height: Double = 0.0
 
   @Field
-  var uri: URL?
+  var uri: URL? = nil
 
   @Field
   var scale: Double = 1.0
 
   @Field
   var headers: [String: String]?
+
+  var pixelCount: Double {
+    return width * height * scale * scale
+  }
 }


### PR DESCRIPTION
# Why

`source` prop should support an array of sources. In this case, the image view should choose the best source provided, whose size fits best into the view bounds. Different sources should have `width`, `height` and optionally `scale` provided so it's possible to calculate which source to use.

Closes ENG-6646

# How

Prop `source` now supports both, a single source object or an array of source objects. When `ImageView` loads the image, it picks the best source from the array. The best source is the one that has the closest number of pixels compared to the view frame.

# Test Plan

I played with an array of sources in the resizable image screen 👇 It seemed to work fine and compatible with the original RN image component. I'm thinking about a separate demo to show how it handles responsive images, I'd appreciate any suggestions!

```tsx
<Image
  style={styles.image}
  source={[
    { uri: `https://picsum.photos/seed/${seed}/1500/1000`, width: 1500, height: 1000 },
    { uri: `https://picsum.photos/id/237/500/500`, width: 500, height: 500 },
    { uri: `https://picsum.photos/id/236/300/300`, width: 300, height: 300 },
  ]}
  resizeMode={resizeMode}
/>
```