### PR TITLE
[core][ios] Returning object definitions from sync functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for concurrent (async/await) functions in Swift. ([#20645](https://github.com/expo/expo/pull/20645) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Added experimental support for building the function result from the object definition. ([#20623](https://github.com/expo/expo/pull/20623) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -151,14 +151,17 @@ internal final class Conversions {
   /**
    Converts the function result to the type compatible with JavaScript.
    */
-  static func convertFunctionResult<ValueType>(_ value: ValueType?) -> Any {
+  static func convertFunctionResult<ValueType>(_ value: ValueType?, runtime: JavaScriptRuntime? = nil) -> Any {
     if let value = value as? Record {
       return value.toDictionary()
     }
     if let value = value as? [Record] {
       return value.map { $0.toDictionary() }
     }
-    return value
+    if let runtime = runtime, let value = value as? JavaScriptObjectBuilder {
+      return value.build(inRuntime: runtime)
+    }
+    return value as Any
   }
 
   // MARK: - Exceptions

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -82,12 +82,12 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   // MARK: - JavaScriptObjectBuilder
 
   func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
-    return runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args in
-      guard let self = self else {
-        throw NativeFunctionUnavailableException(name)
+    return runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak runtime, self] this, args in
+      guard let runtime = runtime else {
+        throw Exceptions.RuntimeLost()
       }
       let result = try self.call(by: this, withArguments: args)
-      return Conversions.convertFunctionResult(result)
+      return Conversions.convertFunctionResult(result, runtime: runtime)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -82,6 +82,10 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   // MARK: - JavaScriptObjectBuilder
 
   func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    // We intentionally capture a strong reference to `self`, otherwise the "detached" objects would
+    // immediately lose the reference to the definition and thus the underlying native function.
+    // It may potentially cause memory leaks, but at the time of writing this comment,
+    // the native definition instance deallocates correctly when the JS VM triggers the garbage collector.
     return runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak runtime, self] this, args in
       guard let runtime = runtime else {
         throw Exceptions.RuntimeLost()

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionBuilder.swift
@@ -1,0 +1,25 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+public protocol AnyObjectDefinitionElement: AnyDefinition {}
+
+@resultBuilder
+public struct ObjectDefinitionBuilder {
+  public static func buildBlock(_ elements: AnyObjectDefinitionElement...) -> [AnyObjectDefinitionElement] {
+    return elements
+  }
+
+  /**
+   Default implementation without any constraints that just returns type-erased element.
+   */
+  public static func buildExpression<ElementType: AnyObjectDefinitionElement>(_ element: ElementType) -> AnyObjectDefinitionElement {
+    return element
+  }
+}
+
+extension SyncFunctionComponent: AnyObjectDefinitionElement {}
+
+extension AsyncFunctionComponent: AnyObjectDefinitionElement {}
+
+extension PropertyComponent: AnyObjectDefinitionElement {}
+
+extension ConstantsDefinition: AnyObjectDefinitionElement {}

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinitionComponents.swift
@@ -1,6 +1,12 @@
 /// This file implements definition components that are allowed in any object-based definition — `ObjectDefinition`.
 /// So far only constants and functions belong to plain object.
 
+// MARK: - Object
+
+public func Object(@ObjectDefinitionBuilder @_implicitSelfCapture _ body: () -> [AnyDefinition]) -> ObjectDefinition {
+  return ObjectDefinition(definitions: body())
+}
+
 // MARK: - Constants
 
 /**

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -249,17 +249,41 @@ class FunctionSpec: ExpoSpec {
           Function("isArgNull") { (arg: Double?) -> Bool in
             return arg == nil
           }
+
+          Function("returnObjectDefinition") { (initial: Int) -> ObjectDefinition in
+            var foo = initial
+
+            return Object {
+              Function("increment") { () -> Int in
+                foo += 1
+                return foo
+              }
+            }
+          }
         })
       }
-      
+
       it("returns values") {
         expect(try runtime?.eval("expo.modules.TestModule.returnPi()").asDouble()) == Double.pi
         expect(try runtime?.eval("expo.modules.TestModule.returnNull()").isNull()) == true
       }
-      
+
       it("accepts optional arguments") {
         expect(try runtime?.eval("expo.modules.TestModule.isArgNull(3.14)").asBool()) == false
         expect(try runtime?.eval("expo.modules.TestModule.isArgNull(null)").asBool()) == true
+      }
+
+      it("returns object made from definition") {
+        let initialValue = Int.random(in: 1..<100)
+        let object = try runtime?.eval("object = expo.modules.TestModule.returnObjectDefinition(\(initialValue))")
+
+        expect(object?.kind) == .object
+        expect(object?.getObject().hasProperty("increment")) == true
+
+        let result = try runtime?.eval("object.increment()")
+
+        expect(result?.kind) == .number
+        expect(result?.getInt()) == initialValue + 1
       }
     }
   }


### PR DESCRIPTION
# Why

We came up with an idea to make it possible to return object definitions from the functions, like here

```swift
// Swift
Function("download") { () -> ObjectDefinition in
  let operation = ...

  return Object {
    Function("cancel") {
      operation.cancel()
    }
  }
}
```

It would automatically create a JS raw object with the defined function.
```javascript
// JavaScript
{
  cancel: function() {
    [native code]
  }
}
```
We can consider supporting other type of definitions as well, but this is a good start.

# How

- The `ObjectDefinition` was more like an abstract class, used by the module and class definitions. Now it can work on its own, with a separate component function and builder.
- Converter for the function results now supports converting the definitions to `JavaScriptObject` instances

# Test Plan

Added new unit test that covers the most common use case