### PR TITLE
[docs] Add code syntax highlights in e2e tests guide

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -667,22 +667,22 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
   if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
     detox test --configuration android.release --headless
   fi
-  ###### New section ######
+  # @info New section #
   if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
     detox test --configuration android.debug --headless
   fi
-  #########################
+  # @end #
   # Kill emulator
   adb emu kill
 else
   if [[  "$EAS_BUILD_PROFILE" == "test" ]]; then
     detox test --configuration ios.release --headless
   fi
-  ###### New section ######
+  # @info New section #
   if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
     detox test --configuration ios.debug --headless
   fi
-  #########################
+  # @end #
 fi
 ```
 


### PR DESCRIPTION
# Why 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This a follow-up PR for #20260

# How

<!--
How did you build this feature or fix this bug and why?
-->

By converting comments to use code syntax highlighting support for `bash` and `shell` environments for "New sections".

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="875" alt="CleanShot 2022-12-05 at 18 31 13@2x" src="https://user-images.githubusercontent.com/10234615/205644181-6c24226f-6b12-4990-8ed2-34e97a518be6.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
