### PR TITLE
Exclude vendored code from being counted by Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,11 @@
 packages/*/build/** -diff linguist-generated
 packages/*/plugin/build/** -diff linguist-generated
 packages/@*/*/build/** -diff linguist-generated
+
+ios/vendored/** linguist-vendored
+ios/versioned/** linguist-vendored
+ios/versioned-react-native/** linguist-vendored
+android/vendored/** linguist-vendored
+android/versioned-abis/** linguist-vendored
+android/versioned-react-native/** linguist-vendored
+packages/expo-dev-menu/vendored/** linguist-vendored


### PR DESCRIPTION
# Why

GitHub shows that our repo is mostly C++ code which is not quite correct, its stats are as follows:

```
28.43%  23171966   C++
23.70%  19318926   Objective-C
11.14%  9079390    Java
10.59%  8628726    Kotlin
9.62%   7843152    TypeScript
7.63%   6218058    Objective-C++
3.38%   2757489    Swift
2.29%   1868513    C
1.33%   1083283    JavaScript
0.77%   624443     Ruby
0.47%   383361     Starlark
0.30%   245000     Shell
0.15%   125692     CMake
0.11%   93213      Makefile
0.06%   46755      Assembly
0.03%   26496      HTML
0.00%   956        Batchfile
```

whereas, with excluded vendored and versioned code it seems to be more real

```
39.85%  7265246    TypeScript
18.89%  3443835    Objective-C
17.22%  3139612    Kotlin
9.47%   1726049    Java
4.73%   861720     Swift
4.50%   820201     JavaScript
1.65%   301316     C++
1.30%   237463     C
1.03%   188568     Objective-C++
0.84%   152424     Ruby
0.23%   41947      Shell
0.15%   26496      HTML
0.11%   19292      CMake
0.03%   4856       Starlark
0.01%   1511       Makefile
0.00%   89         Batchfile
```

I used [`github-linguist`](https://github.com/github/linguist) to measure it

# How

Marked some paths as `linguist-vendored` in `.gitattributes`
