### PR TITLE
[docs] formatting changes for few API pages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -7,16 +7,18 @@ packageName: 'expo-background-fetch'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-background-fetch`** provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 
 <PlatformsSection android emulator ios simulator />
 
-## Known issues
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
 
-**iOS only**: BackgroundFetch only works when the app is backgrounded, not if the app was terminated or upon device reboot. [Here is the relevant GitHub issue](https://github.com/expo/expo/issues/3582)
+`BackgroundFetch` only works when the app is backgrounded, not if the app was terminated or upon device reboot.
+You can check out [the relevant GitHub issue](https://github.com/expo/expo/issues/3582) for more details.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 > **info** Only one active `BarCodeScanner` preview is currently supported.
 
 When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
-so the following screens can use its own `BarCodeScanner` without issues.
+so the following screens can use their own `BarCodeScanner` without any issue.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -8,12 +8,18 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
-**`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
+`expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
 <PlatformsSection android emulator ios simulator />
 
-> **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
+#### Limitations
+
+> **info** Only one active `BarCodeScanner` preview is currently supported.
+
+When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
+so the following screens can use its own `BarCodeScanner` without issues.
 
 ## Installation
 
@@ -27,32 +33,32 @@ Scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions
 
 ## Supported formats
 
-| Bar code format | iOS   | Android     |
-| --------------- | ----- | ----------- |
-| aztec           | Yes   | Yes         |
-| codabar         | Yes   | Yes         |
-| code39          | Yes   | Yes         |
-| code93          | Yes   | Yes         |
-| code128         | Yes   | Yes         |
-| code39mod43     | Yes   | No          |
-| datamatrix      | Yes   | Yes         |
-| ean13           | Yes   | Yes         |
-| ean8            | Yes   | Yes         |
-| interleaved2of5 | Yes   | use `itf14` |
-| itf14           | Yes\* | Yes         |
-| maxicode        | No    | Yes         |
-| pdf417          | Yes   | Yes         |
-| rss14           | No    | Yes         |
-| rssexpanded     | No    | Yes         |
-| upc_a           | No    | Yes         |
-| upc_e           | Yes   | Yes         |
-| upc_ean         | No    | Yes         |
-| qr              | Yes   | Yes         |
+| Bar code format | Android     | iOS           |
+| --------------- | ----------- | ------------- |
+| aztec           | <YesIcon /> | <YesIcon />   |
+| codabar         | <YesIcon /> | <YesIcon />   |
+| code39          | <YesIcon /> | <YesIcon />\* |
+| code93          | <YesIcon /> | <YesIcon />   |
+| code128         | <YesIcon /> | <YesIcon />   |
+| code39mod43     | <NoIcon />  | <YesIcon />   |
+| datamatrix      | <YesIcon /> | <YesIcon />   |
+| ean13           | <YesIcon /> | <YesIcon />   |
+| ean8            | <YesIcon /> | <YesIcon />   |
+| interleaved2of5 | use `itf14` | <YesIcon />   |
+| itf14           | <YesIcon /> | <YesIcon />\* |
+| maxicode        | <YesIcon /> | <NoIcon />    |
+| pdf417          | <YesIcon /> | <YesIcon />\* |
+| rss14           | <YesIcon /> | <NoIcon />    |
+| rssexpanded     | <YesIcon /> | <NoIcon />    |
+| upc_a           | <YesIcon /> | <NoIcon />    |
+| upc_e           | <YesIcon /> | <YesIcon />   |
+| upc_ean         | <YesIcon /> | <NoIcon />    |
+| qr              | <YesIcon /> | <YesIcon />   |
 
-> **Notes:**
->
-> - When an ITF-14 barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
-> - Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
+#### Additional notes
+
+1. When an `ITF-14` barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
+2. Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -30,7 +30,7 @@ In order to configure detector's behavior modules pass a [`DetectionOptions`](#d
 
 ### Example
 
-You could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling.
+You can use the following snippet to detect faces in a fast mode without detecting landmarks or whether a face is smiling.
 
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 

--- a/docs/pages/versions/unversioned/sdk/facedetector.mdx
+++ b/docs/pages/versions/unversioned/sdk/facedetector.mdx
@@ -8,10 +8,15 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
 <PlatformsSection android ios />
+
+#### Known issues&ensp;<PlatformTags platforms={['android']}  />
+
+Face detector does not recognize faces that aren't aligned with the interface (top of the interface matches top of the head).
 
 ## Installation
 
@@ -19,19 +24,17 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Known issues
-
-- Android does not recognize faces that aren't aligned with the interface (top of the interface matches top of the head).
-
 ### Settings
 
 In order to configure detector's behavior modules pass a [`DetectionOptions`](#detectionoptions) object which is then interpreted by this module.
 
-Eg. you could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling:
+### Example
 
-<SnackInline dependencies={['expo-camera', 'expo-face-detector']}>
+You could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling.
 
-```js
+<SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
+
+```jsx
 import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';

--- a/docs/pages/versions/v47.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/background-fetch.mdx
@@ -7,16 +7,18 @@ packageName: 'expo-background-fetch'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-background-fetch`** provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 
 <PlatformsSection android emulator ios simulator />
 
-## Known issues
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
 
-**iOS only**: BackgroundFetch only works when the app is backgrounded, not if the app was terminated or upon device reboot. [Here is the relevant GitHub issue](https://github.com/expo/expo/issues/3582)
+`BackgroundFetch` only works when the app is backgrounded, not if the app was terminated or upon device reboot.
+You can check out [the relevant GitHub issue](https://github.com/expo/expo/issues/3582) for more details.
 
 ## Installation
 

--- a/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
@@ -19,7 +19,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 > **info** Only one active `BarCodeScanner` preview is currently supported.
 
 When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
-so the following screens can use its own `BarCodeScanner` without issues.
+so the following screens can use their own `BarCodeScanner` without any issue.
 
 ## Installation
 

--- a/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
@@ -8,12 +8,18 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
-**`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
+`expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
 <PlatformsSection android emulator ios simulator />
 
-> **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
+#### Limitations
+
+> **info** Only one active `BarCodeScanner` preview is currently supported.
+
+When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
+so the following screens can use its own `BarCodeScanner` without issues.
 
 ## Installation
 
@@ -27,32 +33,32 @@ Scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions
 
 ## Supported formats
 
-| Bar code format | iOS   | Android     |
-| --------------- | ----- | ----------- |
-| aztec           | Yes   | Yes         |
-| codabar         | Yes   | Yes         |
-| code39          | Yes   | Yes         |
-| code93          | Yes   | Yes         |
-| code128         | Yes   | Yes         |
-| code39mod43     | Yes   | No          |
-| datamatrix      | Yes   | Yes         |
-| ean13           | Yes   | Yes         |
-| ean8            | Yes   | Yes         |
-| interleaved2of5 | Yes   | use `itf14` |
-| itf14           | Yes\* | Yes         |
-| maxicode        | No    | Yes         |
-| pdf417          | Yes   | Yes         |
-| rss14           | No    | Yes         |
-| rssexpanded     | No    | Yes         |
-| upc_a           | No    | Yes         |
-| upc_e           | Yes   | Yes         |
-| upc_ean         | No    | Yes         |
-| qr              | Yes   | Yes         |
+| Bar code format | Android     | iOS           |
+| --------------- | ----------- | ------------- |
+| aztec           | <YesIcon /> | <YesIcon />   |
+| codabar         | <YesIcon /> | <YesIcon />   |
+| code39          | <YesIcon /> | <YesIcon />\* |
+| code93          | <YesIcon /> | <YesIcon />   |
+| code128         | <YesIcon /> | <YesIcon />   |
+| code39mod43     | <NoIcon />  | <YesIcon />   |
+| datamatrix      | <YesIcon /> | <YesIcon />   |
+| ean13           | <YesIcon /> | <YesIcon />   |
+| ean8            | <YesIcon /> | <YesIcon />   |
+| interleaved2of5 | use `itf14` | <YesIcon />   |
+| itf14           | <YesIcon /> | <YesIcon />\* |
+| maxicode        | <YesIcon /> | <NoIcon />    |
+| pdf417          | <YesIcon /> | <YesIcon />\* |
+| rss14           | <YesIcon /> | <NoIcon />    |
+| rssexpanded     | <YesIcon /> | <NoIcon />    |
+| upc_a           | <YesIcon /> | <NoIcon />    |
+| upc_e           | <YesIcon /> | <YesIcon />   |
+| upc_ean         | <YesIcon /> | <NoIcon />    |
+| qr              | <YesIcon /> | <YesIcon />   |
 
-> **Notes:**
->
-> - When an ITF-14 barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
-> - Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
+#### Additional notes
+
+1. When an `ITF-14` barcode is recognized, it's type can sometimes be set to `interleaved2of5`.
+2. Scanning for either `PDF417` and/or `Code39` formats can result in a noticeable increase in battery consumption on iOS. It is recommended to provide only the bar code formats you expect to scan to the `barCodeTypes` prop.
 
 ## Usage
 

--- a/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
@@ -30,7 +30,7 @@ In order to configure detector's behavior modules pass a [`DetectionOptions`](#d
 
 ### Example
 
-You could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling.
+You can use the following snippet to detect faces in a fast mode without detecting landmarks or whether a face is smiling.
 
 <SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
 

--- a/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/facedetector.mdx
@@ -8,10 +8,15 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-face-detector`** lets you use the power of the [Google Mobile Vision](https://developers.google.com/vision/face-detection-concepts) framework to detect faces on images.
 
 <PlatformsSection android ios />
+
+#### Known issues&ensp;<PlatformTags platforms={['android']}  />
+
+Face detector does not recognize faces that aren't aligned with the interface (top of the interface matches top of the head).
 
 ## Installation
 
@@ -19,19 +24,17 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 ## Usage
 
-### Known issues
-
-- Android does not recognize faces that aren't aligned with the interface (top of the interface matches top of the head).
-
 ### Settings
 
 In order to configure detector's behavior modules pass a [`DetectionOptions`](#detectionoptions) object which is then interpreted by this module.
 
-Eg. you could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling:
+### Example
 
-<SnackInline dependencies={['expo-camera', 'expo-face-detector']}>
+You could use the following snippet to detect faces in fast mode without detecting landmarks or whether face is smiling.
 
-```js
+<SnackInline dependencies={['expo-camera', 'expo-face-detector']} label="Quick face detection">
+
+```jsx
 import * as React from 'react';
 import { Camera } from 'expo-camera';
 import * as FaceDetector from 'expo-face-detector';


### PR DESCRIPTION
# Why

One step in the attempts to align the API reference pages a bit more.

# How

Move limitation to the same place, use platform labels to mark the affected platform, use Yes and No icons instead of text content, add titles a labels to the examples.

All of the changes have also been backported to the SDK 47 docs.

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1169" alt="Screenshot 2022-12-15 at 18 33 27" src="https://user-images.githubusercontent.com/719641/207928861-42e5e2e5-e7a2-415c-8c36-c735375788f3.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
