### PR TITLE
[docs] Fix default description not shown in Head component

### DIFF
--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -4,12 +4,9 @@ import type { PropsWithChildren } from 'react';
 type HeadProps = PropsWithChildren<{ title?: string; description?: string }>;
 
 const BASE_TITLE = 'Expo Documentation';
+const DEFAULT_DESCRIPTION = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
 
-const Head = ({
-  title,
-  description = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`,
-  children,
-}: HeadProps) => (
+const Head = ({ title, description, children }: HeadProps) => (
   <NextHead>
     <title>{title ? `${title} - ${BASE_TITLE}` : BASE_TITLE}</title>
     <meta charSet="utf-8" />
@@ -17,7 +14,7 @@ const Head = ({
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/static/images/favicon.ico" sizes="32x32" />
 
-    <meta name="description" content={description} />
+    <meta name="description" content={description === '' ? DEFAULT_DESCRIPTION : description} />
     <meta property="og:title" content={title} />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://docs.expo.dev/static/images/og.png" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Passing the default description text directly in the `<Head>` component is resulting in no `description` for individual docs such as API references (but works for the main/home page of docs site https://expo.dev/). For example, the Glossary currently do not have a description (which is supposed to use the default description).

<img width="1505" alt="CleanShot 2022-12-26 at 21 35 22@2x" src="https://user-images.githubusercontent.com/10234615/209566187-ec7c31c9-4646-4d72-b143-d9f18a0689ae.png">

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR creates a global variable that contains the default description text in the `<Head>` component and then conditionally render the right description to fix the current behavior.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

For pages under Tutorial or go to Glossary (http://localhost:3002/workflow/glossary-of-terms/) to see the default description (as shown below) to see it working:

<img width="1506" alt="CleanShot 2022-12-26 at 21 36 46@2x" src="https://user-images.githubusercontent.com/10234615/209566279-f39bf7c4-7f89-4cf8-af63-2694fdd2a83f.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
