### PR TITLE
Simplify linear gradient on Web

### DIFF
--- a/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
@@ -44,7 +44,6 @@ export default function NativeLinearGradient({
           
           return oldLayout
         });
-        
 
         if (props.onLayout) {
           props.onLayout(event);

--- a/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.web.tsx
@@ -11,9 +11,10 @@ export default function NativeLinearGradient({
   endPoint,
   ...props
 }: NativeLinearGradientProps): React.ReactElement {
-  const [layout, setLayout] = React.useState<LayoutRectangle | null>(null);
-
-  const { width = 1, height = 1 } = layout ?? {};
+  const [{ height, width }, setLayout] = React.useState({
+    height: 1,
+    width: 1
+  });
 
   // TODO(Bacon): In the future we could consider adding `backgroundRepeat: "no-repeat"`. For more
   // browser support.
@@ -31,16 +32,19 @@ export default function NativeLinearGradient({
       ]}
       onLayout={(event) => {
         const { x, y, width, height } = event.nativeEvent.layout;
-        const oldLayout = layout ?? { x: 0, y: 0, width: 1, height: 1 };
-        // don't set new layout state unless the layout has actually changed
-        if (
-          x !== oldLayout.x ||
-          y !== oldLayout.y ||
-          width !== oldLayout.width ||
-          height !== oldLayout.height
-        ) {
-          setLayout({ x, y, width, height });
-        }
+        
+        setLayout(oldLayout => {        
+          // don't set new layout state unless the layout has actually changed
+          if (
+            width !== oldLayout.width ||
+            height !== oldLayout.height
+          ) {
+            return { height, width }
+          }
+          
+          return oldLayout
+        });
+        
 
         if (props.onLayout) {
           props.onLayout(event);


### PR DESCRIPTION
# Why

LinearGradient might re-render from `onLayout` unnecessarily.

# How

1. Updating state now uses the callback instead of reading in current state.
2. Only `height` and `width` are used, so only re-render when these update.
3. Initial state works functionally the same as the current behavior.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
