### PR TITLE
Remove strict null checks for expo location and fix NullPointerException crashes

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Removed strict null checks for expo location and avoid crash on android. ([#20792](https://github.com/expo/expo/pull/20792) by [@jayshah123](https://github.com/jayshah123) and [@forki](https://github.com/forki))
 - Export types with type-only annotation to fix build when using `isolatedModules` flag. ([#20239](https://github.com/expo/expo/pull/20239) by [@zakharchenkoAndrii](https://github.com/zakharchenkoAndrii))
 
 ### 💡 Others

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -841,8 +841,15 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
   private Bundle handleForegroundLocationPermissions(Map<String, PermissionsResponse> result) {
     PermissionsResponse accessFineLocation = result.get(Manifest.permission.ACCESS_FINE_LOCATION);
     PermissionsResponse accessCoarseLocation = result.get(Manifest.permission.ACCESS_COARSE_LOCATION);
-    Objects.requireNonNull(accessFineLocation);
-    Objects.requireNonNull(accessCoarseLocation);
+    /**
+     * Missing permissions from OS callback should be considered as denied permissions
+     */
+    if(accessFineLocation == null) {
+      accessFineLocation = new PermissionsResponse(PermissionsStatus.DENIED, true);
+    }
+    if(accessCoarseLocation == null) {
+      accessCoarseLocation = new PermissionsResponse(PermissionsStatus.DENIED, true);
+    }
 
     PermissionsStatus status = PermissionsStatus.UNDETERMINED;
     String accuracy = "none";


### PR DESCRIPTION
fixes #17426 - all credits go to @jayshah123 who created this fix

# Why

See https://github.com/expo/expo/issues/17426

https://developer.android.com/reference/androidx/core/app/ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int,java.lang.String%5B%5D,int%5B%5D)

Null check leads to crashes in production

# How

We gracefully check the new coditions

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
