### PR TITLE
[iOS][media-library] Rename media library module

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Renamed the module on iOS to match the name used on Android. ([#20283](https://github.com/expo/expo/pull/20283) by [@alanhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 15.0.0 — 2022-10-25

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -42,7 +42,7 @@ NSString *const EXMediaLibraryShouldDownloadFromNetworkKey = @"shouldDownloadFro
 
 @implementation EXMediaLibrary
 
-EX_EXPORT_MODULE(ExponentMediaLibrary);
+EX_EXPORT_MODULE(ExpoMediaLibrary);
 
 - (instancetype) init
 {


### PR DESCRIPTION
# Why
Media library was migrated to the new modules API on android and the name was changed to ExpoMediaLibrary. This change needs to also be made on iOS or it will break the bare test app

# How
Changed the module name

# Test Plan
Ran the test app and the module is found correctly
