### PR TITLE
[docs] Add description for EAS Build reference docs

### DIFF
--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -1,12 +1,13 @@
 ---
 title: Android build process
+description: Learn how an Android project is built on EAS Build.
 ---
 
 This page describes the process of building Android projects with EAS Build. You may want to read this if you are interested in the implementation details of the build service.
 
 ## Build Process
 
-Let's take a closer look at the steps for building Android projects with EAS Build. We'll first run some steps on your local machine to prepare the project, and then we'll actually build the project on a remote service.
+Let's take a closer look at the steps for building Android projects with EAS Build. We'll first run some steps on your local machine to prepare the project, and then we'll build the project on a remote service.
 
 ### Local Steps
 
@@ -17,7 +18,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
 
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.
 
-1. Create a tarball containing a copy of the repository. Actual behavior depends on the VCS workflow you are using. [Learn more here](https://expo.fyi/eas-vcs-workflow).
+1. Create a tarball containing a copy of the repository. Actual behavior depends on the[ VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps
@@ -29,21 +30,21 @@ Next, this is what happens when EAS Build picks up your request:
    - Every build gets its own fresh container with all build tools installed there (Java JDK, Android SDK, NDK, and so on).
 
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
-1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
+1. [Create **.npmrc**](/build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
-1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
+1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Restore the keystore (if it was included in the build request).
-1. Inject the signing configuration into **build.gradle**. [Learn more](#configuring-gradle).
+1. Inject the signing [configuration into **build.gradle**](#configuring-gradle).
 1. Run `./gradlew COMMAND` in the **android** directory inside your project.
 
    - `COMMAND` is the command defined in your **eas.json** at `builds.android.PROFILE_NAME.gradleCommand`. It defaults to `:app:bundleRelease` which produces the AAB (Android App Bundle).
 
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
-1. Store a cache of files and directories defined in the build profile. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
+1. Store a cache of files and directories defined in the [build profile](/build/eas-json/). Subsequent builds will restore this cache.
 1. Upload the application archive to AWS S3.
 
    - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.applicationArchivePath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package for pattern matching.

--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -18,7 +18,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
 
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.
 
-1. Create a tarball containing a copy of the repository. Actual behavior depends on the[ VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
+1. Create a tarball containing a copy of the repository. Actual behavior depends on the [VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps

--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -1,5 +1,6 @@
 ---
 title: Building APKs for Android Emulators and devices
+description: Learn how to configure and install an .apk for Android Emulators and devices when using EAS Build.
 ---
 
 The default file format used when building Android apps with EAS Build is an [Android App Bundle](https://developer.android.com/platform/technology/app-bundle) (AAB/**.aab**). This format is optimized for distribution to the Google Play Store, but AABs can't be installed directly on your device. To install a build directly to your Android device or emulator, you need to build an [Android Package](https://en.wikipedia.org/wiki/Android_application_package) (APK/**.apk**) instead.

--- a/docs/pages/build-reference/app-extensions.mdx
+++ b/docs/pages/build-reference/app-extensions.mdx
@@ -1,20 +1,17 @@
 ---
 title: iOS App Extensions
+description: Learn how to use app extensions with EAS Build to add custom functionality.
 ---
 
-App extensions let you extend custom functionality and content beyond your app and make it available to users while they’re interacting with other apps or iOS system functionality. EAS Build provides affordances for including app extensions in both bare and managed projects.
-
-## Bare projects
-
-When you build a bare project, EAS CLI will automatically detect app extensions configured in your Xcode project and generate all necessary credentials for each target, or you can provide them in **credentials.json** ([Learn more](../../app-signing/local-credentials/#multi-target-project)).
+App extensions let you extend custom functionality and content beyond your app and make it available to users while they're interacting with other apps or iOS system functionality. EAS Build provides affordances for including app extensions in both bare and managed projects.
 
 ## Managed projects (experimental support)
 
 A typical, simple managed project we have a single application target and no app extensions. You can add an app extension to your project by writing a [config plugin](../../guides/config-plugins) (or using a library that creates an extension with its own config plugin). Config plugins let you add targets to the Xcode project that is generated during the "Prebuild" phase of a build job.
 
-Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` in your app config makes it possible for EAS CLI to know what app extensions exist _before the build starts_ (before the Xcode project has been generated) to ensure that the required credentials are generated and validated. Config plugins are also able to modify the app config, and in most cases if you are using a library that adds an extension then the config plugin will also add the required configuration to declare the extension in your app config. If you are writing a library, we recommend that you consider this. The following is an example of what this would look like if it were declared directly in **app.json**:
+Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` in your app config makes it possible for EAS CLI to know what app extensions exist _before the build starts_ (before the Xcode project has been generated) to ensure that the required credentials are generated and validated. Config plugins are also able to modify the app config, and in most cases, if you are using a library that adds an extension then the config plugin will also add the required configuration to declare the extension in your app config. If you are writing a library, we recommend that you consider this. The following is an example of what this would look like if it were declared directly in **app.json**:
 
-```json
+```json app.json
 {
   "expo": {
     ...
@@ -39,3 +36,7 @@ Declaring app extensions with `extra.eas.build.experimental.ios.appExtensions` i
     }
   }
 ```
+
+## Bare projects
+
+When you build a bare project, EAS CLI will automatically detect app extensions configured in your Xcode project and generate all necessary credentials for each target, or you can provide them in **credentials.json** For more information, see [Multi target project](/app-signing/local-credentials/#multi-target-project).

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -1,5 +1,6 @@
 ---
 title: App version management
+description: Learn about different version types and how to manage them remotely or locally.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/build-reference/build-configuration.mdx
+++ b/docs/pages/build-reference/build-configuration.mdx
@@ -1,15 +1,19 @@
 ---
 title: Build configuration process
 sidebar_title: Configuration process
+description: Learn how EAS CLI configures a project for EAS Build.
+hideTOC: true
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Step } from '~/ui/components/Step';
 
 In this guide, you will learn what happens when EAS CLI configures your project with `eas build:configure` (or `eas build` - which runs this same process if the project is not yet configured).
 
 EAS CLI performs the following steps when configuring your project:
 
-#### 1. Ask you about the platform(s) to configure
+<Step label="1">
+## Ask you about the platform(s) to configure
 
 If you only want to use EAS Build for a single platform, that's fine. If you change your mind, you can come back and configure the other later.
 
@@ -19,11 +23,14 @@ If you only want to use EAS Build for a single platform, that's fine. If you cha
   containerStyle={{ paddingBottom: 0 }}
 />
 
-#### 2. Create eas.json
+</Step>
+
+<Step label="2">
+## Create eas.json
 
 The command will create an **eas.json** file in the root directory with the default configuration. It looks something like this:
 
-```json
+```json eas.json
 {
   "build": {
     "development": {
@@ -40,13 +47,17 @@ The command will create an **eas.json** file in the root directory with the defa
 
 If you have a bare project, it will look a bit different.
 
-This is your EAS Build configuration. It defines three build profiles named `development`, `preview`, and `production` (you can have multiple build profiles like `production`, `debug`, `testing`, etc.) for each platform. If you want to learn more about **eas.json** see the [Configuration with eas.json](/build/eas-json.mdx) page.
+This is your EAS Build configuration. It defines three build profiles named `"development"`, `"preview"`, and `"production"` (you can have multiple build profiles like `"production"`, `"debug"`, `"testing"`, and so on) for each platform. If you want to learn more about **eas.json** see the [Configuration with **eas.json**](/build/eas-json) page.
 
-#### 3. Configure the project
+</Step>
+
+<Step label="3">
+## Configure the project
 
 This step varies depending on the project type you have.
 
-#### 3.1. Managed project
+<Step label="3.1">
+### Managed project
 
 If you haven't configured your **app.json** with `android.package` and/or `ios.bundleIdentifier` yet, EAS CLI will prompt you to specify them.
 
@@ -61,11 +72,19 @@ If you haven't configured your **app.json** with `android.package` and/or `ios.b
 
 In the example above, we defined exactly the same Android application id and iOS bundle identifier. However, they don't need to match.
 
-#### 3.2. Bare project
+</Step>
+
+<Step label="3.2">
+### Bare project
 
 There are no additional steps for bare workflow projects.
 
-#### 4. Next steps
+</Step>
+
+</Step>
+
+<Step label="4">
+## Next steps
 
 That's all there is to configuring a project to be compatible with EAS Build.
 There is one final step if you set `cli.requireCommit` to `true` in your **eas.json** — you'll be prompted to commit all the changes we made for you. You can choose to review them before committing, and you can either specify the git commit message or use a default message.
@@ -75,3 +94,5 @@ There is one final step if you set `cli.requireCommit` to `true` in your **eas.j
   src="/static/images/eas-build/configure/03-next-steps.png"
   containerStyle={{ paddingBottom: 0 }}
 />
+
+</Step>

--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -1,6 +1,7 @@
 ---
 title: Setting up EAS Build with a monorepo
 hideTOC: true
+description: Learn how to set up EAS Build with a monorepo.
 ---
 
 To setup EAS Build with a monorepo, you need to follow the standard process as described below:

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -1,38 +1,40 @@
 ---
 title: Caching dependencies
+description: Learn how to speed up your builds by caching dependencies.
 ---
 
 Before a build job can begin compiling your project, all project dependencies need to be available on disk. The longer it takes to acquire the dependencies, the more you need to wait for your build to complete &mdash; so caching dependencies is an important part of speeding up your builds.
 
-> We're actively working on improving caching and other aspects of the build process in order to make builds reliably fast.
+> We're actively working on improving caching and other aspects of the build process to make builds reliably fast.
 
 ## Custom caching
 
-The `cache` field on build profiles in [eas.json](../build/eas-json) can be used to configure caching for specific files and directories. Specified files will be saved to persistent storage after a successful build and restored on subsequent builds after the JavaScript dependencies are installed. Restoring does not overwrite existing files. Changing the `cache.key` value will invalidate the cache. Changing any other property of the `cache` object will also invalidate the cache.
+The `cache` field on build profiles in [eas.json](/build/eas-json) can be used to configure caching for specific files and directories. Specified files will be saved to persistent storage after a successful build and restored on subsequent builds after the JavaScript dependencies are installed. Restoring does not overwrite existing files. Changing the `cache.key` value will invalidate the cache. Changing any other property of the `cache` object will also invalidate the cache.
 
-The caching implementation is built on top of Amazon S3, and it's not fast enough to give you any benefit from caching `node_modules` or CocoaPods; it's intended only for files that require significant computation to generate, e.g. compilation results (both final binaries and any intermediate files).
+The caching implementation is built on top of Amazon S3, and it's not fast enough to give you any benefit from caching **node_modules** or CocoaPods; it's intended only for files that require significant computation to generate, for example, compilation results (both final binaries and any intermediate files).
 
 ## JavaScript dependencies
 
-EAS Build runs an npm cache server that can speed up downloading JavaScript dependencies for your build jobs. Projects that are using npm or yarn v2 will use the cache by default, but yarn v1 will require that you apply this [workaround](how-tos/#using-npm-cache-with-yarn-v1).
+EAS Build runs an npm cache server that can speed up downloading JavaScript dependencies for your build jobs. Projects that are using npm or yarn v2 will use the cache by default, but yarn v1 will require that you apply this [workaround](/build-reference/npm-cache-with-yarn).
 
-It is not yet possible to save and restore `node_modules` between builds.
+It is not yet possible to save and restore **node_modules** between builds.
 
-To disable using our npm cache server for your builds set `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in `eas.json`.
+To disable using our npm cache server for your builds set `EAS_BUILD_DISABLE_NPM_CACHE` env variable value to `"1"` in **eas.json**.
 
-```json
+{/* prettier-ignore */}
+```json eas.json
 {
   "build": {
     "production": {
-        "env": {
-            "EAS_BUILD_DISABLE_NPM_CACHE": "1",
-            // ...
-        }
-        // ...
+      "env": {
+        "EAS_BUILD_DISABLE_NPM_CACHE": "1"
+        /* @hide ... */ /* @end */
+      }
+      /* @hide ... */ /* @end */
     }
-    // ...
+    /* @hide ... */ /* @end */
   }
-  // ...
+  /* @hide ... */ /* @end */
 }
 ```
 
@@ -40,28 +42,29 @@ To disable using our npm cache server for your builds set `EAS_BUILD_DISABLE_NPM
 
 EAS Build runs a Maven cache server that can speed up downloading Android dependencies for your build jobs.
 
-Currently we are caching:
+Currently, we are caching:
 
 - `maven-central` - [https://repo1.maven.org/maven2/](https://repo1.maven.org/maven2/)
 - `google` - [https://maven.google.com/](https://maven.google.com/)
 - `jcenter` - [https://jcenter.bintray.com/](https://jcenter.bintray.com/)
 - `plugins` - [https://plugins.gradle.org/m2/](https://plugins.gradle.org/m2/)
 
-To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_MAVEN_CACHE` env variable value to `"1"` in `eas.json`.
+To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_MAVEN_CACHE` env variable value to `"1"` in **eas.json**.
 
-```json
+{/* prettier-ignore */}
+```json eas.json
 {
   "build": {
     "production": {
-        "env": {
-            "EAS_BUILD_DISABLE_MAVEN_CACHE": "1",
-            // ...
-        }
-        // ...
+      "env": {
+        "EAS_BUILD_DISABLE_MAVEN_CACHE": "1"
+        /* @hide ... */ /* @end */
+      }
+      /* @hide ... */ /* @end */
     }
-    // ...
+    /* @hide ... */ /* @end */
   }
-  // ...
+  /* @hide ... */ /* @end */
 }
 ```
 
@@ -69,24 +72,25 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 
 EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-Currently, EAS Build is configured to cache almost all the pods served from official CocoaPods CDN, minus few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
+Currently, EAS Build is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
 
-We also cache `Podfile.lock` to provide consistent results across managed app builds.
+We also cache **Podfile.lock** to provide consistent results across managed app builds.
 
-To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in `eas.json`.
+To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
-```json
+{/* prettier-ignore */}
+```json eas.json
 {
   "build": {
     "production": {
-        "env": {
-            "EAS_BUILD_DISABLE_COCOAPODS_CACHE": "1",
-            // ...
-        }
-        // ...
+      "env": {
+        "EAS_BUILD_DISABLE_COCOAPODS_CACHE": "1"
+        /* @hide ... */ /* @end */
+      }
+      /* @hide ... */ /* @end */
     }
-    // ...
+    /* @hide ... */ /* @end */
   }
-  // ...
+  /* @hide ... */ /* @end */
 }
 ```

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -1,6 +1,7 @@
 ---
 title: Running E2E tests on EAS Build
 sidebar_title: Running E2E tests
+description: Learn how to set up and run E2E tests on EAS Build with popular libraries such as Detox.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -499,20 +500,19 @@ const { openApp } = require('./utils/openApp');
 /* @end */
 
 describe('Home screen', () => {
-  beforeEach(async () => {
-    /* @info New line */ await openApp(); /* @end */
-  });
+beforeEach(async () => {/* @info New line */ await openApp(); /* @end */});
 
-  it('"Click me" button should be visible', async () => {
-    await expect(element(by.id('click-me-button'))).toBeVisible();
-  });
-
-  it('shows "Hi!" after tapping "Click me"', async () => {
-    await element(by.id('click-me-button')).tap();
-    await expect(element(by.text('Hi!'))).toBeVisible();
-  });
+it('"Click me" button should be visible', async () => {
+await expect(element(by.id('click-me-button'))).toBeVisible();
 });
-```
+
+it('shows "Hi!" after tapping "Click me"', async () => {
+await element(by.id('click-me-button')).tap();
+await expect(element(by.text('Hi!'))).toBeVisible();
+});
+});
+
+````
 
 </Collapsible>
 
@@ -573,7 +573,7 @@ const getLatestUpdateUrl = () =>
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId ?? '';
 
 const sleep = t => new Promise(res => setTimeout(res, t));
-```
+````
 
 </Collapsible>
 
@@ -589,7 +589,7 @@ const sleep = t => new Promise(res => setTimeout(res, t));
       "type": "ios.app",
       "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
       "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app"
-    }, /* @end */
+    } /* @end */,
     "ios.release": {
       "type": "ios.app",
       "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
@@ -599,7 +599,7 @@ const sleep = t => new Promise(res => setTimeout(res, t));
       "type": "android.apk",
       "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
       "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk"
-    }, /* @end */
+    } /* @end */,
     "android.release": {
       "type": "android.apk",
       "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
@@ -624,7 +624,7 @@ const sleep = t => new Promise(res => setTimeout(res, t));
     /* @info New section */ "ios.debug": {
       "device": "simulator",
       "app": "ios.debug"
-    }, /* @end */
+    } /* @end */,
     "ios.release": {
       "device": "simulator",
       "app": "ios.release"
@@ -632,7 +632,7 @@ const sleep = t => new Promise(res => setTimeout(res, t));
     /* @info New section */ "android.debug": {
       "device": "emulator",
       "app": "android.debug"
-    }, /* @end */
+    } /* @end */,
     "android.release": {
       "device": "emulator",
       "app": "android.release"
@@ -640,6 +640,7 @@ const sleep = t => new Promise(res => setTimeout(res, t));
   }
 }
 ```
+
 </Collapsible>
 
 <Collapsible summary="eas-hooks/eas-build-on-success.sh">

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -494,25 +494,27 @@ Development builds typically display an onboarding welcome screen when an app is
 An example of such a Detox test is shown below. Full example code is available on the [eas-tests-example](https://github.com/expo/eas-tests-example) repository.
 
 <Collapsible summary="e2e/homeScreen.e2e.js">
+
 ```js
 /* @info New line */
 const { openApp } = require('./utils/openApp');
 /* @end */
 
 describe('Home screen', () => {
-beforeEach(async () => {/* @info New line */ await openApp(); /* @end */});
+  beforeEach(async () => {
+    /* @info New line */ await openApp(); /* @end */
+  });
 
-it('"Click me" button should be visible', async () => {
-await expect(element(by.id('click-me-button'))).toBeVisible();
-});
+  it('"Click me" button should be visible', async () => {
+    await expect(element(by.id('click-me-button'))).toBeVisible();
+  });
 
-it('shows "Hi!" after tapping "Click me"', async () => {
-await element(by.id('click-me-button')).tap();
-await expect(element(by.text('Hi!'))).toBeVisible();
+  it('shows "Hi!" after tapping "Click me"', async () => {
+    await element(by.id('click-me-button')).tap();
+    await expect(element(by.text('Hi!'))).toBeVisible();
+  });
 });
-});
-
-````
+```
 
 </Collapsible>
 
@@ -530,7 +532,7 @@ module.exports.openApp = async function openApp() {
       newInstance: true,
     });
   }
-}
+};
 
 async function openAppForDebugBuild(platform) {
   const deepLinkUrl = process.env.EXPO_USE_UPDATES
@@ -557,7 +559,7 @@ async function openAppForDebugBuild(platform) {
   }
 
   await sleep(3000);
-};
+}
 
 const getDeepLinkUrl = url =>
   /* @info This is project-specific, replace eastestsexample with correct value */
@@ -573,7 +575,7 @@ const getLatestUpdateUrl = () =>
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId ?? '';
 
 const sleep = t => new Promise(res => setTimeout(res, t));
-````
+```
 
 </Collapsible>
 

--- a/docs/pages/build-reference/eas-json.mdx
+++ b/docs/pages/build-reference/eas-json.mdx
@@ -1,6 +1,6 @@
 ---
 title: Build schema for eas.json
-sidebar_title: Build schema for eas.json
+description: A reference of configuration options for EAS Build and Submit.
 ---
 
 import { EasJsonPropertiesTable } from '~/components/plugins/EasJsonPropertiesTable';
@@ -12,13 +12,13 @@ import iosSchema from '~/scripts/schemas/unversioned/eas-json-build-ios-schema.j
 
 **eas.json** is your go-to place for configuring EAS Build (and [EAS Submit](/submit/eas-json.mdx)). It is located at the root of your project next to your **package.json**.
 
-This document is a reference that outlines the schema for the `"build"` key in **eas.json**. For an explanation of how to use it, please refer to ["Configuring EAS Build eas.json"](/build/eas-json.mdx).
+This document is a reference that outlines the schema for the `"build"` key in **eas.json**. For an explanation of how to use it, see [Configuring EAS Build eas.json](/build/eas-json.mdx).
 
 ## Examples
 
 <Collapsible summary="A managed project with several profiles">
 
-```json
+```json eas.json
 {
   "build": {
     "base": {
@@ -78,7 +78,7 @@ This document is a reference that outlines the schema for the `"build"` key in *
 
 <Collapsible summary="A bare project with several profiles">
 
-```json
+```json eas.json
 {
   "build": {
     "base": {
@@ -135,7 +135,7 @@ This document is a reference that outlines the schema for the `"build"` key in *
 ## Schema
 
 {/* prettier-ignore */}
-```json
+```json eas.json
 {
   "cli": {
     "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
@@ -163,7 +163,7 @@ This document is a reference that outlines the schema for the `"build"` key in *
 
 > You can specify common options both in the platform-specific configuration object or at the profile's root. The platform-specific options take precedence over globally-defined ones.
 
-> EAS Submit is also configured in **eas.json**. You can find the reference for the `"submit"` fields in ["Configuring EAS Submit with eas.json"](/submit/eas-json.mdx).
+> EAS Submit is also configured in **eas.json**. You can find the reference for the `"submit"` fields in [Configuring EAS Submit with eas.json](/submit/eas-json.mdx).
 
 ## Options common to both platforms
 

--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Git Submodules
+description: Learn how to configure EAS Build to use git submodules.
 ---
 
 import { Step } from '~/ui/components/Step';

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -2,6 +2,7 @@
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
+description: Learn about the current build server infrastructure when using EAS.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -1,12 +1,13 @@
 ---
 title: iOS build process
+description: Learn how an iOS project is built on EAS Build.
 ---
 
 This page describes the process of building iOS projects with EAS Build. You may want to read this if you are interested in the implementation details of the build service.
 
 ## Build Process
 
-Let's take a closer look at the steps for building iOS projects with EAS Build. We'll first run some steps on your local machine to prepare the project and then we'll actually build the project on a remote service.
+Let's take a closer look at the steps for building iOS projects with EAS Build. We'll first run some steps on your local machine to prepare the project and then we'll build the project on a remote service.
 
 ### Local Steps
 
@@ -18,7 +19,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
    - Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're offered to generate them.
 
 1. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (i.e. ensure the correct bundle identifier and Apple Team ID are set).
-1. Create the tarball containing a copy of the repository. Actual behavior depends on the VCS workflow you are using. [Learn more here](https://expo.fyi/eas-vcs-workflow).
+1. Create the tarball containing a copy of the repository. Actual behavior depends on the [VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
 1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
 
 ### Remote Steps
@@ -30,26 +31,26 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Every build gets its own fresh macOS VM with all build tools installed there (Xcode, Fastlane, and so on).
 
 1. Download the project tarball from a private AWS S3 bucket and unpack it.
-1. Create `.npmrc` if `NPM_TOKEN` is set. ([Learn more](/build-reference/private-npm-packages).)
+1. [Create **.npmrc**](build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
-1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
+1. Run `npm install` in the project root (or `yarn install` if **yarn.lock** exists).
 1. Run `expo doctor` to diagnose potential issues with your project configuration.
 1. Restore the credentials
 
    - Create a new keychain.
    - Import the Distribution Certificate into the keychain.
-   - Write the Provisioning Profile to the `~/Library/MobileDevice/Provisioning Profiles` directory.
+   - Write the Provisioning Profile to the **~/Library/MobileDevice/Provisioning Profiles** directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
 1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. You can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
-1. Restore a previously saved cache identified by the `cache.key` value in the build profile. ([Learn more](../build/eas-json/).)
+1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from **package.json** if defined.
 1. Update the Xcode project with the ID of the Provisioning Profile.
 1. Create **Gymfile** in the **ios** directory if it does **not** already exist (check out the [Default Gymfile](#default-gymfile) section).
 1. Run `fastlane gym` in the **ios** directory.
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
-1. Store a cache of files and directories defined in the build profile. `Podfile.lock` is cached by default. Subsequent builds will restore this cache. ([Learn more](../build/eas-json/).)
+1. Store a cache of files and directories defined in the [build profile](/build/eas-json). **Podfile.lock** is cached by default. Subsequent builds will restore this cache.
 1. Upload the application archive to a private AWS S3 bucket.
 
    - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.applicationArchivePath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `applicationArchivePath`. We're using the [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) package under the hood.
@@ -67,7 +68,7 @@ EAS Build can use your own **Gymfile**. All you need to do is to place this file
 
 ### Default Gymfile
 
-If the `ios/Gymfile` file doesn't exist, the iOS builder creates a default one. It looks something like this:
+If the **ios/Gymfile** file doesn't exist, the iOS builder creates a default one which looks similar to the following:
 
 ```rb
 suppress_xcode_output(true)

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -1,8 +1,10 @@
 ---
 title: iOS Capabilities
+description: Learn about built-in iOS capabilities supported in EAS Build and how to enable or disable them.
 ---
 
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { Terminal } from '~/ui/components/Snippet';
 
 When you make a change to your iOS entitlements, this change needs to be updated remotely on Apple's servers before making a production build. EAS Build automatically synchronizes capabilities on the Apple Developer Console with your local entitlements configuration when you run `eas build`. Capabilities are web services provided by Apple, think of them like AWS or Firebase services.
 
@@ -10,9 +12,9 @@ When you make a change to your iOS entitlements, this change needs to be updated
 
 ## Entitlements
 
-In bare workflow apps, the entitlements are read from your `ios/**/*.entitlements` file.
+In bare workflow apps, the entitlements are read from your **ios/.entitlements** file.
 
-In managed workflow, the entitlements are read from the introspected Expo config. You can see what your introspected config looks like by running `npx expo config --type introspect` in your project, then look for the `ios.entitlements` object for the results.
+In the managed workflow, the entitlements are read from the introspected Expo config. You can see what your introspected config looks like by running `npx expo config --type introspect` in your project, then look for the `ios.entitlements` object for the results.
 
 ## Enabling
 
@@ -103,21 +105,21 @@ There are two ways to manually enable Apple capabilities, both systems will requ
 
 ### Xcode
 
-> Preferred method for bare workflow or projects that do **not** using [Expo Prebuild](/workflow/prebuild) to continuously generate the native `ios` and `android` directories.
+> Preferred method for bare workflow or projects that do **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the native **android** and **ios** directories.
 
-1. Open the `ios/` directory in Xcode with `xed ios`. If you don't have an `ios/` directory, run `npx expo prebuild -p ios` to generate one.
-2. Then follow [this guide][apple-enable-capability].
+1. Open the **ios** directory in Xcode with `xed ios`. If you don't have an `ios/` directory, run `npx expo prebuild -p ios` to generate one.
+2. Then follow the steps mentioned in [Add a capability][apple-enable-capability].
 
 ### Apple Developer Console
 
-First step is to add the respective key/value pairs to your `ios/[app]/[app].entitlements` (or more specific entitlements file for multi-target apps). You can refer to [Supported Capabilities](#supported-capabilities) to determine which entitlements keys should be added.
+First step is to add the respective key/value pairs to your **ios/[app]/[app].entitlements** (or more specific entitlements file for multi-target apps). You can refer to [Supported Capabilities](#supported-capabilities) to determine which entitlements keys should be added.
 
 1. Log into [Apple Developer Console][apple-dev-console]. Click on "Certificates, IDs & Profiles", then navigate to "Identifiers" page.
 2. Choose the bundle identifier that matches your app's bundle identifier.
 3. Scroll down and enable a capability, some capabilities may require extra setup.
-4. Scroll to the top and press "Save". You will see a dialog that says "Modify App Capabilities", press "Confirm" to continue. You will need to regenerate any provisioning profiles that use this bundle identifier before they'll be valid for building a code signed production ipa.
+4. Scroll to the top and press "Save". You will see a dialog that says "Modify App Capabilities", press "Confirm" to continue. You will need to regenerate any provisioning profiles that use this bundle identifier before they'll be valid for building a code signed production **.ipa**.
 
-If adding capabilities process has not been done correctly then your iOS native build will fail with an error that looks something like:
+If adding capabilities process has not been done correctly then your iOS native build will fail with an error similar to:
 
 ```
 ❌  error: Provisioning profile "*[expo] app.bacon.hello AppStore ..." doesn't support the Associated Domains capability.

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -12,7 +12,7 @@ When you make a change to your iOS entitlements, this change needs to be updated
 
 ## Entitlements
 
-In bare workflow apps, the entitlements are read from your **ios/.entitlements** file.
+In bare workflow apps, the entitlements are read from your __ios/**/*.entitlements__ file.
 
 In the managed workflow, the entitlements are read from the introspected Expo config. You can see what your introspected config looks like by running `npx expo config --type introspect` in your project, then look for the `ios.entitlements` object for the results.
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -1,11 +1,12 @@
 ---
 title: EAS Build Limitations
 sidebar_title: Limitations
+description: Learn about the current limitations of EAS Build.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-EAS Build is designed to work for any React Native project. However, it is good to be aware of certain limitations that we plan to address since they could prevent your from being able to use the service for your applications or might cause an inconvenience.
+EAS Build is designed to work for any React Native project. However, it is good to be aware of certain limitations that we plan to address since they could prevent you from being able to use the service for your applications or might cause an inconvenience.
 
 ## Current limitations
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -1,5 +1,6 @@
 ---
 title: Running builds on your own infrastructure
+description: Learn how to run EAS Build on your own custom infrastructure.
 ---
 
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag.

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -1,5 +1,6 @@
 ---
 title: Migrating from "expo build"
+description: A reference for migrating from "expo build" to EAS Build.
 ---
 
 The purpose of this reference page is to call out some of the practical differences that you may need to account for when migrating your Expo managed app from `expo build` ("classic builds") to EAS Build. If this is your first time using EAS Build, you can use this page as a companion to ["Creating your first build"](/build/setup.mdx).

--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -1,6 +1,7 @@
 ---
 title: Using npm cache with Yarn Classic
 hideTOC: true
+description: Learn how to use npm cache by overriding the registry in Yarn Classic.
 ---
 
 By default, the EAS npm cache won't work with Yarn 1 (Classic), because **yarn.lock** files contain URLs to registries for every package and Yarn does not provide any way to override it. The issue is fixed in Yarn 2+ (Berry), but the Yarn team does not plan to backport it to Yarn v1.

--- a/docs/pages/build-reference/npm-hooks.mdx
+++ b/docs/pages/build-reference/npm-hooks.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build lifecycle hooks
+description: Learn how to use the EAS Build lifecycle hooks with npm to customize your build process.
 ---
 
 There are five EAS Build lifecycle npm hooks that you can set in your **package.json**. See the [Android build process](android-builds.mdx) and [iOS build process](ios-builds.mdx) docs to get a better understanding about the internals of the build process.
@@ -12,7 +13,7 @@ There are five EAS Build lifecycle npm hooks that you can set in your **package.
 - `eas-build-on-error` - this hook is triggered at the end of the build process if the build failed.
 - `eas-build-on-complete` - this hook is triggered at the end of the build process. You can check the build's status with the `EAS_BUILD_STATUS` environment variable. It's either `finished` or `errored`.
 
-This is an example of how your **package.json** might look like:
+Below is an example of how your **package.json** can look with lifecycle hooks:
 
 ```json package.json
 {

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using private npm packages
+description: Learn how to configure EAS Build to use private npm packages.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/build-reference/simulators.mdx
+++ b/docs/pages/build-reference/simulators.mdx
@@ -1,5 +1,6 @@
 ---
 title: Building for iOS Simulators
+description: Learn how to configure and install build for iOS simulators when using EAS Build.
 ---
 
 Running a build of your app in an iOS Simulator is particularly useful in managed apps to get the standalone (independent of Expo Go) version of the app running easily without needing to deploy to TestFlight or even have an Apple Developer account.

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting build errors and crashes
+description: A reference for troubleshooting build errors and crashes when using EAS Build.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -7,7 +8,10 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > This document is under active development; the topic it covers is expansive and finding the right way to explain how to troubleshoot issues will take some trial and error. Your suggestions for improvements are welcome as pull requests.
 
-When something goes wrong, it probably will go wrong in one of two ways: 1) your build will fail, or 2) the build will succeed but encounter a runtime error, eg: it crashes or hangs when you run it.
+When something goes wrong, it probably will go wrong in one of two following ways:
+
+1. Your build will fail.
+2. The build will succeed but encounter a runtime error, for example, it crashes or hangs when you run it.
 
 All standard advice around [narrowing down the source of an error](https://expo.fyi/manual-debugging) applies here; this document provides information that may be useful on top of your typical troubleshooting processes and techniques. Troubleshooting is an art, and you might need to think creatively.
 
@@ -17,7 +21,7 @@ Before you go further, you need to be sure that you have located the error messa
 
 ### Runtime errors
 
-Refer to the [debugging guide](/workflow/debugging.mdx#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
+Refer to the [debugging guide](/workflow/debugging#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
 
 ### Build errors
 
@@ -34,7 +38,7 @@ For example, you might see something like this on your Android builds:
   ]}
 />
 
-While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building a bare project, you will already be good at this. If you are building a [managed project](/introduction/managed-vs-bare.mdx), it may be tricky because you don't directly interact with the native code, only write JavaScript.
+While you may or may not be interested in following up on that warning, it is not the cause of your failed build. So how do you know which logs are truly responsible? If you are building a bare project, you will already be good at this. If you are building a [managed project](/introduction/managed-vs-bare), it may be tricky because you don't directly interact with the native code, only write JavaScript.
 
 A good path forward is to **determine if the build failed due to a native or JavaScript error**. When your build fails due to a JavaScript build error, you will usually see something like this:
 
@@ -45,37 +49,37 @@ A good path forward is to **determine if the build failed due to a native or Jav
   ]}
 />
 
-This particular error means that the app is importing `./src/Routes` and it is not found. The cause could be that the filename case being different in Git than the developer's filesystem (eg: `routes.js` in Git instead of `Routes.js`), or maybe the project has a build step and it wasn't set up to run on EAS Build. In this case, it turns out that in this case `./src/Routes` was intended to import `./src/Routes/index.js`, but that path was accidentally excluded in the developer's `.gitignore`.
+This particular error means that the app is importing **./src/Routes** and it is not found. The cause could be that the filename case is different in Git than the developer's filesystem (for example, **routes.js** in Git instead of **Routes.js**), or maybe the project has a build step and it wasn't set up to run on EAS Build. In this case, it turns out that in this case **./src/Routes** was intended to import **./src/Routes/index.js**, but that path was accidentally excluded in the developer's **.gitignore**.
 
-It's important to note that with iOS builds the build details page only displays an abridged version of the logs, because the full output from `xcodebuild` can be in the order of 10MB. Sometimes it's necessary to open the full Xcode logs in order to find the information that you need; for example, if the JavaScript build failed but you don't see any useful information on the build details page. To open the full Xcode logs, scroll to the bottom of the build details page when the build has completed and either click to view or download them.
+It's important to note that with iOS builds the build details page only displays an abridged version of the logs because the full output from `xcodebuild` can be in the order of 10MB. Sometimes it's necessary to open the full Xcode logs to find the information that you need; for example, if the JavaScript build failed but you don't see any useful information on the build details page. To open the full Xcode logs, scroll to the bottom of the build details page when the build has been completed and either click to view or download them.
 
 {/* TODO: native and js build phases should be separate in eas build logs, this is too much work for people to figure out */}
 
-If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/guides/config-plugins.mdx) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `expo doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
+If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/guides/config-plugins) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `expo doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
 Armed with your error logs, you can often start to fix your build, or you can search the [forums](https://forums.expo.dev) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 
-<Collapsible summary="📦 Are you using a monorepo?">
+<Collapsible summary="Are you using a monorepo?">
 
 Monorepos are incredibly useful but they do introduce their own set of problems. A monorepo that you have set up to work with `expo build` will not necessarily work with `eas build`.
 
 With EAS Build, it's necessary to upload the entire monorepo to the build worker, set it up, and run the build; but, on `expo build` you only had to be able to build the JavaScript bundle locally and upload that to the worker.
 
-EAS Build is more like a typical CI service in that we need the source code, rather than a compiled JavaScript bundle and manifest. EAS Build has first-class support for Yarn workspaces, and [your success may vary when using other monorepo tools](/build-reference/limitations.mdx).
+EAS Build is more like a typical CI service in that we need the source code, rather than a compiled JavaScript bundle and manifest. EAS Build has first-class support for Yarn workspaces, and [your success may vary when using other monorepo tools](/build-reference/limitations).
 
-{/* TODO: link to monorepos guide when ready */}
+For more information, see [Working with monorepos](/guides/monorepos).
 
 </Collapsible>
 
-<Collapsible summary="💥 Out-of-memory (OOM) errors">
+<Collapsible summary="Out-of-memory (OOM) errors">
 
 If your build fails with "Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)" in your Gradle logs, this may be because the Node process responsible for bundling your app JavaScript was killed.
 
-This can often be a sign that your app bundle is extremely large, which will make your overall app binary larger and lead to slow boot up times, especially on low-end Android devices. Sometimes the error can occur when large text files are treated as source code, for example if you have a JavaScript file that contains a string of 1MB+ of HTML to load into a webview, or a similarly sized JSON file.
+This can often be a sign that your app bundle is extremely large, which will make your overall app binary larger and lead to slow boot up times, especially on low-end Android devices. Sometimes the error can occur when large text files are treated as source code, for example, if you have a JavaScript file that contains a string of 1MB+ of HTML to load into a webview, or a similarly sized JSON file.
 
 To determine how large your bundle is and to see a breakdown of where the size comes from, use [react-native-bundle-visualizer](https://github.com/IjzerenHein/react-native-bundle-visualizer).
 
-It's not yet possible to increase memory limits on your build workers, [only one worker configuration is currently available](/build-reference/limitations.mdx).
+It's not yet possible to increase memory limits on your build workers, [only one worker configuration is currently available](/build-reference/limitations).
 
 </Collapsible>
 
@@ -85,7 +89,7 @@ When you get the `Metro encountered an error` during a native iOS build, it mean
 
 <Terminal cmd={[`❌ Metro encountered an error:`]} />
 
-You can reproduce this production bundle locally by running `expo export --experimental-bundle` which simply creates a production bundle. Continue doing this until the command passes without throwing. In general this should save you hours of debugging time.
+You can reproduce this production bundle locally by running `expo export --experimental-bundle` which simply creates a production bundle. Continue doing this until the command passes without throwing. In general, this should save you hours of debugging time.
 
 This behavior comes from React Native on iOS, in the future we plan to rewrite this for EAS Build so the bundle is created before the native runtime.
 
@@ -93,27 +97,27 @@ This behavior comes from React Native on iOS, in the future we plan to rewrite t
 
 If the logs weren't enough to immediately help you understand and fix the root cause, it's time to try to reproduce the issue locally. If your project builds and runs locally in release mode then it will also build on EAS Build, provided that the following are all true:
 
-- Relevant Build tool versions (eg: Xcode, Node, npm, Yarn) are the same in both environments. [Learn more](/build/eas-json.mdx#configuring-your-build-tools).
-- Relevant environment variables are the same in both environments. [Learn more](/build-reference/variables.mdx).
-- The archive that is uploaded to EAS Build includes the same relevant source files. [Learn more](https://expo.fyi/eas-build-archive).
+- Relevant [Build tool versions](/build/eas-json#configuring-your-build-tools) (for example, Xcode, Node.js, npm, Yarn) are the same in both environments.
+- Relevant [environment variables](/build-reference/variables) are the same in both environments.
+- The [archive](https://expo.fyi/eas-build-archive) that is uploaded to EAS Build includes the same relevant source files.
 
-You can verify that your project builds on your local machine with the `expo run` commands with variant/configuration flags set to release to most faithfully reproduce what executes on EAS Build. (Learn more about the [iOS build process](/build-reference/ios-builds.mdx) and [Android build process](/build-reference/android-builds.mdx)).
+You can verify that your project builds on your local machine with the `expo run` commands with variant/configuration flags set to release to most faithfully reproduce what executes on EAS Build. For more information, see [Android build process](/build-reference/android-builds) and [iOS build process](/build-reference/ios-builds).
 
 <Terminal
   cmd={[
     '# Locally compile and run the Android app in release mode',
-    '$ expo run:android --variant release',
+    '$ npx expo run:android --variant release',
     '',
     '# Locally compile and run the iOS app in release mode',
-    '$ expo run:ios --configuration Release',
+    '$ npx expo run:ios --configuration Release',
   ]}
 />
 
-> In managed projects, these commands will run `expo prebuild` to generate native projects &mdash; you likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting.
+> In managed projects, these commands will run `npx expo prebuild` to generate native projects &mdash; you likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting.
 
-<Collapsible summary="💡 Don't have Xcode and Android Studio set up on your machine?">
+<Collapsible summary="Don't have Xcode and Android Studio set up on your machine?">
 
-**If you do not have native toolchains installed locally**, for example because you do not have an Apple computer and therefore cannot build an iOS app on your machine, it can be trickier to get to the bottom of build errors. The feedback loop of making small changes locally and then seeing the result on EAS Build is slower than doing the same steps locally, because the EAS Build worker must set up its environment, download your project, and install dependencies before starting the build.
+**If you do not have native toolchains installed locally**, for example, because you do not have an Apple computer and therefore cannot build an iOS app on your machine, it can be trickier to get to the bottom of build errors. The feedback loop of making small changes locally and then seeing the result on EAS Build is slower than doing the same steps locally because the EAS Build worker must set up its environment, download your project, and install dependencies before starting the build.
 
 If you are willing and able to set up the appropriate native tools, then refer to the [React Native environment setup guide](https://reactnative.dev/docs/environment-setup).
 
@@ -132,11 +136,11 @@ There are two ways to approach this, which are quite similar:
 
 ### Why does my app work in Expo Go and `expo build:[android|ios]` but not with EAS Build?
 
-The classic build service (`expo build`) works completely differently from EAS Build, and there is no guarantee that your app will work out of the box on EAS Build if it works on the classic build service. You can learn more about [migrating from `expo build` in the guide](/build-reference/migrating.mdx), and get a better understanding of how these two services are fundamentally different in [this two-part blog post](https://blog.expo.dev/expo-managed-workflow-in-2021-5b887bbf7dbb).
+The classic build service (`expo build`) works completely differently from EAS Build, and there is no guarantee that your app will work out of the box on EAS Build if it works on the classic build service. You can learn more about [migrating from `expo build` in the guide](/build-reference/migrating), and get a better understanding of how these two services are fundamentally different in [this two-part blog post](https://blog.expo.dev/expo-managed-workflow-in-2021-5b887bbf7dbb).
 
-### Why does my production app does not match my development app?
+### Why does my production app not match my development app?
 
-You can test how the JS part of your app will run in production by starting it with `expo start --no-dev`. This tells the bundler to minify JavaScript before serving it, most notably stripping code protected by the `__DEV__` boolean. This will remove most of the logging, HMR, Fast Refresh functionality, and make debugging a bit harder, but you can iterate on the production bundle faster this way.
+You can test how the JS part of your app will run in production by starting it with [`npx expo start --no-dev`](/workflow/development-mode/#production-mode). This tells the bundler to minify JavaScript before serving it, most notably stripping code protected by the `__DEV__` boolean. This will remove most of the logging, HMR, Fast Refresh functionality, and make debugging a bit harder, but you can iterate on the production bundle faster this way.
 
 ## Still having trouble?
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -1,12 +1,13 @@
 ---
 title: Environment variables and secrets
+description: Learn how to use environment variables and secrets in an EAS Build.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The ["Environment variables in Expo"](/guides/environment-variables.mdx) guide presents several options for how you can access system environment variables to your app JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables.mdx#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
+The [Environment variables in Expo](/guides/environment-variables) guide presents several options for how you can access system environment variables to your app JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
 
 Using the techniques described in the environment variables document above, environment variables are inlined (the `process.env.X` text is replaced with its evaluated result) in your app's JavaScript code _at the time that the app is built_, and included in the app bundle. This means that the substitution would occur on EAS Build servers and not on your development machine, so if you tried to run a build on EAS Build without explicitly providing values or fallbacks for the environment variables, then you are likely to encounter either a build-time or runtime error.
 
@@ -28,7 +29,7 @@ You can specify environment variables for specific build jobs using **eas.json**
 }
 ```
 
-You can access these variables in your application using the techniques described in the ["Environment variables in Expo"](/guides/environment-variables.mdx) guide. You can also share common configurations between different build profiles using the `"extends"` property, if both profiles have an `env` object defined, content will be merged.
+You can access these variables in your application using the techniques described in the ["Environment variables in Expo"](/guides/environment-variables) guide. You can also share common configurations between different build profiles using the `"extends"` property, if both profiles have an `env` object defined, the content will be merged.
 
 ```json eas.json
 {
@@ -46,11 +47,11 @@ You can access these variables in your application using the techniques describe
 }
 ```
 
-See the [eas.json reference](/build/eas-json.mdx) for more information.
+See the [eas.json reference](/build/eas-json) for more information.
 
 ## Environment variables and app.config.js
 
-Environment variables used in your build profile will also be used to evaluate **app.config.js** when you run `eas build`. This is important in order to ensure that the result of evaluating **app.config.js** is the same when it's done locally while initiating the build (in order to gather metadata for the build job) and when it occurs on the remote build worker, for example to configure the project during `npx expo prebuild` or to embed the configuration data in the app.
+Environment variables used in your build profile will also be used to evaluate **app.config.js** when you run `eas build`. This is important to ensure that the result of evaluating **app.config.js** is the same when it's done locally while initiating the build (to gather metadata for the build job) and when it occurs on the remote build worker, for example, to configure the project during `npx expo prebuild` or to embed the configuration data in the app.
 
 ## Built-in environment variables
 
@@ -77,9 +78,9 @@ A secret is made up of a name and a value. The name can only contain alphanumeri
 
 The value can be either a file or a string value. For a file, its contents are saved to a temporary file on EAS Build servers. The file path is available via the environment variable. For example, if you created a file secret named `SECRET_FILE`, EAS Build will create a file at `/Users/expo/workingdir/environment-secrets/__UNIQUE_RANDOM_UUID__`, and `SECRET_FILE` will be set to that path.
 
-The secret values are encrypted at rest and in transit, and are only decrypted in a secure environment by EAS servers.
+The secret values are encrypted at rest and in transit and are only decrypted in a secure environment by EAS servers.
 
-You can create up to 100 account-wide secrets for each Expo account and 100 app-specific secrets for each app. Account-wide secrets will be exposed to every build environment across all of your apps. App-specific secrets only apply to the app they're defined for, and will override any account-wide secrets with the same name.
+You can create up to 100 account-wide secrets for each Expo account and 100 app-specific secrets for each app. Account-wide secrets will be exposed to every build environment across all of your apps. App-specific secrets only apply to the app they're defined for and will override any account-wide secrets with the same name.
 
 You can manage secrets through the Expo website and EAS CLI.
 
@@ -140,7 +141,7 @@ If you're using a **.env** file for storing your secrets locally, you can use th
   ]}
 />
 
-Beware that EAS CLI will fail if some of the secrets defined in the dotenv file already exist on the server. To force overriding those secrets, pass the `--force` flag to the command.
+Beware that EAS CLI will fail if some of the secrets defined in the dotenv file already exist on the server. To force override those secrets, pass the `--force` flag to the command.
 
 #### Doppler integration
 
@@ -158,7 +159,7 @@ After creating a secret, you can read it on subsequent EAS Build jobs with `proc
 
 ## Common questions
 
-Environment variables can be tricky to use if you don't have the correct mental model for how they work. In this section we're going to clarify common sources of confusion, oriented around use cases.
+Environment variables can be tricky to use if you don't have the correct mental model for how they work. In this section, clarify common sources of confusion oriented around use cases are addressed below.
 
 ### Can I share environment variables defined in eas.json with `expo start` and `eas update`?
 
@@ -290,7 +291,7 @@ export default {
 
 A secret created on the Expo website or with `eas secret:create` will take precedence over an environment variable of the same name that is set through the `env` field in **eas.json**.
 
-For example, if you create a secret with name `MY_TOKEN` and value `secret` and also set `"env": { "MY_TOKEN": "public" }` in your **eas.json**, then `process.env.MY_TOKEN` on EAS Build will evaluate to `secret`.
+For example, if you create a secret with the name `MY_TOKEN` and value `secret` and also set `"env": { "MY_TOKEN": "public" }` in your **eas.json**, then `process.env.MY_TOKEN` on EAS Build will evaluate to `secret`.
 
 ### How do environment variables work for my Expo Development Client builds?
 
@@ -298,13 +299,13 @@ Environment variables set in your build profile that impact **app.config.js** wi
 
 ### Can I just set my environment variables on a CI provider?
 
-Environment variables must be defined in **eas.json** in order to be made available to EAS Build workers. If you are [triggering builds from CI](/build/building-on-ci.mdx) this same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets in **eas.json**.
+Environment variables must be defined in **eas.json** to be made available to EAS Build workers. If you are [triggering builds from CI](/build/building-on-ci) this same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets in **eas.json**.
 
 ### How to upload a secret file and use it in my app config?
 
-A common use case for uploading file secrets to EAS is when you want to supply your build with the **google-services.json** and **GoogleService-Info.plist** files. Usually, those files should not be checked in to the repository.
+A common use case for uploading file secrets to EAS is when you want to supply your build with the **google-services.json** and **GoogleService-Info.plist** files. Usually, those files should not be checked into the repository.
 
-Here's an example how to upload **google-services.json** to EAS and use it in your app config:
+Here's an example of how to upload **google-services.json** to EAS and use it in your app config:
 
 <Step label="1">
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -1,14 +1,15 @@
 ---
 title: Installing app variants on the same device
 maxHeadingDepth: 4
+description: Learn how to install multiple instances of an app on the same device.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-When creating [development, preview, and production builds](../build/eas-json/#common-use-cases), it's common to want to install one of each build on your device at the same time.
+When creating [development, preview, and production builds](/build/eas-json/#common-use-cases), it's common to want to install one of each build on your device at the same time.
 This allows you to do development work, preview the next version of your app, and run the production version all on the same device, without needing to uninstall and reinstall the app.
 
-In order to be able to have multiple instances of an app installed on your device, each instance must have a unique Application ID (Android) or Bundle Identifier (iOS).
+To be able to have multiple instances of an app installed on your device, each instance must have a unique Application ID (Android) or Bundle Identifier (iOS).
 
 **If you have a managed project**, this can be accomplished by using **app.config.js** and environment variables in **eas.json**.
 
@@ -183,7 +184,7 @@ The rest of the configuration at this point is not specific to EAS, it's the sam
   ```
 - To change the icon of the app built with the development profile, create `android/app/src/development/res/mipmap-*` directories with appropriate assets (you can copy them from **android/app/src/main/res** and replace the icon files).
 - To specify **google-services.json** for a specific flavor put it in a **android/app/src/&lbrace;flavor&rbrace;/google-services.json** file.
-- To configure sentry, add `project.ext.sentryCli = [ flavorAware: true ]` to **android/app/build.gradle** and name your properties file `android/sentry-{flavor}-{buildType}.properties` (e.g. **android/sentry-production-release.properties**)
+- To configure sentry, add `project.ext.sentryCli = [ flavorAware: true ]` to **android/app/build.gradle** and name your properties file `android/sentry-{flavor}-{buildType}.properties` (for example: **android/sentry-production-release.properties**)
 
 #### iOS
 
@@ -239,7 +240,7 @@ Open project in Xcode, click on the project name in the navigation panel, right 
   style={{ maxWidth: 720 }}
 />
 
-Rename the target to something more meaningful, e.g. `myapp copy` -> `myapp-dev`.
+Rename the target to something more meaningful, for example, `myapp copy` -> `myapp-dev`.
 
 Configure a scheme for the new target:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up for #20412

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `description` to pages under the EAS Build > Reference section. Some minor tweaks and grammar fixes to match our writing style guide are also included.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
