### PR TITLE
[Android] Bump `compileSdkVersion` and `targetSdkVersion` to 33

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,7 @@ android {
   defaultConfig {
     applicationId 'host.exp.exponent'
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     // ADD VERSIONS HERE
     // BEGIN VERSIONS
     versionCode 175

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -92,7 +92,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "1.0"
 

--- a/apps/bare-expo/android/app/src/main/AndroidManifest.xml
+++ b/apps/bare-expo/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
   <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
   <uses-permission android:name="android.permission.WRITE_CONTACTS" />

--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 12
     versionName '5.0.1'
   }

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 13.1.0 — 2022-12-30
 
 ### 🐛 Bug fixes

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -81,7 +81,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   if (rootProject.hasProperty("ndkPath")) {
     ndkPath rootProject.ext.ndkPath
@@ -101,7 +101,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 24
     versionName "13.1.0"
 

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 23
     versionName "11.0.1"
   }

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.2.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 26
     versionName "12.2.0"
   }

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 7.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 11
     versionName '7.0.0'
   }

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 6.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -70,7 +70,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -83,7 +83,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 12
     versionName '6.0.1'
 

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 15
     versionName '11.1.0'
   }

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName '11.0.1'
   }

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 13.1.0 - 2022-11-23
 
 ### 🐛 Bug fixes

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 32
     versionName "13.0.0"
   }

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 11
     versionName '5.0.1'
   }

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 4.0.2 — 2022-12-30
 
 ### 🐛 Bug fixes

--- a/packages/expo-clipboard/android/build.gradle
+++ b/packages/expo-clipboard/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 3
     versionName '4.0.2'
   }

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 14.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -61,7 +61,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -74,7 +74,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 33
     versionName "14.1.0"
   }

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Simplify exported types. ([#20269](https://github.com/expo/expo/pull/20269) by [@Simek](https://github.com/Simek))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 11.0.1 — 2022-10-28
 

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 29
     versionName "11.0.1"
   }

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 25
     versionName "12.1.0"
   }

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 2.0.1 — 2022-11-21
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -33,10 +33,10 @@ buildscript {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "2.0.1"
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Locked `layoutDirection` to LTR to prevent incorrect rendering when used together with a RTL enabled app. ([#19634](https://github.com/expo/expo/pull/19634) by [@aleqsio](https://github.com/aleqsio))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 2.0.2 - 2022-11-21
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -35,10 +35,10 @@ buildscript {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 9
     versionName "2.0.2"
   }

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 6
     versionName '1.0.0'
   }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 2.0.2 - 2022-11-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -192,7 +192,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -205,7 +205,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 10
     versionName '2.0.2'
   }

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 12
     versionName '5.1.0'
   }

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName '11.1.0'
   }

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 0.4.1 — 2022-11-02
 
 ### 💡 Others

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "0.4.1"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/expo-error-recovery/CHANGELOG.md
+++ b/packages/expo-error-recovery/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 4.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 9
     versionName '4.0.1'
   }

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 29
     versionName "12.0.0"
   }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Extract nested object definitions to the separate types, which adds: `DeletingOptions`, `InfoOptions`, `RelocatingOptions` and `MakeDirectoryOptions` types. ([#20103](https://github.com/expo/expo/pull/20103) by [@Simek](https://github.com/Simek))
 - Simplify the way in which types are exported from the package. ([#20103](https://github.com/expo/expo/pull/20103) by [@Simek](https://github.com/Simek))
 - Rename `UploadProgressData` `totalByteSent` field to `totalBytesSent`. ([#20804](https://github.com/expo/expo/pull/20804) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 15.1.1 — 2022-10-28
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 30
     versionName "15.1.1"
   }

--- a/packages/expo-firebase-analytics/CHANGELOG.md
+++ b/packages/expo-firebase-analytics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 8.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-firebase-analytics/android/build.gradle
+++ b/packages/expo-firebase-analytics/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 15
     versionName '8.0.0'
   }

--- a/packages/expo-firebase-core/CHANGELOG.md
+++ b/packages/expo-firebase-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 6.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-firebase-core/android/build.gradle
+++ b/packages/expo-firebase-core/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 10
     versionName '6.0.0'
   }

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 29
     versionName "11.0.1"
   }

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.2.0 — 2022-12-30
 
 ### 🐛 Bug fixes

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -81,7 +81,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   if (rootProject.hasProperty("ndkPath")) {
     ndkPath rootProject.ext.ndkPath
@@ -101,7 +101,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 31
     versionName "12.2.0"
 

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 16
     versionName '12.1.0'
   }

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 4.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 8
     versionName "4.0.0"
   }

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 23
     versionName "11.0.0"
   }

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 14.0.3 — 2022-12-30
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 22
     versionName "14.0.3"
   }

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 1.0.0-beta.0 — 2023-01-19
 
 ### 🎉 New features

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -34,7 +34,7 @@ buildscript {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -47,7 +47,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "1.0.0-beta.0"
   }

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 14.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 13
     versionName '14.0.0'
   }

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 10.4.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 14
     versionName '10.4.0'
   }

--- a/packages/expo-json-utils/CHANGELOG.md
+++ b/packages/expo-json-utils/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 0.4.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 31
     versionName '0.4.0'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - Define `KeepAwakeOptions` type, update the doc comments. ([#20489](https://github.com/expo/expo/pull/20489) by [@Simek](https://github.com/Simek))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 11.0.1 — 2022-10-28
 

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 16
     versionName "11.0.1"
   }

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.1 — 2022-11-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName "12.0.1"
   }

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 13.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 30
     versionName "13.1.0"
   }

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 14.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 22
     versionName "14.0.0"
   }

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 15.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 29
     versionName "15.0.1"
   }

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName "12.0.0"
   }

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 0.4.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 31
     versionName '0.4.0'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName '1.0.0'
   }

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 15.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -60,7 +60,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -73,7 +73,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 37
     versionName "15.1.0"
   }

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "<%- project.version %>"
   }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 1.1.1 — 2023-01-06
 
 ### 🎉 New features

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -150,7 +150,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   if (rootProject.hasProperty("ndkPath")) {
     ndkPath rootProject.ext.ndkPath
@@ -170,7 +170,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     consumerProguardFiles 'proguard-rules.pro'
     versionCode 1
     versionName "1.1.1"

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 3
     versionName '0.10.0'
   }

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 2.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-navigation-bar/android/build.gradle
+++ b/packages/expo-navigation-bar/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName '2.0.1'
   }

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 11
     versionName '5.1.0'
   }

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Update getExpoPushTokenAsync to make projectId required. ([#20833](https://github.com/expo/expo/pull/20833) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.17.0 — 2022-10-25
 

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 21
     versionName '0.17.0'
   }

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 14.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 31
     versionName "14.0.0"
   }

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.1.0 — 2023-01-05
 
 ### 🐛 Bug fixes

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 27
     versionName "12.1.0"
   }

--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ### ⚠️ Notices
 
 - Deprecate the library in favor of expo-crypto. ([#20217](https://github.com/expo/expo/pull/20217) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 27
     versionName "13.0.0"
   }

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 7
     versionName '5.0.0'
   }

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 5.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 7
     versionName '5.0.1'
   }

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName '12.0.0'
   }

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.1 — 2022-10-27
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 27
     versionName "12.0.1"
   }

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 16
     versionName '11.1.0'
   }

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 28
     versionName "11.1.0"
   }

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 18
     versionName "11.0.0"
   }

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 0.17.4 - 2022-11-08
 
 ### 🐛 Bug fixes

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 17
     versionName '0.17.3'
   }

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 18
     versionName "11.0.0"
   }

--- a/packages/expo-status-bar/CHANGELOG.md
+++ b/packages/expo-status-bar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 1.4.2 — 2022-11-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 6.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-store-review/android/build.gradle
+++ b/packages/expo-store-review/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 4
     versionName "6.1.0"
   }

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 3.0.1 — 2022-11-02
 
 ### 💡 Others

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName '3.0.1'
   }

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 2.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-system-ui/android/build.gradle
+++ b/packages/expo-system-ui/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName '2.1.0'
   }

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 11.0.1 — 2022-10-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 23
     versionName "11.0.1"
   }

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 0.8.1 — 2022-11-02
 
 ### 💡 Others

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName '0.8.1'
   }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improvements to setup for Updates E2E tests. ([#20120](https://github.com/expo/expo/pull/20120) by [@douglowder](https://github.com/douglowder))
 - Convert updates E2E workflow to use EAS. ([#20399](https://github.com/expo/expo/pull/20399) by [@douglowder](https://github.com/douglowder))
 - Avoid dependency on `uuid`. ([#20475](https://github.com/expo/expo/pull/20475) by [@LinusU](https://github.com/LinusU))
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
 
 ## 0.15.5 - 2022-11-14
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -64,7 +64,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -77,7 +77,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 31
     versionName '0.15.4'
     consumerProguardFiles("proguard-rules.pro")

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 7.1.0 — 2022-12-30
 
 ### 🎉 New features

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 14
     versionName '7.1.0'
   }

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 12.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -60,7 +60,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -73,7 +73,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 18
     versionName '12.0.0'
   }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 47.0.1 — 2022-11-03
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -89,7 +89,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -102,7 +102,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "47.0.1"
     consumerProguardFiles("proguard-rules.pro")

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))
+
 ## 4.0.0 — 2022-10-25
 
 ### 🛠 Breaking changes

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_11
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 8
     versionName '4.0.0'
   }


### PR DESCRIPTION
# Why

Bumps the compile and target SDK version to 33. 

# How

Changed SDK version from 31 to 33. Version 32 is correlated with Android 12l which improves user experience on tablets or foldable phones. It doesn't require any changes from us. The 33 is introducing a couple of things that we may want to address. Most of them are connected with permissions. Fixes for that will be applied in a separate PR. 
Apart from that, everything else seems to be working fine. 

Behavior changes:
- https://developer.android.com/about/versions/13/behavior-changes-all
- https://developer.android.com/about/versions/13/behavior-changes-13

# Test Plan

- Expo go with NCL and test-suite
  - simulator with API 33 ✅
  - simulator with API 31 ✅
  - physical device with API 33 ✅
  - physical device with API 31 ✅
- Bare expo
  - simulator with API 33 ✅
  - simulator with API 31 ✅
  - physical device with API 33 ✅
  - physical device with API 31 ✅
- Dev-Client
  - simulator with API 33 ✅
  - simulator with API 31 ✅
  - physical device with API 33 ✅
  - physical device with API 31 ✅