### PR TITLE
[core][Android] Add support for the `Long` type as function parameters

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - View-related DSL functions do not require providing the view's type in function parameters on Android. ([#20751](https://github.com/expo/expo/pull/20751) by [@lukmccall](https://github.com/lukmccall))
+- Add support for the `Long` type as function parameters on Android.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - View-related DSL functions do not require providing the view's type in function parameters on Android. ([#20751](https://github.com/expo/expo/pull/20751) by [@lukmccall](https://github.com/lukmccall))
-- Add support for the `Long` type as function parameters on Android.
+- Add support for the `Long` type as function parameters on Android. ([#20787](https://github.com/expo/expo/pull/20787) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -33,6 +33,7 @@ class JSIAsyncFunctionsTest {
       AsyncFunction("doubleF") { a: Double -> a }
       AsyncFunction("floatF") { a: Float -> a }
       AsyncFunction("boolF") { a: Boolean -> a }
+      AsyncFunction("longF") { a: Long -> a }
     }
   ) { methodQueue ->
     val stringValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.stringF('expo')").getString()
@@ -40,12 +41,14 @@ class JSIAsyncFunctionsTest {
     val doubleValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.doubleF(123.3)").getDouble()
     val floatValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
     val boolValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.boolF(true)").getBool()
+    val longValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.longF(21474836470)").getDouble().toLong()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
     Truth.assertThat(intValue).isEqualTo(123)
     Truth.assertThat(doubleValue).isEqualTo(123.3)
     Truth.assertThat(floatValue).isEqualTo(123.3.toFloat())
     Truth.assertThat(boolValue).isEqualTo(true)
+    Truth.assertThat(longValue).isEqualTo(21474836470)
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -38,6 +38,7 @@ class JSIFunctionsTest {
       Function("doubleF") { a: Double -> a }
       Function("floatF") { a: Float -> a }
       Function("boolF") { a: Boolean -> a }
+      Function("longF") { a: Long -> a }
     }
   ) {
     val stringValue = evaluateScript("expo.modules.TestModule.stringF('expo')").getString()
@@ -45,12 +46,14 @@ class JSIFunctionsTest {
     val doubleValue = evaluateScript("expo.modules.TestModule.doubleF(123.3)").getDouble()
     val floatValue = evaluateScript("expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
     val boolValue = evaluateScript("expo.modules.TestModule.boolF(true)").getBool()
+    val longValue = evaluateScript("expo.modules.TestModule.longF(21474836470)").getDouble().toLong()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
     Truth.assertThat(intValue).isEqualTo(123)
     Truth.assertThat(doubleValue).isEqualTo(123.3)
     Truth.assertThat(floatValue).isEqualTo(123.3.toFloat())
     Truth.assertThat(boolValue).isEqualTo(true)
+    Truth.assertThat(longValue).isEqualTo(21474836470)
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -21,6 +21,10 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
     {"<init>", "(I)V"}
   });
 
+  loadJClass(env, "java/lang/Long", {
+    {"<init>", "(J)V"}
+  });
+
   loadJClass(env, "java/lang/Float", {
     {"<init>", "(F)V"}
   });

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -270,6 +270,9 @@ jsi::Value MethodMetadata::callSync(
   if (env->IsInstanceOf(unpackedResult, cache->getJClass("java/lang/Integer").clazz)) {
     return {jni::static_ref_cast<jni::JInteger>(result)->value()};
   }
+  if (env->IsInstanceOf(unpackedResult, cache->getJClass("java/lang/Long").clazz)) {
+    return {(double) jni::static_ref_cast<jni::JLong>(result)->value()};
+  }
   if (env->IsInstanceOf(unpackedResult, cache->getJClass("java/lang/String").clazz)) {
     return jsi::String::createFromUtf8(
       rt,

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -11,16 +11,17 @@ enum CppType {
   NONE = 0,
   DOUBLE = 1 << 0,
   INT = 1 << 1,
-  FLOAT = 1 << 2,
-  BOOLEAN = 1 << 3,
-  STRING = 1 << 4,
-  JS_OBJECT = 1 << 5,
-  JS_VALUE = 1 << 6,
-  READABLE_ARRAY = 1 << 7,
-  READABLE_MAP = 1 << 8,
-  TYPED_ARRAY = 1 << 9,
-  PRIMITIVE_ARRAY = 1 << 10,
-  LIST = 1 << 11,
-  MAP = 1 << 12
+  LONG = 1 << 2,
+  FLOAT = 1 << 3,
+  BOOLEAN = 1 << 4,
+  STRING = 1 << 5,
+  JS_OBJECT = 1 << 6,
+  JS_VALUE = 1 << 7,
+  READABLE_ARRAY = 1 << 8,
+  READABLE_MAP = 1 << 9,
+  TYPED_ARRAY = 1 << 10,
+  PRIMITIVE_ARRAY = 1 << 11,
+  LIST = 1 << 12,
+  MAP = 1 << 13
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -40,6 +40,23 @@ bool IntegerFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &va
   return value.isNumber();
 }
 
+jobject LongFrontendConverter::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  JSIInteropModuleRegistry *moduleRegistry,
+  const jsi::Value &value
+) const {
+  auto &longClass = JavaReferencesCache::instance()
+    ->getJClass("java/lang/Long");
+  jmethodID longConstructor = longClass.getMethod("<init>", "(J)V");
+  return env->NewObject(longClass.clazz, longConstructor,
+                        static_cast<jlong>(value.getNumber()));
+}
+
+bool LongFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+  return value.isNumber();
+}
+
 jobject FloatFrontendConverter::convert(
   jsi::Runtime &rt,
   JNIEnv *env,
@@ -291,6 +308,12 @@ jobject PrimitiveArrayFrontendConverter::convert(
     return _createPrimitiveArray(
       &JNIEnv::NewIntArray,
       &JNIEnv::SetIntArrayRegion
+    );
+  }
+  if (parameterType == CppType::LONG) {
+    return _createPrimitiveArray(
+      &JNIEnv::NewLongArray,
+      &JNIEnv::SetLongArrayRegion
     );
   }
   if (parameterType == CppType::DOUBLE) {

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -56,6 +56,21 @@ public:
 };
 
 /**
+ * Converter from js number to [java.lang.Long].
+ */
+class LongFrontendConverter : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+};
+
+/**
  * Converter from js number to [java.lang.Float].
  */
 class FloatFrontendConverter : public FrontendConverter {

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -12,6 +12,7 @@ void FrontendConverterProvider::createConverters() {
 #define RegisterConverter(type, clazz)  simpleConverters.insert({type, std::make_shared<clazz>()})
   RegisterConverter(CppType::NONE, UnknownFrontendConverter);
   RegisterConverter(CppType::INT, IntegerFrontendConverter);
+  RegisterConverter(CppType::LONG, LongFrontendConverter);
   RegisterConverter(CppType::FLOAT, FloatFrontendConverter);
   RegisterConverter(CppType::DOUBLE, DoubleFrontendConverter);
   RegisterConverter(CppType::BOOLEAN, BooleanFrontendConverter);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -16,6 +16,7 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   NONE(Nothing::class, 0),
   DOUBLE(Double::class),
   INT(Int::class),
+  LONG(Long::class),
   FLOAT(Float::class),
   BOOLEAN(Boolean::class),
   STRING(String::class),

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -39,6 +39,7 @@ object JSTypeConverter {
       is Uri -> value.toJSValue()
       is File -> value.toJSValue()
       is Pair<*, *> -> value.toJSValue(containerProvider)
+      is Long -> value.toDouble()
       else -> value
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -135,6 +135,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
     val intTypeConverter = createTrivialTypeConverter(
       isOptional, ExpectedType(CppType.INT)
     ) { it.asDouble().toInt() }
+    val longTypeConverter = createTrivialTypeConverter(
+      isOptional, ExpectedType(CppType.LONG)
+    ) { it.asDouble().toLong() }
     val doubleTypeConverter = createTrivialTypeConverter(
       isOptional, ExpectedType(CppType.DOUBLE)
     ) { it.asDouble() }
@@ -148,6 +151,9 @@ object TypeConverterProviderImpl : TypeConverterProvider {
     val converters = mapOf(
       Int::class.createType(nullable = isOptional) to intTypeConverter,
       java.lang.Integer::class.createType(nullable = isOptional) to intTypeConverter,
+
+      Long::class.createType(nullable = isOptional) to longTypeConverter,
+      java.lang.Long::class.createType(nullable = isOptional) to longTypeConverter,
 
       Double::class.createType(nullable = isOptional) to doubleTypeConverter,
       java.lang.Double::class.createType(nullable = isOptional) to doubleTypeConverter,


### PR DESCRIPTION
# Why

Adds support for a `Long` type as a function parameter or return type. 
It could be used in the https://github.com/expo/expo/pull/20784.

# How

- Added a CPP frontend converter.
- Added new Kotlin converter.
- Ensured that react-native can understand Long as a return value. 

# Test Plan

- Unit tests ✅