### PR TITLE
[docs][expo-updates] Clarify "extra" field in expo-updates protocol

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/technical-specs/expo-updates-0.mdx
@@ -135,7 +135,7 @@ type Asset = {
     A conforming client SHOULD prefix a file extension with a `.` if a file extension is not empty and missing the `.` prefix.
   - `url`: Location at which the file may be fetched.
 - `metadata`: The metadata associated with an update. It is a string-valued dictionary. The server MUST send back an empty object at a minimum, but MAY send back anything it wishes within the object to be used for filtering the updates. The metadata MUST pass the filter defined in the accompanying `expo-manifest-filters` header.
-- `extra`: For specification of optional "extra" information such as third-party configuration. The server MUST send back an empty object at a minimum. Expo Updates does not specify or rely upon this field, but other libraries may. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID and Expo config (which is used by many Expo libraries through expo-constants) may be included:
+- `extra`: For specification of optional "extra" information such as third-party configuration. The server MUST send back an empty object at a minimum. Expo Updates does not specify or rely upon this field, but other libraries may. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID and Expo config (which is used by many Expo libraries through `expo-constants`) may be included:
 
 ```json
 "extra": {
@@ -146,7 +146,7 @@ type Asset = {
     "name": "...",
     "version": "...",
     "iconUrl": "...",
-    ...
+    /* @hide ... */ /* @end */
   },
 }
 ```

--- a/docs/pages/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/technical-specs/expo-updates-0.mdx
@@ -134,14 +134,20 @@ type Asset = {
   - `fileExtension`: The suggested extension to use when a file is saved on a client. Some platforms, such as iOS, require certain file types to be saved with an extension. The extension MUST be prefixed with a `.`. e.g. **.jpeg**. In some cases, such as the launchAsset, this field will be ignored in favor of a locally determined extension. If the field is omitted and there is no locally stipulated extension, the asset will be saved without an extension, e.g. `./filename` with no `.` at the end.
     A conforming client SHOULD prefix a file extension with a `.` if a file extension is not empty and missing the `.` prefix.
   - `url`: Location at which the file may be fetched.
-- `metadata`: The metadata associated with an update. It is a string-valued dictionary. The server MAY send back anything it wishes to be used for filtering the updates. The metadata MUST pass the filter defined in the accompanying `expo-manifest-filters` header.
-- `extra`: For storage of optional "extra" information such as third-party configuration. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID may be included:
+- `metadata`: The metadata associated with an update. It is a string-valued dictionary. The server MUST send back an empty object at a minimum, but MAY send back anything it wishes within the object to be used for filtering the updates. The metadata MUST pass the filter defined in the accompanying `expo-manifest-filters` header.
+- `extra`: For specification of optional "extra" information such as third-party configuration. The server MUST send back an empty object at a minimum. Expo Updates does not specify or rely upon this field, but other libraries may. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID and Expo config (which is used by many Expo libraries through expo-constants) may be included:
 
 ```json
 "extra": {
   "eas": {
     "projectId": "00000000-0000-0000-0000-000000000000"
-  }
+  },
+  "expoConfig": {
+    "name": "...",
+    "version": "...",
+    "iconUrl": "...",
+    ...
+  },
 }
 ```
 


### PR DESCRIPTION
# Why

Part (2) of https://github.com/expo/custom-expo-updates-server/issues/12#issuecomment-1334121928.

# How

Add more clarifying language to indicate how other libraries may choose to interact with the expo-updates protocol.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
