### PR TITLE
fix(cli): add react-native-web alias for metro web that doesn't rely on Babel

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Add react-native-web alias for metro web that doesn't rely on Babel.
 - Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error. ([#20704](https://github.com/expo/expo/pull/20704) by [@EvanBacon](https://github.com/EvanBacon))
 - Escape ampersands in URLs sent to adb. ([#20398](https://github.com/expo/expo/pull/20398) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Add react-native-web alias for metro web that doesn't rely on Babel.
+- Add react-native-web alias for metro web that doesn't rely on Babel. ([#20828](https://github.com/expo/expo/pull/20828) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow chained Metro resolvers to resolve when the predecessor resolver throws a Metro resolution error. ([#20704](https://github.com/expo/expo/pull/20704) by [@EvanBacon](https://github.com/EvanBacon))
 - Escape ampersands in URLs sent to adb. ([#20398](https://github.com/expo/expo/pull/20398) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -73,6 +73,12 @@ export function withWebResolvers(config: ConfigT, projectRoot: string) {
     },
   };
 
+  const aliases: { [key: string]: Record<string, string> } = {
+    web: {
+      'react-native': 'react-native-web',
+    },
+  };
+
   const preferredMainFields: { [key: string]: string[] } = {
     // Defaults from Expo Webpack. Most packages using `react-native` don't support web
     // in the `react-native` field, so we should prefer the `browser` field.
@@ -85,6 +91,14 @@ export function withWebResolvers(config: ConfigT, projectRoot: string) {
     (immutableContext: ResolutionContext, moduleName: string, platform: string | null) => {
       const context = { ...immutableContext } as ResolutionContext & { mainFields: string[] };
 
+      // Conditionally remap `react-native` to `react-native-web` on web in
+      // a way that doesn't require Babel to resolve the alias.
+      if (platform && platform in aliases && aliases[platform][moduleName]) {
+        moduleName = aliases[platform][moduleName];
+      }
+
+      // TODO: We may be able to remove this in the future, it's doing no harm
+      // by staying here.
       // Conditionally remap `react-native` to `react-native-web`
       if (platform && platform in extraNodeModules) {
         context.extraNodeModules = {


### PR DESCRIPTION
# Why

- If you disable Babel (e.g. in exotic mode) then the fallback system doesn't work (it effectively never "works").

# How

- Simply remap `react-native` to `react-native-web` when resolving for the web.
 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

`EXPO_USE_EXOTIC=1 nexpo -c -w` -> Works (never attempts to access `react-native/index.js`)