### PR TITLE
[docs] Stripe: fix changelog link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -18,7 +18,7 @@ If you're looking for a quick example, check out [this Snack](https://snack.expo
 
 ## Installation
 
-Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.mdx) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
+Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
 
 <APIInstallSection href="https://github.com/stripe/stripe-react-native" />
 

--- a/docs/pages/versions/v45.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ If you're looking for a quick example, check out [this Snack](https://snack.expo
 
 ## Installation
 
-Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.mdx) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
+Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
 
 <APIInstallSection href="https://github.com/stripe/stripe-react-native" />
 

--- a/docs/pages/versions/v46.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/stripe.mdx
@@ -18,7 +18,7 @@ If you're looking for a quick example, check out [this Snack](https://snack.expo
 
 ## Installation
 
-Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.mdx) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
+Each Expo SDK version requires a specific `@stripe/stripe-react-native` version. See the [Stripe CHANGELOG](https://github.com/stripe/stripe-react-native/blob/master/CHANGELOG.md) for a mapping of versions. To automatically install the correct version for your Expo SDK version, run:
 
 <APIInstallSection href="https://github.com/stripe/stripe-react-native" />
 


### PR DESCRIPTION
# Why

Follow up to #20383

# How

Apply the link correction in `unversioned` and older docs.

# Test Plan

The changes have been tested by running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
