### PR TITLE
[core][Android] View-related DSL functions do not require providing the view's type in function parameters

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- View-related DSL functions do not require providing the view's type in function parameters on Android.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- View-related DSL functions do not require providing the view's type in function parameters on Android.
+- View-related DSL functions do not require providing the view's type in function parameters on Android. ([#20751](https://github.com/expo/expo/pull/20751) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -122,7 +122,7 @@ class ViewDefinitionBuilder<T : View>(@PublishedApi internal val viewType: KClas
   /**
    * Creates the group view definition that scopes group view-related definitions.
    */
-  inline fun <reified ParentType: ViewGroup> GroupView(body: ViewGroupDefinitionBuilder<ParentType>.() -> Unit) {
+  inline fun <reified ParentType : ViewGroup> GroupView(body: ViewGroupDefinitionBuilder<ParentType>.() -> Unit) {
     assert(viewType == ParentType::class) { "Provided type and view type have to be the same." }
     require(viewGroupDefinition == null) { "The viewManager definition may have exported only one groupView definition." }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.views
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.types.toAnyType
@@ -13,7 +14,7 @@ import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.typeOf
 
 @DefinitionMarker
-class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
+class ViewDefinitionBuilder<T : View>(@PublishedApi internal val viewType: KClass<T>) {
   @PublishedApi
   internal var props = mutableMapOf<String, AnyViewProp>()
 
@@ -41,20 +42,57 @@ class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
   /**
    * Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
    */
-  inline fun <reified ViewType : View> OnViewDestroys(noinline body: (view: ViewType) -> Unit) {
+  @Suppress("UNCHECKED_CAST")
+  inline fun OnViewDestroys(crossinline body: (view: T) -> Unit) {
+    onViewDestroys = {
+      body(it as T)
+    }
+  }
+
+  /**
+   * Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
+   */
+  @JvmName("OnViewDestroysGeneric")
+  inline fun <reified ViewType : T> OnViewDestroys(noinline body: (view: ViewType) -> Unit) {
     onViewDestroys = { body(it as ViewType) }
   }
 
   /**
    * Defines the view lifecycle method that is called when the view finished updating all props.
    */
-  inline fun <reified ViewType : View> OnViewDidUpdateProps(noinline body: (view: ViewType) -> Unit) {
+  @Suppress("UNCHECKED_CAST")
+  inline fun OnViewDidUpdateProps(crossinline body: (view: T) -> Unit) {
+    onViewDidUpdateProps = {
+      body(it as T)
+    }
+  }
+
+  /**
+   * Defines the view lifecycle method that is called when the view finished updating all props.
+   */
+  @JvmName("OnViewDidUpdatePropsGeneric")
+  inline fun <reified ViewType : T> OnViewDidUpdateProps(noinline body: (view: ViewType) -> Unit) {
     onViewDidUpdateProps = { body(it as ViewType) }
   }
 
   /**
    * Creates a view prop that defines its name and setter.
    */
+  inline fun <reified PropType> Prop(
+    name: String,
+    noinline body: (view: T, prop: PropType) -> Unit
+  ) {
+    props[name] = ConcreteViewProp(
+      name,
+      typeOf<PropType>().toAnyType(),
+      body
+    )
+  }
+
+  /**
+   * Creates a view prop that defines its name and setter.
+   */
+  @JvmName("PropGeneric")
   inline fun <reified ViewType : View, reified PropType> Prop(
     name: String,
     noinline body: (view: ViewType, prop: PropType) -> Unit
@@ -84,10 +122,11 @@ class ViewDefinitionBuilder<T : View>(private val viewType: KClass<T>) {
   /**
    * Creates the group view definition that scopes group view-related definitions.
    */
-  inline fun GroupView(body: ViewGroupDefinitionBuilder.() -> Unit) {
+  inline fun <reified ParentType: ViewGroup> GroupView(body: ViewGroupDefinitionBuilder<ParentType>.() -> Unit) {
+    assert(viewType == ParentType::class) { "Provided type and view type have to be the same." }
     require(viewGroupDefinition == null) { "The viewManager definition may have exported only one groupView definition." }
 
-    val groupViewDefinitionBuilder = ViewGroupDefinitionBuilder()
+    val groupViewDefinitionBuilder = ViewGroupDefinitionBuilder<ParentType>()
     body.invoke(groupViewDefinitionBuilder)
     viewGroupDefinition = groupViewDefinitionBuilder.build()
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
@@ -7,7 +7,79 @@ import android.view.ViewGroup
 import expo.modules.kotlin.modules.DefinitionMarker
 
 @DefinitionMarker
-class ViewGroupDefinitionBuilder {
+class ViewGroupDefinitionBuilder<ParentType: ViewGroup> {
+  @PublishedApi
+  internal var addViewAction: AddViewAction? = null
+
+  @PublishedApi
+  internal var getChildAtAction: GetChildAtAction? = null
+
+  @PublishedApi
+  internal var getChildCountAction: GetChildCountAction? = null
+
+  @PublishedApi
+  internal var removeViewAction: RemoveViewAction? = null
+
+  @PublishedApi
+  internal var removeViewAtAction: RemoveViewAtAction? = null
+
+  fun build() = ViewGroupDefinition(
+    addViewAction,
+    getChildAtAction,
+    getChildCountAction,
+    removeViewAction,
+    removeViewAtAction
+  )
+
+  @Suppress("UNCHECKED_CAST")
+  inline fun <reified ChildViewType : View> AddChildView(
+    crossinline body: (parent: ParentType, child: ChildViewType, index: Int) -> Unit
+  ) {
+    addViewAction = { parent, child, index ->
+      body(parent as ParentType, child as ChildViewType, index)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  inline fun GetChildCount(
+    crossinline body: (view: ParentType) -> Int
+  ) {
+    getChildCountAction = { view ->
+      body(view as ParentType)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  inline fun <reified ChildViewType : View> GetChildViewAt(
+    crossinline body: (view: ParentType, index: Int) -> ChildViewType?
+  ) {
+    getChildAtAction = { view, index ->
+      body(view as ParentType, index)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  inline fun RemoveChildViewAt(
+    crossinline body: (view: ParentType, index: Int) -> Unit
+  ) {
+    removeViewAtAction = { view, index ->
+      body(view as ParentType, index)
+    }
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  inline fun <reified ChildViewType : View> RemoveChildView(
+    noinline body: (parent: ParentType, child: ChildViewType) -> Unit
+  ) {
+    removeViewAction = { view, child ->
+      body(view as ParentType, child as ChildViewType)
+    }
+  }
+}
+
+@Deprecated("Use `ViewGroupDefinitionBuilder` instead.")
+@DefinitionMarker
+class ViewGroupDefinitionLegacyBuilder {
   @PublishedApi
   internal var addViewAction: AddViewAction? = null
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewGroupDefinitionBuilder.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import expo.modules.kotlin.modules.DefinitionMarker
 
 @DefinitionMarker
-class ViewGroupDefinitionBuilder<ParentType: ViewGroup> {
+class ViewGroupDefinitionBuilder<ParentType : ViewGroup> {
   @PublishedApi
   internal var addViewAction: AddViewAction? = null
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinitionBuilder.kt
@@ -122,10 +122,10 @@ class ViewManagerDefinitionBuilder {
   /**
    * Creates the group view definition that scopes group view-related definitions.
    */
-  inline fun GroupView(body: ViewGroupDefinitionBuilder.() -> Unit) {
+  inline fun GroupView(body: ViewGroupDefinitionLegacyBuilder.() -> Unit) {
     require(viewGroupDefinition == null) { "The viewManager definition may have exported only one groupView definition." }
 
-    val groupViewDefinitionBuilder = ViewGroupDefinitionBuilder()
+    val groupViewDefinitionBuilder = ViewGroupDefinitionLegacyBuilder()
     body.invoke(groupViewDefinitionBuilder)
     viewGroupDefinition = groupViewDefinitionBuilder.build()
   }


### PR DESCRIPTION
# Why

DSL Functions related to views don't require specificating the view type anymore.

# How

Before:
``` kt
View(ExpoImageViewWrapper::class) {
	Prop("source") { view: ExpoImageViewWrapper, sources: List<SourceMap>? ->
		view.sources = sources ?: emptyList()
	}
	
	Prop("contentFit") { view: ExpoImageViewWrapper, contentFit: ContentFit? ->
		view.contentFit = contentFit ?: ContentFit.Cover
	}

	...
}
```

After:
``` kt
View(ExpoImageViewWrapper::class) {
	Prop("source") { view, sources: List<SourceMap>? ->
		view.sources = sources ?: emptyList()
	}
	
	Prop("contentFit") { view, contentFit: ContentFit? ->
		view.contentFit = contentFit ?: ContentFit.Cover
	}
    
	...
}
```

# Test Plan

- bare-expo ✅