### PR TITLE
[github] bump `github-script` to prevent warnings

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -41,7 +41,7 @@ jobs:
 
               This is useful knowledge, but it's still valuable to have the resulting project that is produced from running the steps, where you have verified you can reproduce the issue.
             `})
-            github.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -52,11 +52,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -70,7 +70,7 @@ jobs:
               - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
               - ["How to narrow down the source of an error"](https://expo.fyi/manual-debugging)
             `})
-            github.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -81,11 +81,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.event.label.name == 'issue accepted'
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -98,11 +98,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -115,7 +115,7 @@ jobs:
               - ["How do I ask a good question?"](https://stackoverflow.com/help/how-to-ask)
               - ["Join the community"](https://docs.expo.dev/next-steps/community/)
             `})
-            github.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -126,11 +126,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -138,7 +138,7 @@ jobs:
 
               If you would like to request a feature, please post to https://expo.canny.io/feature-requests.
             `})
-            github.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -149,11 +149,11 @@ jobs:
     runs-on: ubuntu-20.04
     if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -166,7 +166,7 @@ jobs:
               - ["How to create a Minimal, Reproducible Example"](https://stackoverflow.com/help/minimal-reproducible-example)
               - ["How to narrow down the source of an error"](https://expo.fyi/manual-debugging)
             `})
-            github.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
# Why

While working on docs preview workflow I have used the comment code from the triage workflow, but then I spotted that using `v3` leads to warnings in the workflow.

<img width="634" alt="Screenshot 2022-12-22 160528" src="https://user-images.githubusercontent.com/719641/209164122-08be47b0-97fa-4aa8-b8f1-45c9ded2f17d.png">

# How

Update `github-script` action to the latest version to fix the workflow warnings.

Placing all calls as `rest` was a breaking change in `v5`, besides that everything should work te same:
* https://github.com/actions/github-script#breaking-changes-in-v5

# Test Plan

Run the CI.
