### PR TITLE
[docs] ensure monospace font have a swap period

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -20,7 +20,7 @@ const isDev = process.env.NODE_ENV === 'development';
 export const regularFont = Inter();
 export const monospaceFont = Fira_Code({
   weight: '400',
-  display: 'swap'
+  display: 'swap',
 });
 
 Sentry.init({

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -17,13 +17,10 @@ import 'tippy.js/dist/tippy.css';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-export const regularFont = Inter({
-  subsets: ['latin'],
-});
-
+export const regularFont = Inter();
 export const monospaceFont = Fira_Code({
   weight: '400',
-  subsets: ['latin'],
+  display: 'swap'
 });
 
 Sentry.init({


### PR DESCRIPTION
# Why

<img width="567" alt="image (4)" src="https://user-images.githubusercontent.com/719641/211403208-46802804-dba4-4988-9008-e386a37bd1f3.png">


# How

Let's allow late swap for monospace font. Probably `fallback` could be enough, but `swap` guarantees that.

* https://nextjs.org/docs/basic-features/font-optimization#choosing-font-display
* https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#values

# Test Plan

N/A - doesn't happen locally.
