### PR TITLE
[core][ios] Make Enumerable implement CaseIterable to get rid of unsafe pointers

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 ### 💡 Others
 
+- [iOS] Make `Enumerable` protocol implement `CaseIterable` to get rid of operating on unsafe pointers. ([#20640](https://github.com/expo/expo/pull/20640) by [@tsapeta](https://github.com/tsapeta))
+
 ## 1.0.4 - 2022-12-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/ios/Swift/Arguments/Enumerable.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Enumerable.swift
@@ -3,7 +3,7 @@
 /**
  A protocol that allows converting raw values to enum cases.
  */
-public protocol Enumerable: AnyArgument {
+public protocol Enumerable: AnyArgument, CaseIterable {
   /**
    Tries to create an enum case using given raw value.
    May throw errors, e.g. when the raw value doesn't match any case.
@@ -44,21 +44,7 @@ public extension Enumerable where Self: RawRepresentable, Self: Hashable {
   }
 
   static var allRawValues: [Any] {
-    // Be careful — it operates on unsafe pointers!
-    let sequence = AnySequence { () -> AnyIterator<RawValue> in
-      var raw = 0
-      return AnyIterator {
-        let current: Self? = withUnsafePointer(to: &raw) { ptr in
-          ptr.withMemoryRebound(to: Self.self, capacity: 1) { $0.pointee }
-        }
-        guard let value = current?.rawValue else {
-          return nil
-        }
-        raw += 1
-        return value
-      }
-    }
-    return Array(sequence)
+    return allCases.map { $0.rawValue }
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
@@ -4,7 +4,7 @@
  A dynamic type representing an enum that conforms to `Enumerable`.
  */
 internal struct DynamicEnumType: AnyDynamicType {
-  let innerType: Enumerable.Type
+  let innerType: any Enumerable.Type
 
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return innerType == InnerType.self

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
@@ -18,7 +18,7 @@ internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let ConvertibleType = T.self as? Convertible.Type {
     return DynamicConvertibleType(innerType: ConvertibleType)
   }
-  if let EnumType = T.self as? Enumerable.Type {
+  if let EnumType = T.self as? any Enumerable.Type {
     return DynamicEnumType(innerType: EnumType)
   }
   if let SharedObjectType = T.self as? SharedObject.Type {


### PR DESCRIPTION
# Why

Converting enum cases to an array of raw values was a bit risky as it is operating on unsafe pointers. It turned out there is [`CaseIterable`](https://developer.apple.com/documentation/swift/caseiterable) protocol. The compiler automatically provides an implementation of `allCases` property for enums implementing this protocol.

# How

- Added `CaseIterable` to the conformance list of `Enumerable`
- Removed code that operated on unsafe pointers to get all raw values and replaced with `allCases` mapped to their raw values

# Test Plan

There are already a bunch of unit tests for enums, so I believe they cover what we need to test
