### PR TITLE
[ios] Fix File.exist? for ruby@3.2

### DIFF
--- a/ios/versioned-react-native/ABI47_0_0/ReactNative/sdks/hermes-engine/ABI47_0_0hermes-engine.podspec
+++ b/ios/versioned-react-native/ABI47_0_0/ReactNative/sdks/hermes-engine/ABI47_0_0hermes-engine.podspec
@@ -36,7 +36,7 @@ elsif currentremote.strip.end_with?("facebook/react-native.git") and currentbran
   source[:git] = git
   source[:tag] = hermestag
 else
-  if File.exists?(File.join(__dir__, "destroot"))
+  if File.exist?(File.join(__dir__, "destroot"))
     source[:path] = '.'
   else
     source[:http] = 'https://github.com/expo/react-native/releases/download/sdk-47.0.0/ABI47_0_0hermes.tar.gz'

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Replace deprecated `File.exists?` with `File.exist?` to fix usage with `ruby@3.2`. ([#20470](https://github.com/expo/expo/pull/20757) by [@KiwiKilian](https://github.com/kiwikilian))
+
 ### 💡 Others
 
 ## 1.0.1 — 2022-12-30

--- a/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb
@@ -5,7 +5,7 @@ require 'pathname'
 def maybe_generate_xcode_env_file!()
   project_directory = Pod::Config.instance.project_root
   xcode_env_file = File.join(project_directory, '.xcode.env.local')
-  if File.exists?(xcode_env_file)
+  if File.exist?(xcode_env_file)
     return
   end
 

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -388,7 +388,7 @@ async function generateReactNativePodScriptAsync(
         'gm'
       ),
       replaceWith: `
-    if File.exists?("#{react_native_path}/sdks/hermes-engine/destroot")
+    if File.exist?("#{react_native_path}/sdks/hermes-engine/destroot")
       pod '${versionName}hermes-engine', :path => "#{react_native_path}/sdks/hermes-engine", :project_name => '${versionName}'
     else
       pod '${versionName}hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/${versionName}hermes-engine.podspec", :project_name => '${versionName}'

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -96,7 +96,7 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         replace:
           '  source[:http] = "https://github.com/facebook/react-native/releases/download/v#{version}/hermes-runtime-darwin-v#{version}.tar.gz"',
         with: `\
-  if File.exists?(File.join(__dir__, "destroot"))
+  if File.exist?(File.join(__dir__, "destroot"))
     source[:path] = '.'
   else
     source[:http] = 'https://github.com/expo/react-native/releases/download/sdk-${versionName


### PR DESCRIPTION
# Why

[`ruby@3.2` removed`File.exists?`](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/), therefore builds are now failing, when using `ruby@3.2`

Fixes #20707

# How

I basically searched for all occurences of `File.exists?`. I'm not sure, if this should be added to a changelog and if so which one.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I tried the patch mainly on our own project, showed #20707 beeing fixed but failing later on with other [packages also currently fixing this problem](https://github.com/software-mansion/react-native-gesture-handler/issues/2367).

I'm not sure about how to test the fixes outside of autolinking.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
