### PR TITLE
[core][Android] Allow to skip trailing optional arguments

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -481,4 +481,29 @@ class JSIFunctionsTest {
     Truth.assertThat(int).isEqualTo(123)
     Truth.assertThat(string).isEqualTo("expo")
   }
+
+  @Test
+  fun allows_to_skip_trailing_optional_arguemnts() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("test") { a: String, b: Int?, c: Boolean? ->
+        Truth.assertThat(a).isEqualTo("abc")
+        if (b != null) {
+          Truth.assertThat(b).isEqualTo(123)
+        }
+        if (c != null) {
+          Truth.assertThat(c).isTrue()
+        }
+        return@Function "expo"
+      }
+    }
+  ) {
+    val result1 = evaluateScript("expo.modules.TestModule.test('abc')").getString()
+    val result2 = evaluateScript("expo.modules.TestModule.test('abc', 123)").getString()
+    val result3 = evaluateScript("expo.modules.TestModule.test('abc', 123, true)").getString()
+
+    Truth.assertThat(result1).isEqualTo("expo")
+    Truth.assertThat(result2).isEqualTo("expo")
+    Truth.assertThat(result3).isEqualTo("expo")
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -164,7 +164,7 @@ MethodMetadata::MethodMetadata(
     args(args),
     isAsync(isAsync),
     jBodyReference(std::move(jBodyReference)),
-    longLivedObjectCollection_(longLivedObjectCollection) {
+    longLivedObjectCollection_(std::move(longLivedObjectCollection)) {
   argTypes.reserve(args);
   for (size_t i = 0; i < args; i++) {
     auto expectedType = expectedArgTypes->getElement(i);
@@ -186,7 +186,7 @@ MethodMetadata::MethodMetadata(
     isAsync(isAsync),
     argTypes(std::move(expectedArgTypes)),
     jBodyReference(std::move(jBodyReference)),
-    longLivedObjectCollection_(longLivedObjectCollection) {
+    longLivedObjectCollection_(std::move(longLivedObjectCollection)) {
 }
 
 std::shared_ptr<jsi::Function> MethodMetadata::toJSFunction(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -85,8 +85,14 @@ internal class MissingTypeConverter(
   message = "Cannot find type converter for '$forType'.",
 )
 
-internal class InvalidArgsNumberException(received: Int, expected: Int) :
-  CodedException(message = "Received $received arguments, but $expected was expected.")
+internal class InvalidArgsNumberException(received: Int, expected: Int, required: Int = expected) :
+  CodedException(
+    message = if (required < expected) {
+      "Received $received arguments, but $expected was expected and at least $required is required"
+    } else {
+      "Received $received arguments, but $expected was expected"
+    }
+  )
 
 internal class MethodNotFoundException :
   CodedException(message = "Method does not exist.")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -23,6 +23,20 @@ abstract class AnyFunction(
   internal val argsCount get() = desiredArgsTypes.size
 
   /**
+   * A minimum number of arguments the functions needs which equals to `argumentsCount` reduced by the number of trailing optional arguments.
+   */
+  internal val requiredArgumentsCount = run {
+    val nonNullableArgIndex = desiredArgsTypes
+      .reversed()
+      .indexOfFirst { !it.kType.isMarkedNullable }
+    if (nonNullableArgIndex < 0) {
+      return@run desiredArgsTypes.size
+    }
+
+    return@run desiredArgsTypes.size - nonNullableArgIndex
+  }
+
+  /**
    * Tries to convert arguments from RN representation to expected types.
    *
    * @return An array of converted arguments
@@ -30,23 +44,22 @@ abstract class AnyFunction(
    */
   @Throws(CodedException::class)
   protected fun convertArgs(args: ReadableArray): Array<out Any?> {
-    if (desiredArgsTypes.size != args.size()) {
-      throw InvalidArgsNumberException(args.size(), desiredArgsTypes.size)
+    if (requiredArgumentsCount > args.size() || args.size() > desiredArgsTypes.size) {
+      throw InvalidArgsNumberException(args.size(), desiredArgsTypes.size, requiredArgumentsCount)
     }
 
     val finalArgs = Array<Any?>(desiredArgsTypes.size) { null }
     val argIterator = args.iterator()
-    desiredArgsTypes
-      .withIndex()
-      .forEach { (index, desiredType) ->
-        argIterator.next().recycle {
-          exceptionDecorator({ cause ->
-            ArgumentCastException(desiredType.kType, index, type, cause)
-          }) {
-            finalArgs[index] = desiredType.convert(this)
-          }
+    for (index in 0 until args.size()) {
+      val desiredType = desiredArgsTypes[index]
+      argIterator.next().recycle {
+        exceptionDecorator({ cause ->
+          ArgumentCastException(desiredType.kType, index, type, cause)
+        }) {
+          finalArgs[index] = desiredType.convert(this)
         }
       }
+    }
     return finalArgs
   }
 
@@ -58,23 +71,21 @@ abstract class AnyFunction(
    */
   @Throws(CodedException::class)
   protected fun convertArgs(args: Array<Any?>): Array<out Any?> {
-    if (desiredArgsTypes.size != args.size) {
-      throw InvalidArgsNumberException(args.size, desiredArgsTypes.size)
+    if (requiredArgumentsCount > args.size || args.size > desiredArgsTypes.size) {
+      throw InvalidArgsNumberException(args.size, desiredArgsTypes.size, requiredArgumentsCount)
     }
 
     val finalArgs = Array<Any?>(desiredArgsTypes.size) { null }
     val argIterator = args.iterator()
-    desiredArgsTypes
-      .withIndex()
-      .forEach { (index, desiredType) ->
-        val element = argIterator.next()
-
-        exceptionDecorator({ cause ->
-          ArgumentCastException(desiredType.kType, index, ReadableType.String, cause)
-        }) {
-          finalArgs[index] = desiredType.convert(element)
-        }
+    for (index in args.indices) {
+      val element = argIterator.next()
+      val desiredType = desiredArgsTypes[index]
+      exceptionDecorator({ cause ->
+        ArgumentCastException(desiredType.kType, index, ReadableType.String, cause)
+      }) {
+        finalArgs[index] = desiredType.convert(element)
       }
+    }
     return finalArgs
   }
 

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -142,7 +142,7 @@ class KotlinInteropModuleRegistryTest {
         JavaOnlyArray().apply { pushInt(1) }
       ) to """
         Call to function 'test-1.f1' has been rejected.
-        → Caused by: Received 1 arguments, but 0 was expected.
+        → Caused by: Received 1 arguments, but 0 was expected
       """.trimIndent(),
       Triple(
         "test-2",
@@ -159,7 +159,7 @@ class KotlinInteropModuleRegistryTest {
         JavaOnlyArray()
       ) to """
         Call to function 'test-2.f2' has been rejected.
-        → Caused by: Received 0 arguments, but 1 was expected.
+        → Caused by: Received 0 arguments, but 1 was expected
       """.trimIndent(),
       Triple(
         "test-1",

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -36,7 +36,7 @@ class AnyFunctionTest {
     val method = MockedAnyFunction(arrayOf(typeOf<Int>()))
     val promise = PromiseMock()
 
-    assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected.") {
+    assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected") {
       method.call(
         mockk(),
         JavaOnlyArray().apply {
@@ -55,7 +55,7 @@ class AnyFunctionTest {
     val method = MockedAnyFunction(arrayOf(typeOf<Int>(), typeOf<Int>()))
     val promise = PromiseMock()
 
-    assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected.") {
+    assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected") {
       method.call(
         mockk(),
         JavaOnlyArray().apply {


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/pull/20234.

# How

- Added requiredArgumentsCount property to functions
- Throw InvalidArgsNumberException only when the number is less than the required count or greater than the total count
- Improved the exception reason to note how many arguments are required
- Added new unit test

# Test Plan

- Unit tests ✅