### PR TITLE
[gh] Move updates-e2e to M1

### DIFF
--- a/.github/workflows/updates-e2e-android.yml
+++ b/.github/workflows/updates-e2e-android.yml
@@ -86,7 +86,6 @@ jobs:
           profile: 'updates_testing'
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          resourceClass: large
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On Android workflow canceled

--- a/.github/workflows/updates-e2e-ios.yml
+++ b/.github/workflows/updates-e2e-ios.yml
@@ -86,7 +86,6 @@ jobs:
           profile: 'updates_testing'
           projectRoot: './updates-e2e'
           expoToken: ${{ secrets.EAS_BUILD_BOT_TOKEN }}
-          resourceClass: large
           noWait: ${{ github.event.schedule }}
           message: ${{ github.event.pull_request.title }}
       - name: On iOS workflow canceled

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
@@ -15,10 +15,12 @@
     "updates_testing": {
       "android": {
         "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
-        "withoutCredentials": true
+        "withoutCredentials": true,
+        "resourceClass": "large"
       },
       "ios": {
-        "simulator": true
+        "simulator": true,
+        "resourceClass": "m1-medium"
       },
       "distribution": "internal",
       "buildArtifactPaths": ["logs/*.log"]


### PR DESCRIPTION
# Why

I did not realize that there are other workflows using eas, so when I switched builds to M1 here https://github.com/expo/expo/commit/b99590e73eaed450b1fb75ab55f54d8d4a3b6fe3, all other workflows were downgraded to the default resource class.

# How

- Switch to large resource class on Android
- Switch to M1 medium on iOS (large intel worker were removed, so it's either this or medium intel instance)

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
