### PR TITLE
[image][Android] Fix plugin with id 'kotlin-android' not found

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -24,18 +24,12 @@ buildscript {
     }
   }
 
-  // The Android Gradle plugin is only required when opening the android folder stand-alone.
-  // This avoids unnecessary downloads and potential conflicts when the library is included as a
-  // module dependency in an application project.
-  // ref: https://docs.gradle.org/current/userguide/tutorial_using_tasks.html#sec:build_script_external_dependencies
-  if (project == rootProject) {
-    repositories {
-      google()
-    }
-    dependencies {
-      classpath 'com.android.tools.build:gradle:4.2.2'
-      classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getKotlinVersion()}")
-    }
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getKotlinVersion()}")
   }
 }
 


### PR DESCRIPTION
# Why

Fixes:
```
Build file '/Users/tomasz/Work/expo-apps/expo-sdk47/node_modules/expo-image/android/build.gradle' line: 2

A problem occurred evaluating project ':expo-image'.
> Plugin with id 'kotlin-android' not found.
```

# Test Plan

- a fresh project with `expo-image@1.0.0-alpha.1`