### PR TITLE
[docs] APISection: fix comment example in tables, remove legacy code

### DIFF
--- a/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
+++ b/docs/components/plugins/AppConfigSchemaPropertiesTable.tsx
@@ -4,9 +4,10 @@ import ReactMarkdown from 'react-markdown';
 
 import { HeadingType } from '~/common/headingManager';
 import { APIBox } from '~/components/plugins/APIBox';
-import { mdComponents, mdInlineComponents } from '~/components/plugins/api/APISectionUtils';
+import { mdComponents } from '~/components/plugins/api/APISectionUtils';
+import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { P, CALLOUT, CODE, createPermalinkedComponent } from '~/ui/components/Text';
+import { P, CALLOUT, CODE, createPermalinkedComponent, BOLD } from '~/ui/components/Text';
 
 type PropertyMeta = {
   regexHuman?: string;
@@ -185,7 +186,12 @@ const AppConfigProperty = ({
         <ReactMarkdown components={mdComponents}>{bareWorkflow}</ReactMarkdown>
       </Collapsible>
     )}
-    {example && <ReactMarkdown components={mdInlineComponents}>{`> ${example}`}</ReactMarkdown>}
+    {example && (
+      <Callout>
+        <BOLD>Example</BOLD>
+        <ReactMarkdown components={mdComponents}>{example}</ReactMarkdown>
+      </Callout>
+    )}
     <div>
       {subproperties.length > 0 &&
         subproperties.map((formattedProperty, index) => (

--- a/docs/components/plugins/EasJsonPropertiesTable.tsx
+++ b/docs/components/plugins/EasJsonPropertiesTable.tsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown';
 
 import { HeadingType } from '~/common/headingManager';
-import { mdInlineComponentsNoValidation } from '~/components/plugins/api/APISectionUtils';
+import { mdComponentsNoValidation } from '~/components/plugins/api/APISectionUtils';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { P, CODE, createPermalinkedComponent } from '~/ui/components/Text';
 
@@ -111,7 +111,7 @@ export const EasJsonPropertiesTable = ({ schema }: Props) => {
               </div>
             </Cell>
             <Cell>
-              <ReactMarkdown components={mdInlineComponentsNoValidation}>
+              <ReactMarkdown components={mdComponentsNoValidation}>
                 {property.description}
               </ReactMarkdown>
             </Cell>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -265,12 +265,16 @@ not appear on the screen.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidbutton"
@@ -282,7 +286,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <h2
@@ -2767,12 +2771,16 @@ which contains all of the pertinent user and credential information.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidcredential"
@@ -2784,7 +2792,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -3569,12 +3577,16 @@ You must include the ID string of the user whose credentials you'd like to refre
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
@@ -3586,7 +3598,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -3874,12 +3886,16 @@ None of these options are required.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
@@ -3891,7 +3907,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -4200,12 +4216,16 @@ You must include the ID string of the user to sign out.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationopenidrequest"
@@ -4217,7 +4237,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -5189,12 +5209,16 @@ OAuth 2.0 protocol
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationappleidprovidercredentialstate"
@@ -5206,7 +5230,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -5912,12 +5936,16 @@ You will still need to handle null values for any fields you request.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asauthorizationscope"
@@ -5929,7 +5957,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div
@@ -6146,12 +6174,16 @@ for more details.
       <div
         class="css-1m74yfi-Callout"
       >
-        <strong
-          class="css-bvflvn-TextComponent"
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
         >
-          See: 
-        </strong>
-        <span>
+          <strong
+            class="css-bvflvn-TextComponent"
+          >
+            See:
+          </strong>
+           
           <a
             class="css-dqmbnf-A"
             href="https://developer.apple.com/documentation/authenticationservices/asuserdetectionstatus"
@@ -6163,7 +6195,7 @@ Documentation
           </a>
           
 for more details.
-        </span>
+        </p>
       </div>
     </blockquote>
     <div

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -746,13 +746,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       <div
         class="css-1m74yfi-Callout"
       >
-        
-
-        <span>
+        <strong
+          class="css-bvflvn-TextComponent"
+        >
+          Example
+        </strong>
+        <p
+          class="css-1oym3r-TextComponent"
+          data-text="true"
+        >
           [{  "autoVerify": true,  "data": {"host": "*.example.com"  }  }]
-        </span>
-        
-
+        </p>
       </div>
     </blockquote>
     <div>

--- a/docs/components/plugins/api/APISectionDeprecationNote.tsx
+++ b/docs/components/plugins/api/APISectionDeprecationNote.tsx
@@ -6,7 +6,7 @@ import { CommentData } from '~/components/plugins/api/APIDataTypes';
 import {
   getCommentContent,
   getTagData,
-  mdInlineComponents,
+  mdComponents,
 } from '~/components/plugins/api/APISectionUtils';
 import { Callout } from '~/ui/components/Callout';
 import { BOLD } from '~/ui/components/Text';
@@ -27,8 +27,7 @@ export const APISectionDeprecationNote = ({ comment }: Props) => {
     <div css={deprecationNoticeStyle}>
       <Callout type="warning" key="deprecation-note">
         {content.length ? (
-          <ReactMarkdown
-            components={mdInlineComponents}>{`**Deprecated.** ${content}`}</ReactMarkdown>
+          <ReactMarkdown components={mdComponents}>{`**Deprecated.** ${content}`}</ReactMarkdown>
         ) : (
           <BOLD>Deprecated</BOLD>
         )}

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -12,7 +12,6 @@ import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatf
 import {
   CommentTextBlock,
   getTagData,
-  mdComponents,
   parseCommentContent,
   renderFlags,
   renderParamRow,
@@ -54,8 +53,8 @@ const renderInterfaceComment = (
             <br />
             <APISectionDeprecationNote comment={comment} />
             <CommentTextBlock
+              inlineHeaders
               comment={signatureComment}
-              components={mdComponents}
               afterContent={renderDefaultValue(initValue)}
             />
           </>
@@ -71,7 +70,6 @@ const renderInterfaceComment = (
         <APISectionDeprecationNote comment={comment} />
         <CommentTextBlock
           comment={comment}
-          components={mdComponents}
           afterContent={renderDefaultValue(initValue)}
           emptyCommentFallback="-"
         />

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -9,7 +9,6 @@ import {
 } from '~/components/plugins/api/APIDataTypes';
 import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDeprecationNote';
 import {
-  mdComponents,
   resolveTypeName,
   renderFlags,
   CommentTextBlock,
@@ -91,8 +90,8 @@ const renderTypePropertyRow = ({
       <Cell fitContent>
         <APISectionDeprecationNote comment={comment} />
         <CommentTextBlock
+          inlineHeaders
           comment={commentData}
-          components={mdComponents}
           afterContent={renderDefaultValue(initValue)}
           emptyCommentFallback={hasDeprecationNote ? undefined : '-'}
         />

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/react';
-import * as React from 'react';
 
 import type { CommentData } from './APIDataTypes';
-import { CommentTextBlock, mdInlineComponents, resolveTypeName } from './APISectionUtils';
+import { CommentTextBlock, resolveTypeName } from './APISectionUtils';
 
 describe('APISectionUtils.resolveTypeName', () => {
   test('void', () => {
@@ -420,17 +419,6 @@ describe('APISectionUtils.CommentTextBlock component', () => {
     };
 
     const { container } = render(<CommentTextBlock comment={comment} />);
-    expect(container).toMatchSnapshot();
-  });
-
-  test('basic inline comment', () => {
-    const comment: CommentData = {
-      summary: [{ kind: 'text', text: 'This is the basic comment.' }],
-    };
-
-    const { container } = render(
-      <CommentTextBlock comment={comment} components={mdInlineComponents} withDash />
-    );
     expect(container).toMatchSnapshot();
   });
 

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -11,15 +11,6 @@ exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 </div>
 `;
 
-exports[`APISectionUtils.CommentTextBlock component basic inline comment 1`] = `
-<div>
-   - 
-  <span>
-    This is the basic comment.
-  </span>
-</div>
-`;
-
 exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
 <div>
   <strong


### PR DESCRIPTION
# Why

Fixes:
<img width="1119" alt="Screenshot 2023-01-12 at 15 09 28" src="https://user-images.githubusercontent.com/719641/212088578-601ff250-a25e-44c9-ae6d-fa63461b36bc.png">

# How

This display issue is a regression after latest TypeDoc update. The section headers should just use plain bold text while comment is rendered in tables.

Additionally, I have removed some of the legacy code, like inline Markdown components required before we have finished base components refactor, as well as few no longer used props for comment block.

# Test Plan

The changes have been tested by running docs app locally. Lint and tests do not yield any errors, but I had to regenerte the snapshots.

# Preview

<img width="1119" alt="Screenshot 2023-01-12 at 15 14 41" src="https://user-images.githubusercontent.com/719641/212089555-fe71ede4-8345-40f0-b6d1-79f33054f00f.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
