### PR TITLE
[tools] Adding "published" label to pull requests

### DIFF
--- a/tools/package.json
+++ b/tools/package.json
@@ -57,6 +57,7 @@
     "npm-packlist": "^5.1.3",
     "nullthrows": "^1.1.1",
     "open": "^8.4.0",
+    "ora": "^5.4.1",
     "pacote": "^13.1.1",
     "parse-diff": "^0.9.0",
     "plist": "^3.0.6",

--- a/tools/src/GitHub.ts
+++ b/tools/src/GitHub.ts
@@ -9,6 +9,8 @@ const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
 });
 
+const cachedPullRequests = new Map<number, PullRequest>();
+
 // Predefine some params used across almost all requests.
 const owner = 'expo';
 const repo = 'expo';
@@ -24,12 +26,22 @@ export async function getAuthenticatedUserAsync() {
 /**
  * Requests for the pull request object.
  */
-export async function getPullRequestAsync(pull_number: number): Promise<PullRequest> {
+export async function getPullRequestAsync(
+  pull_number: number,
+  cached: boolean = false
+): Promise<PullRequest> {
+  if (cached) {
+    const cachedPullRequest = cachedPullRequests.get(pull_number);
+    if (cachedPullRequest) {
+      return cachedPullRequest;
+    }
+  }
   const { data } = await octokit.pulls.get({
     owner,
     repo,
     pull_number,
   });
+  cachedPullRequests.set(pull_number, data);
   return data;
 }
 

--- a/tools/src/GitHubActions.ts
+++ b/tools/src/GitHubActions.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { EXPO_DIR } from './Constants';
+import { getPullRequestAsync } from './GitHub';
 import { execAll, filterAsync } from './Utils';
 
 const octokit = new Octokit({
@@ -106,22 +107,10 @@ export async function dispatchWorkflowEventAsync(
 }
 
 /**
- * Requests for the pull request object.
- */
-export async function getPullRequestAsync(pull_number: number) {
-  const { data } = await octokit.pulls.get({
-    owner,
-    repo,
-    pull_number,
-  });
-  return data;
-}
-
-/**
  * Returns an array of issue IDs that has been auto-closed by the pull request.
  */
 export async function getClosedIssuesAsync(pullRequestId: number): Promise<number[]> {
-  const pullRequest = await getPullRequestAsync(pullRequestId);
+  const pullRequest = await getPullRequestAsync(pullRequestId, true);
   const matches = execAll(
     /(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) (#|https:\/\/github\.com\/expo\/expo\/issues\/)(\d+)/gi,
     pullRequest.body ?? '',

--- a/tools/src/Utils.ts
+++ b/tools/src/Utils.ts
@@ -2,6 +2,7 @@ import basicSpawnAsync, { SpawnResult, SpawnOptions, SpawnPromise } from '@expo/
 import chalk from 'chalk';
 import { IOptions as GlobOptions } from 'glob';
 import glob from 'glob-promise';
+import ora from 'ora';
 
 import { EXPO_DIR } from './Constants';
 
@@ -165,4 +166,28 @@ export async function applyPatchAsync(options: {
   procPromise.child.stdin?.write(options.patchContent);
   procPromise.child.stdin?.end();
   await procPromise;
+}
+
+export async function runWithSpinner<Result>(
+  title: string,
+  action: (step: ora.Ora) => Promise<Result> | Result,
+  options: ora.Options = {}
+): Promise<Result> {
+  const disabled = process.env.CI || process.env.EXPO_DEBUG;
+  const step = ora({
+    text: chalk.bold(title),
+    isEnabled: !disabled,
+    stream: disabled ? process.stdout : process.stderr,
+    ...options,
+  });
+
+  step.start();
+
+  try {
+    return await action(step);
+  } catch (error) {
+    step.fail();
+    console.error(error);
+    process.exit(1);
+  }
 }

--- a/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
+++ b/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
@@ -1,0 +1,110 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+import { UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
+import { link } from '../../Formatter';
+import * as GitHub from '../../GitHub';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { Parcel, TaskArgs } from '../types';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+
+// https://github.com/expo/expo/pulls?q=label:published
+const PUBLISHED_LABEL_NAME = 'published';
+
+/**
+ * Adds "published" label to pull requests mentioned in changelog entries.
+ */
+export const addPublishedLabelToPullRequests = new Task<TaskArgs>(
+  {
+    name: 'addPublishedLabelToPullRequests',
+    dependsOn: [selectPackagesToPublish],
+  },
+  async (parcels: Parcel[]) => {
+    if (!process.env.GITHUB_TOKEN) {
+      logger.error(
+        'Environment variable `%s` must be set to add labels to pull requests',
+        chalk.magenta('GITHUB_TOKEN')
+      );
+      return;
+    }
+
+    const pullRequestIds: number[] = [];
+
+    // Find all pull requests mentioned in changelogs
+    for (const { state } of parcels) {
+      const versionChanges = state.changelogChanges?.versions[UNPUBLISHED_VERSION_NAME];
+
+      if (!versionChanges) {
+        continue;
+      }
+      for (const entry of Object.values(versionChanges).flat()) {
+        const { pullRequests } = entry;
+        if (pullRequests && pullRequests.length > 0) {
+          pullRequestIds.push(...pullRequests);
+        }
+      }
+    }
+
+    if (pullRequestIds.length === 0) {
+      return;
+    }
+    const pullRequestIdsSet = new Set<number>(pullRequestIds);
+    const pullRequestsToLabel: GitHub.PullRequest[] = [];
+
+    logger.info(`\n🐙 List of published pull requests (${pullRequestIdsSet.size}):`);
+
+    // Request and log all published pull requests
+    for (const pullRequestId of pullRequestIdsSet) {
+      const pr = await GitHub.getPullRequestAsync(pullRequestId, true);
+
+      logger.log(`${linkToPullRequest(pr)}: ${chalk.bold(pr.title)}`);
+      pullRequestsToLabel.push(pr);
+    }
+
+    // Ask whether to continue adding the label to pull requests logged above
+    if (!(await shouldLabelPullRequestsAsync())) {
+      return;
+    }
+
+    await runWithSpinner('Adding the label...', async (spinner) => {
+      // Finally add the label to each pull request
+      for (const pullRequest of pullRequestsToLabel) {
+        const hasLabel = pullRequest.labels.some((label) => label.name === PUBLISHED_LABEL_NAME);
+
+        if (!hasLabel) {
+          await GitHub.addIssueLabelsAsync(pullRequest.number, [PUBLISHED_LABEL_NAME]);
+        }
+      }
+      spinner.succeed('Added the published label');
+    });
+
+    logger.log();
+  }
+);
+
+function linkToPullRequest(pr: GitHub.PullRequest): string {
+  return link(chalk.blue('#' + pr.number), pr.html_url);
+}
+
+/**
+ * Prompts the user whether to add the label to pull requests.
+ */
+async function shouldLabelPullRequestsAsync(): Promise<boolean> {
+  if (process.env.CI) {
+    return true;
+  }
+  const { proceed } = await inquirer.prompt<{ proceed: boolean }>([
+    {
+      type: 'confirm',
+      name: 'proceed',
+      prefix: '❔',
+      message: chalk.yellow(
+        `Do you want to add '${chalk.magenta(PUBLISHED_LABEL_NAME)}' label to these pull requests?`
+      ),
+      default: true,
+    },
+  ]);
+  return proceed;
+}

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
@@ -46,6 +47,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       pushCommittedChanges,
       publishPackages,
       grantTeamAccessToPackages,
+      addPublishedLabelToPullRequests,
       commentOnIssuesTask,
     ],
   },


### PR DESCRIPTION
# Why

It's good to see whether the PR was published or not. Some time ago I created the [published](https://github.com/expo/expo/pulls?q=label:published) label and already used it many times (all manually).

# How

Added another step in the publish script that prints all pull requests gathered from changelog entries and prompts whether to add the label or not (I think we won't need to say "no", but just a confirmation would be nice).

I intentionally handle PRs one by one so our GitHub tokens won't get rate-limited but it may take some time. Thus I decided to add `ora` spinner for this action. 

There are now two tasks that need to request GitHub for pull requests, so I added a simple caching mechanism.

# Test Plan

- I ran the publish command for expo-modules-core

<img width="883" alt="Screenshot 2023-01-15 at 21 45 25" src="https://user-images.githubusercontent.com/1714764/212568871-157dab8b-fbe4-40ea-a9a2-4c37c3ff4ed9.png">

- I mocked the script to include only #20623 and the script successfully added the label to that PR