### PR TITLE
[docs] Align "What is Expo" with the FAQ page's corresponding item

### DIFF
--- a/docs/pages/introduction/expo.mdx
+++ b/docs/pages/introduction/expo.mdx
@@ -1,5 +1,5 @@
 ---
-title: What is Expo
+title: What is Expo?
 description: An overview of Expo tools, features and services.
 ---
 
@@ -7,7 +7,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { PlanEnterpriseIcon, ExpoGoLogo, DocsLogo } from '@expo/styleguide';
 
-Expo is an npm package that enables a suite of incredible features for React Native apps. The `expo` package can be installed in nearly **any React Native project**.
+Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
+
+The `expo` npm package enables a suite of incredible features for React Native apps. The `expo` package can be installed in nearly **any React Native project**.
 
 ## Tools and Features
 


### PR DESCRIPTION
Why
---
The answer to "What is Expo used for?" on the [FAQ page](https://docs.expo.dev/introduction/faq/) has fuller text than the "What is Expo" page does. This lets us explain better than Expo is much more than an npm package.

How
---
Copy over some of the text from the FAQ item, shorten it, keep most of existing text as well since we can afford to have more text here on the FAQ page.

Also, end "What is Expo?" with a question mark.

Test Plan
---
Run `yarn dev` in the docs directory and browse to: http://localhost:3002/introduction/expo/

<img width="660" alt="Screenshot 2022-12-20 at 1 21 56 PM" src="https://user-images.githubusercontent.com/379606/208770407-cb092aad-af84-4ab0-890c-e0b2440c4a4b.png">
