### PR TITLE
[docs] tweaks related to the new color palette

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -51,7 +51,7 @@ const STYLES_CODE_BLOCK = css`
 `;
 
 const STYLES_CODE_CONTAINER_BLOCK = css`
-  border: 1px solid ${theme.border.default};
+  border: 1px solid ${theme.border.secondary};
   padding: 16px;
   margin: 16px 0;
   background-color: ${theme.background.subtle};

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -115,7 +115,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </strong>
        
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         React.Element
@@ -150,7 +150,7 @@ available via the provided properties.
         href="#isavailableasync"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -159,7 +159,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         true
@@ -167,7 +167,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         __DEV__ === true
@@ -182,7 +182,7 @@ a warning in development mode (
     >
       The properties of this component extend from 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         View
@@ -190,21 +190,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         style
@@ -212,7 +212,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         buttonStyle
@@ -220,7 +220,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         cornerRadius
@@ -352,7 +352,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 buttonStyle
@@ -399,7 +399,7 @@ for more details.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <a
@@ -436,7 +436,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 buttonType
@@ -483,7 +483,7 @@ for more details.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <a
@@ -520,7 +520,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 cornerRadius
@@ -572,7 +572,7 @@ for more details.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             number
@@ -585,7 +585,7 @@ for more details.
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             style.borderRadius
@@ -612,7 +612,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 onPress
@@ -659,7 +659,7 @@ for more details.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             (
@@ -677,7 +677,7 @@ for more details.
             href="#isavailableasync"
           >
             <code
-              class="css-106i24p-TextComponent"
+              class="css-zmv3vl-TextComponent"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -706,7 +706,7 @@ in here.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 style
@@ -758,7 +758,7 @@ in here.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             StyleProp
@@ -804,14 +804,14 @@ in here.
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             borderRadius
@@ -875,7 +875,7 @@ properties.
           data-text="true"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <a
@@ -957,7 +957,7 @@ properties.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -1039,7 +1039,7 @@ properties.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -1059,7 +1059,7 @@ This should come from the user field of an
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="css-106i24p-TextComponent"
+                    class="css-zmv3vl-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1203,7 +1203,7 @@ This should come from the user field of an
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -1238,7 +1238,7 @@ This should come from the user field of an
         href="#appleauthenticationcredentialstate"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredentialState
@@ -1267,7 +1267,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -1386,7 +1386,7 @@ value depending on the state of the credential.
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -1412,14 +1412,14 @@ value depending on the state of the credential.
     >
       A promise that fulfills with 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         true
       </code>
        if the system supports Apple authentication, and 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         false
@@ -1446,7 +1446,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             refreshAsync(options)
@@ -1528,7 +1528,7 @@ value depending on the state of the credential.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1552,7 +1552,7 @@ value depending on the state of the credential.
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="css-106i24p-TextComponent"
+                    class="css-zmv3vl-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1650,7 +1650,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -1685,7 +1685,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -1694,7 +1694,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         ERR_CANCELED
@@ -1722,7 +1722,7 @@ refresh operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             signInAsync(options)
@@ -1810,7 +1810,7 @@ refresh operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1834,7 +1834,7 @@ refresh operation.
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="css-106i24p-TextComponent"
+                    class="css-zmv3vl-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1887,7 +1887,7 @@ You can use
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -1973,7 +1973,7 @@ the user, since this remains the same for apps released by the same developer.
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -2008,7 +2008,7 @@ the user, since this remains the same for apps released by the same developer.
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -2017,7 +2017,7 @@ the user, since this remains the same for apps released by the same developer.
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         ERR_CANCELED
@@ -2045,7 +2045,7 @@ sign-in operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             signOutAsync(options)
@@ -2127,7 +2127,7 @@ sign-in operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -2151,7 +2151,7 @@ sign-in operation.
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="css-106i24p-TextComponent"
+                    class="css-zmv3vl-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -2186,7 +2186,7 @@ from using
         href="./#signinasync"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           signInAsync
@@ -2198,7 +2198,7 @@ from using
         href="./#refreshasync"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           refreshAsync
@@ -2283,7 +2283,7 @@ from using
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -2318,7 +2318,7 @@ from using
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -2327,7 +2327,7 @@ from using
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         ERR_CANCELED
@@ -2402,7 +2402,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2484,7 +2484,7 @@ sign-out operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -2579,7 +2579,7 @@ sign-out operation.
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -2659,7 +2659,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2705,7 +2705,7 @@ sign-out operation.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2718,7 +2718,7 @@ sign-out operation.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2730,7 +2730,7 @@ sign-out operation.
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2833,7 +2833,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2855,7 +2855,7 @@ for more details.
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   user
@@ -2880,7 +2880,7 @@ the app's server counterpart. Unlike
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2901,7 +2901,7 @@ the app's server counterpart. Unlike
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   EMAIL
@@ -2929,7 +2929,7 @@ an Apple domain.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2955,21 +2955,21 @@ an Apple domain.
               >
                 The user's name. May be 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   FULL_NAME
@@ -2996,7 +2996,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3035,7 +3035,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3073,7 +3073,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3094,7 +3094,7 @@ your app.
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   state
@@ -3103,7 +3103,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   state
@@ -3111,7 +3111,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
@@ -3136,7 +3136,7 @@ will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -3179,7 +3179,7 @@ developers.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -3222,7 +3222,7 @@ developers.
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         null
@@ -3275,7 +3275,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3309,7 +3309,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3343,7 +3343,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3377,7 +3377,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3411,7 +3411,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3445,7 +3445,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3486,7 +3486,7 @@ may be
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3532,7 +3532,7 @@ may be
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3641,7 +3641,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3664,7 +3664,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
@@ -3673,14 +3673,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   []
@@ -3711,7 +3711,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -3756,7 +3756,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -3791,7 +3791,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3837,7 +3837,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -3946,7 +3946,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -3995,7 +3995,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -4018,7 +4018,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
@@ -4027,14 +4027,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   []
@@ -4065,7 +4065,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -4117,7 +4117,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -4163,7 +4163,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -4272,7 +4272,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -4317,7 +4317,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -4352,7 +4352,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             Subscription
@@ -4434,7 +4434,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -4518,7 +4518,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonStyle
@@ -4564,7 +4564,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationButton
@@ -4591,7 +4591,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               WHITE
@@ -4628,7 +4628,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -4659,7 +4659,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               WHITE_OUTLINE
@@ -4696,7 +4696,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -4727,7 +4727,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               BLACK
@@ -4764,7 +4764,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -4796,7 +4796,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonType
@@ -4842,7 +4842,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthenticationButton
@@ -4869,7 +4869,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               SIGN_IN
@@ -4906,7 +4906,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -4937,7 +4937,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               CONTINUE
@@ -4974,7 +4974,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -4996,7 +4996,7 @@ OAuth 2.0 protocol
          
       </strong>
       <div
-        class="css-1b8ehh7-PlatformTag"
+        class="css-ia0kxc-PlatformTag"
       >
         <svg
           color="var(--blue12)"
@@ -5038,7 +5038,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               SIGN_UP
@@ -5075,7 +5075,7 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -5107,7 +5107,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -5153,7 +5153,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.getCredentialStateAsync()
@@ -5228,7 +5228,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               REVOKED
@@ -5265,7 +5265,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5290,7 +5290,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               AUTHORIZED
@@ -5327,7 +5327,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5352,7 +5352,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               NOT_FOUND
@@ -5389,7 +5389,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5414,7 +5414,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               TRANSFERRED
@@ -5451,7 +5451,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5477,7 +5477,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationOperation
@@ -5532,7 +5532,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               IMPLICIT
@@ -5569,7 +5569,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -5600,7 +5600,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               LOGIN
@@ -5637,7 +5637,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5662,7 +5662,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               REFRESH
@@ -5699,7 +5699,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5724,7 +5724,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               LOGOUT
@@ -5761,7 +5761,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5787,7 +5787,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationScope
@@ -5833,7 +5833,7 @@ for more details.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -5951,7 +5951,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               FULL_NAME
@@ -5988,7 +5988,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -6013,7 +6013,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               EMAIL
@@ -6050,7 +6050,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6076,7 +6076,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             AppleAuthenticationUserDetectionStatus
@@ -6185,7 +6185,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               UNSUPPORTED
@@ -6222,7 +6222,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -6253,7 +6253,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               UNKNOWN
@@ -6290,7 +6290,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -6321,7 +6321,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               LIKELY_REAL
@@ -6358,7 +6358,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -6442,7 +6442,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeScanner
@@ -6489,7 +6489,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </strong>
        
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         React.
@@ -6573,7 +6573,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 barCodeTypes
@@ -6625,7 +6625,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             string[]
@@ -6637,7 +6637,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
         >
           An array of bar code types. Usage: 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
@@ -6645,7 +6645,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
            where
 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             codeType
@@ -6669,7 +6669,7 @@ minimize battery usage.
         >
           For example: 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
@@ -6696,7 +6696,7 @@ minimize battery usage.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6748,7 +6748,7 @@ minimize battery usage.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <a
@@ -6816,14 +6816,14 @@ provided with an
               </strong>
                Passing 
               <code
-                class="css-106i24p-TextComponent"
+                class="css-zmv3vl-TextComponent"
                 data-text="true"
               >
                 undefined
               </code>
                to the 
               <code
-                class="css-106i24p-TextComponent"
+                class="css-zmv3vl-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6856,7 +6856,7 @@ data has been retrieved.
               class="css-6n7j50"
             >
               <code
-                class="css-1wb1qhy-TextComponent"
+                class="css-1oape9q-TextComponent"
                 data-text="true"
               >
                 type
@@ -6908,7 +6908,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <span>
@@ -6931,7 +6931,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               Type.back
@@ -6944,21 +6944,21 @@ data has been retrieved.
         >
           Camera facing. Use one of 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             Type.front
           </code>
            or 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             Type.back
@@ -6966,7 +6966,7 @@ data has been retrieved.
           .
 Same as 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             Camera.Constants.Type
@@ -7029,7 +7029,7 @@ Same as
           data-text="true"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             <a
@@ -7111,7 +7111,7 @@ Same as
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             usePermissions(options)
@@ -7199,7 +7199,7 @@ Same as
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -7232,14 +7232,14 @@ Same as
       Check or request permissions for the barcode scanner.
 This uses both 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         requestPermissionAsync
       </code>
        and 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         getPermissionsAsync
@@ -7258,7 +7258,7 @@ This uses both
     </div>
     <pre>
       <pre
-        class="css-micsoa"
+        class="css-1tmj8fm"
         data-text="true"
       >
         <code
@@ -7406,7 +7406,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           [
@@ -7524,7 +7524,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             BarCodeScanner.getPermissionsAsync()
@@ -7643,7 +7643,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -7678,7 +7678,7 @@ This uses both
         href="#permissionresponse"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           PermissionResponse
@@ -7706,7 +7706,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             BarCodeScanner.requestPermissionsAsync()
@@ -7756,14 +7756,14 @@ This uses both
     >
       On iOS this will require apps to specify the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         Info.plist
@@ -7847,7 +7847,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -7882,7 +7882,7 @@ This uses both
         href="#permissionresponse"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           PermissionResponse
@@ -7910,7 +7910,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             BarCodeScanner.scanFromURLAsync(url, barCodeTypes)
@@ -7992,7 +7992,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -8031,7 +8031,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string[]
@@ -8183,7 +8183,7 @@ the platform.
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -8215,7 +8215,7 @@ the platform.
     >
       A possibly empty array of objects of the 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         BarCodeScannerResult
@@ -8291,7 +8291,7 @@ code.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -8431,7 +8431,7 @@ code.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8466,7 +8466,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8504,7 +8504,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8537,7 +8537,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8630,7 +8630,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeBounds
@@ -8712,7 +8712,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8750,7 +8750,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8795,7 +8795,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeEvent
@@ -8836,7 +8836,7 @@ in order to enable/disable the permission.
       data-text="true"
     >
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         <a
@@ -8902,7 +8902,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -8937,7 +8937,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -9019,7 +9019,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9059,7 +9059,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodePoint
@@ -9148,7 +9148,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -9163,7 +9163,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               >
                 The 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   x
@@ -9188,7 +9188,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -9203,7 +9203,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               >
                 The 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   y
@@ -9235,7 +9235,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -9319,7 +9319,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-y1i413-TextComponent"
+                  class="css-kzvbfm-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -9360,7 +9360,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeScannerResult
@@ -9442,7 +9442,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9470,7 +9470,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  object.
 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   bounds
@@ -9478,7 +9478,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  in some case will be representing an empty rectangle.
 Moreover, 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   bounds
@@ -9504,7 +9504,7 @@ For some types, they will represent the area used by the scanner.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9526,21 +9526,21 @@ For some types, they will represent the area used by the scanner.
                 Corner points of the bounding box.
 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   cornerPoints
                 </code>
                  is not always available and may be empty. On iOS, for 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   code39
                 </code>
                  and 
                 <code
-                  class="css-106i24p-TextComponent"
+                  class="css-zmv3vl-TextComponent"
                   data-text="true"
                 >
                   pdf417
@@ -9566,7 +9566,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -9599,7 +9599,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string
@@ -9639,7 +9639,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             BarCodeSize
@@ -9721,7 +9721,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -9754,7 +9754,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -9794,7 +9794,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionHookOptions
@@ -9838,7 +9838,7 @@ you don't get this value.
        
       <span>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           PermissionHookBehavior
@@ -9847,7 +9847,7 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           Options
@@ -9922,7 +9922,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -9977,7 +9977,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               DENIED
@@ -10014,7 +10014,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -10045,7 +10045,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               GRANTED
@@ -10082,7 +10082,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -10113,7 +10113,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               UNDETERMINED
@@ -10150,7 +10150,7 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
@@ -10234,7 +10234,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             getPermissionsAsync()
@@ -10353,7 +10353,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -10398,7 +10398,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -10480,7 +10480,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10520,7 +10520,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10631,7 +10631,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -10666,7 +10666,7 @@ exports[`APISection expo-pedometer 1`] = `
         href="#pedometerresult"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           PedometerResult
@@ -10754,7 +10754,7 @@ a start date that is more than seven days in the past returns only the available
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -10873,7 +10873,7 @@ a start date that is more than seven days in the past returns only the available
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -10899,7 +10899,7 @@ a start date that is more than seven days in the past returns only the available
     >
       Returns a promise that fulfills with a 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         boolean
@@ -10927,7 +10927,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -11046,7 +11046,7 @@ available on this device.
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -11091,7 +11091,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1wb1qhy-TextComponent"
+            class="css-1oape9q-TextComponent"
             data-text="true"
           >
             watchStepCount(callback)
@@ -11173,7 +11173,7 @@ available on this device.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11198,7 +11198,7 @@ provided with a single argument that is
                   href="#pedometerresult"
                 >
                   <code
-                    class="css-106i24p-TextComponent"
+                    class="css-zmv3vl-TextComponent"
                     data-text="true"
                   >
                     PedometerResult
@@ -11295,7 +11295,7 @@ provided with a single argument that is
           />
         </svg>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           <a
@@ -11318,7 +11318,7 @@ provided with a single argument that is
         href="#subscription"
       >
         <code
-          class="css-106i24p-TextComponent"
+          class="css-zmv3vl-TextComponent"
           data-text="true"
         >
           Subscription
@@ -11327,7 +11327,7 @@ provided with a single argument that is
        that enables you to call
 
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         remove()
@@ -11401,7 +11401,7 @@ provided with a single argument that is
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -11541,7 +11541,7 @@ provided with a single argument that is
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11576,7 +11576,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11614,7 +11614,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11647,7 +11647,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11740,7 +11740,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PedometerResult
@@ -11822,7 +11822,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 number
@@ -11862,7 +11862,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11952,7 +11952,7 @@ in order to enable/disable the permission.
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-y1i413-TextComponent"
+                  class="css-kzvbfm-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -11993,7 +11993,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionExpiration
@@ -12043,7 +12043,7 @@ in order to enable/disable the permission.
        
       <span>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           'never'
@@ -12052,7 +12052,7 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="css-y1i413-TextComponent"
+          class="css-kzvbfm-TextComponent"
           data-text="true"
         >
           number
@@ -12080,7 +12080,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             Subscription
@@ -12162,7 +12162,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -12246,7 +12246,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -12301,7 +12301,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               DENIED
@@ -12338,7 +12338,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -12369,7 +12369,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               GRANTED
@@ -12406,7 +12406,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -12437,7 +12437,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-y1i413-TextComponent"
+              class="css-kzvbfm-TextComponent"
               data-text="true"
             >
               UNDETERMINED
@@ -12474,7 +12474,7 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-1ark2fa-TextComponent"
+        class="css-7rjo46-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1g0fv71-PropertyName"
+            class="css-cj6ctd-PropertyName"
             data-text="true"
           >
             name
@@ -63,7 +63,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         string
@@ -141,7 +141,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1g0fv71-PropertyName"
+            class="css-cj6ctd-PropertyName"
             data-text="true"
           >
             androidNavigationBar
@@ -183,7 +183,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         object
@@ -305,7 +305,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1g0fv71-PropertyName"
+                class="css-cj6ctd-PropertyName"
                 data-text="true"
               >
                 visible
@@ -347,7 +347,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             enum
@@ -433,7 +433,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-6n7j50"
                 >
                   <code
-                    class="css-1g0fv71-PropertyName"
+                    class="css-cj6ctd-PropertyName"
                     data-text="true"
                   >
                     always
@@ -475,7 +475,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -519,7 +519,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1g0fv71-PropertyName"
+                class="css-cj6ctd-PropertyName"
                 data-text="true"
               >
                 backgroundColor
@@ -561,7 +561,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             string
@@ -590,7 +590,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           6 character long hex color string, eg: 
           <code
-            class="css-106i24p-TextComponent"
+            class="css-zmv3vl-TextComponent"
             data-text="true"
           >
             '#000000'
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1g0fv71-PropertyName"
+            class="css-cj6ctd-PropertyName"
             data-text="true"
           >
             intentFilters
@@ -661,7 +661,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-y1i413-TextComponent"
+        class="css-kzvbfm-TextComponent"
         data-text="true"
       >
         array
@@ -775,7 +775,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1g0fv71-PropertyName"
+                class="css-cj6ctd-PropertyName"
                 data-text="true"
               >
                 autoVerify
@@ -817,7 +817,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             boolean
@@ -859,7 +859,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1g0fv71-PropertyName"
+                class="css-cj6ctd-PropertyName"
                 data-text="true"
               >
                 data
@@ -901,7 +901,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-y1i413-TextComponent"
+            class="css-kzvbfm-TextComponent"
             data-text="true"
           >
             array || object
@@ -936,7 +936,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-6n7j50"
                 >
                   <code
-                    class="css-1g0fv71-PropertyName"
+                    class="css-cj6ctd-PropertyName"
                     data-text="true"
                   >
                     host
@@ -978,7 +978,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="css-y1i413-TextComponent"
+                class="css-kzvbfm-TextComponent"
                 data-text="true"
               >
                 string

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
      
   </strong>
   <div
-    class="css-yr8cnu-PlatformTag"
+    class="css-1r58h1i-PlatformTag"
   >
     <svg
       color="var(--green12)"
@@ -67,7 +67,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       target="_blank"
     >
       <code
-        class="css-106i24p-TextComponent"
+        class="css-zmv3vl-TextComponent"
         data-text="true"
       >
         Install Referrer API
@@ -88,7 +88,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
   </div>
   <pre>
     <pre
-      class="css-micsoa"
+      class="css-1tmj8fm"
       data-text="true"
     >
       <code

--- a/docs/global-styles/prism.ts
+++ b/docs/global-styles/prism.ts
@@ -52,14 +52,13 @@ export const globalPrism = css`
     color: ${theme.palette.gray10}
   }
 
+  .token.operator,
   .token.punctuation {
-    color: ${theme.palette.gray11}
+    color: ${theme.palette.gray9}
   }
 
   .token.property,
-  .token.tag,
   .token.boolean,
-  .token.number,
   .token.function-name,
   .token.constant,
   .token.symbol,
@@ -68,33 +67,40 @@ export const globalPrism = css`
   }
 
   .token.selector,
-  .token.attr-name,
   .token.char,
-  .token.function,
   .token.builtin,
+  .token.script,
   .token.inserted {
-    color: ${theme.palette.green11}
+    color: ${theme.palette.green10}
   }
 
-  .token.operator,
   .token.entity,
-  .token.url,
   .token.variable {
     color: ${theme.palette.green11}
+  }
+  
+  .token.attr-name,
+  .token.url {
+    color: ${theme.palette.blue11}
+  }
+
+  .token.keyword {
+    color: ${theme.palette.pink10}
   }
 
   .token.atrule,
   .token.attr-value,
-  .token.keyword,
-  .token.class-name {
+  .token.function {
     color: ${theme.palette.purple11}
   }
 
+  .token.class-name,
   .token.regex,
   .token.important {
     color: ${theme.palette.orange11}
   }
 
+  .token.number,
   .token.string {
     color: ${theme.palette.yellow11}
   }

--- a/docs/global-styles/prism.ts
+++ b/docs/global-styles/prism.ts
@@ -57,7 +57,6 @@ export const globalPrism = css`
     color: ${theme.palette.gray9}
   }
 
-  .token.property,
   .token.boolean,
   .token.function-name,
   .token.constant,
@@ -88,6 +87,7 @@ export const globalPrism = css`
     color: ${theme.palette.pink10}
   }
 
+  .token.property,
   .token.atrule,
   .token.attr-value,
   .token.function {

--- a/docs/ui/components/Callout/index.tsx
+++ b/docs/ui/components/Callout/index.tsx
@@ -140,12 +140,12 @@ const warningColorStyle = css({
   borderColor: theme.border.warning,
 
   code: {
-    backgroundColor: theme.palette.yellow5,
-    borderColor: theme.palette.yellow7,
+    backgroundColor: theme.palette.yellow4,
+    borderColor: theme.palette.yellow6,
   },
 
   '.dark-theme & code': {
-    backgroundColor: theme.palette.yellow6,
+    backgroundColor: theme.palette.yellow5,
     borderColor: theme.palette.yellow7,
   },
 });
@@ -165,7 +165,7 @@ const infoColorStyle = css({
   borderColor: theme.border.info,
 
   code: {
-    backgroundColor: theme.palette.blue5,
-    borderColor: theme.palette.blue7,
+    backgroundColor: theme.palette.blue4,
+    borderColor: theme.palette.blue6,
   },
 });

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -16,10 +16,10 @@ export const PlatformTag = ({ platform, type }: PlatformTagProps) => {
     <div
       css={[
         tagStyle,
-        platformName === 'android' && getTagStyle('green'),
-        platformName === 'ios' && getTagStyle('blue'),
-        platformName === 'web' && getTagStyle('orange'),
-        platformName === 'expo' && getTagStyle('purple'),
+        platformName === 'android' && getTagStyle(platformName),
+        platformName === 'ios' && getTagStyle(platformName),
+        platformName === 'web' && getTagStyle(platformName),
+        platformName === 'expo' && getTagStyle(platformName),
         type === 'toc' && tagToCStyle,
       ]}>
       {type !== 'toc' && <PlatformIcon platform={platformName} />}

--- a/docs/ui/components/Tag/helpers.ts
+++ b/docs/ui/components/Tag/helpers.ts
@@ -12,15 +12,37 @@ export const getPlatformName = (text: string): PlatformName => {
   return '';
 };
 
-export const getTagStyle = (color: string) => {
-  return css({
-    // @ts-ignore
-    backgroundColor: theme.palette[`${color}2`],
-    // @ts-ignore
-    color: theme.palette[`${color}12`],
-    // @ts-ignore
-    borderColor: theme.palette[`${color}5`],
-  });
+export const getTagStyle = (platform: string) => {
+  switch (platform) {
+    case 'android': {
+      return css({
+        backgroundColor: theme.palette.green4,
+        color: theme.palette.green12,
+        borderColor: theme.palette.green5,
+      });
+    }
+    case 'ios': {
+      return css({
+        backgroundColor: theme.palette.blue4,
+        color: theme.palette.blue12,
+        borderColor: theme.palette.blue5,
+      });
+    }
+    case 'web': {
+      return css({
+        backgroundColor: theme.palette.orange4,
+        color: theme.palette.orange12,
+        borderColor: theme.palette.orange5,
+      });
+    }
+    case 'expo': {
+      return css({
+        backgroundColor: theme.palette.purple4,
+        color: theme.palette.purple12,
+        borderColor: theme.palette.purple5,
+      });
+    }
+  }
 };
 
 export const formatName = (name: PlatformName) => {

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -113,6 +113,7 @@ const listStyle = css({
 });
 
 const codeStyle = css({
+  borderColor: theme.border.secondary,
   borderRadius: borderRadius.sm,
   verticalAlign: 'initial',
 });


### PR DESCRIPTION
# Why

Earlier today we have shipped the styleguide colors update. Let's tweak some shades after using the new docs palette for a while.

# How

This PR includes tweaks for the following parts:
* platforms labels - they should be a bit more vibrant now
* inline code in `Callout`s - they should now better blend in into the component, the background shade difference is just one level, so for some colors the difference is not that obvious
* inline code in text - border contrast is less harsh
* code block highlight - we have made the initial tweaks for that in main PR, but I have spend a little bit more time trying with different options and attempting to differentiate the code parts better, with component and code parsing results which we currently have

# Test Plan

The changes have been tested by running docs app locally.

# Preview

## Inline code in Callout and platform labels 

<img width="1527" alt="Screenshot 2023-01-12 at 22 24 52" src="https://user-images.githubusercontent.com/719641/212185955-6dc02914-d0dd-447a-875c-e71bcc101b6a.png">
<img width="1527" alt="Screenshot 2023-01-12 at 22 24 46" src="https://user-images.githubusercontent.com/719641/212185965-8bd9b671-880a-437d-8b3e-04fe60c261d6.png">

## Inline code in text

<img width="1170" alt="Screenshot 2023-01-12 at 22 40 50" src="https://user-images.githubusercontent.com/719641/212187381-83ea8ae4-094b-4b78-997a-d754c6002043.png">
<img width="1170" alt="Screenshot 2023-01-12 at 22 40 45" src="https://user-images.githubusercontent.com/719641/212187388-ae575a4f-bda3-4531-8568-7b8f227f8afe.png">

## Code block highlight

### JSX
<img width="1920" alt="Screenshot 2023-01-12 at 22 16 10" src="https://user-images.githubusercontent.com/719641/212186084-3ab1a836-1617-45ad-a992-cc8346dd7cbe.png">

### Swift
<img width="1920" alt="Screenshot 2023-01-12 at 22 14 26" src="https://user-images.githubusercontent.com/719641/212186118-595c8752-1d0b-4f56-af0c-7367f4ad95b0.png">

### Kotlin
<img width="1920" alt="Screenshot 2023-01-12 at 22 44 03" src="https://user-images.githubusercontent.com/719641/212187651-fcf643a9-d47f-49f0-b691-009927e6b26e.png">

### TS
<img width="1920" alt="Screenshot 2023-01-12 at 22 15 22" src="https://user-images.githubusercontent.com/719641/212186195-21c215a8-5a9a-4b02-a194-0e92dd9e313b.png">

