### PR TITLE
[Docs] Android support for debug E2E testing example

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -491,7 +491,6 @@ const { openApp } = require('./utils/openApp');
 
 describe('Home screen', () => {
   beforeEach(async () => {
-    // await device.launchApp();
     /* @info New line */ await openApp(); /* @end */
   });
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -142,41 +142,57 @@ Edit **.detoxrc.json** and replace the configuration with:
   "runnerConfig": "e2e/config.json",
   "skipLegacyWorkersInjection": true,
   "apps": {
+    "ios.debug": {
+      "type": "ios.app",
+      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
+      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app"
+    },
+    "ios.release": {
+      "type": "ios.app",
+      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
+      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
+    },
+    "android.debug": {
+      "type": "android.apk",
+      "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
+      "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+    },
     "android.release": {
       "type": "android.apk",
       "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk"
-    },
-    "ios.release": {
-      "type": "ios.app",
-      /* @info This is project-specific, replace eastestsexample with correct value */
-      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
-      /* @end */
     }
   },
   "devices": {
+    "simulator": {
+      "type": "ios.simulator",
+      "device": {
+        "type": "iPhone 14"
+      }
+    },
     "emulator": {
       "type": "android.emulator",
       "device": {
         "avdName": "pixel_4"
       }
-    },
-    "simulator": {
-      "type": "ios.simulator",
-      "device": {
-        "type": "iPhone 11"
-      }
     }
   },
   "configurations": {
-    "android.release": {
-      "device": "emulator",
-      "app": "android.release"
+    "ios.debug": {
+      "device": "simulator",
+      "app": "ios.debug"
     },
     "ios.release": {
       "device": "simulator",
       "app": "ios.release"
+    },
+    "android.debug": {
+      "device": "emulator",
+      "app": "android.debug"
+    },
+    "android.release": {
+      "device": "emulator",
+      "app": "android.release"
     }
   }
 }
@@ -307,7 +323,7 @@ set -eox pipefail
 
 ANDROID_EMULATOR=pixel_4
 
-if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
+if [[ "$EAS_BUILD_PROFILE" == "test"* ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     # Start emulator
     $ANDROID_SDK_ROOT/emulator/emulator @$ANDROID_EMULATOR -no-audio -no-boot-anim -no-window -use-system-libs 2>&1 >/dev/null &

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -142,25 +142,19 @@ Edit **.detoxrc.json** and replace the configuration with:
   "runnerConfig": "e2e/config.json",
   "skipLegacyWorkersInjection": true,
   "apps": {
-    "ios.debug": {
-      "type": "ios.app",
-      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app"
-    },
     "ios.release": {
       "type": "ios.app",
+      /* @info This is project-specific, replace eastestsexample with correct value */
       "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
       "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
-    },
-    "android.debug": {
-      "type": "android.apk",
-      "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
-      "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+      /* @end */
     },
     "android.release": {
       "type": "android.apk",
+      /* @info This is project-specific, replace eastestsexample with correct value */
       "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
       "binaryPath": "android/app/build/outputs/apk/release/app-release.apk"
+      /* @end */
     }
   },
   "devices": {
@@ -178,17 +172,9 @@ Edit **.detoxrc.json** and replace the configuration with:
     }
   },
   "configurations": {
-    "ios.debug": {
-      "device": "simulator",
-      "app": "ios.debug"
-    },
     "ios.release": {
       "device": "simulator",
       "app": "ios.release"
-    },
-    "android.debug": {
-      "device": "emulator",
-      "app": "android.debug"
     },
     "android.release": {
       "device": "emulator",
@@ -530,7 +516,7 @@ describe('Home screen', () => {
 
 </Collapsible>
 
-<Collapsible summary="e2e/utils/openApp.js">
+<Collapsible summary="e2e/utils/openApp.js (new file)">
 
 ```js
 const appConfig = require('../../../app.json');
@@ -587,6 +573,151 @@ const getLatestUpdateUrl = () =>
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId ?? '';
 
 const sleep = t => new Promise(res => setTimeout(res, t));
+```
+
+</Collapsible>
+
+<Collapsible summary=".detoxrc.json">
+
+```json
+{
+  "testRunner": "jest",
+  "runnerConfig": "e2e/config.json",
+  "skipLegacyWorkersInjection": true,
+  "apps": {
+    /* @info New section */ "ios.debug": {
+      "type": "ios.app",
+      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
+      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app"
+    }, /* @end */
+    "ios.release": {
+      "type": "ios.app",
+      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
+      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
+    },
+    /* @info New section */ "android.debug": {
+      "type": "android.apk",
+      "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
+      "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk"
+    }, /* @end */
+    "android.release": {
+      "type": "android.apk",
+      "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
+      "binaryPath": "android/app/build/outputs/apk/release/app-release.apk"
+    }
+  },
+  "devices": {
+    "simulator": {
+      "type": "ios.simulator",
+      "device": {
+        "type": "iPhone 14"
+      }
+    },
+    "emulator": {
+      "type": "android.emulator",
+      "device": {
+        "avdName": "pixel_4"
+      }
+    }
+  },
+  "configurations": {
+    /* @info New section */ "ios.debug": {
+      "device": "simulator",
+      "app": "ios.debug"
+    }, /* @end */
+    "ios.release": {
+      "device": "simulator",
+      "app": "ios.release"
+    },
+    /* @info New section */ "android.debug": {
+      "device": "emulator",
+      "app": "android.debug"
+    }, /* @end */
+    "android.release": {
+      "device": "emulator",
+      "app": "android.release"
+    }
+  }
+}
+```
+</Collapsible>
+
+<Collapsible summary="eas-hooks/eas-build-on-success.sh">
+
+```sh
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+ANDROID_EMULATOR=pixel_4
+
+if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+  # Start emulator
+  $ANDROID_SDK_ROOT/emulator/emulator @$ANDROID_EMULATOR -no-audio -no-boot-anim -no-window -use-system-libs 2>&1 >/dev/null &
+
+  # Wait for emulator
+  max_retry=10
+  counter=0
+  until adb shell getprop sys.boot_completed; do
+    sleep 10
+    [[ counter -eq $max_retry ]] && echo "Failed to start the emulator!" && exit 1
+    counter=$((counter + 1))
+  done
+
+  if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
+    detox test --configuration android.release --headless
+  fi
+  ###### New section ######
+  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
+    detox test --configuration android.debug --headless
+  fi
+  #########################
+  # Kill emulator
+  adb emu kill
+else
+  if [[  "$EAS_BUILD_PROFILE" == "test" ]]; then
+    detox test --configuration ios.release --headless
+  fi
+  ###### New section ######
+  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
+    detox test --configuration ios.debug --headless
+  fi
+  #########################
+fi
+```
+
+</Collapsible>
+
+<Collapsible summary="eas.json">
+
+```json
+{
+  "build": {
+    "test": {
+      "android": {
+        "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
+        "withoutCredentials": true
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
+    /* @info New section */ "test_debug": {
+      "android": {
+        "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
+        "withoutCredentials": true
+      },
+      "ios": {
+        "buildConfiguration": "Debug",
+        "simulator": true
+      },
+      "env": {
+        "EXPO_USE_UPDATES": "1"
+      },
+      "channel": "test_debug"
+    } /* @end */
+  }
+}
 ```
 
 </Collapsible>

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -475,8 +475,6 @@ The full example from this guide is available at https://github.com/expo/eas-tes
 
 ### Using development builds to speed up test run time
 
-> **Warning** This might not work properly on Android.
-
 The above guide explains how to run E2E tests against a release build of your project, which requires executing a full native build before each test run. Re-building the native app each time you run E2E tests may not be desirable if only the project JavaScript or assets have changed. However, this is necessary for release builds because the app JavaScript bundle is embedded into the binary.
 
 Instead, we can use [development builds](/development/introduction/) to load from a local development server or from [published updates](/eas-update/introduction/) to save time and CI resources. This can be done by having your E2E test runner invoke the app with a URL that points to a specific update bundle URL, as described in the [development builds deep linking URLs guide](/development/development-workflows/#deep-linking-urls).
@@ -486,18 +484,15 @@ Development builds typically display an onboarding welcome screen when an app is
 An example of such a Detox test is shown below. Full example code is available on the [eas-tests-example](https://github.com/expo/eas-tests-example) repository.
 
 <Collapsible summary="e2e/homeScreen.e2e.js">
-
 ```js
 /* @info New line */
-const { openAppForDebugBuild } = require('./utils/openAppForDebugBuild');
+const { openApp } = require('./utils/openApp');
 /* @end */
 
 describe('Home screen', () => {
   beforeEach(async () => {
-    await device.launchApp({
-      newInstance: true,
-    });
-    /* @info New line */ await openAppForDebugBuild(); /* @end */
+    // await device.launchApp();
+    /* @info New line */ await openApp(); /* @end */
   });
 
   it('"Click me" button should be visible', async () => {
@@ -513,25 +508,46 @@ describe('Home screen', () => {
 
 </Collapsible>
 
-<Collapsible summary="e2e/utils/openAppForDebugBuild.js">
+<Collapsible summary="e2e/utils/openApp.js">
 
 ```js
 const appConfig = require('../../../app.json');
 
-module.exports.openAppForDebugBuild = async function openAppForDebugBuild() {
+module.exports.openApp = async function openApp() {
   const [platform, target] = process.env.DETOX_CONFIGURATION.split('.');
-  if (target !== 'debug') {
-    return;
+  if (target === 'debug') {
+    return await openAppForDebugBuild(platform);
+  } else {
+    return await device.launchApp({
+      newInstance: true,
+    });
+  }
+}
+
+async function openAppForDebugBuild(platform) {
+  const deepLinkUrl = process.env.EXPO_USE_UPDATES
+    ? // Testing latest published EAS update for the test_debug channel
+      getDeepLinkUrl(getLatestUpdateUrl())
+    : // Local testing with packager
+      getDeepLinkUrl(getDevLauncherPackagerUrl(platform));
+
+  if (platform === 'ios') {
+    // For iOS, the app must be launched, then the deep link URL invoked
+    await device.launchApp({
+      newInstance: true,
+    });
+    sleep(3000);
+    await device.openURL({
+      url: deepLinkUrl,
+    });
+  } else {
+    // For Android, the app must be launched directly with the deep link URL
+    await device.launchApp({
+      newInstance: true,
+      url: deepLinkUrl,
+    });
   }
 
-  await sleep(1000);
-  await device.openURL({
-    url: process.env.EXPO_USE_UPDATES
-      ? // Testing latest published EAS update for the test_debug channel
-        getDeepLinkUrl(getLatestUpdateUrl())
-      : // Local testing with packager
-        getDeepLinkUrl(getDevLauncherPackagerUrl(platform)),
-  });
   await sleep(3000);
 };
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -323,27 +323,34 @@ set -eox pipefail
 
 ANDROID_EMULATOR=pixel_4
 
-if [[ "$EAS_BUILD_PROFILE" == "test"* ]]; then
-  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
-    # Start emulator
-    $ANDROID_SDK_ROOT/emulator/emulator @$ANDROID_EMULATOR -no-audio -no-boot-anim -no-window -use-system-libs 2>&1 >/dev/null &
+if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+  # Start emulator
+  $ANDROID_SDK_ROOT/emulator/emulator @$ANDROID_EMULATOR -no-audio -no-boot-anim -no-window -use-system-libs 2>&1 >/dev/null &
 
-    # Wait for emulator
-    max_retry=10
-    counter=0
-    until adb shell getprop sys.boot_completed; do
-      sleep 10
-      [[ counter -eq $max_retry ]] && echo "Failed to start the emulator!" && exit 1
-      counter=$((counter + 1))
-    done
+  # Wait for emulator
+  max_retry=10
+  counter=0
+  until adb shell getprop sys.boot_completed; do
+    sleep 10
+    [[ counter -eq $max_retry ]] && echo "Failed to start the emulator!" && exit 1
+    counter=$((counter + 1))
+  done
 
-    # Run tests
+  if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
     detox test --configuration android.release --headless
+  fi
+  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
+    detox test --configuration android.debug --headless
+  fi
 
-    # Kill emulator
-    adb emu kill
-  else
+  # Kill emulator
+  adb emu kill
+else
+  if [[  "$EAS_BUILD_PROFILE" == "test" ]]; then
     detox test --configuration ios.release --headless
+  fi
+  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
+    detox test --configuration ios.debug --headless
   fi
 fi
 ```


### PR DESCRIPTION
# Why

Update the example code added in #19196 to support E2E testing for both iOS and Android debug builds.

# How

Copied the new fully tested example code from https://github.com/expo/eas-tests-example/pull/5

# Test Plan

Tested the changes to `eas-tests-example` on EAS with the different build profiles and platforms.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
