### PR TITLE
[Expo Go][iOS] No remote home app loads in release builds

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -3,7 +3,7 @@
 #import "EXHomeAppManager.h"
 #import "EXKernel.h"
 #import "EXAppFetcher.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXKernelLinkingManager.h"
 #import "EXHomeModule.h"
 #import "EXKernelUtil.h"

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -7,7 +7,7 @@
 #import "EXAppViewController.h"
 #import "EXHomeAppManager.h"
 #import "EXKernel.h"
-#import "EXAppLoader.h"
+#import "EXHomeLoader.h"
 #import "EXKernelAppRecord.h"
 #import "EXKernelAppRegistry.h"
 #import "EXKernelLinkingManager.h"
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)createRootAppAndMakeVisible
 {
   EXHomeAppManager *homeAppManager = [[EXHomeAppManager alloc] init];
-  EXAppLoader *homeAppLoader = [[EXAppLoader alloc] initWithLocalManifest:[EXHomeAppManager bundledHomeManifest]];
+  EXHomeLoader *homeAppLoader = [[EXHomeLoader alloc] initWithLocalManifest:[EXHomeAppManager bundledHomeManifest]];
   EXKernelAppRecord *homeAppRecord = [[EXKernelAppRecord alloc] initWithAppLoader:homeAppLoader appManager:homeAppManager];
   [[EXKernel sharedInstance].appRegistry registerHomeAppRecord:homeAppRecord];
   [self moveAppToVisible:homeAppRecord];

--- a/ios/Client/Menu/EXDevMenuViewController.m
+++ b/ios/Client/Menu/EXDevMenuViewController.m
@@ -6,7 +6,7 @@
 #import "EXDevMenuViewController.h"
 #import "EXDevMenuManager.h"
 #import "EXKernel.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXKernelAppRegistry.h"
 #import "EXUtil.h"
 

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		28F885A428FEC26000CFD75C /* EXTextDirectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F885A328FEC26000CFD75C /* EXTextDirectionController.swift */; };
 		2CFE1F25CD524A7ABFCAA366 /* RNSharedElementNodeManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 80598B49D2DB4720B1935D89 /* RNSharedElementNodeManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		2D27CAA71656C7458DE5E8BA /* libPods-ExponentIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36E1417121838E61F500BA69 /* libPods-ExponentIntegrationTests.a */; };
+		2D5265EB294998B5001BB2BB /* EXHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXHomeLoader.m */; };
+		2D5265EC294998B5001BB2BB /* EXHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXHomeLoader.m */; };
 		2E2E55ADAE3243799CC2CDFE /* RNCPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = A60CC11587F645D0BF1C832F /* RNCPicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		2F7A50E095D6492596EA0B26 /* RNSharedElementNode.m in Sources */ = {isa = PBXBuildFile; fileRef = D29BDFCEEA8F4701829ADCD1 /* RNSharedElementNode.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		312D2ED2234DF2DC002F4049 /* EXScopedFacebook.m in Sources */ = {isa = PBXBuildFile; fileRef = 312D2ED1234DF2DC002F4049 /* EXScopedFacebook.m */; };
@@ -182,7 +184,7 @@
 		B5A72C2E20A0D1BF00974CCE /* EXAppFetcherWithTimeout.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C2520A0D1BF00974CCE /* EXAppFetcherWithTimeout.m */; };
 		B5A72C2F20A0D1BF00974CCE /* EXAppFetcherDevelopmentMode.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C2720A0D1BF00974CCE /* EXAppFetcherDevelopmentMode.m */; };
 		B5A72C3020A0D1BF00974CCE /* EXAppFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C2B20A0D1BF00974CCE /* EXAppFetcher.m */; };
-		B5A72C3420A0D42D00974CCE /* EXAppLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C3120A0D42C00974CCE /* EXAppLoader.m */; };
+		B5A72C3420A0D42D00974CCE /* EXAbstractLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C3120A0D42C00974CCE /* EXAbstractLoader.m */; };
 		B5AC39A71E95A90B00540AA7 /* EXKernel.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AC398E1E95A90B00540AA7 /* EXKernel.m */; };
 		B5AC39AF1E95A90B00540AA7 /* EXVersions.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AC39A11E95A90B00540AA7 /* EXVersions.m */; };
 		B5AC39B01E95A90B00540AA7 /* EXUserNotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B5AC39A41E95A90B00540AA7 /* EXUserNotificationManager.m */; };
@@ -278,7 +280,7 @@
 		F1421819262CB68600BB97E6 /* EXDevSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74001FF6DADB001C764B /* EXDevSettings.m */; };
 		F142181A262CB68600BB97E6 /* EXScopedNotificationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */; };
 		F142181B262CB68600BB97E6 /* NSData+EXRemoteNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 78D8252D2051217F00CBD9D9 /* NSData+EXRemoteNotifications.m */; };
-		F142181C262CB68600BB97E6 /* EXAppLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C3120A0D42C00974CCE /* EXAppLoader.m */; };
+		F142181C262CB68600BB97E6 /* EXAbstractLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C3120A0D42C00974CCE /* EXAbstractLoader.m */; };
 		F142181F262CB68600BB97E6 /* EXAppFetcherWithTimeout.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C2520A0D1BF00974CCE /* EXAppFetcherWithTimeout.m */; };
 		F1421820262CB68600BB97E6 /* EXDevMenuWindow.m in Sources */ = {isa = PBXBuildFile; fileRef = F116A3BF2445EBBB008FA957 /* EXDevMenuWindow.m */; };
 		F1421821262CB68600BB97E6 /* EXAppFetcherCacheOnly.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C2420A0D1BF00974CCE /* EXAppFetcherCacheOnly.m */; };
@@ -562,6 +564,8 @@
 		2596F06A22201A9400DEEFF9 /* EXScopedFileSystemModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedFileSystemModule.m; sourceTree = "<group>"; };
 		28F885A328FEC26000CFD75C /* EXTextDirectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXTextDirectionController.swift; sourceTree = "<group>"; };
 		2A9DD7D91B97F78E98C01A4A /* Pods-Expo Go-Expo Go (versioned).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Expo Go-Expo Go (versioned).debug.xcconfig"; path = "Target Support Files/Pods-Expo Go-Expo Go (versioned)/Pods-Expo Go-Expo Go (versioned).debug.xcconfig"; sourceTree = "<group>"; };
+		2D5265E9294998B5001BB2BB /* EXHomeLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXHomeLoader.h; sourceTree = "<group>"; };
+		2D5265EA294998B5001BB2BB /* EXHomeLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXHomeLoader.m; sourceTree = "<group>"; };
 		312D2ED1234DF2DC002F4049 /* EXScopedFacebook.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedFacebook.m; sourceTree = "<group>"; };
 		312D2ED3234DF2F6002F4049 /* EXScopedFacebook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedFacebook.h; sourceTree = "<group>"; };
 		31361A582260B2F600662769 /* EXScopedSecureStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedSecureStore.h; sourceTree = "<group>"; };
@@ -848,9 +852,9 @@
 		B5A72C2A20A0D1BF00974CCE /* EXAppFetcherDevelopmentMode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXAppFetcherDevelopmentMode.h; sourceTree = "<group>"; };
 		B5A72C2B20A0D1BF00974CCE /* EXAppFetcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXAppFetcher.m; sourceTree = "<group>"; };
 		B5A72C2C20A0D1BF00974CCE /* EXAppFetcher+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXAppFetcher+Private.h"; sourceTree = "<group>"; };
-		B5A72C3120A0D42C00974CCE /* EXAppLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXAppLoader.m; sourceTree = "<group>"; };
-		B5A72C3220A0D42C00974CCE /* EXAppLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXAppLoader.h; sourceTree = "<group>"; };
-		B5A72C3320A0D42D00974CCE /* EXAppLoader+Updates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXAppLoader+Updates.h"; sourceTree = "<group>"; };
+		B5A72C3120A0D42C00974CCE /* EXAbstractLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXAbstractLoader.m; sourceTree = "<group>"; };
+		B5A72C3220A0D42C00974CCE /* EXAbstractLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXAbstractLoader.h; sourceTree = "<group>"; };
+		B5A72C3320A0D42D00974CCE /* EXAbstractLoader+Updates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "EXAbstractLoader+Updates.h"; sourceTree = "<group>"; };
 		B5AC398D1E95A90B00540AA7 /* EXKernel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXKernel.h; sourceTree = "<group>"; };
 		B5AC398E1E95A90B00540AA7 /* EXKernel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXKernel.m; sourceTree = "<group>"; };
 		B5AC39931E95A90B00540AA7 /* EXKernelUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXKernelUtil.h; sourceTree = "<group>"; };
@@ -1654,9 +1658,9 @@
 			children = (
 				B5D0D667204F4C0400DDFC99 /* EXApiUtil.h */,
 				B5D0D661204F4C0400DDFC99 /* EXApiUtil.m */,
-				B5A72C3220A0D42C00974CCE /* EXAppLoader.h */,
-				B5A72C3120A0D42C00974CCE /* EXAppLoader.m */,
-				B5A72C3320A0D42D00974CCE /* EXAppLoader+Updates.h */,
+				B5A72C3220A0D42C00974CCE /* EXAbstractLoader.h */,
+				B5A72C3120A0D42C00974CCE /* EXAbstractLoader.m */,
+				B5A72C3320A0D42D00974CCE /* EXAbstractLoader+Updates.h */,
 				07C6733324D230FB003F3F5C /* EXAppLoaderExpoUpdates.h */,
 				07C6733424D2310C003F3F5C /* EXAppLoaderExpoUpdates.m */,
 				B5D0D666204F4C0400DDFC99 /* EXFileDownloader.h */,
@@ -1664,6 +1668,8 @@
 				B5A72C2320A0D1BF00974CCE /* AppFetcher */,
 				B5A72C1920A0D13E00974CCE /* CachedResource */,
 				B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */,
+				2D5265E9294998B5001BB2BB /* EXHomeLoader.h */,
+				2D5265EA294998B5001BB2BB /* EXHomeLoader.m */,
 			);
 			path = AppLoader;
 			sourceTree = "<group>";
@@ -2630,7 +2636,7 @@
 				B5FB74DF1FF6DADC001C764B /* EXDevSettings.m in Sources */,
 				B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */,
 				78D8252E2051217F00CBD9D9 /* NSData+EXRemoteNotifications.m in Sources */,
-				B5A72C3420A0D42D00974CCE /* EXAppLoader.m in Sources */,
+				B5A72C3420A0D42D00974CCE /* EXAbstractLoader.m in Sources */,
 				B5A72C2E20A0D1BF00974CCE /* EXAppFetcherWithTimeout.m in Sources */,
 				F116A3C02445EBBB008FA957 /* EXDevMenuWindow.m in Sources */,
 				B5A72C2D20A0D1BF00974CCE /* EXAppFetcherCacheOnly.m in Sources */,
@@ -2760,6 +2766,7 @@
 				8767F97324D17CB2009F9372 /* EXManagedAppSplashScreenViewProvider.m in Sources */,
 				31AD99DF2285B51100F19090 /* AIRGoogleMapCalloutSubview.m in Sources */,
 				B5AC39B11E95A90B00540AA7 /* EXRemoteNotificationManager.m in Sources */,
+				2D5265EB294998B5001BB2BB /* EXHomeLoader.m in Sources */,
 				07295CD920559E7300ED42D4 /* EXUpdatesManager.m in Sources */,
 				25742BE72174B8BE003E7453 /* EXExpoUserNotificationCenterProxy.m in Sources */,
 				8767F5B824D177AD009F9372 /* EXManagedAppSplashScreenConfigurationBuilder.m in Sources */,
@@ -2867,7 +2874,7 @@
 				F1421819262CB68600BB97E6 /* EXDevSettings.m in Sources */,
 				F142181A262CB68600BB97E6 /* EXScopedNotificationBuilder.m in Sources */,
 				F142181B262CB68600BB97E6 /* NSData+EXRemoteNotifications.m in Sources */,
-				F142181C262CB68600BB97E6 /* EXAppLoader.m in Sources */,
+				F142181C262CB68600BB97E6 /* EXAbstractLoader.m in Sources */,
 				F142181F262CB68600BB97E6 /* EXAppFetcherWithTimeout.m in Sources */,
 				F1421820262CB68600BB97E6 /* EXDevMenuWindow.m in Sources */,
 				F1421821262CB68600BB97E6 /* EXAppFetcherCacheOnly.m in Sources */,
@@ -2968,6 +2975,7 @@
 				F14218B0262CB68600BB97E6 /* AIRGoogleMapOverlayManager.m in Sources */,
 				F14218B1262CB68600BB97E6 /* EXKernelDevKeyCommands.m in Sources */,
 				F14218B2262CB68600BB97E6 /* AIRMapUrlTileManager.m in Sources */,
+				2D5265EC294998B5001BB2BB /* EXHomeLoader.m in Sources */,
 				F14218B3262CB68600BB97E6 /* EXKernelAppRegistry.m in Sources */,
 				F14218B4262CB68600BB97E6 /* EXErrorRecoveryManager.m in Sources */,
 				F14218B9262CB68600BB97E6 /* AIRMapUrlTile.m in Sources */,

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher+Private.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher+Private.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXAppFetcher ()
 
-@property (nonatomic, weak) EXAppLoader *appLoader;
+@property (nonatomic, weak) EXAbstractLoader *appLoader;
 
 @property (nonatomic, strong) EXManifestsManifest * _Nullable manifest;
 @property (nonatomic, strong) NSData * _Nullable bundle;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.h
@@ -4,7 +4,7 @@
 #import "EXResourceLoader.h"
 #import <EXManifests/EXManifestsManifest.h>
 
-@class EXAppLoader;
+@class EXAbstractLoader;
 @class EXAppFetcher;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) id<EXAppFetcherDataSource> dataSource;
 @property (nonatomic, weak) id<EXAppFetcherCacheDataSource> cacheDataSource;
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader;
 - (void)start;
 
 - (void)fetchJSBundleWithManifest:(EXManifestsManifest *)manifest

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -2,7 +2,7 @@
 
 #import "EXApiUtil.h"
 #import "EXAppFetcher+Private.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXEnvironment.h"
 #import "EXErrorRecoveryManager.h"
 #import "EXJavaScriptResource.h"
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcher
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader
 {
   if (self = [super init]) {
     _appLoader = appLoader;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXAppFetcherCacheOnly : EXAppFetcher
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
@@ -1,14 +1,14 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppFetcherCacheOnly.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXEnvironment.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcherCacheOnly
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
 {
   if (self = [super initWithAppLoader:appLoader]) {
     self.manifest = manifest;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<EXAppFetcherDevelopmentModeDelegate> developmentModeDelegate;
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
 
 - (void)forceBundleReload;
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherDevelopmentMode.m
@@ -1,13 +1,13 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXAppFetcherDevelopmentMode.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcherDevelopmentMode
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader manifest:(EXManifestsManifest *)manifest;
 {
   if (self = [super initWithAppLoader:appLoader]) {
     self.manifest = manifest;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.h
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak) id<EXAppFetcherWithTimeoutDelegate> withTimeoutDelegate;
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader timeout:(NSTimeInterval)timeout;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader timeout:(NSTimeInterval)timeout;
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherWithTimeout.m
@@ -3,7 +3,7 @@
 #import "EXAppFetcherCacheOnly.h"
 #import "EXAppFetcherDevelopmentMode.h"
 #import "EXAppFetcherWithTimeout.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation EXAppFetcherWithTimeout
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)appLoader timeout:(NSTimeInterval)timeout;
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)appLoader timeout:(NSTimeInterval)timeout;
 {
   if (self = [super initWithAppLoader:appLoader]) {
     _timeout = timeout;

--- a/ios/Exponent/Kernel/AppLoader/EXAbstractLoader+Updates.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAbstractLoader+Updates.h
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 
 #import <EXUpdates/EXUpdatesAppLauncher.h>
 #import <EXUpdates/EXUpdatesConfig.h>
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Private header that should only be used by EXUpdatesManager kernel service
  */
 
-@interface EXAppLoader ()
+@interface EXAbstractLoader ()
 
 @property (nonatomic, readonly, nullable) EXUpdatesConfig *config;
 @property (nonatomic, readonly, nullable) EXUpdatesSelectionPolicy *selectionPolicy;

--- a/ios/Exponent/Kernel/AppLoader/EXAbstractLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAbstractLoader.h
@@ -8,7 +8,7 @@
 #import <EXManifests/EXManifestsManifest.h>
 
 @class EXKernelAppRecord;
-@class EXAppLoader;
+@class EXAbstractLoader;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -29,15 +29,20 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 
 @protocol EXAppLoaderDelegate <NSObject>
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(EXManifestsManifest *)manifest;
-- (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress;
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)data;
-- (void)appLoader:(EXAppLoader *)appLoader didFailWithError:(NSError *)error;
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadOptimisticManifest:(EXManifestsManifest *)manifest;
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress;
+- (void)appLoader:(EXAbstractLoader *)appLoader didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)data;
+- (void)appLoader:(EXAbstractLoader *)appLoader didFailWithError:(NSError *)error;
+- (void)appLoader:(EXAbstractLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error;
 
 @end
 
-@interface EXAppLoader : NSObject <EXAppFetcherDelegate, EXAppFetcherDevelopmentModeDelegate, EXAppFetcherWithTimeoutDelegate, EXAppFetcherCacheDataSource>
+/**
+ Class with stub methods to load apps.
+ It has two subclasses: EXHomeLoader (for loading the home app), and
+ EXAppLoaderExpoUpdates (for loading and displaying apps in the home UI)
+ */
+@interface EXAbstractLoader : NSObject <EXAppFetcherDelegate, EXAppFetcherDevelopmentModeDelegate, EXAppFetcherWithTimeoutDelegate, EXAppFetcherCacheDataSource>
 
 @property (nonatomic, readonly) NSURL *manifestUrl;
 @property (nonatomic, readonly) EXManifestsManifest * _Nullable manifest; // possibly optimistic

--- a/ios/Exponent/Kernel/AppLoader/EXAbstractLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAbstractLoader.m
@@ -1,0 +1,101 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXEnvironment.h"
+#import "EXErrorRecoveryManager.h"
+#import "EXFileDownloader.h"
+#import "EXKernel.h"
+#import "EXAppFetcher.h"
+#import "EXAppFetcherDevelopmentMode.h"
+#import "EXAppFetcherCacheOnly.h"
+#import "EXAppFetcherWithTimeout.h"
+#import "EXAbstractLoader.h"
+#import "EXKernelAppRecord.h"
+#import "EXKernelAppRegistry.h"
+#import "EXKernelLinkingManager.h"
+#import "EXManifestResource.h"
+#import <EXManifests/EXManifestsManifestFactory.h>
+
+#import <React/RCTUtils.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation EXAbstractLoader
+
+- (instancetype)initWithManifestUrl:(NSURL *)url
+{
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+- (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest
+{
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+- (void)fetchManifestWithCacheBehavior:(EXManifestCacheBehavior)cacheBehavior success:(void (^)(EXManifestsManifest * _Nonnull))success failure:(void (^)(NSError * _Nonnull))failure
+{
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)request
+{
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)requestFromCache
+{
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)forceBundleReload
+{
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (BOOL)supportsBundleReload
+{
+  [self doesNotRecognizeSelector:_cmd];
+  return NO;
+}
+
+- (void)writeManifestToCache
+{
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+#pragma mark -
+#pragma mark EXAppFetcher delegate methods
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didFailWithError:(nonnull NSError *)error {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didFinishLoadingManifest:(nonnull EXManifestsManifest *)manifest bundle:(nonnull NSData *)bundle {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didLoadOptimisticManifest:(nonnull EXManifestsManifest *)manifest {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didSwitchToAppFetcher:(nonnull EXAppFetcher *)newAppFetcher retainingCurrent:(BOOL)shouldRetain {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didLoadBundleWithProgress:(nonnull EXLoadingProgress *)progress {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (void)appFetcher:(nonnull EXAppFetcher *)appFetcher didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error {
+  [self doesNotRecognizeSelector:_cmd];
+}
+
+- (BOOL)isCacheUpToDateWithAppFetcher:(nonnull EXAppFetcher *)appFetcher {
+  [self doesNotRecognizeSelector:_cmd];
+  return NO;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -134,8 +134,11 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   [self _reset];
   if (_localManifest) {
     [self _beginRequestWithLocalManifest];
+// ENG-7047: no home updates or remote manifests in release builds
+#if DEBUG
   } else if (_manifestUrl) {
     [self _beginRequestWithRemoteManifest];
+#endif
   } else {
     [self _finishWithError:RCTErrorWithMessage(@"Can't load app with no remote url nor local manifest.")];
   }
@@ -147,8 +150,11 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   _shouldUseCacheOnly = YES;
   if (_localManifest) {
     [self _beginRequestWithLocalManifest];
+// ENG-7047: no home updates or remote manifests in release builds
+#if DEBUG
   } else if (_manifestUrl) {
     [self _beginRequestWithRemoteManifest];
+#endif
   } else {
     [self _finishWithError:RCTErrorWithMessage(@"Can't load app with no remote url nor local manifest.")];
   }
@@ -186,6 +192,8 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   [self _fetchCachedManifest];
 }
 
+// ENG-7047: no home updates or remote manifests in release builds
+#if DEBUG
 - (void)_beginRequestWithRemoteManifest
 {
   // if we're in dev mode, don't try loading cached manifest
@@ -197,6 +205,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
     [self _fetchCachedManifest];
   }
 }
+#endif
 
 - (void)_fetchCachedManifest
 {
@@ -212,6 +221,9 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 {
   BOOL shouldCheckForUpdate = YES;
   NSTimeInterval fallbackToCacheTimeout = kEXAppLoaderDefaultTimeout;
+
+// ENG-7047: no home updates or remote manifests in release builds
+#if DEBUG
 
   // in case check for dev mode failed before, check again
   if (manifest.isUsingDeveloperTool) {
@@ -259,6 +271,11 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
       ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled)) {
     shouldCheckForUpdate = NO;
   }
+
+// ENG-7047: no home updates or remote manifests in release builds
+#else
+  shouldCheckForUpdate = NO;
+#endif // DEBUG
 
   if (shouldCheckForUpdate) {
     [self _startAppFetcher:[[EXAppFetcherWithTimeout alloc] initWithAppLoader:self timeout:fallbackToCacheTimeout]];

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.h
@@ -1,11 +1,11 @@
 // Copyright 2020-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader+Updates.h"
+#import "EXAbstractLoader+Updates.h"
 #import <EXUpdates/EXUpdatesAppLoaderTask.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXAppLoaderExpoUpdates : EXAppLoader <EXUpdatesAppLoaderTaskDelegate>
+@interface EXAppLoaderExpoUpdates : EXAbstractLoader <EXUpdatesAppLoaderTaskDelegate>
 
 @end
 

--- a/ios/Exponent/Kernel/AppLoader/EXHomeLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXHomeLoader.h
@@ -1,0 +1,17 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXAbstractLoader.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Subclass of EXAbstractLoader, specifically for loading
+ the home app.
+ */
+@interface EXHomeLoader : EXAbstractLoader
+
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/EXHomeLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXHomeLoader.m
@@ -8,7 +8,7 @@
 #import "EXAppFetcherDevelopmentMode.h"
 #import "EXAppFetcherCacheOnly.h"
 #import "EXAppFetcherWithTimeout.h"
-#import "EXAppLoader+Updates.h"
+#import "EXHomeLoader.h"
 #import "EXKernelAppRecord.h"
 #import "EXKernelAppRegistry.h"
 #import "EXKernelLinkingManager.h"
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 NSTimeInterval const kEXAppLoaderDefaultTimeout = 30;
 NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
-@interface EXAppLoader ()
+@interface EXHomeLoader()
 
 @property (nonatomic, strong) NSURL * _Nullable manifestUrl;
 @property (nonatomic, strong) EXManifestsManifest * _Nullable localManifest; // used by Home. TODO: ben: clean up
@@ -39,23 +39,37 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 @property (nonatomic, assign) BOOL hasFinished;
 @property (nonatomic, assign) BOOL shouldUseCacheOnly;
 
+@property (nonatomic, assign) BOOL shouldShowRemoteUpdateStatus;
+@property (nonatomic, assign) BOOL isUpToDate;
+
 @end
 
-@implementation EXAppLoader
+@implementation EXHomeLoader
+
+@synthesize manifestUrl;
+@synthesize cachedManifest;
+@synthesize shouldShowRemoteUpdateStatus;
+@synthesize isUpToDate;
 
 - (instancetype)initWithManifestUrl:(NSURL *)url
 {
+// ENG-7047: no home updates or remote manifests in release builds
+#if DEBUG
   if (self = [super init]) {
-    _manifestUrl = url;
-    _httpManifestUrl = [EXAppLoader _httpUrlFromManifestUrl:_manifestUrl];
+    self.manifestUrl = url;
+    self.httpManifestUrl = [EXHomeLoader _httpUrlFromManifestUrl:self.manifestUrl];
   }
   return self;
+#else
+  [self doesNotRecognizeSelector:_cmd];
+  return self;
+#endif
 }
 
 - (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest
 {
   if (self = [super init]) {
-    _localManifest = manifest;
+    self.localManifest = manifest;
   }
   return self;
 }
@@ -64,25 +78,25 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)_reset
 {
-  _confirmedManifest = nil;
-  _cachedManifest = nil;
-  _error = nil;
-  _appFetcher = nil;
-  _previousAppFetcherWaitingForBundle = nil;
-  _hasFinished = NO;
-  _shouldUseCacheOnly = NO;
-  _manifestResource = nil;
-  _shouldShowRemoteUpdateStatus = NO;
-  _isUpToDate = YES;
+  self.confirmedManifest = nil;
+  self.cachedManifest = nil;
+  self.error = nil;
+  self.appFetcher = nil;
+  self.previousAppFetcherWaitingForBundle = nil;
+  self.hasFinished = NO;
+  self.shouldUseCacheOnly = NO;
+  self.manifestResource = nil;
+  self.shouldShowRemoteUpdateStatus = NO;
+  self.isUpToDate = YES;
 }
 
 - (EXAppLoaderStatus)status
 {
-  if (_error || (_appFetcher && _appFetcher.error)) {
+  if (self.error || (self.appFetcher && self.appFetcher.error)) {
     return kEXAppLoaderStatusError;
-  } else if (_appFetcher && _appFetcher.bundle && _confirmedManifest) {
+  } else if (self.appFetcher && self.appFetcher.bundle && self.confirmedManifest) {
     return kEXAppLoaderStatusHasManifestAndBundle;
-  } else if (_cachedManifest || (_appFetcher && _appFetcher.manifest)) {
+  } else if (self.cachedManifest || (self.appFetcher && self.appFetcher.manifest)) {
     return kEXAppLoaderStatusHasManifest;
   }
   return kEXAppLoaderStatusNew;
@@ -90,23 +104,23 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (EXManifestsManifest * _Nullable)manifest
 {
-  if (_confirmedManifest) {
-    return _confirmedManifest;
+  if (self.confirmedManifest) {
+    return self.confirmedManifest;
   }
   // remote manifest
-  if (_appFetcher && _appFetcher.manifest) {
-    return _appFetcher.manifest;
+  if (self.appFetcher && self.appFetcher.manifest) {
+    return self.appFetcher.manifest;
   }
-  if (_cachedManifest) {
-    return _cachedManifest;
+  if (self.cachedManifest) {
+    return self.cachedManifest;
   }
   return nil;
 }
 
 - (NSData * _Nullable)bundle
 {
-  if (_appFetcher) {
-    return _appFetcher.bundle;
+  if (self.appFetcher) {
+    return self.appFetcher.bundle;
   }
   return nil;
 }
@@ -119,12 +133,12 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
                                  userInfo:@{}];
   }
   RCTAssert([self supportsBundleReload], @"Tried to force a bundle reload on a non-development bundle");
-  [(EXAppFetcherDevelopmentMode *)_appFetcher forceBundleReload];
+  [(EXAppFetcherDevelopmentMode *)self.appFetcher forceBundleReload];
 }
 
 - (BOOL)supportsBundleReload
 {
-  return (_appFetcher && [_appFetcher isKindOfClass:[EXAppFetcherDevelopmentMode class]]);
+  return (self.appFetcher && [self.appFetcher isKindOfClass:[EXAppFetcherDevelopmentMode class]]);
 }
 
 #pragma mark - public
@@ -132,11 +146,11 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)request
 {
   [self _reset];
-  if (_localManifest) {
+  if (self.localManifest) {
     [self _beginRequestWithLocalManifest];
 // ENG-7047: no home updates or remote manifests in release builds
 #if DEBUG
-  } else if (_manifestUrl) {
+  } else if (self.manifestUrl) {
     [self _beginRequestWithRemoteManifest];
 #endif
   } else {
@@ -147,12 +161,12 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)requestFromCache
 {
   [self _reset];
-  _shouldUseCacheOnly = YES;
-  if (_localManifest) {
+  self.shouldUseCacheOnly = YES;
+  if (self.localManifest) {
     [self _beginRequestWithLocalManifest];
 // ENG-7047: no home updates or remote manifests in release builds
 #if DEBUG
-  } else if (_manifestUrl) {
+  } else if (self.manifestUrl) {
     [self _beginRequestWithRemoteManifest];
 #endif
   } else {
@@ -162,9 +176,9 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)writeManifestToCache
 {
-  if (_manifestResource) {
-    [_manifestResource writeToCache];
-    _manifestResource = nil;
+  if (self.manifestResource) {
+    [self.manifestResource writeToCache];
+    self.manifestResource = nil;
   }
 }
 
@@ -187,8 +201,8 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)_beginRequestWithLocalManifest
 {
-  _confirmedManifest = _localManifest;
-  _cachedManifest = _localManifest;
+  self.confirmedManifest = self.localManifest;
+  self.cachedManifest = self.localManifest;
   [self _fetchCachedManifest];
 }
 
@@ -197,7 +211,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)_beginRequestWithRemoteManifest
 {
   // if we're in dev mode, don't try loading cached manifest
-  if ([_httpManifestUrl.host isEqualToString:@"localhost"]
+  if ([self.httpManifestUrl.host isEqualToString:@"localhost"]
       || ([EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].isDebugXCodeScheme)) {
     // we can't pre-detect if this person is using a developer tool, but using localhost is a pretty solid indicator.
     [self _startAppFetcher:[[EXAppFetcherDevelopmentMode alloc] initWithAppLoader:self]];
@@ -267,7 +281,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
   // if remote updates are disabled, or we're using `reloadFromCache`, don't check for an update.
   // these checks need to be here because they need to happen after the dev mode check above.
-  if (_shouldUseCacheOnly ||
+  if (self.shouldUseCacheOnly ||
       ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled)) {
     shouldCheckForUpdate = NO;
   }
@@ -286,23 +300,23 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)_startAppFetcher:(EXAppFetcher *)appFetcher
 {
-  _appFetcher = appFetcher;
-  _appFetcher.delegate = self;
-  _appFetcher.dataSource = _dataSource;
-  _appFetcher.cacheDataSource = self;
-  if ([_appFetcher isKindOfClass:[EXAppFetcherDevelopmentMode class]]) {
-    ((EXAppFetcherDevelopmentMode *)_appFetcher).developmentModeDelegate = self;
-  } else if ([_appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]]) {
-    ((EXAppFetcherWithTimeout *)_appFetcher).withTimeoutDelegate = self;
+  self.appFetcher = appFetcher;
+  self.appFetcher.delegate = self;
+  self.appFetcher.dataSource = self.dataSource;
+  self.appFetcher.cacheDataSource = self;
+  if ([self.appFetcher isKindOfClass:[EXAppFetcherDevelopmentMode class]]) {
+    ((EXAppFetcherDevelopmentMode *)self.appFetcher).developmentModeDelegate = self;
+  } else if ([self.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]]) {
+    ((EXAppFetcherWithTimeout *)self.appFetcher).withTimeoutDelegate = self;
   }
-  [_appFetcher start];
+  [self.appFetcher start];
 }
 
 - (void)_finishWithError:(NSError * _Nullable)err
 {
-  _error = err;
-  if (_delegate) {
-    [_delegate appLoader:self didFailWithError:err];
+  self.error = err;
+  if (self.delegate) {
+    [self.delegate appLoader:self didFailWithError:err];
   }
 }
 
@@ -310,7 +324,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (BOOL)isCacheUpToDateWithAppFetcher:(EXAppFetcher *)appFetcher
 {
-  if (_localManifest) {
+  if (self.localManifest) {
     // local manifest won't give us sufficient information to tell
     return NO;
   }
@@ -328,37 +342,37 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)appFetcher:(EXAppFetcher *)appFetcher didSwitchToAppFetcher:(EXAppFetcher *)newAppFetcher retainingCurrent:(BOOL)shouldRetain
 {
   if (shouldRetain) {
-    _previousAppFetcherWaitingForBundle = appFetcher;
+    self.previousAppFetcherWaitingForBundle = appFetcher;
   }
   [self _startAppFetcher:newAppFetcher];
 }
 
 - (void)appFetcher:(EXAppFetcher *)appFetcher didLoadOptimisticManifest:(EXManifestsManifest *)manifest
 {
-  if (_delegate) {
-    [_delegate appLoader:self didLoadOptimisticManifest:manifest];
+  if (self.delegate) {
+    [self.delegate appLoader:self didLoadOptimisticManifest:manifest];
   }
 }
 
 - (void)appFetcher:(EXAppFetcher *)appFetcher didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)bundle
 {
-  _confirmedManifest = manifest;
-  if (_delegate) {
-    [_delegate appLoader:self didFinishLoadingManifest:manifest bundle:bundle];
+  self.confirmedManifest = manifest;
+  if (self.delegate) {
+    [self.delegate appLoader:self didFinishLoadingManifest:manifest bundle:bundle];
   }
 }
 
 - (void)appFetcher:(EXAppFetcher *)appFetcher didFailWithError:(NSError *)error
 {
   // don't nullify appFetcher - we need to use its state to record the circumstances of the error
-  _error = error;
-  if (_delegate) {
-    [_delegate appLoader:self didFailWithError:error];
+  self.error = error;
+  if (self.delegate) {
+    [self.delegate appLoader:self didFailWithError:error];
   }
-  if (appFetcher == _previousAppFetcherWaitingForBundle) {
+  if (appFetcher == self.previousAppFetcherWaitingForBundle) {
     // previous app fetcher errored while trying to fetch a new bundle
     // so we can deallocate it now
-    _previousAppFetcherWaitingForBundle = nil;
+    self.previousAppFetcherWaitingForBundle = nil;
   }
 }
 
@@ -366,8 +380,8 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)appFetcher:(EXAppFetcher *)appFetcher didLoadBundleWithProgress:(EXLoadingProgress *)progress
 {
-  if (_delegate) {
-    [_delegate appLoader:self didLoadBundleWithProgress:progress];
+  if (self.delegate) {
+    [self.delegate appLoader:self didLoadBundleWithProgress:progress];
   }
 }
 
@@ -375,13 +389,13 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
 - (void)appFetcher:(EXAppFetcher *)appFetcher didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
 {
-  if (_delegate) {
-    [_delegate appLoader:self didResolveUpdatedBundleWithManifest:manifest isFromCache:isFromCache error:error];
+  if (self.delegate) {
+    [self.delegate appLoader:self didResolveUpdatedBundleWithManifest:manifest isFromCache:isFromCache error:error];
   }
-  if (appFetcher == _previousAppFetcherWaitingForBundle) {
+  if (appFetcher == self.previousAppFetcherWaitingForBundle) {
     // we no longer need to retain the previous app fetcher
     // as the only reason to retain is to wait for it to finish downloading the new bundle
-    _previousAppFetcherWaitingForBundle = nil;
+    self.previousAppFetcherWaitingForBundle = nil;
   }
 }
 
@@ -390,18 +404,18 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)fetchManifestWithCacheBehavior:(EXManifestCacheBehavior)manifestCacheBehavior success:(void (^)(EXManifestsManifest *))success failure:(void (^)(NSError *))failure
 {
   // if we're using a localManifest, just return it immediately
-  if (_localManifest) {
-    success(_localManifest);
+  if (self.localManifest) {
+    success(self.localManifest);
     return;
   }
 
-  if (!([_httpManifestUrl.scheme isEqualToString:@"http"] || [_httpManifestUrl.scheme isEqualToString:@"https"])) {
-    NSURLComponents *components = [NSURLComponents componentsWithURL:_httpManifestUrl resolvingAgainstBaseURL:NO];
+  if (!([self.httpManifestUrl.scheme isEqualToString:@"http"] || [self.httpManifestUrl.scheme isEqualToString:@"https"])) {
+    NSURLComponents *components = [NSURLComponents componentsWithURL:self.httpManifestUrl resolvingAgainstBaseURL:NO];
     components.scheme = @"http";
-    _httpManifestUrl = [components URL];
+    self.httpManifestUrl = [components URL];
   }
 
-  EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:_httpManifestUrl originalUrl:_manifestUrl];
+  EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:self.httpManifestUrl originalUrl:self.manifestUrl];
 
   EXCachedResourceBehavior cachedResourceBehavior = EXCachedResourceNoCache;
   if (manifestCacheBehavior == EXManifestOnlyCache) {
@@ -409,7 +423,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   } else if (manifestCacheBehavior == EXManifestPrepareToCache) {
     // in this case, we don't want to use the cache but will prepare to write the resulting manifest
     // to the cache later, after the bundle is finished downloading, so we save the reference
-    _manifestResource = manifestResource;
+    self.manifestResource = manifestResource;
   }
   [manifestResource loadResourceWithBehavior:cachedResourceBehavior progressBlock:nil successBlock:^(NSData * _Nonnull data) {
     NSError *error;

--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -5,7 +5,7 @@
 #import "EXAppViewController.h"
 #import "EXBuildConstants.h"
 #import "EXKernel.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXKernelAppRecord.h"
 #import "EXKernelLinkingManager.h"
 #import "EXLinkingManager.h"

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.h
@@ -9,7 +9,7 @@ FOUNDATION_EXPORT NSString *kEXKernelBridgeDidBackgroundNotification;
 
 @class EXAppViewController;
 @class EXReactAppManager;
-@class EXAppLoader;
+@class EXAbstractLoader;
 
 typedef enum EXKernelAppRecordStatus {
   kEXKernelAppRecordStatusNew, // record just created
@@ -22,14 +22,14 @@ typedef enum EXKernelAppRecordStatus {
 @interface EXKernelAppRecord : NSObject
 
 - (instancetype)initWithManifestUrl:(NSURL *)manifestUrl initialProps:(nullable NSDictionary *)initialProps;
-- (instancetype)initWithAppLoader:(EXAppLoader *)customAppLoader
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)customAppLoader
                        appManager:(EXReactAppManager *)customAppManager;
 
 @property (nonatomic, readonly, assign) EXKernelAppRecordStatus status;
 @property (nonatomic, readonly, strong) NSDate *timeCreated;
 @property (nonatomic, readonly) NSString * _Nullable scopeKey;
 @property (nonatomic, readonly) EXReactAppManager *appManager;
-@property (nonatomic, readonly, strong) EXAppLoader *appLoader;
+@property (nonatomic, readonly, strong) EXAbstractLoader *appLoader;
 @property (nonatomic, readonly) EXAppViewController *viewController;
 
 /**

--- a/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRecord.m
@@ -23,7 +23,7 @@ NSString *kEXKernelBridgeDidBackgroundNotification = @"EXKernelBridgeDidBackgrou
   return self;
 }
 
-- (instancetype)initWithAppLoader:(EXAppLoader *)customAppLoader appManager:(EXReactAppManager *)customAppManager
+- (instancetype)initWithAppLoader:(EXAbstractLoader *)customAppLoader appManager:(EXReactAppManager *)customAppManager
 {
   if (self = [super init]) {
     _appManager = customAppManager;

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "EXKernelAppRegistry.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXEnvironment.h"
 #import "EXReactAppManager.h"
 #import "EXKernel.h"

--- a/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppLoader.h
+++ b/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppLoader.h
@@ -1,7 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import "EXReactAppManager.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 
 #import <Foundation/Foundation.h>
 #import <UMAppLoader/UMAppLoaderInterface.h>

--- a/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.h
+++ b/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.h
@@ -2,7 +2,7 @@
 
 #import "EXKernelAppRecord.h"
 #import "EXReactAppManager.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 
 #import <UMAppLoader/UMAppRecordInterface.h>
 

--- a/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.m
+++ b/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.m
@@ -79,14 +79,14 @@
 
 # pragma mark - EXAppLoaderDelegate
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [self rebuildBridge];
   });
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
+- (void)appLoader:(EXAbstractLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [self rebuildBridge];
@@ -96,7 +96,7 @@
   });
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFailWithError:(NSError *)error
+- (void)appLoader:(EXAbstractLoader *)appLoader didFailWithError:(NSError *)error
 {
   if (_appManager.status == kEXReactAppManagerStatusBridgeLoading) {
     [_appManager appLoaderFailedWithError:error];
@@ -104,7 +104,7 @@
   [self maybeExecuteCallbackWithSuccess:NO error:error];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress {}
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary *)manifest isFromCache:(BOOL)isFromCache error:(NSError *)error {}
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress {}
+- (void)appLoader:(EXAbstractLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary *)manifest isFromCache:(BOOL)isFromCache error:(NSError *)error {}
 
 @end

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -4,7 +4,7 @@
 #import "EXErrorRecoveryManager.h"
 #import "EXUserNotificationManager.h"
 #import "EXKernel.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXKernelLinkingManager.h"
 #import "EXKernelServiceRegistry.h"
 #import "EXKernelUtil.h"

--- a/ios/Exponent/Kernel/Services/EXHomeModuleManager.m
+++ b/ios/Exponent/Kernel/Services/EXHomeModuleManager.m
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXEnvironment.h"
 #import "EXFileDownloader.h"
 #import "EXHomeModuleManager.h"

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXEnvironment.h"
 #import "EXKernel.h"
 #import "EXKernelLinkingManager.h"

--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader+Updates.h"
+#import "EXAbstractLoader+Updates.h"
 #import "EXKernel.h"
 #import "EXKernelAppRecord.h"
 #import "EXReactAppManager.h"
@@ -50,7 +50,7 @@ ofDownloadWithManifest:(EXManifestsManifest * _Nullable)manifest
 
 # pragma mark - internal
 
-- (EXAppLoader *)_appLoaderWithScopeKey:(NSString *)scopeKey
+- (EXAbstractLoader *)_appLoaderWithScopeKey:(NSString *)scopeKey
 {
   EXKernelAppRecord *appRecord = [[EXKernel sharedInstance].appRegistry newestRecordWithScopeKey:scopeKey];
   return appRecord.appLoader;

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -4,7 +4,7 @@
 #import "EXKernel.h"
 #import "EXRemoteNotificationManager.h"
 #import "EXEnvironment.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 
 static NSString * const scopedIdentifierSeparator = @":";
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -3,7 +3,7 @@
 @import UIKit;
 
 #import "EXAnalytics.h"
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXAppViewController.h"
 #import "EXAppLoadingProgressWindowController.h"
 #import "EXAppLoadingCancelView.h"
@@ -377,7 +377,7 @@ NS_ASSUME_NONNULL_BEGIN
   });
 }
 
-- (void)_setLoadingViewStatusIfEnabledFromAppLoader:(EXAppLoader *)appLoader
+- (void)_setLoadingViewStatusIfEnabledFromAppLoader:(EXAbstractLoader *)appLoader
 {
   if (appLoader.shouldShowRemoteUpdateStatus) {
     [self.appLoadingProgressWindowController updateStatus:appLoader.remoteUpdateStatus];
@@ -455,7 +455,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - EXAppLoaderDelegate
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(EXManifestsManifest *)manifest
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadOptimisticManifest:(EXManifestsManifest *)manifest
 {
   if (_appLoadingCancelView) {
     EX_WEAKIFY(self);
@@ -473,14 +473,14 @@ NS_ASSUME_NONNULL_BEGIN
   [self _rebuildBridge];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
+- (void)appLoader:(EXAbstractLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
 {
   if (self->_appRecord.appManager.status != kEXReactAppManagerStatusRunning) {
     [self.appLoadingProgressWindowController updateStatusWithProgress:progress];
   }
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)data
+- (void)appLoader:(EXAbstractLoader *)appLoader didFinishLoadingManifest:(EXManifestsManifest *)manifest bundle:(NSData *)data
 {
   [self _showOrReconfigureManagedAppSplashScreen:manifest];
   if (!_isHomeApp) {
@@ -496,7 +496,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFailWithError:(NSError *)error
+- (void)appLoader:(EXAbstractLoader *)appLoader didFailWithError:(NSError *)error
 {
   if (_appRecord.appManager.status == kEXReactAppManagerStatusBridgeLoading) {
     [_appRecord.appManager appLoaderFailedWithError:error];
@@ -504,7 +504,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self maybeShowError:error];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
+- (void)appLoader:(EXAbstractLoader *)appLoader didResolveUpdatedBundleWithManifest:(EXManifestsManifest * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
 {
   [[EXKernel sharedInstance].serviceRegistry.updatesManager notifyApp:_appRecord ofDownloadWithManifest:manifest isNew:!isFromCache error:error];
 }

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -1,6 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXErrorView.h"
 #import "EXEnvironment.h"
 #import "EXKernel.h"

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.h
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-#import "EXAppLoader.h"
+#import "EXAbstractLoader.h"
 #import "EXResourceLoader.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/Tests/AppLoader/EXAppLoader+Tests.h
+++ b/ios/Tests/AppLoader/EXAppLoader+Tests.h
@@ -1,9 +1,9 @@
-#import "EXAppLoader.h"
+#import "EXHomeLoader.h"
 #import <EXManifests/EXManifestsManifest.h>
 
 #pragma mark - private/internal methods in App Loader & App Fetchers
 
-@interface EXAppLoader (EXAppLoaderTests)
+@interface EXHomeLoader (EXAppLoaderTests)
 
 @property (nonatomic, readonly) EXAppFetcher * _Nullable appFetcher;
 

--- a/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
+++ b/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
@@ -31,7 +31,7 @@
 - (void)testIsDefaultUpdatesConfigUsed
 {
   NSDictionary *manifest = @{};
-  EXAppLoader *appLoader = [[EXAppLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should choose to use AppFetcherWithTimeout when fetching remotely");
   XCTAssert([(EXAppFetcherWithTimeout *)appLoader.appFetcher timeout] == kEXAppLoaderDefaultTimeout, @"AppFetcherWithTimeout should have the correct user-specified timeout length");
@@ -44,7 +44,7 @@
       @"fallbackToCacheTimeout": @1000,
     }
   };
-  EXAppLoader *appLoader = [[EXAppLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should choose to use AppFetcherWithTimeout when fetching remotely");
   XCTAssert([(EXAppFetcherWithTimeout *)appLoader.appFetcher timeout] == 1.0f, @"AppFetcherWithTimeout should have the correct user-specified timeout length");
@@ -57,7 +57,7 @@
       @"checkAutomatically": @"ON_ERROR_RECOVERY"
     }
   };
-  EXAppLoader *appLoader = [[EXAppLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should ignore ON_ERROR_RECOVERY in Expo Go");
 }

--- a/ios/Tests/AppLoader/EXAppLoaderConfigurationTestsProdService.m
+++ b/ios/Tests/AppLoader/EXAppLoaderConfigurationTestsProdService.m
@@ -23,7 +23,7 @@
                                  },
                              @"bundleUrl": @"https://classic-assets.eascdn.net/%40esamelson%2Ftest-fetch-update%2F1.0.0%2Fddf3e9977eedb14313d242302df6cf70-27.0.0-ios.js", // value doesn't matter
                              };
-  EXAppLoader *appLoader = [[EXAppLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXAbstractLoader *appLoader = [[EXAbstractLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherCacheOnly class]], @"AppLoader should choose to use AppFetcherCacheOnly in a shell app with ON_ERROR_RECOVERY");
 }

--- a/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.h
+++ b/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.h
@@ -11,6 +11,6 @@
                expectToFail:(XCTestExpectation *)expectToFail;
 - (void)request;
 
-@property (nonatomic, readonly) EXAppLoader *appLoader;
+@property (nonatomic, readonly) EXHomeLoader *appLoader;
 
 @end

--- a/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.m
+++ b/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.m
@@ -9,7 +9,7 @@
 @property (nonatomic, strong) NSURL *url;
 @property (nonatomic, strong) XCTestExpectation *expectToSucceed;
 @property (nonatomic, strong) XCTestExpectation *expectToFail;
-@property (nonatomic, strong) EXAppLoader *appLoader;
+@property (nonatomic, strong) EXHomeLoader *appLoader;
 
 @end
 
@@ -21,7 +21,7 @@
     _url = url;
     _expectToSucceed = expectToSucceed;
     _expectToFail = expectToFail;
-    _appLoader = [[EXAppLoader alloc] initWithManifestUrl:_url];
+    _appLoader = [[EXHomeLoader alloc] initWithManifestUrl:_url];
     _appLoader.delegate = self;
   }
   return self;
@@ -34,27 +34,27 @@
 
 #pragma mark - AppLoaderDelegate
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
+- (void)appLoader:(EXHomeLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
 {
   
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
+- (void)appLoader:(EXHomeLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
 {
 
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
+- (void)appLoader:(EXHomeLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
 {
   [_expectToSucceed fulfill];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didFailWithError:(NSError *)error
+- (void)appLoader:(EXHomeLoader *)appLoader didFailWithError:(NSError *)error
 {
   [_expectToFail fulfill];
 }
 
-- (void)appLoader:(EXAppLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
+- (void)appLoader:(EXHomeLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
 {
   
 }


### PR DESCRIPTION
# Why

Per ENG-7047, we need to disable remote loading of home app, and checking for home app updates, for release builds.
Updates and loading from the packager will still work in debug builds.

# How

Add `#ifdef DEBUG` in several places in `Exponent/Kernel/AppLoader/EXAppLoader.m`

# Test Plan

- CI should pass
- Test Expo Go builds locally and verify that updates are not loaded, and that nothing else is broken

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
