### PR TITLE
[docs] fix font in diff block component

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -59,7 +59,7 @@ export default function App({ Component, pageProps }: AppProps) {
               'html, body, kbd, button, input, select': {
                 fontFamily: regularFont.style.fontFamily,
               },
-              'code, pre': {
+              'code, pre, table.diff': {
                 fontFamily: monospaceFont.style.fontFamily,
               },
             })}


### PR DESCRIPTION
# Why

When switching to Next 13 font package I have missed setting the correct font for the diff blocks.

# How

Apply monospace font rule for the diff block container.

# Test Plan

The change has been tested by running docs website locally.

# Preview

<img width="513" alt="Screenshot 2023-01-02 at 11 06 48" src="https://user-images.githubusercontent.com/719641/210217335-791091f7-8f47-47bb-9c18-c51b3bb61d6c.png">
