### PR TITLE
[docs] Properly handle pure components

### DIFF
--- a/docs/components/plugins/APISection.tsx
+++ b/docs/components/plugins/APISection.tsx
@@ -48,7 +48,7 @@ const isComponent = ({ type, extendedTypes, signatures }: GeneratedData) => {
   if (type?.name && ['React.FC', 'ForwardRefExoticComponent'].includes(type?.name)) {
     return true;
   } else if (extendedTypes && extendedTypes.length) {
-    return extendedTypes[0].name === 'Component';
+    return extendedTypes[0].name === 'Component' || extendedTypes[0].name === 'PureComponent';
   } else if (signatures && signatures.length) {
     if (
       signatures[0].type.name === 'Element' ||

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -108,6 +108,7 @@ const nonLinkableTypes = [
   'ColorValue',
   'Component',
   'ComponentClass',
+  'PureComponent',
   'E',
   'EventSubscription',
   'Listener',


### PR DESCRIPTION
# Why

`PureComponent` was not handled properly and as the result, all its methods (like `componentDidMount`) were shown on the docs right sidebar. It should also be a non-linkable type.

# How

- `isComponent` function now treats `PureComponent` class as a component class
- `PureComponent` is no longer linkable

# Test Plan

I tested that with docs generated for expo-image

![Screenshot 2022-12-18 at 19 40 02](https://user-images.githubusercontent.com/1714764/208313778-550ce231-e12a-4fc8-94ed-b7ec689d9299.png)
