### PR TITLE
[image][ios] Support accessibility props on iOS

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added support for crossfade transition on Android. ([#20784](https://github.com/expo/expo/pull/20784) by [@lukmccall](https://github.com/lukmccall))
 - Added web support for the `blurRadius` prop. ([#20845](https://github.com/expo/expo/pull/20845) by [@aleqsio](https://github.com/aleqsio))
 - Support for `accessible` and `accessibilityLabel` props on Android. ([#20801](https://github.com/expo/expo/pull/20801) by [@lukmccall](https://github.com/lukmccall))
+- Support for `accessible` and `accessibilityLabel` props on iOS. ([#20892](https://github.com/expo/expo/pull/20892) by [@alanhughes](https://github.com/alanjhughes))
 
 ## 1.0.0-alpha.6 — 2023-01-10
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -65,12 +65,12 @@ public final class ImageModule: Module {
         view.cachePolicy = cachePolicy ?? .disk
       }
 
-      Prop("accessible") { (view, accessible: Bool) in
-        view.accessible = accessible
+      Prop("accessible") { (view, accessible: Bool?) in
+        view.accessible = accessible ?? false
       }
 
-      Prop("accessibilityLabel") { (view, label: String) in
-        view.accessibilityLabel = label
+      Prop("accessibilityLabel") { (view, label: String?) in
+        view.sdImageView.accessibilityLabel = label
       }
 
       OnViewDidUpdateProps { view in

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -66,7 +66,7 @@ public final class ImageModule: Module {
       }
 
       Prop("accessible") { (view, accessible: Bool?) in
-        view.accessible = accessible ?? false
+        view.sdImageView.isAccessibilityElement = accessible ?? false
       }
 
       Prop("accessibilityLabel") { (view, label: String?) in

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -65,6 +65,14 @@ public final class ImageModule: Module {
         view.cachePolicy = cachePolicy ?? .disk
       }
 
+      Prop("accessible") { (view, accessible: Bool) in
+        view.accessible = accessible
+      }
+
+      Prop("accessibilityLabel") { (view, label: String) in
+        view.accessibilityLabel = label
+      }
+
       OnViewDidUpdateProps { view in
         view.reload()
       }

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -63,12 +63,6 @@ public final class ImageView: ExpoView {
     }
   }
 
-  public override var accessibilityLabel: String? {
-    didSet {
-      sdImageView.accessibilityLabel = accessibilityLabel
-    }
-  }
-
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -40,8 +40,6 @@ public final class ImageView: ExpoView {
 
   var cachePolicy: ImageCachePolicy = .disk
 
-  var accessible: Bool = false
-
   // MARK: - Events
 
   let onLoadStart = EventDispatcher()
@@ -137,8 +135,6 @@ public final class ImageView: ExpoView {
     // Some loaders (e.g. blurhash) need access to the source and the screen scale.
     context[ImageView.contextSourceKey] = source
     context[ImageView.screenScaleKey] = screenScale
-
-    sdImageView.isAccessibilityElement = accessible
 
     onLoadStart([:])
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -76,7 +76,6 @@ public final class ImageView: ExpoView {
     sdImageView.contentMode = contentFit.toContentMode()
     sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     sdImageView.layer.masksToBounds = false
-    sdImageView.isAccessibilityElement = accessible
 
     // Apply trilinear filtering to smooth out mis-sized images.
     sdImageView.layer.magnificationFilter = .trilinear

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -40,6 +40,8 @@ public final class ImageView: ExpoView {
 
   var cachePolicy: ImageCachePolicy = .disk
 
+  var accessible: Bool = false
+
   // MARK: - Events
 
   let onLoadStart = EventDispatcher()
@@ -61,6 +63,12 @@ public final class ImageView: ExpoView {
     }
   }
 
+  public override var accessibilityLabel: String? {
+    didSet {
+      sdImageView.accessibilityLabel = accessibilityLabel
+    }
+  }
+
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
 
@@ -68,6 +76,7 @@ public final class ImageView: ExpoView {
     sdImageView.contentMode = contentFit.toContentMode()
     sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
     sdImageView.layer.masksToBounds = false
+    sdImageView.isAccessibilityElement = accessible
 
     // Apply trilinear filtering to smooth out mis-sized images.
     sdImageView.layer.magnificationFilter = .trilinear
@@ -135,6 +144,8 @@ public final class ImageView: ExpoView {
     // Some loaders (e.g. blurhash) need access to the source and the screen scale.
     context[ImageView.contextSourceKey] = source
     context[ImageView.screenScaleKey] = screenScale
+
+    sdImageView.isAccessibilityElement = accessible
 
     onLoadStart([:])
 


### PR DESCRIPTION
# Why
Added `accessible` and `accessibilityLabel` props as discussed with @tsapeta 

# How
Added props to the native module

# Test Plan
Tested on a real device using Voiceover and on the simulator using the Accessibility Inspector. 