### PR TITLE
[home] Simplify menu language

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -51,10 +51,14 @@ export function DevMenuTaskInfo({ task }: Props) {
       </Row>
       <Divider />
       <View bg="default" padding="medium">
-        <Text size="small" type="InterRegular">
-          {devServerName ? `Connected to ${devServerName}` : `Running from URL`}
-        </Text>
-        <Spacer.Vertical size="tiny" />
+        {devServerName ? (
+          <>
+            <Text size="small" type="InterRegular">
+              Connected to {devServerName}
+            </Text>
+            <Spacer.Vertical size="tiny" />
+          </>
+        ) : null}
         <Row align="center">
           {devServerName ? (
             <DevIndicator style={styles.taskDevServerIndicator} isActive isNetworkAvailable />

--- a/home/package.json
+++ b/home/package.json
@@ -9,6 +9,7 @@
     "test": "jest",
     "lint": "eslint .",
     "report": "react-native-bundle-visualizer --entry-file __generated__/AppEntry.js",
+    "start": "expo start",
     "generate-graphql-code": "graphql-codegen --config graphql-codegen.yml"
   },
   "author": "Expo",


### PR DESCRIPTION
Why
---
It's useful to signal when local development is enabled. Remove other placeholder text.

How
---
Render the Text element only if `devServerName` is set.

Test Plan
---
Ran Expo Go with the kernel project set to LOCAL and loaded Home itself. Confirmed it 

<img width="565" alt="Screenshot 2022-12-14 at 9 36 23 PM" src="https://user-images.githubusercontent.com/379606/207781088-07760549-6ff6-4145-a035-9e770bf46830.png">
