### PR TITLE
[core][ios] Refactor dynamic properties to work well with shared objects

### DIFF
--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -624,10 +624,10 @@ SPEC CHECKSUMS:
   EXManifests: 347f49430b63444579aa013f0ad057d16b8d1cc8
   Expo: 8ee43334b657268299454a67f30f60e5a8ca89d9
   expo-dev-launcher: 953f564f7d006f1af50b119cacb48cafcad40c73
-  expo-dev-menu: 9e3dddd191ef96d9b60cff56f707e02223200bf1
+  expo-dev-menu: 330211ba6e93b8195b43aa9e84555ec861131af4
   expo-dev-menu-interface: c8ad2dc7bb9513c6668c0b0fdf2391727a3d19a7
   ExpoClipboard: 334921ae215b4be261e393e6fdd9050025008a20
-  ExpoModulesCore: e47e5d3e3f8fbc03b6c41cfc1d54421381201dd5
+  ExpoModulesCore: f58d3a1df4c7ac1c2342a933795714a20af44668
   ExpoModulesTestCore: fe0a7344268158f254dadc9ac947b2c66bb19fed
   EXStructuredHeaders: fb774e45eac2e5d62ba40b28176bfbfba61b843e
   EXUpdates: d0c361e15f668d22dd33633717a8d24991ea4925

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the `Exceptions.MissingActivity` on Android. ([#20174](https://github.com/expo/expo/pull/20174) by [@lukmccall](https://github.com/lukmccall))
 - Trailing optional arguments can be skipped when calling native functions from JavaScript on iOS. ([#20234](https://github.com/expo/expo/pull/20234) by [@tsapeta](https://github.com/tsapeta))
 - `Events` component can now be initialized with an array of event names (not only variadic arguments). ([#20590](https://github.com/expo/expo/pull/20590) by [@tsapeta](https://github.com/tsapeta))
+- `Property` component can now take the native shared object instance as the first argument. ([#20608](https://github.com/expo/expo/pull/20608) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponentElement.swift
@@ -25,7 +25,7 @@ extension AsyncFunctionComponent: ClassComponentElement {
 }
 
 extension PropertyComponent: ClassComponentElement {
-  public typealias OwnerType = Void
+  // It already has the `OwnerType`
 }
 
 extension ConstantsDefinition: ClassComponentElement {

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
@@ -18,6 +18,10 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType) throws -> Any {
+    if let value = value as? SharedObject, type(of: value) == innerType {
+      // Given value is a shared object already
+      return value
+    }
     if let jsObject = try (value as? JavaScriptValue)?.asObject(),
        let nativeSharedObject = SharedObjectRegistry.toNativeObject(jsObject) {
       return nativeSharedObject

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
@@ -17,7 +17,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   /**
    A map of dynamic properties defined by the object.
    */
-  let properties: [String: PropertyComponent]
+  let properties: [String: AnyPropertyComponent]
 
   /**
    A map of classes defined within the object.
@@ -38,8 +38,8 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
       .compactMap { $0 as? ConstantsDefinition }
 
     self.properties = definitions
-      .compactMap { $0 as? PropertyComponent }
-      .reduce(into: [String: PropertyComponent]()) { dict, property in
+      .compactMap { $0 as? AnyPropertyComponent }
+      .reduce(into: [String: AnyPropertyComponent]()) { dict, property in
         dict[property.name] = property
       }
 
@@ -90,7 +90,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
   internal func decorateWithProperties(runtime: JavaScriptRuntime, object: JavaScriptObject) {
     for property in properties.values {
-      let descriptor = property.buildDescriptor(inRuntime: runtime, withCaller: object)
+      let descriptor = property.buildDescriptor(inRuntime: runtime)
       object.defineProperty(property.name, descriptor: descriptor)
     }
   }

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -1,6 +1,18 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-public final class PropertyComponent: AnyDefinition {
+protocol AnyPropertyComponent {
+  /**
+   Name of the property.
+   */
+  var name: String { get }
+
+  /**
+   Creates the JavaScript object representing the property descriptor.
+   */
+  func buildDescriptor(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject
+}
+
+public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyComponent {
   /**
    Name of the property.
    */
@@ -16,110 +28,161 @@ public final class PropertyComponent: AnyDefinition {
    */
   var setter: AnySyncFunctionComponent?
 
+  /**
+   Initializes an unowned PropertyComponent without getter and setter functions.
+   */
   init(name: String) {
     self.name = name
+  }
+
+  /**
+   Initializes an unowned PropertyComponent with a getter without arguments.
+   */
+  init<ReturnType>(name: String, getter: @escaping () -> ReturnType) {
+    self.name = name
+
+    // Set the getter right away
+    self.get(getter)
+  }
+
+  /**
+   Initializes an owned PropertyComponent with a getter that takes the owner as its first argument.
+   */
+  init<ReturnType>(name: String, getter: @escaping (_ this: OwnerType) -> ReturnType) {
+    self.name = name
+
+    // Set the getter right away
+    self.get(getter)
   }
 
   // MARK: - Modifiers
 
   /**
-   Modifier that sets property getter that has no arguments (the caller is not used).
+   Modifier that sets property getter that has no arguments (the owner is not used).
    */
-  public func get<Value>(_ getter: @escaping () -> Value) -> Self {
+  @discardableResult
+  public func get<ReturnType>(_ getter: @escaping () -> ReturnType) -> Self {
     self.getter = SyncFunctionComponent(
       "get",
       firstArgType: Void.self,
-      dynamicArgumentTypes: [~Any.self],
-      { (caller: Any) in getter() }
-    )
-    return self
-  }
-
-  /**
-   Modifier that sets property setter that receives only the new value as an argument.
-   */
-  public func set<Value>(_ setter: @escaping (_ newValue: Value) -> ()) -> Self {
-    self.setter = SyncFunctionComponent(
-      "set",
-      firstArgType: Void.self,
-      dynamicArgumentTypes: [~Any.self, ~Value.self],
-      { (caller: Any, value: Value) in setter(value) }
-    )
-    return self
-  }
-
-  /**
-   Modifier that sets property getter that receives the caller as an argument.
-   The caller is an object on which the function is called, like `this` in JavaScript.
-   */
-  public func get<Value, Caller>(_ getter: @escaping (_ this: Caller) -> Value) -> Self {
-    self.getter = SyncFunctionComponent(
-      "get",
-      firstArgType: Caller.self,
-      dynamicArgumentTypes: [~Caller.self],
+      dynamicArgumentTypes: [],
       getter
     )
     return self
   }
 
   /**
-   Modifier that sets property setter that receives the caller and the new value as arguments.
-   The caller is an object on which the function is called, like `this` in JavaScript.
+   Modifier that sets property getter that receives the owner as an argument.
+   The owner is an object on which the function is called, like `this` in JavaScript.
    */
-  public func set<Value, Caller>(_ setter: @escaping (_ this: Caller, _ newValue: Value) -> ()) -> Self {
+  @discardableResult
+  public func get<ReturnType>(_ getter: @escaping (_ this: OwnerType) -> ReturnType) -> Self {
+    self.getter = SyncFunctionComponent(
+      "get",
+      firstArgType: OwnerType.self,
+      dynamicArgumentTypes: [~OwnerType.self],
+      getter
+    )
+    self.getter?.takesOwner = true
+    return self
+  }
+
+  /**
+   Modifier that sets property setter that receives only the new value as an argument.
+   */
+  @discardableResult
+  public func set<ValueType>(_ setter: @escaping (_ newValue: ValueType) -> ()) -> Self {
     self.setter = SyncFunctionComponent(
       "set",
-      firstArgType: Caller.self,
-      dynamicArgumentTypes: [~Caller.self, ~Value.self],
+      firstArgType: ValueType.self,
+      dynamicArgumentTypes: [~ValueType.self],
       setter
     )
     return self
   }
 
-  // MARK: - Internals
-
-  internal func getValue<Value>(caller: AnyObject? = nil) -> Value? {
-    let value = try? getter?.call(by: caller, withArguments: [caller as Any])
-    return value as? Value
+  /**
+   Modifier that sets property setter that receives the owner and the new value as arguments.
+   The owner is an object on which the function is called, like `this` in JavaScript.
+   */
+  @discardableResult
+  public func set<ValueType>(_ setter: @escaping (_ this: OwnerType, _ newValue: ValueType) -> ()) -> Self {
+    self.setter = SyncFunctionComponent(
+      "set",
+      firstArgType: OwnerType.self,
+      dynamicArgumentTypes: [~OwnerType.self, ~ValueType.self],
+      setter
+    )
+    self.setter?.takesOwner = true
+    return self
   }
 
-  internal func setValue(_ value: Any, caller: AnyObject? = nil) {
-    let _ = try? setter?.call(by: caller, withArguments: [caller as Any, value])
+  // MARK: - Internals
+
+  internal func getValue<ValueType>(owner: OwnerType? = nil) throws -> ValueType? {
+    let owner = owner as? AnyObject
+    let value = try getter?.call(by: owner, withArguments: [])
+    return value as? ValueType
+  }
+
+  internal func setValue(_ value: Any, owner: OwnerType? = nil) {
+    let owner = owner as? AnyObject
+    let _ = try? setter?.call(by: owner, withArguments: [value])
   }
 
   /**
    Creates the JavaScript function that will be used as a getter of the property.
    */
-  internal func buildGetter(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
-    return runtime.createSyncFunction(name, argsCount: 0) { [weak self, weak caller] this, args in
-      return self?.getValue(caller: caller)
+  internal func buildGetter(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    return runtime.createSyncFunction(name, argsCount: 0) { [weak self, name] this, args in
+      guard let self = self else {
+        throw NativePropertyUnavailableException(name)
+      }
+      guard let getter = self.getter else {
+        return
+      }
+      return try getter.call(by: this, withArguments: args)
     }
   }
 
   /**
    Creates the JavaScript function that will be used as a setter of the property.
    */
-  internal func buildSetter(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
-    return runtime.createSyncFunction(name, argsCount: 1) { [weak self, weak caller] this, args in
-      return self?.setValue(args.first as Any, caller: caller)
+  internal func buildSetter(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    return runtime.createSyncFunction(name, argsCount: 1) { [weak self, name] this, args in
+      guard let self = self else {
+        throw NativePropertyUnavailableException(name)
+      }
+      guard let setter = self.setter else {
+        return
+      }
+      return try setter.call(by: this, withArguments: args)
     }
   }
 
   /**
    Creates the JavaScript object representing the property descriptor.
    */
-  internal func buildDescriptor(inRuntime runtime: JavaScriptRuntime, withCaller caller: AnyObject?) -> JavaScriptObject {
+  internal func buildDescriptor(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
     let descriptor = runtime.createObject()
 
     descriptor.setProperty("enumerable", value: true)
 
     if getter != nil {
-      descriptor.setProperty("get", value: buildGetter(inRuntime: runtime, withCaller: caller))
+      descriptor.setProperty("get", value: buildGetter(inRuntime: runtime))
     }
     if setter != nil {
-      descriptor.setProperty("set", value: buildSetter(inRuntime: runtime, withCaller: caller))
+      descriptor.setProperty("set", value: buildSetter(inRuntime: runtime))
     }
     return descriptor
+  }
+}
+
+// MARK: - Exceptions
+
+internal final class NativePropertyUnavailableException: GenericException<String> {
+  override var reason: String {
+    return "Native property '\(param)' is no longer available in memory"
   }
 }
 
@@ -128,23 +191,23 @@ public final class PropertyComponent: AnyDefinition {
 /**
  Creates the property with given name. The component is basically no-op if you don't call `.get(_:)` or `.set(_:)` on it.
  */
-public func Property(_ name: String) -> PropertyComponent {
+public func Property(_ name: String) -> PropertyComponent<Void> {
   return PropertyComponent(name: name)
 }
 
 /**
- Creates the read-only property whose getter doesn't take the caller as an argument.
+ Creates the read-only property whose getter doesn't take the owner as an argument.
  */
-public func Property<Value: AnyArgument>(_ name: String, @_implicitSelfCapture get: @escaping () -> Value) -> PropertyComponent {
-  return PropertyComponent(name: name).get(get)
+public func Property<Value: AnyArgument>(_ name: String, @_implicitSelfCapture get: @escaping () -> Value) -> PropertyComponent<Void> {
+  return PropertyComponent(name: name, getter: get)
 }
 
 /**
- Creates the read-only property whose getter takes the caller as an argument.
+ Creates the read-only property whose getter takes the owner as an argument.
  */
-public func Property<Value: AnyArgument, Caller>(
+public func Property<Value: AnyArgument, OwnerType>(
   _ name: String,
-  @_implicitSelfCapture get: @escaping (Caller) -> Value
-) -> PropertyComponent {
-  return PropertyComponent(name: name).get(get)
+  @_implicitSelfCapture get: @escaping (_ this: OwnerType) -> Value
+) -> PropertyComponent<OwnerType> {
+  return PropertyComponent<OwnerType>(name: name, getter: get)
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -91,7 +91,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
    Modifier that sets property setter that receives only the new value as an argument.
    */
   @discardableResult
-  public func set<ValueType>(_ setter: @escaping (_ newValue: ValueType) -> ()) -> Self {
+  public func set<ValueType>(_ setter: @escaping (_ newValue: ValueType) -> Void) -> Self {
     self.setter = SyncFunctionComponent(
       "set",
       firstArgType: ValueType.self,
@@ -106,7 +106,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
    The owner is an object on which the function is called, like `this` in JavaScript.
    */
   @discardableResult
-  public func set<ValueType>(_ setter: @escaping (_ this: OwnerType, _ newValue: ValueType) -> ()) -> Self {
+  public func set<ValueType>(_ setter: @escaping (_ this: OwnerType, _ newValue: ValueType) -> Void) -> Self {
     self.setter = SyncFunctionComponent(
       "set",
       firstArgType: OwnerType.self,
@@ -127,7 +127,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
 
   internal func setValue(_ value: Any, owner: OwnerType? = nil) {
     let owner = owner as? AnyObject
-    let _ = try? setter?.call(by: owner, withArguments: [value])
+    _ = try? setter?.call(by: owner, withArguments: [value])
   }
 
   /**

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -169,6 +169,17 @@ class ClassComponentSpec: ExpoSpec {
         expect(newValue.kind) == .number
         expect(newValue.getInt()) == value + incrementBy
       }
+
+      it("gets value from the dynamic property") {
+        let initialValue = Int.random(in: 1..<100)
+        let value = try runtime!.eval([
+          "object = new expo.modules.TestModule.Counter(\(initialValue))",
+          "object.currentValue"
+        ])
+
+        expect(value.kind) == .number
+        expect(value.getInt()) == initialValue
+      }
     }
   }
 }
@@ -188,6 +199,10 @@ fileprivate final class ModuleWithCounterClass: Module {
         counter.increment(by: value)
       }
       Function("getValue") { counter in
+        return counter.currentValue
+      }
+
+      Property("currentValue") { counter in
         return counter.currentValue
       }
     }

--- a/packages/expo-modules-core/ios/Tests/PropertyComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/PropertyComponentSpec.swift
@@ -7,7 +7,7 @@ class PropertyComponentSpec: ExpoSpec {
     describe("property") {
       it("gets the value") {
         let property = Property("test") { return "expo" }
-        expect(property.getValue()) == "expo"
+        expect(try property.getValue()) == "expo"
       }
 
       it("sets the value") {
@@ -21,7 +21,7 @@ class PropertyComponentSpec: ExpoSpec {
         let newValue = Int.random(in: 0..<100)
         property.setValue(newValue)
 
-        expect(property.getValue()) == value
+        expect(try property.getValue()) == value
         expect(value) == newValue
       }
     }
@@ -31,32 +31,6 @@ class PropertyComponentSpec: ExpoSpec {
       let runtime = appContext.runtime
 
       beforeSuite {
-        class PropertyTestModule: Module {
-          func definition() -> ModuleDefinition {
-            Name("PropertyTest")
-
-            Property("readOnly") {
-              return "foo"
-            }
-
-            var writablePropertyValue = 444
-            Property("writable")
-              .get {
-                return writablePropertyValue
-              }
-              .set { value in
-                writablePropertyValue = value
-              }
-
-            Property("withCaller") { (caller: JavaScriptObject) -> String in
-              // Here, the caller is a JS object of the module.
-              // Return another property of itself.
-              return caller.getProperty("readOnly").getString()
-            }
-
-            Property("undefined")
-          }
-        }
         appContext.moduleRegistry.register(moduleType: PropertyTestModule.self)
       }
 
@@ -78,18 +52,94 @@ class PropertyComponentSpec: ExpoSpec {
 
       it("is enumerable") {
         let keys = try runtime?.eval("Object.keys(expo.modules.PropertyTest)").getArray().map { $0.getString() } ?? []
-        expect(keys).to(contain("readOnly", "writable", "withCaller", "undefined"))
+        expect(keys).to(contain("readOnly", "writable", "undefined"))
       }
 
-      it("is called with the caller") {
-        let value = try runtime?.eval("expo.modules.PropertyTest.withCaller")
-        expect(value?.getString()) == "foo"
-      }
+// TODO: Using JavaScriptObject as the owner is no longer possible, but we may want to bring this feature back
+//      it("is called with the caller") {
+//        let value = try runtime?.eval("expo.modules.PropertyTest.withCaller")
+//        expect(value?.getString()) == "foo"
+//      }
 
       it("returns undefined when getter is not specified") {
         let value = try runtime?.eval("expo.modules.PropertyTest.undefined")
         expect(value?.isUndefined()) == true
       }
     }
+
+    describe("class property") {
+      let appContext = AppContext.create()
+      let runtime = appContext.runtime
+
+      beforeSuite {
+        appContext.moduleRegistry.register(moduleType: PropertyTestModule.self)
+      }
+
+      it("gets the value") {
+        let value = try runtime?.eval("new expo.modules.PropertyTest.TestClass().someValue")
+
+        expect(value?.kind) == .number
+        expect(value?.getInt()) == TestClass.constantValue
+      }
+
+      it("sets the value") {
+        let newValue = Int.random(in: 1..<100)
+        let value = try runtime?.eval([
+          "object = new expo.modules.PropertyTest.TestClass()",
+          "object.someValue = \(newValue)",
+          "object.someValue"
+        ])
+
+        expect(value?.kind) == .number
+        expect(value?.getInt()) == newValue
+      }
+    }
   }
+}
+
+class PropertyTestModule: Module {
+  func definition() -> ModuleDefinition {
+    Name("PropertyTest")
+
+    Property("readOnly") {
+      return "foo"
+    }
+
+    var writablePropertyValue = 444
+    Property("writable")
+      .get {
+        return writablePropertyValue
+      }
+      .set { value in
+        writablePropertyValue = value
+      }
+
+// TODO: Using JavaScriptObject as the owner is no longer possible, but we may want to bring this feature back
+//            Property("withCaller") { (caller: JavaScriptObject) -> String in
+//              // Here, the caller is a JS object of the module.
+//              // Return another property of itself.
+//              return caller.getProperty("readOnly").getString()
+//            }
+
+    Property("undefined")
+
+    Class(TestClass.self) {
+      Constructor {
+        return TestClass()
+      }
+
+      Property("someValue") { object in
+        return object.someValue
+      }
+      .set { object, newValue in
+        object.someValue = newValue
+      }
+    }
+  }
+}
+
+fileprivate final class TestClass: SharedObject {
+  static let constantValue = Int.random(in: 1..<100)
+
+  var someValue = TestClass.constantValue
 }


### PR DESCRIPTION
# Why

Fixes #20543, but doesn't implement some other ideas that came up in the discussion

# How

- Refactored dynamic properties so they can take the owner (shared object instance)
- Added new native unit tests
- It's no longer possible for properties to take the caller (`JavaScriptObject`) as an argument. I think it's a less useful feature for now so I'll bring it back in a separate PR in the future

# Test Plan

All native unit tests are passing