### PR TITLE
[docs] Add description for EAS Submit and Metadata docs

### DIFF
--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring EAS Metadata
 sidebar_title: store.config.json
+description: Learn about different ways to configure EAS Metadata.
 ---
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';

--- a/docs/pages/eas/metadata/faq.mdx
+++ b/docs/pages/eas/metadata/faq.mdx
@@ -1,6 +1,7 @@
 ---
 title: EAS Metadata - FAQ
 sidebar_title: FAQ
+description: Frequently asked questions about EAS Metadata.
 ---
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Getting started with EAS Metadata
 sidebar_title: Getting started
+description: Learn how to automate and maintain your app store presence from the command line with EAS Metadata.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
@@ -67,7 +68,7 @@ If EAS Metadata runs into any issues with your store config, it will warn you wh
 
 When the store config partially fails, you can change the store config and retry. `eas metadata:push` can be used to retry pushing the missing items.
 
-## Next
+## Next steps
 
 <BoxLink
   title="Customize the store config"

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -2,6 +2,7 @@
 title: EAS Metadata
 sidebar_title: Introduction
 hideTOC: true
+description: An introduction to automate and maintain your app store presence from the command line with EAS Metadata.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -715,6 +715,7 @@ You can release the app automatically after store approval or gradually release 
 
 </Collapsible>
 
+{/* prettier-ignore */}
 <MetadataTable>
   {[
     {
@@ -726,19 +727,17 @@ You can release the app automatically after store approval or gradually release 
         </MD.p>,
         <MD.ul>
           <MD.li>
-            <MD.code>false</MD.code> - Manually release the app after store approval. (default
-            behavior)
+            <MD.code>false</MD.code> - Manually release the app after store approval. (default behavior)
           </MD.li>
           <MD.li>
             <MD.code>true</MD.code> - Automatically release after store approval.
           </MD.li>
           <MD.li>
-            <MD.code>Date</MD.code> - Automatically schedule release on this date after store
-            approval. (using the{' '}
+            <MD.code>Date</MD.code> - Automatically schedule release on this date after store approval (using the{' '}
             <MD.a openInNewTab href="https://www.rfc-editor.org/rfc/rfc3339">
               RFC 3339
             </MD.a>{' '}
-            format)
+            format).
           </MD.li>
         </MD.ul>,
         <MD.p>

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -2,14 +2,12 @@
 title: Schema for EAS Metadata
 sidebar_title: Metadata schema
 maxHeadingDepth: 4
+description: A reference of store config in EAS Metadata.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { markdownComponents as MD } from '~/ui/components/Markdown';
-import {
-  MetadataTable,
-  MetadataSubcategories,
-} from '~/components/plugins/EasMetadataTable';
+import { MetadataTable, MetadataSubcategories } from '~/components/plugins/EasMetadataTable';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.
 
@@ -728,15 +726,15 @@ You can release the app automatically after store approval or gradually release 
         </MD.p>,
         <MD.ul>
           <MD.li>
-            <MD.code>false</MD.code> - Manually release the app after store approval.
-            (default behavior)
+            <MD.code>false</MD.code> - Manually release the app after store approval. (default
+            behavior)
           </MD.li>
           <MD.li>
             <MD.code>true</MD.code> - Automatically release after store approval.
           </MD.li>
           <MD.li>
-            <MD.code>Date</MD.code> - Automatically schedule release on this date after
-            store approval. (using the{' '}
+            <MD.code>Date</MD.code> - Automatically schedule release on this date after store
+            approval. (using the{' '}
             <MD.a openInNewTab href="https://www.rfc-editor.org/rfc/rfc3339">
               RFC 3339
             </MD.a>{' '}
@@ -888,9 +886,8 @@ The App Store review team must have all the information to test your app, or you
       description: [
         <MD.p>Additional information about your app that can help during the review process.</MD.p>,
         <MD.p theme="warning">
-          Do not include demo account details in the notes. Use the{' '}
-          <MD.code>demoUsername</MD.code> and{' '}
-          <MD.code>demoPassword</MD.code> properties instead.
+          Do not include demo account details in the notes. Use the <MD.code>demoUsername</MD.code>{' '}
+          and <MD.code>demoPassword</MD.code> properties instead.
         </MD.p>,
       ],
     },

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -1,7 +1,10 @@
 ---
 title: Submitting to the Google Play Store
 sidebar_title: Submitting to Google
+description: Learn how to submit your app to the Google Play Store from your computer and CI.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 This guide outlines how to submit your app to the Google Play Store from your own computer and from CI.
 
@@ -14,13 +17,13 @@ This guide outlines how to submit your app to the Google Play Store from your ow
 
 ### Creating a Google Service Account
 
-See [expo.fyi/creating-google-service-account](https://expo.fyi/creating-google-service-account) to learn more.
+For more information, see [expo.fyi/creating-google-service-account](https://expo.fyi/creating-google-service-account).
 
 ### Manually uploading your app for the first time
 
 Before using `eas submit -p android` for uploading your builds, you have to upload your app manually at least once. This is a limitation of the Google Play Store API.
 
-See [expo.fyi/first-android-submission](https://expo.fyi/first-android-submission) to learn more.
+For more information, see [expo.fyi/first-android-submission](https://expo.fyi/first-android-submission).
 
 ## 1. Build a standalone app
 
@@ -53,15 +56,13 @@ The command will perform the following steps:
 
 ## Submitting your app using CI
 
-The `eas submit` command is able to perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the Android package name is present in your [app config file](/workflow/configuration.mdx).
+The `eas submit` command can perform submissions from a CI environment. All you have to do is ensure that all required information is provided with **eas.json** and environment variables. Mainly, providing the archive source (`--latest`, `--id`, `--path`, or `--url`) is essential. Also, make sure that the Android package name is present in your [app config file](/workflow/configuration.mdx).
 
 For Android submissions, you must provide the path to your Google Services JSON key using the `serviceAccountKeyPath` key in **eas.json**. You may also find the `track` and `releaseStatus` parameters useful.
 
 Example usage:
 
-```sh
-eas submit -p android --profile foobar
-```
+<Terminal cmd={['$ eas submit -p android --profile foobar']} />
 
 ## Automating submissions
 

--- a/docs/pages/submit/classic-builds.mdx
+++ b/docs/pages/submit/classic-builds.mdx
@@ -1,6 +1,8 @@
 ---
 title: Using EAS Submit with "expo build"
 sidebar_title: Using with "expo build"
+hideTOC: true
+description: Learn how to use EAS Submit with builds produced by "expo build".
 ---
 
 EAS Submit is optimized to work with EAS Build, but you can also use it to upload builds produced from `expo build:[ios|android]`. To do this, you need to pass in the build artifact URL to `eas submit`.

--- a/docs/pages/submit/eas-json.mdx
+++ b/docs/pages/submit/eas-json.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring EAS Submit with eas.json
 sidebar_title: Configuration with eas.json
+description: Learn how to configure your project for EAS Submit with eas.json.
 ---
 
 import { EasJsonPropertiesTable } from '~/components/plugins/EasJsonPropertiesTable';
@@ -8,11 +9,11 @@ import { EasJsonPropertiesTable } from '~/components/plugins/EasJsonPropertiesTa
 import submitAndroidSchema from '~/scripts/schemas/unversioned/eas-json-submit-android-schema.js';
 import submitIosSchema from '~/scripts/schemas/unversioned/eas-json-submit-ios-schema.js';
 
-**eas.json** is your go-to place for configuring EAS Submit (and [EAS Build](/build/eas-json.mdx)). It is located at the root of your project next to your **package.json**. Even though **eas.json** is not mandatory for using EAS Submit, it makes your life easier if you'll need to switch between different configurations.
+**eas.json** is your go-to place for configuring EAS Submit (and [EAS Build](/build/eas-json)). It is located at the root of your project next to your **package.json**. Even though **eas.json** is not mandatory for using EAS Submit, it makes your life easier if you'll need to switch between different configurations.
 
 **eas.json** looks something like this:
 
-```json
+```json eas.json
 {
   "cli": {
     "version": ">= 0.34.0"
@@ -38,7 +39,7 @@ The JSON object under the `submit` key can contain multiple submit profiles. Eve
 The schema of this file looks like this:
 
 {/* prettier-ignore */}
-```json
+```json eas.json
 {
   "cli": {
     "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
@@ -46,7 +47,7 @@ The schema of this file looks like this:
   },
   "build": {
     // EAS Build configuration
-    ...
+    /* @hide ... */ /* @end */
   }
   "submit": {
     /* @info any arbitrary name - used as an identifier */"SUBMIT_PROFILE_NAME_1"/* @end */: {
@@ -63,16 +64,16 @@ The schema of this file looks like this:
         /* @info Android-specific configuration */...ANDROID_OPTIONS/* @end */
       }
     },
-    ...
+    /* @hide ... */ /* @end */
   }
 }
 ```
 
-If you're also using EAS Build, [see how to use **eas.json** to configure your builds](/build/eas-json.mdx).
+If you're also using EAS Build, [see how to use **eas.json** to configure your builds](/build/eas-json).
 
 ### Sharing configuration between profiles
 
-Submit profiles can extend another submit profile using the `"extends"` key. For example, in the `preview` profile you may have `"extends": "production"`; this would make the `preview` profile inherit configuration of the `production` profile.
+Submit profiles can extend another submit profile using the `"extends"` key. For example, in the `preview` profile you may have `"extends": "production"`; this would make the `preview` profile inherit the configuration of the `production` profile.
 
 ## Android-specific options
 

--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -2,13 +2,14 @@
 title: EAS Submit
 sidebar_title: Introduction
 hideTOC: true
+description: EAS Submit is a hosted service for uploading and submitting an ap binary to the app stores.
 ---
 
 import { CODE } from '~/ui/components/Text';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { AppleAppStoreIcon, GoogleAppStoreIcon } from '@expo/styleguide';
 
-**EAS Submit** is a hosted service for uploading and submitting your app binaries to the Apple App Store and Google Play Store. Since it's a hosted service, you can submit your app to both stores as long as you can run EAS CLI on your machine. This means you can easily submit your iOS and Android apps from your macOS, Windows, or Linux workstation or from CI.
+**EAS Submit** is a hosted service for uploading and submitting your app binaries to the app stores. Since it's a hosted service, you can submit your app to both stores as long as you can run EAS CLI on your machine. This means you can easily submit your iOS and Android apps from your macOS, Windows, or Linux workstation or from CI.
 
 ### Get started
 

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -1,6 +1,7 @@
 ---
 title: Submitting to the Apple App Store
 sidebar_title: Submitting to Apple
+description: Learn how to submit your app to the Apple App Store from your computer and CI.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
@@ -83,10 +84,7 @@ You must do the following:
 
 Example usage:
 
-<Terminal
-  cmd={['$ eas submit -p ios --latest --profile foobar']}
-  copyCmd="eas submit -p ios --latest --profile foobar"
-/>
+<Terminal cmd={['$ eas submit -p ios --latest --profile foobar']} />
 
 ## Manual submissions
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up for #20412

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds `description` to pages under the EAS Submit & EAS Metadata sections. Some minor tweaks and grammar fixes to match our writing style guide are also included.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
