### PR TITLE
[docs] Collapsible: correct inline code appearance in title

### DIFF
--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1nmf69-Collapsible"
     >
       <summary
-        class="css-15fupqd-Collapsible"
+        class="css-1jgn1er-Collapsible"
       >
         <div
           class="css-166ujkg-Collapsible"
@@ -199,7 +199,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1nmf69-Collapsible"
     >
       <summary
-        class="css-15fupqd-Collapsible"
+        class="css-1jgn1er-Collapsible"
       >
         <div
           class="css-166ujkg-Collapsible"
@@ -244,7 +244,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1nmf69-Collapsible"
     >
       <summary
-        class="css-15fupqd-Collapsible"
+        class="css-1jgn1er-Collapsible"
       >
         <div
           class="css-166ujkg-Collapsible"
@@ -372,7 +372,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-1nmf69-Collapsible"
         >
           <summary
-            class="css-15fupqd-Collapsible"
+            class="css-1jgn1er-Collapsible"
           >
             <div
               class="css-166ujkg-Collapsible"
@@ -677,7 +677,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       class="css-1nmf69-Collapsible"
     >
       <summary
-        class="css-15fupqd-Collapsible"
+        class="css-1jgn1er-Collapsible"
       >
         <div
           class="css-166ujkg-Collapsible"

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -78,6 +78,12 @@ const summaryStyle = css({
     marginTop: 0,
     marginBottom: 0,
   },
+
+  code: {
+    backgroundColor: theme.background.tertiary,
+    display: 'inline',
+    fontSize: '90%',
+  },
 });
 
 const markerWrapperStyle = css({


### PR DESCRIPTION
# Why

Currently, when code block is used in element with different background than default we dim it a notch for the readability and this tweak is missing for the `Collapsible` summary.

# How

Dim the `code` background in the `Collapsible` title and ensure that code font size is correct. Percentage value is based on the parent font size, so it works as tuned `inherit`, and results in slightly larger font, than currently used.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="730" alt="Screenshot 2022-12-28 at 12 12 00" src="https://user-images.githubusercontent.com/719641/209804182-552bd5b9-c7d8-4e3d-8e3e-598dc89bd7ad.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
