### PR TITLE
[core] Fix react-native 0.71 integration errors on ios

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h
@@ -1,5 +1,7 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
+#if __cplusplus
+
 #import <UIKit/UIKit.h>
 #import <ExpoModulesCore/EXReactDelegateWrapper.h>
 
@@ -28,3 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#else
+
+// Workaround the main.m build error when running with new architecture mode
+// Context: https://github.com/facebook/react-native/pull/35661
+@interface EXAppDelegateWrapper : UIResponder
+@end
+
+#endif

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -44,10 +44,30 @@
 
 #if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
 
+- (UIView *)findRootView:(UIApplication *)application
+{
+  UIWindow *mainWindow = application.delegate.window;
+  if (mainWindow == nil) {
+    return nil;
+  }
+  UIViewController *rootViewController = mainWindow.rootViewController;
+  if (rootViewController == nil) {
+    return nil;
+  }
+  UIView *rootView = rootViewController.view;
+  return rootView;
+}
+
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  [super application:application didFinishLaunchingWithOptions:launchOptions];
-  [_expoAppDelegate application:application didFinishLaunchingWithOptions:launchOptions];
+  UIView *rootView = [self findRootView:application];
+  // Backward compatible with react-native 0.71 running with legacy template,
+  // i.e. still creating bridge, rootView in AppDelegate.mm.
+  // In this case, we don't go through RCTAppDelegate's setup.
+  if (rootView == nil || ![rootView isKindOfClass:[RCTRootView class]]) {
+    [super application:application didFinishLaunchingWithOptions:launchOptions];
+    [_expoAppDelegate application:application didFinishLaunchingWithOptions:launchOptions];
+  }
   return YES;
 }
 


### PR DESCRIPTION
# Why

fix further regressions from #20470

# How

- bare-expo is still running with legacy AppDelegate where it creates bridge, rootView in AppDelegate.mm. even running with 0.71, the EXAppDelegateWrapper should handle this case and not create the bridge from RCTAppDelegate.
- workaround a build error when running with new arch mode

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - #20470 doesn't publish yet, i'm going to update changelog in this pr.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
