### PR TITLE
[core] fix installing expo hostobject thread issue on ios hermes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed libraries using the `ViewDefinitionBuilder` crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
 - Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
 - Fixed Function not supporting certain arities on Android. ([#20419](https://github.com/expo/expo/pull/20419) by [@motiz88](https://github.com/motiz88))
-- Fixed threading crash issue when running with Realm and Hermes on iOS. ([#20506](https://github.com/expo/expo/pull/20506) by [@kudo](https://github.com/kudo))
+- Fixed threading crash issue when running with Hermes on iOS. ([#20506](https://github.com/expo/expo/pull/20506) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed libraries using the `ViewDefinitionBuilder` crashes when ProGuard or R8 is enabled on Android. ([#20197](https://github.com/expo/expo/pull/20197) by [@lukmccall](https://github.com/lukmccall))
 - Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
 - Fixed Function not supporting certain arities on Android. ([#20419](https://github.com/expo/expo/pull/20419) by [@motiz88](https://github.com/motiz88))
+- Fixed threading crash issue when running with Realm and Hermes on iOS. ([#20506](https://github.com/expo/expo/pull/20506) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -308,12 +308,10 @@ public final class AppContext: NSObject {
   // MARK: - Runtime
 
   internal func installExpoModulesHostObject() throws {
-    guard runtime != nil, let bridge = reactBridge else {
+    guard runtime != nil else {
       throw RuntimeLostException()
     }
-    bridge.dispatchBlock({
-      EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
-    }, queue: RCTJSThread)
+    EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -308,10 +308,12 @@ public final class AppContext: NSObject {
   // MARK: - Runtime
 
   internal func installExpoModulesHostObject() throws {
-    guard runtime != nil else {
+    guard runtime != nil, let bridge = reactBridge else {
       throw RuntimeLostException()
     }
-    EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
+    bridge.dispatchBlock({
+      EXJavaScriptRuntimeManager.installExpoModulesHostObject(self)
+    }, queue: RCTJSThread)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -22,12 +22,6 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
   override init() {
     appContext = AppContext()
     super.init()
-
-    // Listen to React Native notifications posted just before the JS is executed.
-    NotificationCenter.default.addObserver(self,
-                                           selector: #selector(javaScriptWillStartExecutingNotification(_:)),
-                                           name: NSNotification.Name.RCTJavaScriptWillStartExecuting,
-                                           object: nil)
   }
 
   deinit {
@@ -47,6 +41,10 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
   public var bridge: RCTBridge! {
     didSet {
       appContext.reactBridge = bridge
+      bridge.dispatchBlock({ [weak self] in
+        guard let self = self, let bridge = self.appContext.reactBridge else { return }
+        self.appContext.runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
+      }, queue: RCTJSThread)
     }
   }
   
@@ -63,17 +61,5 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
     // otherwise legacy modules (e.g. permissions) won't be available in OnCreate { }
     appContext.useModulesProvider("ExpoModulesProvider")
     appContext.moduleRegistry.register(moduleType: NativeModulesProxyModule.self)
-  }
-
-  // MARK: - Notifications
-
-  @objc
-  public func javaScriptWillStartExecutingNotification(_ notification: Notification) {
-    if (notification.object as? RCTBridge)?.batched == bridge {
-      // The JavaScript bundle will start executing in a moment,
-      // so the runtime is already initialized and we can get it from the bridge.
-      // This should automatically install the ExpoModules host object.
-      appContext.runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
-    }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -42,7 +42,9 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
     didSet {
       appContext.reactBridge = bridge
       bridge.dispatchBlock({ [weak self] in
-        guard let self = self, let bridge = self.appContext.reactBridge else { return }
+        guard let self = self, let bridge = self.appContext.reactBridge else {
+          return
+        }
         self.appContext.runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
       }, queue: RCTJSThread)
     }


### PR DESCRIPTION
# Why

Hermes is much thread sensitive, there are some crashes if we don't setup js stuffs on js thread.
possible fix for https://github.com/realm/realm-js/issues/4735

# How

install expo host object in js thread (originally it' in another worker thread)

# Test Plan

- ci passed
- try realm repro in https://github.com/realm/realm-js/issues/4735

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
