### PR TITLE
[image][ios] Use SDImageAWebPCoder to speed up loading WebP images

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use `SDImageAWebPCoder` on iOS 14+ to speed up loading WebP images.
+
 ### 💡 Others
 
 - On Android bump `compileSdkVersion` and `targetSdkVersion` to `31`. ([#20721](https://github.com/expo/expo/pull/20721) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Use `SDImageAWebPCoder` on iOS 14+ to speed up loading WebP images.
+- Use `SDImageAWebPCoder` on iOS 14+ to speed up loading WebP images. ([#20897](https://github.com/expo/expo/pull/20897) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -87,7 +87,13 @@ public final class ImageModule: Module {
   }
 
   static func registerCoders() {
-    SDImageCodersManager.shared.addCoder(SDImageWebPCoder.shared)
+    if #available(iOS 14.0, *) {
+      // By default Animated WebP is not supported
+      SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
+    } else {
+      // This coder is much slower, but it's the only one that works in iOS 13
+      SDImageCodersManager.shared.addCoder(SDImageWebPCoder.shared)
+    }
     SDImageCodersManager.shared.addCoder(SDImageAVIFCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
     SDImageCodersManager.shared.addCoder(SDImageHEICCoder.shared)


### PR DESCRIPTION
# Why

Using `SDImageAWebPCoder` makes loading WebP images a bit faster than `SDImageWebPCoder`.

# How

Replaced the coders that we use for WebP images, but I had to keep `SDImageWebPCoder` for iOS 13 because it's the only one that supports it.

# Test Plan

Tested with our own examples and also https://github.com/alantoa/expo-image-issue