### PR TITLE
[docs] Add troubleshooting to sentry guide with expo-dev-client

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -307,7 +307,7 @@ Make sure your `organization`, `project` and `authToken` properties are set corr
 
 <Collapsible summary={<>`expo-dev-client` transactions never finish</>}>
 
-This is caused by the HTTP request tracking, that is creating spans for log requests to the development server.
+This error is caused by the HTTP request tracking, which creates spans for log requests to the development server. To fix this, stop creating spans by adding the following code snippet:
 
 ```js
 import * as Sentry from 'sentry-expo';

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -305,6 +305,33 @@ Make sure your `organization`, `project` and `authToken` properties are set corr
 
 </Collapsible>
 
+<Collapsible summary={<>`expo-dev-client` transactions never finish</>}>
+
+This is caused by the HTTP request tracking, that is creating spans for log requests to the development server.
+
+```js
+import * as Sentry from 'sentry-expo';
+import * as Network from 'expo-network';
+
+const devServerPort = 8081;
+let devServerIpAddress: string | null = null;
+Network.getIpAddressAsync().then((ip) => {devServerIpAddress = ip});
+
+Sentry.init({
+  tracesSampleRate: 1.0,
+  integrations: [
+    new Sentry.Native.ReactNativeTracing({
+      shouldCreateSpanForRequest: (url) => {
+        return !__DEV__ || !url.startsWith(`http://${devServerIpAddress}:${devServerPort}/logs`);
+      },
+    }),
+  ],
+});
+```
+
+</Collapsible>
+
+
 ## Learn more about Sentry
 
 Sentry does more than just catch fatal errors, learn more about how to use Sentry from their [JavaScript usage docs](https://docs.sentry.io/platforms/javascript/).


### PR DESCRIPTION
# Why

This issue first appeared in the `sentry-react-native` repository. But I believe its outcome will be helpful for user reading Expo documentation as well. 

- https://github.com/getsentry/sentry-react-native/issues/2721

# How

I've tested the solution with the open-source app mentioned in the issue.

# Test Plan

before the fix: https://github.com/nikolovlazar/goodbyemoney-reactnative/tree/99d7fc448e4a2d0012b0c72b0ef2cf8b8583e3dc
after the fix: https://github.com/nikolovlazar/goodbyemoney-reactnative/tree/695dc9cb9a9ecced1b6d77e8adb4e60d9be2f62f

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
