### PR TITLE
feature(cli): move expensive prerequisite asserts to workers

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -71,6 +71,7 @@
     "https-proxy-agent": "^5.0.1",
     "internal-ip": "4.3.0",
     "is-root": "^2.1.0",
+    "jest-worker": "^29.3.1",
     "js-yaml": "^3.13.1",
     "json-schema-deref-sync": "^0.13.0",
     "md5-file": "^3.2.3",

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -2,7 +2,7 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import { Log } from '../../log';
-import { WebSupportProjectPrerequisite } from '../../start/doctor/web/WebSupportProjectPrerequisite';
+import { WebSupportProjectPrerequisiteWorker } from '../../start/doctor/web/WebSupportProjectPrerequisite';
 import { getPlatformBundlers } from '../../start/server/platformBundlers';
 import { WebpackBundlerDevServer } from '../../start/server/webpack/WebpackBundlerDevServer';
 import { CommandError } from '../../utils/errors';
@@ -10,7 +10,7 @@ import { Options } from './resolveOptions';
 
 export async function exportWebAsync(projectRoot: string, options: Options) {
   // Ensure webpack is available
-  await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
+  await new WebSupportProjectPrerequisiteWorker(projectRoot).assertAsync();
 
   const { exp } = getConfig(projectRoot);
   const platformBundlers = getPlatformBundlers(exp);

--- a/packages/@expo/cli/src/start/doctor/Prerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/Prerequisite.ts
@@ -72,8 +72,9 @@ export function createPrerequisiteWorker(prerequisiteFile: string): typeof Proje
       if (!this.worker) {
         const { Worker: JestWorker } = await import('jest-worker');
         const worker = new JestWorker(require.resolve('./ProjectPrerequisiteWorker'), {
-          maxRetries: 1,
           exposedMethods: ['assertImplementation'],
+          maxRetries: 1,
+          numWorkers: 1, // TODO(cedric): check if we need to maintain a pool of workers to increase performance
         });
 
         // Forward the worker's console logs to the main thread.
@@ -99,7 +100,7 @@ export function createPrerequisiteWorker(prerequisiteFile: string): typeof Proje
       const worker = await this.startWorkerAsync();
       const result = await worker.assertImplementation(this.workerFile, this.projectRoot);
 
-      // If we want to keep long running workers alive, we need a "destroy" lifecycle method.
+      // TODO(cedric): If we want to keep long running workers alive, we need a "destroy" lifecycle method.
       this.stopWorkerAsync();
 
       if (result.type === 'error') {

--- a/packages/@expo/cli/src/start/doctor/ProjectPrerequisiteWorker.ts
+++ b/packages/@expo/cli/src/start/doctor/ProjectPrerequisiteWorker.ts
@@ -1,0 +1,37 @@
+import { PrerequisiteCommandError, ProjectPrerequisite } from './Prerequisite';
+
+type PrerequisiteWorkerResult =
+  | { type: 'success' }
+  | { type: 'failure'; error: PrerequisiteCommandError }
+  | { type: 'error'; error: Error };
+
+/**
+ * Dynamically load the prerequisite class within the jest worker.
+ * This is executed from a wrapped Prerequisite class, from `createPrerequisiteWorker`.
+ * Once initialized, the prerequisite methods are piped from the original thread to the worker.
+ */
+function createInstance(
+  prerequisiteFile: string,
+  ...params: ConstructorParameters<typeof ProjectPrerequisite>
+): ProjectPrerequisite {
+  const PrerequisiteClass = require(prerequisiteFile).default as typeof ProjectPrerequisite;
+  return new PrerequisiteClass(...params);
+}
+
+/** Execute the prerequisite assertion within this worker instance */
+export async function assertImplementation(
+  ...params: Parameters<typeof createInstance>
+): Promise<PrerequisiteWorkerResult> {
+  try {
+    const instance = createInstance(...params);
+    await instance.assertImplementation();
+
+    return { type: 'success' };
+  } catch (error) {
+    if (error instanceof PrerequisiteCommandError) {
+      return { type: 'failure', error };
+    }
+
+    return { type: 'error', error: error as Error };
+  }
+}

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -5,9 +5,6 @@ import wrapAnsi from 'wrap-ansi';
 import { installAsync } from '../../../install/installAsync';
 import * as Log from '../../../log';
 import { CommandError } from '../../../utils/errors';
-import { isInteractive } from '../../../utils/interactive';
-import { logNewSection } from '../../../utils/ora';
-import { confirmAsync } from '../../../utils/prompts';
 import { getMissingPackagesAsync, ResolvedPackage } from './getMissingPackages';
 
 export async function ensureDependenciesAsync(
@@ -17,14 +14,13 @@ export async function ensureDependenciesAsync(
     requiredPackages,
     warningMessage,
     installMessage,
-    // Don't prompt in CI
-    skipPrompt = !isInteractive(),
+    disableMessage,
   }: {
     exp?: ExpoConfig;
     installMessage: string;
     warningMessage: string;
+    disableMessage?: string;
     requiredPackages: ResolvedPackage[];
-    skipPrompt?: boolean;
   }
 ): Promise<boolean> {
   const { missing } = await getMissingPackagesAsync(projectRoot, {
@@ -35,57 +31,42 @@ export async function ensureDependenciesAsync(
     return true;
   }
 
-  // Prompt to install or bail out...
+  // Inform about the missing packages
+  Log.log(installMessage, '\n');
+  if (disableMessage) {
+    Log.warn(warningMessage);
+    Log.warn(disableMessage, '\n');
+  } else {
+    Log.warn(warningMessage, '\n');
+  }
+
+  // Format with version if available.
+  const packages = missing.map(({ pkg, version }) => (version ? [pkg, version].join('@') : pkg));
+
+  // Install packages with versions
+  await installPackagesAsync(projectRoot, {
+    packages,
+  });
+
+  // Verify that the packages were installed correctly
+  const { missing: missingAfterInstall } = await getMissingPackagesAsync(projectRoot, {
+    sdkVersion: exp.sdkVersion,
+    requiredPackages,
+  });
+  if (!missingAfterInstall.length) {
+    return true;
+  }
+
+  // When failed, inform the user how to install the packages manually
+  const installCommand = createInstallCommand({ packages: missing });
   const readableMissingPackages = missing
     .map(({ pkg, version }) => (version ? [pkg, version].join('@') : pkg))
     .join(', ');
 
-  let title = installMessage;
-
-  if (skipPrompt) {
-    title += '\n\n';
-  } else {
-    const confirm = await confirmAsync({
-      message: wrapForTerminal(
-        title + ` Would you like to install ${chalk.cyan(readableMissingPackages)}?`
-      ),
-      initial: true,
-    });
-
-    if (confirm) {
-      // Format with version if available.
-      const packages = missing.map(({ pkg, version }) =>
-        version ? [pkg, version].join('@') : pkg
-      );
-      // Install packages with versions
-      await installPackagesAsync(projectRoot, {
-        packages,
-      });
-      // Try again but skip prompting twice, simply fail if the packages didn't install correctly.
-      return await ensureDependenciesAsync(projectRoot, {
-        skipPrompt: true,
-        installMessage,
-        warningMessage,
-        requiredPackages,
-      });
-    }
-
-    // Reset the title so it doesn't print twice in interactive mode.
-    title = '';
-  }
-
-  const installCommand = createInstallCommand({
-    packages: missing,
-  });
-
-  const disableMessage = warningMessage;
-
-  const solution = `Please install ${chalk.bold(
-    readableMissingPackages
-  )} by running:\n\n  ${chalk.reset.bold(installCommand)}\n\n`;
+  const solution = chalk`Please install {bold ${readableMissingPackages}} by running:\n\n  {reset.bold ${installCommand}}\n\n`;
 
   // This prevents users from starting a misconfigured JS or TS project by default.
-  throw new CommandError(wrapForTerminal(title + solution + disableMessage + '\n'));
+  throw new CommandError(wrapForTerminal(installMessage + solution + warningMessage + '\n'));
 }
 
 /**  Wrap long messages to fit smaller terminals. */
@@ -118,14 +99,12 @@ export function createInstallCommand({
 
 /** Install packages in the project. */
 async function installPackagesAsync(projectRoot: string, { packages }: { packages: string[] }) {
-  const packagesStr = chalk.bold(packages.join(', '));
-  Log.log();
-  const installingPackageStep = logNewSection(`Installing ${packagesStr}`);
+  const readablePackages = chalk.bold(packages.join(', '));
+
   try {
     await installAsync(packages, { projectRoot });
   } catch (e: any) {
-    installingPackageStep.fail(`Failed to install ${packagesStr} with error: ${e.message}`);
+    Log.error(chalk`Failed to install {bold ${readablePackages}} because of: ${e.message}`);
     throw e;
   }
-  installingPackageStep.succeed(`Installed ${packagesStr}`);
 }

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -31,14 +31,22 @@ export async function ensureDependenciesAsync(
     return true;
   }
 
-  // Inform about the missing packages
+  // Inform the user about what is wrong, and is currently being fixed
   Log.log(installMessage, '\n');
   if (disableMessage) {
     Log.warn(warningMessage);
-    Log.warn(disableMessage, '\n');
+    Log.log(chalk.dim(disableMessage), '\n');
   } else {
     Log.warn(warningMessage, '\n');
   }
+
+  // Show the exact packages that are incorrect or missing
+  Log.log('Missing packages:');
+  Log.log(
+    '  -',
+    missing.map(({ pkg, version }) => chalk`${pkg}{dim @${version}}`).join('\n  - '),
+    '\n'
+  ); // TODO(cedric): collapse this into the package manager
 
   // Format with version if available.
   const packages = missing.map(({ pkg, version }) => (version ? [pkg, version].join('@') : pkg));

--- a/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/ensureDependenciesAsync.ts
@@ -40,14 +40,6 @@ export async function ensureDependenciesAsync(
     Log.warn(warningMessage, '\n');
   }
 
-  // Show the exact packages that are incorrect or missing
-  Log.log('Missing packages:');
-  Log.log(
-    '  -',
-    missing.map(({ pkg, version }) => chalk`${pkg}{dim @${version}}`).join('\n  - '),
-    '\n'
-  ); // TODO(cedric): collapse this into the package manager
-
   // Format with version if available.
   const packages = missing.map(({ pkg, version }) => (version ? [pkg, version].join('@') : pkg));
 

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -76,8 +76,8 @@ export default class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
       return await ensureDependenciesAsync(this.projectRoot, {
         exp,
         installMessage: `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`,
-        warningMessage:
-          "If you're not using TypeScript, please remove the TypeScript files from your project",
+        warningMessage: `If you're not using TypeScript, please remove the TypeScript files from your project.`,
+        disableMessage: `You can disable this setup with EXPO_NO_TYPESCRIPT_SETUP.`,
         requiredPackages: [
           // use typescript/package.json to skip node module cache issues when the user installs
           // the package and attempts to resolve the module in the same process.

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config';
+import chalk from 'chalk';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -77,7 +78,7 @@ export default class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
         exp,
         installMessage: `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`,
         warningMessage: `If you're not using TypeScript, please remove the TypeScript files from your project.`,
-        disableMessage: `You can disable this setup with EXPO_NO_TYPESCRIPT_SETUP.`,
+        disableMessage: chalk`You can disable this setup with {bold EXPO_NO_TYPESCRIPT_SETUP}.`,
         requiredPackages: [
           // use typescript/package.json to skip node module cache issues when the user installs
           // the package and attempts to resolve the module in the same process.

--- a/packages/@expo/cli/src/start/doctor/typescript/__tests__/TypeScriptProjectPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/__tests__/TypeScriptProjectPrerequisite-test.ts
@@ -1,7 +1,7 @@
 import { vol } from 'memfs';
 
 import * as Log from '../../../../log';
-import { TypeScriptProjectPrerequisite } from '../TypeScriptProjectPrerequisite';
+import TypeScriptProjectPrerequisite from '../TypeScriptProjectPrerequisite';
 
 jest.mock('../../../../log');
 

--- a/packages/@expo/cli/src/start/doctor/typescript/updateTSConfig.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/updateTSConfig.ts
@@ -42,8 +42,6 @@ export async function updateTSConfigAsync({
   // Write changes and log out a summary of what changed
   await JsonFile.writeAsync(tsConfigPath, projectTSConfig);
 
-  Log.log();
-
   if (isBootstrapping) {
     Log.log(chalk`{bold TypeScript}: A {cyan tsconfig.json} has been auto-generated`);
   } else {

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -82,11 +82,10 @@ export default class WebSupportProjectPrerequisite extends ProjectPrerequisite {
 
     try {
       return await ensureDependenciesAsync(this.projectRoot, {
-        // This never seems to work when prompting, installing, and running -- instead just inform the user to run the install command and try again.
-        skipPrompt: true,
         exp,
         installMessage: `It looks like you're trying to use web support but don't have the required dependencies installed.`,
         warningMessage: chalk`If you're not using web, please ensure you remove the {bold "web"} string from the platforms array in the project Expo config.`,
+        disableMessage: chalk`You can disable this setup with {bold EXPO_NO_WEB_SETUP}.`,
         requiredPackages,
       });
     } catch (error) {

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -10,20 +10,29 @@ import chalk from 'chalk';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { getPlatformBundlers } from '../../server/platformBundlers';
-import { PrerequisiteCommandError, ProjectPrerequisite } from '../Prerequisite';
+import {
+  createPrerequisiteWorker,
+  PrerequisiteCommandError,
+  ProjectPrerequisite,
+} from '../Prerequisite';
 import { ensureDependenciesAsync } from '../dependencies/ensureDependenciesAsync';
 import { ResolvedPackage } from '../dependencies/getMissingPackages';
 
 const debug = require('debug')('expo:doctor:webSupport') as typeof console.log;
 
+/** Create a worker version of this prerequisite, to execute async in a different thread */
+export const WebSupportProjectPrerequisiteWorker = createPrerequisiteWorker(
+  require.resolve(__filename)
+);
+
 /** Ensure the project has the required web support settings. */
-export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
+export default class WebSupportProjectPrerequisite extends ProjectPrerequisite {
   /** Ensure a project that hasn't explicitly disabled web support has all the required packages for running in the browser. */
   async assertImplementation(): Promise<void> {
     if (env.EXPO_NO_WEB_SETUP) {
-      Log.warn('Skipping web setup: EXPO_NO_WEB_SETUP is enabled.');
-      return;
+      return Log.warn('Skipping web setup: EXPO_NO_WEB_SETUP is enabled.');
     }
+
     debug('Ensuring web support is setup');
 
     const result = await this._shouldSetupWebSupportAsync();

--- a/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/web/__tests__/WebSupportProjectPrerequisite-test.ts
@@ -3,9 +3,8 @@ import { getConfig, getProjectConfigDescriptionWithPaths, ProjectConfig } from '
 import { asMock } from '../../../../__tests__/asMock';
 import * as Log from '../../../../log';
 import { stripAnsi } from '../../../../utils/ansi';
-import {
+import WebSupportProjectPrerequisite, {
   isWebPlatformExcluded,
-  WebSupportProjectPrerequisite,
 } from '../WebSupportProjectPrerequisite';
 
 jest.mock('../../../../log');

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -6,7 +6,7 @@ import { AbortCommandError } from '../../utils/errors';
 import { getAllSpinners, ora } from '../../utils/ora';
 import { getProgressBar, setProgressBar } from '../../utils/progress';
 import { addInteractionListener, pauseInteractions } from '../../utils/prompts';
-import { WebSupportProjectPrerequisite } from '../doctor/web/WebSupportProjectPrerequisite';
+import { WebSupportProjectPrerequisiteWorker } from '../doctor/web/WebSupportProjectPrerequisite';
 import { DevServerManager } from '../server/DevServerManager';
 import { KeyPressHandler } from './KeyPressHandler';
 import { BLT, printHelp, printUsage, StartOptions } from './commandsTable';
@@ -138,7 +138,9 @@ export async function startInterfaceAsync(
     switch (key) {
       case 'w': {
         try {
-          await devServerManager.ensureProjectPrerequisiteAsync(WebSupportProjectPrerequisite);
+          await devServerManager.ensureProjectPrerequisiteAsync(
+            WebSupportProjectPrerequisiteWorker
+          );
           if (!platforms.includes('web')) {
             platforms.push('web');
             options.platforms?.push('web');

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { env } from '../../../utils/env';
-import { WebSupportProjectPrerequisite } from '../../doctor/web/WebSupportProjectPrerequisite';
+import { WebSupportProjectPrerequisiteWorker } from '../../doctor/web/WebSupportProjectPrerequisite';
 import { PlatformBundlers } from '../platformBundlers';
 import { importMetroResolverFromProject } from './resolveFromProject';
 import { getAppRouterRelativeEntryPath } from './router';
@@ -170,7 +170,7 @@ export async function withMetroMultiPlatformAsync(
   process.env.EXPO_PROJECT_ROOT = process.env.EXPO_PROJECT_ROOT ?? projectRoot;
 
   if (platformBundlers.web === 'metro') {
-    await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
+    await new WebSupportProjectPrerequisiteWorker(projectRoot).assertAsync();
   } else {
     // Bail out early for performance enhancements if web is not enabled.
     return config;

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -8,8 +8,8 @@ import { installExitHooks } from '../utils/exit';
 import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
 import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
-import { TypeScriptProjectPrerequisite } from './doctor/typescript/TypeScriptProjectPrerequisite';
-import { WebSupportProjectPrerequisite } from './doctor/web/WebSupportProjectPrerequisite';
+import { TypeScriptProjectPrerequisiteWorker } from './doctor/typescript/TypeScriptProjectPrerequisite';
+import { WebSupportProjectPrerequisiteWorker } from './doctor/web/WebSupportProjectPrerequisite';
 import { startInterfaceAsync } from './interface/startInterface';
 import { Options, resolvePortsAsync } from './resolveOptions';
 import { BundlerStartOptions } from './server/BundlerDevServer';
@@ -91,10 +91,10 @@ export async function startAsync(
   // Validations
 
   if (options.web || settings.webOnly) {
-    await devServerManager.ensureProjectPrerequisiteAsync(WebSupportProjectPrerequisite);
+    await devServerManager.ensureProjectPrerequisiteAsync(WebSupportProjectPrerequisiteWorker);
   }
 
-  await devServerManager.ensureProjectPrerequisiteAsync(TypeScriptProjectPrerequisite);
+  await devServerManager.ensureProjectPrerequisiteAsync(TypeScriptProjectPrerequisiteWorker);
 
   if (!settings.webOnly && !options.devClient) {
     await profile(validateDependenciesVersionsAsync)(projectRoot, exp, pkg);


### PR DESCRIPTION
# Why

Fixes ENG-7289

# How

This effectively modifies the auto setup for both TypeScript and Web support. It:
- Removes the prompts to install the packages immediately when missing
- Simplifies the logging/output to the user
  - Tells the user what envvar is required to disable it (dimmed text)
- Runs expensive operations, that may or may not change the project dependencies/config, to a different thread. The main thread only loads the bundler/app whenever these prerequisites are finished.

# Concept

This adds a dynamic version of a `ProjectPrerequisiteWorker`. With this, we can move a full `Prerequisite` class, including expensive operations (such as crawling through the project to find TypeScript files) to a jest worker/different thread.

The idea here is that:
- `createPrerequisiteWorker` generates a new class that defers the prerequisite internals to a jest worker. This includes caching the response inside the main thread class instance and shutting down the worker once it's not needed anymore.
- The worker itself is always loading the `ProjectPrerequisiteWorker` file, which loads and bootstraps the actual `Prerequisite` instance. This is requires because normally, a worker is stateless.

The content of the `Prerequisite` class remains unchanged, meaning that we can drop this feature without meaningful code changes. We can change it back to the original (unwrapped) prerequisite class.

# TODOS

- [x] Test these workers in `apps/bare-expo`
- [ ] Test these workers in `apps/native-component-list`
- [x] Test performance benefit vs non-workers
- [ ] Test if performance increases when using more `maxWorkers` (e.g. default jest-worker settings)
- [ ] Explore what would be necessary for long-running workers (e.g. watching project for new TypeScript files)
- [ ] Add tests for prerequisite worker

# Test Plan

- `$ npx create-expo-app ./test-workers`
- `$ cd ./test-workers`

**To test the Typescript prerequisites**
- `$ mv App.js App.tsx`
- `$ npx expod start`

**To test the web support prerequisites**
- `$ npx expod start --web`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
