### PR TITLE
[ENG-7158][ENG-7060][docs] add `resourceClass` field to eas json schema

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -16,6 +16,9 @@ export default [
   {
     name: 'resourceClass',
     enum: ['default', 'medium', 'large'],
+    description: [
+      'The Android-specific resource class that will be used to run this build.',
+    ],
   },
   {
     name: 'ndk',

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -18,8 +18,6 @@ export default [
     enum: ['default', 'large'],
     description: [
       'The Android-specific resource class that will be used to run this build.',
-      "- `default` - Medium resource class",
-      "- `large` - Large resource class",
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -14,6 +14,15 @@ export default [
     ],
   },
   {
+    name: 'resourceClass',
+    enum: ['default', 'large'],
+    description: [
+      'The Android-specific resource class that will be used to run this build.',
+      "- `default` - Medium resource class",
+      "- `large` - Large resource class",
+    ],
+  },
+  {
     name: 'ndk',
     type: 'string',
     description: [ 'Version of Android NDK.' ],

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -15,10 +15,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'large'],
-    description: [
-      'The Android-specific resource class that will be used to run this build.',
-    ],
+    enum: ['default', 'medium', 'large'],
   },
   {
     name: 'ndk',

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -51,6 +51,9 @@ export default [
   {
     name: 'resourceClass',
     enum: ['default', 'medium'],
+    description: [
+      'The resource class that will be used to run this build.',
+    ],
   },
   {
     name: 'prebuildCommand',

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -49,6 +49,15 @@ export default [
     ],
   },
   {
+    name: 'resourceClass',
+    enum: ['default', 'large'],
+    description: [
+      'The resource class that will be used to run this build.',
+      "- `default` - Medium Intel resource class for iOS and medium resource class for Android",
+      "- `large` - Medium Intel resource class for iOS and large resource class for Android",
+    ],
+  },
+  {
     name: 'prebuildCommand',
     type: 'string',
     description: [

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -50,12 +50,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'large'],
-    description: [
-      'The resource class that will be used to run this build.',
-      "- `default` - Medium Intel resource class for iOS and medium resource class for Android",
-      "- `large` - Medium Intel resource class for iOS and large resource class for Android",
-    ],
+    enum: ['default', 'medium'],
   },
   {
     name: 'prebuildCommand',

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -34,6 +34,9 @@ export default [
   {
     name: 'resourceClass',
     enum: ['default', 'medium', 'm1-medium', 'intel-medium'],
+    description: [
+      'The iOS-specific resource class that will be used to run this build.',
+    ],
   },
   {
     name: 'bundler',

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -33,10 +33,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'm1-medium', 'intel-medium'],
-    description: [
-      'The iOS-specific resource class that will be used to run this build.',
-    ],
+    enum: ['default', 'medium', 'm1-medium', 'intel-medium'],
   },
   {
     name: 'bundler',

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -36,9 +36,6 @@ export default [
     enum: ['default', 'm1-medium', 'intel-medium'],
     description: [
       'The iOS-specific resource class that will be used to run this build.',
-      "- `default` - Medium Intel resource class",
-      "- `m1-medium` - Medium M1 resource class",
-      "- `intel-medium` - Medium Intel resource class",
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -32,6 +32,16 @@ export default [
     ],
   },
   {
+    name: 'resourceClass',
+    enum: ['default', 'm1-medium', 'intel-medium'],
+    description: [
+      'The iOS-specific resource class that will be used to run this build.',
+      "- `default` - Medium Intel resource class",
+      "- `m1-medium` - Medium M1 resource class",
+      "- `intel-medium` - Medium Intel resource class",
+    ],
+  },
+  {
     name: 'bundler',
     type: 'string',
     description: [ 'Version of [bundler](https://bundler.io/).' ],


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7158/add-resourceclass-to-build-profile
https://linear.app/expo/issue/ENG-7060/addupdate-resource-class-names

# How

Add information about new `resourceClass` field in eas json schema

# Test Plan

Test locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
