### PR TITLE
[docs] small batch of tweaks and fixes

### DIFF
--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from 'react';
 
-import { STYLES_APIBOX } from '~/components/plugins/api/APISectionUtils';
+import { STYLES_APIBOX, STYLES_APIBOX_WRAPPER } from '~/components/plugins/api/APISectionUtils';
 import { PlatformName } from '~/types/common';
 import { PlatformTags } from '~/ui/components/Tag';
 import { H3 } from '~/ui/components/Text';
@@ -13,7 +13,7 @@ type APIBoxProps = PropsWithChildren<{
 
 export const APIBox = ({ header, platforms, children, className }: APIBoxProps) => {
   return (
-    <div css={STYLES_APIBOX} className={className}>
+    <div css={[STYLES_APIBOX, STYLES_APIBOX_WRAPPER]} className={className}>
       {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
       {header && <H3 tags={platforms}>{header}</H3>}
       {children}

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -5010,7 +5010,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-149efi7-PlatformTag"
+        class="css-mfw8bi-PlatformTag"
       >
         <svg
           color="var(--expo-theme-palette-blue-900)"
@@ -5030,7 +5030,7 @@ OAuth 2.0 protocol
           />
         </svg>
         <span
-          class="css-1y4xxhe-PlatformTag"
+          class="css-6g4m4t-PlatformTag"
         >
           iOS 13.2+
         </span>

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="css-h5ouib-AppConfigProperty"
+    class="css-mhnilp-AppConfigProperty"
   >
     <p
       class="  css-yszm2s-TextComponent"
@@ -76,7 +76,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Name of your app.
     </p>
     <details
-      class="css-1nmf69-Collapsible"
+      class="css-1a7iuj-Collapsible"
     >
       <summary
         class="css-1jgn1er-Collapsible"
@@ -123,7 +123,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     <div />
   </div>
   <div
-    class="css-h5ouib-AppConfigProperty"
+    class="css-mhnilp-AppConfigProperty"
   >
     <p
       class="  css-yszm2s-TextComponent"
@@ -196,7 +196,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Configuration for the bottom navigation bar on Android.
     </p>
     <details
-      class="css-1nmf69-Collapsible"
+      class="css-1a7iuj-Collapsible"
     >
       <summary
         class="css-1jgn1er-Collapsible"
@@ -241,7 +241,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </details>
     <details
-      class="css-1nmf69-Collapsible"
+      class="css-1a7iuj-Collapsible"
     >
       <summary
         class="css-1jgn1er-Collapsible"
@@ -287,7 +287,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
     <div>
       <div
-        class="css-h5ouib-AppConfigProperty"
+        class="css-mhnilp-AppConfigProperty"
       >
         <p
           class="  css-yszm2s-TextComponent"
@@ -369,7 +369,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="css-1nmf69-Collapsible"
+          class="css-1a7iuj-Collapsible"
         >
           <summary
             class="css-1jgn1er-Collapsible"
@@ -415,7 +415,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </details>
         <div>
           <div
-            class="css-h5ouib-AppConfigProperty"
+            class="css-mhnilp-AppConfigProperty"
           >
             <p
               class="  css-yszm2s-TextComponent"
@@ -501,7 +501,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="css-h5ouib-AppConfigProperty"
+        class="css-mhnilp-AppConfigProperty"
       >
         <p
           class="  css-yszm2s-TextComponent"
@@ -601,7 +601,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="css-h5ouib-AppConfigProperty"
+    class="css-mhnilp-AppConfigProperty"
   >
     <p
       class="  css-yszm2s-TextComponent"
@@ -674,7 +674,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Configuration for setting an array of custom intent filters in Android manifest.
     </p>
     <details
-      class="css-1nmf69-Collapsible"
+      class="css-1a7iuj-Collapsible"
     >
       <summary
         class="css-1jgn1er-Collapsible"
@@ -757,7 +757,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </blockquote>
     <div>
       <div
-        class="css-h5ouib-AppConfigProperty"
+        class="css-mhnilp-AppConfigProperty"
       >
         <p
           class="  css-yszm2s-TextComponent"
@@ -841,7 +841,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         <div />
       </div>
       <div
-        class="css-h5ouib-AppConfigProperty"
+        class="css-mhnilp-AppConfigProperty"
       >
         <p
           class="  css-yszm2s-TextComponent"
@@ -918,7 +918,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
         <div>
           <div
-            class="css-h5ouib-AppConfigProperty"
+            class="css-mhnilp-AppConfigProperty"
           >
             <p
               class="  css-yszm2s-TextComponent"

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -675,6 +675,15 @@ export const STYLES_APIBOX_NESTED = css({
   },
 });
 
+export const STYLES_APIBOX_WRAPPER = css({
+  marginBottom: spacing[4],
+  padding: `${spacing[4]}px ${spacing[5]}px 0`,
+
+  [`.css-${tableWrapperStyle.name}:last-child`]: {
+    marginBottom: spacing[4],
+  },
+});
+
 export const STYLE_APIBOX_NO_SPACING = css({ marginBottom: -spacing[5] });
 
 export const STYLES_NESTED_SECTION_HEADER = css({

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -70,7 +70,7 @@ Only the second purpose applies with the new build system. All assets referenced
 
 If your app depends on a custom `"main"` entry point, you will need to remove that field from **package.json** and then create **index.js** in the root of your project and use [registerRootComponent](/versions/latest/sdk/register-root-component/) to register your root component. For example, if your app root component lives in **src/App.tsx**, your **index.js** should look like the following:
 
-```js
+```js index.js
 import { registerRootComponent } from 'expo';
 import App from './src/App';
 
@@ -105,13 +105,13 @@ In projects built with `expo build` the native primitives required by AWS Amplif
 
 Most apps do not use this format and support for it adds ~3.4 MB to the final app size, so it is omitted by default. You can enable it by switching `expo.webp.animated=false` to `expo.webp.animated=true` in `android/gradle.properties`. [This forums post](https://forums.expo.dev/t/animated-webp-expected-to-work-with-eas-builds/58960/5?u=notbrent) provides an example of a config plugin for making this change.
 
-### **metro.config.js** must export the entire default config from `expo/metro-config`
+### metro.config.js must export the entire default config from `expo/metro-config`
 
 > `expo/metro-config` is a versioned re-export of `@expo/metro-config`.
 
 Previously, with classic builds, your **metro.config.js** might have looked something like:
 
-```js
+```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
@@ -125,7 +125,7 @@ module.exports = {
 
 In the example above, you're only exporting _part_ of the default config, but EAS Build requires the _full_ config. To do that, you should modify `defaultConfig` directly, and then return the resulting object, like this:
 
-```js
+```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
@@ -137,10 +137,4 @@ module.exports = defaultConfig;
 
 If you don't set up your **metro.config.js** file properly, your assets could fail to load in release builds.
 
-<hr />
-
-<div style={{ marginTop: 20 }} />
-
-> 🆘 Having trouble migrating? [Join us in the #eas channel on the Expo Discord](https://discord.com/invite/4gtbPAdpaE) and let us know, we'll do our best to help.
-
-<div style={{ marginTop: 20 }} />
+> **info** Having trouble migrating? [Join us in the #eas channel on the Expo Discord](https://discord.com/invite/4gtbPAdpaE) and let us know, we'll do our best to help.

--- a/docs/pages/guides/using-bugsnag.mdx
+++ b/docs/pages/guides/using-bugsnag.mdx
@@ -3,58 +3,47 @@ title: Using Bugsnag
 description: A guide on installing and configuring Bugsnag for end-to-end error reporting and analytics.
 ---
 
-[Bugsnag](https://www.bugsnag.com) is a stability monitoring solution that provides rich, end-to-end error reporting and analytics to reproduce and fix errors with speed and precision. Bugsnag supports the full stack with open-source libraries for [50+ platforms](https://www.bugsnag.com/platforms), including [React Native](https://docs.bugsnag.com/platforms/react-native/react-native/).
+import { Terminal } from '~/ui/components/Snippet';
+
+[Bugsnag](https://www.bugsnag.com) is a stability monitoring solution that provides rich, end-to-end error reporting and analytics to reproduce and fix errors with speed and precision.
+Bugsnag supports the full stack with open-source libraries for [50+ platforms](https://www.bugsnag.com/platforms), including [React Native](https://docs.bugsnag.com/platforms/react-native/react-native/).
 
 With Bugsnag, developers and engineering organizations can:
 
-**Stabilize**: Innovate faster by knowing when to build new features vs. fix bugs
+* **Stabilize:** Innovate faster by knowing when to build new features vs. fix bugs.
 
-- Release health dashboard
-- Stability scores and targets
-- Built-in alerts via email, Slack, PagerDuty, and more
+  Use release health dashboard, stability scores and targets, built-in alerts via email, Slack, PagerDuty, and more.
 
-**Prioritize**: Improve customer experience by identifying and prioritizing bugs that have the greatest impact on app stability
+* **Prioritize:** Improve customer experience by identifying and prioritizing bugs that have the greatest impact on app stability.
 
-- Issues grouped by root cause and sorted by business impact
-- Customer segmentation
-- A/B testing and experiment analysis
+  Analyze issues grouped by root cause and sorted by business impact, customer segmentation, A/B testing and experiments results.
 
-**Fix**: Increase productivity by spending less time on reproducing and fixing bugs
+* **Fix:** Increase productivity by spending less time on reproducing and fixing bugs.
 
-- Powerful diagnostic data
-- Full stacktraces
-- Automatic breadcrumbs
+  Utilize powerful diagnostic data, full stacktraces and automatic breadcrumbs.
 
-### Get Started
+## Get Started
 
-Add Bugsnag to your native apps to automatically capture and report JavaScript errors. Follow the guide below and read the [blog post](https://www.bugsnag.com/blog/build-apps-in-expo-with-bugsnag) announcing Bugsnag’s Expo integration. If you’re new to Bugsnag, you can [create an account](https://app.bugsnag.com/user/new/) or [request a demo](https://www.bugsnag.com/demo-request).
+Add Bugsnag to your Expo apps to automatically capture and report JavaScript errors.
+Follow the guide below and read the [blog post](https://www.bugsnag.com/blog/build-apps-in-expo-with-bugsnag) announcing Bugsnag’s Expo integration.
+If you’re new to Bugsnag, you can [create an account](https://app.bugsnag.com/user/new/) or [request a demo](https://www.bugsnag.com/demo-request).
 
-## Add Bugsnag to your Expo project
-
-### Installation and configuration
+## Installation and configuration
 
 The easiest way to add Bugsnag to your Expo project is to use our CLI. Alternatively you can follow the [manual setup guide](https://docs.bugsnag.com/platforms/react-native/expo/manual-setup).
 
-```sh
-# using npx (recommended)
-npx bugsnag-expo-cli init
-
-# using npm (if npx isn't available)
-npm install --global bugsnag-expo-cli
-bugsnag-expo-cli init
-```
-
-Note: [`npx`](https://www.npmjs.com/package/npx) (included with npm 5.2+) is a tool that lets you invoke command line tools from npm without installing them first.
+<Terminal cmd={['$ npx bugsnag-expo-cli init']} />
 
 This will install the [`@bugsnag/expo`](https://www.npmjs.com/package/@bugsnag/expo) notifier, add some configuration to **app.json** and initialize Bugsnag in your application.
 
-#### Capturing React render errors
+### Capturing React render errors
 
-An [error boundary](https://reactjs.org/docs/error-boundaries.html) component is included which you can use to wrap your application. When render errors happen, they will be reported to Bugsnag along with any React-specific info that was available at the time.
+An [error boundary](https://reactjs.org/docs/error-boundaries.html) component is included which you can use to wrap your application.
+When render errors happen, they will be reported to Bugsnag along with any React-specific info that was available at the time.
 
 To catch all render errors in your application and show a custom error screen to your users, follow this example:
 
-```js
+```jsx App.jsx
 const ErrorBoundary = Bugsnag.getPlugin('react');
 
 export default () => (
@@ -74,11 +63,11 @@ class ErrorView extends React.Component {
 
 See [React’s documentation on Error Boundaries](https://reactjs.org/docs/error-boundaries.html) to find out more.
 
-#### TypeScript support
+### TypeScript support
 
 Type definitions are provided and will be picked up automatically by the TypeScript compiler when you import `@bugsnag/expo`.
 
-### Next steps
+## Next steps
 
 - Read the [full integration guide](https://docs.bugsnag.com/platforms/react-native/expo/)
 - View [`@bugsnag/js`](https://github.com/bugsnag/bugsnag-js), the library powering Bugsnag’s JavaScript error reporting, on GitHub

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -152,7 +152,7 @@ async function getMessageAsync() {
 }
 ```
 
-<hr />
+---
 
 #### Kotlin coroutines <PlatformTags prefix="" platforms={['android']} />
 
@@ -372,6 +372,8 @@ All functions and view prop setters accept all common primitive types in Swift a
 
 _Convertibles_ are native types that can be initialized from certain specific kinds of data received from JavaScript. Such types are allowed to be used as an argument type in `Function`'s body. For example, when the `CGPoint` type is used as a function argument type, its instance can be created from an array of two numbers `(x, y)` or a JavaScript object with numeric `x` and `y` properties.
 
+---
+
 Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are already made convertible.
 
 | Native iOS Type         | TypeScript                                                                                                                                                                        |
@@ -383,6 +385,8 @@ Some common iOS types from `CoreGraphics` and `UIKit` system frameworks are alre
 | `CGVector`              | `{ dx: number, dy: number }` or `number[]` with _dx_ and _dy_ vector differentials                                                                                                |
 | `CGRect`                | `{ x: number, y: number, width: number, height: number }` or `number[]` with _x_, _y_, _width_ and _height_ values                                                                |
 | `CGColor`<br/>`UIColor` | Color hex strings (`#RRGGBB`, `#RRGGBBAA`, `#RGB`, `#RGBA`), named colors following the [CSS3/SVG specification](https://www.w3.org/TR/css-color-3/#svg-color) or `"transparent"` |
+
+---
 
 Similarly, some common Android types from packages like `java.io`, `java.net`, or `android.graphics` are also made convertible.
 
@@ -670,8 +674,6 @@ On iOS, `ExpoView` extends the `RCTView` which handles some styles (e.g. borders
   isProperty={true}
   isReturnTypeReference={true}
 />
-
-<hr />
 
 #### Extending `ExpoView`
 

--- a/docs/pages/versions/unversioned/sdk/audio.mdx
+++ b/docs/pages/versions/unversioned/sdk/audio.mdx
@@ -8,6 +8,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 import APISection from '~/components/plugins/APISection';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-av`** allows you to implement audio playback and recording in your app.
 
@@ -26,11 +27,12 @@ Try the [playlist example app](https://expo.dev/@documentation/playlist-example)
 ### Playing sounds
 
 <SnackInline
-label='Playing sounds'
-dependencies={['expo-av', 'expo-asset']}
-files={{
+  label='Playing sounds'
+  dependencies={['expo-av', 'expo-asset']}
+  files={{
     'assets/Hello.mp3': 'https://snack-code-uploads.s3.us-west-1.amazonaws.com/~asset/c9c43b458d6daa9771a7287cae9f5b47'
-  }}>
+  }}
+>
 
 ```jsx
 import * as React from 'react';
@@ -148,7 +150,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-### Playing or recording audio in background (iOS)
+### Playing or recording audio in background&ensp;<PlatformTags platforms={['ios']} />
 
 On iOS, audio playback and recording in background is only available in standalone apps, and it requires some extra configuration.
 On iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file.

--- a/docs/pages/workflow/common-development-errors.mdx
+++ b/docs/pages/workflow/common-development-errors.mdx
@@ -10,47 +10,39 @@ This page outlines a list of errors that are commonly encountered by developers 
 > **info** This applies to the [legacy `expo-cli`](/archived/expo-cli) package which is no longer used in Expo SDK 46 and greater.
 
 - Either you do not have `expo-cli` installed or it is not properly configured in your `$PATH`.
-
 - [Install expo-cli](/get-started/installation) if you have not already. Otherwise, check how to set your `$PATH` based on your OS.
 
 ### Metro bundler ECONNREFUSED 127.0.0.1:19001
 
 - An error is preventing the connection to your local development server.
-
 - Run `rm -rf .expo` to clear your local state. Check for firewalls or [proxies](/guides/troubleshooting-proxies) affecting the network you are currently connected to.
 
 ### Module AppRegistry is not a registered callable module (calling runApplication)
 
 - An error in your code is preventing the JavaScript bundle from being executed on startup.
-
 - Try running `npx expo start --no-dev --minify` to reproduce the production JS bundle locally. If possible, connect your device and access the device logs via Android Studio or Xcode. Device logs contain much more detailed stacktraces and information. Check to see if you have any changes or errors in your Babel configuration. In some rare cases, this issue could be caused by incompatibility between the Metro JavaScript minifier and certain code in your app ([more information](https://forums.expo.dev/t/change-minifierconfig-for-minify-uglify/36460/2)).
 
 ### npm ERR! No git binary found in \$PATH
 
 - Either you do not have git installed or it is not properly configured in your `$PATH`.
-
 - [Install git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) if you have not already. Otherwise, check how to set it in your `$PATH` based on your OS.
 
 ### XX.X.X is not a valid SDK version
 
 - The SDK version you are running has been deprecated and is no longer supported.
-
 - [Upgrade your project](/workflow/upgrading-expo-sdk-walkthrough) to a supported SDK version. If you are using a supported version and see this message, you'll need to update your Expo Go app.
 
 ### React Native version mismatch
 
 - The development server running in your terminal is bundling a different version of React Native than the app in your device or simulator.
-
 - [Align your versions of react-native](/troubleshooting/react-native-version-mismatch) by checking the versions in your **app.json** and **package.json**
 
 ### Application has not been registered
 
 - There is a mismatch between the AppKey registered in the native and JS portion of your app.
-
 - [Align your AppKey](../troubleshooting/application-has-not-been-registered) with the native side of your project.
 
 ### Application not behaving as expected
 
 - It is possible caches may be preventing you from seeing the current state of your application.
-
 - Clear all caches associated with your project in [Unix-like](../troubleshooting/clear-cache-macos-linux/) or [Windows](../troubleshooting/clear-cache-windows/) systems.

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -16,10 +16,7 @@ Install the `expo` package which contains the [Expo CLI](/workflow/expo-cli) use
 
 Then you can use Expo CLI to install the web dependencies in your project:
 
-<Terminal
-  cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']}
-  cmdCopy="npx expo install react-dom react-native-web @expo/webpack-config"
-/>
+<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']} />
 
 ### Update the entry file
 

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -49,7 +49,7 @@ const detailsStyle = css({
     boxShadow: shadows.micro,
   },
 
-  'h4 + &, li > &': {
+  'h4 + &, p + &, li > &': {
     marginTop: spacing[3],
   },
 });

--- a/docs/ui/components/Tag/styles.ts
+++ b/docs/ui/components/Tag/styles.ts
@@ -23,10 +23,15 @@ export const tagStyle = css({
   'nav &': {
     whiteSpace: 'pre',
   },
+
+  'h3 &': {
+    fontSize: '80%',
+  },
 });
 
 export const labelStyle = css({
   lineHeight: `${spacing[4]}px`,
+  fontWeight: 'normal',
 });
 
 export const tagToCStyle = css({
@@ -34,5 +39,5 @@ export const tagToCStyle = css({
   marginBottom: 0,
   marginRight: 0,
   marginLeft: spacing[1],
-  padding: `0px ${spacing[1.5]}px`,
+  padding: `0 ${spacing[1.5]}px`,
 });


### PR DESCRIPTION
# Why

During the work on the TypeDoc update I have spotted few small display or formatting issues across the docs, let's fix them.

# How

Summary of changes:
* corrected appearance of `APIBox`es used directly in Markdown
* replacement of unstyled `<hr />` with Markdown syntax
* code block file names added here and there
* better appearance of labels nested in Markdown headers
* other formatting/arrangement changes

# Test Plan

Changes have been tested by running docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
