### PR TITLE
[image][Android] Apply cache fix from fast image for local assets

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -240,7 +240,7 @@ class ExpoImageView(
     if (sourceToLoad != loadedSource || propsChanged) {
       propsChanged = false
       loadedSource = sourceToLoad
-      val options = sourceMap?.createOptions() ?: RequestOptions()
+      val options = sourceMap?.createOptions(context) ?: RequestOptions()
       val propOptions = createPropOptions()
       progressInterceptor.registerProgressListener(
         sourceToLoad.toStringUrl(),


### PR DESCRIPTION
# Why

Closes ENG-6961.
Related to https://github.com/DylanVann/react-native-fast-image/pull/472.

# How

More information was provided in the linked PR.

# Test Plan

- NCL with bare-expo ✅