### PR TITLE
[core] Initializing Events component with an array of event names

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added a new `executeOnJavaScriptThread` method to `appContext` to allow for running code blocks on the JS thread. ([#20161](https://github.com/expo/expo/pull/20161) by [@aleqsio](https://github.com/aleqsio))
 - Added the `Exceptions.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
 - Trailing optional arguments can be skipped when calling native functions from JavaScript on iOS. ([#20234](https://github.com/expo/expo/pull/20234) by [@tsapeta](https://github.com/tsapeta))
-- `Events` component can now be initialized with an array of event names (not only variadic arguments).
+- `Events` component can now be initialized with an array of event names (not only variadic arguments). ([#20590](https://github.com/expo/expo/pull/20590) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added a new `executeOnJavaScriptThread` method to `appContext` to allow for running code blocks on the JS thread. ([#20161](https://github.com/expo/expo/pull/20161) by [@aleqsio](https://github.com/aleqsio))
 - Added the `Exceptions.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
 - Trailing optional arguments can be skipped when calling native functions from JavaScript on iOS. ([#20234](https://github.com/expo/expo/pull/20234) by [@tsapeta](https://github.com/tsapeta))
+- `Events` component can now be initialized with an array of event names (not only variadic arguments).
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -310,6 +310,14 @@ open class ObjectDefinitionBuilder {
   }
 
   /**
+   * Defines event names that this module can send to JavaScript.
+   */
+  @JvmName("EventsWithArray")
+  fun Events(events: Array<String>) {
+    eventsDefinition = EventsDefinition(events)
+  }
+
+  /**
    * Creates module's lifecycle listener that is called right after the first event listener is added.
    */
   inline fun OnStartObserving(crossinline body: () -> Unit) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -74,6 +74,14 @@ class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
   }
 
   /**
+   * Defines prop names that should be treated as callbacks.
+   */
+  @JvmName("EventsWithArray")
+  fun Events(callbacks: Array<String>) {
+    callbacksDefinition = CallbacksDefinition(callbacks)
+  }
+
+  /**
    * Creates the group view definition that scopes group view-related definitions.
    */
   inline fun GroupView(body: ViewGroupDefinitionBuilder.() -> Unit) {

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -27,6 +27,13 @@ public func Events(_ names: String...) -> EventsDefinition {
 }
 
 /**
+ Defines event names that the object can send to JavaScript.
+ */
+public func Events(_ names: [String]) -> EventsDefinition {
+  return EventsDefinition(names: names)
+}
+
+/**
  Function that is invoked when the first event listener is added.
  */
 public func OnStartObserving(@_implicitSelfCapture _ body: @escaping () -> Void) -> AsyncFunctionComponent<(), Void, Void> {


### PR DESCRIPTION
# Why

Addresses the need described in #20488 to allow initializing `Events` component with an array of event names.

# How

Added alternative versions of `Events` in Swift and also in Kotlin (even though it's possible to pass arrays to a function with variadic arguments using `*`, but there is no cost to add that too).

# Test Plan

Verified that it works in both Module and View definitions.
