### PR TITLE
[android][expo-document-picker] remove incorrect intent extra property

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -58,6 +58,7 @@ _This version does not introduce any user-facing changes._
 
 - Fix `Plugin with id 'maven' not found` build error from Android Gradle 7. ([#16080](https://github.com/expo/expo/pull/16080) by [@kudo](https://github.com/kudo))
 - Handle nil MIME type. ([#16156](https://github.com/expo/expo/pull/16156) by [@brentvatne](https://github.com/brentvatne))
+- Fix incorrectly allowing multiple document selection ([#20363](https://github.com/expo/expo/pull/20363)) by [@alanhughes](https://github.com/alanjhughes)
 
 ## 10.1.1 - 2022-01-26
 

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -36,10 +36,8 @@ class DocumentPickerModule : Module() {
       copyToCacheDirectory = options.copyToCacheDirectory
       val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
         addCategory(Intent.CATEGORY_OPENABLE)
-        putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
         type = if (options.type.size > 1) {
           putExtra(Intent.EXTRA_MIME_TYPES, options.type.toTypedArray())
-
           "*/*"
         } else {
           options.type[0]


### PR DESCRIPTION
# Why
I set an incorrect property on the intent that allows multiple document selection when it shouldn't

# How
Removed the property

# Test Plan
Tested in bare expo app. Correctly does not allow multiple selection

