### PR TITLE
[docs] Add redirects for broken archived links

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -272,7 +272,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/tutorial/text/': '/tutorial/introduction/',
 
   // Redirects for removed /archived pages
-  '/archived/': '/',
+  '/archived/': '/archive/',
 
   // Redirects for removed API docs based on Sentry
   '/versions/latest/sdk/facebook/': '/guides/authentication/',

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -247,6 +247,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/worfkflow/publishing/': '/archive/classic-updates/publishing/',
   '/classic/building-standalone-apps/': '/archive/classic-updates/building-standalone-apps/',
   '/classic/turtle-cli/': '/archive/classic-updates/turtle-cli/',
+  '/archive/classic-updates/getting-started/': '/eas-update/getting-started/',
 
   // Redirect bare guides to unified workflow guides
   '/bare/using-libraries/': '/workflow/using-libraries/',
@@ -281,4 +282,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/latest/sdk/branch/':
     'https://github.com/expo/config-plugins/tree/main/packages/react-native-branch',
   '/versions/latest/sdk/appstate/': '/versions/latest/react-native/appstate/',
+  '/versions/latest/sdk/google/': '/guides/authentication/',
 };

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -271,6 +271,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/tutorial/sharing/': '/tutorial/introduction/',
   '/tutorial/text/': '/tutorial/introduction/',
 
+  // Redirects for removed /archived pages
+  '/archived/': '/',
+
   // Redirects for removed API docs based on Sentry
   '/versions/latest/sdk/facebook/': '/guides/authentication/',
   '/versions/latest/sdk/taskmanager/': '/versions/latest/sdk/task-manager/',
@@ -283,4 +286,5 @@ const RENAMED_PAGES: Record<string, string> = {
     'https://github.com/expo/config-plugins/tree/main/packages/react-native-branch',
   '/versions/latest/sdk/appstate/': '/versions/latest/react-native/appstate/',
   '/versions/latest/sdk/google/': '/guides/authentication/',
+  '/versions/latest/sdk/amplitude/': '/guides/using-analytics/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -153,7 +153,7 @@ redirects[worfkflow/publishing]=archive/classic-updates/publishing
 redirects[classic/building-standalone-apps/]=archive/classic-updates/building-standalone-apps/
 redirects[classic/turtle-cli/]=archive/classic-updates/turtle-cli/
 redirects[archive/classic-updates/getting-started/]=eas-update/getting-started/
-redirects[archived/]=/
+redirects[archived/]=archive/
 
 # Old tutorial pages
 redirects[introduction/walkthrough]=tutorial/introduction/

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -152,6 +152,7 @@ redirects[eas-update/bare-react-native]=bare/updating-your-app
 redirects[worfkflow/publishing]=archive/classic-updates/publishing
 redirects[classic/building-standalone-apps/]=archive/classic-updates/building-standalone-apps/
 redirects[classic/turtle-cli/]=archive/classic-updates/turtle-cli/
+redirects[archive/classic-updates/getting-started/]=eas-update/getting-started/
 
 # Old tutorial pages
 redirects[introduction/walkthrough]=tutorial/introduction/
@@ -167,6 +168,7 @@ redirects[versions/latest/sdk/appearance]=versions/latest/react-native/appearanc
 redirects[versions/latest/sdk/app-loading]=versions/latest/sdk/splash-screen/
 redirects[versions/latest/sdk/app-auth]=guides/authentication/
 redirects[versions/latest/sdk/google-sign-in]=guides/authentication/
+redirects[versions/latest/sdk/google]=guides/authentication/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -153,6 +153,7 @@ redirects[worfkflow/publishing]=archive/classic-updates/publishing
 redirects[classic/building-standalone-apps/]=archive/classic-updates/building-standalone-apps/
 redirects[classic/turtle-cli/]=archive/classic-updates/turtle-cli/
 redirects[archive/classic-updates/getting-started/]=eas-update/getting-started/
+redirects[archived/]=/
 
 # Old tutorial pages
 redirects[introduction/walkthrough]=tutorial/introduction/
@@ -169,6 +170,7 @@ redirects[versions/latest/sdk/app-loading]=versions/latest/sdk/splash-screen/
 redirects[versions/latest/sdk/app-auth]=guides/authentication/
 redirects[versions/latest/sdk/google-sign-in]=guides/authentication/
 redirects[versions/latest/sdk/google]=guides/authentication/
+redirects[versions/latest/sdk/amplitude/]=guides/using-analytics/
 
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR fixes the issues raised in the Sentry report for the following broken links:
- `versions/latest/sdk/google/`
- `versions/latest/sdk/amplitude/`
- `archived/`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
