### PR TITLE
[docs] cleanup website common files

### DIFF
--- a/docs/common/redirect.tsx
+++ b/docs/common/redirect.tsx
@@ -1,15 +1,11 @@
 import Head from 'next/head';
-import * as React from 'react';
 
-const redirect = (destination: string) =>
-  class RedirectRoute extends React.Component {
-    render() {
-      return (
-        <Head>
-          <meta httpEquiv="refresh" content={`0; url=${destination}`} />
-        </Head>
-      );
-    }
-  };
+const redirect = (destination: string) => {
+  return () => (
+    <Head>
+      <meta httpEquiv="refresh" content={`0; url=${destination}`} />
+    </Head>
+  );
+};
 
 export default redirect;

--- a/docs/common/stripVersionFromPath.ts
+++ b/docs/common/stripVersionFromPath.ts
@@ -1,6 +1,0 @@
-export default function stripVersionFromPath(path: string) {
-  if (!path) {
-    return path;
-  }
-  return path.replace(/\/versions\/[\w.]+/, '');
-}

--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -31,18 +31,10 @@ export const generateSlug = (slugger: GithubSlugger, node: React.ReactNode, leng
   return slugger.slug(stringToSlug);
 };
 
-export const isVersionedUrl = (url: string) => {
-  return /https?:\/\/(.*)(\/versions\/.*)/.test(url);
-};
-
 export const replaceVersionInUrl = (url: string, replaceWith: string) => {
   const urlArr = url.split('/');
   urlArr[2] = replaceWith;
   return urlArr.join('/');
-};
-
-export const getVersionFromUrl = (url: string) => {
-  return url.split('/')[2];
 };
 
 /**
@@ -65,4 +57,11 @@ export const getUserFacingVersionString = (
   }
 
   return versionString;
+};
+
+export const stripVersionFromPath = (path: string) => {
+  if (!path) {
+    return path;
+  }
+  return path.replace(/\/versions\/[\w.]+/, '');
 };

--- a/docs/common/window.ts
+++ b/docs/common/window.ts
@@ -1,7 +1,3 @@
-const getNavigatorAgent = (userAgent: string) => {
-  return userAgent ? userAgent : navigator.userAgent || navigator.vendor || window.opera;
-};
-
 export const getViewportSize = () => {
   const width = Math.max(
     document.documentElement ? document.documentElement.clientWidth : 0,
@@ -16,27 +12,4 @@ export const getViewportSize = () => {
     width,
     height,
   };
-};
-
-export const isAndroid = (userAgent: string) => {
-  const navigatorAgent = getNavigatorAgent(userAgent);
-  return /Android/i.test(navigatorAgent);
-};
-
-export const isIOS = (userAgent: string) => {
-  const navigatorAgent = getNavigatorAgent(userAgent);
-  return /iPhone|iPad|iPod/i.test(navigatorAgent);
-};
-
-export const isMobileBrowser = (userAgent: string) => {
-  const navigatorAgent = getNavigatorAgent(userAgent);
-
-  return (
-    /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ipad|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(
-      navigatorAgent
-    ) ||
-    /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw-(n|u)|c55\/|capi|ccwa|cdm-|cell|chtm|cldc|cmd-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc-s|devi|dica|dmob|do(c|p)o|ds(12|-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(-|_)|g1 u|g560|gene|gf-5|g-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd-(m|p|t)|hei-|hi(pt|ta)|hp( i|ip)|hs-c|ht(c(-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i-(20|go|ma)|i230|iac( |-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|-[a-w])|libw|lynx|m1-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|-([1-8]|c))|phil|pire|pl(ay|uc)|pn-2|po(ck|rt|se)|prox|psio|pt-g|qa-a|qc(07|12|21|32|60|-[2-7]|i-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h-|oo|p-)|sdk\/|se(c(-|0|1)|47|mc|nd|ri)|sgh-|shar|sie(-|m)|sk-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h-|v-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl-|tdg-|tel(i|m)|tim-|t-mo|to(pl|sh)|ts(70|m-|m3|m5)|tx-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas-|your|zeto|zte-/i.test(
-      navigatorAgent.substr(0, 4)
-    )
-  );
 };

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -1,19 +1,20 @@
 import { css } from '@emotion/react';
 import { theme, iconSize, spacing, ChevronDownIcon, borderRadius, shadows } from '@expo/styleguide';
 import { useRouter } from 'next/router';
-import React, { useEffect, useRef, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { ButtonBase } from '../Button';
 import { CALLOUT } from '../Text';
 
-import stripVersionFromPath from '~/common/stripVersionFromPath';
+import { stripVersionFromPath } from '~/common/utilities';
 import { NavigationRoute } from '~/types/common';
 
 if (typeof window !== 'undefined' && !window.hasOwnProperty('sidebarState')) {
   window.sidebarState = {};
 }
 
-type Props = React.PropsWithChildren<{
+type Props = PropsWithChildren<{
   info: NavigationRoute;
 }>;
 

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/react';
 import { theme, typography, spacing, ArrowUpRightIcon, iconSize } from '@expo/styleguide';
 import { useRouter } from 'next/router';
-import * as React from 'react';
+import type { PropsWithChildren } from 'react';
 import { useEffect, useRef } from 'react';
 
-import stripVersionFromPath from '~/common/stripVersionFromPath';
+import { stripVersionFromPath } from '~/common/utilities';
 import { NavigationRoute } from '~/types/common';
 import { LinkBase } from '~/ui/components/Text';
 
-type SidebarLinkProps = React.PropsWithChildren<{
+type SidebarLinkProps = PropsWithChildren<{
   info: NavigationRoute;
 }>;
 


### PR DESCRIPTION
# Why

This PR aims to cleanup files in the `common` directory.

# How

Unused code has been removed, `stripVersionFromPath` has been moved into `utils` from the separate file and redirect method has been simplified. 

In future, we will be able to remove the redirect helper, but we need to streamline the redirects setup first.

# Test Plan

Website app runs locally correctly, tests and lints are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
