### PR TITLE
[docs] fix minor regressions after MDX components switch

### DIFF
--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -58,7 +58,7 @@ export const APIGridCell = ({
   xl = 3,
 }: APIGridCellProps) => (
   <CustomCol css={cellWrapperStyle} md={md} sm={sm} lg={lg} xl={xl}>
-    <A href={link} css={[cellStyle, cellAPIStyle, cellHoverStyle]} className={className}>
+    <A href={link} css={[cellStyle, cellAPIStyle, cellHoverStyle]} className={className} isStyled>
       <div css={cellIconWrapperStyle}>{icon}</div>
       <div css={cellTitleWrapperStyle}>
         {title}

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -40,11 +40,11 @@ const stepContentStyle = css({
   paddingTop: spacing[1],
 
   'h2:first-child': {
-    marginTop: -spacing[1],
+    marginTop: `${-spacing[1]}px !important`,
   },
 
   'h3:first-child, h4:first-child': {
-    marginTop: -spacing[0.5],
+    marginTop: `0 !important`,
   },
 
   'ul, ol': {


### PR DESCRIPTION
# Why

Fixes `Step` component additional spacing and `APIGridCell` hover appearance.

# How

Make sure that `Step` overwrites works for the temporary headers, the `!important` should not be needed after we migrate the header fully.

Add `isStyled` flag for the `APIGridCell`s, so the default link style is not applied to the grid content.

# Test Plan

The changes have been tested locally.

# Preview

<img width="1191" alt="Screenshot 2022-12-13 at 14 36 34" src="https://user-images.githubusercontent.com/719641/207337596-d670a337-09e5-4b72-9524-a99782cbce4e.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
