### PR TITLE
[docs] Fixes broken links for FAQ and glossary, and other minor fixes

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The [Environment variables in Expo](/guides/environment-variables) guide presents several options for how you can access system environment variables to your app JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
+The [Environment variables in Expo](/guides/environment-variables) guide presents several options for how you can access system environment variables to your app's JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
 
 Using the techniques described in the environment variables document above, environment variables are inlined (the `process.env.X` text is replaced with its evaluated result) in your app's JavaScript code _at the time that the app is built_, and included in the app bundle. This means that the substitution would occur on EAS Build servers and not on your development machine, so if you tried to run a build on EAS Build without explicitly providing values or fallbacks for the environment variables, then you are likely to encounter either a build-time or runtime error.
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 
-The [Environment variables in Expo](/guides/environment-variables) guide presents several options for how you can access system environment variables to your app's JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
+The [Environment variables in Expo](/guides/environment-variables) guide presents several options for accessing system environment variables in your app's JavaScript code. This can be a useful way to inject values in your code, but [these values should not be secrets](/guides/environment-variables#security-considerations), and so the value it provides can be summarized as a convenience for accommodating certain development workflows.
 
 Using the techniques described in the environment variables document above, environment variables are inlined (the `process.env.X` text is replaced with its evaluated result) in your app's JavaScript code _at the time that the app is built_, and included in the app bundle. This means that the substitution would occur on EAS Build servers and not on your development machine, so if you tried to run a build on EAS Build without explicitly providing values or fallbacks for the environment variables, then you are likely to encounter either a build-time or runtime error.
 

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -7,6 +7,7 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { CODE } from '~/ui/components/Text';
 
 It is often desirable for regular HTTPS links (without a custom URL scheme) to directly open your app on mobile devices. This allows you to send notification emails with links that work as expected in the web browser on a desktop, while opening the content in your app on mobile. Android refers to this concept as "deep links" and iOS refers to it as "universal links". In this section, deep links that do not use a custom URL scheme are specifically discussed.
 
@@ -191,9 +192,9 @@ It may be desirable for links to your domain to always open your app (without pr
 }
 ```
 
-<Collapsible summary="Handle App Links on Android for expo-dev-client's version 1.2.1 and below">
+<Collapsible summary={<>Handle App Links on Android for <CODE>expo-dev-client</CODE> version 1.2.1 and below</>}>
 
-From Android 12 onwards, there is an issue reported when verifying the App Links with [`expo-dev-client`](/development/create-development-builds)'s version 1.2.1 and below.
+From Android 12 onwards, there is an issue reported when verifying the App Links with [`expo-dev-client`](/development/create-development-builds) version 1.2.1 and below.
 
 In Expo config, when `expo.android.intentFilters` is used and `"autoVerify"` is set to `true`, the `expo-dev-client` adds a scheme `<data android:scheme="exp+<slug>" />` to the intent filter. This scheme breaks the App Links verification.
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -283,7 +283,7 @@ When building tests for your application, you want to assert that the right flow
 
 [`sentry-testkit`](https://wix.github.io/sentry-testkit) enables Sentry to work natively in your application, and by overriding the default Sentry transport mechanism, the report is not really sent but rather logged locally into memory. In this way, the logged reports can be fetched later for your own usage, verification, or any other use you may have in your local developing/testing environment.
 
-See how to get started with `sentry-testkit` in their [documentation site here](https://wix.github.io/sentry-testkit/)
+For more information on how to get started, see [`sentry-testkit` documentation](https://wix.github.io/sentry-testkit/).
 
 > If you're using `jest`, make sure to add `@sentry/.*` and `sentry-expo` to your `transformIgnorePatterns`.
 
@@ -300,7 +300,7 @@ Unless `enableInExpoDevelopment: true` is set, all your dev/local errors will be
 <Collapsible summary={<>I'm seeing <CODE>error: project not found</CODE> in my build logs</>}>
 
 This error is caused by the script that tries to upload source maps during build.
-  
+
 Make sure your `organization`, `project` and `authToken` properties are set correctly.
 
 </Collapsible>

--- a/docs/pages/introduction/faq.mdx
+++ b/docs/pages/introduction/faq.mdx
@@ -49,13 +49,13 @@ Many popular web packages such as three.js or Firebase work with Expo and React 
 
 <Collapsible summary="Can I use Expo with my native library?">
 
-You can use native iOS and Android libraries with Expo by creating a [custom native module](/modules/) with Swift and Kotlin. Many popular libraries already have custom native modules. Check out our [React Native directory](https://reactnative.directory/) to learn more.
+You can use native Android and iOS libraries with Expo by creating a [custom native module](/modules/) with Swift and Kotlin. Many popular libraries already have custom native modules. Check out our [React Native directory](https://reactnative.directory/) to learn more.
 
 </Collapsible>
 
 <Collapsible summary="Is Expo similar to React for web development?">
 
-Expo is a framework for React Native, which is a library for building iOS and Android apps. React Native is similar to `react-dom` for web development, enabling you to run React on a particular platform, but it has a few key differences:
+Expo is a framework for React Native, which is a library for building Android and iOS apps. React Native is similar to `react-dom` for web development, enabling you to run React on a particular platform, but it has a few key differences:
 
 - React Native does not support HTML or CSS.
 - Instead of using the DOM, React Native uses native components. For example, `<View />` instead of `<div />`. Native components are more performant than the DOM and provide a much nicer user experience.
@@ -139,7 +139,7 @@ Unlike the `expo eject` library, authors can configure their libraries to work w
 
 Expo CLI can be used simultaneously with React Native CLI. Expo CLI provides the same core functionality as React Native CLI, and additional functionality like automatic [TypeScript setup](/guides/typescript), [web support](/workflow/web), [auto installing compatible libraries](/workflow/expo-cli#install), [improved native build commands](/workflow/expo-cli#compiling), [tunneling](/workflow/expo-cli#tunneling), [prebuild](/workflow/prebuild), [and more](/workflow/expo-cli).
 
-Regardless of which CLI you use, you can use any part of the [Expo SDK](/versions/latest/) and [Expo Application Services](/eas/index) with your project.
+Regardless of which CLI you use, you can use any part of the [Expo SDK](/versions/latest/) and [Expo Application Services](/eas) with your project.
 
 </Collapsible>
 

--- a/docs/pages/workflow/glossary-of-terms.mdx
+++ b/docs/pages/workflow/glossary-of-terms.mdx
@@ -99,11 +99,11 @@ The development server is typically hosted on `http://localhost:19000`. It hosts
 
 ### EAS
 
-[Expo Application Services (EAS)](/eas/index.mdx) are deeply-integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction.mdx) and [EAS Submit](/submit/introduction.mdx).
+[Expo Application Services (EAS)](/eas) are deeply-integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction) and [EAS Submit](/submit/introduction).
 
 ### EAS CLI
 
-The command-line tool for working with EAS. {/* Pending creation of eas-cli [Read more](eas-cli.mdx). */}
+The command-line tool for working with EAS. {/* Pending creation of eas-cli [Read more](/eas-cli). */}
 
 ### EAS Config
 
@@ -111,7 +111,7 @@ The `eas.json` file used to configure [EAS CLI](#eas-cli). For more information,
 
 ### EAS Metadata
 
-A command line tool for uploading and downloading Apple App Store metadata as JSON. This tool is available in the [EAS CLI](#eas-cli) package and should be used to improve the iOS submission process, see [EAS Metadata](../eas/metadata/index.mdx).
+A command line tool for uploading and downloading Apple App Store metadata as JSON. This tool is available in the [EAS CLI](#eas-cli) package and should be used to improve the iOS submission process. For more information, see [EAS Metadata](/eas/metadata).
 
 ### EAS Update
 
@@ -122,9 +122,9 @@ A command line tool for uploading and downloading Apple App Store metadata as JS
 
 > **warning** Deprecated technology
 
-The term "eject" was popularized by [create-react-app](https://github.com/facebookincubator/create-react-app), and it is used in Expo to describe leaving the cozy comfort of the standard Expo development environment, where you do not have to deal with build configuration or native code. When you "eject" from Expo, you have two choices:
+The term "eject" was popularized by [create-react-app](https://github.com/facebook/create-react-app), and it is used in Expo to describe leaving the cozy comfort of the standard Expo development environment, where you do not have to deal with build configuration or native code. When you "eject" from Expo, you have two choices:
 
-- _Eject to bare workflow_, where you jump between [workflows](../introduction/managed-vs-bare.mdx) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native iOS and Android projects.
+- _Eject to bare workflow_, where you jump between [workflows](/introduction/managed-vs-bare) and move into the bare workflow, where you can continue to use Expo APIs but have access and full control over your native Android and iOS projects.
 - _Eject to ExpoKit_, where you get the native projects along with [ExpoKit](#expokit). This option is deprecated and support for ExpoKit was removed after SDK 38.
 
 ### Emulator
@@ -145,7 +145,7 @@ The original [Autolinking](#autolinking) system that is designed for projects us
 
 ### Expo CLI
 
-The command-line tool for working with Expo. This term now refers to the [Local Expo CLI](#local-expo-cli), but historically referred to the [Global Expo CLI](#global-expo-cli). For more information, see [Expo CLI](expo-cli.mdx).
+The command-line tool for working with Expo. This term now refers to the [Local Expo CLI](#local-expo-cli), but historically referred to the [Global Expo CLI](#global-expo-cli). For more information, see [Expo CLI](/workflow/expo-cli).
 
 ### Expo client
 
@@ -153,7 +153,7 @@ The former name for the [Expo Go](#expo-go) app.
 
 ### Expo Config
 
-A file named `app.json`, `app.config.json`, `app.config.js`, or `app.config.ts` in the root of a project directory. [Learn more](configuration.mdx).
+A file named `app.json`, `app.config.json`, `app.config.js`, or `app.config.ts` in the root of a project directory. For more information, see [Expo Config configuration](/workflow/configuration/).
 
 This file is used for the following purposes:
 
@@ -167,7 +167,7 @@ Refers to the command `npx expo export` from [Expo CLI](#expo-cli). This command
 
 ### Expo Go
 
-The iOS and Android app that runs React Native apps. When you want to run your app outside of the Expo Go app and deploy it to the App and/or Play stores, you can build a [Standalone App](#standalone-app).
+The Android and iOS app that runs React Native apps. When you want to run your app outside of the Expo Go app and deploy it to the App and/or Play stores, you can build a [Standalone App](#standalone-app).
 
 ### Expo Install
 
@@ -195,13 +195,13 @@ Refers to the command `npx expo start` from [Expo CLI](#expo-cli). This command 
 
 > **warning** Deprecated technology
 
-ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. [Read more](../expokit/eject.mdx).
+ExpoKit is an Objective-C and Java library that allows you to use the [Expo SDK](#expo-sdk) and platform and your existing Expo project as part of a larger standard native project — one that you would normally create using Xcode, Android Studio, or `react-native init`. For more information, see [Ejecting to ExpoKit](/expokit/eject/).
 
 **Support for ExpoKit ended after SDK 38. Expo modules can implement support for custom native configuration, and projects that need even more custom native code can [expose their Android Studio and Xcode projects with `npx expo prebuild`](/workflow/customizing/).**
 
 ### Fabric
 
-The React Native rendering system that is used to create and manage native views. This package supports [iOS](#ios) and [Android](#android). For more information, see [Fabric Renderer](https://reactnative.dev/architecture/fabric-renderer).
+The React Native rendering system is used to create and manage native views. This package supports [Android](#android) and [iOS](#iOS). For more information, see [Fabric Renderer](https://reactnative.dev/architecture/fabric-renderer).
 
 ### Flipper
 
@@ -213,7 +213,7 @@ Sometimes referred to as "Expo FYI", this is a collection of tailored solutions 
 
 ### Global Expo CLI
 
-The package `expo-cli` which was installed globally on the user's machine and used across all projects. This CLI was introduced in SDK 30 (2018), and deprecated in favor of the [Local Expo CLI](#local-expo-cli) in SDK 46 (2022).
+The package `expo-cli` was installed globally on the user's machine and used across all projects. This CLI was introduced in SDK 30 (2018), and deprecated in favor of the [Local Expo CLI](#local-expo-cli) in SDK 46 (2022).
 
 ### Gradle
 
@@ -237,15 +237,15 @@ A [JavaScript engine](#javascript-engine) developed by Apple and built-in to [iO
 
 ### Linking
 
-Linking can mean [deep linking into apps similar to how you link to websites on the web](linking.mdx) or [autolinking](#autolinking).
+Linking can mean [deep linking into apps similar to how you link to websites on the web](/guides/linking) or [autolinking](#autolinking).
 
 ### Local Expo CLI
 
-The package `@expo/cli` which is installed with the `expo` package. This is sometimes referred to as the "Versioned Expo CLI" because it is installed inside of the user's project as opposed to the now deprecated `expo-cli` which was installed globally.
+The package `@expo/cli` is installed with the `expo` package. This is sometimes referred to as the "Versioned Expo CLI" because it is installed inside of the user's project as opposed to the now deprecated `expo-cli` which was installed globally.
 
 ### Manifest
 
-An Expo app manifest is similar to a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) - it provides information that Expo Go needs to know how to run the app and other relevant data. [Read more in "Expo Go"](/workflow/expo-go#manifest).
+An Expo app manifest is similar to a [web app manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest) - it provides information that Expo Go needs to know how to run the app and other relevant data. For more information, see [Expo Go](/workflow/expo-go#manifest).
 
 ### Meta
 
@@ -253,11 +253,11 @@ Formerly Facebook, Meta is the group that develops [React Native](#react-native)
 
 ### Metro Bundler
 
-The bundler used for converting JavaScript files and assets into a format that runs on a native client. This bundler is maintained by [Meta](#meta) and used exclusively for React Native apps. [Learn more](https://facebook.github.io/metro).
+The bundler used for converting JavaScript files and assets into a format that runs on a native client. This bundler is maintained by [Meta](#meta) and used exclusively for React Native apps. For more information, see [Metro documentation](https://facebook.github.io/metro).
 
 ### Metro Config
 
-The `metro.config.js` file used to configure [Metro bundler](#metro-bundler). This should extend the package `@expo/metro-config` when using [Expo CLI](#expo-cli). For more information, see [Customizing Metro](/guides/customizing-metro.mdx).
+The `metro.config.js` file used to configure [Metro bundler](#metro-bundler). This should extend the package `@expo/metro-config` when using [Expo CLI](#expo-cli). For more information, see [Customizing Metro](/guides/customizing-metro).
 
 ### Monorepo
 
@@ -356,7 +356,7 @@ A development agency in Krakow, Poland. Maintainers of `react-native-gesture-han
 
 ### Standalone app
 
-An application binary that can be submitted to the iOS App Store or Android Play Store. [Read more in "Building Standalone Apps"](/archive/classic-updates/building-standalone-apps.mdx).
+An application binary that can be submitted to the iOS App Store or Android Play Store. For more information, see [Building Standalone Apps](/archive/classic-updates/building-standalone-apps).
 
 ### Store Config
 
@@ -372,7 +372,7 @@ TypeScript is a strongly typed programming language that builds on JavaScript, g
 
 ### Updates
 
-Traditionally, apps for iOS and Android are updated by submitting an updated binary to the App and Play stores. Updates allow you to push an update to your app without the overhead of submitting a new release to the stores. For more information, see our [Publishing](publishing.mdx) documentation.
+Traditionally, apps for Android and iOS are updated by submitting an updated binary to the App and Play stores. Updates allow you to push an update to your app without the overhead of submitting a new release to the stores. For more information, see [Publishing](/eas-update/introduction) documentation.
 
 ### VS Code Expo
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, some links are broken on the Glossary and FAQ pages.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- fixes broken links on FAQ and Glossary pages
- for consistency, follows the same URL paths that we are now using in other places
- updates collapsible on Deep Linking guide to use code syntax 
- applies other style guidelines on some places

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
