### PR TITLE
[docs] update eas-cli republish docs

### DIFF
--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -328,11 +328,13 @@ If "update 2" turned out to be a bad update, we can re-publish "update 1" with a
 
 <Terminal
   cmd={[
-    '# eas update --branch [branch-name] --republish --group [update-group-id]',
+    '# eas update:republish --group [update-group-id]',
+    '# eas update:republish --branch [branch-name]',
     '',
     '',
     '# Example',
-    '$ eas update --branch production --republish --group abc1',
+    '$ eas update:republish --group abc1',
+    '$ eas update:republish --branch production'
   ]}
 />
 

--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -118,8 +118,12 @@ We can make a previous update immediately available to all users. This command t
 > Republish is similar to a Git reversion, where the correct commit is placed on top of the Git history.
 
 ```bash
-eas update --branch [branch-name] --republish --group [update-group-id]
+eas update:republish --group [update-group-id]
+eas update:republish --branch [branch-name]
 
 # Example
-eas update --branch version-1.0 --republish --group dbfd479f-d981-44ce-8774-f2fbcc386aa
+eas update:republish --group dbfd479f-d981-44ce-8774-f2fbcc386aa
+eas update:republish --branch version-1.0
 ```
+
+> If you don't know the exact update group ID, you can use the `--branch` flag. This shows a list of the recent updates on the branch and allows you to select the update group to republish.


### PR DESCRIPTION
# Why

The split republish command has been published, so we need these docs to be up to date.

# How

- See the [tests of what can be used/how it should work](https://github.com/expo/eas-cli/blob/main/packages/eas-cli/src/commands/update/__tests__/republish.test.ts)

# Test Plan

- Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
