### PR TITLE
[location][Android] Fix geofences stop working after crash (#20252)

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Export types with type-only annotation to fix build when using `isolatedModules` flag. ([#20239](https://github.com/expo/expo/pull/20239) by [@zakharchenkoAndrii](https://github.com/zakharchenkoAndrii))
+- Use Service instead of Broadcast for listening to geofences to survive app crashes. ([#20571](https://github.com/expo/expo/pull/20571) by [@KurtHuwig](https://github.com/KurtHuwig))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -10,5 +10,9 @@
       android:name=".services.LocationTaskService"
       android:exported="false"
       android:foregroundServiceType="location" />
+    <service
+      android:name=".services.GeofenceService"
+      android:exported="false"
+      android:foregroundServiceType="location" />
   </application>
 </manifest>

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/GeofenceService.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/GeofenceService.java
@@ -1,0 +1,73 @@
+package expo.modules.location.services;
+
+import android.app.Service;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.PendingIntent.CanceledException;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+
+public class GeofenceService extends Service {
+    private static final String KEY_UPSTREAM_INTENT = "upstreamIntent";
+
+    public static PendingIntent createIntent(Context context, PendingIntent upstreamIntent) {
+        final Intent intent = new Intent(context, GeofenceService.class);
+        intent.putExtra(KEY_UPSTREAM_INTENT, upstreamIntent);
+        final int flags = Build.VERSION_CODES.S <= Build.VERSION.SDK_INT
+                ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE
+                : PendingIntent.FLAG_UPDATE_CURRENT;
+        return Build.VERSION_CODES.O <= Build.VERSION.SDK_INT
+                ? PendingIntent.getForegroundService(context, 0, intent, flags)
+                : PendingIntent.getService(context, 0, intent, flags);
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        if (Build.VERSION_CODES.O <= Build.VERSION.SDK_INT) {
+            final String CHANNEL_ID = "GeofenceService";
+            final NotificationChannel channel =
+                    new NotificationChannel(
+                            CHANNEL_ID,
+                            "Receive geofence events",
+                            NotificationManager.IMPORTANCE_LOW);
+
+            ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
+                    .createNotificationChannel(channel);
+
+            Notification notification = new NotificationCompat.Builder(this, CHANNEL_ID)
+                    .setContentTitle("")
+                    .setSmallIcon(android.R.drawable.ic_menu_mylocation)
+                    .setContentText("").build();
+
+            startForeground(1, notification);
+        }
+    }
+
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (null != intent) {
+            try {
+                final PendingIntent upstreamIntent = intent.getParcelableExtra(KEY_UPSTREAM_INTENT);
+                upstreamIntent.send(this, 0, intent);
+            } catch (CanceledException e) {
+                // ignored
+            }
+        }
+        stopSelf();
+        return START_NOT_STICKY;
+    }
+}

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/GeofencingTaskConsumer.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 
 import expo.modules.location.LocationHelpers;
 import expo.modules.location.LocationModule;
+import expo.modules.location.services.GeofenceService;
 import expo.modules.interfaces.taskManager.TaskConsumer;
 import expo.modules.interfaces.taskManager.TaskConsumerInterface;
 import expo.modules.interfaces.taskManager.TaskExecutionCallback;
@@ -209,7 +210,8 @@ public class GeofencingTaskConsumer extends TaskConsumer implements TaskConsumer
   }
 
   private PendingIntent preparePendingIntent() {
-    return getTaskManagerUtils().createTaskIntent(getContext(), mTask);
+    final PendingIntent taskIntent = getTaskManagerUtils().createTaskIntent(getContext(), mTask);
+    return GeofenceService.createIntent(getContext(), taskIntent);
   }
 
   private Geofence geofenceFromRegion(Map<String, Object> region) {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/20252.
Fixes:
```
- expo-location
- Location.startGeofencingAsync() stops working when app crashes / is
  killed reported here https://github.com/expo/expo/issues/20252
```

# How

Broadcast pending intents are not sent after a crash. Therefore change to a service pending intent that is sent after a crash.

# Test Plan

Using the example from https://github.com/expo/expo/issues/20252:

1. Use

        adb shell am crash <package id>

    to crash the process.
2. Trigger a geofence, e.g. with locations in the emulator while Google Maps is open
3. Crash the process again (required when the UI-process was running during the first crash); you might need to dismiss the "App keeps crashing" with "Close app".
4. Trigger a geofence again

## Expected

Process restarts and geofence is always detected, even if the crashing is repeated many times.

## Actual

Process does not start and therefore the geofence is not detected.


