### PR TITLE
[docs] Add linebreak in debug-updates republish example

### DIFF
--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -329,6 +329,7 @@ If "update 2" turned out to be a bad update, we can re-publish "update 1" with a
 <Terminal
   cmd={[
     '# eas update:republish --group [update-group-id]',
+    '',
     '# eas update:republish --branch [branch-name]',
     '',
     '',


### PR DESCRIPTION
# Why

Fixes a bad linebreak in the CLI example.

# How

See https://docs.expo.dev/eas-update/debug-updates/#re-publishing-a-previous-update

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
