### PR TITLE
[tools] Improve versions suggested by the publish command

### DIFF
--- a/tools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
+++ b/tools/src/publish-packages/tasks/resolveReleaseTypeAndVersion.ts
@@ -28,10 +28,16 @@ export const resolveReleaseTypeAndVersion = new Task<TaskArgs>(
       );
       const allVersions = pkgView?.versions ?? [];
 
-      // Make it a prerelease version if `--prerelease` was passed and assign to the state.
-      state.releaseType = prerelease
-        ? (('pre' + highestReleaseType) as ReleaseType)
-        : highestReleaseType;
+      if (prerelease) {
+        // Make it a prerelease version if `--prerelease` was passed and assign to the state.
+        state.releaseType = ('pre' + highestReleaseType) as ReleaseType;
+      } else if (getPrereleaseIdentifier(pkg.packageVersion)) {
+        // If the current version is a prerelease, just increment its number.
+        state.releaseType = ReleaseType.PRERELEASE;
+      } else {
+        // Set the release type depending on changes made in the package.
+        state.releaseType = highestReleaseType;
+      }
 
       // If the version to bump is not published yet, then we do want to use it instead,
       // no matter which release type is suggested.

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -55,7 +55,7 @@ async function selectPackageToPublishAsync(
     return true;
   }
   const packageName = parcel.pkg.packageName;
-  const releaseVersion = parcel.state.releaseVersion;
+  const { releaseVersion } = parcel.state;
   const { selected } = await inquirer.prompt([
     {
       type: 'confirm',
@@ -112,7 +112,7 @@ async function selectPackageToPublishAsync(
   ]);
 
   if (customVersion || version) {
-    parcel.state.releaseVersion = customVersion || version;
+    parcel.state.releaseVersion = customVersion ?? version;
     return true;
   }
   return false;

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -55,83 +55,96 @@ async function selectPackageToPublishAsync(
     return true;
   }
   const packageName = parcel.pkg.packageName;
-  const version = parcel.state.releaseVersion;
+  const releaseVersion = parcel.state.releaseVersion;
   const { selected } = await inquirer.prompt([
     {
       type: 'confirm',
       name: 'selected',
       prefix: '❔',
-      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(version!)}?`,
+      message: `Do you want to publish ${green.bold(packageName)} as ${cyan.bold(releaseVersion)}?`,
       default: true,
     },
   ]);
-  if (!selected) {
-    const incrementedVersions = incrementVersion(
-      parcel.pkg.packageVersion,
-      parcel.pkgView?.versions ?? [],
-      options.prerelease === true ? 'rc' : options.prerelease || null
-    );
-    const { version, customVersion } = await inquirer.prompt([
-      {
-        type: 'list',
-        name: 'version',
-        prefix: '❔',
-        message: `What do you want to do with ${green.bold(packageName)}?`,
-        choices: [
-          {
-            name: "Don't publish",
-            value: null,
-          },
-          ...Object.keys(incrementedVersions).map((type) => {
-            return {
-              name: `Publish as ${cyan.bold(incrementedVersions[type])} (${type})`,
-              value: incrementedVersions[type],
-            };
-          }),
-          {
-            name: 'Publish as custom version',
-            value: CUSTOM_VERSION_CHOICE_VALUE,
-          },
-        ],
-        validate: validateVersion(parcel),
-      },
-      {
-        type: 'input',
-        name: 'customVersion',
-        prefix: '❔',
-        message: 'Type in custom version to publish:',
-        when(answers: Record<string, string>): boolean {
-          return answers.version === CUSTOM_VERSION_CHOICE_VALUE;
-        },
-        validate: validateVersion(parcel),
-      },
-    ]);
-    if (customVersion || version) {
-      parcel.state.releaseVersion = customVersion || version;
-      return true;
-    }
+
+  if (selected) {
+    return true;
   }
-  return selected;
+
+  const suggestedVersions = getSuggestedVersions(
+    parcel.pkg.packageVersion,
+    parcel.pkgView?.versions ?? [],
+    options.prerelease === true ? 'rc' : options.prerelease || null
+  );
+  const { version, customVersion } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'version',
+      prefix: '❔',
+      message: `What do you want to do with ${green.bold(packageName)}?`,
+      choices: [
+        {
+          name: "Don't publish",
+          value: null,
+        },
+        ...suggestedVersions.map((version) => {
+          return {
+            name: `Publish as ${cyan.bold(version)}`,
+            value: version,
+          };
+        }),
+        {
+          name: 'Publish as custom version',
+          value: CUSTOM_VERSION_CHOICE_VALUE,
+        },
+      ],
+      validate: validateVersion(parcel),
+    },
+    {
+      type: 'input',
+      name: 'customVersion',
+      prefix: '❔',
+      message: 'Type in custom version to publish:',
+      when(answers: Record<string, string>): boolean {
+        return answers.version === CUSTOM_VERSION_CHOICE_VALUE;
+      },
+      validate: validateVersion(parcel),
+    },
+  ]);
+
+  if (customVersion || version) {
+    parcel.state.releaseVersion = customVersion || version;
+    return true;
+  }
+  return false;
 }
 
 /**
- * Creates an object with possible incrementations of given version.
+ * Returns a list of suggested versions to publish.
  */
-function incrementVersion(
+function getSuggestedVersions(
   version: string,
   otherVersions: string[],
   prerelease?: string | null
-): Record<string, string> {
-  const releaseTypes: ReleaseType[] = [ReleaseType.MAJOR, ReleaseType.MINOR, ReleaseType.PATCH];
+): string[] {
+  const [currentPrereleaseId] = semver.prerelease(version) ?? [];
 
-  // Add more options for prerelease versions
-  if (prerelease) {
-    releaseTypes.push(ReleaseType.PREMAJOR, ReleaseType.PREMINOR, ReleaseType.PREPATCH);
+  // The current version is a prerelease version
+  if (typeof currentPrereleaseId === 'string') {
+    const prereleaseIds = ['alpha', 'beta', 'rc'];
+
+    if (!prereleaseIds.includes(currentPrereleaseId)) {
+      prereleaseIds.unshift(currentPrereleaseId);
+    }
+    return prereleaseIds
+      .slice(prereleaseIds.indexOf(currentPrereleaseId))
+      .map((identifier) => {
+        return resolveSuggestedVersion(version, otherVersions, ReleaseType.PRERELEASE, identifier);
+      })
+      .concat(version.replace(/\-.*$/, ''));
   }
-  return releaseTypes.reduce((acc, type) => {
-    acc[type] = resolveSuggestedVersion(version, otherVersions, type, prerelease);
-    return acc;
-  }, {});
+  return [ReleaseType.MAJOR, ReleaseType.MINOR, ReleaseType.PATCH].map((type) => {
+    return resolveSuggestedVersion(version, otherVersions, type, prerelease);
+  });
 }
 
 /**


### PR DESCRIPTION
# Why

The publish command doesn't handle prereleases very well.

# How

For packages that already have the prerelease version:
- the first suggested version is just the next number with the same prerelease identifier
- versions listed as other choices are now the next prerelease identifier that we use (`alpha`, `beta`, `rc`)

Basically the case where the package is already a prerelease needs to be handled differently than when the `--prerelease` option is provided.

# Test Plan

`expo-image` is currently an alpha version so `et publish expo-image` first suggests the version with increased prerelease number instead of the next patch/minor/major. If I choose not to publish it, the other choices now include `beta` and `rc` versions too 👇 

<img width="559" alt="Screenshot 2023-01-16 at 17 35 30" src="https://user-images.githubusercontent.com/1714764/212738427-60a13b4e-0850-4aac-9630-3657c0a951d2.png">
