### PR TITLE
[core] fix boost build error on android

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed boost build error on Android. ([#20719](https://github.com/expo/expo/pull/20719) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 1.1.0 — 2022-12-30

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -404,10 +404,25 @@ def prepareBoost = tasks.register('prepareBoost', Copy) {
   }
 }
 
+void nativeBuildDependsOn(project, dependsOnTask, buildTypesIncludes) {
+  def buildTasks = project.tasks.findAll { task ->
+    def taskName = task.name
+    if (taskName.contains("Clean")) { return false }
+    if (taskName.contains("externalNative") || taskName.contains("CMake") || taskName.contains("generateJsonModel")) {
+      if (buildTypesIncludes == null) { return true }
+      for (buildType in buildTypesIncludes) {
+        if (taskName.contains(buildType)) { return true }
+      }
+    }
+    return false
+  }
+  buildTasks.forEach { task -> task.dependsOn(dependsOnTask) }
+}
+
 afterEvaluate {
-  preBuild.dependsOn(prepareBoost)
+  nativeBuildDependsOn(project, prepareBoost, null)
   if (USE_HERMES) {
-    preBuild.dependsOn(prepareHermes)
+    nativeBuildDependsOn(project, prepareHermes, null)
     if (hasHermesProject && !prebuiltHermesCacheHit) {
       prepareHermes.dependsOn(":ReactAndroid:hermes-engine:assembleDebug")
     }


### PR DESCRIPTION
# Why

fix #20679 which is a regression from #20470

# How

preBuild task could be executed after cmake. we should rely on `externalNative` or `CMake` tasks. this pr copies the `nativeBuildDependsOn` from `ExpoModulesCorePlugin.gradle` and setup `prepareBoost` dependency by the `nativeBuildDependsOn`.

# Test Plan

- test the reproducible example provided by #20679 
- ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
