### PR TITLE
[ios][camera] Fix path where camera saves picture on simulator

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix path where simulator saves photos ([#20872](https://github.com/expo/expo/pull/20872) by [@pettomartino](https://github.com/pettomartino))
+
 ### 💡 Others
 
 ## 13.1.0 - 2022-11-23

--- a/packages/expo-camera/ios/EXCamera/CameraViewModule.swift
+++ b/packages/expo-camera/ios/EXCamera/CameraViewModule.swift
@@ -283,7 +283,7 @@ private func generatePictureForSimulator(appContext: AppContext?, options: TakeP
   guard let fs = appContext?.fileSystem else {
     throw Exceptions.FileSystemModuleNotFound()
   }
-  let path = fs.generatePath(inDirectory: fs.cachesDirectory.appending("Camera"), withExtension: ".jpg")
+  let path = fs.generatePath(inDirectory: fs.cachesDirectory.appending("/Camera"), withExtension: ".jpg")
   let generatedPhoto = EXCameraUtils.generatePhoto(of: CGSize(width: 200, height: 200))
   let photoData = generatedPhoto.jpegData(compressionQuality: options.quality)
 


### PR DESCRIPTION
# Why
When taking photo using `takePictureAsync` there is a specific implementation for the simulator.
However when building the directory where the file will be save, there is a small bug with the concatenation. The concatenation with the cacheDirectory is missing the slash (`/`) so it creates a folder called `CachesCamera` rather than `Caches/Camera` as the device implementation does.
This creates an issue because FileSystem can't access this folder thus files can't be deleted. This issue creates in inconsistency between development environment and real device.

# How

I added a slash `/` to the string. Assuming this implementation works only on simulator which works only on macOS, the file system will always use `/` as directory separator so I believe we can just add this missing `/`

# Test Plan

Use `expo-camera` and call the method takePictureAsync. Check the uri of the file generated.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
