### PR TITLE
fix(expo-dev-menu): reanimated podspec issue

### DIFF
--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -86,11 +86,11 @@ Pod::Spec.new do |s|
     reanimated.preserve_paths = 'vendored/react-native-reanimated/Common/cpp/hidden_headers/**'
     reanimated.pod_target_xcconfig = {
       "USE_HEADERMAP" => "YES",
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/boost\"  \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" "
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"$(PODS_ROOT)/boost\"  \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" ",
+      'CLANG_CXX_LIBRARY' => 'libc++',
+      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     reanimated.xcconfig = {
-      'CLANG_CXX_LIBRARY' => 'libc++',
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
       "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\"",
                                  "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags
     }


### PR DESCRIPTION
# Why

To prevent `pod install` error, see [here](20331) for more details. But I do wonder if these are needed at all, and if we can just remove them?
# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Install with a fresh app, hermes enabled and with react-native-reanimated@2.12.0
-  Ensure there are no errors when running `pod install`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
