### PR TITLE
[docs] fix code block annotations for bash/shell examples

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -227,7 +227,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
       }
 
       html = Prism.highlight(html, grammar, lang as Language);
-      if (['properties', 'ruby'].includes(lang)) {
+      if (['properties', 'ruby', 'bash'].includes(lang)) {
         html = this.replaceHashCommentsWithAnnotations(html);
       } else if (['xml', 'html'].includes(lang)) {
         html = this.replaceXmlCommentsWithAnnotations(html);


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/pull/20260#discussion_r1037739849

# How

Add `bash` (which all shell scripts are resolved to) to the list of code block languages which use the hash comments.

This should fix the `# @info #` and other custom code annotation used in those code blocks.

# Test Plan

The change have been tested by altering one of the codee block locally, and adding a test annotation.

# Preview

<img width="680" alt="Screenshot 2022-12-02 at 16 58 19" src="https://user-images.githubusercontent.com/719641/205333640-a9c8f1ef-0ae5-4fa8-8079-210a19697a9c.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
