### PR TITLE
[tools] Fix expotools not rebuilding on source change

### DIFF
--- a/tools/bin/expotools.js
+++ b/tools/bin/expotools.js
@@ -111,9 +111,9 @@ async function calculateSourceChecksumAsync() {
     files: {
       include: [
         // source files
-        'src/**/*.ts',
+        '**.ts',
         // src/versioning files
-        'src/**/*.json',
+        '**.json',
         'expotools.js',
         // swc build files
         'taskfile.js',


### PR DESCRIPTION
# Why

Fixes regression introduced by #20790, it turned out `src/**/*.ts` pattern doesn't work well in `folder-hash` so the rebuilding mechanism was not working for files in the `src` folder.

# How

I tried upgrading the lib and using many different combinations of options, but none of them worked so I gave up. `**/*.ts` works fine so I'll leave it that way 🤷‍♂️ 

# Test Plan

Modifying any source file causes expotools to prebuild
