### PR TITLE
[docs] Update get-started to have typescript guide

### DIFF
--- a/docs/pages/get-started/create-a-new-app.mdx
+++ b/docs/pages/get-started/create-a-new-app.mdx
@@ -27,6 +27,8 @@ To initialize a new project, use [`create-expo-app`](/workflow/glossary-of-terms
   cmdCopy="npx create-expo-app my-app && cd my-app"
 />
 
+Also you can Use the [TypeScript template](/guides/typescript/#starting-from-scratch-using-a-typescript-template)
+
 > **info** You can also use the `--template` option with the `create-expo-app` command. Run `npx create-expo-app --template` to see the list of available templates.
 
 ## Starting the development server


### PR DESCRIPTION
# Why

Save some time finding create typescript project guide

# How

Include a link in Get Started

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
