### PR TITLE
[docs] Fix the "-" character in Expo Update tech specs

### DIFF
--- a/docs/pages/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/technical-specs/expo-updates-0.mdx
@@ -234,4 +234,4 @@ Expo Updates supports code signing the manifest. This also transitively signs th
 
 ## Client Library
 
-See the [reference client library](https://github.com/expo/expo/tree/main/packages/expo-updates)
+See the [reference client library](https://github.com/expo/expo/tree/main/packages/expo-updates).

--- a/docs/pages/technical-specs/expo-updates-0.mdx
+++ b/docs/pages/technical-specs/expo-updates-0.mdx
@@ -17,9 +17,9 @@ This is the specification for Expo Updates, a protocol for delivering updates to
 
 Conforming servers and client libraries must fulfill all normative requirements. Conformance requirements are described in this document by both descriptive assertions and key words with clearly defined meanings.
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non‐normative.
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in the normative portions of this document are to be interpreted as described in [IETF RFC 2119](https://tools.ietf.org/html/rfc2119). These key words may appear in lowercase and still retain their meaning unless explicitly declared as non-normative.
 
-A conforming implementation of this protocol may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non‐conformance.
+A conforming implementation of this protocol may provide additional functionality, but must not where explicitly disallowed or would otherwise result in non-conformance.
 
 ### Overview
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently the character for "-" is not rendering correctly in https://docs.expo.dev/technical-specs/expo-updates-0/

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the "-" character to render it correctly.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
