### PR TITLE
[apple-authentication] Fix build errors caused by CaseIterable protocol

### DIFF
--- a/packages/expo-apple-authentication/ios/AppleAuthenticationButton.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationButton.swift
@@ -4,8 +4,8 @@ import ExpoModulesCore
 public final class AppleAuthenticationButton: ExpoView {
   let onButtonPress = EventDispatcher()
 
-  var type: ASAuthorizationAppleIDButton.ButtonType = .default
-  var style: ASAuthorizationAppleIDButton.Style = .white
+  var type: ButtonType = .signIn
+  var style: ButtonStyle = .white
   var childView: ASAuthorizationAppleIDButton?
 
   var needsUpdate = true
@@ -26,7 +26,10 @@ public final class AppleAuthenticationButton: ExpoView {
   }
 
   private func mountNewChild() {
-    let newChildView = ASAuthorizationAppleIDButton(authorizationButtonType: type, authorizationButtonStyle: style)
+    let newChildView = ASAuthorizationAppleIDButton(
+      authorizationButtonType: type.toAppleAuthButtonType(),
+      authorizationButtonStyle: style.toAppleAuthButtonStyle()
+    )
 
     newChildView.cornerRadius = cornerRadius
     newChildView.translatesAutoresizingMaskIntoConstraints = false

--- a/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
+++ b/packages/expo-apple-authentication/ios/AppleAuthenticationModule.swift
@@ -3,9 +3,6 @@ import ExpoModulesCore
 
 let credentialRevokedEventName = "Expo.appleIdCredentialRevoked"
 
-extension ASAuthorizationAppleIDButton.ButtonType: Enumerable {}
-extension ASAuthorizationAppleIDButton.Style: Enumerable {}
-
 public final class AppleAuthenticationModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoAppleAuthentication")
@@ -39,8 +36,8 @@ public final class AppleAuthenticationModule: Module {
     View(AppleAuthenticationButton.self) {
       Events("onButtonPress")
 
-      Prop("buttonType") { (view, type: ASAuthorizationAppleIDButton.ButtonType?) in
-        let type = type ?? .default
+      Prop("buttonType") { (view, type: ButtonType?) in
+        let type = type ?? .signIn
 
         if view.type != type {
           view.type = type
@@ -48,7 +45,7 @@ public final class AppleAuthenticationModule: Module {
         }
       }
 
-      Prop("buttonStyle") { (view, style: ASAuthorizationAppleIDButton.Style?) in
+      Prop("buttonStyle") { (view, style: ButtonStyle?) in
         let style = style ?? .white
 
         if view.style != style {

--- a/packages/expo-apple-authentication/ios/ButtonStyle.swift
+++ b/packages/expo-apple-authentication/ios/ButtonStyle.swift
@@ -1,0 +1,12 @@
+import AuthenticationServices
+import ExpoModulesCore
+
+enum ButtonStyle: Int, Enumerable {
+  case white = 0
+  case whiteOutline = 1
+  case black = 2
+
+  func toAppleAuthButtonStyle() -> ASAuthorizationAppleIDButton.Style {
+    return ASAuthorizationAppleIDButton.Style(rawValue: self.rawValue) ?? .white
+  }
+}

--- a/packages/expo-apple-authentication/ios/ButtonType.swift
+++ b/packages/expo-apple-authentication/ios/ButtonType.swift
@@ -1,0 +1,12 @@
+import AuthenticationServices
+import ExpoModulesCore
+
+enum ButtonType: Int, Enumerable {
+  case signIn = 0
+  case `continue` = 1
+  case signUp = 2
+
+  func toAppleAuthButtonType() -> ASAuthorizationAppleIDButton.ButtonType {
+    return ASAuthorizationAppleIDButton.ButtonType(rawValue: self.rawValue) ?? .signIn
+  }
+}


### PR DESCRIPTION
# Why

Unfortunately #20640 introduced one limitation that I wasn't aware of — it's now not possible to add an extension to the enum that was defined outside of that same file. It means that we cannot make the platform enums (like `ASAuthorizationAppleIDButton.ButtonType`) conform to `Enumerable` protocol and instead we need to define our own enum.

# How

Added our own `ButtonType` and `ButtonStyle` enums that are just proxying to the corresponding platform enums.

# Test Plan

Tested in native-component-list demo