### PR TITLE
[core][Android] Returning object definitions from sync functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - View-related DSL functions do not require providing the view's type in function parameters on Android. ([#20751](https://github.com/expo/expo/pull/20751) by [@lukmccall](https://github.com/lukmccall))
 - Add support for the `Long` type as function parameters on Android. ([#20787](https://github.com/expo/expo/pull/20787) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Added experimental support for building the function result from the object definition. ([#20864](https://github.com/expo/expo/pull/20864) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptAnonymousObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptAnonymousObjectTest.kt
@@ -1,0 +1,58 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.objects.Object
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JavaScriptAnonymousObjectTest {
+  @Test
+  fun returns_object_made_from_definition() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("getObject") {
+        Object {
+          Property("p1") { 123 }
+          Function("f1") { "abc" }
+          AsyncFunction("f2") { "def" }
+        }
+      }
+    }
+  ) {
+    val anonymousObject = evaluateScript("object = expo.modules.TestModule.getObject()")
+      .getObject()
+    val p1 = evaluateScript("object.p1").getInt()
+    val f1 = evaluateScript("object.f1()").getString()
+    val f2 = waitForAsyncFunction(it, "object.f2()").getString()
+
+    Truth.assertThat(anonymousObject.getPropertyNames()).isEqualTo(arrayOf("f2", "f1", "p1"))
+    Truth.assertThat(p1).isEqualTo(123)
+    Truth.assertThat(f1).isEqualTo("abc")
+    Truth.assertThat(f2).isEqualTo("def")
+  }
+
+  @Test
+  fun anonymous_object_can_be_nested() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("getObject") {
+        Object {
+          Function("f1") {
+            Object {
+              Property("p1") { 123 }
+            }
+          }
+        }
+      }
+    }
+  ) {
+    val anonymousObject = evaluateScript("object = expo.modules.TestModule.getObject().f1()")
+      .getObject()
+    val p1 = evaluateScript("object.p1").getInt()
+
+    Truth.assertThat(anonymousObject.getPropertyNames()).isEqualTo(arrayOf("p1"))
+    Truth.assertThat(p1).isEqualTo(123)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -105,7 +105,7 @@ public:
   public:
     HostObject(JavaScriptModuleObject *);
 
-  ~HostObject() override;
+    ~HostObject() override;
 
     jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
 
@@ -113,6 +113,7 @@ public:
 
     std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
 
+    jni::global_ref<jobject> jObjectRef;
   private:
     JavaScriptModuleObject *jsModule;
   };
@@ -126,7 +127,7 @@ private:
    * A reference to the `JavaScriptModuleObject::HostObject`.
    * Simple we cached that value to return the same object each time.
    */
-  std::shared_ptr<jsi::Object> jsiObject = nullptr;
+  std::weak_ptr<jsi::Object> jsiObject;
   jni::global_ref<JavaScriptModuleObject::javaobject> javaPart_;
 
   /**
@@ -149,6 +150,5 @@ private:
    * The `LongLivedObjectCollection` to hold `LongLivedObject` (callbacks or promises) for this module.
    */
   std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
-
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -126,6 +126,8 @@ private:
   /**
    * A reference to the `JavaScriptModuleObject::HostObject`.
    * Simple we cached that value to return the same object each time.
+   * It's a weak reference because the JS runtime holds the actual object. 
+   * Doing that allows the runtime to deallocate jsi::Object if it's not needed anymore.
    */
   std::weak_ptr<jsi::Object> jsiObject;
   jni::global_ref<JavaScriptModuleObject::javaobject> javaPart_;

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -303,6 +303,14 @@ jsi::Value MethodMetadata::callSync(
       ->consume();
     return jsi::valueFromDynamic(rt, dynamic);
   }
+  if (env->IsInstanceOf(unpackedResult, JavaScriptModuleObject::javaClassStatic().get())) {
+    auto anonymousObject = jni::static_ref_cast<JavaScriptModuleObject::javaobject>(result)
+      ->cthis();
+    anonymousObject->jsiInteropModuleRegistry = moduleRegistry;
+    auto hostObject = std::make_shared<JavaScriptModuleObject::HostObject>(anonymousObject);
+    hostObject->jObjectRef = jni::make_global(result);
+    return jsi::Object::createFromHostObject(rt, hostObject);
+  }
 
   return jsi::Value::undefined();
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -92,7 +92,7 @@ abstract class AnyFunction(
   /**
    * Attaches current function to the provided js object.
    */
-  internal abstract fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
+  abstract fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
 
   fun getCppRequiredTypes(): List<ExpectedType> {
     return desiredArgsTypes.map { it.getCppRequiredTypes() }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.modules
 
-import expo.modules.kotlin.ConcatIterator
 import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
@@ -20,7 +19,5 @@ class ModuleDefinitionData(
   val asyncFunctions = objectDefinition.asyncFunctions
   val eventsDefinition = objectDefinition.eventsDefinition
   val properties = objectDefinition.properties
-
-  val functions
-    get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())
+  val functions = objectDefinition.functions
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -14,6 +14,7 @@
 
 package expo.modules.kotlin.objects
 
+import com.facebook.react.bridge.Arguments
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.functions.AsyncFunction
@@ -21,6 +22,9 @@ import expo.modules.kotlin.functions.AsyncFunctionBuilder
 import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
 import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.typeOf
 
@@ -349,4 +353,30 @@ open class ObjectDefinitionBuilder {
       properties[name] = it
     }
   }
+}
+
+inline fun ModuleDefinitionBuilder.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptModuleObject {
+  return module!!.Object(block)
+}
+
+inline fun Module.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptModuleObject {
+  val objectData = ObjectDefinitionBuilder().also(block).buildObject()
+  return JavaScriptModuleObject("[Anonymous Object]")
+    .apply {
+      val constants = objectData.constantsProvider()
+      val convertedConstants = Arguments.makeNativeMap(constants)
+      exportConstants(convertedConstants)
+
+      objectData
+        .functions
+        .forEach { function ->
+          function.attachToJSObject(appContext, this)
+        }
+
+      objectData
+        .properties
+        .forEach { (_, prop) ->
+          prop.attachToJSObject(this)
+        }
+    }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.objects
 
+import expo.modules.kotlin.ConcatIterator
 import expo.modules.kotlin.events.EventsDefinition
 import expo.modules.kotlin.functions.BaseAsyncFunctionComponent
 import expo.modules.kotlin.functions.SyncFunctionComponent
@@ -10,4 +11,7 @@ class ObjectDefinitionData(
   val asyncFunctions: Map<String, BaseAsyncFunctionComponent>,
   val eventsDefinition: EventsDefinition?,
   val properties: Map<String, PropertyComponent>
-)
+) {
+  val functions
+    get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())
+}


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/pull/20623.

# How

Adds an ability to return objects from the sync functions. I've reused code responsible for handling modules. It's not the cleanest solution, but I plan to refactor that later. 

# Test Plan

- bare-expo with custom code ✅
- test suite ✅
- I've doubled checked if all objects are deallocated ✅
