### PR TITLE
[core][ios] Support for concurrent (async/await) functions in Swift

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for concurrent (async/await) functions in Swift. ([#20645](https://github.com/expo/expo/pull/20645) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -60,6 +60,10 @@ extension AnyFunction {
     return argumentsCount - trailingOptionalArgumentsCount
   }
 
+  var argumentsCount: Int {
+    return dynamicArgumentTypes.count
+  }
+
   /**
    Calls the function just like `call(by:withArguments:callback:)`, but without an owner
    and with an empty callback. Might be useful when you only want to call the function,

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
@@ -45,6 +45,7 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
       let result: Result<Any, Exception>
 
       do {
+        // swiftlint:disable force_cast
         let argumentsTuple = try Conversions.toTuple(arguments) as! Args
         let returnValue = try await action(argumentsTuple)
 
@@ -232,7 +233,17 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 /**
  Asynchronous function with eight arguments.
  */
-public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
+public func AsyncFunction<
+  R,
+  A0: AnyArgument,
+  A1: AnyArgument,
+  A2: AnyArgument,
+  A3: AnyArgument,
+  A4: AnyArgument,
+  A5: AnyArgument,
+  A6: AnyArgument,
+  A7: AnyArgument
+>(
   _ name: String,
   @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) async throws -> R
 ) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
@@ -1,0 +1,254 @@
+import Dispatch
+
+public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyFunction {
+  typealias ClosureType = (Args) async throws -> ReturnType
+
+  let action: ClosureType
+
+  init(
+    _ name: String,
+    firstArgType: FirstArgType.Type,
+    dynamicArgumentTypes: [AnyDynamicType],
+    _ action: @escaping ClosureType
+  ) {
+    self.name = name
+    self.action = action
+    self.dynamicArgumentTypes = dynamicArgumentTypes
+  }
+
+  // MARK: - AnyFunction
+
+  let name: String
+
+  let dynamicArgumentTypes: [AnyDynamicType]
+
+  var takesOwner: Bool = false
+
+  func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> Void) {
+    let arguments: [Any]
+
+    do {
+      arguments = concat(
+        arguments: try cast(arguments: args, forFunction: self),
+        withOwner: owner,
+        forFunction: self
+      )
+    } catch let error as Exception {
+      callback(.failure(error))
+      return
+    } catch {
+      callback(.failure(UnexpectedException(error)))
+      return
+    }
+
+    Task { [arguments] in
+      let result: Result<Any, Exception>
+
+      do {
+        let argumentsTuple = try Conversions.toTuple(arguments) as! Args
+        let returnValue = try await action(argumentsTuple)
+
+        result = .success(returnValue)
+      } catch let error as Exception {
+        result = .failure(FunctionCallException(name).causedBy(error))
+      } catch {
+        result = .failure(UnexpectedException(error))
+      }
+
+      callback(result)
+    }
+  }
+
+  // MARK: - JavaScriptObjectBuilder
+
+  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+    return runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args, resolve, reject in
+      guard let self = self else {
+        let exception = NativeFunctionUnavailableException(name)
+        return reject(exception.code, exception.description, nil)
+      }
+      self.call(by: this, withArguments: args) { result in
+        switch result {
+        case .failure(let error):
+          reject(error.code, error.description, nil)
+        case .success(let value):
+          resolve(value)
+        }
+      }
+    }
+  }
+}
+
+/**
+ Asynchronous function without arguments.
+ */
+public func AsyncFunction<R>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping () async throws -> R
+) -> ConcurrentFunctionDefinition<(), Void, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: Void.self,
+    dynamicArgumentTypes: [],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with one argument.
+ */
+public func AsyncFunction<R, A0: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [~A0.self],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with two arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [~A0.self, ~A1.self],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with three arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with four arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self,
+      ~A3.self
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with five arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3, A4), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self,
+      ~A3.self,
+      ~A4.self
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with six arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3, A4, A5), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self,
+      ~A3.self,
+      ~A4.self,
+      ~A5.self
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with seven arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3, A4, A5, A6), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self,
+      ~A3.self,
+      ~A4.self,
+      ~A5.self,
+      ~A6.self
+    ],
+    closure
+  )
+}
+
+/**
+ Asynchronous function with eight arguments.
+ */
+public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument, A7: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, A1, A2, A3, A4, A5, A6, A7) async throws -> R
+) -> ConcurrentFunctionDefinition<(A0, A1, A2, A3, A4, A5, A6, A7), A0, R> {
+  return ConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: [
+      ~A0.self,
+      ~A1.self,
+      ~A2.self,
+      ~A3.self,
+      ~A4.self,
+      ~A5.self,
+      ~A6.self,
+      ~A7.self
+    ],
+    closure
+  )
+}

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
@@ -1,18 +1,22 @@
-import Dispatch
+// Copyright 2022-present 650 Industries. All rights reserved.
 
+/**
+ Represents a concurrent function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
+ As opposed to `AsyncFunctionComponent`, it can leverage the new Swift's concurrency model and take the async/await closure.
+ */
 public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyFunction {
   typealias ClosureType = (Args) async throws -> ReturnType
 
-  let action: ClosureType
+  let body: ClosureType
 
   init(
     _ name: String,
     firstArgType: FirstArgType.Type,
     dynamicArgumentTypes: [AnyDynamicType],
-    _ action: @escaping ClosureType
+    _ body: @escaping ClosureType
   ) {
     self.name = name
-    self.action = action
+    self.body = body
     self.dynamicArgumentTypes = dynamicArgumentTypes
   }
 
@@ -41,13 +45,15 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
       return
     }
 
+    // Switch from the synchronous context to asynchronous
     Task { [arguments] in
       let result: Result<Any, Exception>
 
       do {
+        // TODO: Right now we force cast the tuple in all types of functions, but we should throw another exception here.
         // swiftlint:disable force_cast
         let argumentsTuple = try Conversions.toTuple(arguments) as! Args
-        let returnValue = try await action(argumentsTuple)
+        let returnValue = try await body(argumentsTuple)
 
         result = .success(returnValue)
       } catch let error as Exception {
@@ -81,7 +87,7 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
 }
 
 /**
- Asynchronous function without arguments.
+ Concurrently-executing asynchronous function without arguments.
  */
 public func AsyncFunction<R>(
   _ name: String,
@@ -96,7 +102,7 @@ public func AsyncFunction<R>(
 }
 
 /**
- Asynchronous function with one argument.
+ Concurrently-executing asynchronous function with one argument.
  */
 public func AsyncFunction<R, A0: AnyArgument>(
   _ name: String,
@@ -111,7 +117,7 @@ public func AsyncFunction<R, A0: AnyArgument>(
 }
 
 /**
- Asynchronous function with two arguments.
+ Concurrently-executing asynchronous function with two arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
   _ name: String,
@@ -126,7 +132,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument>(
 }
 
 /**
- Asynchronous function with three arguments.
+ Concurrently-executing asynchronous function with three arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
   _ name: String,
@@ -145,7 +151,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
 }
 
 /**
- Asynchronous function with four arguments.
+ Concurrently-executing asynchronous function with four arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument>(
   _ name: String,
@@ -165,7 +171,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 }
 
 /**
- Asynchronous function with five arguments.
+ Concurrently-executing asynchronous function with five arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument>(
   _ name: String,
@@ -186,7 +192,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 }
 
 /**
- Asynchronous function with six arguments.
+ Concurrently-executing asynchronous function with six arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument>(
   _ name: String,
@@ -208,7 +214,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 }
 
 /**
- Asynchronous function with seven arguments.
+ Concurrently-executing asynchronous function with seven arguments.
  */
 public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: AnyArgument, A4: AnyArgument, A5: AnyArgument, A6: AnyArgument>(
   _ name: String,
@@ -231,7 +237,7 @@ public func AsyncFunction<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, 
 }
 
 /**
- Asynchronous function with eight arguments.
+ Concurrently-executing asynchronous function with eight arguments.
  */
 public func AsyncFunction<
   R,


### PR DESCRIPTION
# Why

It was not yet possible to use Swift's async/await in `AsyncFunction` component.
With the support for concurrent functions, we can write

```swift
AsyncFunction("download") { (url: URL) async in
  let (data, _) = try await URLSession.shared.data(from: url)
  return String(data: data, encoding: .utf8)
}
```

Instead of using a promise and callbacks 🙂 

# How

Added separate definition class for concurrently-executed asynchronous function. In the future we could combine it with the original async one, but this would require some refactor that I don't want to do right now because we can't use async functions in unit tests yet, so a regression might occur.

# Test Plan

It builds and I could call the above function from JS. Additionally I checked the performance by calling a no-op functions hundred of thousands of times and the concurrent async function seems to be very slightly faster than an async function using GCD dispatch queues but it started to be noticeable above 500 thousands iterations.