### PR TITLE
[tools] Avoid dependency on uuid

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -63,7 +63,6 @@
     "strip-ansi": "^6.0.0",
     "terminal-link": "^2.1.1",
     "typedoc": "^0.22.15",
-    "uuid": "^3.1.0",
     "xcode": "^3.0.1"
   },
   "devDependencies": {
@@ -78,7 +77,6 @@
     "@types/node": "16.11.43",
     "@types/node-fetch": "^2.6.2",
     "@types/semver": "^7.3.12",
-    "@types/uuid": "^3.4.4",
     "eslint": "^8.29.0",
     "eslint-config-universe": "^11.1.1",
     "eslint-plugin-lodash": "^7.4.0",

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -2,11 +2,11 @@ import JsonFile from '@expo/json-file';
 import spawnAsync from '@expo/spawn-async';
 import { ExponentTools, Project, UrlUtils } from '@expo/xdl';
 import chalk from 'chalk';
+import crypto from 'crypto';
 import ip from 'ip';
 import fetch from 'node-fetch';
 import os from 'os';
 import path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 
 import { getExpoRepositoryRootDir } from '../Directories';
 import { getHomeSDKVersionAsync } from '../ProjectVersions';
@@ -102,7 +102,7 @@ export default {
   },
 
   async TEST_RUN_ID() {
-    return process.env.UNIVERSE_BUILD_ID || uuidv4();
+    return process.env.UNIVERSE_BUILD_ID || crypto.randomUUID();
   },
 
   async BUILD_MACHINE_LOCAL_HOSTNAME() {

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -2193,13 +2193,6 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/uuid@^3.4.4":
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
-  integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/webpack-sources@*":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-1.4.0.tgz#e58f1f05f87d39a5c64cf85705bdbdbb94d4d57e"
@@ -12124,7 +12117,7 @@ uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
   integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
-uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.2.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
# Why

Older versions of uuid is deprecated. This will start using a secure random source, and will produce one less deprecation warning when installing!

> uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.

# How

The tools module only used the UUID v4 function from a Node.js context, and Node.js already have a `randomUUID` function built in.

# Test Plan

I'm not sure, since this is used in tooling I'm hoping the CI will cover it? 😅 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).