### PR TITLE
[config-plugins] add build.gradle namespace test

### DIFF
--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -18,7 +18,8 @@ const EXAMPLE_BUILD_GRADLE = `
   android {
       compileSdkVersion rootProject.ext.compileSdkVersion
       buildToolsVersion rootProject.ext.buildToolsVersion
-  
+
+      namespace "com.helloworld"
       defaultConfig {
           applicationId "com.helloworld"
           minSdkVersion rootProject.ext.minSdkVersion
@@ -52,6 +53,12 @@ describe('package', () => {
     expect(
       setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
     ).toMatch("applicationId 'my.new.app'");
+  });
+
+  it(`sets the namespace in build.gradle if package is given`, () => {
+    expect(
+      setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)
+    ).toMatch("namespace 'my.new.app'");
   });
 
   it('adds package to android manifest', async () => {


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/20799#discussion_r1072511176 to add unit test for build.gradle namespace updates

# How

add namespace unit test

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
