### PR TITLE
[updates] Avoid dependency on uuid

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Improvements to setup for Updates E2E tests. ([#20120](https://github.com/expo/expo/pull/20120) by [@douglowder](https://github.com/douglowder))
 - Convert updates E2E workflow to use EAS. ([#20399](https://github.com/expo/expo/pull/20399) by [@douglowder](https://github.com/douglowder))
+- Avoid dependency on `uuid`. ([#20475](https://github.com/expo/expo/pull/20475) by [@LinusU](https://github.com/LinusU))
 
 ## 0.15.5 - 2022-11-14
 

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -1,6 +1,6 @@
+const crypto = require('crypto');
 const path = require('path');
 const { setTimeout } = require('timers/promises');
-const uuid = require('uuid/v4');
 const { device, beforeEach } = require('detox');
 
 const Server = require('./utils/server');
@@ -235,7 +235,7 @@ describe('Asset deletion recovery', () => {
       })
     );
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -1,6 +1,6 @@
+const crypto = require('crypto');
 const path = require('path');
 const { setTimeout } = require('timers/promises');
-const uuid = require('uuid/v4');
 const { device, beforeEach } = require('detox');
 
 const Server = require('./utils/server');
@@ -75,7 +75,7 @@ describe('', () => {
       platform
     );
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {
@@ -125,7 +125,7 @@ describe('', () => {
     await copyBundleToStaticFolder(updateDistPath, bundleFilename, newNotifyString, platform);
     const hash = 'invalid-hash';
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {
@@ -193,7 +193,7 @@ describe('', () => {
       })
     );
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {
@@ -283,7 +283,7 @@ describe('', () => {
       })
     );
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date().toISOString(),
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {
@@ -327,7 +327,7 @@ describe('', () => {
       platform
     );
     const manifest = {
-      id: uuid(),
+      id: crypto.randomUUID(),
       createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // yesterday
       runtimeVersion: RUNTIME_VERSION,
       launchAsset: {

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -49,8 +49,7 @@
     "expo-structured-headers": "~3.0.0",
     "expo-updates-interface": "~0.8.0",
     "fbemitter": "^3.0.0",
-    "resolve-from": "^5.0.0",
-    "uuid": "^3.4.0"
+    "resolve-from": "^5.0.0"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",

--- a/packages/expo-updates/scripts/createManifest.js
+++ b/packages/expo-updates/scripts/createManifest.js
@@ -1,9 +1,9 @@
 const { resolveEntryPoint } = require('@expo/config/paths');
 const { loadAsync } = require('@expo/metro-config');
+const crypto = require('crypto');
 const fs = require('fs');
 const Server = require('metro/src/Server');
 const path = require('path');
-const { v4: uuidv4 } = require('uuid');
 
 const filterPlatformAssetScales = require('./filterPlatformAssetScales');
 
@@ -63,7 +63,7 @@ function getRelativeEntryPoint(projectRoot, platform) {
   }
 
   const manifest = {
-    id: uuidv4(),
+    id: crypto.randomUUID(),
     commitTime: new Date().getTime(),
     assets: [],
   };


### PR DESCRIPTION
# Why

Older versions of uuid is deprecated. This will start using a secure random source, and will produce one less deprecation warning when installing!

> uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

# How

The updates module only used the UUID v4 function from a Node.js context, and Node.js already have a `randomUUID` function built in.

# Test Plan

Since I mostly edited test files I'm hoping that CI will test this 😅 

Open to more input here!

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
