### PR TITLE
[gh] Skip fetching local manifest on CI

### DIFF
--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -156,6 +156,11 @@ export default {
       return '';
     }
 
+    if (process.env.CI) {
+      console.log('Skip fetching local manifest on CI.');
+      return '';
+    }
+
     const pathToHome = 'home';
     const url = await UrlUtils.constructManifestUrlAsync(path.join(EXPO_DIR, pathToHome));
 


### PR DESCRIPTION
# Why

Builds on M1 take a long time because generating dynamic macros script hangs for few minutes waiting for a response from local port 80. Packet filtering rules on EAS Build are dropping all the traffic to the local network, to stop vm to vm communication, which includes requests sent to your own IP.

# How

I assume generating dynamic macros checks the local port in case that script is run on the developer machine, so skipping that on CI should be safe.

If this change is not ok, I can always check for `EAS_BUILD` env there.

Another alternative would be to use there 127.0.0.1 ip, but I'm not sure if this would be valid for whatever use case that manifest is needed normally.

# Test Plan

CI

Build time improvement  from `34m 51s` to `13m 41s`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
