### PR TITLE
[android][ios] Upgrade react-native-safe-area-context to 4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-async-storage/async-storage` from `1.17.3' to `1.17.11`. ([#20780](https://github.com/expo/expo/pull/20780) by [@kudo](https://github.com/kudo))
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.0`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo))
 - Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.171`. ([#20857](https://github.com/expo/expo/pull/20857) by [@kudo](https://github.com/kudo))
+- Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -552,7 +552,7 @@ PODS:
     - React-Core
   - react-native-pager-view (6.0.1):
     - React-Core
-  - react-native-safe-area-context (4.4.1):
+  - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1294,7 +1294,7 @@ SPEC CHECKSUMS:
   React-logger: a6c0b3a807a8e81f6d7fea2e72660766f55daa50
   react-native-netinfo: 85b2a435c4d3705c08b0c42ff2d6ef6b9622ea0a
   react-native-pager-view: 3051346698a0ba0c4e13e40097cc11b00ee03cca
-  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
+  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-slider: cecabb58ecffad671d2ad3ccc58c7f4d2d029e95
   react-native-view-shot: a60a98a18c72bcaaaf2138f9aab960ae9b0d96c7

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -85,7 +85,7 @@
     "react-native-gesture-handler": "~2.8.0",
     "react-native-pager-view": "6.0.1",
     "react-native-reanimated": "~2.14.0",
-    "react-native-safe-area-context": "4.4.1",
+    "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.18.0",
     "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -147,7 +147,7 @@
     "react-native-pager-view": "6.0.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.0",
-    "react-native-safe-area-context": "4.4.1",
+    "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.18.0",
     "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",

--- a/home/package.json
+++ b/home/package.json
@@ -63,7 +63,7 @@
     "react-native-maps": "1.3.2",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.0",
-    "react-native-safe-area-context": "4.4.1",
+    "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.18.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1970,7 +1970,7 @@ PODS:
     - React-Core
   - react-native-pager-view (6.0.1):
     - React-Core
-  - react-native-safe-area-context (4.4.1):
+  - react-native-safe-area-context (4.5.0):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -3620,7 +3620,7 @@ SPEC CHECKSUMS:
   React-logger: a6c0b3a807a8e81f6d7fea2e72660766f55daa50
   react-native-netinfo: 85b2a435c4d3705c08b0c42ff2d6ef6b9622ea0a
   react-native-pager-view: 3051346698a0ba0c4e13e40097cc11b00ee03cca
-  react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
+  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-skia: 571e20d8f275a305d5d30f17d4329862b852d65e
   react-native-slider: cecabb58ecffad671d2ad3ccc58c7f4d2d029e95

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/Fabric/RNCSafeAreaProviderComponentView.h
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/Fabric/RNCSafeAreaProviderComponentView.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNCSafeAreaProviderComponentView : RCTViewComponentView
 
-extern NSString * const RNCSafeAreaDidChange;
+extern NSString *const RNCSafeAreaDidChange;
 
 @end
 

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaProvider.m
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaProvider.m
@@ -36,10 +36,7 @@
   _currentSafeAreaInsets = safeAreaInsets;
   _currentFrame = frame;
 
-  [NSNotificationCenter.defaultCenter
-   postNotificationName:RNCSafeAreaDidChange
-   object:self
-   userInfo:nil];
+  [NSNotificationCenter.defaultCenter postNotificationName:RNCSafeAreaDidChange object:self userInfo:nil];
 
   self.onInsetsChange(@{
     @"insets" : @{

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaUtils.h
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaUtils.h
@@ -2,7 +2,7 @@
 #import <React/RCTView.h>
 #import <UIKit/UIKit.h>
 
-extern NSString * const RNCSafeAreaDidChange;
+extern NSString *const RNCSafeAreaDidChange;
 
 RCT_EXTERN BOOL
 UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIEdgeInsets insets2, CGFloat threshold);

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaUtils.m
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaUtils.m
@@ -2,7 +2,7 @@
 
 #import <React/RCTUIManager.h>
 
-NSString * const RNCSafeAreaDidChange = @"RNCSafeAreaDidChange";
+NSString *const RNCSafeAreaDidChange = @"RNCSafeAreaDidChange";
 
 BOOL UIEdgeInsetsEqualToEdgeInsetsWithThreshold(UIEdgeInsets insets1, UIEdgeInsets insets2, CGFloat threshold)
 {

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaView.m
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaView.m
@@ -14,7 +14,7 @@
   UIEdgeInsets _currentSafeAreaInsets;
   RNCSafeAreaViewMode _mode;
   RNCSafeAreaViewEdges _edges;
-  __weak UIView *_Nullable _providerView;
+  __weak RNCSafeAreaProvider *_Nullable _providerView;
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
@@ -55,15 +55,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   [self invalidateSafeAreaInsets];
 
   if (previousProviderView != _providerView) {
-    [NSNotificationCenter.defaultCenter
-     removeObserver:self
-     name:RNCSafeAreaDidChange
-     object:previousProviderView];
-    [NSNotificationCenter.defaultCenter
-     addObserver:self
-     selector:@selector(safeAreaProviderInsetsDidChange:)
-     name:RNCSafeAreaDidChange
-     object:_providerView];
+    if (previousProviderView != nil) {
+      [NSNotificationCenter.defaultCenter removeObserver:self name:RNCSafeAreaDidChange object:previousProviderView];
+    }
+
+    if (_providerView != nil) {
+      [NSNotificationCenter.defaultCenter addObserver:self
+                                             selector:@selector(safeAreaProviderInsetsDidChange:)
+                                                 name:RNCSafeAreaDidChange
+                                               object:_providerView];
+    }
   }
 }
 
@@ -87,16 +88,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   [self updateLocalData];
 }
 
-- (UIView *)findNearestProvider
+- (nullable RNCSafeAreaProvider *)findNearestProvider
 {
   UIView *current = self.reactSuperview;
   while (current != nil) {
     if ([current isKindOfClass:RNCSafeAreaProvider.class]) {
-      return current;
+      return (RNCSafeAreaProvider *)current;
     }
     current = current.reactSuperview;
   }
-  return self;
+  return nil;
 }
 
 - (void)updateLocalData

--- a/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
+++ b/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-safe-area-context",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "summary": "A flexible way to handle safe area, also works on Android and web.",
   "license": "MIT",
   "authors": "Janic Duplessis <janicduplessis@gmail.com>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/th3rdwave/react-native-safe-area-context.git",
-    "tag": "v4.4.1"
+    "tag": "v4.5.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "exclude_files": "ios/Fabric",

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
     "react-native-gesture-handler": "~2.8.0",
-    "react-native-safe-area-context": "4.4.1",
+    "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.18.0",
     "react-native-svg": "13.4.0",
     "sane": "^5.0.1"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -95,7 +95,7 @@
   "react-native-pager-view": "6.0.1",
   "react-native-reanimated": "~2.14.0",
   "react-native-screens": "~3.18.0",
-  "react-native-safe-area-context": "4.4.1",
+  "react-native-safe-area-context": "4.5.0",
   "react-native-shared-element": "0.8.7",
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15884,10 +15884,10 @@ react-native-reanimated@~2.14.0:
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
-react-native-safe-area-context@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.4.1.tgz#239c60b8a9a80eac70a38a822b04c0f1d15ffc01"
-  integrity sha512-N9XTjiuD73ZpVlejHrUWIFZc+6Z14co1K/p1IFMkImU7+avD69F3y+lhkqA2hN/+vljdZrBSiOwXPkuo43nFQA==
+react-native-safe-area-context@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz#9208313236e8f49e1920ac1e2a2c975f03aed284"
+  integrity sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"


### PR DESCRIPTION
# Why

Closes ENG-7321

# How

- `et update-module -m react-native-safe-area-context -c 'v4.5.0'`
- `et pods -f`
- `yarn`


# Test Plan

- [x] test using `bare-expo` Android + NCL safe area context (Expo go is currently broken)
- [x] test using `bare-expo` iOS + NCL safe area context
- [ ] test unversioned expo go ios + NCL safe area context
- [ ] test unversioned expo go android + NCL safe area context

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
