### PR TITLE
[bare-expo] Switch from deprecated Xcode build system

### DIFF
--- a/apps/bare-expo/ios/BareExpo.xcodeproj/xcshareddata/xcschemes/BareExpo.xcscheme
+++ b/apps/bare-expo/ios/BareExpo.xcodeproj/xcshareddata/xcschemes/BareExpo.xcscheme
@@ -3,23 +3,9 @@
    LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
+      parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
-               BuildableName = "libReact.a"
-               BlueprintName = "React"
-               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"


### PR DESCRIPTION
# Why

`BareExpo` project scheme was using the legacy build system (surprisingly `BareExpoDetox` uses the new one).

![Screenshot 2022-12-22 at 11 50 18](https://user-images.githubusercontent.com/1714764/209118685-ff83dbbb-e023-443f-b99e-4418fb1503b5.png)

Also, there was a `React` target listed in the scheme, but it was never used and missing, so I removed it.

# How

Switched to the new build system and removed unused `React` target

# Test Plan

The app builds as expected. Even thought it enables parallelization, I didn't notice any difference in the build time (locally and on the CI)