### PR TITLE
[core][Android] Add convenient getters to the `JavaScriptValue`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -36,9 +36,9 @@ class JSIAsyncFunctionsTest {
     }
   ) { methodQueue ->
     val stringValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.stringF('expo')").getString()
-    val intValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.intF(123)").getDouble().toInt()
+    val intValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.intF(123)").getInt()
     val doubleValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.doubleF(123.3)").getDouble()
-    val floatValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
+    val floatValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.floatF(123.3)").getFloat()
     val boolValue = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.boolF(true)").getBool()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
@@ -155,7 +155,7 @@ class JSIAsyncFunctionsTest {
     ) { methodQueue ->
       val result = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
 
-      val x = result.getProperty("x").getDouble().toInt()
+      val x = result.getProperty("x").getInt()
       val s = result.getProperty("s").getString()
 
       Truth.assertThat(x).isEqualTo(123)
@@ -217,9 +217,9 @@ class JSIAsyncFunctionsTest {
     val array = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.intArray([1, 2, 3])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
-    val e1 = array[0].getDouble().toInt()
-    val e2 = array[1].getDouble().toInt()
-    val e3 = array[2].getDouble().toInt()
+    val e1 = array[0].getInt()
+    val e2 = array[1].getInt()
+    val e3 = array[2].getInt()
 
     Truth.assertThat(e1).isEqualTo(1)
     Truth.assertThat(e2).isEqualTo(2)
@@ -261,10 +261,10 @@ class JSIAsyncFunctionsTest {
     Truth.assertThat(a1.size).isEqualTo(2)
     Truth.assertThat(a2.size).isEqualTo(2)
 
-    val e1 = a1[0].getDouble().toInt()
-    val e2 = a1[1].getDouble().toInt()
-    val e3 = a2[0].getDouble().toInt()
-    val e4 = a2[1].getDouble().toInt()
+    val e1 = a1[0].getInt()
+    val e2 = a1[1].getInt()
+    val e3 = a2[0].getInt()
+    val e4 = a2[1].getInt()
 
     Truth.assertThat(e1).isEqualTo(1)
     Truth.assertThat(e2).isEqualTo(2)

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -41,9 +41,9 @@ class JSIFunctionsTest {
     }
   ) {
     val stringValue = evaluateScript("expo.modules.TestModule.stringF('expo')").getString()
-    val intValue = evaluateScript("expo.modules.TestModule.intF(123)").getDouble().toInt()
+    val intValue = evaluateScript("expo.modules.TestModule.intF(123)").getInt()
     val doubleValue = evaluateScript("expo.modules.TestModule.doubleF(123.3)").getDouble()
-    val floatValue = evaluateScript("expo.modules.TestModule.floatF(123.3)").getDouble().toFloat()
+    val floatValue = evaluateScript("expo.modules.TestModule.floatF(123.3)").getFloat()
     val boolValue = evaluateScript("expo.modules.TestModule.boolF(true)").getBool()
 
     Truth.assertThat(stringValue).isEqualTo("expo")
@@ -86,7 +86,7 @@ class JSIFunctionsTest {
     Truth.assertThat(e2).hasLength(3)
     val newArray = arrayOf(*e1, *e2)
     newArray.forEachIndexed { index, element ->
-      Truth.assertThat(element.getDouble().toInt()).isEqualTo(index + 1)
+      Truth.assertThat(element.getInt()).isEqualTo(index + 1)
     }
   }
 
@@ -242,7 +242,7 @@ class JSIFunctionsTest {
     ) {
       val result = evaluateScript("expo.modules.TestModule.f({ 'x': 123, 's': 'expo' })").getObject()
 
-      val x = result.getProperty("x").getDouble().toInt()
+      val x = result.getProperty("x").getInt()
       val s = result.getProperty("s").getString()
 
       Truth.assertThat(x).isEqualTo(123)
@@ -378,9 +378,9 @@ class JSIFunctionsTest {
     val array = evaluateScript("expo.modules.TestModule.intArray([1, 2, 3])").getArray()
     Truth.assertThat(array.size).isEqualTo(3)
 
-    val e1 = array[0].getDouble().toInt()
-    val e2 = array[1].getDouble().toInt()
-    val e3 = array[2].getDouble().toInt()
+    val e1 = array[0].getInt()
+    val e2 = array[1].getInt()
+    val e3 = array[2].getInt()
 
     Truth.assertThat(e1).isEqualTo(1)
     Truth.assertThat(e2).isEqualTo(2)
@@ -422,10 +422,10 @@ class JSIFunctionsTest {
     Truth.assertThat(a1.size).isEqualTo(2)
     Truth.assertThat(a2.size).isEqualTo(2)
 
-    val e1 = a1[0].getDouble().toInt()
-    val e2 = a1[1].getDouble().toInt()
-    val e3 = a2[0].getDouble().toInt()
-    val e4 = a2[1].getDouble().toInt()
+    val e1 = a1[0].getInt()
+    val e2 = a1[1].getInt()
+    val e3 = a2[0].getInt()
+    val e4 = a2[1].getInt()
 
     Truth.assertThat(e1).isEqualTo(1)
     Truth.assertThat(e2).isEqualTo(2)
@@ -475,7 +475,7 @@ class JSIFunctionsTest {
       }
     }
   ) {
-    val int = evaluateScript("expo.modules.TestModule.eitherFirst(123)").getDouble().toInt()
+    val int = evaluateScript("expo.modules.TestModule.eitherFirst(123)").getInt()
     val string = evaluateScript("expo.modules.TestModule.eitherSecond('expo')").getString()
 
     Truth.assertThat(int).isEqualTo(123)

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIInteropModuleRegistryTest.kt
@@ -50,7 +50,7 @@ class JSIInteropModuleRegistryTest {
     val f2Value = evaluateScript("expo.modules.TestModule.f2(\"expo\")")
 
     Truth.assertThat(f1Value.isNumber()).isTrue()
-    val unboxedF1Value = f1Value.getDouble().toInt()
+    val unboxedF1Value = f1Value.getInt()
     Truth.assertThat(unboxedF1Value).isEqualTo(20)
 
     Truth.assertThat(f2Value.isString()).isTrue()
@@ -69,7 +69,7 @@ class JSIInteropModuleRegistryTest {
   ) { methodQueue ->
     val promiseResult = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.f()")
     Truth.assertThat(promiseResult.isNumber()).isTrue()
-    Truth.assertThat(global().getProperty("promiseResult").getDouble().toInt()).isEqualTo(20)
+    Truth.assertThat(global().getProperty("promiseResult").getInt()).isEqualTo(20)
   }
 
   @Test
@@ -89,7 +89,7 @@ class JSIInteropModuleRegistryTest {
     val i1Value = evaluateScript("expo.modules.TestModule.c3.i1")
 
     Truth.assertThat(c1Value.isNumber()).isTrue()
-    val unboxedC1Value = c1Value.getDouble().toInt()
+    val unboxedC1Value = c1Value.getInt()
     Truth.assertThat(unboxedC1Value).isEqualTo(123)
 
     Truth.assertThat(c2Value.isString()).isTrue()
@@ -97,7 +97,7 @@ class JSIInteropModuleRegistryTest {
     Truth.assertThat(unboxedC2Value).isEqualTo("string")
 
     Truth.assertThat(i1Value.isNumber()).isTrue()
-    val unboxedI1Value = i1Value.getDouble().toInt()
+    val unboxedI1Value = i1Value.getInt()
     Truth.assertThat(unboxedI1Value).isEqualTo(123)
   }
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIPropertiesTest.kt
@@ -36,8 +36,8 @@ internal class JSIPropertiesTest {
       Property("p2").get { return@get 321 }
     }
   ) {
-    val p1 = evaluateScript("expo.modules.TestModule.p1").getDouble().toInt()
-    val p2 = evaluateScript("expo.modules.TestModule.p2").getDouble().toInt()
+    val p1 = evaluateScript("expo.modules.TestModule.p1").getInt()
+    val p2 = evaluateScript("expo.modules.TestModule.p2").getInt()
 
     Truth.assertThat(p1).isEqualTo(123)
     Truth.assertThat(p2).isEqualTo(321)
@@ -55,9 +55,9 @@ internal class JSIPropertiesTest {
     }
   ) {
     evaluateScript("expo.modules.TestModule.p = 987")
-    val p1 = evaluateScript("expo.modules.TestModule.p").getDouble().toInt()
+    val p1 = evaluateScript("expo.modules.TestModule.p").getInt()
     evaluateScript("expo.modules.TestModule.p = 123")
-    val p2 = evaluateScript("expo.modules.TestModule.p").getDouble().toInt()
+    val p2 = evaluateScript("expo.modules.TestModule.p").getInt()
 
     Truth.assertThat(p1).isEqualTo(987)
     Truth.assertThat(p2).isEqualTo(123)

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptObjectTest.kt
@@ -178,8 +178,8 @@ class JavaScriptObjectTest {
         """.trimIndent()
       ).getObject()
 
-      Truth.assertThat(result.getProperty("expo").getDouble().toInt()).isEqualTo(123)
-      Truth.assertThat(receivedObject!!.getProperty("expo").getDouble().toInt()).isEqualTo(123)
+      Truth.assertThat(result.getProperty("expo").getInt()).isEqualTo(123)
+      Truth.assertThat(receivedObject!!.getProperty("expo").getInt()).isEqualTo(123)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -58,7 +58,7 @@ class JavaScriptValueTest {
     val p1 = jsObject.getProperty("p1")
     Truth.assertThat(p1.kind()).isEqualTo("number")
     Truth.assertThat(p1.isNumber()).isEqualTo(true)
-    Truth.assertThat(p1.getDouble().toInt()).isEqualTo(123)
+    Truth.assertThat(p1.getInt()).isEqualTo(123)
 
     val properties = jsObject.getPropertyNames()
     Truth.assertThat(properties).hasLength(1)
@@ -86,8 +86,8 @@ class JavaScriptValueTest {
         """.trimIndent()
       ).getObject()
 
-      Truth.assertThat(result.getProperty("expo").getDouble().toInt()).isEqualTo(123)
-      Truth.assertThat(receivedObject!!.getProperty("expo").getDouble().toInt()).isEqualTo(123)
+      Truth.assertThat(result.getProperty("expo").getInt()).isEqualTo(123)
+      Truth.assertThat(receivedObject!!.getProperty("expo").getInt()).isEqualTo(123)
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -30,6 +30,10 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
   external fun getArray(): Array<JavaScriptValue>
   external fun getTypedArray(): JavaScriptTypedArray
 
+  fun getInt() = getDouble().toInt()
+  fun getLong() = getDouble().toLong()
+  fun getFloat() = getDouble().toFloat()
+
   @Throws(Throwable::class)
   protected fun finalize() {
     mHybridData.resetNative()


### PR DESCRIPTION
# Why

Adds convenient helpers to the `JavaScriptValue` class. Those methods create a shortcut for getting the `Int`, `Float`, or `Long` type from the js value. 

# Test Plan

- Unit tests ✅