### PR TITLE
[docs] Add eas channel:delete to the documentation

### DIFF
--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -48,6 +48,19 @@ Create a channel:
   cmdCopy="eas channel:create [channel-name]"
 />
 
+Delete a channel:
+
+<Terminal
+  cmd={[
+    '$ eas channel:delete [channel-name]',
+    '',
+    '',
+    '# Example',
+    '$ eas channel:delete version-1.0',
+  ]}
+  cmdCopy="eas channel:delete [channel-name]"
+/>
+
 ### Inspect branches
 
 See all branches:


### PR DESCRIPTION
# Why

Providing documentation for the missing eas channel:delete method on the page.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Include method according to the pattern of other lines of documentation.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Preview change on page.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
