### PR TITLE
[Android][image] Implement `contentFit` and `contentPosition` as a replacement for `resizeMode`

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -9,7 +9,8 @@ import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.ViewProps
 import com.facebook.yoga.YogaConstants
 import expo.modules.core.errors.ModuleDestroyedException
-import expo.modules.image.enums.ImageResizeMode
+import expo.modules.image.enums.ContentFit
+import expo.modules.image.records.ContentPosition
 import expo.modules.image.records.SourceMap
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
@@ -83,8 +84,12 @@ class ExpoImageModule : Module() {
         view.imageView.sourceMap = sourceMap
       }
 
-      Prop("resizeMode") { view: ExpoImageViewWrapper, resizeMode: ImageResizeMode ->
-        view.imageView.resizeMode = resizeMode
+      Prop("contentFit") { view: ExpoImageViewWrapper, contentFit: ContentFit? ->
+        view.imageView.contentFit = contentFit ?: ContentFit.Cover
+      }
+
+      Prop("contentPosition") { view: ExpoImageViewWrapper, contentPosition: ContentPosition? ->
+        view.imageView.contentPosition = contentPosition ?: ContentPosition.center
       }
 
       Prop("blurRadius") { view: ExpoImageViewWrapper, blurRadius: Int ->

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageUtils.kt
@@ -3,6 +3,7 @@ package expo.modules.image
 import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.RectF
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
@@ -32,3 +33,42 @@ internal fun Drawable.toBitmapDrawable(appResources: Resources): BitmapDrawable 
     }
     else -> throw IllegalArgumentException("Drawable must be either BitmapDrawable or PictureDrawable")
   }
+
+fun calcXTranslation(
+  value: Float,
+  imageRect: RectF,
+  viewRect: RectF,
+  isPercentage: Boolean = false,
+  isReverse: Boolean = false
+): Float = calcTranslation(value, imageRect.width(), viewRect.width(), isPercentage, isReverse)
+
+fun calcYTranslation(
+  value: Float,
+  imageRect: RectF,
+  viewRect: RectF,
+  isPercentage: Boolean = false,
+  isReverse: Boolean = false
+): Float = calcTranslation(value, imageRect.height(), viewRect.height(), isPercentage, isReverse)
+
+fun calcTranslation(
+  value: Float,
+  imageRefValue: Float,
+  viewRefValue: Float,
+  isPercentage: Boolean = false,
+  isReverse: Boolean = false
+): Float {
+  if (isPercentage) {
+    val finalPercentage = if (isReverse) {
+      100f - value
+    } else {
+      value
+    }
+    return (finalPercentage / 100f) * (viewRefValue - imageRefValue)
+  }
+
+  if (isReverse) {
+    return viewRefValue - imageRefValue - value
+  }
+
+  return value
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ContentFit.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ContentFit.kt
@@ -55,12 +55,14 @@ enum class ContentFit(val value: String) : Enumerable {
         setScale(scale, scale)
       }
       Fill -> setRectToRect(imageRect, viewRect, Matrix.ScaleToFit.FILL)
-      None -> { /* we don't need to do anything */
+      None -> {
+        // we don't need to do anything
       }
-      ScaleDown ->
+      ScaleDown -> {
         if (imageRect.width() >= viewRect.width() || imageRect.height() >= viewRect.height()) {
           setRectToRect(imageRect, viewRect, Matrix.ScaleToFit.START)
         }
+      }
     }
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ContentFit.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ContentFit.kt
@@ -1,0 +1,66 @@
+package expo.modules.image.enums
+
+import android.graphics.Matrix
+import android.graphics.RectF
+import expo.modules.kotlin.types.Enumerable
+
+/**
+ * Describes how the image should be resized to fit its container.
+ * - Note: It mirrors the CSS [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) property.
+ */
+enum class ContentFit(val value: String) : Enumerable {
+  /**
+   * The image is scaled to maintain its aspect ratio while fitting within the container's box.
+   * The entire image is made to fill the box, while preserving its aspect ratio,
+   * so the image will be "letterboxed" if its aspect ratio does not match the aspect ratio of the box.
+   */
+  Contain("contain"),
+
+  /**
+   * The image is sized to maintain its aspect ratio while filling the element's entire content box.
+   * If the image's aspect ratio does not match the aspect ratio of its box, then the object will be clipped to fit.
+   */
+  Cover("cover"),
+
+  /**
+   * The image is sized to fill the element's content box. The entire object will completely fill the box.
+   * If the image's aspect ratio does not match the aspect ratio of its box, then the image will be stretched to fit.
+   */
+  Fill("fill"),
+
+  /**
+   * The image is not resized and is centered by default.
+   * When specified, the exact position can be controlled with `ContentPosition`.
+   */
+  None("none"),
+
+  /**
+   * The image is sized as if `none` or `contain` were specified,
+   * whichever would result in a smaller concrete image size.
+   */
+  ScaleDown("scale-down");
+
+  internal fun toMatrix(imageRect: RectF, viewRect: RectF) = Matrix().apply {
+    when (this@ContentFit) {
+      Contain -> setRectToRect(imageRect, viewRect, Matrix.ScaleToFit.START)
+      Cover -> {
+        val imageWidth = imageRect.width()
+        val imageHeight = imageRect.height()
+
+        val reactWidth = viewRect.width()
+        val reactHeight = viewRect.height()
+
+        val scale = Math.max(reactWidth / imageWidth, reactHeight / imageHeight)
+
+        setScale(scale, scale)
+      }
+      Fill -> setRectToRect(imageRect, viewRect, Matrix.ScaleToFit.FILL)
+      None -> { /* we don't need to do anything */
+      }
+      ScaleDown ->
+        if (imageRect.width() >= viewRect.width() || imageRect.height() >= viewRect.height()) {
+          setRectToRect(imageRect, viewRect, Matrix.ScaleToFit.START)
+        }
+    }
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
@@ -1,0 +1,88 @@
+package expo.modules.image.records
+
+import android.graphics.Matrix
+import android.graphics.RectF
+import expo.modules.image.calcXTranslation
+import expo.modules.image.calcYTranslation
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+/**
+ * Represents a position value that might be either `Double` or `String`.
+ * TODO(@lukmccall): Use `Either` instead of `Any`
+ */
+typealias ContentPositionValue = Any
+
+private typealias CalcAxisOffset = (value: Float,
+                                    imageRect: RectF,
+                                    viewRect: RectF,
+                                    isPercentage: Boolean,
+                                    isReverse: Boolean) -> Float
+
+class ContentPosition : Record {
+  @Field
+  val top: ContentPositionValue? = null
+
+  @Field
+  val bottom: ContentPositionValue? = null
+
+  @Field
+  val right: ContentPositionValue? = null
+
+  @Field
+  val left: ContentPositionValue? = null
+
+  private fun ContentPositionValue?.calcOffset(
+    isReverse: Boolean,
+    imageRect: RectF,
+    viewRect: RectF,
+    calcAxisOffset: CalcAxisOffset
+  ): Float? {
+    if (this == null) {
+      return null
+    }
+
+    return if (this is Double) {
+      val value = this.toFloat()
+      calcAxisOffset(value, imageRect, viewRect, false, isReverse)
+    } else {
+      val value = this as String
+
+      if (value == "center") {
+        calcAxisOffset(50f, imageRect, viewRect, true, isReverse)
+      } else {
+        calcAxisOffset(value.removeSuffix("%").toFloat(), imageRect, viewRect, true, isReverse)
+      }
+    }
+  }
+
+  private fun offsetX(
+    imageRect: RectF,
+    viewRect: RectF
+  ): Float {
+    return left.calcOffset(false, imageRect, viewRect, ::calcXTranslation)
+      ?: right.calcOffset(true, imageRect, viewRect, ::calcXTranslation)
+      ?: calcXTranslation(50f, imageRect, viewRect, isPercentage = true) // default value
+  }
+
+  private fun offsetY(
+    imageRect: RectF,
+    viewRect: RectF
+  ): Float {
+    return top.calcOffset(false, imageRect, viewRect, ::calcYTranslation)
+      ?: bottom.calcOffset(true, imageRect, viewRect, ::calcYTranslation)
+      ?: calcYTranslation(50f, imageRect, viewRect, isPercentage = true) // default value
+  }
+
+  internal fun apply(to: Matrix, imageRect: RectF, viewRect: RectF) {
+    val xOffset = offsetX(imageRect, viewRect)
+    val yOffset = offsetY(imageRect, viewRect)
+
+    to.postTranslate(xOffset, yOffset)
+  }
+
+  companion object {
+    val center = ContentPosition()
+  }
+}
+

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
@@ -13,11 +13,13 @@ import expo.modules.kotlin.records.Record
  */
 typealias ContentPositionValue = Any
 
-private typealias CalcAxisOffset = (value: Float,
-                                    imageRect: RectF,
-                                    viewRect: RectF,
-                                    isPercentage: Boolean,
-                                    isReverse: Boolean) -> Float
+private typealias CalcAxisOffset = (
+  value: Float,
+  imageRect: RectF,
+  viewRect: RectF,
+  isPercentage: Boolean,
+  isReverse: Boolean
+) -> Float
 
 class ContentPosition : Record {
   @Field
@@ -85,4 +87,3 @@ class ContentPosition : Record {
     val center = ContentPosition()
   }
 }
-


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/pull/20312.

# How

Implemented `object-fit` and partially `object-position` behaviors. An example 👇 

```tsx
<Image
  contentFit={"cover" | "contain" | "fill" | "none" | "scale-down"}
  contentPosition={{ top, left } | { top, right } | { bottom, left } | { bottom, right }}
/>
```

The values for `top`, `right`, `bottom`, `left` can be
- a number — an absolute distance from that specific edge
- a string with a percentage value — an offset relative to the container (it's well described on [`background-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position#regarding_percentages) docs)

# Test Plan

- Resizable image demo
- Using the dedicated demo screen

![image](https://user-images.githubusercontent.com/9578601/205878195-19184295-218a-404c-bc55-ca6bb1903508.png)

