### PR TITLE
[docs] cleanup in docs plugins related to the latest changes

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -1,35 +1,9 @@
-import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
 import { PropsWithChildren, useContext } from 'react';
 
 import { PageApiVersionContext } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
 import { Terminal } from '~/ui/components/Snippet';
-import { A } from '~/ui/components/Text';
-
-const STYLES_P = css`
-  line-height: 1.8rem;
-  margin-top: 1.4rem;
-  margin-bottom: 1.4rem;
-  color: ${theme.text.default};
-`;
-
-const STYLES_BOLD = css`
-  font-family: ${typography.fontFaces.medium};
-  font-weight: 400;
-  text-decoration: none;
-  color: ${theme.link.default};
-  :hover {
-    text-decoration: underline;
-  }
-`;
-const STYLES_LINK = css`
-  text-decoration: none;
-  color: ${theme.link.default};
-  :hover {
-    text-decoration: underline;
-  }
-`;
+import { A, P, DEMI } from '~/ui/components/Text';
 
 type InstallSectionProps = PropsWithChildren<{
   packageName: string;
@@ -41,9 +15,7 @@ type InstallSectionProps = PropsWithChildren<{
 const getPackageLink = (packageNames: string) =>
   `https://github.com/expo/expo/tree/main/packages/${packageNames.split(' ')[0]}`;
 
-function getInstallCmd(packageName: string) {
-  return `$ npx expo install ${packageName}`;
-}
+const getInstallCmd = (packageName: string) => `$ npx expo install ${packageName}`;
 
 const InstallSection = ({
   packageName,
@@ -54,9 +26,9 @@ const InstallSection = ({
   const { sourceCodeUrl } = usePageMetadata();
   const { version } = useContext(PageApiVersionContext);
 
-  // Recommend just `expo install` for SDK 43, 44, and 45.
+  // Recommend just `expo install` for SDK 45.
   // TODO: remove this when we drop SDK 45 from docs
-  if (version.startsWith('v43') || version.startsWith('v44') || version.startsWith('v45')) {
+  if (version.startsWith('v45')) {
     if (cmd[0] === getInstallCmd(packageName)) {
       cmd[0] = cmd[0].replace('npx expo', 'expo');
     }
@@ -66,17 +38,15 @@ const InstallSection = ({
     <>
       <Terminal cmd={cmd} />
       {hideBareInstructions ? null : (
-        <p css={STYLES_P}>
+        <P>
           If you're installing this in a{' '}
-          <A css={STYLES_LINK} href="/introduction/managed-vs-bare/#bare-workflow">
-            bare React Native app
-          </A>
-          , you should also follow{' '}
-          <A css={STYLES_BOLD} href={sourceCodeUrl ?? href}>
-            these additional installation instructions
+          <A href="/introduction/managed-vs-bare/#bare-workflow">bare React Native app</A>, you
+          should also follow{' '}
+          <A href={sourceCodeUrl ?? href}>
+            <DEMI>these additional installation instructions</DEMI>
           </A>
           .
-        </p>
+        </P>
       )}
     </>
   );

--- a/docs/components/plugins/PlatformsSection.tsx
+++ b/docs/components/plugins/PlatformsSection.tsx
@@ -12,12 +12,9 @@ const STYLES_TITLE = css`
 `;
 
 const STYLES_LINK = css`
-  text-decoration: none;
   display: grid;
   grid-template-columns: 20px auto;
-  text-align: left;
   grid-gap: 8px;
-  color: ${theme.link.default};
 `;
 
 const platforms = [


### PR DESCRIPTION
# Why

This PR includes small cleanups in docs plugin components, related to the latest refactor. Those changes should not collide with other PRs.

# How

Use the defined components instead of raw tags with styles overwrites. I have also removed a check for the SDK versions on longer present on website.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="1142" alt="Screenshot 2022-12-13 at 18 14 09" src="https://user-images.githubusercontent.com/719641/207399551-f0586ab2-19c8-4cd9-8e44-ae529c2f6f6f.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
