### PR TITLE
[docs] update broken link react-native-maps API reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -13,7 +13,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
-No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploying-app-with-google-maps).
+No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).
 
 <PlatformsSection android emulator ios simulator />
 


### PR DESCRIPTION
Update broken link in the docs.