### PR TITLE
[docs] Add redirects based on Sentry report of the week

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -202,6 +202,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/push-notifications/': '/push-notifications/overview/',
   '/guides/using-fcm/': '/push-notifications/using-fcm/',
 
+  // Redirects based on Sentry (29/12/2022)
+  '/push-notifications/': '/push-notifications/overview/',
+
   // Renaming a submit section
   '/submit/submit-ios': '/submit/ios/',
   '/submit/submit-android': '/submit/android/',

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -188,21 +188,17 @@ const RENAMED_PAGES: Record<string, string> = {
   // Errors and debugging is better suited for getting started than tutorial
   '/tutorial/errors/': '/get-started/errors/',
 
-  // Additional redirects based on Sentry (04/28/2020)
-  '/next-steps/installation/': '/get-started/installation/',
-  '/guides/release-channels/': '/archive/classic-updates/release-channels/',
-
   // Redirects based on Next 9 upgrade (09/11/2020)
   '/api/': '/versions/latest/',
 
   // Redirect to expand Expo Accounts and permissions
   '/guides/account-permissions/': '/accounts/personal/',
 
-  // Redirects based on Sentry (11/26/2020)
+  // Redirects based on Sentry reports
+  '/next-steps/installation/': '/get-started/installation/',
+  '/guides/release-channels/': '/archive/classic-updates/release-channels/',
   '/guides/push-notifications/': '/push-notifications/overview/',
   '/guides/using-fcm/': '/push-notifications/using-fcm/',
-
-  // Redirects based on Sentry (29/12/2022)
   '/push-notifications/': '/push-notifications/overview/',
 
   // Renaming a submit section

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -291,4 +291,5 @@ const RENAMED_PAGES: Record<string, string> = {
   '/versions/latest/sdk/appstate/': '/versions/latest/react-native/appstate/',
   '/versions/latest/sdk/google/': '/guides/authentication/',
   '/versions/latest/sdk/amplitude/': '/guides/using-analytics/',
+  '/versions/latest/sdk/util/': '/versions/latest/',
 };

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -171,6 +171,7 @@ redirects[versions/latest/sdk/app-auth]=guides/authentication/
 redirects[versions/latest/sdk/google-sign-in]=guides/authentication/
 redirects[versions/latest/sdk/google]=guides/authentication/
 redirects[versions/latest/sdk/amplitude/]=guides/using-analytics/
+redirects[versions/latest/sdk/util/]=versions/latest/
 
 # Redirects based on Sentry reports
 redirects[push-notifications]=push-notifications/overview/

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -172,6 +172,9 @@ redirects[versions/latest/sdk/google-sign-in]=guides/authentication/
 redirects[versions/latest/sdk/google]=guides/authentication/
 redirects[versions/latest/sdk/amplitude/]=guides/using-analytics/
 
+# Redirects based on Sentry reports
+redirects[push-notifications]=push-notifications/overview/
+
 echo "::group::[5/6] Add custom redirects"
 for i in "${!redirects[@]}" # iterate over keys
 do


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This week's Sentry report showed that the redirect for `/push-notifications/` fails and there have been significant number of events captured based on this. Similarly, `/versions/sdk/latest/util/` is also reported since it doesn't have a redirect.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding redirects for the URLs reported in Sentry.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
