### PR TITLE
[docs] APISection tweaks, prevent hydration issue

### DIFF
--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -79,20 +79,21 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(
     const component = props.children as JSX.Element;
     const children = component.props.children || '';
 
-    const heading = props.nestingLevel
-      ? props.headingManager.addHeading(
-          children,
-          props.nestingLevel,
-          props.additionalProps,
-          props.id
-        )
-      : undefined;
-    const permalinkKey = props.id ?? heading?.slug;
+    if (!props.nestingLevel) {
+      return children;
+    }
+
+    const heading = props.headingManager.addHeading(
+      children,
+      props.nestingLevel,
+      props.additionalProps,
+      props.id
+    );
 
     return (
       <PermalinkBase component={component} style={props.additionalProps?.style}>
-        <LinkBase css={STYLES_PERMALINK_LINK} href={'#' + permalinkKey} ref={heading?.ref}>
-          <span css={STYLES_PERMALINK_TARGET} id={permalinkKey} />
+        <LinkBase css={STYLES_PERMALINK_LINK} href={'#' + heading.slug} ref={heading.ref}>
+          <span css={STYLES_PERMALINK_TARGET} id={heading.slug} />
           <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
           <span css={STYLES_PERMALINK_ICON}>
             <PermalinkIcon />

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1124,7 +1124,7 @@ This should come from the user field of an
       </div>
     </blockquote>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -1307,7 +1307,7 @@ value depending on the state of the credential.
       Determine if the current device's operating system supports Apple authentication.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -1571,7 +1571,7 @@ value depending on the state of the credential.
 Calling this method will show the sign in modal before actually refreshing the user credentials.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -1892,7 +1892,7 @@ You can use
 the user, since this remains the same for apps released by the same developer.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -2200,7 +2200,7 @@ from using
        methods.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -2496,7 +2496,7 @@ sign-out operation.
     </div>
     <br />
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -7283,7 +7283,7 @@ Same as
 This can be used to quickly create specific permission hooks in every module.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="css-1gu5rqd-TextComponent"
@@ -7366,7 +7366,7 @@ This can be used to quickly create specific permission hooks in every module.
       </pre>
     </pre>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -7603,7 +7603,7 @@ This can be used to quickly create specific permission hooks in every module.
       Checks user's permissions for accessing the camera.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -7805,7 +7805,7 @@ This can be used to quickly create specific permission hooks in every module.
       .
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -8141,7 +8141,7 @@ the platform.
       Scan bar codes from the image given by the URL.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -8368,7 +8368,7 @@ code.
       An object obtained by permissions get and request functions.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -10314,7 +10314,7 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -10592,7 +10592,7 @@ exports[`APISection expo-pedometer 1`] = `
       Get the step count between two dates.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -10834,7 +10834,7 @@ a start date that is more than seven days in the past returns only the available
       Returns whether the pedometer is enabled on the device.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -11001,7 +11001,7 @@ available on this device.
       </a>
     </h3>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -11250,7 +11250,7 @@ provided with a single argument that is
       Subscribe to pedometer updates.
     </p>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -11469,7 +11469,7 @@ provided with a single argument that is
       </a>
     </h3>
     <div
-      class="css-r72x6k"
+      class="css-1cc2eo9"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -50,7 +50,7 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   !child?.implementationOf;
 
 const remapClass = (clx: ClassDefinitionData) => {
-  clx.isSensor = clx.name.endsWith('Sensor') || clx.extendedTypes?.[0].name === 'DeviceSensors';
+  clx.isSensor = !!classNamesMap[clx.name] || Object.values(classNamesMap).includes(clx.name);
   clx.name = classNamesMap[clx.name] ?? clx.name;
 
   if (clx.isSensor && clx.extendedTypes) {

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -7,6 +7,7 @@ import {
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import { renderMethod } from '~/components/plugins/api/APISectionMethods';
+import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
 import { renderProp } from '~/components/plugins/api/APISectionProps';
 import {
   CommentTextBlock,
@@ -49,7 +50,7 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
   !child?.implementationOf;
 
 const remapClass = (clx: ClassDefinitionData) => {
-  clx.isSensor = clx.name.endsWith('Sensor');
+  clx.isSensor = clx.name.endsWith('Sensor') || clx.extendedTypes?.[0].name === 'DeviceSensors';
   clx.name = classNamesMap[clx.name] ?? clx.name;
 
   if (clx.isSensor && clx.extendedTypes) {
@@ -75,6 +76,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
   return (
     <div key={`class-definition-${name}`} css={[STYLES_APIBOX, STYLES_APIBOX_NESTED]}>
       <APISectionDeprecationNote comment={comment} />
+      <APISectionPlatformTags comment={comment} prefix="Only for:" />
       <H3Code tags={getTagNamesList(comment)}>
         <CODE>{name}</CODE>
       </H3Code>
@@ -102,7 +104,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
           )}
         </P>
       )}
-      <CommentTextBlock comment={comment} />
+      <CommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>
           <div css={STYLES_NESTED_SECTION_HEADER}>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -682,7 +682,7 @@ export const STYLES_NESTED_SECTION_HEADER = css({
   borderTop: `1px solid ${theme.border.default}`,
   borderBottom: `1px solid ${theme.border.default}`,
   margin: `${spacing[4]}px -${spacing[5]}px ${spacing[4]}px`,
-  padding: `${spacing[2.5]}px ${spacing[5]}px`,
+  padding: `${spacing[2]}px ${spacing[5]}px`,
   backgroundColor: theme.background.secondary,
 
   h4: {

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
   <div
-    class="css-r72x6k"
+    class="css-1cc2eo9"
   >
     <h4
       class="css-1gu5rqd-TextComponent"


### PR DESCRIPTION
# Why

This PR addresses small display issue and hydration problem on the pages using `APISection` component.

# How

Ensure that classes platform labels are displayed correctly, prior this change they were displayed mid-content.

Fix hydration issue popping out on all sensor pages, it was caused by heading manger, but the culprit was a client side remap of data object, which lead to incorrect check result and cause re-render.

Additionally, I have clean up the heading manager flow a bit and made a small UI tweak for the nested headers in API boxes.

# Test Plan

The changes have been tested by running docs website locally. Lint check and tests are passing, snapshot has been regenerated.

# Preview

<img width="604" alt="Screenshot 2022-12-30 at 09 40 19" src="https://user-images.githubusercontent.com/719641/210054862-f56dbbde-a7ba-475b-9aee-65ed2abf7acc.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
