### PR TITLE
[modules][Android] Support sync functions with 4/5/7/8 arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed views are not correctly initialized after reloading on Android. ([#20063](https://github.com/expo/expo/pull/20063) by [@lukmccall](https://github.com/lukmccall))
 - Fixed libraries using the `ViewDefinitionBuilder` crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
 - Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
+- Fixed Function not supporting certain arities on Android. ([#20419](https://github.com/expo/expo/pull/20419) by [@motiz88](https://github.com/motiz88))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -138,7 +138,7 @@ open class ObjectDefinitionBuilder {
       syncFunctions[name] = it
     }
   }
-  
+
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
@@ -147,7 +147,7 @@ open class ObjectDefinitionBuilder {
       syncFunctions[name] = it
     }
   }
-  
+
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
@@ -165,7 +165,7 @@ open class ObjectDefinitionBuilder {
       syncFunctions[name] = it
     }
   }
-  
+
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
@@ -174,7 +174,7 @@ open class ObjectDefinitionBuilder {
       syncFunctions[name] = it
     }
   }
-  
+
   @JvmName("AsyncFunctionWithoutArgs")
   inline fun AsyncFunction(
     name: String,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -130,6 +130,24 @@ open class ObjectDefinitionBuilder {
     }
   }
 
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+      syncFunctions[name] = it
+    }
+  }
+  
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+      syncFunctions[name] = it
+    }
+  }
+  
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Function(
     name: String,
     crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
@@ -139,6 +157,24 @@ open class ObjectDefinitionBuilder {
     }
   }
 
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+      syncFunctions[name] = it
+    }
+  }
+  
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Function(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+      syncFunctions[name] = it
+    }
+  }
+  
   @JvmName("AsyncFunctionWithoutArgs")
   inline fun AsyncFunction(
     name: String,


### PR DESCRIPTION
# Why

[`Function`](https://docs.expo.dev/modules/module-api/#function) is documented as supporting up to 8 arguments, but the 4-, 5-, 7-, and 8-argument cases were unimplemented in Kotlin.

# How

Copied code from the other cases and added arguments as needed.

# Test Plan

**Did not test**, just made sure the code looks right. I'm not really familiar with this codebase; are there tests I should extend for this?

# Checklist

- [x] Documentation is up to date to reflect these changes (no change was needed)
