### PR TITLE
[docs] Add minimum Android/iIOS versions & compileSdkVersion to API reference index

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK version | React Native version | React Native Web version |
-| ---------------- | -------------------- | ------------------------ |
-| 47.0.0           | 0.70.5               | 0.18.9                   |
-| 46.0.0           | 0.69.6               | 0.18.7                   |
-| 45.0.0           | 0.68.2               | 0.17.7                   |
-| 44.0.0           | 0.64.3               | 0.17.1                   |
+| Expo SDK version | React Native version | React Native Web version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
+| ---------------- | -------------------- | ------------------------ | ----------------------- | ------------------- | ------------------- |
+| 47.0.0           | 0.70.5               | 0.18.9                   | 5                       | 13                  | 31                  |
+| 46.0.0           | 0.69.6               | 0.18.7                   | 5                       | 12.4                | 31                  |
+| 45.0.0           | 0.68.2               | 0.17.7                   | 5                       | 12                  | 31                  |
+| 44.0.0           | 0.64.3               | 0.17.1                   | 5                       | 12                  | 30                  |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -54,13 +54,24 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK version | React Native version | React Native Web version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
-| ---------------- | -------------------- | ------------------------ | ----------------------- | ------------------- | ------------------- |
-| 47.0.0           | 0.70.5               | 0.18.9                   | 5                       | 13                  | 31                  |
-| 46.0.0           | 0.69.6               | 0.18.7                   | 5                       | 12.4                | 31                  |
-| 45.0.0           | 0.68.2               | 0.17.7                   | 5                       | 12                  | 31                  |
-| 44.0.0           | 0.64.3               | 0.17.1                   | 5                       | 12                  | 30                  |
+| Expo SDK version | React Native version | React Native Web version |
+| ---------------- | -------------------- | ------------------------ |
+| 47.0.0           | 0.70.5               | 0.18.9                   |
+| 46.0.0           | 0.69.6               | 0.18.7                   |
+| 45.0.0           | 0.68.2               | 0.17.7                   |
+| 44.0.0           | 0.64.3               | 0.17.1                   |
 
 ### Support for other React Native versions
 
 Packages in the Expo SDK are intended to support the target React Native version for that SDK. Typically, they will not support older versions of React Native, but they may. When a new version of React Native is released, the latest versions of the Expo SDK packages are typically updated to support it. However, this may take weeks or more, depending on the extent of the changes in the release.
+
+## Support for Android and iOS versions
+
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
+| ---------------- | --------------- | ------------------- | ----------- |
+| 47.0.0           | 5+              | 31                  | 13+         |
+| 46.0.0           | 5+              | 31                  | 12.4+       |
+| 45.0.0           | 5+              | 31                  | 12+         |
+| 44.0.0           | 5+              | 30                  | 12+         |

--- a/docs/pages/versions/v45.0.0/index.mdx
+++ b/docs/pages/versions/v45.0.0/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version |
-| ---------------- | -------------------- |
-| 45.0.0           | 0.68.2               |
-| 44.0.0           | 0.64.3               |
-| 43.0.0           | 0.64.3               |
-| 42.0.0           | 0.63.3               |
+| Expo SDK Version | React Native Version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
+| ---------------- | -------------------- | ----------------------- | ------------------- | ------------------- |
+| 45.0.0           | 0.68.2               | 5                       | 12                  | 31                  |
+| 44.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
+| 43.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
+| 42.0.0           | 0.63.3               | 5                       | 11                  | 30                  |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v45.0.0/index.mdx
+++ b/docs/pages/versions/v45.0.0/index.mdx
@@ -54,13 +54,24 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
-| ---------------- | -------------------- | ----------------------- | ------------------- | ------------------- |
-| 45.0.0           | 0.68.2               | 5                       | 12                  | 31                  |
-| 44.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
-| 43.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
-| 42.0.0           | 0.63.3               | 5                       | 11                  | 30                  |
+| Expo SDK Version | React Native Version |
+| ---------------- | -------------------- |
+| 45.0.0           | 0.68.2               |
+| 44.0.0           | 0.64.3               |
+| 43.0.0           | 0.64.3               |
+| 42.0.0           | 0.63.3               |
 
 ### Support for other React Native versions
 
 Packages in the Expo SDK are intended to support the target React Native version for that SDK. Typically, they will not support older versions of React Native, but they may. When a new version of React Native is released, the latest versions of the Expo SDK packages are typically updated to support it. However, this may take weeks or more, depending on the extent of the changes in the release.
+
+## Support for Android and iOS versions
+
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
+| ---------------- | --------------- | ------------------- | ----------- |
+| 45.0.0           | 5+              | 31                  | 12+         |
+| 44.0.0           | 5+              | 30                  | 12+         |
+| 43.0.0           | 5+              | 30                  | 12+         |
+| 42.0.0           | 5+              | 30                  | 11+         |

--- a/docs/pages/versions/v46.0.0/index.mdx
+++ b/docs/pages/versions/v46.0.0/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version |
-| ---------------- | -------------------- |
-| 46.0.0           | 0.69.6               |
-| 45.0.0           | 0.68.2               |
-| 44.0.0           | 0.64.3               |
-| 43.0.0           | 0.64.3               |
+| Expo SDK Version | React Native Version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
+| ---------------- | -------------------- | ----------------------- | ------------------- | ------------------- |
+| 46.0.0           | 0.69.6               | 5                       | 12.4                | 31                  |
+| 45.0.0           | 0.68.2               | 5                       | 12                  | 31                  |
+| 44.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
+| 43.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v46.0.0/index.mdx
+++ b/docs/pages/versions/v46.0.0/index.mdx
@@ -54,13 +54,24 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable version of React Native and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK Version | React Native Version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
-| ---------------- | -------------------- | ----------------------- | ------------------- | ------------------- |
-| 46.0.0           | 0.69.6               | 5                       | 12.4                | 31                  |
-| 45.0.0           | 0.68.2               | 5                       | 12                  | 31                  |
-| 44.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
-| 43.0.0           | 0.64.3               | 5                       | 12                  | 30                  |
+| Expo SDK Version | React Native Version |
+| ---------------- | -------------------- |
+| 46.0.0           | 0.69.6               |
+| 45.0.0           | 0.68.2               |
+| 44.0.0           | 0.64.3               |
+| 43.0.0           | 0.64.3               |
 
 ### Support for other React Native versions
 
 Packages in the Expo SDK are intended to support the target React Native version for that SDK. Typically, they will not support older versions of React Native, but they may. When a new version of React Native is released, the latest versions of the Expo SDK packages are typically updated to support it. However, this may take weeks or more, depending on the extent of the changes in the release.
+
+## Support for Android and iOS versions
+
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
+| ---------------- | --------------- | ------------------- | ----------- |
+| 46.0.0           | 5+              | 31                  | 12.4+       |
+| 45.0.0           | 5+              | 31                  | 12+         |
+| 44.0.0           | 5+              | 30                  | 12+         |
+| 43.0.0           | 5+              | 30                  | 12+         |

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -54,12 +54,12 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK version | React Native version | React Native Web version |
-| ---------------- | -------------------- | ------------------------ |
-| 47.0.0           | 0.70.5               | 0.18.9                   |
-| 46.0.0           | 0.69.6               | 0.18.7                   |
-| 45.0.0           | 0.68.2               | 0.17.7                   |
-| 44.0.0           | 0.64.3               | 0.17.1                   |
+| Expo SDK version | React Native version | React Native Web version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
+| ---------------- | -------------------- | ------------------------ | ----------------------- | ------------------- | ------------------- |
+| 47.0.0           | 0.70.5               | 0.18.9                   | 5                       | 13                  | 31                  |
+| 46.0.0           | 0.69.6               | 0.18.7                   | 5                       | 12.4                | 31                  |
+| 45.0.0           | 0.68.2               | 0.17.7                   | 5                       | 12                  | 31                  |
+| 44.0.0           | 0.64.3               | 0.17.1                   | 5                       | 12                  | 30                  |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -54,13 +54,24 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
 
 Every quarter there is a new Expo SDK release that typically updates to the latest stable versions of React Native and React Native Web, and includes a variety of bug fixes, features, and improvements to the Expo SDK.
 
-| Expo SDK version | React Native version | React Native Web version | Minimum Android version | Minimum iOS version | `compileSdkVersion` |
-| ---------------- | -------------------- | ------------------------ | ----------------------- | ------------------- | ------------------- |
-| 47.0.0           | 0.70.5               | 0.18.9                   | 5                       | 13                  | 31                  |
-| 46.0.0           | 0.69.6               | 0.18.7                   | 5                       | 12.4                | 31                  |
-| 45.0.0           | 0.68.2               | 0.17.7                   | 5                       | 12                  | 31                  |
-| 44.0.0           | 0.64.3               | 0.17.1                   | 5                       | 12                  | 30                  |
+| Expo SDK version | React Native version | React Native Web version |
+| ---------------- | -------------------- | ------------------------ |
+| 47.0.0           | 0.70.5               | 0.18.9                   |
+| 46.0.0           | 0.69.6               | 0.18.7                   |
+| 45.0.0           | 0.68.2               | 0.17.7                   |
+| 44.0.0           | 0.64.3               | 0.17.1                   |
 
 ### Support for other React Native versions
 
 Packages in the Expo SDK are intended to support the target React Native version for that SDK. Typically, they will not support older versions of React Native, but they may. When a new version of React Native is released, the latest versions of the Expo SDK packages are typically updated to support it. However, this may take weeks or more, depending on the extent of the changes in the release.
+
+## Support for Android and iOS versions
+
+Each version of Expo SDK supports a minimum OS version of Android and iOS. For Android, the `compileSdkVersion` is defined which tells the [Gradle](https://developer.android.com/studio/build) which Android SDK version to use to compile the app. This also means that you can use the Android API features included in that SDK version and from the previous versions.
+
+| Expo SDK version | Android version | `compileSdkVersion` | iOS version |
+| ---------------- | --------------- | ------------------- | ----------- |
+| 47.0.0           | 5+              | 31                  | 13+         |
+| 46.0.0           | 5+              | 31                  | 12.4+       |
+| 45.0.0           | 5+              | 31                  | 12+         |
+| 44.0.0           | 5+              | 30                  | 12+         |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6981

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the table with minimum versions of Android and iOS platforms and `compileSdkVersion` for SDK 47, 45, 46.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="1151" alt="CleanShot 2022-12-08 at 18 06 33@2x" src="https://user-images.githubusercontent.com/10234615/206447862-868e4807-be8c-4cb6-92ca-4fcb5c1cffac.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
