### PR TITLE
[expo-go][ios] Disable home remote app loads

### DIFF
--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)createRootAppAndMakeVisible
 {
   EXHomeAppManager *homeAppManager = [[EXHomeAppManager alloc] init];
-  EXAppLoader *homeAppLoader = [[EXAppLoader alloc] initWithLocalManifest:[EXHomeAppManager bundledHomeManifest]];
+  EXAppLoader *homeAppLoader = [[EXAppLoader alloc] initWithLocalManifest:[EXHomeAppManager bundledHomeManifest] forceNoRemoteFetch:YES];
   EXKernelAppRecord *homeAppRecord = [[EXKernelAppRecord alloc] initWithAppLoader:homeAppLoader appManager:homeAppManager];
   [[EXKernel sharedInstance].appRegistry registerHomeAppRecord:homeAppRecord];
   [self moveAppToVisible:homeAppRecord];

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.h
@@ -52,7 +52,7 @@ typedef enum EXAppLoaderRemoteUpdateStatus {
 @property (nonatomic, weak) id<EXAppFetcherDataSource> dataSource;
 
 - (instancetype)initWithManifestUrl:(NSURL *)url;
-- (instancetype)initWithLocalManifest:(EXManifestsManifest * _Nonnull)manifest;
+- (instancetype)initWithLocalManifest:(EXManifestsManifest * _Nonnull)manifest forceNoRemoteFetch:(BOOL)forceNoRemoteFetch;
 
 /**
  *  Begin a new request.

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoader.m
@@ -39,6 +39,8 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 @property (nonatomic, assign) BOOL hasFinished;
 @property (nonatomic, assign) BOOL shouldUseCacheOnly;
 
+@property (nonatomic, assign) BOOL forceNoRemoteFetch;
+
 @end
 
 @implementation EXAppLoader
@@ -52,10 +54,11 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   return self;
 }
 
-- (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest
+- (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest forceNoRemoteFetch:(BOOL)forceNoRemoteFetch
 {
   if (self = [super init]) {
     _localManifest = manifest;
+    _forceNoRemoteFetch = forceNoRemoteFetch;
   }
   return self;
 }
@@ -257,6 +260,10 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   // these checks need to be here because they need to happen after the dev mode check above.
   if (_shouldUseCacheOnly ||
       ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled)) {
+    shouldCheckForUpdate = NO;
+  }
+  
+  if (_forceNoRemoteFetch) {
     shouldCheckForUpdate = NO;
   }
 


### PR DESCRIPTION
# Why

Alternative to https://github.com/expo/expo/pull/20416.

# How

Add bool flag (no ifdef) so that it doesn't affect other usages of EXAppLoader.

# Test Plan

Using charles proxy, verify that before this change a request to the home bundle was made. Now, see that one is not.
Note though that we still make a ton of requests to exp.host for graphql and apiv2 so I doubt they're really discernible. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
