### PR TITLE
[core][ios] Fix view prop setters ignoring null and undefined values

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix view prop setter not being called when its new value is `null` or `undefined`.
+
 ### 💡 Others
 
 ## 1.1.1 — 2023-01-06

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix view prop setter not being called when its new value is `null` or `undefined`.
+- [iOS] Fix view prop setter not being called when its new value is `null` or `undefined`. ([#20755](https://github.com/expo/expo/pull/20755) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -51,17 +51,17 @@ public class ExpoFabricView: ExpoFabricViewObjC {
 
   // MARK: - ExpoFabricViewInterface
 
-  public override func updateProp(_ propName: String, withValue value: Any) {
-    guard let view = contentView else {
+  public override func updateProps(_ props: [String: Any]) {
+    guard let view = contentView, let propsDict = viewManagerPropDict else {
       return
     }
-    if let _ = moduleHolder, let prop = viewManagerPropDict?[propName] {
+    for (key, prop) in propsDict {
+      let newValue = props[key] as Any
+
       // TODO: @tsapeta: Figure out better way to rethrow errors from here.
       // Adding `throws` keyword to the function results in different
       // method signature in Objective-C. Maybe just call `RCTLogError`?
-      try? prop.set(value: value, onView: view)
-    } else if let _ = legacyViewManager {
-      legacyViewManager?.updateProp(propName, withValue: value, on: view)
+      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view)
     }
   }
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.h
@@ -33,7 +33,7 @@
 
 - (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload;
 
-- (void)updateProp:(nonnull NSString *)propName withValue:(nonnull id)value;
+- (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props;
 
 - (void)viewDidUpdateProps;
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricViewObjC.mm
@@ -140,15 +140,9 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
 - (void)updateProps:(const facebook::react::Props::Shared &)props oldProps:(const facebook::react::Props::Shared &)oldProps
 {
   const auto &newViewProps = *std::static_pointer_cast<ExpoViewProps const>(props);
-  auto proxiedProperties = newViewProps.proxiedProperties;
-  if (proxiedProperties.isObject()) {
-    for (auto& item : proxiedProperties.items()) {
-      NSString *name = [NSString stringWithCString:item.first.c_str() encoding:NSUTF8StringEncoding];
-      id value = convertFollyDynamicToId(item.second);
-      [self updateProp:name withValue:value];
-    }
-  }
+  NSDictionary<NSString *, id> *proxiedProperties = convertFollyDynamicToId(newViewProps.proxiedProperties);
 
+  [self updateProps:proxiedProperties];
   [super updateProps:props oldProps:oldProps];
   [self viewDidUpdateProps];
 }
@@ -170,7 +164,7 @@ static std::unordered_map<std::string, ExpoViewComponentDescriptor::Flavor> _com
 
 #pragma mark - Methods to override in Swift
 
-- (void)updateProp:(nonnull NSString *)propName withValue:(nonnull id)value
+- (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props
 {
   // Implemented in `ExpoFabricView.swift`
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -109,15 +109,13 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
     }
     let props = viewManager.propsDict()
 
-    for (key, value) in json {
-      if let prop = props[key] {
-        let value = Conversions.fromNSObject(value)
+    for (key, prop) in props {
+      let newValue = json[key] as Any
 
-        // TODO: @tsapeta: Figure out better way to rethrow errors from here.
-        // Adding `throws` keyword to the function results in different
-        // method signature in Objective-C. Maybe just call `RCTLogError`?
-        try? prop.set(value: value, onView: view)
-      }
+      // TODO: @tsapeta: Figure out better way to rethrow errors from here.
+      // Adding `throws` keyword to the function results in different
+      // method signature in Objective-C. Maybe just call `RCTLogError`?
+      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view)
     }
     viewManager.callLifecycleMethods(withType: .didUpdateProps, forView: view)
   }


### PR DESCRIPTION
# Why

Since the props object is passed through the bridge, all `null` and `undefined` values were skipped when updating the props natively.

# How

Instead of iterating through the JS object, we can go through the dictionary with native prop setters to cover all defined props.

# Test Plan

I've tested this on both the old and new architectures with the following code:

```javascript
function Test() {
  const [start, setStart] = React.useState([0, 0]);

  React.useEffect(() => {
    setTimeout(() => {
      setStart(null);
    }, 1000);
  }, []);

  return <LinearGradient colors={['red', 'papayawhip']} start={start} />;
}
```

The starting point has successfully unset itself (after the timeout) to its default value.
- before timeout: the gradient is drawn from top left to bottom right corner (x: 0.0, y: 0.0)
- after timeout: the gradient is drawn from top to bottom (default behavior, x: 0.5, y: 0.0)
