### PR TITLE
[docs] fix broken monorepo link in EAS Build Setup page

### DIFF
--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -79,7 +79,7 @@ Additional configuration may be required for some scenarios:
 
 - Are you migrating an Expo managed app from `"expo build"`? [Learn about the differences](/build-reference/migrating).
 - Does your app code depend on environment variables? [Add them to your build configuration](/build-reference/variables).
-- Is your project inside of a monorepo? [Follow these instructions](/build-reference/how-tos#how-to-set-up-eas-build-with).
+- Is your project inside of a monorepo? [Follow these instructions](/build-reference/build-with-monorepos).
 - Do you use private npm packages? [Add your npm token](/build-reference/private-npm-packages).
 - Does your app depend on specific versions of tools like Node, Yarn, npm, CocoaPods, or Xcode? [Specify these versions in your build configuration](/build/eas-json).
 


### PR DESCRIPTION
# Why

The monorepo link on the [Creating your first build](https://docs.expo.dev/build/setup/) page 404s.

# How

Updated to [correct link](https://docs.expo.dev/build-reference/build-with-monorepos/) (I think!)

# Test Plan

Link works and docs tests pass.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
