### PR TITLE
[github] allow to deploy docs preview on demand

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,90 @@
+name: Docs Website Preview
+
+defaults:
+  run:
+    shell: bash
+    working-directory: docs
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-preview:
+    if: contains(github.event.pull_request.labels.*.name, 'Deploy Preview')
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-docs: 'true'
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-docs-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🔺 Install Vercel CLI
+        run: yarn global add vercel@latest
+      - name: 🚚 Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: 🏗️ Build Documentation Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: 🚀 Deploy Documentation Artifacts to Vercel
+        id: vercel_deploy
+        run: echo "PREVIEW_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | tail -n 1)" >> $GITHUB_OUTPUT
+      - name: 🔍 Find old comment if exist
+        uses: peter-evans/find-comment@v2
+        id: old_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'expo-bot'
+          body-includes: The documentation preview URL
+      - name: 💬 Add comment with preview URL
+        if: steps.old_comment.outputs.comment-id == ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'The documentation preview URL is: ${{ steps.vercel_deploy.outputs.PREVIEW_URL }}.'
+            });
+      - name: 💬 Update comment with preview URL
+        if: steps.old_comment.outputs.comment-id != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.updateComment({
+              issue_number: context.issue.number,
+              comment_id: '${{ steps.old_comment.outputs.comment-id }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'The documentation preview URL is: ${{ steps.vercel_deploy.outputs.PREVIEW_URL }}.'
+            });

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -8,3 +8,5 @@ pages/versions/latest/
 
 # staticly generated constants
 public/static/constants
+
+.vercel


### PR DESCRIPTION
# Why

We need this, trust me! 😉 

# How

Add workflow, which will utilize our Vercel account to deploy documentation previews and uses GitHub API to create or update comment with preview deployment URL posted by `expo-bot`.

# Test Plan

Run the CI, iteratively improve on script if needed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
