### PR TITLE
[tracking-transparency][iOS] Run methods on the main thread

### DIFF
--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash caused by accessing UIApplication apis off the main thread. ([#20272](https://github.com/expo/expo/pull/20272) by [@cltnschlosser](https://github.com/cltnschlosser))
+
 ### 💡 Others
 
 ## 3.3.0 — 2023-11-14

--- a/packages/expo-tracking-transparency/ios/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/TrackingTransparencyModule.swift
@@ -22,6 +22,7 @@ public class TrackingTransparencyModule: Module {
         reject: promise.legacyRejecter
       )
     }
+    .runOnQueue(.main)
 
     AsyncFunction("requestPermissionsAsync") { (promise: Promise) in
       EXPermissionsMethodsDelegate.askForPermission(
@@ -31,5 +32,6 @@ public class TrackingTransparencyModule: Module {
         reject: promise.legacyRejecter
       )
     }
+    .runOnQueue(.main)
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/20271

# How

Added `.runOnQueue(.main)` for expo-tracking-transparency module.

# Test Plan

`yarn ios` in `apps/bare-expo`
![Simulator Screen Shot - iPhone 14 - 2022-11-30 at 10 01 04](https://user-images.githubusercontent.com/1498529/204847391-c603b42a-9bd5-4ff2-b9d0-6c880f14feb8.png)


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
