### PR TITLE
[fabric-tester] Update expo-image example and add expo-apple-authentication

### DIFF
--- a/apps/fabric-tester/App.tsx
+++ b/apps/fabric-tester/App.tsx
@@ -1,7 +1,8 @@
+import * as AppleAuthentication from 'expo-apple-authentication';
 import { Video } from 'expo-av';
 import { BlurView } from 'expo-blur';
 import { Camera, CameraType } from 'expo-camera';
-import { Image, ImageContentFit } from 'expo-image';
+import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import React, { useCallback, useRef, useState } from 'react';
 import {
@@ -14,6 +15,7 @@ import {
   ScrollView,
   TouchableOpacity,
   Platform,
+  Alert,
 } from 'react-native';
 
 function randomColor() {
@@ -36,6 +38,7 @@ export default class App extends React.PureComponent {
           {Platform.OS === 'ios' && <BlurExample />}
           <VideoExample />
           <CameraExample />
+          <AppleAuthenticationExample />
         </ScrollView>
       </SafeAreaView>
     );
@@ -47,11 +50,7 @@ export function ImageExample() {
 
   return (
     <View style={styles.exampleContainer}>
-      <Image
-        style={styles.image}
-        contentFit={ImageContentFit.COVER}
-        source={{ uri: `https://picsum.photos/id/${seed}/1000/1000` }}
-      />
+      <Image style={styles.image} source={{ uri: `https://picsum.photos/id/${seed}/1000/1000` }} />
     </View>
   );
 }
@@ -186,6 +185,36 @@ export function CameraExample() {
   );
 }
 
+export function AppleAuthenticationExample() {
+  const signIn = useCallback(async () => {
+    try {
+      await AppleAuthentication.signInAsync({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+        state: 'this-is-a-test',
+      });
+    } catch (error) {
+      Alert.alert(error.code, error.message);
+    }
+  }, []);
+
+  return (
+    <View style={styles.exampleContainer}>
+      <View style={{ flex: 1, alignItems: 'center' }}>
+        <AppleAuthentication.AppleAuthenticationButton
+          buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+          buttonType={AppleAuthentication.AppleAuthenticationButtonType.CONTINUE}
+          cornerRadius={10}
+          onPress={signIn}
+          style={{ width: 250, height: 44, margin: 15 }}
+        />
+      </View>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -213,7 +242,6 @@ const styles = StyleSheet.create({
     height: 200,
   },
   blurImage: {
-    resizeMode: 'cover',
     ...StyleSheet.absoluteFillObject,
   },
   blurContainer: {

--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -16,6 +16,8 @@ PODS:
     - ExpoModulesCore
   - Expo (47.0.1):
     - ExpoModulesCore
+  - ExpoAppleAuthentication (5.0.1):
+    - ExpoModulesCore
   - ExpoBlur (12.0.1):
     - ExpoModulesCore
   - ExpoImage (1.0.0-alpha.3):
@@ -710,6 +712,7 @@ DEPENDENCIES:
   - EXFileSystem (from `../../../packages/expo-file-system/ios`)
   - EXFont (from `../../../packages/expo-font/ios`)
   - Expo (from `../../../packages/expo`)
+  - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoBlur (from `../../../packages/expo-blur/ios`)
   - ExpoImage (from `../../../packages/expo-image/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
@@ -789,6 +792,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-font/ios"
   Expo:
     :path: "../../../packages/expo"
+  ExpoAppleAuthentication:
+    :path: "../../../packages/expo-apple-authentication/ios"
   ExpoBlur:
     :path: "../../../packages/expo-blur/ios"
   ExpoImage:
@@ -884,6 +889,7 @@ SPEC CHECKSUMS:
   EXFileSystem: ed61548927905e157b95b3b49bd83a26ff24e1ce
   EXFont: 319606bfe48c33b5b5063fb0994afdc496befe80
   Expo: 8ee43334b657268299454a67f30f60e5a8ca89d9
+  ExpoAppleAuthentication: c0e39d8cf1aec4495e719ea108f5fb8c9970c2db
   ExpoBlur: d200843e33d6f0230ddb6b412d6c67baa0dc2c88
   ExpoImage: 191ac66d00b42323adebd48d594001a4b70fa336
   ExpoKeepAwake: 69b59d0a8d2b24de9f82759c39b3821fec030318

--- a/apps/fabric-tester/ios/fabrictester.xcodeproj/project.pbxproj
+++ b/apps/fabric-tester/ios/fabrictester.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = fabrictester/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		F171B05D295C5FAD00CB8AB7 /* fabrictester.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = fabrictester.entitlements; path = fabrictester/fabrictester.entitlements; sourceTree = "<group>"; };
 		FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-fabrictester/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -50,15 +51,16 @@
 		13B07FAE1A68108700A75B9A /* fabrictester */ = {
 			isa = PBXGroup;
 			children = (
-				BB2F792B24A3F905000567C9 /* Supporting */,
-				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
+				F171B05D295C5FAD00CB8AB7 /* fabrictester.entitlements */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
+				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FB71A68108700A75B9A /* main.m */,
-				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
 				A0DB1EF9BC6248218DEE76C0 /* noop-file.swift */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+				BB2F792B24A3F905000567C9 /* Supporting */,
 			);
 			name = fabrictester;
 			sourceTree = "<group>";

--- a/apps/fabric-tester/ios/fabrictester/fabrictester.entitlements
+++ b/apps/fabric-tester/ios/fabrictester/fabrictester.entitlements
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>development</string>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
 </plist>

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -9,12 +9,13 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "~47.0.0-alpha.1",
+    "expo": "~47.0.1",
+    "expo-apple-authentication": "~5.0.1",
     "expo-av": "~13.1.0",
     "expo-blur": "~12.1.0",
-    "expo-camera": "~13.0.0-beta.1",
-    "expo-image": "^1.0.0-alpha.1",
-    "expo-linear-gradient": "~12.0.0-beta.1",
+    "expo-camera": "~13.0.0",
+    "expo-image": "^1.0.0-alpha.4",
+    "expo-linear-gradient": "~12.0.1",
     "expo-splash-screen": "~0.17.0",
     "react": "18.1.0",
     "react-dom": "18.0.0",


### PR DESCRIPTION
# Why

fabric-tester app needs an update for some recent changes in expo-image and also a new example for expo-apple-authentication

# How

- Using `ImageContentFit` enum is no longer working, we changed it to just strings. In case of fabric-tester, we can just remove `contentFit` prop since `cover` is the default option already. 
- Added example for `expo-apple-authentication`. It required me to add entitlements for Sign In with Apple capability

# Test Plan

It just works