### PR TITLE
[image][ios] Add `priority` prop to prioritize image download requests

### DIFF
--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -53,6 +53,14 @@ public final class ImageModule: Module {
         view.imageTintColor = tintColor ?? .clear
       }
 
+      Prop("priority") { (view, priority: ImagePriority?) in
+        view.loadingOptions.remove([.lowPriority, .highPriority])
+
+        if let priority = priority?.toSDWebImageOptions() {
+          view.loadingOptions.insert(priority)
+        }
+      }
+
       OnViewDidUpdateProps { view in
         view.reload()
       }

--- a/packages/expo-image/ios/ImagePriority.swift
+++ b/packages/expo-image/ios/ImagePriority.swift
@@ -1,0 +1,22 @@
+import ExpoModulesCore
+import SDWebImage
+
+enum ImagePriority: String, Enumerable {
+  case low
+  case normal
+  case high
+
+  /**
+   Maps the priority to `SDWebImageOptions` which is a bitmask thus has only low and high priority options.
+   */
+  func toSDWebImageOptions() -> SDWebImageOptions? {
+    switch self {
+    case .low:
+      return .lowPriority
+    case .high:
+      return .highPriority
+    default:
+      return nil
+    }
+  }
+}

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -8,6 +8,7 @@ private typealias SDWebImageContext = [SDWebImageContextOption: Any]
 public final class ImageView: ExpoView {
   let sdImageView = SDAnimatedImageView(frame: .zero)
   let imageManager = SDWebImageManager()
+  var loadingOptions = SDWebImageOptions()
 
   var sources: [ImageSource]?
 
@@ -101,10 +102,13 @@ public final class ImageView: ExpoView {
 
     onLoadStart([:])
 
-    imageManager.loadImage(with: source.uri,
-                           context: context,
-                           progress: imageLoadProgress(_:_:_:),
-                           completed: imageLoadCompleted(_:_:_:_:_:_:))
+    imageManager.loadImage(
+      with: source.uri,
+      options: loadingOptions,
+      context: context,
+      progress: imageLoadProgress(_:_:_:),
+      completed: imageLoadCompleted(_:_:_:_:_:_:)
+    )
   }
 
   // MARK: - Loading


### PR DESCRIPTION
# Why

Follow up #20358 but on iOS

# How

Added view prop that maps to `SDWebImageOptions`

# Test Plan

- Used prioritizing images screen on NCL, the difference is not really visible though
- Checked the order of load completions on the native side, it was mostly `high, normal, low` and sometimes `normal, high, low`, even though they are rendered in `low, normal, high` order