### PR TITLE
[image][Android] Improve `onLoad`, `onProgress` and `onError` events

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageAppGlideModule.kt
@@ -1,5 +1,8 @@
 package expo.modules.image
 
+import android.content.Context
+import android.util.Log
+import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
 
@@ -8,4 +11,9 @@ import com.bumptech.glide.module.AppGlideModule
  * to work.
  */
 @GlideModule
-class ExpoImageAppGlideModule : AppGlideModule()
+class ExpoImageAppGlideModule : AppGlideModule() {
+  override fun applyOptions(context: Context, builder: GlideBuilder) {
+    super.applyOptions(context, builder)
+    builder.setLogLevel(Log.ERROR)
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageCacheType.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/enums/ImageCacheType.kt
@@ -2,22 +2,13 @@ package expo.modules.image.enums
 
 import com.bumptech.glide.load.DataSource
 
-enum class ImageCacheType(private val dataSources: Array<DataSource>, val enumValue: Int) {
-  UNKNOWN(DataSource.LOCAL, 0),
-  NONE(DataSource.REMOTE, 1),
-  DISK(
-    arrayOf(
-      DataSource.DATA_DISK_CACHE,
-      DataSource.RESOURCE_DISK_CACHE
-    ),
-    2
-  ),
-  MEMORY(DataSource.MEMORY_CACHE, 3);
-
-  constructor(dataSource: DataSource, enumValue: Int) : this(arrayOf(dataSource), enumValue)
+enum class ImageCacheType(private vararg val dataSources: DataSource) {
+  NONE(DataSource.LOCAL, DataSource.REMOTE),
+  DISK(DataSource.DATA_DISK_CACHE, DataSource.RESOURCE_DISK_CACHE),
+  MEMORY(DataSource.MEMORY_CACHE);
 
   companion object {
     fun fromNativeValue(value: DataSource): ImageCacheType =
-      values().firstOrNull { it.dataSources.contains(value) } ?: UNKNOWN
+      values().firstOrNull { it.dataSources.contains(value) } ?: NONE
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
@@ -1,6 +1,7 @@
 package expo.modules.image.events
 
 import android.graphics.drawable.Drawable
+import android.util.Log
 import com.bumptech.glide.load.DataSource
 import com.bumptech.glide.load.engine.GlideException
 import com.bumptech.glide.request.RequestListener
@@ -11,6 +12,7 @@ import expo.modules.image.records.ImageErrorEvent
 import expo.modules.image.records.ImageLoadEvent
 import expo.modules.image.records.ImageSource
 import java.lang.ref.WeakReference
+import java.util.*
 
 class GlideRequestListener(
   private val expoImageViewWrapper: WeakReference<ExpoImageViewWrapper>
@@ -21,10 +23,20 @@ class GlideRequestListener(
     target: Target<Drawable>,
     isFirstResource: Boolean
   ): Boolean {
+    val errorMessage = e
+      ?.message
+      // Glide always append that line to the end of the message.
+      // It's not possible to call `logRootCauses` from the JS, so we decided to remove it.
+      ?.removeSuffix("\n call GlideException#logRootCauses(String) for more detail")
+      ?: "Unknown error"
+
     expoImageViewWrapper
       .get()
       ?.onError
-      ?.invoke(ImageErrorEvent(e.toString()))
+      ?.invoke(ImageErrorEvent(errorMessage))
+
+    Log.e("ExpoImage", errorMessage)
+    e?.logRootCauses("ExpoImage")
     return false
   }
 
@@ -37,7 +49,7 @@ class GlideRequestListener(
   ): Boolean {
     expoImageViewWrapper.get()?.onLoad?.invoke(
       ImageLoadEvent(
-        cacheType = ImageCacheType.fromNativeValue(dataSource).enumValue,
+        cacheType = ImageCacheType.fromNativeValue(dataSource).name.lowercase(Locale.getDefault()),
         source = ImageSource(
           url = model.toString(),
           width = resource.intrinsicWidth,

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/OkHttpProgressListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/OkHttpProgressListener.kt
@@ -9,7 +9,10 @@ class OkHttpProgressListener(
   private val expoImageViewWrapper: WeakReference<ExpoImageViewWrapper>
 ) : ProgressListener {
   override fun onProgress(bytesWritten: Long, contentLength: Long, done: Boolean) {
-    if (contentLength <= 0) {
+    // OkHttp calls that function twice at the end - when the last byte was downloaded with done set to false,
+    // and also shortly after, with done set to true. In both cases, the bytesWritten and the contentLength are equal.
+    // We want to avoid sending two same events to JS, that's why we return when done is set to true.
+    if (contentLength <= 0 || done) {
       return
     }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/events.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/events.kt
@@ -11,7 +11,7 @@ data class ImageSource(
 ) : Record
 
 data class ImageLoadEvent(
-  @Field val cacheType: Int,
+  @Field val cacheType: String,
   @Field val source: ImageSource
 ) : Record
 


### PR DESCRIPTION
# Why

Improves and adds some small tweaks to `onLoad`, `onProgress`, and `onError` events

# How

- Fixed the `onProgress` was called twice when the image finished downloading. 
- Fixed the `onLoad` returning incorrect cache type. 
- Improved the error message in the `onError` event. Turn off annoying Glide's logs to improve general readability - we log those messages anyway 🤷 

# Test Plan

- event screen