### PR TITLE
[docs] Add missing comma to docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -715,7 +715,7 @@ export default function App() {
           const url = response?.notification.request.content.data.url;
 
           return url;
-        }
+        },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.mdx
@@ -715,7 +715,7 @@ export default function App() {
           const url = response?.notification.request.content.data.url;
 
           return url;
-        }
+        },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 

--- a/docs/pages/versions/v46.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/notifications.mdx
@@ -715,7 +715,7 @@ export default function App() {
           const url = response?.notification.request.content.data.url;
 
           return url;
-        }
+        },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 

--- a/docs/pages/versions/v47.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/notifications.mdx
@@ -715,7 +715,7 @@ export default function App() {
           const url = response?.notification.request.content.data.url;
 
           return url;
-        }
+        },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 


### PR DESCRIPTION
# Why

Expo docs are missing a comma that's required for NavigationContainer linking to work with expo-notifications

# How

Added a comma that separates parts of the `linkingConfig`

# Test Plan

If you go to packages/expo-notifications/README.md, the comma is there on line 668. It was however missing in the docs that show up on the expo documentation website.

# Checklist

- [√ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [√ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [√ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
