### PR TITLE
[image][Android] Disable memory cache

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -304,6 +304,7 @@ class ExpoImageView(
         .downsample(DownsampleStrategy.NONE)
         .addListener(GlideRequestListener(expoImageViewWrapper))
         .encodeQuality(100)
+        .skipMemoryCache(true)
         .apply(propOptions)
         .into(object : DrawableImageViewTarget(this) {
           override fun getSize(cb: SizeReadyCallback) {


### PR DESCRIPTION
# Why

Disables memory cache to speed up the overall performance. 

# Test Plan


https://user-images.githubusercontent.com/9578601/206479262-7abb126c-07f7-4fea-8995-6840889de3e0.mp4

