### PR TITLE
[image][ios] Add support for assets from the Photo Library

### DIFF
--- a/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
@@ -1,7 +1,8 @@
 import { StackScreenProps } from '@react-navigation/stack';
+import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import React from 'react';
-import { Image, ScrollView, StyleSheet, View, Alert } from 'react-native';
+import { Image as RNImage, ScrollView, StyleSheet, View, Alert } from 'react-native';
 
 import Button from '../../components/Button';
 import HeadingText from '../../components/HeadingText';
@@ -90,7 +91,7 @@ export default class MediaDetailsScreen extends React.Component<Props> {
           <Image
             style={[styles.image, { aspectRatio }]}
             source={{ uri: asset.uri }}
-            resizeMode="cover"
+            contentFit="cover"
           />
         );
       default:

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaDetailsScreen.tsx
@@ -2,7 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack';
 import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import React from 'react';
-import { Image as RNImage, ScrollView, StyleSheet, View, Alert } from 'react-native';
+import { ScrollView, StyleSheet, View, Alert } from 'react-native';
 
 import Button from '../../components/Button';
 import HeadingText from '../../components/HeadingText';

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
@@ -1,8 +1,9 @@
 import FontAwesome from '@expo/vector-icons/build/FontAwesome';
+import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import React from 'react';
 import {
-  Image,
+  Image as RNImage,
   StyleProp,
   StyleSheet,
   Text,
@@ -10,7 +11,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
-
+global.expo?.modules.ExpoImage.clearDiskCache();
 export default class MediaLibraryCell extends React.Component<{
   asset: MediaLibrary.Asset;
   onPress: (asset: MediaLibrary.Asset) => void;

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
@@ -2,16 +2,8 @@ import FontAwesome from '@expo/vector-icons/build/FontAwesome';
 import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library';
 import React from 'react';
-import {
-  Image as RNImage,
-  StyleProp,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from 'react-native';
-global.expo?.modules.ExpoImage.clearDiskCache();
+import { StyleProp, StyleSheet, Text, TouchableOpacity, View, ViewStyle } from 'react-native';
+
 export default class MediaLibraryCell extends React.Component<{
   asset: MediaLibrary.Asset;
   onPress: (asset: MediaLibrary.Asset) => void;

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added support for assets from the iOS Photo Library (`ph://` urls). ([#20700](https://github.com/expo/expo/pull/20700) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 - Fixed `ImageProps` type not allowing an array of styles. ([#20701](https://github.com/expo/expo/pull/20701) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-image/ios/BlurhashLoader.swift
+++ b/packages/expo-image/ios/BlurhashLoader.swift
@@ -16,12 +16,12 @@ class BlurhashLoader: NSObject, SDImageLoader {
     completed completedBlock: SDImageLoaderCompletedBlock? = nil
   ) -> SDWebImageOperation? {
     guard let url = url else {
-      let error = error(description: "URL provided to BlurhashLoader is missing")
+      let error = makeNSError(description: "URL provided to BlurhashLoader is missing")
       completedBlock?(nil, nil, error, false)
       return nil
     }
     guard let source = context?[ImageView.contextSourceKey] as? ImageSource else {
-      let error = error(description: "Image source was not provided to the context")
+      let error = makeNSError(description: "Image source was not provided to the context")
       completedBlock?(nil, nil, error, false)
       return nil
     }
@@ -37,7 +37,7 @@ class BlurhashLoader: NSObject, SDImageLoader {
           completedBlock?(UIImage(cgImage: image), nil, nil, true)
         }
       } else {
-        let error = error(description: "Unable to generate an image from the given blurhash")
+        let error = makeNSError(description: "Unable to generate an image from the given blurhash")
         completedBlock?(nil, nil, error, false)
       }
     }
@@ -49,9 +49,4 @@ class BlurhashLoader: NSObject, SDImageLoader {
     // it's not possible that next time it will work :)
     return true
   }
-}
-
-private func error(description: String) -> NSError {
-  let userInfo = [NSLocalizedDescriptionKey: description]
-  return NSError(domain: "expo.modules.image", code: 0, userInfo: userInfo)
 }

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -95,5 +95,6 @@ public final class ImageModule: Module {
 
   static func registerLoaders() {
     SDImageLoadersManager.shared.addLoader(BlurhashLoader())
+    SDImageLoadersManager.shared.addLoader(PhotoLibraryAssetLoader())
   }
 }

--- a/packages/expo-image/ios/ImageSource.swift
+++ b/packages/expo-image/ios/ImageSource.swift
@@ -25,4 +25,13 @@ struct ImageSource: Record {
   var isBlurhash: Bool {
     return uri?.scheme == "blurhash"
   }
+
+  var isPhotoLibraryAsset: Bool {
+    return isPhotoLibraryAssetUrl(uri)
+  }
+
+  var isCachingAllowed: Bool {
+    // TODO: Don't cache other non-network requests (e.g. data URIs, local files)
+    return !isPhotoLibraryAsset
+  }
 }

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -173,3 +173,8 @@ extension CGSize {
     return CGSize(width: width.rounded(rule), height: height.rounded(rule))
   }
 }
+
+func makeNSError(description: String) -> NSError {
+  let userInfo = [NSLocalizedDescriptionKey: description]
+  return NSError(domain: "expo.modules.image", code: 0, userInfo: userInfo)
+}

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -8,6 +8,7 @@ private typealias SDWebImageContext = [SDWebImageContextOption: Any]
 // swiftlint:disable:next type_body_length
 public final class ImageView: ExpoView {
   static let contextSourceKey = SDWebImageContextOption(rawValue: "source")
+  static let screenScaleKey = SDWebImageContextOption(rawValue: "screenScale")
 
   let sdImageView = SDAnimatedImageView(frame: .zero)
 
@@ -117,17 +118,22 @@ public final class ImageView: ExpoView {
     // incorrectly rendered images for resize modes that don't scale (`center` and `repeat`).
     context[.imageScaleFactor] = source.scale
 
+    if source.isCachingAllowed {
+      let sdCacheType = cachePolicy.toSdCacheType().rawValue
+      context[.originalQueryCacheType] = sdCacheType
+      context[.originalStoreCacheType] = sdCacheType
+    } else {
+      context[.originalQueryCacheType] = SDImageCacheType.none.rawValue
+      context[.originalQueryCacheType] = SDImageCacheType.none.rawValue
+    }
     // Set which cache can be used to query and store the downloaded image.
     // We want to store only original images (without transformations).
-    // TODO: Don't cache non-network requests (e.g. data URIs, local files)
-    let sdCacheType = cachePolicy.toSdCacheType().rawValue
-    context[.originalQueryCacheType] = sdCacheType
-    context[.originalStoreCacheType] = sdCacheType
     context[.queryCacheType] = SDImageCacheType.none.rawValue
     context[.storeCacheType] = SDImageCacheType.none.rawValue
 
-    // Some loaders (e.g. blurhash) need access to the source.
+    // Some loaders (e.g. blurhash) need access to the source and the screen scale.
     context[ImageView.contextSourceKey] = source
+    context[ImageView.screenScaleKey] = screenScale
 
     onLoadStart([:])
 
@@ -143,9 +149,14 @@ public final class ImageView: ExpoView {
   // MARK: - Loading
 
   private func imageLoadProgress(_ receivedSize: Int, _ expectedSize: Int, _ imageUrl: URL?) {
+    // Photos library requester emits the progress as a double `0...1` that we map to `0...100` int in `PhotosLoader`.
+    // When that loader is used, we don't have any information about the sizes in bytes, so we only send the `progress` param.
+    let isPhotoLibraryAsset = isPhotoLibraryAssetUrl(imageUrl)
+
     onProgress([
-      "loaded": receivedSize,
-      "total": expectedSize
+      "loaded": isPhotoLibraryAsset ? nil : receivedSize,
+      "total": isPhotoLibraryAsset ? nil : expectedSize,
+      "progress": Double(receivedSize) / Double(expectedSize)
     ])
   }
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -3,7 +3,7 @@
 import SDWebImage
 import ExpoModulesCore
 
-private typealias SDWebImageContext = [SDWebImageContextOption: Any]
+typealias SDWebImageContext = [SDWebImageContextOption: Any]
 
 // swiftlint:disable:next type_body_length
 public final class ImageView: ExpoView {

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -1,0 +1,126 @@
+import Photos
+import Dispatch
+import SDWebImage
+import ExpoModulesCore
+
+/**
+ A custom loader for assets from the Photo Library. It handles all urls with the `ph` scheme.
+ */
+final class PhotoLibraryAssetLoader: NSObject, SDImageLoader {
+  // MARK: - SDImageLoader
+
+  func canRequestImage(for url: URL?) -> Bool {
+    return isPhotoLibraryAssetUrl(url)
+  }
+
+  func requestImage(
+    with url: URL?,
+    options: SDWebImageOptions = [],
+    context: [SDWebImageContextOption: Any]?,
+    progress progressBlock: SDImageLoaderProgressBlock?,
+    completed completedBlock: SDImageLoaderCompletedBlock? = nil
+  ) -> SDWebImageOperation? {
+    guard isPhotoLibraryStatusAuthorized() else {
+      let error = makeNSError(description: "Unauthorized access to the Photo Library")
+      completedBlock?(nil, nil, error, false)
+      return nil
+    }
+    let operation = PhotoLibraryAssetLoaderOperation()
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      guard let assetLocalIdentifier = assetLocalIdentifier(fromUrl: url) else {
+        let error = makeNSError(description: "Unable to obtain the asset identifier from the url: '\(url?.absoluteString)'")
+        completedBlock?(nil, nil, error, false)
+        return
+      }
+      guard let asset = PHAsset.fetchAssets(withLocalIdentifiers: [assetLocalIdentifier], options: .none).firstObject else {
+        let error = makeNSError(description: "Asset with identifier '\(assetLocalIdentifier)' not found in the Photo Library")
+        completedBlock?(nil, nil, error, false)
+        return
+      }
+
+      let options = PHImageRequestOptions()
+      options.isSynchronous = false
+      options.version = .current
+      options.deliveryMode = .highQualityFormat
+      options.resizeMode = .fast
+      options.normalizedCropRect = .zero
+      options.isNetworkAccessAllowed = true
+
+      if let progressBlock = progressBlock {
+        options.progressHandler = { (progress, error, stop, info) in
+          // The `progress` is a double from 0.0 to 1.0, but the loader needs integers so we map it to 0...100 range
+          let progressPercentage = Int((progress * 100.0).rounded())
+          progressBlock(progressPercentage, 100, url)
+        }
+      }
+
+      let screenScale = context?[ImageView.screenScaleKey] as? Double ?? UIScreen.main.scale
+      let targetSize = CGSize(width: Double(asset.pixelWidth) / screenScale, height: Double(asset.pixelHeight) / screenScale)
+
+      let requestId = PHImageManager.default().requestImage(
+        for: asset,
+        targetSize: targetSize,
+        contentMode: .aspectFit,
+        options: options,
+        resultHandler: { image, info in
+          // This value can be `true` only when network access is allowed and the photo is stored in the iCloud.
+          let isDegraded: Bool = info?[PHImageResultIsDegradedKey] as? Bool ?? false
+
+          completedBlock?(image, nil, nil, !isDegraded)
+        }
+      )
+
+      operation.requestId = requestId
+    }
+    return operation
+  }
+
+  func shouldBlockFailedURL(with url: URL, error: Error) -> Bool {
+    // The lack of permission is one of the reasons of failed request,
+    // but in that single case we don't want to blacklist the url as
+    // the permission might be granted later and then the retry should be possible.
+    return isPhotoLibraryStatusAuthorized()
+  }
+}
+
+internal func isPhotoLibraryAssetUrl(_ url: URL?) -> Bool {
+  return url?.scheme == "ph"
+}
+
+/**
+ Returns the local identifier of the asset from the given `ph://` url.
+ These urls have the form of "ph://26687849-33F9-4402-8EC0-A622CD011D70",
+ where the asset local identifier is used as the host part.
+ */
+private func assetLocalIdentifier(fromUrl url: URL?) -> String? {
+  return url?.host
+}
+
+/**
+ Checks whether the app is authorized to read the Photo Library.
+ */
+private func isPhotoLibraryStatusAuthorized() -> Bool {
+  if #available(iOS 14, *) {
+    return PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
+  } else {
+    return PHPhotoLibrary.authorizationStatus() == .authorized
+  }
+}
+
+/**
+ Loader operation specialized for the Photo Library by keeping the request identifier.
+ */
+private class PhotoLibraryAssetLoaderOperation: NSObject, SDWebImageOperation {
+  var canceled: Bool = false
+  var requestId: PHImageRequestID?
+
+  // MARK: - SDWebImageOperation
+
+  func cancel() {
+    if let requestId = requestId {
+      PHImageManager.default().cancelImageRequest(requestId)
+    }
+    canceled = true
+  }
+}

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -87,7 +87,13 @@ private func isPhotoLibraryStatusAuthorized() -> Bool {
 /**
  Requests the image of the given asset object and returns the request identifier.
  */
-private func requestAsset(_ asset: PHAsset, url: URL, context: SDWebImageContext?, progressBlock: SDImageLoaderProgressBlock?, completedBlock: SDImageLoaderCompletedBlock?) -> PHImageRequestID {
+private func requestAsset(
+  _ asset: PHAsset,
+  url: URL,
+  context: SDWebImageContext?,
+  progressBlock: SDImageLoaderProgressBlock?,
+  completedBlock: SDImageLoaderCompletedBlock?
+) -> PHImageRequestID {
   let options = PHImageRequestOptions()
   options.isSynchronous = false
   options.version = .current
@@ -97,7 +103,7 @@ private func requestAsset(_ asset: PHAsset, url: URL, context: SDWebImageContext
   options.isNetworkAccessAllowed = true
 
   if let progressBlock = progressBlock {
-    options.progressHandler = { progress, error, stop, info in
+    options.progressHandler = { progress, _, _, _ in
       // The `progress` is a double from 0.0 to 1.0, but the loader needs integers so we map it to 0...100 range
       let progressPercentage = Int((progress * 100.0).rounded())
       progressBlock(progressPercentage, 100, url)


### PR DESCRIPTION
# Why

Fixes #20595 

# How

Added a custom loader for `ph://` urls and adjusted expo-media-library examples to use `expo-image`

# Test Plan

MediaLibrary examples seem to work as expected