### PR TITLE
[docs] update Stripe changelog link

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ If you're looking for a quick example, check out [this Snack](https://snack.expo
 
 ## Installation
 
-Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.mdx) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
+Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
 
 <APIInstallSection href="https://github.com/stripe/stripe-react-native" />
 


### PR DESCRIPTION
The Stripe changelog link was broken. Now it's fixed.