### PR TITLE
[docs] Add description for EAS intro, EAS Build & App Signing

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -1,19 +1,39 @@
 ---
-title: App credentials explained
+title: App credentials
+description: Learn about what app credentials that Android and iOS requires.
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
-Expo automates the process of signing your app for iOS and Android, but in both cases you can choose to provide your own overrides. [EAS Build](/build/introduction.mdx) can generate signed or unsigned applications, but in order to distribute your application through the stores, it **must** be a signed application.
+Expo automates the process of signing your app for Android and iOS, but in both cases, you can choose to provide your overrides. [EAS Build](/build/introduction) can generate signed or unsigned applications, but to distribute your application through the stores, it **must** be a signed application.
 
-On this page, we'll talk about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](/app-signing/security).
+On this page, you'll learn about the credentials that each platform requires. If you're curious about how we store your credentials on our end, take a look at our [security documentation](/app-signing/security).
 
 <ConfigClassic>
 
 App credentials are the same for both EAS Build, and the classic `expo build` system. However for anyone using `expo build`, you'll run `expo credentials:manager` to interact with them, **not** `eas credentials`.
 
 </ConfigClassic>
+
+## Android
+
+Google requires all Android apps to be digitally signed with a certificate before they are installed on a device or updated. Usually,
+a private key and its public certificate are stored in a keystore. In the past, APKs uploaded to the store were required to be signed with
+the **app signing certificate** (a certificate that will be attached to the app in the Play Store), and if the keystore was lost there was no way to
+recover or reset it. Now, you can opt-in to App Signing by Google Play and simply upload an APK signed with an **upload certificate**, and Google Play will automatically replace it with the **app signing certificate**. Both the old method (app signing certificate) and new method (upload certificate) are essentially the same mechanisms, but using the new method, if your upload keystore is lost or compromised, you can contact the Google Play support team to reset the key.
+
+From the Expo build process's perspective, there is no difference between whether an app is signed with an **upload certificate** or an **app signing key**. Either way, `eas build` will generate an **.apk** or **.aab** signed with the keystore currently associated with your application. If you want to generate an upload keystore manually, you can do that the same way you created your original keystore.
+
+See [here](https://developer.android.com/studio/publish/app-signing) to find more information about this process.
+
+### App signing by Google Play
+
+When you [upload your first release to Google Play](https://expo.fyi/first-android-submission) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
+
+> If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
+
+If you currently manage your app signing key and want Google to manage it for you, see [Use app signing by Google Play](https://support.google.com/googleplay/android-developer/answer/9842756).
 
 ## iOS
 
@@ -28,13 +48,13 @@ Whether you let EAS handle all your credentials, or you handle them yourself, it
 ### Distribution Certificate
 
 The distribution certificate is all about you, the developer, and not about any particular app. You may only have one distribution certificate associated with your Apple Developer account.
-This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store, or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `eas credentials` and following the prompts.
+This certificate will be used for all of your apps. If this certificate expires, your apps in production will not be affected. However, you will need to generate a new certificate if you want to upload new apps to the App Store or update any of your existing apps. Deleting a distribution certificate has no effect on any apps already on the App Store. You can clear the distribution certificate Expo currently has stored for your app the next time you build by running `eas credentials` and following the prompts.
 
 ### Push Notification Keys
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](../versions/latest/sdk/notifications.mdx#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts.
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts.
 
 ### Provisioning Profiles
 
@@ -52,23 +72,4 @@ Provisioning profiles expire after 12 months, but this won't affect apps in prod
 
 ### Clearing Credentials
 
-When you use the `eas credentials` command to delete your credentials, this only removes those credentials from Expo's servers, **it does not delete the credentials from Apple's perspective**. This means that to fully delete your credentials (let's say, because you want a new push notification key but you already have 2), you'll need to do so from the [Apple Developer Console](https://developer.apple.com/account/resources/certificates/list).
-
-## Android
-
-Google requires all Android apps to be digitally signed with a certificate before they are installed on a device or updated. Usually
-a private key and its public certificate are stored in a keystore. In the past, APKs uploaded to the store were required to be signed with
-the **app signing certificate** (certificate that will be attached to the app in the Play Store), and if the keystore was lost there was no way to
-recover or reset it. Now, you can opt in to App Signing by Google Play and simply upload an APK signed with an **upload certificate**, and Google Play will automatically replace it with the **app signing certificate**. Both the old method (app signing certificate) and new method (upload certificate) are essentially the same mechanism, but using the new method, if your upload keystore is lost or compromised, you can contact the Google Play support team to reset the key.
-
-From the Expo build process's perspective, there is no difference whether an app is signed with an **upload certificate** or an **app signing key**. Either way, `eas build` will generate an APK or AAB signed with the keystore currently associated with your application. If you want to generate an upload keystore manually, you can do that the same way you created your original keystore.
-
-See [here](https://developer.android.com/studio/publish/app-signing) to find more information about this process.
-
-### App signing by Google Play
-
-When you [upload your first release to Google Play](https://expo.fyi/first-android-submission) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
-
-> If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
-
-If you currently manage your app signing key and want Google to manage it for you, read ["Use app signing by Google Play"](https://support.google.com/googleplay/android-developer/answer/9842756).
+When you use the `eas credentials` command to delete your credentials, this only removes those credentials from Expo's servers, **it does not delete the credentials from Apple's perspective**. This means that to fully delete your credentials (for example, if you want a new push notification key, however, you already have two), you'll need to do so from the [Apple Developer Console](https://developer.apple.com/account/resources/certificates/list).

--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using existing credentials
+description: Learn about different options for supplying your app signing credentials to EAS Build.
 ---
 
 EAS Build gives you two options for how you can supply your build jobs with app signing credentials:

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -1,18 +1,19 @@
 ---
 title: Using local credentials
+description: Learn how to configure and use local credentials when using EAS.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 You can usually get away with not being a code signing expert by [letting EAS handle it for you](managed-credentials.mdx). However, there are cases where some users might want to manage their project keystore, certificates and profiles on their own.
 
-If you would like to manage your own app signing credentials, you can use **credentials.json** to give EAS Build relative paths to the credentials on your local file system and their associated passwords in order to use them to sign your builds.
+If you would like to manage your own app signing credentials, you can use **credentials.json** to give EAS Build relative paths to the credentials on your local file system and their associated passwords to use them to sign your builds.
 
 ## credentials.json
 
-If you opt in to local credentials configuration, you'll need to create a **credentials.json** file at the root of your project and it should look something like this:
+If you opt-in to local credentials configuration, you'll need to create a **credentials.json** file at the root of your project and it should look something like this:
 
-```json
+```json credentials.json
 {
   "android": {
     "keystore": {
@@ -33,37 +34,6 @@ If you opt in to local credentials configuration, you'll need to create a **cred
 ```
 
 > Remember to add **credentials.json** and all of your credentials to `.gitignore` so you don't accidentally commit them to the repository and potentially leak your secrets.
-
-### iOS Credentials
-
-There are a few more prerequisites for building the iOS app binary. You need a paid Apple Developer Account, and then you'll need to generate the Distribution Certificate and Provisioning Profile for your application, which can be done via the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list).
-
-Once you have the Distribution Certificate and Provisioning Profile on your computer, you should move them to the appropriate directory. We recommend you keep them in the `ios/certs` directory. In the rest of this document we assume that they are named **dist.p12** and `profile.mobileprovision` respectively. **Remember to git-ignore all files in the directory!** If you've placed the credentials in the suggested directory, you can ignore those files by adding the following line to `.gitignore`:
-
-```
-ios/certs/*
-```
-
-Create (or edit) **credentials.json** and configure it with the credentials:
-
-```json
-{
-  "android": {
-    ...
-  },
-  "ios": {
-    "provisioningProfilePath": "ios/certs/profile.mobileprovision",
-    "distributionCertificate": {
-      "path": "ios/certs/dist.p12",
-      "password": "DISTRIBUTION_CERTIFICATE_PASSWORD"
-    }
-  }
-}
-```
-
-- `provisioningProfilePath` points to where the Provisioning Profile is located on your computer. Both relative (to the project root) and absolute paths are supported.
-- `distributionCertificate.path` points to where the Distribution Certificate is located on your computer. Both relative (to the project root) and absolute paths are supported.
-- `distributionCertificate.password` is the password for the Distribution Certificate located at `distributionCertificate.path`.
 
 ### Android credentials
 
@@ -91,7 +61,7 @@ android/keystores/release.keystore
 
 Create **credentials.json** and configure it with the credentials:
 
-```json
+```json credentials.json
 {
   "android": {
     "keystore": {
@@ -109,6 +79,37 @@ Create **credentials.json** and configure it with the credentials:
 - `keyAlias` is the key alias. If you've followed the previous steps it's the value of `KEY_ALIAS`.
 - `keyPassword` is the key password. If you've followed the previous steps it's the value of `KEY_PASSWORD`.
 
+### iOS Credentials
+
+There are a few more prerequisites for building the iOS app binary. You need a paid Apple Developer Account, and then you'll need to generate the Distribution Certificate and Provisioning Profile for your application, which can be done via the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list).
+
+Once you have the Distribution Certificate and Provisioning Profile on your computer, you should move them to the appropriate directory. We recommend you keep them in the `ios/certs` directory. In the rest of this document we assume that they are named **dist.p12** and `profile.mobileprovision` respectively. **Remember to git-ignore all files in the directory!** If you've placed the credentials in the suggested directory, you can ignore those files by adding the following line to `.gitignore`:
+
+```
+ios/certs/*
+```
+
+Create (or edit) **credentials.json** and configure it with the credentials:
+
+```json credentials.json
+{
+  "android": {
+    ...
+  },
+  "ios": {
+    "provisioningProfilePath": "ios/certs/profile.mobileprovision",
+    "distributionCertificate": {
+      "path": "ios/certs/dist.p12",
+      "password": "DISTRIBUTION_CERTIFICATE_PASSWORD"
+    }
+  }
+}
+```
+
+- `provisioningProfilePath` points to where the Provisioning Profile is located on your computer. Both relative (to the project root) and absolute paths are supported.
+- `distributionCertificate.path` points to where the Distribution Certificate is located on your computer. Both relative (to the project root) and absolute paths are supported.
+- `distributionCertificate.password` is the password for the Distribution Certificate located at `distributionCertificate.path`.
+
 #### Multi-target project
 
 If your iOS app is using [App Extensions](https://developer.apple.com/app-extensions/) like Share Extension, Widget Extension, and so on, you need to provide credentials for every target of the Xcode project. This is necessary because each extension is identified by an individual bundle identifier.
@@ -124,7 +125,7 @@ Let's say that your project consists of a main application target (named `multit
 In this case, your **credentials.json** should look like below:
 
 {/* prettier-ignore */}
-```json
+```json credentials.json
 {
   "ios": {
     "multitarget": {
@@ -154,7 +155,7 @@ You can tell EAS Build how it should resolve credentials by specifying `"credent
 
 For example, maybe you want to use local credentials when deploying to the Amazon Appstore and remote credentials when deploying to the Google Play Store:
 
-```json
+```json credentials.json
 {
   "build": {
     "amazon-production": {
@@ -188,6 +189,6 @@ Consider the following steps:
   echo $CREDENTIALS_JSON_BASE64 | base64 -d > credentials.json
   ```
 
-Similarly, you can encode your keystore, provisioning profile and distribution certificate so you can restore them later on the CI. In order to successfully trigger your build using local credentials from CI, you'll have to make sure all the credentials exist in the CI instance's file system (at the same locations as defined in **credentials.json**).
+Similarly, you can encode your keystore, provisioning profile and distribution certificate so you can restore them later on the CI. To successfully trigger your build using local credentials from CI, you'll have to make sure all the credentials exist in the CI instance's file system (at the same locations as defined in **credentials.json**).
 
 Once the restoring steps are in place, you can use the same process described in the [Triggering builds from CI](/build/building-on-ci.mdx) guide to trigger the builds.

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -1,12 +1,13 @@
 ---
 title: Using automatically managed credentials
+description: Learn how to automatically manage your app credentials with EAS.
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';
 
-For your app to be distributed in an app store, it needs to be digitally signed with credentials such as a keystore or a distribution certificate. This certifies the source of the app and ensures that it can't be tampered with. Other credentials, such as your Apple Push Key and FCM API Key, are needed to send push notifications, but they are not involved in app signing.
+For your app to be distributed in an app store, it needs to be digitally signed with credentials such as a keystore or a distribution certificate. This certifies the source of the app and ensures that it can't be tampered with. Other credentials, such as your FCM API Key and Apple Push Key are needed to send push notifications, but they are not involved in app signing.
 
-Thankfully, that's all that you need to know about any of this to build an app with EAS Build, but if you would like to learn more you can refer to the ["App Signing"](/app-signing/app-credentials.mdx) guide.
+Thankfully, that's all that you need to know about any of this to build an app with EAS Build, but if you would like to learn more you can refer to the [App Signing](/app-signing/app-credentials.mdx) guide.
 
 <ConfigClassic>
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -1,5 +1,6 @@
 ---
 title: Security
+description: Learn how credentials and other sensitive data are handled when using EAS.
 ---
 
 Before you enter outside credentials or provide other sensitive data to third-party software you should ask yourself whether you trust the software to use it responsibly and protect it. Due to the nature of what goes into building an app binary for distribution on app stores, the Expo standalone app build service requires various pieces of information with varying degrees of sensitivity. This document explains what those are, how we store them, and what could go wrong if they were to be compromised.
@@ -10,7 +11,7 @@ All of the data related to the information explained below can be downloaded and
 
 ## iOS Push Notification credentials
 
-There are two types of iOS push notification credentials: one modern recommended approach recommended by Apple and the legacy approach. The default behavior is to use the modern approach, but developers may opt in to the legacy approach by providing a p12 certificate.
+There are two types of iOS push notification credentials: one modern recommended approach recommended by Apple and the legacy approach. The default behavior is to use the modern approach, but developers may opt-in to the legacy approach by providing a p12 certificate.
 
 ### APNs auth key (p8) + key ID (string)
 
@@ -28,11 +29,11 @@ The Apple Developer console lets you download an APNs Auth Key only when it is c
 
 ## iOS build credentials
 
-This refers to the production distribution certificate and password (which are automatically generated if you let Expo manage them for you) and provisioning profiles (which are not secret). Like most credential data stored by Expo these are all encrypted with KMS. Your build credentials let you build an app to upload to App Store Connect. In order to actually upload it and submit it for review, though, you need to have your Apple Developer account credentials.
+This refers to the production distribution certificate and password (which are automatically generated if you let Expo manage them for you) and provisioning profiles (which are not secret). Like most credential data stored by Expo these are all encrypted with KMS. Your build credentials let you build an app to upload to App Store Connect. To actually upload it and submit it for review, though, you need to have your Apple Developer account credentials.
 
 ### Consequences if compromised
 
-There isn't much that a malicious actor could do with this alone &mdash; they would be unable to actually submit any apps without having your Apple Developer account credentials. You can revoke the distribution certificate and provisioning profile from the Apple Developer website.
+There isn't much that a malicious actor could do with this alone &mdash; they would be unable to submit any apps without having your Apple Developer account credentials. You can revoke the distribution certificate and provisioning profile from the Apple Developer website.
 
 ### Consequences if lost
 
@@ -42,7 +43,7 @@ None, they are available through the Apple Developer console.
 
 When creating a standalone app build, or uploading to the App Store you will be prompted for your Apple Developer account credentials. We do not store these on our servers &mdash; EAS CLI only uses them locally. Your computer alone provisions distribution certificates and auth keys that are sent to Expo servers; your developer credentials are not sent to Expo servers. An additional layer of security is enforced by Apple, as they require two-factor authentication for all Apple Developer accounts.
 
-When creating ad-hoc builds, we temporarily store an Apple Developer session token used to create an ad-hoc provisioning profile with your development device’s UDID. Once we are done using this session token we destroy it.
+When creating ad-hoc builds, we temporarily store an Apple Developer session token used to create an ad-hoc provisioning profile with your development device's UDID. Once we are done using this session token we destroy it.
 
 ### Keychain
 
@@ -53,11 +54,11 @@ Disable Keychain support with the environment variable `EXPO_NO_KEYCHAIN=1`. You
 
 ### Changing Apple ID Password in Keychain
 
-To delete the locally stored password, open the "Keychain Access" app, switch to "All Items", and search for "deliver.[Your Apple ID]" (ex. `deliver.bacon@expo.dev`). Select the item you wish to modify and delete it. Next time running an Expo command you'll be prompted for a new password.
+To delete the locally stored password, open the "Keychain Access" app, switch to "All Items", and search for "deliver. [Your Apple ID]" (example: `deliver.bacon@expo.dev`). Select the item you wish to modify and delete it. Next time running an Expo command you'll be prompted for a new password.
 
 ### Consequences if compromised
 
-For standalone builds, as explained above, your own machine would need to be compromised for a malicious actor to have access to your username and password. They would also need to have access to your two-factor authentication code generator, which for Apple Developer accounts is a pre-authorized Apple device. At this point you may have worse problems, but as you may expect, the actor would be able to do whatever they like with your Apple Developer account.
+For standalone builds, as explained above, your machine would need to be compromised for a malicious actor to have access to your username and password. They would also need to have access to your two-factor authentication code generator, which for Apple Developer accounts is a pre-authorized Apple device. At this point, you may have worse problems, but as you may expect, the actor would be able to do whatever they like with your Apple Developer account.
 
 For ad-hoc builds, if a user were to gain access to your session token it would be comparable to being signed in to your account.
 
@@ -81,7 +82,7 @@ None, you can access it through the Firebase console.
 
 ## Android build credentials
 
-A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. After an app is first submitted to the Google Play Store, the same keystore must be used to sign the app again in order to update it. It proves that the APK came from the developer who owns the keystore. The keystore alone doesn’t let you submit to Google Play &mdash; your Google account needs access to the Google Play Console as well.
+A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. After an app is first submitted to the Google Play Store, the same keystore must be used to sign the app again to update it. It proves that the APK came from the developer who owns the keystore. The keystore alone doesn’t let you submit to Google Play &mdash; your Google account needs access to the Google Play Console as well.
 
 ### Consequences if compromised
 
@@ -95,7 +96,7 @@ You will not be able to update your app on Google Play. You may want to download
 
 Expo tools never ask you to provide your Google account credentials.
 
-## Device tokens for iOS and Android push notifications
+## Device tokens for Android and iOS push notifications
 
 On top of the platform-specific credentials, a device token is necessary to send a push notification. Expo manages this for you and provides an abstraction on top of it with the Expo Push Token. The device token identifies the recipient, i.e., the device who the notification is being sent to. The device tokens are encrypted at rest and periodically cycled automatically by iOS and Android.
 

--- a/docs/pages/app-signing/syncing-credentials.mdx
+++ b/docs/pages/app-signing/syncing-credentials.mdx
@@ -1,5 +1,6 @@
 ---
 title: Syncing credentials between remote and local sources
+description: Learn how to sync credentials between remote and local sources.
 ---
 
 If you use automatically managed credentials, your credentials will be hosted remotely on EAS servers, but you may encounter a situation where you want to pull your credentials down to run a build locally. And if you use local credentials, you may find yourself in a position where you want to upload credentials specified in **credentials.json** up to EAS to be managed for you. Both of these are possible using the `eas credentials` command.
@@ -10,7 +11,7 @@ To download your automatically managed credentials, run `eas credentials` in the
 
 Android credentials will be ready to use immediately because your project will read the credentials from **credentials.json**.
 
-iOS credentials requires two steps to set up locally. You will first need to install the distribution certificate into your keychain. Next, open your project Xcode and navigate to the "Signing & Capabilities" section, then import your provisioning profile and select it.
+iOS credentials require two steps to set up locally. You will first need to install the distribution certificate into your keychain. Next, open your project Xcode and navigate to the "Signing & Capabilities" section, then import your provisioning profile and select it.
 
 ## Uploading credentials
 

--- a/docs/pages/build/automating-submissions.mdx
+++ b/docs/pages/build/automating-submissions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Automating submissions
+description: Learn how to enable automatic submissions with EAS Build.
 ---
 
 Many mobile deployment processes eventually evolve to the point where the app is automatically submitted to the respective store once an appropriate build is completed. This saves developers from having to wait around for the build to complete, avoids a bit of manual work, and eliminates the need to coordinate providing app store credentials to the team.

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -1,11 +1,12 @@
 ---
 title: Triggering builds from CI
+description: Learn how to trigger builds on EAS for your app from a CI environment such as GitHub Action and more.
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 
-This document outlines how to trigger builds on EAS for your app from a CI environment such as GitHub Actions.
+This document outlines how to trigger builds on EAS for your app from a CI environment such as GitHub Actions, Travis CI, and more.
 
 Before building with EAS on CI, we need to install and configure `eas-cli`. Then, we can trigger new builds with the `eas build` command.
 
@@ -81,7 +82,9 @@ This will trigger a new build on EAS and print the URLs for the built files afte
 
 <Collapsible summary="Travis CI">
 
-```yaml
+Add the following code snippet in **.travis.yml** at the root of your project repository.
+
+```yaml travis.yml
 ---
 language: node_js
 node_js:
@@ -102,13 +105,13 @@ jobs:
         - npx eas-cli build --platform all --non-interactive
 ```
 
-> Put this into `.travis.yml` in the root of your repository.
-
 </Collapsible>
 
 <Collapsible summary="GitLab CI">
 
-```yaml
+Add the following code snippet in **.gitlab-ci.yml** at the root of your project repository.
+
+```yaml .gitlab-ci.yml
 image: node:alpine
 
 cache:
@@ -133,13 +136,13 @@ eas-build:
     - npx eas-cli build --platform all --non-interactive
 ```
 
-> Put this into `.gitlab-ci.yml` in the root of your repository.
-
 </Collapsible>
 
 <Collapsible summary="Bitbucket Pipelines">
 
-```yaml
+Add the following code snippet in **bitbucket-pipelines.yml** at the root of your project repository.
+
+```yaml bitbucket-pipelines.yml
 image: node:alpine
 
 definitions:
@@ -159,13 +162,13 @@ pipelines:
           - npx eas-cli build --platform all --non-interactive
 ```
 
-> Put this into `bitbucket-pipelines.yml` in the root of your repository.
-
 </Collapsible>
 
 <Collapsible summary="CircleCI">
 
-```yaml
+Add the following code snippet in **circleci/config.yml** at the root of your project repository.
+
+```yaml .circleci/config.yml
 version: 2.1
 
 executors:
@@ -195,13 +198,13 @@ workflows:
               only: master
 ```
 
-> Put this into `.circleci/config.yml` in the root of your repository.
-
 </Collapsible>
 
 <Collapsible summary="GitHub Actions">
 
-```yaml
+Add the following code snippet in **.github/workflows/eas-build.yml** at the root of your project repository.
+
+```yaml .github/workflows/eas-build.yml
 name: EAS Build
 on:
   workflow_dispatch:
@@ -229,7 +232,5 @@ jobs:
       - name: Build on EAS
         run: eas build --platform all --non-interactive
 ```
-
-> Put this into `.github/workflows/eas-build.yml` in the root of your repository.
 
 </Collapsible>

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -1,11 +1,12 @@
 ---
 title: Configuring EAS Build with eas.json
 sidebar_title: Configuration with eas.json
+description: Learn how a project using EAS services is configured with eas.json.
 ---
 
 **eas.json** is the configuration file for EAS CLI and services. It is located at the root of your project next to your **package.json**. Configuration for EAS Build all belongs under the `"build"` key. A minimal **eas.json** may look something like this:
 
-```json
+```json eas.json
 {
   "build": {
     "development": {
@@ -50,7 +51,7 @@ The `development` profile also defaults to `"distribution": "internal"`. This wi
 
 You may alternatively prefer for your development build to [run on an iOS Simulator](/build-reference/simulators.mdx). To do this, use the following configuration for `development` profile:
 
-```json
+```json eas.json
 {
   "build": {
     "development": {
@@ -74,7 +75,7 @@ These builds don't include developer tools, they are intended to be installed by
 
 A minimal `preview` profile looks like this:
 
-```json
+```json eas.json
 {
   "build": {
     "preview": {
@@ -96,7 +97,7 @@ Production builds must be installed through their respective app stores; they ca
 
 A minimal `production` profile looks like this:
 
-```json
+```json eas.json
 {
   "build": {
     "production": {}
@@ -118,7 +119,7 @@ Every build depends either implicitly or explicitly on a specific set of version
 
 Versions for the most common build tools can be set on build profiles with fields corresponding to names of the tools, for example `"node"`:
 
-```json
+```json eas.json
 {
   "build": {
     "production": {
@@ -132,7 +133,7 @@ Versions for the most common build tools can be set on build profiles with field
 
 It's common to want to share build tool configuration between profiles, and we can use `extends` for that:
 
-```json
+```json eas.json
 {
   "build": {
     "production": {
@@ -155,7 +156,7 @@ It's common to want to share build tool configuration between profiles, and we c
 
 ### Selecting a base image
 
-The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and Cocoapods. You can override them using the specific named fields as described above. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
+The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and Cocoapods. You can override them using the specific named fields as described in the previous section. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
 
 If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to read about the available images on ["Build server infrastructure"](/build-reference/infrastructure.mdx).
 
@@ -163,7 +164,7 @@ If you are using the Expo managed workflow, EAS Build will pick the appropriate 
 
 You can configure environment variables on your build profiles using the `"env"` field. These environment variable will be used to evaluate **app.config.js** locally when you run `eas build`, and they will also be set on the EAS Build worker.
 
-```json
+```json eas.json
 {
   "build": {
     "production": {

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -1,5 +1,6 @@
 ---
 title: Internal distribution
+description: Learn how EAS Build provides shareable URLs for your builds with your team for internal distribution.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -2,6 +2,7 @@
 title: EAS Build
 sidebar_title: Introduction
 hideTOC: true
+description: EAS Build is a hosted service for building app binaries for your Expo and React Native projects.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: Creating your first build
+description: Learn how to create a build for your app with EAS Build.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -9,7 +10,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 EAS Build allows you to build a ready-to-submit binary of your app for the Google Play Store or Apple App Store. In this guide, let's learn how to do that.
 
-Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you towards resources that explain how to do that.
+Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you toward resources that explain how to do that.
 
 For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on the [Expo forums](https://forums.expo.dev/) or [Discord](https://chat.expo.dev/).
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -1,8 +1,11 @@
 ---
 title: Using EAS Update
+description: Learn how to use EAS Update with EAS Build.
 ---
 
-EAS Build includes some special affordances for Expo's [`expo-updates`](/versions/latest/sdk/updates.mdx) library. In particular, you can configure the `channel` property in **eas.json** and EAS Build will take care of updating it in your native project at build time. Not sure what a channel is? [Learn more about channels](/eas-update/how-eas-update-works/#distributing-builds). This document covers concerns specific to using `expo-updates` with EAS Build; for more general information about configuring the expo-updates library with EAS Update, refer to the [EAS Update getting started doc](/eas-update/getting-started).
+EAS Build includes some special affordances for Expo's [`expo-updates`](/versions/latest/sdk/updates.mdx) library. In particular, you can configure the [`channel`](/eas-update/how-eas-update-works/#distributing-builds) property in **eas.json** and EAS Build will take care of updating it in your native project at build time.
+
+This document covers concerns specific to using `expo-updates` library with EAS Build. For more general information about configuring the library with EAS Update, see [Getting started with EAS Update ](/eas-update/getting-started).
 
 ## Setting the channel for a build profile
 
@@ -10,7 +13,7 @@ Each [build profile](./eas-json.mdx#build-profiles) can be assigned to a channel
 
 The following example demonstrates how you might use the `"production"` channel for production builds, and the `"staging"` channel for test builds distributed with [internal distribution](internal-distribution.mdx).
 
-```json
+```json eas.json
 {
   "build": {
     "production": {

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -2,6 +2,7 @@
 title: Expo Application Services
 sidebar_title: Introduction
 hideTOC: true
+description: Learn about Expo Application Services (EAS) for Expo and React Native apps.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/eas/webhooks.mdx
+++ b/docs/pages/eas/webhooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Webhooks
+description: Learn how to configure webhooks to get alerts on EAS Build and EAS submit completion.
 ---
 
 import { ConfigClassic } from '~/components/plugins/ConfigSection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up for #20412

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `description` to pages under the EAS, EAS Build (Start building and App signing) sections. Some minor tweaks and grammar fixes to match our writing style guide are also included.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
