### PR TITLE
[core][ios] Make SharedObject initializer public

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
 - Fixed Function not supporting certain arities on Android. ([#20419](https://github.com/expo/expo/pull/20419) by [@motiz88](https://github.com/motiz88))
 - Added React Native 0.71 support. ([#20470](https://github.com/expo/expo/pull/20470) by [@kudo](https://github.com/kudo))
+- Fixed the `SharedObject` initializer being inaccessible due to `internal` protection level.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Fixed Either types not supporting non-primitive types on iOS. ([#20247](https://github.com/expo/expo/pull/20247) by [@tsapeta](https://github.com/tsapeta))
 - Fixed Function not supporting certain arities on Android. ([#20419](https://github.com/expo/expo/pull/20419) by [@motiz88](https://github.com/motiz88))
 - Added React Native 0.71 support. ([#20470](https://github.com/expo/expo/pull/20470) by [@kudo](https://github.com/kudo))
-- Fixed the `SharedObject` initializer being inaccessible due to `internal` protection level.
+- Fixed the `SharedObject` initializer being inaccessible due to `internal` protection level. ([#20588](https://github.com/expo/expo/pull/20588) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedObject.swift
@@ -12,6 +12,11 @@ open class SharedObject: AnySharedObject {
   public internal(set) var sharedObjectId: SharedObjectId = 0
 
   /**
+   The default public initializer of the shared object.
+   */
+  public init() {}
+
+  /**
    Returns the JavaScript shared object associated with the native shared object.
    */
   public func getJavaScriptObject() -> JavaScriptObject? {


### PR DESCRIPTION
# Why

Fixes #20488 

# How

Added default public initializer to `SharedObject` class to make it possible to add custom initializer

# Test Plan

Added the minimal reproducible example (provided in the issue) to another module and verified that it's now possible to inherit from `SharedObject` with the custom initializer
