### PR TITLE
[docs] AppleAuthentication: update example, minor content tweaks

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -108,8 +108,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  button: { 
-    width: 200, 
+  button: {
+    width: 200,
     height: 44
   }
 });
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
 ## Development and Testing
 
 You can test this library in Expo Go on iOS without following any of the instructions above.
-However, you'll need to do this setup to use Apple Authentication in your standalone app.
+However, you'll need to add the config plugin to use this library if you are using EAS Build.
 When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 
 You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device,

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -13,9 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
 Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
-in order to comply with App Store Review guidelines.
-
-Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
+in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -122,7 +120,7 @@ const styles = StyleSheet.create({
 
 ## Development and Testing
 
-You can test this library in development in Expo Go on iOS without following any of the instructions above.
+You can test this library in Expo Go on iOS without following any of the instructions above.
 However, you'll need to do this setup to use Apple Authentication in your standalone app.
 When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -8,10 +8,14 @@ import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/Con
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option in order to comply with App Store Review guidelines. Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
+Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
+in order to comply with App Store Review guidelines.
+
+Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
 
 <PlatformsSection ios simulator />
 
@@ -21,13 +25,18 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins
+in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
+The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
 <ConfigReactNative>
 
-Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup) the **Apple Sign In** capability for their bundle identifier.
+Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup)
+the **Apple Sign In** capability for their bundle identifier.
 
-If you enable the **Apple Sign In** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file:
+If you enable the **Apple Sign In** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console),
+then be sure to add the following entitlements in your **ios/[app]/[app].entitlements** file:
 
 ```xml
 <key>com.apple.developer.applesignin</key>
@@ -36,7 +45,7 @@ If you enable the **Apple Sign In** capability through the [Apple Developer Cons
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
+Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -46,7 +55,7 @@ Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your `ios/[ap
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": ["expo-apple-authentication"]
@@ -58,47 +67,73 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
 
 ## Usage
 
-```js
-import * as AppleAuthentication from 'expo-apple-authentication';
+<SnackInline label="Apple Authentication Usage" dependencies={['expo-apple-authentication']} platforms={['ios']}>
 
-function YourComponent() {
+```jsx
+import * as AppleAuthentication from 'expo-apple-authentication';
+import { View, StyleSheet } from 'react-native';
+
+export default function App() {
   return (
-    <AppleAuthentication.AppleAuthenticationButton
-      buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
-      buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
-      cornerRadius={5}
-      style={{ width: 200, height: 44 }}
-      onPress={async () => {
-        try {
-          const credential = await AppleAuthentication.signInAsync({
-            requestedScopes: [
-              AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
-              AppleAuthentication.AppleAuthenticationScope.EMAIL,
-            ],
-          });
-          // signed in
-        } catch (e) {
-          if (e.code === 'ERR_CANCELED') {
-            // handle that the user canceled the sign-in flow
-          } else {
-            // handle other errors
+    <View style={styles.container}>
+      <AppleAuthentication.AppleAuthenticationButton
+        buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+        buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+        cornerRadius={5}
+        style={styles.button}
+        onPress={async () => {
+          try {
+            const credential = await AppleAuthentication.signInAsync({
+              requestedScopes: [
+                AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+                AppleAuthentication.AppleAuthenticationScope.EMAIL,
+              ],
+            });
+            // signed in
+          } catch (e) {
+            if (e.code === 'ERR_CANCELED') {
+              // handle that the user canceled the sign-in flow
+            } else {
+              // handle other errors
+            }
           }
-        }
-      }}
-    />
+        }}
+      />
+    </View>
   );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: { 
+    width: 200, 
+    height: 44
+  }
+});
+/* @end */
 ```
+
+</SnackInline>
 
 ## Development and Testing
 
-You can test this library in development in Expo Go on iOS without following any of the instructions above; however, you'll need to do this setup to use Apple Authentication in your standalone app. When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
+You can test this library in development in Expo Go on iOS without following any of the instructions above.
+However, you'll need to do this setup to use Apple Authentication in your standalone app.
+When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 
-You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device, so we highly recommend testing on a real device when possible while developing.
+You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device,
+so we highly recommend testing on a real device when possible while developing.
 
 ## Verifying the Response from Apple
 
-Apple's response includes a signed JWT with information about the user. To ensure that the response came from Apple, you can cryptographically verify the signature with Apple's public key, which is published at https://appleid.apple.com/auth/keys. This process is not specific to Expo.
+Apple's response includes a signed JWT with information about the user. To ensure that the response came from Apple,
+you can cryptographically verify the signature with Apple's public key, which is published at https://appleid.apple.com/auth/keys.
+This process is not specific to Expo.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
@@ -121,7 +121,7 @@ const styles = StyleSheet.create({
 ## Development and Testing
 
 You can test this library in Expo Go on iOS without following any of the instructions above.
-However, you'll need to do this setup to use Apple Authentication in your standalone app.
+However, you'll need to add the config plugin to use this library if you are using EAS Build.
 When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 
 You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device,

--- a/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
@@ -13,9 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
 Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
-in order to comply with App Store Review guidelines.
-
-Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
+in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -122,7 +120,7 @@ const styles = StyleSheet.create({
 
 ## Development and Testing
 
-You can test this library in development in Expo Go on iOS without following any of the instructions above.
+You can test this library in Expo Go on iOS without following any of the instructions above.
 However, you'll need to do this setup to use Apple Authentication in your standalone app.
 When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 

--- a/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
@@ -8,10 +8,14 @@ import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/Con
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option in order to comply with App Store Review guidelines. Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
+Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
+in order to comply with App Store Review guidelines.
+
+Learn more about Apple authentication on the ["Sign In with Apple" website](https://developer.apple.com/sign-in-with-apple/).
 
 <PlatformsSection ios simulator />
 
@@ -21,13 +25,18 @@ Beginning with iOS 13, any app that includes third-party authentication options 
 
 ## Configuration in app.json / app.config.js
 
-You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins
+in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
+The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
 <ConfigReactNative>
 
-Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup) the **Apple Sign In** capability for their bundle identifier.
+Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup)
+the **Apple Sign In** capability for their bundle identifier.
 
-If you enable the **Apple Sign In** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file:
+If you enable the **Apple Sign In** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console),
+then be sure to add the following entitlements in your **ios/[app]/[app].entitlements** file:
 
 ```xml
 <key>com.apple.developer.applesignin</key>
@@ -36,7 +45,7 @@ If you enable the **Apple Sign In** capability through the [Apple Developer Cons
 </array>
 ```
 
-Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your `ios/[app]/Info.plist` to ensure the sign in button uses the device locale.
+Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
 
 </ConfigReactNative>
 
@@ -46,7 +55,7 @@ Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your `ios/[ap
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": ["expo-apple-authentication"]
@@ -58,47 +67,73 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
 
 ## Usage
 
-```js
-import * as AppleAuthentication from 'expo-apple-authentication';
+<SnackInline label="Apple Authentication Usage" dependencies={['expo-apple-authentication']} platforms={['ios']}>
 
-function YourComponent() {
+```jsx
+import * as AppleAuthentication from 'expo-apple-authentication';
+import { View, StyleSheet } from 'react-native';
+
+export default function App() {
   return (
-    <AppleAuthentication.AppleAuthenticationButton
-      buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
-      buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
-      cornerRadius={5}
-      style={{ width: 200, height: 44 }}
-      onPress={async () => {
-        try {
-          const credential = await AppleAuthentication.signInAsync({
-            requestedScopes: [
-              AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
-              AppleAuthentication.AppleAuthenticationScope.EMAIL,
-            ],
-          });
-          // signed in
-        } catch (e) {
-          if (e.code === 'ERR_CANCELED') {
-            // handle that the user canceled the sign-in flow
-          } else {
-            // handle other errors
+    <View style={styles.container}>
+      <AppleAuthentication.AppleAuthenticationButton
+        buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+        buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+        cornerRadius={5}
+        style={styles.button}
+        onPress={async () => {
+          try {
+            const credential = await AppleAuthentication.signInAsync({
+              requestedScopes: [
+                AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+                AppleAuthentication.AppleAuthenticationScope.EMAIL,
+              ],
+            });
+            // signed in
+          } catch (e) {
+            if (e.code === 'ERR_CANCELED') {
+              // handle that the user canceled the sign-in flow
+            } else {
+              // handle other errors
+            }
           }
-        }
-      }}
-    />
+        }}
+      />
+    </View>
   );
 }
+
+/* @hide const styles = StyleSheet.create({ ... }); */
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    width: 200,
+    height: 44
+  }
+});
+/* @end */
 ```
+
+</SnackInline>
 
 ## Development and Testing
 
-You can test this library in development in Expo Go on iOS without following any of the instructions above; however, you'll need to do this setup to use Apple Authentication in your standalone app. When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
+You can test this library in development in Expo Go on iOS without following any of the instructions above.
+However, you'll need to do this setup to use Apple Authentication in your standalone app.
+When you sign into Expo Go, the identifiers and values you receive will likely be different than what you'll receive in standalone apps.
 
-You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device, so we highly recommend testing on a real device when possible while developing.
+You can do limited testing of this library on the iOS Simulator. However, not all methods will behave the same as on a device,
+so we highly recommend testing on a real device when possible while developing.
 
 ## Verifying the Response from Apple
 
-Apple's response includes a signed JWT with information about the user. To ensure that the response came from Apple, you can cryptographically verify the signature with Apple's public key, which is published at https://appleid.apple.com/auth/keys. This process is not specific to Expo.
+Apple's response includes a signed JWT with information about the user. To ensure that the response came from Apple,
+you can cryptographically verify the signature with Apple's public key, which is published at https://appleid.apple.com/auth/keys.
+This process is not specific to Expo.
 
 ## API
 


### PR DESCRIPTION
# Why

Update the AppleAuthentication usage example to enable Snack usage.

# How

Update the example to be compatible with Snack, then wrap it `SnackInline` component.

Beside those changes I have made few stylistic changes and formatted content for the editors readability.

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
