### PR TITLE
[docs] Update local-credentials.mdx

### DIFF
--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -155,7 +155,7 @@ You can tell EAS Build how it should resolve credentials by specifying `"credent
 
 For example, maybe you want to use local credentials when deploying to the Amazon Appstore and remote credentials when deploying to the Google Play Store:
 
-```json credentials.json
+```json eas.json
 {
   "build": {
     "amazon-production": {


### PR DESCRIPTION
Setting the credentials source should be done in eas.json and not credentials.json.  

# Why
I believe this is a typo and confused me.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
