### PR TITLE
[modules][av][Android] Added support for HLS Stream with ExoPlayer in favour of multivariant playlist.

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-
+- Added support for HLS Stream with ExoPlayer in favor of multi-variant playlist. ([#20537](https://github.com/expo/expo/pull/20537) by [@asharamseervi](https://github.com/asharamseervi))
 ### 🐛 Bug fixes
 
 - Fixed build errors when testing on React Native nightly builds. ([#19805](https://github.com/expo/expo/pull/19805) by [@kudo](https://github.com/kudo))

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -167,6 +167,9 @@ dependencies {
 
   api 'com.google.android.exoplayer:exoplayer:2.18.1'
   api 'com.google.android.exoplayer:extension-okhttp:2.18.1'
+  
+  // Enable support for HLS module for ExoPlayer
+  implementation 'com.google.android.exoplayer:exoplayer-hls:2.18.1'
 
   api "com.squareup.okhttp3:okhttp:3.14.9"
   api "com.squareup.okhttp3:okhttp-urlconnection:3.14.9"


### PR DESCRIPTION
# Why
While streaming, many of us are willing to leverage multi-variant playlist with ExoPlayer which could help automatically adapt among other available variants (720p to 1080p or similar), and bandwidth.

# How

As mentioned here at ExoPlayer Documentation, if we need to leverage HLS module, we need to define this: https://exoplayer.dev/hls.html#accessing-the-manifest

# Test Plan

This is my first contribution; I didn't know much about testing, if anyone could help me, I'll try my best.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
