### PR TITLE
fix(cli): allow chained Metro resolvers to resolve when the predecessor resolvers throw a Metro resolution error.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error.
+- Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error. ([#20704](https://github.com/expo/expo/pull/20704) by [@EvanBacon](https://github.com/EvanBacon))
 - Escape ampersands in URLs sent to adb. ([#20398](https://github.com/expo/expo/pull/20398) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error.
 - Escape ampersands in URLs sent to adb. ([#20398](https://github.com/expo/expo/pull/20398) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade @expo/code-signing-certificates dependency. ([#20078](https://github.com/expo/expo/pull/20078) by [@wschurman](https://github.com/wschurman))

--- a/packages/@expo/cli/src/start/server/metro/__tests__/metroErrors.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/metroErrors.test.ts
@@ -1,0 +1,21 @@
+import FailedToResolveNameError from 'metro-resolver/src/FailedToResolveNameError';
+import FailedToResolvePathError from 'metro-resolver/src/FailedToResolvePathError';
+
+import { isFailedToResolveNameError, isFailedToResolvePathError } from '../metroErrors';
+
+it(`matches upstream metro-resolver errors`, () => {
+  expect(isFailedToResolveNameError(new FailedToResolveNameError(['/'], ['/']))).toBe(true);
+  expect(
+    isFailedToResolvePathError(
+      new FailedToResolvePathError({
+        dir: { type: 'asset', name: 'foobar' },
+        file: { type: 'asset', name: 'foobar' },
+      })
+    )
+  ).toBe(true);
+});
+
+it(`doesn't match other errors`, () => {
+  expect(isFailedToResolveNameError(new Error())).toBe(false);
+  expect(isFailedToResolvePathError(new Error())).toBe(false);
+});

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroResolvers.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroResolvers.test.ts
@@ -1,0 +1,73 @@
+import { ConfigT } from 'metro-config';
+import FailedToResolveNameError from 'metro-resolver/src/FailedToResolveNameError';
+import FailedToResolvePathError from 'metro-resolver/src/FailedToResolvePathError';
+
+import { withMetroResolvers } from '../withMetroResolvers';
+
+const asMetroConfig = (config: Partial<ConfigT>): ConfigT => config as any;
+
+describe(withMetroResolvers, () => {
+  it(`falls back to the default resolver if the custom resolver doesn't return a result`, () => {
+    const customResolver1 = jest.fn(() => {
+      throw new FailedToResolveNameError(['/'], ['/']);
+    });
+    const customResolver2 = jest.fn(() => {
+      const mockCandidate = {
+        type: 'asset',
+        name: 'foobar',
+      };
+      throw new FailedToResolvePathError({ dir: mockCandidate, file: mockCandidate });
+    });
+    const customResolver3 = jest.fn(() => {
+      return null;
+    });
+    const originalResolveRequest = jest.fn();
+    const modified = withMetroResolvers(
+      asMetroConfig({
+        // @ts-expect-error
+        resolver: {
+          resolveRequest: originalResolveRequest,
+        },
+      }),
+      '/',
+      [customResolver1, customResolver2, customResolver3]
+    );
+
+    // @ts-expect-error: invalid types on resolveRequest
+    modified.resolver.resolveRequest!({}, 'react-native', 'ios');
+
+    // Throws a FailedToResolveNameError
+    expect(customResolver1).toBeCalledTimes(1);
+    // Throws a FailedToResolvePathError
+    expect(customResolver2).toBeCalledTimes(1);
+    // Returns null
+    expect(customResolver3).toBeCalledTimes(1);
+    // Falls back to the original resolver
+    expect(originalResolveRequest).toBeCalledTimes(1);
+  });
+  it(`skips extra resolvers when an additional resolver works`, () => {
+    const customResolver1 = jest.fn(() => {
+      return {} as any;
+    });
+
+    const originalResolveRequest = jest.fn();
+    const modified = withMetroResolvers(
+      asMetroConfig({
+        // @ts-expect-error
+        resolver: {
+          resolveRequest: originalResolveRequest,
+        },
+      }),
+      '/',
+      [customResolver1]
+    );
+
+    // @ts-expect-error: invalid types on resolveRequest
+    modified.resolver.resolveRequest!({}, 'react-native', 'ios');
+
+    // Resolves
+    expect(customResolver1).toBeCalledTimes(1);
+    // Never called
+    expect(originalResolveRequest).not.toBeCalled();
+  });
+});

--- a/packages/@expo/cli/src/start/server/metro/metroErrors.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrors.ts
@@ -1,0 +1,40 @@
+// Used to cast a type to metro errors without depending on specific versions of metro.
+
+export type FileAndDirCandidates = {
+  dir: FileCandidates;
+  file: FileCandidates;
+};
+
+/**
+ * This is a way to describe what files we tried to look for when resolving
+ * a module name as file. This is mainly used for error reporting, so that
+ * we can explain why we cannot resolve a module.
+ */
+export type FileCandidates =
+  // We only tried to resolve a specific asset.
+  | { type: 'asset'; name: string }
+  // We attempted to resolve a name as being a source file (ex. JavaScript,
+  // JSON...), in which case there can be several extensions we tried, for
+  // example `/js/foo.ios.js`, `/js/foo.js`, etc. for a single prefix '/js/foo'.
+  | {
+      type: 'sourceFile';
+      filePathPrefix: string;
+      candidateExts: readonly string[];
+    };
+
+type FailedToResolveNameError = Error & {
+  dirPaths: string[];
+  extraPaths: string[];
+};
+
+type FailedToResolvePathError = Error & {
+  candidates: FileAndDirCandidates;
+};
+
+export function isFailedToResolveNameError(error: any): error is FailedToResolveNameError {
+  return !!error && 'extraPaths' in error && error.constructor.name === 'FailedToResolveNameError';
+}
+
+export function isFailedToResolvePathError(error: any): error is FailedToResolvePathError {
+  return !!error && 'candidates' in error && error.constructor.name === 'FailedToResolvePathError';
+}

--- a/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
@@ -68,8 +68,9 @@ export function withMetroResolvers(
             if (!isResolutionError) {
               throw error;
             }
-            debug(`${error.constructor.name}: ${error.message}`);
-            debug(error);
+            debug(
+              `Custom resolver threw: ${error.constructor.name}. (module: ${args[1]}, platform: ${args[2]})`
+            );
           }
         }
         // If we haven't returned by now, use the original resolver or upstream resolver.

--- a/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroResolvers.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright © 2022 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { ConfigT as MetroConfig } from 'metro-config';
+import { ResolutionContext } from 'metro-resolver';
+
+import { isFailedToResolveNameError, isFailedToResolvePathError } from './metroErrors';
+import { importMetroResolverFromProject } from './resolveFromProject';
+
+const debug = require('debug')('expo:metro:withMetroResolvers') as typeof console.log;
+
+export type MetroResolver = NonNullable<MetroConfig['resolver']['resolveRequest']>;
+
+/** Expo Metro Resolvers can return `null` to skip without throwing an error. Metro Resolvers will throw either a `FailedToResolveNameError` or `FailedToResolvePathError`. */
+export type ExpoCustomMetroResolver = (
+  ...args: Parameters<MetroResolver>
+) => ReturnType<MetroResolver> | null;
+
+/** @returns `MetroResolver` utilizing the upstream `resolve` method. */
+export function getDefaultMetroResolver(projectRoot: string): MetroResolver {
+  const { resolve } = importMetroResolverFromProject(projectRoot);
+  return (context: ResolutionContext, moduleName: string, platform: string | null) => {
+    return resolve(context, moduleName, platform);
+  };
+}
+
+/**
+ * Extend the Metro config `resolver.resolveRequest` method with additional resolvers that can
+ * exit early by returning a `Resolution` or skip to the next resolver by returning `null`.
+ *
+ * @param config Metro config.
+ * @param projectRoot path to the project root used to resolve the default Metro resolver.
+ * @param resolvers custom MetroResolver to chain.
+ * @returns a new `MetroConfig` with the `resolver.resolveRequest` method chained.
+ */
+export function withMetroResolvers(
+  config: MetroConfig,
+  projectRoot: string,
+  resolvers: ExpoCustomMetroResolver[]
+): MetroConfig {
+  debug(
+    `Appending ${
+      resolvers.length
+    } custom resolvers to Metro config. (has custom resolver: ${!!config.resolver.resolveRequest})`
+  );
+  const originalResolveRequest =
+    config.resolver.resolveRequest || getDefaultMetroResolver(projectRoot);
+
+  return {
+    ...config,
+    resolver: {
+      ...config.resolver,
+      resolveRequest(...args: Parameters<MetroResolver>) {
+        for (const resolver of resolvers) {
+          try {
+            const resolution = resolver(...args);
+            if (resolution) {
+              return resolution;
+            }
+          } catch (error: any) {
+            // If the error is directly related to a resolver not being able to resolve a module, then
+            // we can ignore the error and try the next resolver. Otherwise, we should throw the error.
+            const isResolutionError =
+              isFailedToResolveNameError(error) || isFailedToResolvePathError(error);
+            if (!isResolutionError) {
+              throw error;
+            }
+            debug(`${error.constructor.name}: ${error.message}`);
+            debug(error);
+          }
+        }
+        // If we haven't returned by now, use the original resolver or upstream resolver.
+        return originalResolveRequest(...args);
+      },
+    },
+  };
+}


### PR DESCRIPTION
# Why

Reimplements #19874 but with tests and proper checking.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- When a metro resolver throws a metro resolution error, we should attempt to resolve using the next resolver in the chain.
- Added debug logs so users can examine the progress.
- Added tests for all known cases.
