### PR TITLE
[core][Android] Fix view prop setters ignoring null and undefined values

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix view prop setter not being called when its new value is `null` or `undefined`. ([#20755](https://github.com/expo/expo/pull/20755) by [@tsapeta](https://github.com/tsapeta))
+- Fix view prop setter not being called when its new value is `null` or `undefined`. ([#20755](https://github.com/expo/expo/pull/20755) & [#20766](https://github.com/expo/expo/pull/20766) by [@tsapeta](https://github.com/tsapeta) & [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/DynamicExtenstions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/DynamicExtenstions.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin
 
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.DynamicFromObject
 
 inline fun <T> Dynamic.recycle(block: Dynamic.() -> T): T {
   try {
@@ -9,3 +10,5 @@ inline fun <T> Dynamic.recycle(block: Dynamic.() -> T): T {
     this.recycle()
   }
 }
+
+val DynamicNull = DynamicFromObject(null)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
@@ -7,4 +7,6 @@ abstract class AnyViewProp(
   val name: String
 ) {
   abstract fun set(prop: Dynamic, onView: View)
+
+  abstract val isNullable: Boolean
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -20,4 +20,6 @@ class ConcreteViewProp<ViewType : View, PropType>(
       setter(onView as ViewType, propType.convert(prop) as PropType)
     }
   }
+
+  override val isNullable: Boolean = propType.kType.isMarkedNullable
 }


### PR DESCRIPTION
# Why

Fixes view prop setters ignoring null and undefined values
This a follow-up to the https://github.com/expo/expo/pull/20755.

# Test Plan

I used the same test as it was in #20755:
```
function Test() {
  const [start, setStart] = React.useState([0, 0]);

  React.useEffect(() => {
    setTimeout(() => {
      setStart(null);
    }, 1000);
  }, []);

  return <LinearGradient colors={['red', 'papayawhip']} start={start} />;
}
```