### PR TITLE
[docs] Update verbiage around no installation required for Expo CLI

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -31,7 +31,7 @@ For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-
 
 ### Using Expo CLI
 
-Inside a project, you can use Expo CLI by leveraging `npx` &mdash; a Node.js package runner. It is a part of the `expo` package and no installation is required to use it.
+Expo CLI is part of the `expo` package, and you can use it by leveraging `npx` &mdash; a Node.js package runner. No installation is required.
 
 For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
 

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -31,7 +31,7 @@ For Windows users we recommend using [PowerShell](https://docs.microsoft.com/en-
 
 ### Using Expo CLI
 
-You can use Expo CLI without installation by leveraging `npx` &mdash; a Node.js package runner.
+Inside a project, you can use Expo CLI by leveraging `npx` &mdash; a Node.js package runner. It is a part of the `expo` package and no installation is required to use it.
 
 For example, to see a list of available commands in Expo CLI, open the terminal on your development machine and run the following command:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #20027

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the verbiage in "Using Expo CLI" to be more explicit that Expo CLI is part of `expo` package and doesn't require any installation.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
