### PR TITLE
[docs] Remove monochrome icon reference in App icon guide

### DIFF
--- a/docs/pages/guides/app-icons.mdx
+++ b/docs/pages/guides/app-icons.mdx
@@ -21,12 +21,14 @@ Create an app icon and splash image with the [Figma template](https://www.figma.
 
 ### Android
 
+{/* TODO: (@aman) Remove comments below when monochrome is released for the next SDK. */}
+
 - The Android Adaptive Icon is formed from two separate layers -- a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects.
-- For Android 13 and later, the OS supports a monochrome foreground image layer which will use a background color taken from the device's theme.
+  {/* - For Android 13 and later, the OS supports a monochrome foreground image layer which will use a background color taken from the device's theme. */}
 - The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive) for launcher icons.
 - Use PNG files.
 - Use the `android.adaptiveIcon.foregroundImage` field in **app.json** to specify your foreground image.
-- Use the `android.adaptiveIcon.monochromeImage` field in **app.json** to specify your monochrome image.
+  {/* - Use the `android.adaptiveIcon.monochromeImage` field in **app.json** to specify your monochrome image. */}
 - The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` field. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` field; ensure that it has the same dimensions as your foreground image.
 - You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons; you can do so with the `android.icon` field. This single icon would probably be a combination of your foreground and background layers.
 - You may still want to follow some of the [Apple best practices](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/) to ensure your icon looks professional, such as testing your icon on different wallpapers and avoiding text beside your product's wordmark.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #20549

# How

<!--
How did you build this feature or fix this bug and why?
-->

By commenting out the monochrome related information in the App icon guide for Android. Will circle back to it when the the support is released (maybe in the next SDK).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
