### PR TITLE
[docs] Add GA4 analytics measurement ID

### DIFF
--- a/docs/providers/Analytics.tsx
+++ b/docs/providers/Analytics.tsx
@@ -5,6 +5,7 @@ import React, { PropsWithChildren, useEffect } from 'react';
 
 /** The global analytics measurement ID */
 const MEASUREMENT_ID = 'UA-107832480-3';
+const GA4_MEASUREMENT_ID = 'G-YKNPYCMLWY';
 
 type AnalyticsProps = PropsWithChildren<object>;
 
@@ -22,6 +23,13 @@ export function AnalyticsProvider(props: AnalyticsProps) {
     };
   }, []);
 
+  useEffect(function didMount() {
+    events.on('routeChangeComplete', reportPageViewForGA4);
+    return function didUnmount() {
+      events.off('routeChangeComplete', reportPageViewForGA4);
+    };
+  }, []);
+
   return (
     <>
       <Script
@@ -35,6 +43,17 @@ export function AnalyticsProvider(props: AnalyticsProps) {
         gtag('js', new Date());
         gtag('config', '${MEASUREMENT_ID}', { 'transport_type': 'beacon', 'anonymize_ip': true });
       `}</Script>
+      <Script
+        id="gtm-script"
+        strategy="lazyOnload"
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
+      />
+      <Script id="gtm-init" strategy="lazyOnload">{`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${GA4_MEASUREMENT_ID}', { 'transport_type': 'beacon', 'anonymize_ip': true });
+      `}</Script>
       {props.children}
     </>
   );
@@ -42,6 +61,14 @@ export function AnalyticsProvider(props: AnalyticsProps) {
 
 export function reportPageView(url: string) {
   window?.gtag?.('config', MEASUREMENT_ID, {
+    page_path: url,
+    transport_type: 'beacon',
+    anonymize_ip: true,
+  });
+}
+
+export function reportPageViewForGA4(url: string) {
+  window?.gtag?.('config', GA4_MEASUREMENT_ID, {
     page_path: url,
     transport_type: 'beacon',
     anonymize_ip: true,

--- a/docs/providers/Analytics.tsx
+++ b/docs/providers/Analytics.tsx
@@ -48,11 +48,11 @@ export function AnalyticsProvider(props: AnalyticsProps) {
         strategy="lazyOnload"
         src={`https://www.googletagmanager.com/gtag/js?id=${GA4_MEASUREMENT_ID}`}
       />
-      <Script id="gtm-init" strategy="lazyOnload">{`
+      <Script id="ga4-init" strategy="lazyOnload">{`
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '${GA4_MEASUREMENT_ID}', { 'transport_type': 'beacon', 'anonymize_ip': true });
+        function ga4tag(){dataLayer.push(arguments);}
+        ga4tag('js', new Date());
+        ga4tag('config', '${GA4_MEASUREMENT_ID}', { 'transport_type': 'beacon', 'anonymize_ip': true });
       `}</Script>
       {props.children}
     </>
@@ -68,7 +68,7 @@ export function reportPageView(url: string) {
 }
 
 export function reportPageViewForGA4(url: string) {
-  window?.gtag?.('config', GA4_MEASUREMENT_ID, {
+  window?.ga4tag?.('config', GA4_MEASUREMENT_ID, {
     page_path: url,
     transport_type: 'beacon',
     anonymize_ip: true,


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds the measurement ID for GA4 gtag script simultaneously to the existing one since, in near future, Universal analytics (GA3) will be deprecated.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
