### PR TITLE
[docs] Fix typo in create a modal chapter in tutorial

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -507,7 +507,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       /* rest of the code remains unchanged */
-      <EmojiPicker modalVisible={modalVisible} onClose={onModalClose}>
+      <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
         /* @info Render the EmojiList component inside the EmojiPicker component. */
         <EmojiList onSelect={setPickedEmoji} onCloseModal={onModalClose} />
         /* @end */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.

The expo tutorial docs have an error, link to docs: https://docs.expo.dev/tutorial/create-a-modal/
In "Step 3: Create an emoji picker modal", we see the code:  '<EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>'.
Later, in "Step 4: Display a list of emojis", the same line has incorrect changes which cause an error.  Here, the line has been changed to: "<EmojiPicker modalVisible={modalVisible} onClose={onModalClose}>".
On the command line, this is my error, "ReferenceError: Can't find variable: modalVisible"
-->

# How

<!--
How did you build this feature or fix this bug and why?

The bug can be fixed by fixing the line in step 4 back to the line in step 3.
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.

To reproduce the bug, go to "Step 4: Display a list of Emoji" in the App.js section and use the code with the line: "`<EmojiPicker modalVisible={modalVisible} onClose={onModalClose}>`" instead of `<EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>` and you'll notice that the error appears.

I changed the line from the what was shown in step4 back to the line given in step3. 
TERMINAL OUTPUT: 
```
ERROR  ReferenceError: Can't find variable: modalVisible
This error is located at:
    in App (created by withDevTools(App))
    in withDevTools(App)
    in RCTView (created by View)
    in View (created by AppContainer)
    in RCTView (created by View)
    in View (created by AppContainer)
    in AppContainer
    in main(RootComponent)
```
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
