### PR TITLE
[docs] remove --experimental-bundle reference from EAS Build troubleshooting guide

### DIFF
--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -87,7 +87,7 @@ It's not yet possible to increase memory limits on your build workers, [only one
 
 When a build fails with `Task :app:bundleReleaseJsAndAssets FAILED` (Android) or `Metro encountered an error` (iOS), it means Metro bundler was unable to bundle the app's JavaScript code while trying to embed it in your app's binary. This error message is usually followed by a syntax error or other details about why bundling failed. Unfortunately, a standard React Native project is configured to perform this step late in the Gradle/Xcode build step, meaning it can take a while to see this error.
 
-You can build this production bundle directly by running `npx expo export` locally, bypassing all of the other build steps so you can see this error much more quickly. Run this command repeatedly, resolving any syntax errors or other issues uncovered, until the bundle builds successfully. Then try your EAS build again.
+You can build the production bundle locally by running `npx expo export` to bypass all of the other build steps so you can see this error much more quickly. Run this command repeatedly, resolving any syntax errors or other issues uncovered until the bundle builds successfully. Then try your EAS build again.
 
 ## Verify that your project builds and runs locally
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -85,7 +85,7 @@ It's not yet possible to increase memory limits on your build workers, [only one
 
 ## Verify that your JavaScript bundles locally
 
-When a build fails with `Metro encountered an error` (iOS) or `Task :app:bundleReleaseJsAndAssets FAILED` (Android), it means Metro bundler failed to bundle the app's JavaScript code while trying to embed it in your app's binary. This error message is usually followed by a syntax error or other details related to why bundling failed. A standard React Native project is configured to perform this step late in the Xcode / Gradle build step, meaning it can take a while to see this error.
+When a build fails with `Task :app:bundleReleaseJsAndAssets FAILED` (Android) or `Metro encountered an error` (iOS), it means Metro bundler was unable to bundle the app's JavaScript code while trying to embed it in your app's binary. This error message is usually followed by a syntax error or other details about why bundling failed. Unfortunately, a standard React Native project is configured to perform this step late in the Gradle/Xcode build step, meaning it can take a while to see this error.
 
 You can build this production bundle directly by running `npx expo export` locally, bypassing all of the other build steps so you can see this error much more quickly. Run this command repeatedly, resolving any syntax errors or other issues uncovered, until the bundle builds successfully. Then try your EAS build again.
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -85,13 +85,9 @@ It's not yet possible to increase memory limits on your build workers, [only one
 
 ## Verify that your JavaScript bundles locally
 
-When you get the `Metro encountered an error` during a native iOS build, it means Metro bundler failed to bundle the app. This unfortunately runs at the end of the native build process, meaning it takes a while to fail.
+When a build fails with `Metro encountered an error` (iOS) or `Task :app:bundleReleaseJsAndAssets FAILED` (Android), it means Metro bundler failed to bundle the app's JavaScript code while trying to embed it in your app's binary. This error message is usually followed by a syntax error or other details related to why bundling failed. A standard React Native project is configured to perform this step late in the Xcode / Gradle build step, meaning it can take a while to see this error.
 
-<Terminal cmd={[`❌ Metro encountered an error:`]} />
-
-You can reproduce this production bundle locally by running `expo export --experimental-bundle` which simply creates a production bundle. Continue doing this until the command passes without throwing. In general, this should save you hours of debugging time.
-
-This behavior comes from React Native on iOS, in the future we plan to rewrite this for EAS Build so the bundle is created before the native runtime.
+You can build this production bundle directly by running `npx expo export` locally, bypassing all of the other build steps so you can see this error much more quickly. Run this command repeatedly, resolving any syntax errors or other issues uncovered, until the bundle builds successfully. Then try your EAS build again.
 
 ## Verify that your project builds and runs locally
 


### PR DESCRIPTION
# Why

Might be the last reference in a non-deprecated doc to `expo export --experimental-bundle` :).

Also tried to make this less iOS-specific, and removed the vague future-looking statement about us potentially re-sequencing build phases. Once I did that, it seemed like we'd either need to show both iOS and Android terminal snippets or neither, so went with neither... also because snippet was exactly the same as the error message described above.
