### PR TITLE
[docs] TaskManager: update example, other small tweaks

### DIFF
--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -30,14 +30,14 @@ Some features of this module are used by other modules under the hood. Here is a
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your **app.json** configuration.
 Here is an example of an **app.json** configuration that enables background location and background fetch:
 
-```json
+```json app.json
 {
   "expo": {
-    ...
+    /* @hide ... */ /* @end */
     "ios": {
-      ...
+      /* @hide ... */ /* @end */
       "infoPlist": {
-        ...
+        /* @hide ... */ /* @end */
         "UIBackgroundModes": [
           "location",
           "fetch"
@@ -52,29 +52,32 @@ For bare React Native apps, you need to add those keys manually. You can do it b
 
 ## Example
 
-<SnackInline dependencies={["expo-task-manager", "expo-location"]}>
+<SnackInline dependencies={["expo-task-manager", "expo-location"]} platforms={['android', 'ios']}>
 
-```javascript
+```jsx
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { Button, View, StyleSheet } from 'react-native';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
 
 const LOCATION_TASK_NAME = 'background-location-task';
 
 const requestPermissions = async () => {
-  const { status } = await Location.requestPermissionsAsync();
-  if (status === 'granted') {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+  const { status: foregroundStatus } = await Location.requestForegroundPermissionsAsync();
+  if (foregroundStatus === 'granted') {
+    const { status: backgroundStatus } = await Location.requestBackgroundPermissionsAsync();
+    if (backgroundStatus === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   }
 };
 
 const PermissionsButton = () => (
-  <TouchableOpacity onPress={requestPermissions}>
-    <Text>Enable background location</Text>
-  </TouchableOpacity>
+  <View style={styles.container}>
+    <Button onPress={requestPermissions} title="Enable background location" />
+  </View>
 );
 
 TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
@@ -87,6 +90,16 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
     // do something with the locations captured in the background
   }
 });
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});
+/* @end */
 
 export default PermissionsButton;
 ```

--- a/docs/pages/versions/v47.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/task-manager.mdx
@@ -30,14 +30,14 @@ Some features of this module are used by other modules under the hood. Here is a
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your **app.json** configuration.
 Here is an example of an **app.json** configuration that enables background location and background fetch:
 
-```json
+```json app.json
 {
   "expo": {
-    ...
+    /* @hide ... */ /* @end */
     "ios": {
-      ...
+      /* @hide ... */ /* @end */
       "infoPlist": {
-        ...
+        /* @hide ... */ /* @end */
         "UIBackgroundModes": [
           "location",
           "fetch"
@@ -52,29 +52,32 @@ For bare React Native apps, you need to add those keys manually. You can do it b
 
 ## Example
 
-<SnackInline dependencies={["expo-task-manager", "expo-location"]}>
+<SnackInline dependencies={["expo-task-manager", "expo-location"]} platforms={['android', 'ios']}>
 
-```javascript
+```jsx
 import React from 'react';
-import { Text, TouchableOpacity } from 'react-native';
+import { Button, View, StyleSheet } from 'react-native';
 import * as TaskManager from 'expo-task-manager';
 import * as Location from 'expo-location';
 
 const LOCATION_TASK_NAME = 'background-location-task';
 
 const requestPermissions = async () => {
-  const { status } = await Location.requestPermissionsAsync();
-  if (status === 'granted') {
-    await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
-      accuracy: Location.Accuracy.Balanced,
-    });
+  const { status: foregroundStatus } = await Location.requestForegroundPermissionsAsync();
+  if (foregroundStatus === 'granted') {
+    const { status: backgroundStatus } = await Location.requestBackgroundPermissionsAsync();
+    if (backgroundStatus === 'granted') {
+      await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
+        accuracy: Location.Accuracy.Balanced,
+      });
+    }
   }
 };
 
 const PermissionsButton = () => (
-  <TouchableOpacity onPress={requestPermissions}>
-    <Text>Enable background location</Text>
-  </TouchableOpacity>
+  <View style={styles.container}>
+    <Button onPress={requestPermissions} title="Enable background location" />
+  </View>
 );
 
 TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
@@ -87,6 +90,16 @@ TaskManager.defineTask(LOCATION_TASK_NAME, ({ data, error }) => {
     // do something with the locations captured in the background
   }
 });
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center'
+  }
+});
+/* @end */
 
 export default PermissionsButton;
 ```


### PR DESCRIPTION
# Why

Fixes #19471

# How

Update the `TaskManager` example to use the new permission fetchers instead of the deprecated one. Change have also been backported to the latest SDK.

I have additionally made a few visual oriented tweaks in the code and configuration example.

# Test Plan

The changes have been tested by running the docs app locally. Example have been tested in Snack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
