### PR TITLE
[docs] Update constants import for creating env.ts file to get environment variables

### DIFF
--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -107,7 +107,7 @@ Many developers often create a file named **Env.ts** in their project, which the
 **Env.ts**
 
 ```ts
-import * as Constants from 'expo-constants';
+import Constants from 'expo-constants';
 
 function getApiUrl() {
   const API_URL = Constants.expoConfig.extra.API_URL;


### PR DESCRIPTION
https://docs.expo.dev/versions/latest/sdk/constants/#api

# Why

If you import it like the guide suggests you'll get `Property 'expoConfig' does not exist on type`. This just updates the docs to use the import recommended by the Constants docs: https://docs.expo.dev/versions/latest/sdk/constants/#api

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Resolved type/build errors on our end. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
