### PR TITLE
[docs]  Fix broken infrastructure link on EAS Build limitations page

### DIFF
--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -12,7 +12,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 <Collapsible summary="Fixed memory and CPU limits on build worker servers">
 
-The [Server infrastructure reference](./infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future we will be adding more powerful configurations to increase memory limits and speed up build times.
+The [Server infrastructure reference](/build-reference/infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future, we will add more powerful configurations to increase memory limits and speed up build times.
 
 </Collapsible>
 
@@ -22,7 +22,7 @@ Build jobs for Android install npm and Maven dependencies from a local cache. Bu
 
 Intermediate artifacts like `node_modules` directories are not cached and restored (eg: based on `yarn.lock` or `package-lock.json`), but if you commit them to your git repository then they will be uploaded to build servers.
 
-[Learn more about dependency caching](./caching.mdx).
+[Learn more about dependency caching](/build-reference/caching.mdx).
 
 </Collapsible>
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -12,7 +12,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 <Collapsible summary="Fixed memory and CPU limits on build worker servers">
 
-The [Server infrastructure reference](/infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future we will be adding more powerful configurations to increase memory limits and speed up build times.
+The [Server infrastructure reference](./infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future we will be adding more powerful configurations to increase memory limits and speed up build times.
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

Under the "Fixed memory and CPU limits on build worker servers" section the linked text "Server infrastructure reference" references a missing page.

# How

Added a `.` to the start of the path to reference the current directory rather than the root of the docs.

# Test Plan

Not tested locally but the change is trivial.

To reproduce:
1. Navigate to https://docs.expo.dev/build-reference/limitations/
2. Click on "Server infrastructure reference" under the "Fixed memory and CPU limits on build worker servers" section
3. Observe whether the browser navigates to a valid page.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
