### PR TITLE
[docs] Update monorepos section in expo build migration

### DIFF
--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -81,9 +81,7 @@ Support for custom entry points is in progress and is coming soon.
 
 ### Monorepos may require additional setup
 
-Classic builds had no knowledge of your repository set up, you could use a monorepo or birepo or trirepo, the service was entirely indifferent. As long as you were able to publish a bundle, that's all that was needed. EAS Build needs to be able to install all of your project dependencies and essentially set up your development environment inside of a worker, so in some cases that will require some additional configuration. Learn more: ["How to set up EAS Build with a monorepo"](/build-reference/how-tos.mdx#how-to-set-up-eas-build-with).
-
-> Work is in progress to improve monorepo support for EAS Build managed projects. We recommend using [expo-yarn-workspaces](https://github.com/expo/expo/tree/main/packages/expo-yarn-workspaces/README.mdx).
+Classic builds had no knowledge of your repository set up, you could use a monorepo or birepo or trirepo, the service was entirely indifferent. As long as you were able to publish a bundle, that's all that was needed. EAS Build needs to be able to install all of your project dependencies and essentially set up your development environment inside of a worker, so in some cases that will require some additional configuration. Learn more: ["How to set up EAS Build with a monorepo"](/build-reference/build-with-monorepos).
 
 ### Environment variables used by your app need to be defined for EAS Build
 


### PR DESCRIPTION
# Why

`expo-yarn-workspaces` has some limitations that are now fixed with SDK 43+. Let's not recommend that anymore.

# How

Removed note and fixed a link

# Test Plan

Just a docs change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
