### PR TITLE
[core][Android][docs] Add `Long` to the documentation

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -365,7 +365,7 @@ All functions and view prop setters accept all common primitive types in Swift a
 | Language | Supported primitive types                                                                                                      |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | Swift    | `Bool`, `Int`, `Int8`, `Int16`, `Int32`, `Int64`, `UInt`, `UInt8`, `UInt16`, `UInt32`, `UInt64`, `Float32`, `Double`, `String` |
-| Kotlin   | `Boolean`, `Int`, `UInt`, `Float`, `Double`, `String`, `Pair`                                                                  |
+| Kotlin   | `Boolean`, `Int`, `Long`, `UInt`, `Float`, `Double`, `String`, `Pair`                                                          |
 
 </APIBox>
 <APIBox header="Convertibles">


### PR DESCRIPTION
# Why

Closes https://linear.app/expo/issue/ENG-7152#comment-48407aa4.
This is a follow-up to https://github.com/expo/expo/pull/20787.
