### PR TITLE
[template] Default fallback route set in create expo app template 

### DIFF
--- a/templates/expo-template-tabs/navigation/LinkingConfiguration.ts
+++ b/templates/expo-template-tabs/navigation/LinkingConfiguration.ts
@@ -12,6 +12,7 @@ import { RootStackParamList } from '../types';
 const linking: LinkingOptions<RootStackParamList> = {
   prefixes: [Linking.createURL('/')],
   config: {
+    initialRouteName: 'Root',
     screens: {
       Root: {
         screens: {


### PR DESCRIPTION
# Why
[expo web]
There is no default fallback route on code, so if you reload after moving "modalscreen", the back icon disappears.

# How
Just add fallback route "Root"
https://reactnavigation.org/docs/configuring-links/#rendering-an-initial-route

# Test Plan
- before
lunch expo web -> click right top icon -> move to modalscreen -> check display back button -> refresh(cmd + r) -> hide back button

- after
lunch expo web -> click right top icon -> move to modalscreen -> check display back button -> refresh(cmd + r) -> back button still display

# Checklist
N/A

