### PR TITLE
fix(cli): send Exponent-Server header as JSON string for classic manifests

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))
 - Fix getting UDID for network connected iOS devices. ([#20279](https://github.com/expo/expo/pull/20279) by [@Simek](https://github.com/Simek))
+- Send Exponent-Server header as JSON string for classic manifests. ([#20409](https://github.com/expo/expo/pull/20409) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
@@ -66,7 +66,7 @@ export class ClassicManifestMiddleware extends ManifestMiddleware<ClassicManifes
     const hostInfo = await createHostInfoAsync();
 
     const headers = new Map<string, any>();
-    headers.set('Exponent-Server', hostInfo);
+    headers.set('Exponent-Server', JSON.stringify(hostInfo));
 
     // Create the final string
     const body = await this._fetchComputedManifestStringAsync({

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ClassicManifestMiddleware-test.ts
@@ -216,6 +216,30 @@ describe('_fetchComputedManifestStringAsync', () => {
   });
 });
 
+describe('_getManifestResponseAsync', () => {
+  // Regression
+  it('returns Exponent-Server header as json string', async () => {
+    const middleware = new ClassicManifestMiddleware('/', {
+      constructUrl: (options) => options?.hostname || 'localhost',
+    });
+
+    middleware._getManifestStringAsync = jest.fn(async () => {
+      return 'signed-manifest-lol';
+    });
+
+    const response = await middleware._getManifestResponseAsync({
+      acceptSignature: true,
+      hostname: 'localhost',
+      platform: 'android',
+    });
+
+    const header = response.headers.get('Exponent-Server');
+
+    expect(typeof header).toBe('string');
+    expect(() => JSON.parse(header as string)).not.toThrow();
+  });
+});
+
 describe(`_getManifestStringAsync`, () => {
   it(`uses anon ID for offline mode`, async () => {
     asMock(getUserAsync).mockImplementationOnce(async () => ({} as any));


### PR DESCRIPTION
# Why

See original version: https://github.com/expo/expo-cli/blob/main/packages/xdl/src/start/ManifestHandler.ts#L158

```
$ curl -I http://localhost:19000/
HTTP/1.1 200 OK
Exponent-Server: [object Object]
Date: Fri, 09 Dec 2022 09:35:06 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

# How

Stringified the host info before setting `Exponent-Server` data.

# Test Plan

- Added regression test (run test) or ...
- `npx expo start` + curl the endpoint
- Validate that the `Exponent-Server` header is a JSON string

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
