### PR TITLE
[docs] EAS Build - update npm version

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -67,7 +67,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 11
 
 </Collapsible>
@@ -81,7 +81,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 8
 
 </Collapsible>
@@ -95,7 +95,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 11
 
 </Collapsible>
@@ -109,7 +109,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 8
 
 </Collapsible>
@@ -123,7 +123,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 11
 
 </Collapsible>
@@ -137,7 +137,7 @@ Android workers run on Kubernetes in an isolated environment. Every build gets i
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - Java 8
 
 </Collapsible>
@@ -176,7 +176,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.15.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.210.1
 - CocoaPods 1.11.3
 - Ruby 2.7
@@ -192,7 +192,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.11.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.210.0
 - CocoaPods 1.11.3
 - Ruby 2.7
@@ -208,7 +208,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
@@ -224,7 +224,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.205.2
 - CocoaPods 1.11.3
 - Ruby 2.7
@@ -240,7 +240,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.201.0
 - CocoaPods 1.11.2
 - Ruby 2.7
@@ -256,7 +256,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.185.1
 - CocoaPods 1.10.1
 - Ruby 2.7
@@ -272,7 +272,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Node.js 16.18.1
 - Yarn 1.22.17
 - pnpm 7.0.0
-- npm 8.1.2
+- npm 8.19.2
 - fastlane 2.185.1
 - CocoaPods 1.10.1
 - Ruby 2.7


### PR DESCRIPTION
# Why

In https://github.com/expo/expo/pull/20246 I forgot that npm version was also updated. Update npm version in docs to 8.19.2

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
