### PR TITLE
[docs] bump CMDK to verify resize event loop fix

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "@reach/tabs": "^0.17.0",
     "@sentry/react": "^7.24.1",
     "@sentry/tracing": "^7.24.1",
-    "cmdk": "^0.1.20",
+    "cmdk": "^0.1.21",
     "front-matter": "^4.0.2",
     "fs-extra": "^10.1.0",
     "github-slugger": "^1.3.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2401,10 +2401,10 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-cmdk@^0.1.20:
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.1.20.tgz#1702859b14b13c625301b6989c8107d469c18228"
-  integrity sha512-b05kPE+9jmGRibOf2h34d1ybCFfYYOiwsyylDtvhI0ptDSJ/gbPDQSq6DySL4b74ZnK/JH/WVP3UPuAYXRPypg==
+cmdk@^0.1.21:
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.1.21.tgz#c4e0fbb032fdbcf487c003cc98e1a2ffcaecbb6b"
+  integrity sha512-O5oiYmoBdcoqmax4RMOsnJHrseaXlnkzfCSWgNdyBxneTaSCmUByBF5MliJbsveoHJsjkyL2uNUs2kTBBMmIaw==
   dependencies:
     "@radix-ui/react-dialog" "1.0.0"
     command-score "0.1.2"


### PR DESCRIPTION
# Why

In our Sentry I have spotted that CMDK switch lead to rise of new issue related to the Resize observer events.

# How

Since the issue was not easy reproducible, I have decided to implement a recommended workaround from WICG discussion thread. The new CMDK version including this fix has been released, so let's try it out:
* https://github.com/pacocoursey/cmdk/releases/tag/v0.1.21

# Test Plan

Docs app runs correctly locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
