### PR TITLE
[eslint-config-universe] fix import ignore pattern for Windows

### DIFF
--- a/packages/eslint-config-universe/CHANGELOG.md
+++ b/packages/eslint-config-universe/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix import ignore entry for `react-native`, which do not work correctly on Windows. ([#20785](https://github.com/expo/expo/pull/20785) by [@Simek](https://github.com/Simek))
+
 ### 💡 Others
 
 - Bumped `@typescript-eslint/*` dependencies from 5.27.0 to 5.45.1, to add the TypeScript 4.9 support. ([#20374](https://github.com/expo/expo/pull/20374) by [@Simek](https://github.com/Simek))

--- a/packages/eslint-config-universe/shared/core.js
+++ b/packages/eslint-config-universe/shared/core.js
@@ -164,7 +164,7 @@ module.exports = {
     'import/ignore': [
       // react-native's main module is Flow, not JavaScript, and raises parse errors. Additionally,
       // several other react-native-related packages still publish Flow code as their main source.
-      '/node_modules/@?react-native',
+      'node_modules[\\\\/]+@?react-native',
     ],
     'import/resolver': {
       node: { extensions: jsExtensions },


### PR DESCRIPTION
# Why

Refs: 
* https://github.com/expo/expo/pull/20774

Fixes:

<img width="905" alt="Screenshot 2023-01-11 121110" src="https://user-images.githubusercontent.com/719641/211791842-5c24159b-0ffc-4a09-84e9-b60fd0ec1093.png">

# How

Using `path` utils did not help here since it's a RegExp. I have tried to avoid character escaping, but only the commited form yield an expected result. Any less `/` and lint on Windows fails.

# Test Plan

Run `expo-module lint` in one of the packages on both macOS and Windows.