### PR TITLE
[docs] Correct typo

### DIFF
--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -88,7 +88,7 @@ eas update --branch version-1.0 --message "Fixes typo"
 If you're using Git, we can use the `--auto` flag to auto-fill the branch name and the message. This flag will use the current Git branch as the branch name and the latest Git commit message as the message.
 
 ```bash
-eas update --branch
+eas update --auto
 ```
 
 ### Delete a branch


### PR DESCRIPTION
I think this is what was intended

# Why

Because it's talking about --auto flag but it is using --branch which wouldn't even work that way anyways

# How

Not a bug, just a typo

# Test Plan

No test needed

# Checklist

- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
