### PR TITLE
[docs] Indicate that some iOS images are available only for Intel wokers

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -266,7 +266,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-big-sur-11.4-xcode-12.5` (deprecated, available only for Intel workers)
+#### `macos-big-sur-11.4-xcode-12.5` (deprecated, not available for M1 workers)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -266,7 +266,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-big-sur-11.4-xcode-12.5` (deprecated)
+#### `macos-big-sur-11.4-xcode-12.5` (deprecated, available only for Intel workers)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

Some of our iOS images are available only for Intel workers. We should indicate it in the documentation.

# How

Add information that this image is available for Intel workers only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
