### PR TITLE
[docs] FAQ: Fix broken links to EAS

### DIFF
--- a/docs/pages/introduction/faq.mdx
+++ b/docs/pages/introduction/faq.mdx
@@ -67,13 +67,13 @@ In the same way React.js frameworks help users create larger websites with ease,
 
 <Collapsible summary="What is the difference between Expo and React Native?">
 
-The `expo` package provides a suite of features that make it easier to develop, and scale complex React Native applications. You can install `expo` in nearly any React Native app. The `expo` package is not required to use [Expo Application Services](/eas/index) or React Native, but it is highly recommended. Learn more about [what Expo offers](/introduction).
+The `expo` package provides a suite of features that make it easier to develop, and scale complex React Native applications. You can install `expo` in nearly any React Native app. The `expo` package is not required to use [Expo Application Services (EAS)](/eas) or React Native, but it is highly recommended. Learn more about [what Expo offers](/introduction).
 
 </Collapsible>
 
 <Collapsible summary="Do I need to switch from React Native to use Expo?">
 
-No, the `expo` npm package and CLI work with any React Native app. [Expo Application Services](/eas/index) also works with all React Native apps with first-class support for builds, updates, app store submissions, and more.
+No, the `expo` npm package and CLI work with any React Native app. [Expo Application Services (EAS)](/eas) also works with all React Native apps with first-class support for builds, updates, app store submissions, and more.
 
 </Collapsible>
 
@@ -81,7 +81,7 @@ No, the `expo` npm package and CLI work with any React Native app. [Expo Applica
 
 The Expo platform is [free and open source](https://blog.expo.dev/exponent-is-free-as-in-and-as-in-1d6d948a60dc). This includes the libraries that make up the [Expo SDK](/versions/latest/) and the [Expo CLI](/workflow/expo-cli/) used for development. The Expo Go app, the easiest way to get started, is also free from the app stores.
 
-[Expo Application Services (EAS)](https://expo.dev/eas) is an optional suite of cloud services for React Native apps, from the Expo team. EAS makes it easier to build your app, submit it to the stores, keep it updated, send push notifications, and more. You can use EAS for free if the [Free tier](https://expo.dev/pricing) quotas are sufficient for your app. More information is available on the [pricing page](https://expo.dev/pricing).
+[Expo Application Services (EAS)](/eas) is an optional suite of cloud services for React Native apps, from the Expo team. EAS makes it easier to build your app, submit it to the stores, keep it updated, send push notifications, and more. You can use EAS for free if the [Free tier](https://expo.dev/pricing) quotas are sufficient for your app. More information is available on the [pricing page](https://expo.dev/pricing).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why
The first two links were broken (404 not found), and Also changed so all mentions of Expo Application Services includes the abbreviation (EAS) 

# How
Just changed the text in the FAQ

# Test Plan
Tested that the links now work

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
