### PR TITLE
[docs] Fix broken link in In-app-purchase and stripe pages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
@@ -18,7 +18,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) due to app store restrictions.
 
-You can create a [development build][dev-build] to work with this package.
+You can create a [development build](/development/create-development-builds) to work with this package.
 
 <APIInstallSection />
 
@@ -49,5 +49,3 @@ import * as InAppPurchases from 'expo-in-app-purchases';
 ```
 
 <APISection packageName="expo-in-app-purchases" apiName="InAppPurchases" />
-
-[dev-build]: /development/getting-started.mdx#creating-and-installing-your-first-development-build

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -6,7 +6,7 @@ packageName: '@stripe/stripe-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
@@ -82,16 +82,12 @@ urlScheme:
 
 ### Standalone apps
 
-`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build][eas-build], and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
+`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go][expo-go]. To use Apple Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go][expo-go]. To use Google Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:android`.
-
-[eas-build]: /build/introduction
-[expo-go]: https://expo.dev/expo-go
-[dev-build]: /development/getting-started.mdx#creating-and-installing-your-first-development-build
+Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.

--- a/docs/pages/versions/v47.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/in-app-purchases.mdx
@@ -18,7 +18,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 This module is **not** available in the [Expo Go app](https://expo.dev/expo-go) due to app store restrictions.
 
-You can create a [development build][dev-build] to work with this package.
+You can create a [development build](/development/create-development-builds) to work with this package.
 
 <APIInstallSection />
 
@@ -49,5 +49,3 @@ import * as InAppPurchases from 'expo-in-app-purchases';
 ```
 
 <APISection packageName="expo-in-app-purchases" apiName="InAppPurchases" />
-
-[dev-build]: /development/getting-started.mdx#creating-and-installing-your-first-development-build

--- a/docs/pages/versions/v47.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/stripe.mdx
@@ -6,7 +6,7 @@ packageName: '@stripe/stripe-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
@@ -82,16 +82,12 @@ urlScheme:
 
 ### Standalone apps
 
-`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build][eas-build], and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
+`@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
 ### Apple Pay
 
-Apple Pay **is not** supported in [Expo Go][expo-go]. To use Apple Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:ios`.
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
 
 ### Google Pay
 
-Google Pay **is not** supported in [Expo Go][expo-go]. To use Google Pay, you must create a [development build][dev-build]. This can be done with [EAS Build][eas-build], or locally by running `npx expo run:android`.
-
-[eas-build]: /build/introduction
-[expo-go]: https://expo.dev/expo-go
-[dev-build]: /development/getting-started.mdx#creating-and-installing-your-first-development-build
+Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-7053

# How

<!--
How did you build this feature or fix this bug and why?
-->

By replacing the broken link in the In-app-purchase and Stripe docs. The changes have been backported to SDK 47.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
