### PR TITLE
[docs] Update formatting in guides and API references

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -131,7 +131,7 @@ to your root project file (usually **App.js**), so make sure you remove it (but 
 
 #### Configure a `postPublish` hook
 
-Add `expo.hooks` to your project's `app.json` (or `app.config.js`) file:
+Add `expo.hooks` property to your project's **app.json** or **app.config.js** file:
 
 ```json app.json
 {
@@ -187,12 +187,14 @@ In addition to the required config fields above, you can also provide these **op
 
 #### Add the Config Plugin
 
-Add `expo.plugins` to your project's **app.json** (or **app.config.js**) file:
+Add `expo.plugins` to your project's **app.json** or **app.config.js** file:
 
+{/* prettier-ignore */}
 ```json app.json
 {
   "expo": {
-    /* @hide ... your existing configuration */ /* @end */ "plugins": ["sentry-expo"]
+    "plugins": ["sentry-expo"]
+    /* @hide ... your existing configuration */ /* @end */
   }
 }
 ```

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -21,7 +21,7 @@ in order to comply with App Store Review guidelines. For more information, see A
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins
 in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
@@ -110,8 +110,8 @@ const styles = StyleSheet.create({
   },
   button: {
     width: 200,
-    height: 44
-  }
+    height: 44,
+  },
 });
 /* @end */
 ```

--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -17,11 +17,11 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection hideBareInstructions={true} />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -47,7 +47,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Full configurable properties
 
-Learn more from [`PluginConfigType`](#pluginconfigtype)
+Learn more from [`PluginConfigType`](#pluginconfigtype).
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -25,7 +25,7 @@ import Video from '~/components/plugins/Video';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
@@ -30,7 +30,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigClassic>
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-image-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -45,7 +45,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
@@ -37,7 +37,7 @@ On both iOS and Android platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for the iOS, your iPad is always in the landscape mode unless you open two applications side by side. In order to be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -50,7 +50,7 @@ You can configure `expo-screen-orientation` using its built-in [config plugin](/
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "ios": {

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -14,7 +14,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, etc... This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked, otherwise your app will be rejected by Apple.
 
@@ -26,7 +26,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -44,7 +44,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v45.0.0/sdk/admob.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/admob.mdx
@@ -25,13 +25,13 @@ Expo includes support for the [Google AdMob SDK](https://www.google.com/admob/) 
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-ads-admob` using its built-in [config plugin](../../../guides/config-plugins.mdx) if you use config plugins in your project ([EAS Build](../../../build/introduction.mdx) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 For the module to attribute interactions with ads to your AdMob app properly you will need to add a `googleMobileAdsAppId` property to **app.json** under `[platform].config`. More info on where to find the app ID can be found in [this Google Support answer](https://support.google.com/admob/answer/6232340). A sample valid **app.json** would look like:
 
-```json
+```json app.json
 {
   "expo": {
     "name": "Ads Showcase",

--- a/docs/pages/versions/v45.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/build-properties.mdx
@@ -19,11 +19,11 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection hideBareInstructions={true} />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -49,7 +49,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Full configurable properties
 
-Learn more from [`PluginConfigType`](#pluginconfigtype)
+Learn more from [`PluginConfigType`](#pluginconfigtype).
 
 ## API
 

--- a/docs/pages/versions/v45.0.0/sdk/facebook-ads.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/facebook-ads.mdx
@@ -33,7 +33,7 @@ For bare apps, you will also need to follow [Facebook's Get Started guide](https
 
 You need to create a placement ID to display ads. Follow steps 1 and 3 from the [Getting Started Guide for Facebook Audience](https://developers.facebook.com/docs/audience-network/getting-started) to create the placement ID.
 
-### Configuration in app.json / app.config.js
+### Configuration in app.json/app.config.js
 
 You can configure `expo-ads-facebook` using its built-in [config plugin](../../../guides/config-plugins.mdx) if you use config plugins in your project ([EAS Build](../../../build/introduction.mdx) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 

--- a/docs/pages/versions/v45.0.0/sdk/facebook.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/facebook.mdx
@@ -63,7 +63,7 @@ Add your app's Bundle ID as a _Bundle ID_ in the app settings page pictured belo
 
 </Collapsible>
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 - Add the field `facebookScheme` with your Facebook login redirect URL scheme found [on the Facebook Developer website](https://developers.facebook.com/docs/facebook-login/ios) under "_4. Configure Your info.plist_." It should look like `"fb123456"`. If you do not do this, Facebook will not be able to redirect to your app after logging in.
 - Add the fields `facebookAppId` and `facebookDisplayName`, using your [Facebook App ID and Facebook Display Name](https://developers.facebook.com/docs/facebook-login/ios), respectively.

--- a/docs/pages/versions/v45.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/filesystem.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
@@ -30,7 +30,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigClassic>
 

--- a/docs/pages/versions/v45.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/imagepicker.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 {/* update library name here */}
 
@@ -53,7 +53,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 {/* add some example usage of the plugin. you don't need to provide every option */}
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v45.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/tracking-transparency.mdx
@@ -14,7 +14,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, etc... This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked, otherwise your app will be rejected by Apple.
 
@@ -26,7 +26,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](../../../guides/config-plugins.mdx) if you use config plugins in your project ([EAS Build](../../../build/introduction.mdx) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -44,7 +44,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v46.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/build-properties.mdx
@@ -19,11 +19,11 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection hideBareInstructions={true} />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -49,7 +49,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Full configurable properties
 
-Learn more from [`PluginConfigType`](#pluginconfigtype)
+Learn more from [`PluginConfigType`](#pluginconfigtype).
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/filesystem.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
@@ -30,7 +30,7 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigClassic>
 

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-image-picker` using its built-in [config plugin](../../../guides/config-plugins.mdx) if you use config plugins in your project ([EAS Build](../../../build/introduction.mdx) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -45,7 +45,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v46.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/notifications.mdx
@@ -11,7 +11,7 @@ import {
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
 import { AndroidPermissions } from '~/components/plugins/permissions';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';

--- a/docs/pages/versions/v46.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/screen-orientation.mdx
@@ -38,7 +38,7 @@ Apple added support for _split view_ mode to iPads in iOS 9. This changed how th
 
 Open your **app.json** and add the following inside of the `"expo"` field:
 
-```json
+```json app.json
 {
   "expo": {
     ...

--- a/docs/pages/versions/v46.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/tracking-transparency.mdx
@@ -14,7 +14,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, etc... This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked, otherwise your app will be rejected by Apple.
 
@@ -26,7 +26,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](../../../guides/config-plugins.mdx) if you use config plugins in your project ([EAS Build](../../../build/introduction.mdx) or `expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -44,7 +44,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/apple-authentication.mdx
@@ -21,7 +21,7 @@ in order to comply with App Store Review guidelines. For more information, see A
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-apple-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins
 in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
@@ -110,8 +110,8 @@ const styles = StyleSheet.create({
   },
   button: {
     width: 200,
-    height: 44
-  }
+    height: 44,
+  },
 });
 /* @end */
 ```

--- a/docs/pages/versions/v47.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/build-properties.mdx
@@ -17,11 +17,11 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection hideBareInstructions={true} />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -47,7 +47,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ### Full configurable properties
 
-Learn more from [`PluginConfigType`](#pluginconfigtype)
+Learn more from [`PluginConfigType`](#pluginconfigtype).
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -25,7 +25,7 @@ import Video from '~/components/plugins/Video';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 

--- a/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
@@ -11,7 +11,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
@@ -30,17 +30,17 @@ import { SnackInline} from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 <ConfigClassic>
 
-  You can configure [the permissions for this library](#permissions) using [`ios.infoPlist`](../config/app.mdx#infoplist) and [`android.permissions`](../config/app.mdx#permissions).
+You can configure [the permissions for this library](#permissions) using [`ios.infoPlist`](../config/app.mdx#infoplist) and [`android.permissions`](../config/app.mdx#permissions).
 
 </ConfigClassic>
 
 <ConfigReactNative>
 
-  Learn how to configure the native projects in the [installation instructions in the `expo-file-system` repository](https://github.com/expo/expo/tree/main/packages/expo-file-system#installation-in-bare-react-native-projects).
+Learn how to configure the native projects in the [installation instructions in the `expo-file-system` repository](https://github.com/expo/expo/tree/main/packages/expo-file-system#installation-in-bare-react-native-projects).
 
 </ConfigReactNative>
 
@@ -116,61 +116,61 @@ try {
   }}
 >
 
-  ```typescript
-  import * as FileSystem from 'expo-file-system';
+```typescript
+import * as FileSystem from 'expo-file-system';
 
-  const gifDir = FileSystem.cacheDirectory + 'giphy/';
-  const gifFileUri = (gifId: string) => gifDir + `gif_${gifId}_200.gif`;
-  const gifUrl = (gifId: string) => `https://media1.giphy.com/media/${gifId}/200.gif`;
+const gifDir = FileSystem.cacheDirectory + 'giphy/';
+const gifFileUri = (gifId: string) => gifDir + `gif_${gifId}_200.gif`;
+const gifUrl = (gifId: string) => `https://media1.giphy.com/media/${gifId}/200.gif`;
 
-  // Checks if gif directory exists. If not, creates it
-  async function ensureDirExists() {
+// Checks if gif directory exists. If not, creates it
+async function ensureDirExists() {
   const dirInfo = await FileSystem.getInfoAsync(gifDir);
   if (!dirInfo.exists) {
-  console.log("Gif directory doesn't exist, creating...");
-  await FileSystem.makeDirectoryAsync(gifDir, { intermediates: true });
-}
+    console.log("Gif directory doesn't exist, creating...");
+    await FileSystem.makeDirectoryAsync(gifDir, { intermediates: true });
+  }
 }
 
-  // Downloads all gifs specified as array of IDs
-  export async function addMultipleGifs(gifIds: string[]) {
+// Downloads all gifs specified as array of IDs
+export async function addMultipleGifs(gifIds: string[]) {
   try {
-  await ensureDirExists();
+    await ensureDirExists();
 
-  console.log('Downloading', gifIds.length, 'gif files...');
-  await Promise.all(gifIds.map(id => FileSystem.downloadAsync(gifUrl(id), gifFileUri(id))));
-} catch (e) {
-  console.error("Couldn't download gif files:", e);
-}
+    console.log('Downloading', gifIds.length, 'gif files...');
+    await Promise.all(gifIds.map(id => FileSystem.downloadAsync(gifUrl(id), gifFileUri(id))));
+  } catch (e) {
+    console.error("Couldn't download gif files:", e);
+  }
 }
 
-  // Returns URI to our local gif file
-  // If our gif doesn't exist locally, it downloads it
-  export async function getSingleGif(gifId: string) {
+// Returns URI to our local gif file
+// If our gif doesn't exist locally, it downloads it
+export async function getSingleGif(gifId: string) {
   await ensureDirExists();
 
   const fileUri = gifFileUri(gifId);
   const fileInfo = await FileSystem.getInfoAsync(fileUri);
 
   if (!fileInfo.exists) {
-  console.log("Gif isn't cached locally. Downloading...");
-  await FileSystem.downloadAsync(gifUrl(gifId), fileUri);
-}
+    console.log("Gif isn't cached locally. Downloading...");
+    await FileSystem.downloadAsync(gifUrl(gifId), fileUri);
+  }
 
   return fileUri;
 }
 
-  // Exports shareable URI - it can be shared outside your app
-  export async function getGifContentUri(gifId: string) {
+// Exports shareable URI - it can be shared outside your app
+export async function getGifContentUri(gifId: string) {
   return FileSystem.getContentUriAsync(await getSingleGif(gifId));
 }
 
-  // Deletes whole giphy directory with all its content
-  export async function deleteAllGifs() {
+// Deletes whole giphy directory with all its content
+export async function deleteAllGifs() {
   console.log('Deleting all GIF files...');
   await FileSystem.deleteAsync(gifDir);
 }
-  ```
+```
 
 </SnackInline>
 

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -27,7 +27,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-image-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -45,7 +45,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [

--- a/docs/pages/versions/v47.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/screen-orientation.mdx
@@ -37,7 +37,7 @@ On both iOS and Android platforms, changes to the screen orientation will overri
 
 Apple added support for _split view_ mode to iPads in iOS 9. This changed how the screen orientation is handled by the system. To put the matter shortly, for the iOS, your iPad is always in the landscape mode unless you open two applications side by side. In order to be able to lock screen orientation using this module you will need to disable support for this feature. For more information about the _split view_ mode, check out [the official Apple documentation](https://support.apple.com/en-us/HT207582).
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-screen-orientation` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -50,7 +50,7 @@ You can configure `expo-screen-orientation` using its built-in [config plugin](/
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "ios": {

--- a/docs/pages/versions/v47.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/tracking-transparency.mdx
@@ -14,7 +14,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 A library for requesting permission to track the user or their device. Examples of data used for tracking include email address, device ID, advertising ID, etc... This permission is only necessary on iOS 14 and higher; on iOS 13 and below this permission is always granted. If the "Allow Apps to Request to Track" device-level setting is off, this permission will be denied. Be sure to add `NSUserTrackingUsageDescription` to your [**Info.plist**](/versions/latest/config/app/#infoplist) to explain how the user will be tracked, otherwise your app will be rejected by Apple.
 
@@ -26,7 +26,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 <APIInstallSection />
 
-## Configuration in app.json / app.config.js
+## Configuration in app.json/app.config.js
 
 You can configure `expo-tracking-transparency` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
@@ -44,7 +44,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 <ConfigPluginExample>
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR adds minor formatting updates to Using Sentry guide and multiple API reference pages for consistency and follow our writing style guide.
The API reference changes have been backported wherever necessary.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
