### PR TITLE
[av][gl] Fix duplicated META-INF files

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
 - Fixed crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
+- Fixed error for duplicated META-INF files when building on Android. ([#20251](https://github.com/expo/expo/pull/20251) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -131,7 +131,7 @@ android {
   packagingOptions {
     // Gradle will add cmake target dependencies into packaging.
     // Theses files are intermediated linking files to build reanimated and should not be in final package.
-    excludes = [
+    excludes += [
         "**/libc++_shared.so",
         "**/libreactnativejni.so",
         "**/libglog.so",

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))
+- Fixed error for duplicated META-INF files when building on Android. ([#20251](https://github.com/expo/expo/pull/20251) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -125,7 +125,7 @@ android {
 
   packagingOptions {
     // Gradle will add cmake target dependencies into packaging.
-    excludes = [
+    excludes += [
         "**/libc++_shared.so",
         "**/libjsi.so",
     ]


### PR DESCRIPTION
# Why

fix duplicated META-INF files when building the libraries
fix #20224

# How

append the exclusion rather than override the default exclusion rules. the default exclusion rules include the META-INF already: https://android.googlesource.com/platform/tools/base/+/mirror-goog-studio-main/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/packaging/PackagingOptionsUtils.kt#32

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
