### PR TITLE
[github] use Node 16 for all workflows

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: 👀 Check out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: 👀 Check out repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/dogfooding-clients.yml
+++ b/.github/workflows/dogfooding-clients.yml
@@ -18,7 +18,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -29,7 +29,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
@@ -71,7 +71,7 @@ jobs:
   #     - name: ⬢ Setup Node
   #       uses: actions/setup-node@v3
   #       with:
-  #         node-version: '14.17'
+  #         node-version: 16
   #     - name: ♻️ Restore caches
   #       uses: ./.github/actions/expo-caches
   #       id: expo-caches

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -33,7 +33,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/publish-demo.yml
+++ b/.github/workflows/publish-demo.yml
@@ -27,7 +27,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -101,7 +101,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,7 +35,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
@@ -149,7 +149,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/updates-e2e-android.yml
+++ b/.github/workflows/updates-e2e-android.yml
@@ -42,7 +42,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 16
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/updates-e2e-ios.yml
+++ b/.github/workflows/updates-e2e-ios.yml
@@ -42,7 +42,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 16
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,7 +23,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '14.17'
+          node-version: 16
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.9.0",
     "@tsconfig/node14": "^1.0.3",
     "@types/fs-extra": "^9.0.1",
-    "@types/node": "^12",
+    "@types/node": "^16.18.11",
     "@types/node-fetch": "^2.5.12",
     "eslint-config-universe": "^11.1.0",
     "expo-module-scripts": "^3.0.0",

--- a/tools/package.json
+++ b/tools/package.json
@@ -74,7 +74,7 @@
     "@types/inquirer": "^8.2.1",
     "@types/ip": "^1.1.0",
     "@types/klaw-sync": "^6.0.1",
-    "@types/node": "16.11.43",
+    "@types/node": "^16.18.11",
     "@types/node-fetch": "^2.6.2",
     "@types/semver": "^7.3.12",
     "eslint": "^8.29.0",

--- a/tools/yarn.lock
+++ b/tools/yarn.lock
@@ -2144,10 +2144,15 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@16.11.43":
+"@types/node@*":
   version "16.11.43"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.43.tgz#555e5a743f76b6b897d47f945305b618525ddbe6"
   integrity sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==
+
+"@types/node@^16.18.11":
+  version "16.18.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz#cbb15c12ca7c16c85a72b6bdc4d4b01151bb3cae"
+  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
 
 "@types/q@^1.5.1":
   version "1.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,10 +4365,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
   integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
 
-"@types/node@^12":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
+"@types/node@^16.18.11":
+  version "16.18.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.11.tgz#cbb15c12ca7c16c85a72b6bdc4d4b01151bb3cae"
+  integrity sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
# Why

Evan spotted the inconsistency of Node version in our workflows, let's address that.

# How

Ensure that we are using Node 16 in all of the workflows.

In theory, we could even skip this setup step, since for most of the action runners used Node 16 is the default, but leaving this step in makes our workflows a bit more outside changes prone.

Additionally I have updated `@types/node` in test runner and tools, so they use the latest typing for Node 16.

# Test Plan

Run the CI.
