### PR TITLE
[image][Android] Add support for local files and android assets

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -268,7 +268,7 @@ class ExpoImageView(
   // region ViewManager Lifecycle methods
   internal fun onAfterUpdateTransaction() {
     val bestSource = bestSource
-    val sourceToLoad = bestSource?.createGlideModel()
+    val sourceToLoad = bestSource?.createGlideModel(context)
 
     if (bestSource == null || sourceToLoad == null) {
       requestManager.clear(this)
@@ -295,7 +295,7 @@ class ExpoImageView(
 
       expoImageViewWrapper.get()?.onLoadStart?.invoke(Unit)
 
-      val defaultSourceToLoad = defaultSourceMap?.createGlideModel()
+      val defaultSourceToLoad = defaultSourceMap?.createGlideModel(context)
       requestManager
         .asDrawable()
         .load(sourceToLoad.glideData)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/GlideModel.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/GlideModel.kt
@@ -1,28 +1,35 @@
 package expo.modules.image
 
+import android.net.Uri
 import com.bumptech.glide.load.model.GlideUrl
 
 sealed class GlideModel {
   abstract val glideData: Any
 
   override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is GlideModel) return false
-    if (glideData != other.glideData) return false
-    return true
+    if (this === other) {
+      return true
+    }
+    return other is GlideModel && glideData == other.glideData
   }
 
   override fun hashCode(): Int = glideData.hashCode()
 }
 
-data class GlideUrlModel(
-  private val glideUrl: GlideUrl
+class GlideUrlModel(
+  glideUrl: GlideUrl
 ) : GlideModel() {
   override val glideData: GlideUrl = glideUrl
 }
 
-data class GlideDataUrlModel(
-  private val uri: String
+class GlideRawModel(
+  data: String
 ) : GlideModel() {
-  override val glideData: String = uri
+  override val glideData: String = data
+}
+
+class GlideUriModel(
+  uri: Uri
+) : GlideModel() {
+  override val glideData: Uri = uri
 }


### PR DESCRIPTION
# Why

Adds support for local files and android assets/resources. 

# How

Adds support for URLs starting with:
- `content`
- `file`
- `res`
- `android.resource` (it was supported before, but now it's done cleaner)

# Test Plan

- NCL - will add a separate screen later 