### PR TITLE
fix(cli): use known Expo schemes to use as dev client urls

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix web assets not loading in Metro for web on Windows. ([#19935](https://github.com/expo/expo/pull/19935) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix getting UDID for network connected iOS devices. ([#20279](https://github.com/expo/expo/pull/20279) by [@Simek](https://github.com/Simek))
 - Send Exponent-Server header as JSON string for classic manifests. ([#20409](https://github.com/expo/expo/pull/20409) by [@byCedric](https://github.com/byCedric))
+- Use known Expo schemes when starting with dev clients. ([#20888](https://github.com/expo/expo/pull/20888) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/__tests__/scheme-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/scheme-test.ts
@@ -1,0 +1,88 @@
+import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
+import { getInfoPlistPathFromPbxproj } from '@expo/config-plugins/build/ios/utils/getInfoPlistPath';
+import { vol } from 'memfs';
+import path from 'path';
+
+import { getSchemesForAndroidAsync, getSchemesForIosAsync } from '../scheme';
+
+jest.mock('fs');
+jest.mock('@expo/config-plugins');
+jest.mock('@expo/config-plugins/build/ios/utils/getInfoPlistPath');
+
+// TODO: replace with `jest.mocked`, when updating Jest
+const asMock = (fn: any): jest.Mock => fn;
+
+describe(getSchemesForAndroidAsync, () => {
+  it('resolves longest scheme without known expo schemes', async () => {
+    asMock(AndroidConfig.Scheme.getSchemesFromManifest).mockResolvedValue([
+      'com.expo.test',
+      'com.expo.longertest',
+      'com.expo.longesttest',
+    ]);
+
+    await expect(getSchemesForAndroidAsync('/fake-project')).resolves.toEqual([
+      'com.expo.longesttest',
+      'com.expo.longertest',
+      'com.expo.test',
+    ]);
+  });
+
+  it('resolves known expo schemes before longest schemes', async () => {
+    asMock(AndroidConfig.Scheme.getSchemesFromManifest).mockResolvedValue([
+      'com.expo.longesttest',
+      'exp+com.expo.test',
+    ]);
+
+    await expect(getSchemesForAndroidAsync('/fake-project')).resolves.toEqual([
+      'exp+com.expo.test',
+    ]);
+  });
+});
+
+describe(getSchemesForIosAsync, () => {
+  beforeAll(() => {
+    const fakePlist = `
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+          <key>fake</key>
+          <string>plist</string>
+        </dic>
+      </plist>
+    `;
+
+    vol.fromJSON({
+      [path.join('fake-project', 'ios', 'fake-pbxproject')]: fakePlist,
+    });
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it('resolves longest scheme without known expo schemes', async () => {
+    asMock(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
+    asMock(IOSConfig.Scheme.getSchemesFromPlist).mockReturnValue([
+      'com.expo.test',
+      'com.expo.longertest',
+      'com.expo.longesttest',
+    ]);
+
+    await expect(getSchemesForIosAsync('fake-project')).resolves.toEqual([
+      'com.expo.longesttest',
+      'com.expo.longertest',
+      'com.expo.test',
+    ]);
+  });
+
+  it('resolves known expo schemes before longest schemes', async () => {
+    asMock(getInfoPlistPathFromPbxproj).mockReturnValue('fake-pbxproject');
+    asMock(IOSConfig.Scheme.getSchemesFromPlist).mockReturnValue([
+      'com.expo.longesttest',
+      'exp+com.expo.test',
+    ]);
+
+    await expect(getSchemesForIosAsync('fake-project')).resolves.toEqual(['exp+com.expo.test']);
+  });
+});

--- a/packages/@expo/cli/src/utils/scheme.ts
+++ b/packages/@expo/cli/src/utils/scheme.ts
@@ -21,6 +21,16 @@ function sortLongest(obj: string[]): string[] {
   return obj.sort((a, b) => b.length - a.length);
 }
 
+/**
+ * Resolve the scheme for the dev client using two methods:
+ *   - filter on known Expo schemes, starting with `exp+`, avoiding 3rd party schemes.
+ *   - filter on longest to ensure uniqueness.
+ */
+function resolveExpoOrLongestScheme(schemes: string[]): string[] {
+  const expoOnlySchemes = schemes.filter((scheme) => scheme.startsWith('exp+'));
+  return expoOnlySchemes.length > 0 ? sortLongest(expoOnlySchemes) : sortLongest(schemes);
+}
+
 // TODO: Revisit and test after run code is merged.
 export async function getSchemesForIosAsync(projectRoot: string): Promise<string[]> {
   try {
@@ -32,7 +42,7 @@ export async function getSchemesForIosAsync(projectRoot: string): Promise<string
       const plistObject = plist.parse(rawPlist);
       const schemes = IOSConfig.Scheme.getSchemesFromPlist(plistObject);
       debug(`ios application schemes:`, schemes);
-      return sortLongest(schemes);
+      return resolveExpoOrLongestScheme(schemes);
     }
   } catch (error) {
     debug(`expected error collecting ios application schemes for the main target:`, error);
@@ -48,7 +58,7 @@ export async function getSchemesForAndroidAsync(projectRoot: string): Promise<st
     const manifest = await AndroidConfig.Manifest.readAndroidManifestAsync(configPath);
     const schemes = await AndroidConfig.Scheme.getSchemesFromManifest(manifest);
     debug(`android application schemes:`, schemes);
-    return sortLongest(schemes);
+    return resolveExpoOrLongestScheme(schemes);
   } catch (error) {
     debug(`expected error collecting android application schemes for the main activity:`, error);
     // No android folder or some other error


### PR DESCRIPTION
# Why

Fixes #20887

# How

Instead of always picking the longest scheme, this adds "search for known expo schemes, starting with `exp+`". If that's found, it's still sorting on longest. And if it's not found, it's doing what it's doing now.

# Test Plan

(see added tests)

- Add a custom scheme to the native files that includes a very long scheme
- Start the project (should be a bad scheme)
- Add a shorter `exp+...` scheme
- Start the project (should be that `expo+...` scheme)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
