### PR TITLE
[docs] EAS webhook server side example code

### DIFF
--- a/docs/pages/eas/webhooks.mdx
+++ b/docs/pages/eas/webhooks.mdx
@@ -166,7 +166,7 @@ app.post('/webhook', (req, res) => {
   const expoSignature = req.headers['expo-signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match SECRET value set with `eas webhook:create` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
-  hmac.update(req.body);
+  hmac.update(JSON.stringify(req.body))
   const hash = `sha1=${hmac.digest('hex')}`;
   if (!safeCompare(expoSignature, hash)) {
     res.status(500).send("Signatures didn't match!");

--- a/docs/pages/eas/webhooks.mdx
+++ b/docs/pages/eas/webhooks.mdx
@@ -166,7 +166,7 @@ app.post('/webhook', (req, res) => {
   const expoSignature = req.headers['expo-signature'];
   // process.env.SECRET_WEBHOOK_KEY has to match SECRET value set with `eas webhook:create` command
   const hmac = crypto.createHmac('sha1', process.env.SECRET_WEBHOOK_KEY);
-  hmac.update(JSON.stringify(req.body))
+  hmac.update(JSON.stringify(req.body));
   const hash = `sha1=${hmac.digest('hex')}`;
   if (!safeCompare(expoSignature, hash)) {
     res.status(500).send("Signatures didn't match!");


### PR DESCRIPTION
# Why

During implement of eas webhook, I encountered the following errors that were raised by `hmac.update()`
```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Object
```
According to an official document from node about [hmac](https://nodejs.org/api/crypto.html#hmacupdatedata-inputencoding), the parameter data shoulds be String type instead of the Object, therefore this pull request has been made.

# How

Implement `JSON.stringify` in `hmac.update`

# Test Plan

Execute `yarn dev` and browser to http://localhost:3002/eas/webhooks/#webhook-payload to check if changes have been made  
P.S: I've also noticed that the default port has been changed to 3002 instead of 3000 mentioned in [CONTRIBUTING.md](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-updating-documentation), we might need to fix this as well  
<img width="1405" alt="image" src="https://user-images.githubusercontent.com/33322926/209308231-a6bf5080-75f1-494b-9bf6-580c8c72beaf.png">

