### PR TITLE
[home] catch all try/finally blocks and remove apollo connectivity link

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-9b471ac899b27e725a3e54e028934d93e40b11e2"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-db0f3dfb43341932d21ff12f1d3a2f55e068b6b4"
 }

--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -177,6 +177,8 @@ export default function HomeApp() {
         // if there is no current user data, clear the accountName
         setAccountName(undefined);
       }
+    } catch (e) {
+      console.error(e);
     } finally {
       return;
     }

--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -4,17 +4,9 @@ import { HttpLink } from '@apollo/client/link/http';
 
 import Store from '../redux/Store';
 import Config from './Config';
-import Connectivity from './Connectivity';
 
 const httpLink = new HttpLink({
   uri: `${Config.api.origin}/--/graphql`,
-});
-
-const connectivityLink = setContext(async (): Promise<any> => {
-  const isConnected = await Connectivity.isAvailableAsync();
-  if (!isConnected) {
-    throw new Error('No connection available');
-  }
 });
 
 const authMiddlewareLink = setContext((): any => {
@@ -27,7 +19,7 @@ const authMiddlewareLink = setContext((): any => {
   }
 });
 
-const link = connectivityLink.concat(authMiddlewareLink.concat(httpLink));
+const link = authMiddlewareLink.concat(httpLink);
 
 const cache = new InMemoryCache({
   possibleTypes: {

--- a/home/api/__tests__/AuthSessions-test.js
+++ b/home/api/__tests__/AuthSessions-test.js
@@ -82,6 +82,8 @@ describe('User Authentication Flow', () => {
         `,
         variables: null,
       });
+    } catch (e) {
+      console.error(e);
     } finally {
       ApolloClient.resetStore();
     }

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -39,6 +39,8 @@ export function LoggedOutAccountView({ refetch }: Props) {
       if (isFinishedAuthenticating && sessionSecretExists) {
         try {
           await refetch();
+        } catch (e) {
+          console.error(e);
         } finally {
           // in the case that it rejects, we still want to dismiss the modal
 

--- a/home/screens/ProjectsListScreen/ProjectList.tsx
+++ b/home/screens/ProjectsListScreen/ProjectList.tsx
@@ -1,5 +1,4 @@
 import { spacing } from '@expo/styleguide-native';
-import dedent from 'dedent';
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { FlatList, ActivityIndicator, ListRenderItem, View as RNView } from 'react-native';
@@ -10,16 +9,6 @@ import { ProjectsListItem } from '../../components/ProjectsListItem';
 import { StyledText } from '../../components/Text';
 import SharedStyles from '../../constants/SharedStyles';
 import { CommonAppDataFragment } from '../../graphql/types';
-
-const NETWORK_ERROR_TEXT = dedent`
-  Your connection appears to be offline.
-  Check back when you have a better connection.
-`;
-
-const SERVER_ERROR_TEXT = dedent`
-  An unexpected server error has occurred.
-  Sorry about this. We will resolve the issue as soon as quickly as possible.
-`;
 
 type Props = {
   data: { apps?: CommonAppDataFragment[]; appCount?: number };
@@ -60,10 +49,6 @@ export function ProjectList(props: Props) {
 
   if (!props.data?.apps?.length) {
     if (!props.loading && props.error) {
-      // Error
-      // NOTE(brentvatne): sorry for this
-      const isConnectionError = props.error.message.includes('No connection available');
-
       const refetchDataAsync = async () => {
         if (isRetrying.current) return;
         isRetrying.current = true;
@@ -89,7 +74,7 @@ export function ProjectList(props: Props) {
             style={SharedStyles.noticeDescriptionText}
             lightColor="rgba(36, 44, 58, 0.7)"
             darkColor="#ccc">
-            {isConnectionError ? NETWORK_ERROR_TEXT : SERVER_ERROR_TEXT}
+            {props.error.message}
           </StyledText>
 
           <PrimaryButton plain onPress={refetchDataAsync}>


### PR DESCRIPTION
# Why

Expo Go crashes when you press the "Log In" button if you launch the app while offline. Going offline after the app is launched doesn't result in a crash, nor does going from offline to online.

Fixes ENG-7091
(maybe)

# How

The start of the error log is: `2022-12-20 00:04:50.513832-0500 Expo Go[737:110201] 2022-12-20 00:04:50.514 [error][tid:com.facebook.react.JavaScript] [Error: No connection available]`.

Searching that string in the `home` codebase reveals an Apollo link that throws an error with text that matches the error above. The app doesn't crash when this error is thrown in every scenario. For example, open the app when online+logged in, go offline, open the project list page and we show an offline message telling us that this error was thrown.

The functionality provided by `connectivityLink` wasn't super useful, so I removed it and exposed the error message from the projects list query directly instead of trying to detect offline status ourselves.

Hopefully, because we're no longer throwing an error, the crash won't happen. I'm still not certain why that error would crash the app only when the app never has access to the internet. The only thing I can think of is maybe the error-handling module changes when we render an iOS modal. That's the only noticeable difference between the queries we do on the home screen and the query we run in the account modal that causes a fatal crash.

# Test Plan

I haven't found a way to test that this solves the crashing problem. If possible, I'd like to create an Expo Go build embedded with the code from this PR and not attempt to load from a local dev server or production manifest so I can test launching this app offline.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Full Crash Error Logs

```
2022-12-20 00:04:50.513832-0500 Expo Go[737:110201] 2022-12-20 00:04:50.514 [error][tid:com.facebook.react.JavaScript] [Error: No connection available]
2022-12-20 00:04:50.518197-0500 Expo Go[737:110201] -[EXReactAppExceptionHandler handleSoftJSExceptionWithMessage:stack:exceptionId:extraDataAsJSON:]: unrecognized selector sent to instance 0x2811f4900
2022-12-20 00:04:50.525911-0500 Expo Go[737:110097] 2022-12-20 00:04:50.526 [fatal][tid:com.facebook.react.ExceptionsManagerQueue] Exception '-[EXReactAppExceptionHandler handleSoftJSExceptionWithMessage:stack:exceptionId:extraDataAsJSON:]: unrecognized selector sent to instance 0x2811f4900' was thrown while invoking reportException on target ExceptionsManager with params (
        {
        componentStack = "<null>";
        extraData =         {
            rawStack = "s@https://exp.host/@exponent/home/bundle:594:578\n@https://exp.host/@exponent/home/bundle:448:29285\n@https://exp.host/@exponent/home/bundle:581:10790\nf@https://exp.host/@exponent/home/bundle:71:207\ny@https://exp.host/@exponent/home/bundle:71:1625\nc@https://exp.host/@exponent/home/bundle:71:490\nthen@https://exp.host/@exponent/home/bundle:581:10767\n@https://exp.host/@exponent/home/bundle:581:10877\nm@https://exp.host/@exponent/home/bundle:584:1597\nx@https://exp.host/@exponent/home/bundle:584:1905\nvalue@https://exp.host/@exponent/home/bundle:584:2525\nforEach@[native code]\nie@https://exp.host/@exponent/home/bundle:581:8006\nerror@https://exp.host/@exponent/home/bundle:581:8880\nm@https://exp.host/@exponent/home/bundle:584:1597\nx@https://exp.host/@exponent/home/bundle:584:1905\nvalue@https://exp.host/@exponent/home/bundle:584:2525\nvalue@[native code]\nu@https://exp.host/@exponent/home/bundle:71:157\n@https://exp.host/@exponent/home/bundle:71:884\n@https://exp.host/@exponent/home/bundle:77:1692\np@https://exp.host/@exponent/home/bundle:77:528\nN@https://exp.host/@exponent/home/bundle:77:918\ncallReactNativeMicrotasks@https://exp.host/@exponent/home/bundle:77:3079\nvalue@https://exp.host/@exponent/home/bundle:60:2936\n@https://exp.host/@exponent/home/bundle:60:1046\nvalue@https://exp.host/@exponent/home/bundle:60:2584\nvalue@https://exp.host/@exponent/home/bundle:60:1005\nvalue@[native code]\nvalue@[native code]";
        };
        id = 1;
        isFatal = 0;
        message = "Error: No connection available";
        name = Error;
        originalMessage = "No connection available";
        stack =         (
                        {
                arguments =                 (
                );
                column = 577;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 594;
                methodName = s;
            },
                        {
                arguments =                 (
                );
                column = 29284;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 448;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 10789;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 581;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 206;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 71;
                methodName = f;
            },
                        {
                arguments =                 (
                );
                column = 1624;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 71;
                methodName = y;
            },
                        {
                arguments =                 (
                );
                column = 489;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 71;
                methodName = c;
            },
                        {
                arguments =                 (
                );
                column = 10766;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 581;
                methodName = then;
            },
                        {
                arguments =                 (
                );
                column = 10876;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 581;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 1596;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = m;
            },
                        {
                arguments =                 (
                );
                column = 1904;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = x;
            },
                        {
                arguments =                 (
                );
                column = 2524;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = "<null>";
                file = "[native code]";
                lineNumber = "<null>";
                methodName = forEach;
            },
                        {
                arguments =                 (
                );
                column = 8005;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 581;
                methodName = ie;
            },
                        {
                arguments =                 (
                );
                column = 8879;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 581;
                methodName = error;
            },
                        {
                arguments =                 (
                );
                column = 1596;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = m;
            },
                        {
                arguments =                 (
                );
                column = 1904;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = x;
            },
                        {
                arguments =                 (
                );
                column = 2524;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 584;
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = "<null>";
                file = "[native code]";
                lineNumber = "<null>";
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = 156;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 71;
                methodName = u;
            },
                        {
                arguments =                 (
                );
                column = 883;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 71;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 1691;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 77;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 527;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 77;
                methodName = p;
            },
                        {
                arguments =                 (
                );
                column = 917;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 77;
                methodName = N;
            },
                        {
                arguments =                 (
                );
                column = 3078;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 77;
                methodName = callReactNativeMicrotasks;
            },
                        {
                arguments =                 (
                );
                column = 2935;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 60;
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = 1045;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 60;
                methodName = "<unknown>";
            },
                        {
                arguments =                 (
                );
                column = 2583;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 60;
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = 1004;
                file = "https://exp.host/@exponent/home/bundle";
                lineNumber = 60;
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = "<null>";
                file = "[native code]";
                lineNumber = "<null>";
                methodName = value;
            },
                        {
                arguments =                 (
                );
                column = "<null>";
                file = "[native code]";
                lineNumber = "<null>";
                methodName = value;
            }
        );
    }
)
callstack: (
	0   CoreFoundation                      0x000000019f0ede94 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 40596
	1   libobjc.A.dylib                     0x000000019848f8d8 objc_exception_throw + 60
	2   CoreFoundation                      0x000000019f26284c 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 1566796
	3   CoreFoundation                      0x000000019f103d38 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 130360
	4   CoreFoundation                      0x000000019f16c350 _CF_forwarding_prep_0 + 96
	5   Expo Go                             0x000000010543ebf0 -[RCTExceptionsManager reportSoft:stack:exceptionId:extraDataAsJSON:] + 328
	6   Expo Go                             0x000000010543fb40 -[RCTExceptionsManager reportException:] + 1584
	7   CoreFoundation                      0x000000019f158704 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 476932
	8   CoreFoundation                      0x000000019f104b6c 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 133996
	9   CoreFoundation                      0x000000019f104584 5CDC5D9A-E506-3740-B64E-BB30867B4F1B + 132484
	10  Expo Go                             0x000000010538cb50 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 1732
	11  Expo Go                             0x0000000105390470 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicEiN12_GLOBAL__N_117SchedulingContextE + 1108
	12  Expo Go                             0x000000010538fe40 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 144
	13  Expo Go                             0x000000010538fda4 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
	14  libdispatch.dylib                   0x000000010e9845a8 _dispatch_call_block_and_release + 32
	15  libdispatch.dylib                   0x000000010e98605c _dispatch_client_callout + 20
	16  libdispatch.dylib                   0x000000010e98e10c _dispatch_lane_serial_drain + 988
	17  libdispatch.dylib                   0x000000010e98ee34 _dispatch_lane_invoke + 420
	18  libdispatch.dylib                   0x000000010e99bcbc _dispatch_workloop_worker_thread + 740
	19  libsystem_pthread.dylib             0x00000001eb7c6df8 _pthread_wqthread + 288
	20  libsystem_pthread.dylib             0x00000001eb7c6b98 start_wqthread + 8
)
2022-12-20 00:04:50.537856-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:50.639013-0500 Expo Go[737:105788] EXCachedResource: Using cached resource at /var/mobile/Containers/Data/Application/FE1885CE-36BC-48A6-B5D8-C29FC75CFD20/Library/Caches/Sources/47.0.0-kernel.ios-7715208365446102603.bundle...
2022-12-20 00:04:50.642147-0500 Expo Go[737:110202] Connection 4: received failure notification
2022-12-20 00:04:50.642182-0500 Expo Go[737:110202] Connection 4: failed to connect 1:50, reason -1
2022-12-20 00:04:50.642200-0500 Expo Go[737:110202] Connection 4: encountered error(1:50)
2022-12-20 00:04:50.642519-0500 Expo Go[737:110201] Task <1E53B373-EB64-4E78-A267-9E6CA30368E0>.<1> HTTP load failed, 0/0 bytes (error code: -1009 [1:50])
2022-12-20 00:04:50.642719-0500 Expo Go[737:110201] Task <1E53B373-EB64-4E78-A267-9E6CA30368E0>.<1> finished with error [-1009] Error Domain=NSURLErrorDomain Code=-1009 "The Internet connection appears to be offline." UserInfo={_kCFStreamErrorCodeKey=50, NSUnderlyingError=0x281d09470 {Error Domain=kCFErrorDomainCFNetwork Code=-1009 "(null)" UserInfo={_NSURLErrorNWPathKey=unsatisfied (No network route), _kCFStreamErrorCodeKey=50, _kCFStreamErrorDomainKey=1}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <1E53B373-EB64-4E78-A267-9E6CA30368E0>.<1>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <1E53B373-EB64-4E78-A267-9E6CA30368E0>.<1>"
), NSLocalizedDescription=The Internet connection appears to be offline., NSErrorFailingURLStringKey=https://exp.host/@exponent/home/bundle, NSErrorFailingURLKey=https://exp.host/@exponent/home/bundle, _kCFStreamErrorDomainKey=1}
2022-12-20 00:04:50.643778-0500 Expo Go[737:110201] EXCachedResource: Using cached resource at /var/mobile/Containers/Data/Application/FE1885CE-36BC-48A6-B5D8-C29FC75CFD20/Library/Caches/Sources/47.0.0-kernel.ios-7715208365446102603.bundle...
2022-12-20 00:04:50.645686-0500 Expo Go[737:110202] 9.5.0 - [FirebaseCore][I-COR000004] App with name __sandbox_QGV4cG9uZW50L2hvbWU does not exist.
2022-12-20 00:04:50.647710-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoVideoView'
2022-12-20 00:04:50.648048-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoBattery'
2022-12-20 00:04:50.648114-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoBlurView'
2022-12-20 00:04:50.648669-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExponentCamera'
2022-12-20 00:04:50.648747-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoCellular'
2022-12-20 00:04:50.648830-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoClipboard'
2022-12-20 00:04:50.648876-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExponentConstants'
2022-12-20 00:04:50.648938-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoCrypto'
2022-12-20 00:04:50.648985-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoDevice'
2022-12-20 00:04:50.649020-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'EASClient'
2022-12-20 00:04:50.649073-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExponentGLView'
2022-12-20 00:04:50.649117-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoHaptics'
2022-12-20 00:04:50.649163-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoImageManipulator'
2022-12-20 00:04:50.649244-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExponentImagePicker'
2022-12-20 00:04:50.649296-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoKeepAwake'
2022-12-20 00:04:50.649359-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoLinearGradient'
2022-12-20 00:04:50.649415-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoLocalAuthentication'
2022-12-20 00:04:50.649469-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoLocalization'
2022-12-20 00:04:50.649514-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoMailComposer'
2022-12-20 00:04:50.649554-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoRandom'
2022-12-20 00:04:50.649596-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoSMS'
2022-12-20 00:04:50.649637-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoStoreReview'
2022-12-20 00:04:50.649694-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoSystemUI'
2022-12-20 00:04:50.649749-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoTrackingTransparency'
2022-12-20 00:04:50.649790-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoVideoThumbnails'
2022-12-20 00:04:50.649861-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'ExpoWebBrowser'
2022-12-20 00:04:50.649909-0500 Expo Go[737:105788] [expo] 🟢 Registering module 'NativeModulesProxy'
2022-12-20 00:04:50.662632-0500 Expo Go[737:110188] [expo] 🟢 Posting 'appContextDestroys' event to registered modules
2022-12-20 00:04:50.676143-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:50.999975-0500 Expo Go[737:105788] [native] [GESTURE HANDLER] Initialize gesture handler for view <RCTRootContentView: 0x111e3ba80; reactTag: 21; frame = (0 0; 1366 1024); gestureRecognizers = <NSArray: 0x281d17870>; layer = <CALayer: 0x281318220>>
2022-12-20 00:04:51.000907-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.000953-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.000975-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.001000-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.001026-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.001049-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
2022-12-20 00:04:51.007072-0500 Expo Go[737:105788] [Orientation] BUG IN CLIENT OF UIKIT: Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)
```
