### PR TITLE
[image] Fix shared-element compatibility on iOS

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed compatibility with `react-native-shared-element` on iOS. ([#20592](https://github.com/expo/expo/pull/20592) by [@IjzerenHein](https://github.com/ijzerenhein))
+
 ### 💡 Others
 
 ## 1.0.0-alpha.3 — 2022-12-21

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -64,7 +64,7 @@ public final class ImageView: ExpoView {
     super.init(appContext: appContext)
 
     clipsToBounds = true
-    sdImageView.contentMode = .scaleAspectFill
+    sdImageView.contentMode = contentFit.toContentMode()
     sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     sdImageView.layer.masksToBounds = false
 
@@ -96,6 +96,9 @@ public final class ImageView: ExpoView {
     guard let source = bestSource else {
       displayPlaceholderIfNecessary()
       return
+    }
+    if sdImageView.image == nil {
+      sdImageView.contentMode = contentFit.toContentMode()
     }
     var context = SDWebImageContext()
 


### PR DESCRIPTION
# Why

Adds a "tiny" change  to `expo-image` on iOS to fix compatibility with `react-native-shared-element`.

`react-native-shared-element` was updated to support `expo-image` (see https://github.com/IjzerenHein/react-native-shared-element/releases/tag/v0.8.7)

One issue was identified, and that was that RNSE was not able to identify the `contentMode` of the `expo-image` ImageView. This was because this property on the SDImageView was not set until after the image was loaded (which could take a little while and caused a problem because every millisecond counts with shared-element transitions..)

# How

- Makes sure the `contentMode` is set initially on the underlying `SDImageView` so that RNSE can obtain it natively.

# Test Plan

**before**

https://user-images.githubusercontent.com/6184593/209347892-5151f9bd-02f8-4062-b171-a1bf7503111a.mp4

**after**

https://user-images.githubusercontent.com/6184593/209347725-b534f975-14c9-4963-bc83-ca4b8a67547e.mp4

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
