### PR TITLE
[docs] Add the command to generate webpack config for older sdks

### DIFF
--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -3,16 +3,30 @@ title: Bundling with webpack
 description: Learn about different webpack bundler configurations that can be customized.
 ---
 
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+
 When you run `npx expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
 
-> This is similar to `react-scripts` & `create-react-app`.
+> This is similar to `react-scripts` and `create-react-app`.
 
-If you need to edit the config the best way to do this is by running `npx expo customize webpack.config.js`.
-This will install `@expo/webpack-config` as a dev dependency and create a template `./webpack.config.js` in your project.
-You can now make changes to a config object based on the default config and return it for Expo CLI to use.
-Deleting the config will cause Expo to fall back to the default again.
+To edit the config, install `@expo/webpack-config` as a dev dependency and create a template **webpack.config.js** at the root of your project. This can be done by running the following command:
 
-If you create a new webpack config or make any changes to it you'll need to restart your webpack dev server with `npx expo start`.
+<Terminal cmd={['$ npx expo customize webpack.config.js']} />
+
+<Collapsible summary="Using SDK 45 or below?">
+
+For SDK 45 or below, run the following command:
+
+<Terminal cmd={['$ npx expo customize:web']} />
+
+</Collapsible>
+
+You can now make changes to a config object based on the default config and return it for Expo CLI to use. Deleting the config will cause Expo to fall back to the default again.
+
+If you create a new webpack config or make any changes to it you'll need to restart your webpack dev server by running:
+
+<Terminal cmd={['$ npx expo start']} />
 
 ## Example
 
@@ -42,15 +56,13 @@ module.exports = async function (env, argv) {
 
 ## Polyfills
 
-React Native for web uses [some advanced browser features](https://github.com/necolas/react-native-web/blob/e4ed0fd3c863e6c61aa3ea8afeff79b7fa74b461/packages/docs/src/introduction.stories.mdx#install) that might not be available in every browser. Expo web tries to make including these features as simple and efficient as possible with `@expo/webpack-config`.
+React Native for Web uses [some advanced browser features](https://github.com/necolas/react-native-web/blob/e4ed0fd3c863e6c61aa3ea8afeff79b7fa74b461/packages/docs/src/introduction.stories.mdx#install) that might not be available in every browser. Expo web tries to include these features with `@expo/webpack-config`.
 
 ### ResizeObserver
 
-- [Browser support](https://caniuse.com/#feat=resizeobserver)
-
 **TL;DR:** To fully support `onLayout` install `resize-observer-polyfill`.
 
-The `onLayout` prop that's used in all of the core primitives like View, Image, Text, ScrollView, etc. requires an API called [`ResizeObserver`](https://drafts.csswg.org/resize-observer-1/). This API isn't fully supported across all browsers, iOS Safari (in iOS 13) is a good example. If the device doesn't support `ResizeObserver` then `react-native-web` will fallback on `window.onresize` and you'll see a warning in the logs:
+The `onLayout` prop that's used in all of the core primitives such as View, Image, Text, ScrollView, and so on, requires an API called [`ResizeObserver`](https://drafts.csswg.org/resize-observer-1/). This API isn't fully [supported across all browsers](https://caniuse.com/#feat=resizeobserver), for example, iOS Safari (in iOS 13). If the device doesn't support `ResizeObserver` then `react-native-web` will fallback on `window.onresize` and you'll see a warning in the logs:
 
 ```
 onLayout relies on ResizeObserver which is not supported by your browser.
@@ -62,29 +74,29 @@ To get everything working properly, you'll want to install and include a global 
 
 ### Adding ResizeObserver
 
-- Install the polyfill: `yarn add resize-observer-polyfill`
+- Install the polyfill:
+  <Terminal cmd={['$ npm install resize-observer-polyfill']} />
 - Restart the project and `@expo/webpack-config` will automatically include the polyfill.
 
-The reason it automatically includes the polyfill is because `react-native-web` needs it included immediately. webpack is able to inject the polyfill before any of the application code has been executed. Alternatively you can customize the webpack config and include the polyfill in the `entry` field yourself.
+The reason it automatically includes the polyfill is that `react-native-web` needs it included immediately. webpack can inject the polyfill before any of the application code has been executed. Alternatively, you can customize the webpack config and include the polyfill in the `entry` field yourself.
 
 ### Testing the ResizeObserver polyfill
 
-- Open the running Expo project in iOS Safari
-- Connect the device to an Apple computer
-- Open Safari on the computer in go to `Develop > [YOUR DEVICE] > [YOUR HOST]`
+- Open the running Expo project in iOS Safari.
+- Connect the device to an Apple computer.
+- Open Safari on the computer in go to `Develop > [YOUR DEVICE] > [YOUR HOST]`.
 - Ensure the logs don't have the `onLayout relies on ResizeObserver...` warning.
 
 ## Editing static files
 
-You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, and so on.
-These can be used to customize your project in a more familiar way.
+You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, and so on. These can be used to customize your project more familiarly.
 
-All of the files you select from the terminal prompt will be copied to a **web/** directory in your project's root directory. Think of this directory as **public/** in Create React App. We use "web" instead of "public" because Expo webpack is web-only, the static directory does not work for Android or iOS apps. For mobile platforms, we similarly put platform-specific project files in **android** and **ios** directories.
+All of the files you select from the terminal prompt will be copied to a **web** directory in your project's root directory. Think of this directory as **public** in Create React App. The **web** is used instead of **public** because Expo webpack is web-only, the static directory does not work for Android or iOS apps. For mobile platforms, the platform-specific project files are included in **android** and **ios** directories.
 
 Deleting any of these files will cause Expo webpack to fallback to their respective default copies.
 
 ### Why
 
-- Customizing the favicon icon
-- Adding third-party API code to the `<head/>` in your **index.html**
-- Changing the caching policy in the **serve.json** file
+- Customizing the favicon icon.
+- Adding third-party API code to the `<head/>` in your **index.html**.
+- Changing the caching policy in the **serve.json** file.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The guide doesn't explain which command to use for older SDKs (SDK 45 and below) as mentioned in the [comment here](https://github.com/expo/expo/pull/18656?notification_referrer_id=NT_kwDOAJwq97M0MjA1NjM2MDg0OjEwMjM0NjE1&notifications_query=reason%3Aparticipating#issuecomment-1382719412).

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds the command for older SDKs and updates the overall verbiage to match our writing styleguide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
