### PR TITLE
[docs] fix and align examples in custom checkbox guide

### DIFF
--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -16,21 +16,16 @@ A checkbox is a button that exists in one of two states — it is checked or it 
 <SnackInline>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import Ionicons from '@expo/vector-icons';
+import { Ionicons } from '@expo/vector-icons';
 
 function MyCheckbox() {
-  const [checked, onChange] = useState(false);
-
-  function onCheckmarkPress() {
-    onChange(!checked);
-  }
-
+  const [checked, setChecked] = useState(false);
   return (
     <Pressable
       style={[styles.checkboxBase, checked && styles.checkboxChecked]}
-      onPress={onCheckmarkPress}>
+      onPress={() => setChecked(!checked)}>
       {checked && <Ionicons name="checkmark" size={24} color="white" />}
     </Pressable>
   );
@@ -40,7 +35,6 @@ export default function App() {
   return (
     <View style={styles.appContainer}>
       <Text style={styles.appTitle}>Checkbox Example</Text>
-
       <View style={styles.checkboxContainer}>
         <MyCheckbox />
         <Text style={styles.checkboxLabel}>{`⬅️ Click!`}</Text>
@@ -60,27 +54,23 @@ const styles = StyleSheet.create({
     borderColor: 'coral',
     backgroundColor: 'transparent',
   },
-
   checkboxChecked: {
     backgroundColor: 'coral',
   },
-
   appContainer: {
     flex: 1,
     alignItems: 'center',
+    justifyContent: 'center',
   },
-
   appTitle: {
     marginVertical: 16,
     fontWeight: 'bold',
     fontSize: 24,
   },
-
   checkboxContainer: {
     flexDirection: 'row',
     alignItems: 'center',
   },
-
   checkboxLabel: {
     marginLeft: 8,
     fontWeight: 500,
@@ -100,48 +90,40 @@ This checkbox isn't useful in this state because the `checked` value is accessib
 <SnackInline>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import Ionicons from '@expo/vector-icons/Ionicons';
+import { Ionicons } from '@expo/vector-icons';
 
-function MyCheckbox({
-  /* @info Define checked and onChange as props instead of state */ checked,
-  onChange /* @end */,
+function MyCheckbox({ 
+  /* @info Define checked and onChange as props instead of state */ 
+  onChange, checked
+  /* @end */
 }) {
-  function onCheckmarkPress() {
-    onChange(!checked);
-  }
-
   return (
     <Pressable
       style={[styles.checkboxBase, checked && styles.checkboxChecked]}
-      onPress={onCheckmarkPress}>
+      onPress={onChange}>
       {checked && <Ionicons name="checkmark" size={24} color="white" />}
     </Pressable>
   );
 }
 
-function App() {
-  /* @info Move the checked and onChange values outside of the checkbox component */
-  const [checked, onChange] = useState(false);
+export default function App() {
+  /* @info Move the checked and setChecked values outside of the checkbox component */
+  const [checked, setChecked] = useState(false);
   /* @end */
-
   return (
     <View style={styles.appContainer}>
       <Text style={styles.appTitle}>Checkbox Example</Text>
-
       <View style={styles.checkboxContainer}>
-        <MyCheckbox
-          /* @info Pass the checked and onChange props to the checkbox */ checked={checked}
-          onChange={onChange} /* @end */
-        />
+        /* @info Pass the checked and onChange props to the checkbox */
+        <MyCheckbox onChange={() => setChecked(!checked)} checked={checked} />
+        /* @end */
         <Text style={styles.checkboxLabel}>{`⬅️ Click!`}</Text>
       </View>
     </View>
   );
 }
-
-export default App;
 
 const styles = StyleSheet.create({
   checkboxBase: {
@@ -154,27 +136,23 @@ const styles = StyleSheet.create({
     borderColor: 'coral',
     backgroundColor: 'transparent',
   },
-
   checkboxChecked: {
     backgroundColor: 'coral',
   },
-
   appContainer: {
     flex: 1,
     alignItems: 'center',
+    justifyContent: 'center',
   },
-
   appTitle: {
     marginVertical: 16,
     fontWeight: 'bold',
     fontSize: 24,
   },
-
   checkboxContainer: {
     flexDirection: 'row',
     alignItems: 'center',
   },
-
   checkboxLabel: {
     marginLeft: 8,
     fontWeight: 500,
@@ -194,27 +172,24 @@ It's common enough to need to render different styles when the checkmark is `che
 <SnackInline>
 
 ```jsx
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import Ionicons from '@expo/vector-icons/Ionicons';
+import { Ionicons } from '@expo/vector-icons';
 
 function MyCheckbox({
   checked,
   onChange,
-  /* @info Add style and icon props to make the checkbox reusable throughout your codebase */ buttonStyle = {},
+  /* @info Add style and icon props to make the checkbox reusable throughout your codebase */ 
+  buttonStyle = {},
   activeButtonStyle = {},
   inactiveButtonStyle = {},
   activeIconProps = {},
   inactiveIconProps = {},
   /* @end */
 }) {
-  function onCheckmarkPress() {
-    onChange(!checked);
-  }
-
   /* @info Set icon props based on the checked value */
-  const iconProps = checked ? activeIconProps : inactiveIconProps; /* @end */
-
+  const iconProps = checked ? activeIconProps : inactiveIconProps;
+  /* @end */
   return (
     <Pressable
       style={[
@@ -224,7 +199,7 @@ function MyCheckbox({
           : inactiveButtonStyle,
         /* @end */
       ]}
-      onPress={onCheckmarkPress}>
+      onPress={() => onChange(!checked)}>
       {checked && (
         <Ionicons
           name="checkmark"
@@ -239,17 +214,15 @@ function MyCheckbox({
   );
 }
 
-function App() {
-  const [checked, onChange] = useState(false);
-
+export default function App() {
+  const [checked, setChecked] = useState(false);
   return (
     <View style={styles.appContainer}>
       <Text style={styles.appTitle}>Checkbox Example</Text>
-
       <View style={styles.checkboxContainer}>
         <MyCheckbox
           checked={checked}
-          onChange={onChange}
+          onChange={setChecked}
           /* @info Pass in base and active styles for the checkbox */
           buttonStyle={styles.checkboxBase}
           activeButtonStyle={styles.checkboxChecked}
@@ -260,8 +233,6 @@ function App() {
     </View>
   );
 }
-
-export default App;
 
 const styles = StyleSheet.create({
   checkboxBase: {
@@ -274,27 +245,23 @@ const styles = StyleSheet.create({
     borderColor: 'coral',
     backgroundColor: 'transparent',
   },
-
   checkboxChecked: {
     backgroundColor: 'coral',
   },
-
   appContainer: {
     flex: 1,
     alignItems: 'center',
+    justifyContent: 'center',
   },
-
   appTitle: {
     marginVertical: 16,
     fontWeight: 'bold',
     fontSize: 24,
   },
-
   checkboxContainer: {
     flexDirection: 'row',
     alignItems: 'center',
   },
-
   checkboxLabel: {
     marginLeft: 8,
     fontWeight: 500,

--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -13,7 +13,7 @@ A checkbox is a button that exists in one of two states — it is checked or it 
 
 > You can find more information about using icons in your Expo project in our [Icons guide](/guides/icons).
 
-<SnackInline>
+<SnackInline dependencies={['@expo/vector-icons']}>
 
 ```jsx
 import { useState } from 'react';
@@ -87,15 +87,15 @@ const styles = StyleSheet.create({
 
 This checkbox isn't useful in this state because the `checked` value is accessible only from within the component — more often than not you'll want to control the checkbox from outside. This is achievable by defining `checked` and `onChange` as props that are passed into the checkbox:
 
-<SnackInline>
+<SnackInline dependencies={['@expo/vector-icons']}>
 
 ```jsx
 import { useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 
-function MyCheckbox({ 
-  /* @info Define checked and onChange as props instead of state */ 
+function MyCheckbox({
+  /* @info Define checked and onChange as props instead of state */
   onChange, checked
   /* @end */
 }) {
@@ -169,7 +169,7 @@ const styles = StyleSheet.create({
 
 It's common enough to need to render different styles when the checkmark is `checked` and when it is not. Let's add this to the checkbox's props and make it more reusable:
 
-<SnackInline>
+<SnackInline dependencies={['@expo/vector-icons']}>
 
 ```jsx
 import { useState } from 'react';
@@ -179,7 +179,7 @@ import { Ionicons } from '@expo/vector-icons';
 function MyCheckbox({
   checked,
   onChange,
-  /* @info Add style and icon props to make the checkbox reusable throughout your codebase */ 
+  /* @info Add style and icon props to make the checkbox reusable throughout your codebase */
   buttonStyle = {},
   activeButtonStyle = {},
   inactiveButtonStyle = {},


### PR DESCRIPTION
# Why

Fixes #20406

# How

The culprit for crashes was an invalid `@expo/vector-icons` import in one of the examples.

Additionally I have cleaned up code, fixed display on iOS device and added the missing dependency to all three examples used on this page.

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
