### PR TITLE
fix(cli): pin `@expo/dev-server` to 0.1.120 for sdk 46 and web compatibility

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Pin `@expo/dev-server` to version `0.1.120` to keep webpack support in SDK 46 ([#20878](https://github.com/expo/expo/pull/20878) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 ## 0.3.2 — 2022-10-13

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -40,7 +40,7 @@
     "@expo/code-signing-certificates": "^0.0.2",
     "@expo/config": "~7.0.1",
     "@expo/config-plugins": "~5.0.1",
-    "@expo/dev-server": "~0.1.120",
+    "@expo/dev-server": "0.1.120",
     "@expo/devcert": "^1.0.0",
     "@expo/json-file": "^8.2.35",
     "@expo/metro-config": "~0.4.0",


### PR DESCRIPTION
# Why

Fixes #19833
Fixes #20205

> **Warning**
> This requires a version bumps `expo@46.0.20` and `@expo/cli@0.3.3`

After publishing these changes, users **must** remove dependencies on `@expo/dev-server` to avoid having nested internal dependencies fixed in your project. Doing so causes complications when upgrading Expo to a newer SDK.

# How

This happened because #18439 dropped support for an experimental webpack middleware. Unfortunately, this was released as a non-breaking change while the nested dependency (file) was used in SDK 46. 

This caused the dependency chain of:
  - `expo@46.0.x -> @expo/cli@0.3.x -> @expo/dev-server@0.1.120`

being changed to:
  - `expo@46.0.x -> @expo/cli@0.3.x -> @expo/dev-server@0.1.122 (or 0.1.121)`

# Test Plan

- After publishing these pinned versions, we can test this by creating a new SDK 46 project and run it on web. (See issues #19833 and #20205)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
