### PR TITLE
feat(cli): improve UNVERSIONED (internal-only) support

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Skip uninstalling Expo Go when running in UNVERSIONED (internal).
+
 ### 🐛 Bug fixes
 
 - Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error. ([#20704](https://github.com/expo/expo/pull/20704) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Skip uninstalling Expo Go when running in UNVERSIONED (internal).
+- Skip uninstalling Expo Go when running in UNVERSIONED (internal). ([#20754](https://github.com/expo/expo/pull/20754) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
+++ b/packages/@expo/cli/src/start/platforms/ExpoGoInstaller.ts
@@ -54,7 +54,16 @@ export class ExpoGoInstaller<IDevice> {
       return false;
     }
     ExpoGoInstaller.cache[cacheId] = true;
+
     if (await this.isClientOutdatedAsync(deviceManager)) {
+      if (this.sdkVersion === 'UNVERSIONED') {
+        // This should only happen in the expo/expo repo, e.g. `apps/test-suite`
+        Log.log(
+          `Skipping Expo Go upgrade check for UNVERSIONED project. Manually ensure the Expo Go app is built from source.`
+        );
+        return false;
+      }
+
       // Only prompt once per device, per run.
       const confirm = await confirmAsync({
         initial: true,

--- a/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
@@ -121,6 +121,9 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
       uninstallAppAsync: jest.fn(async () => null),
     } as any;
   }
+  beforeEach(() => {
+    asMock(confirmAsync).mockReset();
+  });
   it(`returns true when the user uninstalls the outdated app`, async () => {
     asMock(confirmAsync).mockResolvedValueOnce(true);
     const installer = createInstaller('android');
@@ -130,16 +133,6 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
     await expect(installer.uninstallExpoGoIfOutdatedAsync(deviceManager)).resolves.toBe(true);
     expect(confirmAsync).toBeCalled();
     expect(deviceManager.uninstallAppAsync).toBeCalled();
-  });
-  it(`returns false when the project is unversioned`, async () => {
-    asMock(confirmAsync).mockResolvedValueOnce(true);
-    const installer = new ExpoGoInstaller('ios', 'host.fake.expo', 'UNVERSIONED');
-    installer.isClientOutdatedAsync = jest.fn(async () => true);
-    const deviceManager = createDeviceManager();
-
-    await expect(installer.uninstallExpoGoIfOutdatedAsync(deviceManager)).resolves.toBe(false);
-    expect(confirmAsync).not.toBeCalled();
-    expect(deviceManager.uninstallAppAsync).not.toBeCalled();
   });
 
   it(`prevents checking the same device twice`, async () => {
@@ -182,6 +175,16 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
     const installer = createInstaller('ios');
     installer.isClientOutdatedAsync = jest.fn(async () => false);
     const deviceManager = createDeviceManager();
+    await expect(installer.uninstallExpoGoIfOutdatedAsync(deviceManager)).resolves.toBe(false);
+    expect(confirmAsync).not.toBeCalled();
+    expect(deviceManager.uninstallAppAsync).not.toBeCalled();
+  });
+
+  it(`returns false when the project is unversioned`, async () => {
+    const installer = new ExpoGoInstaller('android', 'host.fake.expo', 'UNVERSIONED');
+    installer.isClientOutdatedAsync = jest.fn(async () => true);
+    const deviceManager = createDeviceManager();
+
     await expect(installer.uninstallExpoGoIfOutdatedAsync(deviceManager)).resolves.toBe(false);
     expect(confirmAsync).not.toBeCalled();
     expect(deviceManager.uninstallAppAsync).not.toBeCalled();

--- a/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/ExpoGoInstaller-test.ts
@@ -131,6 +131,16 @@ describe('uninstallExpoGoIfOutdatedAsync', () => {
     expect(confirmAsync).toBeCalled();
     expect(deviceManager.uninstallAppAsync).toBeCalled();
   });
+  it(`returns false when the project is unversioned`, async () => {
+    asMock(confirmAsync).mockResolvedValueOnce(true);
+    const installer = new ExpoGoInstaller('ios', 'host.fake.expo', 'UNVERSIONED');
+    installer.isClientOutdatedAsync = jest.fn(async () => true);
+    const deviceManager = createDeviceManager();
+
+    await expect(installer.uninstallExpoGoIfOutdatedAsync(deviceManager)).resolves.toBe(false);
+    expect(confirmAsync).not.toBeCalled();
+    expect(deviceManager.uninstallAppAsync).not.toBeCalled();
+  });
 
   it(`prevents checking the same device twice`, async () => {
     asMock(confirmAsync).mockResolvedValueOnce(true);

--- a/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
+++ b/packages/@expo/cli/src/utils/downloadExpoGoAsync.ts
@@ -1,8 +1,10 @@
 import { getExpoHomeDirectory } from '@expo/config/build/getUserState';
 import path from 'path';
 import ProgressBar from 'progress';
+import { gt } from 'semver';
 
 import { getVersionsAsync, SDKVersion } from '../api/getVersions';
+import { Log } from '../log';
 import { downloadAppAsync } from './downloadAppAsync';
 import { CommandError } from './errors';
 import { ora } from './ora';
@@ -33,6 +35,37 @@ const platformSettings: Record<
   },
 };
 
+/**
+ * @internal exposed for testing.
+ * @returns the matching `SDKVersion` object from the Expo API.
+ */
+export async function getExpoGoVersionEntryAsync(sdkVersion: string): Promise<SDKVersion> {
+  const { sdkVersions: versions } = await getVersionsAsync();
+  let version: SDKVersion;
+
+  if (sdkVersion.toUpperCase() === 'UNVERSIONED') {
+    // find the latest version
+    const latestVersionKey = Object.keys(versions).reduce((a, b) => {
+      if (gt(b, a)) {
+        return b;
+      }
+      return a;
+    }, '0.0.0');
+
+    Log.warn(
+      `Downloading the latest Expo Go client (${latestVersionKey}). This will not fully conform to UNVERSIONED.`
+    );
+    version = versions[latestVersionKey];
+  } else {
+    version = versions[sdkVersion];
+  }
+
+  if (!version) {
+    throw new CommandError(`Unable to find a version of Expo Go for SDK ${sdkVersion}`);
+  }
+  return version;
+}
+
 /** Download the Expo Go app from the Expo servers (if only it was this easy for every app). */
 export async function downloadExpoGoAsync(
   platform: keyof typeof platformSettings,
@@ -50,22 +83,22 @@ export async function downloadExpoGoAsync(
 
   let bar: ProgressBar | null = null;
 
-  if (!url) {
-    if (!sdkVersion) {
-      throw new CommandError(
-        `Unable to determine which Expo Go version to install (platform: ${platform})`
-      );
-    }
-    const { sdkVersions: versions } = await getVersionsAsync();
+  try {
+    if (!url) {
+      if (!sdkVersion) {
+        throw new CommandError(
+          `Unable to determine which Expo Go version to install (platform: ${platform})`
+        );
+      }
 
-    const version = versions[sdkVersion];
-    if (!version) {
-      throw new CommandError(
-        `Unable to find a version of Expo Go for SDK ${sdkVersion} (platform: ${platform})`
-      );
+      const version = await getExpoGoVersionEntryAsync(sdkVersion);
+
+      debug(`Installing Expo Go version for SDK ${sdkVersion} at URL: ${version[versionsKey]}`);
+      url = version[versionsKey] as string;
     }
-    debug(`Installing Expo Go version for SDK ${sdkVersion} at URL: ${version[versionsKey]}`);
-    url = version[versionsKey] as string;
+  } catch (error) {
+    spinner.fail();
+    throw error;
   }
 
   const filename = path.parse(url).name;


### PR DESCRIPTION
# Why

Fail a little bit more expectedly when using Expo CLI for UNVERSIONED projects.

# Test Plan

- unit tests
- tested against apps/test-suite