### PR TITLE
[docs] Add redirect based on weekly Sentry report

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -200,6 +200,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/push-notifications/': '/push-notifications/overview/',
   '/guides/using-fcm/': '/push-notifications/using-fcm/',
   '/push-notifications/': '/push-notifications/overview/',
+  '/distribution/hosting-your-app/': '/distribution/publishing-websites/',
 
   // Renaming a submit section
   '/submit/submit-ios': '/submit/ios/',

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -136,6 +136,7 @@ redirects[guides/testing-on-devices]=workflow/run-on-device
 redirects[distribution/uploading-apps]=submit/introduction
 redirects[guides/setup-native-firebase/]=guides/using-firebase
 redirects[guides/using-clojurescript/]=/
+redirects[distribution/hosting-your-app/]=distribution/publishing-websites/
 
 # We should change this redirect to a more general EAS guide later
 redirects[guides/setting-up-continuous-integration]=build/building-on-ci


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This week in Sentry reports, the URL `/distribution/hosting-your-app/` doesn't have a redirect.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a redirect for the URL path causing a high number of events.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
