### PR TITLE
[docs] Update installing-updates.mdx

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -28,7 +28,7 @@ Once installation is complete, apply the changes from the following diffs to con
 
 You'll need to modify **index.js** to import `expo-asset` early in your app, to be able to update assets with updates.
 
-```diff app.json
+```diff index.js
 + import 'expo-asset';
 import { registerRootComponent } from 'expo';
 


### PR DESCRIPTION
# Why

This code block should be added to index.js, not app.json. I believe this was a typo.

Page url: https://docs.expo.dev/bare/installing-updates/#configuration-in-javascript-and-json

# How

# Test Plan

# Checklist


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
