### PR TITLE
[android][barcode-scanner] Rename ExpoBarCodeScanner Module on Android

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🎉 New features
 
 - Native module for barcode scanner view is now written in Swift using the new API. ([#20441](https://github.com/expo/expo/pull/20441) by [@alanhughes](https://github.com/alanjhughes))
+- Renamed module on Android. ([#20662](https://github.com/expo/expo/pull/20662) by [@alanhughes](https://github.com/alanjhughes))
 
 ## 12.1.0 - 2022-11-23
 

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerModule.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerModule.kt
@@ -98,7 +98,7 @@ class BarCodeScannerModule(
   }
 
   companion object {
-    private const val TAG = "ExpoBarCodeScannerModule"
+    private const val TAG = "ExpoBarCodeScanner"
     private const val ERROR_TAG = "E_BARCODE_SCANNER"
   }
 }

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewManager.kt
@@ -48,6 +48,6 @@ class BarCodeScannerViewManager(
   }
 
   companion object {
-    private const val TAG = "ExpoBarCodeScannerView"
+    private const val TAG = "ExpoBarCodeScanner"
   }
 }


### PR DESCRIPTION
# Why
While migrating the view manager for barcode-scanner to the new modules API on iOS, the module name was changed. This also needs to be changed on Android

# How
Changed the name

# Test Plan
NCL works as before