### PR TITLE
Add configuration explanations for location module

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -59,8 +59,8 @@ Apple App Store review guidelines require [detailed justification](https://devel
         locationAlwaysAndWhenInUsePermission: 'string',
         locationAlwaysPermission: 'string',
         locationWhenInUsePermission: 'string',
-        isIosBackgroundLocationEnabled: 'string',
-        isAndroidBackgroundLocationEnabled: 'string',
+        isIosBackgroundLocationEnabled: false,
+        isAndroidBackgroundLocationEnabled: false,
       }]
   ]
 ```

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -49,6 +49,22 @@ Another example can be stated using [available location accuracies](#accuracy). 
 
 To learn more on how to exclude a permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
 
+### iOS Permissions
+
+Apple App Store review guidelines require [detailed justification](https://developer.apple.com/design/human-interface-guidelines/patterns/accessing-private-data#requesting-permission) for requesting location access. This library includes default request strings but it is unlikely they will be sufficient to pass app review. Use the [config plugin](/guides/config-plugins/) to specify customized strings for inclusion in `Info.plist`:
+
+```js
+  "plugins": [
+      ["expo-location", {
+        locationAlwaysAndWhenInUsePermission: 'string',
+        locationAlwaysPermission: 'string',
+        locationWhenInUsePermission: 'string',
+        isIosBackgroundLocationEnabled: 'string',
+        isAndroidBackgroundLocationEnabled: 'string',
+      }]
+  ]
+```
+
 ### Background Location Methods
 
 To use Background Location methods, the following requirements apply:

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -34,20 +34,6 @@ Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` keys to your `
 
 Run `npx pod-install` after installing the npm package.
 
-#### Alternative: Configure with config plugin
-
-```js
-  "plugins": [
-      ["expo-location", {
-        locationAlwaysAndWhenInUsePermission: 'string',
-        locationAlwaysPermission: 'string',
-        locationWhenInUsePermission: 'string',
-        isIosBackgroundLocationEnabled: 'string',
-        isAndroidBackgroundLocationEnabled: 'string',
-      }]
-  ]
-```
-
 ### Configure for Android
 
 This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO`.

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -34,6 +34,20 @@ Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` keys to your `
 
 Run `npx pod-install` after installing the npm package.
 
+#### Alternative: Configure with config plugin
+
+```js
+  "plugins": [
+      ["expo-location", {
+        locationAlwaysAndWhenInUsePermission: 'string',
+        locationAlwaysPermission: 'string',
+        locationWhenInUsePermission: 'string',
+        isIosBackgroundLocationEnabled: 'string',
+        isAndroidBackgroundLocationEnabled: 'string',
+      }]
+  ]
+```
+
 ### Configure for Android
 
 This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO`.

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Add config plugin documentation. ([#20290](https://github.com/expo/expo/pull/20290) by [@bradjones1](https://github.com/bradjones1))
+
 ## 15.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -36,6 +36,20 @@ Add `NSLocationAlwaysAndWhenInUseUsageDescription`, `NSLocationAlwaysUsageDescri
 
 Run `npx pod-install` after installing the npm package.
 
+#### Alternative: Configure with config plugin
+
+```js
+  "plugins": [
+      ["expo-location", {
+        locationAlwaysAndWhenInUsePermission: 'string',
+        locationAlwaysPermission: 'string',
+        locationWhenInUsePermission: 'string',
+        isIosBackgroundLocationEnabled: 'string',
+        isAndroidBackgroundLocationEnabled: 'string',
+      }]
+  ]
+```
+
 ### Configure for Android
 
 This module requires the permissions for approximate and exact device location. It also needs the foreground service permission to subscribe to location updates, while the app is in use. These permissions are automatically added.

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -44,8 +44,8 @@ Run `npx pod-install` after installing the npm package.
         locationAlwaysAndWhenInUsePermission: 'string',
         locationAlwaysPermission: 'string',
         locationWhenInUsePermission: 'string',
-        isIosBackgroundLocationEnabled: 'string',
-        isAndroidBackgroundLocationEnabled: 'string',
+        isIosBackgroundLocationEnabled: false,
+        isAndroidBackgroundLocationEnabled: false,
       }]
   ]
 ```


### PR DESCRIPTION
# Why

The default permissions strings from Location aren't sufficient for iOS production app review, so encourage developers to configure these strings.

# How

Discovered that Location has a basically undocumented config plugin and use it.

# Test Plan

Review docs for correctness/completeness.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).