### PR TITLE
[linear-gradient] Stop using deprecated `ViewManager` DSL function

### DIFF
--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientModule.kt
@@ -8,11 +8,8 @@ typealias ViewType = LinearGradientView
 class LinearGradientModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoLinearGradient")
-    ViewManager {
-      View { context ->
-        LinearGradientView(context)
-      }
 
+    View(LinearGradientView::class) {
       Prop("colors") { view: ViewType, colors: IntArray ->
         view.setColors(colors)
       }

--- a/packages/expo-linear-gradient/ios/LinearGradientModule.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientModule.swift
@@ -7,11 +7,7 @@ public class LinearGradientModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoLinearGradient")
 
-    ViewManager {
-      View {
-        LinearGradientView()
-      }
-
+    View(LinearGradientView.self) {
       Prop("colors") { (view: LinearGradientView, colors: [CGColor]) in
         view.gradientLayer.setColors(colors)
       }


### PR DESCRIPTION
# Why

Removes usage of a deprecated `ViewManager` function from `expo-linear-gradient`