### PR TITLE
[tools] Add utils to create a dependency graph of monorepo packages

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -23,6 +23,15 @@ export interface CodegenConfigLibrary {
   jsSrcsDir: string;
 }
 
+export enum DependencyKind {
+  Normal = 'dependencies',
+  Dev = 'devDependencies',
+  Peer = 'peerDependencies',
+  Optional = 'optionalDependencies',
+}
+
+export const DefaultDependencyKind = [DependencyKind.Normal, DependencyKind.Dev];
+
 /**
  * An object representing `package.json` structure.
  */
@@ -34,6 +43,10 @@ export type PackageJson = {
   codegenConfig?: {
     libraries: CodegenConfigLibrary[];
   };
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
   [key: string]: unknown;
 };
 
@@ -42,7 +55,7 @@ export type PackageJson = {
  */
 export type PackageDependency = {
   name: string;
-  group: string;
+  kind: DependencyKind;
   versionRange: string;
 };
 
@@ -229,23 +242,17 @@ export class Package {
     return await Npm.getPackageViewAsync(this.packageName, this.packageVersion);
   }
 
-  getDependencies(includeDev: boolean = false): PackageDependency[] {
-    const depsGroups = ['dependencies', 'peerDependencies', 'optionalDependencies'];
-
-    if (includeDev) {
-      depsGroups.push('devDependencies');
-    }
-
-    const dependencies = depsGroups.map((group) => {
-      const deps = this.packageJson[group] as Record<string, string>;
+  getDependencies(kinds: DependencyKind[] = [DependencyKind.Normal]): PackageDependency[] {
+    const dependencies = kinds.map((kind) => {
+      const deps = this.packageJson[kind];
 
       return !deps
         ? []
         : Object.entries(deps).map(([name, versionRange]) => {
             return {
               name,
-              group,
-              versionRange: versionRange as string,
+              kind,
+              versionRange,
             };
           });
     });

--- a/tools/src/commands/PackagesDependencyGraphCommand.ts
+++ b/tools/src/commands/PackagesDependencyGraphCommand.ts
@@ -1,0 +1,42 @@
+import { Command } from '@expo/commander';
+
+import { DependencyKind } from '../Packages';
+import { PackagesGraph, printGraph, printNodeDependants } from '../packages-graph';
+
+type ActionOptions = {
+  dev: boolean;
+  peer: boolean;
+  listDependantsOf: string;
+};
+
+async function action(packageNames: string[], options: ActionOptions) {
+  const graph = await PackagesGraph.makeFromPublicPackages();
+  const dependencyKinds = [
+    DependencyKind.Normal,
+    options.dev && DependencyKind.Dev,
+    options.peer && DependencyKind.Peer,
+  ].filter(Boolean) as DependencyKind[];
+
+  if (options.listDependantsOf) {
+    const packageName = options.listDependantsOf;
+    const node = graph.getNode(packageName);
+
+    if (!node) {
+      throw new Error(`Package with name "${packageName}" not found`);
+    }
+    printNodeDependants(node, dependencyKinds);
+    return;
+  }
+
+  printGraph(graph, packageNames, dependencyKinds);
+}
+
+export default (program: Command) => {
+  program
+    .command('packages-dependency-graph [packageNames...]')
+    .alias('pdg')
+    .option('--dev', 'Whether to include dev dependencies', false)
+    .option('--peer', 'Whether to include peer dependencies', false)
+    .option('--list-dependants-of <packageName>', 'Lists all dependants of the given package', '')
+    .asyncAction(action);
+};

--- a/tools/src/commands/PackagesDependencyGraphCommand.ts
+++ b/tools/src/commands/PackagesDependencyGraphCommand.ts
@@ -1,12 +1,12 @@
 import { Command } from '@expo/commander';
 
 import { DependencyKind } from '../Packages';
-import { PackagesGraph, printGraph, printNodeDependants } from '../packages-graph';
+import { PackagesGraph, printGraph, printNodeDependents } from '../packages-graph';
 
 type ActionOptions = {
   dev: boolean;
   peer: boolean;
-  listDependantsOf: string;
+  listDependentsOf: string;
 };
 
 async function action(packageNames: string[], options: ActionOptions) {
@@ -17,14 +17,14 @@ async function action(packageNames: string[], options: ActionOptions) {
     options.peer && DependencyKind.Peer,
   ].filter(Boolean) as DependencyKind[];
 
-  if (options.listDependantsOf) {
-    const packageName = options.listDependantsOf;
+  if (options.listDependentsOf) {
+    const packageName = options.listDependentsOf;
     const node = graph.getNode(packageName);
 
     if (!node) {
       throw new Error(`Package with name "${packageName}" not found`);
     }
-    printNodeDependants(node, dependencyKinds);
+    printNodeDependents(node, dependencyKinds);
     return;
   }
 
@@ -37,6 +37,6 @@ export default (program: Command) => {
     .alias('pdg')
     .option('--dev', 'Whether to include dev dependencies', false)
     .option('--peer', 'Whether to include peer dependencies', false)
-    .option('--list-dependants-of <packageName>', 'Lists all dependants of the given package', '')
+    .option('--list-dependents-of <packageName>', 'Lists all dependents of the given package', '')
     .asyncAction(action);
 };

--- a/tools/src/packages-graph/PackagesGraph.ts
+++ b/tools/src/packages-graph/PackagesGraph.ts
@@ -1,0 +1,116 @@
+import chalk from 'chalk';
+
+import {
+  DefaultDependencyKind,
+  DependencyKind,
+  getListOfPackagesAsync,
+  Package,
+} from '../Packages';
+import PackagesGraphEdge from './PackagesGraphEdge';
+import PackagesGraphNode from './PackagesGraphNode';
+
+type PackagesMap = Map<string, PackagesGraphNode>;
+
+export default class PackagesGraph {
+  nodes: PackagesMap = new Map();
+
+  static async makeFromPublicPackages(): Promise<PackagesGraph> {
+    const packages = await getListOfPackagesAsync();
+    const graph = new PackagesGraph(packages.filter((pkg) => pkg.packageJson.private !== true));
+    return graph;
+  }
+
+  constructor(packages: Package[]) {
+    for (const pkg of packages) {
+      const node = new PackagesGraphNode(pkg);
+      this.nodes.set(pkg.packageName, node);
+    }
+    for (const node of this.nodes.values()) {
+      resolveDependencies(this, node);
+    }
+  }
+
+  getNode(packageName: string): PackagesGraphNode | null {
+    return this.nodes.get(packageName) ?? null;
+  }
+
+  getOriginNodes(): PackagesGraphNode[] {
+    return [...this.nodes.values()].filter((node) => node.depth === 0);
+  }
+}
+
+function resolveDependencies(
+  graph: PackagesGraph,
+  node: PackagesGraphNode,
+  visitedNodes: Record<string, boolean> = {}
+) {
+  const dependencies = node.pkg.getDependencies([
+    DependencyKind.Normal,
+    DependencyKind.Dev,
+    DependencyKind.Peer,
+    DependencyKind.Optional,
+  ]);
+
+  // Mark the node as visited.
+  visitedNodes[node.name] = true;
+
+  for (const dependency of dependencies) {
+    const dependencyNode = graph.getNode(dependency.name);
+
+    if (!dependencyNode) {
+      // The dependency is probably not our package, so just skip it.
+      continue;
+    }
+    addDependency(
+      graph,
+      node,
+      dependencyNode,
+      dependency.kind,
+      dependency.versionRange,
+      visitedNodes
+    );
+  }
+}
+
+function addDependency(
+  graph: PackagesGraph,
+  origin: PackagesGraphNode,
+  destination: PackagesGraphNode,
+  kind: DependencyKind = DependencyKind.Normal,
+  versionRange: string,
+  visitedNodes: Record<string, boolean> = {}
+) {
+  const existingEdge = origin.getOutgoingEdgeForNode(destination);
+
+  // Given nodes are already connected in that direction.
+  // Just make sure to add another kind.
+  if (existingEdge) {
+    existingEdge.addKind(kind);
+    return;
+  }
+
+  const edge = new PackagesGraphEdge(origin, destination, versionRange);
+
+  edge.addKind(kind);
+
+  // If the target node was already visited, mark the edge as a cycling edge.
+  edge.isCyclic = visitedNodes[destination.name] === true;
+
+  // Connect nodes.
+  origin.outgoingEdges.push(edge);
+  destination.incomingEdges.push(edge);
+
+  // The dependency node is at least one level deeper than the parent.
+  destination.depth = Math.max(origin.depth + 1, destination.depth);
+
+  if (edge.isCyclic) {
+    // Possible cycle in dependencies. Cycles in peer and optional dependency relations are fine though.
+    if (DefaultDependencyKind.includes(kind)) {
+      console.error(
+        chalk.red(`Detected a cycle in ${kind}! ${origin.name} -> ${destination.name}`)
+      );
+    }
+    return;
+  }
+  resolveDependencies(graph, destination, { ...visitedNodes });
+}

--- a/tools/src/packages-graph/PackagesGraphEdge.ts
+++ b/tools/src/packages-graph/PackagesGraphEdge.ts
@@ -1,0 +1,64 @@
+import { DependencyKind } from '../Packages';
+import PackagesGraphNode from './PackagesGraphNode';
+
+/**
+ * A graph edge that refers to the relation between two packages.
+ */
+export default class PackagesGraphEdge {
+  /**
+   * The graph node that depends on the destination node.
+   */
+  origin: PackagesGraphNode;
+
+  /**
+   * The graph node that is dependant of the origin node.
+   */
+  destination: PackagesGraphNode;
+
+  /**
+   * Version range that the origin node package requires on the destination node package.
+   */
+  versionRange: string;
+
+  /**
+   * A set of dependency kinds that connect these two nodes. Usually it's just one kind,
+   * but in theory it's possible that the package is both a dependency and dev or peer dependency.
+   */
+  kinds = new Set<DependencyKind>();
+
+  /**
+   * Determines whether the edge is part of the cycle.
+   */
+  isCyclic: boolean = false;
+
+  constructor(origin: PackagesGraphNode, destination: PackagesGraphNode, versionRange: string) {
+    this.origin = origin;
+    this.destination = destination;
+    this.versionRange = versionRange;
+  }
+
+  addKind(kind: DependencyKind) {
+    this.kinds.add(kind);
+  }
+
+  isOfKind(kind: DependencyKind): boolean {
+    return this.kinds.has(kind);
+  }
+
+  getDominantKind(): DependencyKind {
+    const kindsInImportanceOrder: DependencyKind[] = [
+      DependencyKind.Normal,
+      DependencyKind.Dev,
+      DependencyKind.Peer,
+      DependencyKind.Optional,
+    ];
+    const dominant = kindsInImportanceOrder.find((kind) => this.kinds.has(kind));
+
+    if (!dominant) {
+      throw new Error(
+        `Cannot find a dominant edge kind between ${this.origin.name} and ${this.destination.name}`
+      );
+    }
+    return dominant;
+  }
+}

--- a/tools/src/packages-graph/PackagesGraphEdge.ts
+++ b/tools/src/packages-graph/PackagesGraphEdge.ts
@@ -11,7 +11,7 @@ export default class PackagesGraphEdge {
   origin: PackagesGraphNode;
 
   /**
-   * The graph node that is dependant of the origin node.
+   * The graph node that is dependent of the origin node.
    */
   destination: PackagesGraphNode;
 

--- a/tools/src/packages-graph/PackagesGraphNode.ts
+++ b/tools/src/packages-graph/PackagesGraphNode.ts
@@ -1,0 +1,77 @@
+import { DefaultDependencyKind, DependencyKind, Package } from '../Packages';
+import PackagesGraphEdge from './PackagesGraphEdge';
+
+/**
+ * A graph node that refers to the single package.
+ */
+export default class PackagesGraphNode {
+  /**
+   * The package represented by the node.
+   */
+  pkg: Package;
+
+  /**
+   * The package name.
+   */
+  name: string;
+
+  /**
+   * Indicates how deep the node is placed in the graph.
+   * Depth of nodes without incoming edges is equal to `0`.
+   */
+  depth: number = 0;
+
+  /**
+   * Edges connecting this node with its dependencies.
+   */
+  outgoingEdges: PackagesGraphEdge[] = [];
+
+  /**
+   * Edges connecting this node with its dependants.
+   */
+  incomingEdges: PackagesGraphEdge[] = [];
+
+  constructor(pkg: Package) {
+    this.pkg = pkg;
+    this.name = pkg.packageName;
+  }
+
+  getOutgoingEdgeForNode(node: PackagesGraphNode): PackagesGraphEdge | null {
+    return this.outgoingEdges.find((edge) => edge.destination === node) ?? null;
+  }
+
+  getIncomingEdgeForNode(node: PackagesGraphNode): PackagesGraphEdge | null {
+    return this.incomingEdges.find((edge) => edge.origin === node) ?? null;
+  }
+
+  getAllDependantEdges(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphEdge[] {
+    const allDependantEdges = this.incomingEdges
+      .map((edge) => {
+        if (!edge.isCyclic && kinds.includes(edge.getDominantKind())) {
+          return [edge, ...edge.origin.getAllDependantEdges(kinds)];
+        }
+        return [];
+      })
+      .flat();
+
+    return [...new Set(allDependantEdges)];
+  }
+
+  getAllDependants(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphNode[] {
+    return [...new Set(this.getAllDependantEdges(kinds).map((edge) => edge.origin))];
+  }
+
+  getOutgoingEdgesOfKinds(kinds: DependencyKind[]): PackagesGraphEdge[] {
+    return this.outgoingEdges.filter((edge) => {
+      return kinds.some((kind) => edge.isOfKind(kind));
+    });
+  }
+
+  isDependantOf(node: PackagesGraphNode): boolean {
+    return !!this.getOutgoingEdgeForNode(node);
+  }
+
+  isDependencyOf(node: PackagesGraphNode): boolean {
+    return !!this.getIncomingEdgeForNode(node);
+  }
+}

--- a/tools/src/packages-graph/PackagesGraphNode.ts
+++ b/tools/src/packages-graph/PackagesGraphNode.ts
@@ -27,7 +27,7 @@ export default class PackagesGraphNode {
   outgoingEdges: PackagesGraphEdge[] = [];
 
   /**
-   * Edges connecting this node with its dependants.
+   * Edges connecting this node with its dependents.
    */
   incomingEdges: PackagesGraphEdge[] = [];
 
@@ -44,21 +44,21 @@ export default class PackagesGraphNode {
     return this.incomingEdges.find((edge) => edge.origin === node) ?? null;
   }
 
-  getAllDependantEdges(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphEdge[] {
-    const allDependantEdges = this.incomingEdges
+  getAllDependentEdges(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphEdge[] {
+    const allDependentEdges = this.incomingEdges
       .map((edge) => {
         if (!edge.isCyclic && kinds.includes(edge.getDominantKind())) {
-          return [edge, ...edge.origin.getAllDependantEdges(kinds)];
+          return [edge, ...edge.origin.getAllDependentEdges(kinds)];
         }
         return [];
       })
       .flat();
 
-    return [...new Set(allDependantEdges)];
+    return [...new Set(allDependentEdges)];
   }
 
-  getAllDependants(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphNode[] {
-    return [...new Set(this.getAllDependantEdges(kinds).map((edge) => edge.origin))];
+  getAllDependents(kinds: DependencyKind[] = DefaultDependencyKind): PackagesGraphNode[] {
+    return [...new Set(this.getAllDependentEdges(kinds).map((edge) => edge.origin))];
   }
 
   getOutgoingEdgesOfKinds(kinds: DependencyKind[]): PackagesGraphEdge[] {
@@ -67,7 +67,7 @@ export default class PackagesGraphNode {
     });
   }
 
-  isDependantOf(node: PackagesGraphNode): boolean {
+  isDependentOf(node: PackagesGraphNode): boolean {
     return !!this.getOutgoingEdgeForNode(node);
   }
 

--- a/tools/src/packages-graph/PackagesGraphUtils.ts
+++ b/tools/src/packages-graph/PackagesGraphUtils.ts
@@ -1,0 +1,124 @@
+import chalk from 'chalk';
+import { EOL } from 'os';
+
+import { DefaultDependencyKind, DependencyKind } from '../Packages';
+import PackagesGraph from './PackagesGraph';
+import PackagesGraphEdge from './PackagesGraphEdge';
+import PackagesGraphNode from './PackagesGraphNode';
+
+type NodeVisitingData = {
+  visited: Record<string, boolean>;
+  node: PackagesGraphNode;
+  edges: PackagesGraphEdge[];
+  kind: DependencyKind;
+  version: string;
+  level: number;
+  prefix: string;
+};
+
+export function printGraph(
+  graph: PackagesGraph,
+  packageNames: string[] = [],
+  kinds: DependencyKind[] = DefaultDependencyKind
+) {
+  function visitNodeEdges(visitingData: NodeVisitingData) {
+    const { node, edges, kind, version, level, prefix, visited } = visitingData;
+    const name = formatNodeName(node.name, kind, level);
+
+    if (visited[node.name] === true) {
+      process.stdout.write(chalk.dim(`${name} ...`) + EOL);
+      return;
+    }
+
+    visited[node.name] = true;
+
+    process.stdout.write(`${name} ${chalk.cyan(version)}` + EOL);
+
+    if (edges.length === 0 && level === 0) {
+      // It has no dependencies, but let's explicitly show that for the origin nodes.
+      process.stdout.write(edgePointer(true, false, false) + chalk.dim('none') + EOL);
+      return;
+    }
+    for (let i = 0; i < edges.length; i++) {
+      const edge = edges[i];
+      const isLast = i === edges.length - 1;
+      const nextEdges = edge.destination.getOutgoingEdgesOfKinds(kinds);
+      const hasMore = nextEdges.length > 0 && visited[edge.destination.name] !== true;
+
+      process.stdout.write(chalk.gray(prefix) + edgePointer(isLast, hasMore, edge.isCyclic));
+
+      visitNodeEdges({
+        node: edge.destination,
+        edges: nextEdges,
+        kind: edge.getDominantKind(),
+        version: edge.versionRange,
+        level: level + 1,
+        prefix: prefix + nodeIndent(isLast),
+        visited: { ...visited },
+      });
+    }
+  }
+
+  for (const node of graph.nodes.values()) {
+    if (packageNames.length > 0 && !packageNames.includes(node.name)) {
+      continue;
+    }
+    visitNodeEdges({
+      node,
+      edges: node.getOutgoingEdgesOfKinds(kinds),
+      kind: DependencyKind.Normal,
+      version: node.pkg.packageVersion,
+      level: 0,
+      prefix: '',
+      visited: {},
+    });
+  }
+}
+
+export function printNodeDependants(
+  node: PackagesGraphNode,
+  kinds: DependencyKind[] = DefaultDependencyKind
+) {
+  const nodes = node.getAllDependants(kinds);
+
+  if (nodes.length === 0) {
+    console.log(`${chalk.bold(node.name)} has no dependants`);
+    return;
+  }
+
+  console.log(`All dependants of the ${chalk.bold(node.name)} package:`);
+
+  for (const node of nodes) {
+    console.log(`- ${chalk.bold(node.name)}`);
+  }
+}
+
+function edgePointer(isLast: boolean, hasMore: boolean, isCyclic: boolean): string {
+  const rawPointer = [
+    isLast ? '└─' : '├─',
+    hasMore ? '┬─' : '──',
+    isCyclic ? chalk.red('∞') : '',
+    ' ',
+  ].join('');
+  return chalk.gray(rawPointer);
+}
+
+function nodeIndent(isLast: boolean): string {
+  return isLast ? '  ' : '│ ';
+}
+
+function formatNodeName(name: string, kind: DependencyKind, level: number): string {
+  if (level === 0) {
+    return chalk.bold(name);
+  }
+  switch (kind) {
+    case DependencyKind.Normal:
+      return chalk.green(name);
+    case DependencyKind.Dev:
+      return chalk.yellow(name);
+    case DependencyKind.Peer:
+      return chalk.magenta(name);
+    case DependencyKind.Optional:
+      return chalk.gray(name);
+  }
+}

--- a/tools/src/packages-graph/PackagesGraphUtils.ts
+++ b/tools/src/packages-graph/PackagesGraphUtils.ts
@@ -75,18 +75,18 @@ export function printGraph(
   }
 }
 
-export function printNodeDependants(
+export function printNodeDependents(
   node: PackagesGraphNode,
   kinds: DependencyKind[] = DefaultDependencyKind
 ) {
-  const nodes = node.getAllDependants(kinds);
+  const nodes = node.getAllDependents(kinds);
 
   if (nodes.length === 0) {
-    console.log(`${chalk.bold(node.name)} has no dependants`);
+    console.log(`${chalk.bold(node.name)} has no dependents`);
     return;
   }
 
-  console.log(`All dependants of the ${chalk.bold(node.name)} package:`);
+  console.log(`All dependents of the ${chalk.bold(node.name)} package:`);
 
   for (const node of nodes) {
     console.log(`- ${chalk.bold(node.name)}`);

--- a/tools/src/packages-graph/index.ts
+++ b/tools/src/packages-graph/index.ts
@@ -1,0 +1,6 @@
+import PackagesGraph from './PackagesGraph';
+import PackagesGraphEdge from './PackagesGraphEdge';
+import PackagesGraphNode from './PackagesGraphNode';
+
+export { PackagesGraph, PackagesGraphEdge, PackagesGraphNode };
+export * from './PackagesGraphUtils';


### PR DESCRIPTION
# Why

`et publish-packages` needs some improvements to make publishing versioned CLI and dev client packages more convenient. One of the things we'll need is to detect all dependencies and dependants in packages in the monorepo. To help with this, I built a class that represents a graph of packages.

# How

- Added utils to create a dependency directed graph
- Added `et packages-dependency-graph` command that prints the dependency tree for each non-private package (probably temporarily until we start using it in the publish script)

# Test Plan

![Screenshot 2023-01-05 at 17 51 42](https://user-images.githubusercontent.com/1714764/210837167-bd353dd1-c8ca-43a4-b1a4-209307d93698.png)
