### PR TITLE
[contributing]: Update docs port number to 3002

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Our docs are made with [Next.js](https://github.com/zeit/next.js). They're locat
 **TL;DR:**
 
 1. Navigate to the `docs/` directory and run `yarn`.
-2. Start the project with `yarn dev` (make sure you don't have another server running on port `3000`).
+2. Start the project with `yarn dev` (make sure you don't have another server running on port `3002`).
 3. Navigate to the docs you want to edit: `cd docs/pages/versions/unversioned/`
 4. If you update an older version, ensure the relevant changes are copied into `unversioned/`
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The contribution guide currently states an outdated port number for docs. This was reported by @ShiriNmi1520 in #20587.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the port number to `3002`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
