### PR TITLE
[expo] Update react-native-shared-element to 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `react-native-shared-element` from `0.8.4` to `0.8.7`. ([#20593](https://github.com/expo/expo/pull/20593) by [@ijzerenhein](https://github.com/ijzerenhein))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -88,7 +88,7 @@
     "react-native-reanimated": "~2.12.0",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",
-    "react-native-shared-element": "0.8.4",
+    "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.4.0",
     "react-native-webview": "11.23.1",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-reanimated": "~2.12.0",
     "react-native-safe-area-context": "4.4.1",
     "react-native-screens": "~3.18.0",
-    "react-native-shared-element": "0.8.4",
+    "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.4.0",
     "react-native-web": "~0.18.9",

--- a/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementContent.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementContent.m
@@ -20,9 +20,11 @@
 
 + (BOOL) isKindOfImageView:(UIView*) view
 {
+  NSString* className = NSStringFromClass(view.class);
   return (
           [view isKindOfClass:[UIImageView class]] ||
-          [NSStringFromClass(view.class) isEqualToString:@"RCTImageView"]
+          [className isEqualToString:@"RCTImageView"] ||
+          [className isEqualToString:@"ExpoImage.ImageView"]
           );
 }
 
@@ -30,10 +32,9 @@
 {
   if ([view isKindOfClass:[UIImageView class]]) {
     return (UIImageView*) view;
-  } else if ([NSStringFromClass(view.class) isEqualToString:@"RCTImageView"]) {
-    // As of react-native 0.60, RCTImageView is no longer inherited from
-    // UIImageView, but has a UIImageView as child. That will cause this code-path
-    // to be executed, where the first child view is returned.
+  } else if ([RNSharedElementContent isKindOfImageView:view]) {
+    // Both react-native and expo-image have a UIImageView
+    // as the first child.
     return (UIImageView*) view.subviews.firstObject;
   } else {
     // Error

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-reanimated": "~2.12.0",
   "react-native-screens": "~3.18.0",
   "react-native-safe-area-context": "4.4.1",
-  "react-native-shared-element": "0.8.4",
+  "react-native-shared-element": "0.8.7",
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.4.0",
   "react-native-webview": "11.23.1",


### PR DESCRIPTION
# Why

Adds support for `expo-image` to `react-native-shared-element`

# How

```
et update-vendored-module -m react-native-shared-element -c main
```

The changes are minimal, the only changes are for RNSE for detecting `expo-image` on iOS.

# Test Plan

:eyes:

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
