### PR TITLE
[docs] formatting Local Credentials doc

### DIFF
--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -4,6 +4,7 @@ description: Learn how to configure and use local credentials when using EAS.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
 You can usually get away with not being a code signing expert by [letting EAS handle it for you](managed-credentials.mdx). However, there are cases where some users might want to manage their project keystore, certificates and profiles on their own.
 
@@ -33,29 +34,31 @@ If you opt-in to local credentials configuration, you'll need to create a **cred
 }
 ```
 
-> Remember to add **credentials.json** and all of your credentials to `.gitignore` so you don't accidentally commit them to the repository and potentially leak your secrets.
+> Remember to add **credentials.json** and all of your credentials to **.gitignore** so you don't accidentally commit them to the repository and potentially leak your secrets.
 
 ### Android credentials
 
 If you want to build an Android app binary you'll need to have a keystore. If you don't have a release keystore yet, you can generate it on your own using the following command (replace `KEYSTORE_PASSWORD`, `KEY_PASSWORD`, `KEY_ALIAS` and `com.expo.your.android.package` with the values of your choice):
 
-```sh
-keytool \\
- -genkey -v \\
- -storetype JKS \\
- -keyalg RSA \\
- -keysize 2048 \\
- -validity 10000 \\
- -storepass KEYSTORE_PASSWORD \\
- -keypass KEY_PASSWORD \\
- -alias KEY_ALIAS \\
- -keystore release.keystore \\
- -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"
-```
+
+<Terminal cmd={[
+  '$ keytool \\',
+  '  -genkey -v \\',
+  '  -storetype JKS \\',
+  '  -keyalg RSA \\',
+  '  -keysize 2048 \\',
+  '  -validity 10000 \\',
+  '  -storepass KEYSTORE_PASSWORD \\',
+  '  -keypass KEY_PASSWORD \\',
+  '  -alias KEY_ALIAS \\',
+  '  -keystore release.keystore \\',
+  '  -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"',
+]}
+cmdCopy='keytool -genkey -v -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -storepass KEYSTORE_PASSWORD -keypass KEY_PASSWORD -alias KEY_ALIAS -keystore release.keystore -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"'/>
 
 Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the `android/keystores` directory. **Remember to git-ignore all your release keystores!** If you've run the above keytool command and placed the keystore at `android/keystores/release.keystore`, you can ignore that file by adding the following line to `.gitignore`:
 
-```
+```sh .gitignore
 android/keystores/release.keystore
 ```
 
@@ -70,6 +73,9 @@ Create **credentials.json** and configure it with the credentials:
       "keyAlias": "KEY_ALIAS",
       "keyPassword": "KEY_PASSWORD"
     }
+  },
+  "ios": {
+    /* @hide ... */ /* @end */
   }
 }
 ```
@@ -83,9 +89,13 @@ Create **credentials.json** and configure it with the credentials:
 
 There are a few more prerequisites for building the iOS app binary. You need a paid Apple Developer Account, and then you'll need to generate the Distribution Certificate and Provisioning Profile for your application, which can be done via the [Apple Developer Portal](https://developer.apple.com/account/resources/certificates/list).
 
-Once you have the Distribution Certificate and Provisioning Profile on your computer, you should move them to the appropriate directory. We recommend you keep them in the `ios/certs` directory. In the rest of this document we assume that they are named **dist.p12** and `profile.mobileprovision` respectively. **Remember to git-ignore all files in the directory!** If you've placed the credentials in the suggested directory, you can ignore those files by adding the following line to `.gitignore`:
+Once you have the Distribution Certificate and Provisioning Profile on your computer, you should move them to the appropriate directory. We recommend you keep them in the `ios/certs` directory. In the rest of this document we assume that they are named **dist.p12** and **profile.mobileprovision** respectively.
 
-```
+> Remember to add directory with your credentials to **.gitignore**, so you don't accidentally commit them to the repository and potentially leak your secrets.
+
+If you've placed the credentials in the suggested directory, you can ignore those files by adding the following line to **.gitignore**:
+
+```sh .gitignore
 ios/certs/*
 ```
 
@@ -94,7 +104,7 @@ Create (or edit) **credentials.json** and configure it with the credentials:
 ```json credentials.json
 {
   "android": {
-    ...
+    /* @hide ... */ /* @end */
   },
   "ios": {
     "provisioningProfilePath": "ios/certs/profile.mobileprovision",
@@ -137,10 +147,12 @@ In this case, your **credentials.json** should look like below:
     },
     "shareextension": {
       "provisioningProfilePath": "ios/certs/shareextension-profile.mobileprovision",
-      /* @info You can use either the same distribution certificate (as for the first target) or a new one */ "distributionCertificate": {
+      /* @info You can use either the same distribution certificate (as for the first target) or a new one */
+      "distributionCertificate": {
         "path": "ios/certs/another-dist.p12",
         "password": "ANOTHER_DISTRIBUTION_CERTIFICATE_PASSWORD"
-      } /* @end */
+      }
+      /* @end */
     }
   }
 }
@@ -182,12 +194,11 @@ Developers tend to provide CI jobs with secrets by using environment variables. 
 
 Consider the following steps:
 
-- Run `base64 credentials.json` in the console.
+- Run the following command in the console to generate Base64 string based on your credentials file:
+  <Terminal cmd={['$ base64 credentials.json']} />
 - On your CI, set the `CREDENTIALS_JSON_BASE64` environment variable with the output of the above command.
 - In the CI job, restore the file using a simple shell command:
-  ```sh
-  echo $CREDENTIALS_JSON_BASE64 | base64 -d > credentials.json
-  ```
+  <Terminal cmd={['$ echo $CREDENTIALS_JSON_BASE64 | base64 -d > credentials.json']} />
 
 Similarly, you can encode your keystore, provisioning profile and distribution certificate so you can restore them later on the CI. To successfully trigger your build using local credentials from CI, you'll have to make sure all the credentials exist in the CI instance's file system (at the same locations as defined in **credentials.json**).
 


### PR DESCRIPTION
# Why

Make the Local Credential page up to the current docs standards.

# How

Use `Terminal` where applicable, add missing code block file names, emphasize the `.gitignore` and commit warning for iOS.

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
