### PR TITLE
[image][Android] Fix placeholder is not displaying when src is null

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/ViewConnectedTarget.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ViewConnectedTarget.kt
@@ -24,7 +24,7 @@ class ViewConnectedTarget(
   /**
    * An enum representing the state of the target.
    */
-  private enum class State {
+  enum class State {
     /**
      * Target is free to use.
      */
@@ -41,9 +41,12 @@ class ViewConnectedTarget(
     ACTIVE
   }
 
-  private var state = State.FREE
+  var state = State.FREE
+    private set
 
   var placeholderContentFit: ContentFit = ContentFit.ScaleDown
+  var hasSource = false
+  var placeholderIsVisible = false
 
   /**
    * Gets the currently unused target.
@@ -118,7 +121,9 @@ class ViewConnectedTarget(
       if (fullRequest?.isComplete != true) {
         // We know that we received a thumbnail.
         // But if something is already displayed, we don't want to show the placeholder.
-        if (imageView.drawable != null) {
+        // One exception is when the current target doesn't have the primary source.
+        // In that case, we want to display the placeholder anyway.
+        if (imageView.drawable != null && hasSource) {
           return
         }
 
@@ -134,8 +139,10 @@ class ViewConnectedTarget(
 
     imageView.setImageDrawable(resource)
     if (isPlaceholder) {
+      placeholderIsVisible = true
       imageView.applyTransformationMatrix(resource, placeholderContentFit)
     } else {
+      placeholderIsVisible = false
       imageView.applyTransformationMatrix()
     }
 
@@ -157,11 +164,15 @@ class ViewConnectedTarget(
 
   private fun clearSelf() {
     state = State.FREE
+    hasSource = false
+    placeholderIsVisible = false
     requestManager.clear(this)
   }
 
   private fun clearBgTarget() {
     bgTarget?.state = State.FREE
+    bgTarget?.hasSource = false
+    bgTarget?.placeholderIsVisible = false
     requestManager.clear(bgTarget)
   }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGSoftwareLayerSetter.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGSoftwareLayerSetter.kt
@@ -15,7 +15,7 @@ import com.bumptech.glide.request.target.Target
  * and rewritten to Kotlin.
  */
 class SVGSoftwareLayerSetter @JvmOverloads constructor(private val mDefaultLayerType: Int = ImageView.LAYER_TYPE_NONE) : RequestListener<Any> {
-  override fun onLoadFailed(e: GlideException?, model: Any, target: Target<Any>, isFirstResource: Boolean): Boolean {
+  override fun onLoadFailed(e: GlideException?, model: Any?, target: Target<Any>, isFirstResource: Boolean): Boolean {
     getViewOfTarget(target)?.setLayerType(mDefaultLayerType, null)
     return false
   }


### PR DESCRIPTION
# Why

To match the iOS implementation, the placeholder should be visible when the source is set to null.

# How

Unfortunately, Glide doesn't make that job easy and I had to find a tricky solution. It seems to work fine. However, I'll do more research on how we can better solve that.  

# Test Plan

![image](https://user-images.githubusercontent.com/9578601/208109906-f5b7cf5e-fba3-487d-99a2-35f1930c86e1.png)
