### PR TITLE
[docs] fix page header separator on Safari

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: true
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:

--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -12,7 +12,7 @@ export const Separator = ({ spacing }: SeparatorProps) => (
       marginBottom: spacing ?? themeSpacing[6],
       backgroundColor: theme.border.default,
       border: 0,
-      height: '0.01rem',
+      height: '0.05rem',
     })}
   />
 );


### PR DESCRIPTION
# Why

Currently, page header separator is not visible in Safari.

# How

Change the value to be still below `1px` so Windows is unaffected, but the separator appears in Safari.

Additionally, I have removed legacy checkout submodules flag form the docs workflow.

# Test Plan

The change have been tested by running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
