### PR TITLE
[docs] fix tooltip calculation for ToC elements

### DIFF
--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
+import Link from 'next/link';
 import * as React from 'react';
 
 import { BASE_HEADING_LEVEL, Heading, HeadingType } from '~/common/headingManager';
@@ -89,7 +90,8 @@ const isOverflowing = (el: HTMLElement) => {
   }
 
   const childrenWidth = Array.from(el.children).reduce((sum, child) => sum + child.scrollWidth, 0);
-  return childrenWidth >= el.scrollWidth - parseInt(el.style.paddingLeft, 10);
+  const indent = parseInt(window.getComputedStyle(el).paddingLeft, 10);
+  return childrenWidth >= el.scrollWidth - indent;
 };
 
 type TooltipProps = React.PropsWithChildren<{
@@ -145,7 +147,7 @@ const DocumentationSidebarRightLink = React.forwardRef<HTMLAnchorElement, Sideba
             {displayTitle}
           </Tooltip>
         )}
-        <a
+        <Link
           ref={ref}
           onMouseOver={onMouseOver}
           onMouseOut={onMouseOut}
@@ -167,7 +169,7 @@ const DocumentationSidebarRightLink = React.forwardRef<HTMLAnchorElement, Sideba
               ))}
             </div>
           ) : undefined}
-        </a>
+        </Link>
       </>
     );
   }


### PR DESCRIPTION
# Why

Fixes:
* https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1672387896944779

# How

While switching to the new HTML/Markdown components we have move the ToC element indent from raw `style` to the Emotion class, which lead to `NaN` in the overflow calculation (since all non set style values are an empty string).

To fix that we need to relay now on the computed styles. Additionally, I have replaced missed in refactor `a` tag with Next `Link` component.

# Test Plan

The changes have been tested by running docs website locally and tooltips are appearing as expected.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
