### PR TITLE
[docs] Add Tamagui to list of UI libraries for Expo

### DIFF
--- a/docs/pages/guides/userinterface.mdx
+++ b/docs/pages/guides/userinterface.mdx
@@ -13,5 +13,6 @@ Below (in no particular order) are some of the most popular UI Libraries. Test t
 - [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten), and their [docs](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten)
 - [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit), and their [docs](https://callstack.github.io/react-native-ios-kit/docs/installation)
 - [Fluent UI](https://github.com/microsoft/fluentui-react-native), and their [docs](https://developer.microsoft.com/en-us/fluentui#/get-started)
+- [Tamagui](https://tamagui.dev), and their [docs](https://tamagui.dev/docs/intro/installation)
 
 > As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.


### PR DESCRIPTION
# Why

It's a UI library that's not listed right now.

# How

Docs.

# Test Plan

Docs.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
