### PR TITLE
[docs] Set correct `code` data type for ticket response in notification guides

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -289,7 +289,7 @@ Each message must be a JSON object with the given fields (only the `to` field is
   ],
   // only populated if there was an error with the entire request
   "errors": [{
-    "code": number,
+    "code": string,
     "message": string
   }]
 }


### PR DESCRIPTION
From what I see the `code` field is a string, not a number.

# Why
The documentation is wrong. 

# How
Sent a push ticket and saw that `code` was a string

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
