### PR TITLE
[docs] Remove global cli reference from QuickStart on Home page

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -83,7 +83,6 @@ const Home = () => {
                   <QuickStartIcon /> Quick Start
                 </RawH2>
                 <br />
-                <br />
                 <Terminal includeMargin={false} cmd={['$ npx create-expo-app my-app']} />
               </div>
             </GridCell>
@@ -331,7 +330,7 @@ const quickStartCellStyle = css({
   backgroundColor: theme.background.secondary,
   backgroundImage: 'url("/static/images/home/QuickStartPattern.svg")',
   backgroundBlendMode: 'multiply',
-  minHeight: 250,
+  minHeight: 220,
 
   [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
     minHeight: 200,
@@ -342,7 +341,7 @@ const tutorialCellStyle = css({
   backgroundColor: theme.palette.primary['100'],
   backgroundImage: 'url("/static/images/home/TutorialPattern.svg")',
   backgroundBlendMode: 'multiply',
-  minHeight: 250,
+  minHeight: 220,
 
   [`@media screen and (max-width: ${breakpoints.medium}px)`]: {
     minHeight: 200,

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -83,11 +83,8 @@ const Home = () => {
                   <QuickStartIcon /> Quick Start
                 </RawH2>
                 <br />
-                <Terminal
-                  includeMargin={false}
-                  cmd={['$ npm i -g expo-cli', '$ npx create-expo-app my-app']}
-                  cmdCopy="npm install --global expo-cli && npx create-expo-app my-app"
-                />
+                <br />
+                <Terminal includeMargin={false} cmd={['$ npx create-expo-app my-app']} />
               </div>
             </GridCell>
             <GridCell


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Given that expo-cli is only used for doctor and upgrade, this PR removes the step to install `expo-cli` from the QuickStart section on Home page.
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

<img width="1510" alt="CleanShot 2022-12-18 at 12 11 02@2x" src="https://user-images.githubusercontent.com/10234615/208285134-6a62e804-59a8-49e3-852a-72ffda646dc3.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
