### PR TITLE
[docs] Add description tag in metadata for SEO purposes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,8 @@ metadata: goes here
 
 These metadata items include:
 
-- `title`: Title of the page shown as the heading and in search results
+- `title`: Title of the page shown as the heading and in search results.
+- `description`: Description of the page shown in search results and open graph descriptions when the page is shared on social media sites.
 - `hideFromSearch`: Whether to hide the page from Algolia search results. Defaults to `false`.
 - `hideInSidebar`: Whether to hide this page from the sidebar. Defaults to `false`.
 - `hideTOC`: Whether to hide the table of contents (appears on the right sidebar). Defaults to `false`.

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -38,6 +38,7 @@ const STYLES_DOCUMENT = css`
 type Props = React.PropsWithChildren<{
   router: NextRouter;
   title?: string;
+  description?: string;
   sourceCodeUrl?: string;
   tocVisible: boolean;
   packageName?: string;
@@ -189,6 +190,11 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
       ? `${this.props.title} - Expo Documentation`
       : `Expo Documentation`;
 
+    const description =
+      this.props.description !== ''
+        ? `${this.props.description}`
+        : `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
+
     const pageContent = (
       <>
         {this.props.title && <H1>{this.props.title}</H1>}
@@ -216,6 +222,7 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
         sidebarScrollPosition={sidebarScrollPosition}>
         <Head title={this.props.title}>
           {algoliaTag !== null && <meta name="docsearch:version" content={algoliaTag} />}
+          <meta name="description" content={description} />
           <meta property="og:title" content={title} />
           <meta property="og:type" content="website" />
           <meta property="og:image" content="https://docs.expo.dev/static/images/og.png" />
@@ -226,18 +233,12 @@ class DocumentationPageWithApiVersion extends React.Component<Props, State> {
           />
           <meta property="og:locale" content="en_US" />
           <meta property="og:site_name" content="Expo Documentation" />
-          <meta
-            property="og:description"
-            content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
-          />
+          <meta property="og:description" content={description} />
 
           <meta name="twitter:site" content="@expo" />
           <meta name="twitter:card" content="summary" />
           <meta property="twitter:title" content={title} />
-          <meta
-            name="twitter:description"
-            content="Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React."
-          />
+          <meta name="twitter:description" content={description} />
           <meta
             property="twitter:image"
             content="https://docs.expo.dev/static/images/twitter.png"

--- a/docs/components/page-higher-order/DocumentationElements.tsx
+++ b/docs/components/page-higher-order/DocumentationElements.tsx
@@ -31,6 +31,7 @@ export default function DocumentationElements(props: DocumentationElementsProps)
             <DocumentationPage
               router={router}
               title={props.meta.title || ''}
+              description={props.meta.description || ''}
               sourceCodeUrl={props.meta.sourceCodeUrl}
               tocVisible={!props.meta.hideTOC}
               hideFromSearch={props.meta.hideFromSearch}

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -1,5 +1,6 @@
 export type PageMetadata = {
   title?: string;
+  description?: string;
   sourceCodeUrl?: string;
   packageName?: string;
   maxHeadingDepth?: number;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, our documentation pages' metadata do not include `description` as a front matter tag and shows a generic text when on search engine or when shared on social media sites (such as Twitter, etc.).

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds the `description` tag in the metadata of the documentation page and updates the `<DocumentPage>` component. 

We want this tag to add custom description to most of the pages so that when appearing in search engine results or when shared on social media sites, the page's description instead of a generic text (this is also a part of an on-going task I'm working on).

If the page doesn't contain `description` in the metadata, the following generic text is shown (which was the previous behavior):

```
Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.
```

Also, updated the list of metadata items in the `docs/README.md` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After this PR, a description tag can be added to any documentation page in the metadata such as:
```mdx
title: ...
description: ...
```

On testing with a chrome extension called Detailed SEO extension, here is how a description tag will be shown for a page (if it exists):

- Generic search engine
<img width="1508" alt="CleanShot 2022-12-08 at 17 13 51@2x" src="https://user-images.githubusercontent.com/10234615/206440557-671c723e-bc60-466f-8e1a-f8be941a98e3.png">

- Facebook and Twitter Open graphs

<img width="644" alt="CleanShot 2022-12-08 at 17 14 06@2x" src="https://user-images.githubusercontent.com/10234615/206440652-33015f8f-59ad-4a96-8da6-b2f43c3220c0.png">

<img width="629" alt="CleanShot 2022-12-08 at 17 14 12@2x" src="https://user-images.githubusercontent.com/10234615/206440663-48271cf9-92ba-4107-a7c5-98828fa0990e.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
