### PR TITLE
[config-types] Restore missing requestHeader property

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -210,6 +210,10 @@ export interface ExpoConfig {
              */
             keyid?: string;
         };
+        /**
+         * Extra HTTP headers to include in HTTP requests made by expo-updates. These may override preset headers.
+         */
+        requestHeaders?: Record<string, string>;
     };
     /**
      * Provide overrides by locale for System Dialog prompts like Permissions Boxes
@@ -383,6 +387,15 @@ export interface IOS {
          * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
          */
         googleMobileAdsAutoInit?: boolean;
+        /**
+         * @deprecated Use `ios.googleServicesFile` instead.
+         */
+        googleSignIn?: {
+            /**
+             * @deprecated Use `ios.googleServicesFile` instead.
+             */
+            reservedClientId?: string;
+        };
     };
     /**
      * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -210,6 +210,10 @@ export interface ExpoConfig {
        */
       keyid?: string;
     };
+    /**
+     * Extra HTTP headers to include in HTTP requests made by expo-updates. These may override preset headers.
+     */
+    requestHeaders?: Record<string, string>;
   };
   /**
    * Provide overrides by locale for System Dialog prompts like Permissions Boxes
@@ -385,6 +389,15 @@ export interface IOS {
      * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
      */
     googleMobileAdsAutoInit?: boolean;
+    /**
+     * @deprecated Use `ios.googleServicesFile` instead.
+     */
+    googleSignIn?: {
+      /**
+       * @deprecated Use `ios.googleServicesFile` instead.
+       */
+      reservedClientId?: string;
+    };
   };
   /**
    * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.


### PR DESCRIPTION
# Why

Fix breakages from #20287 

# How

- Restore the `requestHeaders` property from the `updates` section of config-types
- Restore `googleSignIn` temporarily until `@expo/config-plugins` is fixed to remove a remaining dependency on this property

# Test Plan

Execute

```
cd packages/\@expo/config-plugins
yarn build
```
and no errors relating to these properties should appear.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
