### PR TITLE
[updates] Prevent launch ANR by delayed loadApp

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- Added `ReactActivityHandler.getDelayLoadAppHandler` interface on Android. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -30,6 +30,10 @@ ext.applyKotlinExpoModulesCorePlugin = {
   apply plugin: KotlinExpoModulesCorePlugin
 }
 
+ext.boolish = { value ->
+  return value.toString().toBoolean()
+}
+
 // [BEGIN] Remove when we drop SDK 47
 abstract class ExtractReactNativeAARTask extends DefaultTask {
   @Input

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityHandler.java
@@ -6,6 +6,7 @@ import android.view.ViewGroup;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactRootView;
 
 import androidx.annotation.Nullable;
@@ -53,5 +54,18 @@ public interface ReactActivityHandler {
   @Nullable
   default ReactActivityDelegate onDidCreateReactActivityDelegate(ReactActivity activity, ReactActivityDelegate delegate) {
     return null;
+  }
+
+  /**
+   * For modules to delay the call for react-native `loadApp`.
+   * This gives modules a chance to do some early and heavy initialization in background thread and avoid ANR.
+   * Right now it is for expo-updates only.
+   */
+  @Nullable
+  default DelayLoadAppHandler getDelayLoadAppHandler(ReactActivity activity, ReactNativeHost reactNativeHost) {
+    return null;
+  }
+  interface DelayLoadAppHandler {
+    void whenReady(Runnable runnable);
   }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- [Android] Load updates in background thread and prevent ANR from initial launch. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -82,11 +82,9 @@ android {
     versionName '0.17.0'
     consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
 
-    // Enable experimented delay loadApp
-    // toBoolean() first for supporting truthy value, e.g. `expo.delayLoadApp=1` or `expo.delayLoadApp=TRUE`
-    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", findProperty("expo.delayLoadApp").toString().toBoolean().toString())
+    buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
+    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", boolish(findProperty("EX_UPDATES_ANDROID_DELAY_LOAD_APP") ?: true).toString())
 
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -83,6 +83,11 @@ android {
     consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
+
+    // Enable experimented delay loadApp
+    // toBoolean() first for supporting truthy value, e.g. `expo.delayLoadApp=1` or `expo.delayLoadApp=TRUE`
+    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", findProperty("expo.delayLoadApp").toString().toBoolean().toString())
+
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {
       annotationProcessorOptions {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -4,11 +4,20 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import androidx.annotation.UiThread
+import androidx.annotation.WorkerThread
+import com.facebook.react.ReactActivity
 import com.facebook.react.ReactInstanceManager
+import com.facebook.react.ReactNativeHost
 import expo.modules.core.ExportedModule
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.InternalModule
+import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactNativeHostHandler
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
@@ -20,6 +29,9 @@ import expo.modules.updates.UpdatesController
  * applicable environments.
  */
 class UpdatesPackage : Package {
+  private val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
+  private var mShouldAutoSetup: Boolean? = null
+
   override fun createInternalModules(context: Context): List<InternalModule> {
     return listOf(UpdatesService(context) as InternalModule)
   }
@@ -29,9 +41,7 @@ class UpdatesPackage : Package {
   }
 
   override fun createReactNativeHostHandlers(context: Context): List<ReactNativeHostHandler> {
-    val useNativeDebug = BuildConfig.EX_UPDATES_NATIVE_DEBUG
     val handler: ReactNativeHostHandler = object : ReactNativeHostHandler {
-      private var mShouldAutoSetup: Boolean? = null
 
       override fun getJSBundleFile(useDeveloperSupport: Boolean): String? {
         return if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) UpdatesController.instance.launchAssetFile else null
@@ -55,23 +65,61 @@ class UpdatesPackage : Package {
         }
         // WHEN_VERSIONING_REMOVE_TO_HERE
       }
-
-      @UiThread
-      private fun shouldAutoSetup(context: Context): Boolean {
-        if (mShouldAutoSetup == null) {
-          mShouldAutoSetup = try {
-            val pm = context.packageManager
-            val ai = pm.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-            ai.metaData.getBoolean("expo.modules.updates.AUTO_SETUP", true)
-          } catch (e: Exception) {
-            Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e)
-            true
-          }
-        }
-        return mShouldAutoSetup!!
-      }
     }
     return listOf(handler)
+  }
+
+  override fun createReactActivityHandlers(activityContext: Context): List<ReactActivityHandler> {
+    val handler = object : ReactActivityHandler {
+      override fun getDelayLoadAppHandler(activity: ReactActivity, reactNativeHost: ReactNativeHost): ReactActivityHandler.DelayLoadAppHandler? {
+        if (!BuildConfig.EX_UPDATES_ANDROID_DELAY_LOAD_APP) {
+          return null
+        }
+        val context = activity.applicationContext
+        val useDeveloperSupport = reactNativeHost.useDeveloperSupport
+        if (shouldAutoSetup(context) && (useNativeDebug || !useDeveloperSupport)) {
+          return ReactActivityHandler.DelayLoadAppHandler { whenReadyRunnable ->
+            CoroutineScope(Dispatchers.IO).launch {
+              startUpdatesController(context)
+              invokeReadyRunnable(whenReadyRunnable)
+            }
+          }
+        }
+        return null
+      }
+
+      @WorkerThread
+      private suspend fun startUpdatesController(context: Context) {
+        withContext(Dispatchers.IO) {
+          UpdatesController.initialize(context)
+          // Call the synchronous `launchAssetFile()` function to wait for updates ready
+          UpdatesController.instance.launchAssetFile
+        }
+      }
+
+      @UiThread
+      private suspend fun invokeReadyRunnable(whenReadyRunnable: Runnable) {
+        withContext(Dispatchers.Main) {
+          whenReadyRunnable.run()
+        }
+      }
+    }
+
+    return listOf(handler)
+  }
+
+  private fun shouldAutoSetup(context: Context): Boolean {
+    if (mShouldAutoSetup == null) {
+      mShouldAutoSetup = try {
+        val pm = context.packageManager
+        val ai = pm.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
+        ai.metaData.getBoolean("expo.modules.updates.AUTO_SETUP", true)
+      } catch (e: Exception) {
+        Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e)
+        true
+      }
+    }
+    return mShouldAutoSetup!!
   }
 
   companion object {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- Added `ReactActivityHandler.getDelayLoadAppHandler` interface on Android. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others


### PR DESCRIPTION
# Why

experimenting solution for expo-updates ANR mentioned in #19918
close ENG-7652

# How

in #19918 case, the app has a large number of assets. when the app is updated from google play store, expo-updates will copy these assets from app internal storage (apk/aab) to file system and also doing database updates / asset checksums. that may take longer time.

there is a main thread lock in [`UpdatesController.launchAssetFile`](https://github.com/expo/expo/blob/c0e29be13c8d012256bdd6fd2ec751f78a8ab7c6/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt#L148) to wait for loading finish. it is the root cause of ANR.

after visiting several ways toward the problem, this pr is my last attempt - to delay the call to react-native's `loadApp`. at this point, we can initialize expo-updates and do some heavy work in the background thread. since we don't call `setContentView(ReactRootView)`, expo-splash-screen will keep the splash screen showing. at this result, even splash screen is there, we can still send touch events and back key without ANR.

## Note
the solution is getting a little tricky and is still experimenting. to disable this feature, please add `EX_UPDATES_ANDROID_DELAY_LOAD_APP=false` to gradle.properties.

# Test Plan

- ci passed
- test eas update from the build geneated through `./gradlew :app:assembleRelease` 

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
