### PR TITLE
[autolinking] Fix enabling modular headers for subspecs

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -13,7 +13,8 @@ PODS:
   - EXBarCodeScanner (12.0.0):
     - EXImageLoader
     - ExpoModulesCore
-    - ZXingObjC
+    - ZXingObjC/OneD
+    - ZXingObjC/PDF417
   - EXCalendar (11.0.1):
     - ExpoModulesCore
   - EXCamera (13.0.0):
@@ -686,9 +687,11 @@ PODS:
     - SDWebImage/Core (~> 5.13)
   - UMAppLoader (4.0.0)
   - Yoga (1.14.0)
-  - ZXingObjC (3.6.5):
-    - ZXingObjC/All (= 3.6.5)
-  - ZXingObjC/All (3.6.5)
+  - ZXingObjC/Core (3.6.5)
+  - ZXingObjC/OneD (3.6.5):
+    - ZXingObjC/Core
+  - ZXingObjC/PDF417 (3.6.5):
+    - ZXingObjC/Core
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
@@ -1158,7 +1161,7 @@ SPEC CHECKSUMS:
   EXApplication: 034b1c40a8e9fe1bff76a1e511ee90dff64ad834
   EXAV: 766516466675fc5fdd7c500acced5934e8b00de2
   EXBackgroundFetch: 186248a00a38fc4d22d60ec30e4e751449e785ee
-  EXBarCodeScanner: 1bb12031981c4d5d4df4b144b659eed67ca0e553
+  EXBarCodeScanner: 03dd4ae852f92885ac3a7dd0e0af1fe5a7444b38
   EXCalendar: 1234457cffa88adfbfbe7f8937e21963f7b0f5b6
   EXCamera: d7e91d5857faee493ca3cf8dafd42572db61849e
   EXConstants: d9bff28e1d37cd1c05133e6955e9ba8f2a702947

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1968,7 +1968,8 @@ PODS:
   - EXBarCodeScanner (12.0.0):
     - EXImageLoader
     - ExpoModulesCore
-    - ZXingObjC
+    - ZXingObjC/OneD
+    - ZXingObjC/PDF417
   - EXBranch (6.0.1):
     - Branch (= 0.35.0)
     - ExpoModulesCore
@@ -2739,9 +2740,6 @@ PODS:
     - StripeCore (= 22.8.3)
   - UMAppLoader (4.0.0)
   - Yoga (1.14.0)
-  - ZXingObjC (3.6.5):
-    - ZXingObjC/All (= 3.6.5)
-  - ZXingObjC/All (3.6.5)
   - ZXingObjC/Core (3.6.5)
   - ZXingObjC/OneD (3.6.5):
     - ZXingObjC/Core
@@ -4493,7 +4491,7 @@ SPEC CHECKSUMS:
   EXApplication: 034b1c40a8e9fe1bff76a1e511ee90dff64ad834
   EXAV: 766516466675fc5fdd7c500acced5934e8b00de2
   EXBackgroundFetch: 186248a00a38fc4d22d60ec30e4e751449e785ee
-  EXBarCodeScanner: 1bb12031981c4d5d4df4b144b659eed67ca0e553
+  EXBarCodeScanner: 03dd4ae852f92885ac3a7dd0e0af1fe5a7444b38
   EXBranch: 7d74f6ff30a1efc45827517654dcc1508fe925f7
   EXCalendar: 1234457cffa88adfbfbe7f8937e21963f7b0f5b6
   EXCamera: d7e91d5857faee493ca3cf8dafd42572db61849e

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner.podspec
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
 
   s.dependency 'ExpoModulesCore'
   s.dependency 'EXImageLoader'
-  s.dependency 'ZXingObjC'
+  s.dependency 'ZXingObjC/PDF417'
+  s.dependency 'ZXingObjC/OneD'
 
   s.pod_target_xcconfig = {
     # For use_frameworks! to have correct defines, please sync up with ZxingObjC dependencies above

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -173,11 +173,16 @@ module Expo
 
     private def use_modular_headers_for_dependencies(dependencies)
       dependencies.each { |dependency|
-        unless @target_definition.build_pod_as_module?(dependency.name)
-          UI.info "[Expo] ".blue << "Enabling modular headers for pod #{dependency.name.green}"
+        # The dependency name might be a subspec like `ReactCommon/turbomodule/core`,
+        # but the modular headers need to be enabled for the entire `ReactCommon` spec anyway,
+        # so we're stripping the subspec path from the dependency name.
+        root_spec_name = dependency.name.partition('/').first
+
+        unless @target_definition.build_pod_as_module?(root_spec_name)
+          UI.info "[Expo] ".blue << "Enabling modular headers for pod #{root_spec_name.green}"
 
           # This is an equivalent to setting `:modular_headers => true` for the specific dependency.
-          @target_definition.set_use_modular_headers_for_pod(dependency.name, true)
+          @target_definition.set_use_modular_headers_for_pod(root_spec_name, true)
         end
       }
     end


### PR DESCRIPTION
# Why

In #20441, @alanjhughes had to change the dependencies from specific ZXingObjC subspecs to the entire pod (https://github.com/expo/expo/pull/20441/files#diff-3d58e0dcce39a491421411803820d91a9b9bc2142a1fbade4a441b2a5189305b) which results in installing all available subspecs, otherwise we would still get this error:

```
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `EXBarCodeScanner` depends upon `ZXingObjC`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```

In other words, it means that the autolinking script should enable the modular headers for the entire pod instead of specific subspecs.

# How

- Strip the "subspec path" from the dependency name when the script enables modular headers
- Brought back `ZXingObjC/OneD` and `ZXingObjC/PDF417` dependencies in `expo-barcode-scanner` podspec
- Reinstalled pods

# Test Plan

`pod install` is passing now and we no longer have to depend on the entire `ZXingObjC` pod
