### PR TITLE
[docs] Adds docs preview label

### DIFF
--- a/.github/workflows/docs-pr-deploy.yml
+++ b/.github/workflows/docs-pr-deploy.yml
@@ -1,0 +1,114 @@
+
+name: docs-pr-deploy
+
+defaults:
+  run:
+    shell: bash
+    working-directory: docs
+
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr-destroy.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr-destroy.yml'
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-pr-deploy:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-docs: 'true'
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 🪣 Set up docs preview bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        run: |
+          # Create bucket
+          aws s3api create-bucket --bucket docs.expo.dev-pr-${{ github.event.pull_request.number }}
+
+          # Set "block public access" to off
+          aws s3api put-public-access-block --bucket docs.expo.dev-pr-${{ github.event.pull_request.number }} --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+          # Set bucket policy to public
+          aws s3api put-bucket-policy --bucket docs.expo.dev-pr-${{ github.event.pull_request.number }} --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::docs.expo.dev-pr-${{ github.event.pull_request.number }}/*\"}]}"
+
+          # Set up static website hosting
+          aws s3 website s3://docs.expo.dev-pr-${{ github.event.pull_request.number }}/ --index-document index.html
+      - name: 🧶 Yarn install
+        if: steps.expo-caches.outputs.yarn-docs-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - run: yarn danger ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 🏗️ Build Docs website for deploy
+        run: yarn export
+        timeout-minutes: 20
+        env:
+          AWS_BUCKET: 'docs.expo.dev-pr-${{ github.event.pull_request.number }}'
+      - name: 🚀 Deploy Docs website
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+          AWS_BUCKET: docs.expo.dev-pr-${{ github.event.pull_request.number }}
+        run: ./deploy.sh
+      - name: 🔍 Find old comment if it exists
+        uses: peter-evans/find-comment@v2
+        id: old_comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'expo-bot'
+          body-includes: Docs preview created
+      - name: 💬 Add comment with preview URL
+        if: steps.old_comment.outputs.comment-id == ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Docs preview created! View it [here](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/).'
+            });
+      - name: 💬 Update comment with preview URL
+        if: steps.old_comment.outputs.comment-id != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.updateComment({
+              issue_number: context.issue.number,
+              comment_id: '${{ steps.old_comment.outputs.comment-id }}',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Docs preview created! View it [here](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/).'
+            });

--- a/.github/workflows/docs-pr-deploy.yml
+++ b/.github/workflows/docs-pr-deploy.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'expo-bot'
-          body-includes: Docs preview created
+          body-includes: 📘 Your docs
       - name: 💬 Add comment with preview URL
         if: steps.old_comment.outputs.comment-id == ''
         uses: actions/github-script@v6
@@ -97,7 +97,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Docs preview created! View it [here](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/).'
+              body: '📘 Your docs [preview website](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/) is ready!'
             });
       - name: 💬 Update comment with preview URL
         if: steps.old_comment.outputs.comment-id != ''
@@ -110,5 +110,5 @@ jobs:
               comment_id: '${{ steps.old_comment.outputs.comment-id }}',
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Docs preview created! View it [here](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/).'
+              body: '📘 Your docs [preview website](http://docs.expo.dev-pr-${{ github.event.pull_request.number }}.s3-website-us-east-1.amazonaws.com/) is ready!'
             });

--- a/.github/workflows/docs-pr-destroy.yml
+++ b/.github/workflows/docs-pr-destroy.yml
@@ -1,0 +1,27 @@
+
+name: docs-pr-destroy
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs-pr-deploy.yml'
+      - '.github/workflows/docs-pr-destroy.yml'
+    types: [closed, unlabeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-pr-destroy:
+    if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview')) ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 🪣 Delete docs preview bucket
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: 'us-east-1'
+        run: aws s3 rb s3://docs.expo.dev-pr-${{ github.event.pull_request.number }} --force && exit 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: 'us-east-2'
+          AWS_BUCKET: 'docs.expo.dev'
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && github.event.ref == 'refs/heads/main'

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 scriptdir=$(dirname "${BASH_SOURCE[0]}")
-bucket="docs.expo.dev"
+bucket="$AWS_BUCKET"
 target="${1-$scriptdir/out}"
 
 if [ ! -d "$target" ]; then
@@ -215,6 +215,8 @@ done
 echo "::endgroup::"
 
 
-echo "::group::[6/6] Notify Google of sitemap changes"
-curl -m 15 "https://www.google.com/ping\?sitemap\=https%3A%2F%2F${bucket}%2Fsitemap.xml"
-echo "\n::endgroup::"
+if [ "$bucket" = "docs.expo.dev" ]; then
+  echo "::group::[6/6] Notify Google of sitemap changes"
+  curl -m 15 "https://www.google.com/ping\?sitemap\=https%3A%2F%2F${bucket}%2Fsitemap.xml"
+  echo "\n::endgroup::"
+fi

--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -78,6 +78,12 @@ const transformUrl = (url: string) => {
   if (isDev) {
     url = url.replace('https://docs.expo.dev/', 'http://localhost:3002/');
   }
+
+  // If viewing a docs preview hosted on S3, use the current origin instead of production
+  if (window?.location?.origin?.includes('s3-website-us-east-1.amazonaws.com')) {
+    url = url.replace('https://docs.expo.dev/', window.location.origin + '/');
+  }
+
   return url;
 };
 


### PR DESCRIPTION
# Why

We'd like the ability to add a label, then to have GitHub Actions build the docs and deploy them on AWS S3, where we can preview them quickly during PR review.

This PR adds a GitHub Action (GHA) that gets triggered when added the "preview" label. The GHA exports/builds the docs and then uploads them to AWS S3. Then, it comments on the PR with a link to the preview URL. When merging a PR, another GHA runs to clean up and delete the bucket that was created when adding the label.

Closes ENG-5683

# How

- Added a `AWS_BUCKET` field to our **deploy.sh** to specify the bucket to deploy to.
- Edits the search inside the docs to replace `docs.expo.dev` with the preview URL if the docs are hosted on an aws-style URL.

# Test plan

You should see the docs preview website on this PR! Go check it out.

Also, I opened another PR on top of this one where I confirmed both pr-deploy and pr-destroy steps (on label add, remove, and merge). See the screenshots in the comments on this PR: https://github.com/expo/expo/pull/23545