### PR TITLE
[cli] fix getting UDID for network connected iOS devices

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))
-- Fix getting UDID for network connected iOS devices.
+- Fix getting UDID for network connected iOS devices. ([#20279](https://github.com/expo/expo/pull/20279) by [@Simek](https://github.com/Simek))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))
+- Fix getting UDID for network connected iOS devices.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -24,6 +24,8 @@ export interface ConnectedDevice {
   model: string;
   /** @example `device` */
   deviceType: 'device' | 'catalyst';
+  /** @example `USB` */
+  connectionType: 'USB' | 'Network';
   /** @example `15.4.1` */
   osVersion: string;
 }
@@ -37,6 +39,7 @@ export async function getConnectedDevicesAsync(): Promise<ConnectedDevice[]> {
     model: device.ProductType,
     osVersion: device.ProductVersion,
     deviceType: 'device',
+    connectionType: device.ConnectionType,
     udid: device.UniqueDeviceID,
   }));
 }
@@ -55,7 +58,11 @@ export async function getConnectedDeviceValuesAsync(): Promise<DeviceValues[]> {
       );
       const deviceValue = await new LockdowndClient(socket).getAllValues();
       socket.end();
-      return deviceValue;
+      return {
+        ...deviceValue,
+        ConnectionType: device.Properties.ConnectionType,
+        UniqueDeviceID: device.Properties.UDID ?? device.Properties.SerialNumber,
+      };
     })
   );
 }

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -61,7 +61,7 @@ export async function getConnectedDeviceValuesAsync(): Promise<DeviceValues[]> {
       return {
         ...deviceValue,
         ConnectionType: device.Properties.ConnectionType,
-        UniqueDeviceID: device.Properties.UDID ?? device.Properties.SerialNumber,
+        UniqueDeviceID: device.Properties.SerialNumber,
       };
     })
   );

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -27,6 +27,7 @@ export interface DeviceValues {
   BoardId: number;
   BuildVersion: string;
   ChipID: number;
+  ConnectionType: 'USB' | 'Network';
   DeviceClass: string;
   DeviceColor: string;
   DeviceName: string;

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
@@ -17,31 +17,52 @@ import { ResponseError, ServiceClient } from './ServiceClient';
 const debug = Debug('expo:apple-device:client:usbmuxd');
 
 export interface UsbmuxdDeviceProperties {
-  /** 480000000 */
-  ConnectionSpeed?: number;
-  /** 'USB' */
+  /** @example 'USB' */
   ConnectionType: 'USB' | 'Network';
-  /** 7 */
+  /** @example 7 */
   DeviceID: number;
-  /** 339738624 */
+  /** @example 339738624 */
   LocationID?: number;
-  /** 4776 */
-  ProductID?: number;
-  /** '00008101-001964A22629003A' */
+  /** @example '00008101-001964A22629003A' */
   SerialNumber: string;
-  /** '00008101-001964A22629003A' */
+  /**
+   * Only available for USB connection.
+   * @example 480000000
+   */
+  ConnectionSpeed?: number;
+  /**
+   * Only available for USB connection.
+   * @example 4776
+   */
+  ProductID?: number;
+  /**
+   * Only available for USB connection.
+   * @example '00008101-001964A22629003A'
+   */
   UDID?: string;
-  /** '00008101001964A22629003A' */
+  /**
+   * Only available for USB connection.
+   * @example '00008101001964A22629003A'
+   */
   USBSerialNumber?: string;
-  /** '08:c7:29:05:f2:30@fe80::ac7:29ff:fe05:f230-supportsRP._apple-mobdev2._tcp.local.' */
+  /**
+   * Only available for Network connection.
+   * @example '08:c7:29:05:f2:30@fe80::ac7:29ff:fe05:f230-supportsRP._apple-mobdev2._tcp.local.'
+   */
   EscapedFullServiceName?: string;
-  /** 5 **/
+  /**
+   * Only available for Network connection.
+   * @example 5
+   */
   InterfaceIndex?: number;
+  /**
+   * Only available for Network connection.
+   */
   NetworkAddress?: Buffer;
 }
 
 export interface UsbmuxdDevice {
-  /** 7 */
+  /** @example 7 */
   DeviceID: number;
   MessageType: 'Attached'; // TODO: what else?
   Properties: UsbmuxdDeviceProperties;

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/UsbmuxdClient.ts
@@ -18,21 +18,26 @@ const debug = Debug('expo:apple-device:client:usbmuxd');
 
 export interface UsbmuxdDeviceProperties {
   /** 480000000 */
-  ConnectionSpeed: number;
+  ConnectionSpeed?: number;
   /** 'USB' */
-  ConnectionType: 'USB';
+  ConnectionType: 'USB' | 'Network';
   /** 7 */
   DeviceID: number;
   /** 339738624 */
-  LocationID: number;
+  LocationID?: number;
   /** 4776 */
-  ProductID: number;
+  ProductID?: number;
   /** '00008101-001964A22629003A' */
   SerialNumber: string;
   /** '00008101-001964A22629003A' */
-  UDID: string;
+  UDID?: string;
   /** '00008101001964A22629003A' */
-  USBSerialNumber: string;
+  USBSerialNumber?: string;
+  /** '08:c7:29:05:f2:30@fe80::ac7:29ff:fe05:f230-supportsRP._apple-mobdev2._tcp.local.' */
+  EscapedFullServiceName?: string;
+  /** 5 **/
+  InterfaceIndex?: number;
+  NetworkAddress?: Buffer;
 }
 
 export interface UsbmuxdDevice {

--- a/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/promptDevice-test.ts
@@ -2,16 +2,30 @@ import { stripAnsi } from '../../../../utils/ansi';
 import { formatDeviceChoice } from '../promptDevice';
 
 describe(formatDeviceChoice, () => {
-  it(`formats connected device`, () => {
+  it(`formats USB connected device`, () => {
     const option = formatDeviceChoice({
       name: "Evan's phone",
       model: 'iPhone13,4',
       osVersion: '15.4.1',
       deviceType: 'device',
+      connectionType: 'USB',
       udid: '00008101-001964A22629003A',
     });
 
     expect(stripAnsi(option.title)).toEqual(`🔌 Evan's phone (15.4.1)`);
+    expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
+  });
+  it(`formats network connected device`, () => {
+    const option = formatDeviceChoice({
+      name: "Evan's phone",
+      model: 'iPhone13,4',
+      osVersion: '15.4.1',
+      deviceType: 'device',
+      connectionType: 'Network',
+      udid: '00008101-001964A22629003A',
+    });
+
+    expect(stripAnsi(option.title)).toEqual(`🌐 Evan's phone (15.4.1)`);
     expect(stripAnsi(option.value)).toEqual('00008101-001964A22629003A');
   });
   it(`formats active simulator`, () => {

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveDevice-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveDevice-test.ts
@@ -24,6 +24,7 @@ jest.mock('../../appleDevice/AppleDevice', () => ({
       model: 'iPhone13,4',
       osVersion: '15.4.1',
       deviceType: 'device',
+      connectionType: 'USB',
       udid: '00008101-001964A22629003A',
     },
   ]),

--- a/packages/@expo/cli/src/run/ios/options/promptDevice.ts
+++ b/packages/@expo/cli/src/run/ios/options/promptDevice.ts
@@ -18,7 +18,7 @@ function isSimControlDevice(item: AnyDevice): item is SimControl.Device {
 export function formatDeviceChoice(item: AnyDevice): { title: string; value: string } {
   const isConnected = isConnectedDevice(item) && item.deviceType === 'device';
   const isActive = isSimControlDevice(item) && item.state === 'Booted';
-  const symbol = isConnected ? '🔌 ' : '';
+  const symbol = isConnected ? (item.connectionType === 'Network' ? '🌐 ' : '🔌 ') : '';
   const format = isActive ? chalk.bold : (text: string) => text;
   return {
     title: `${symbol}${format(item.name)}${


### PR DESCRIPTION
# Why

Fixes ENG-6617
Fixes ENG-6650
Fixes #19191
Superseeds #20188

# How

This PR ensures that network connect iOS devices have the correct UDID set, while fetching them via `UsbmuxdClient`.

# Test Plan

The fix has been tested locally with a fresh app. I was able to select the network device and run the app just like it through the USB cord.

I have also added a simple test for the promt list and ensured that all test are still passing.

# Preview

<img width="528" alt="Screenshot 2022-12-01 at 12 38 02" src="https://user-images.githubusercontent.com/719641/205043863-c9bdf22e-40de-462c-be0d-52619ee0b895.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
