### PR TITLE
[image][Android] Introduced source.cacheKey to customize the key used for caching the source

### DIFF
--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -6,10 +6,55 @@ import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
 import com.bumptech.glide.load.model.GlideUrl
+import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.module.LibraryGlideModule
 import expo.modules.image.events.OkHttpProgressListener
 import okhttp3.OkHttpClient
 import java.io.InputStream
+
+/**
+ * GlideUrl with custom cache key.
+ * It wraps the base implementation and overrides logic behind cache key and when two
+ * objects are equal. Typically, Glide uses the only cache key to compare objects.
+ * It won't suit our use case. We want to make custom cache key transparent and
+ * not use it to compare objects.
+ */
+class GlideUrlWithCustomCacheKey(
+  uri: String?,
+  headers: Headers?,
+  private val cacheKey: String
+): GlideUrl(uri, headers) {
+  /**
+   * Cached hash code value
+   */
+  private var hashCode = 0
+
+  /**
+   * @return a super cache key from [GlideUrl]
+   */
+  private fun getBaseCacheKey(): String = super.getCacheKey()
+
+  override fun getCacheKey(): String = cacheKey
+
+  // Mostly copied from GlideUrl::equal
+  override fun equals(other: Any?): Boolean {
+    if (other is GlideUrlWithCustomCacheKey) {
+      return getBaseCacheKey() == other.getBaseCacheKey() && headers.equals(other.headers)
+    } else if (other is GlideUrl) {
+      return getBaseCacheKey() == other.cacheKey && headers.equals(other.headers)
+    }
+    return false
+  }
+
+  // Mostly copied from GlideUrl::hashCode
+  override fun hashCode(): Int {
+    if (hashCode == 0) {
+      hashCode = getBaseCacheKey().hashCode()
+      hashCode = 31 * hashCode + headers.hashCode()
+    }
+    return hashCode
+  }
+}
 
 /**
  * To connect listener with the request we have to create custom model.

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -23,7 +23,7 @@ class GlideUrlWithCustomCacheKey(
   uri: String?,
   headers: Headers?,
   private val cacheKey: String
-): GlideUrl(uri, headers) {
+) : GlideUrl(uri, headers) {
   /**
    * Cached hash code value
    */

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -9,11 +9,12 @@ import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.signature.ApplicationVersionSignature
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
 import expo.modules.image.GlideBlurhashModel
-import expo.modules.image.GlideRawModel
 import expo.modules.image.GlideModel
 import expo.modules.image.GlideOptions
+import expo.modules.image.GlideRawModel
 import expo.modules.image.GlideUriModel
 import expo.modules.image.GlideUrlModel
+import expo.modules.image.okhttp.GlideUrlWithCustomCacheKey
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 
@@ -22,7 +23,8 @@ data class SourceMap(
   @Field val width: Int = 0,
   @Field val height: Int = 0,
   @Field val scale: Double = 1.0,
-  @Field val headers: Map<String, String>? = null
+  @Field val headers: Map<String, String>? = null,
+  @Field val cacheKey: String? = null
 ) : Record {
   private var parsedUri: Uri? = null
 
@@ -75,7 +77,12 @@ data class SourceMap(
       return GlideRawModel(parsedUri!!.toString())
     }
 
-    return GlideUrlModel(GlideUrl(uri, getCustomHeaders()))
+    val glideUrl = if (cacheKey == null) {
+      GlideUrl(uri, getCustomHeaders())
+    } else {
+      GlideUrlWithCustomCacheKey(uri, getCustomHeaders(), cacheKey)
+    }
+    return GlideUrlModel(glideUrl)
   }
 
   internal fun createOptions(context: Context): RequestOptions {


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/pull/20772.
Implements feature request: [expo.canny.io/feature-requests/p/expo-image-cachekey-support](https://expo.canny.io/feature-requests/p/expo-image-cachekey-support) on Android

# How

Added a custom cache key to GlideUrl.

# Test Plan

- example created in #20772 