### PR TITLE
[docs] display page description if it is defined

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -14,8 +14,9 @@ import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
+import { Separator } from '~/ui/components/Separator';
 import { Sidebar } from '~/ui/components/Sidebar';
-import { H1 } from '~/ui/components/Text';
+import { H1, P } from '~/ui/components/Text';
 
 const STYLES_DOCUMENT = css`
   background: ${theme.background.default};
@@ -129,6 +130,8 @@ export default function DocumentationPage(props: Props) {
       </Head>
       <div css={STYLES_DOCUMENT}>
         {props.title && <H1>{props.title}</H1>}
+        {props.description && <P theme="secondary">{props.description}</P>}
+        {props.title && <Separator />}
         {props.children}
         {props.title && (
           <Footer

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -1,19 +1,18 @@
 import { css } from '@emotion/react';
 import { theme, spacing as themeSpacing } from '@expo/styleguide';
-import React from 'react';
 
 type SeparatorProps = {
   spacing?: number;
 };
 
-export const Spacer = ({ spacing = themeSpacing[6] }: SeparatorProps) => (
+export const Separator = ({ spacing }: SeparatorProps) => (
   <hr
     css={css({
-      marginTop: spacing,
-      marginBottom: spacing,
+      marginTop: spacing ?? themeSpacing[4],
+      marginBottom: spacing ?? themeSpacing[6],
       backgroundColor: theme.border.default,
       border: 0,
-      height: 1,
+      height: '0.01rem',
     })}
   />
 );

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -140,9 +140,7 @@ const h1Style = {
   ...skipFontFamily,
   fontWeight: 600,
   marginTop: spacing[2],
-  marginBottom: spacing[6],
-  paddingBottom: spacing[4],
-  borderBottom: `1px solid ${theme.border.default}`,
+  marginBottom: spacing[2],
   ...codeInHeaderStyle,
 };
 


### PR DESCRIPTION
# Why

Lately, Aman started to adding the page descriptions for SEO purpose, but we also should show the description as a page subtitle according to the mocks, let's implement that.

# How

Remove additional `H1` element styling, add description as a page subtitle if it is preset, use `Separator` component as a spacer between page header and content.

# Test Plan

The changes have been tested by running docs app locally. Pages without the description have the same spacing as currently on production and subtitle renders correctly when description is defined

# Preview

<img width="875" alt="Screenshot 2022-12-21 191224" src="https://user-images.githubusercontent.com/719641/208976180-1c894ce0-a70c-4fcd-a5e6-c7f5fe6c3f89.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
