### PR TITLE
[docs] remove invalid headers in MD, fix code size in headers

### DIFF
--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -11,9 +11,9 @@ EAS Build can help you with this by providing shareable URLs for your builds wit
 
 > Installing an app on iOS is a bit trickier than on Android, but it's possible thanks to ad hoc and enterprise provisioning profiles. We'll talk more about this later in this doc.
 
-# Setting up internal distribution
+## Setting up internal distribution
 
-The following three steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](setup.mdx). It will only take a few minutes in total to: configure the project, add a couple of test iOS devices to a provisioning profile, and start builds for Android and iOS.
+The following steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](setup.mdx). It will only take a few minutes in total to: configure the project, add a couple of test iOS devices to a provisioning profile, and start builds for Android and iOS.
 
 ## 1. Configure a build profile
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -1,7 +1,7 @@
 ---
 title: Schema for EAS Metadata
 sidebar_title: Metadata schema
-sidebar_depth: 4
+maxHeadingDepth: 4
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/expokit/universal-modules-and-expokit.mdx
+++ b/docs/pages/expokit/universal-modules-and-expokit.mdx
@@ -1,5 +1,6 @@
 ---
 title: Universal Modules and ExpoKit
+maxHeadingDepth: 4
 ---
 
 > **warning** ExpoKit is deprecated and is no longer supported after SDK 38. If you need to make customizations to your Expo project, we recommend using the [bare workflow](../workflow/customizing.mdx) instead.
@@ -11,7 +12,7 @@ Universal Modules are pieces of the Expo SDK with some special properties:
 
 Not all Expo SDK modules are Universal Modules. Right now, only a small part of our SDK has this property. We're continually expanding the number of our APIs that are available as universal modules.
 
-# Omitting Unneeded Modules
+## Omitting Unneeded Modules
 
 When you [create an ExpoKit project](eject.mdx), we automatically add most of the same native APIs that are available in the Expo Go app. Each of these APIs is supported by some native code which increases the size of your native binary.
 
@@ -21,17 +22,17 @@ Omitting Universal Modules is currently supported on iOS but not Android.
 
 > **If you aren't sure what this guide is for or whether you need this,** you are probably better off just leaving it alone. Otherwise you risk causing crashes in your app by ripping out needed APIs.
 
-## iOS
+### iOS
 
 To omit a Universal Module from your iOS ExpoKit project, remove the respective dependency from `ios/Podfile`. Then re-run `npx pod-install` and rebuild your native code.
 
-### These modules are included by default, but can be omitted
+#### These modules are included by default, but can be omitted
 
 - GL (`EXGL` and `EXGL-CPP`)
 - SMS composer (`EXSMS`)
 - Accelerometer, DeviceMotion, Gyroscope, Magnetometer, Pedometer (`EXSensors`)
 
-### These modules are included by default, but can be dangerously omitted
+#### These modules are included by default, but can be dangerously omitted
 
 Some modules implement core Expo functionality through a generic interface. For example, our `Permissions` module implements `expo-permissions-interface`. If you remove the Permissions module, the project will build, but it may not run unless you add some other code which provides Expo Permissions functionality.
 
@@ -40,11 +41,7 @@ Some modules implement core Expo functionality through a generic interface. For 
 - FileSystem (`EXFileSystem`)
 - Permissions (`EXPermissions`)
 
-## Android
-
-Omitting Universal Modules is not currently supported on Android.
-
-# Adding Optional Modules on iOS
+#### Adding Optional Modules
 
 A few Expo modules are not included by default in ExpoKit iOS projects, nor in Standalone iOS Apps produced by `expo build`. Typically this is either because they add a disproportionate amount of bloat to the binary, or because they include APIs that are governed by extra Apple review guidelines. Right now those modules are:
 
@@ -61,3 +58,8 @@ To add FaceDetector:
 3.  Re-run `npx pod-install`.
 
 To add `Payments` or `AR`, add the [respective subspec](https://github.com/expo/expo/blob/sdk-38/ExpoKit.podspec) to your `ExpoKit` dependency in your `Podfile`, and re-run `npx pod-install`.
+
+
+### Android
+
+Omitting Universal Modules is not currently supported on Android.

--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -50,9 +50,7 @@ You can test it to ensure it works like this:
 
 ### Usage in standalone apps
 
-**app.json**
-
-```json
+```json app.json
 {
   "expo": {
     "scheme": "mycoolredirect"
@@ -99,7 +97,7 @@ If you are authenticating with a popular social provider, when you are ready to 
 
 **Never put any secret keys inside of your app, there is no secure way to do this!** Instead, you should store your secret key(s) on a server and expose an endpoint that makes API calls for your client and passes the data back.
 
-# API
+## API
 
 ```js
 import * as AuthSession from 'expo-auth-session';

--- a/docs/pages/versions/v45.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/auth-session.mdx
@@ -47,9 +47,7 @@ You can test it to ensure it works like this:
 
 ### Usage in standalone apps
 
-**app.json**
-
-```json
+```json app.json
 {
   "expo": {
     "scheme": "mycoolredirect"
@@ -96,7 +94,7 @@ If you are authenticating with a popular social provider, when you are ready to 
 
 **Never put any secret keys inside of your app, there is no secure way to do this!** Instead, you should store your secret key(s) on a server and expose an endpoint that makes API calls for your client and passes the data back.
 
-# API
+## API
 
 ```js
 import * as AuthSession from 'expo-auth-session';

--- a/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
@@ -48,9 +48,7 @@ You can test it to ensure it works like this:
 
 ### Usage in standalone apps
 
-**app.json**
-
-```json
+```json app.json
 {
   "expo": {
     "scheme": "mycoolredirect"
@@ -97,7 +95,7 @@ If you are authenticating with a popular social provider, when you are ready to 
 
 **Never put any secret keys inside of your app, there is no secure way to do this!** Instead, you should store your secret key(s) on a server and expose an endpoint that makes API calls for your client and passes the data back.
 
-# API
+## API
 
 ```js
 import * as AuthSession from 'expo-auth-session';

--- a/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
@@ -50,9 +50,7 @@ You can test it to ensure it works like this:
 
 ### Usage in standalone apps
 
-**app.json**
-
-```json
+```json app.json
 {
   "expo": {
     "scheme": "mycoolredirect"
@@ -99,7 +97,7 @@ If you are authenticating with a popular social provider, when you are ready to 
 
 **Never put any secret keys inside of your app, there is no secure way to do this!** Instead, you should store your secret key(s) on a server and expose an endpoint that makes API calls for your client and passes the data back.
 
-# API
+## API
 
 ```js
 import * as AuthSession from 'expo-auth-session';

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -88,12 +88,16 @@ export const kbdStyle = css({
   top: -1,
 });
 
-export const H1 = createTextComponent(TextElement.H1, css(typography.headers.default.h1));
-export const H2 = createTextComponent(TextElement.H2, css(typography.headers.default.h2));
-export const H3 = createTextComponent(TextElement.H4, css(typography.headers.default.h3));
-export const H4 = createTextComponent(TextElement.H4, css(typography.headers.default.h4));
-export const H5 = createTextComponent(TextElement.H5, css(typography.headers.default.h5));
-export const H6 = createTextComponent(TextElement.H6, css(typography.headers.default.h6));
+const codeInHeaderStyle = { '& code': { fontSize: 'inherit' } };
+
+const { h1, h2, h3, h4, h5, h6 } = typography.headers.default;
+export const H1 = createTextComponent(TextElement.H1, css([h1, codeInHeaderStyle]));
+export const H2 = createTextComponent(TextElement.H2, css([h2, codeInHeaderStyle]));
+export const H3 = createTextComponent(TextElement.H3, css([h3, codeInHeaderStyle]));
+export const H4 = createTextComponent(TextElement.H4, css([h4, codeInHeaderStyle]));
+export const H5 = createTextComponent(TextElement.H5, css([h5, codeInHeaderStyle]));
+export const H6 = createTextComponent(TextElement.H6, css([h6, codeInHeaderStyle]));
+
 export const P = createTextComponent(TextElement.P, css(typography.body.paragraph));
 export const CODE = createTextComponent(
   TextElement.CODE,


### PR DESCRIPTION
# Why

Currently, on few Markdown pages we use the `H1` headers, which are invalid with our styleguide, which states that only one H1 tag should be present and it should be the page title.

# How

Replace the problematic header on various pages, alter the structure accordingly. Also code inside the header will have the correct size - this was an another small regression from the latest changes.

Additionally, I have fixed small things like invalid frontmatter param name and file code block in `AuthSession` doc.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="791" alt="Screenshot 2022-12-13 at 18 37 03" src="https://user-images.githubusercontent.com/719641/207405848-fda1faad-bf4f-4b26-9cc3-cbff4d1d82ab.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
