### PR TITLE
[docs][style] allow padding top for `APISectionUtils`

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -661,7 +661,7 @@ export const STYLES_APIBOX = css({
   },
 
   [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
-    padding: `0 ${spacing[4]}px`,
+    paddingInline: spacing[4],
   },
 });
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Hello Expo team 👋, this pr basically allows padding top for  `APISectionUtils ` for screens smaller than `1024px` 
this was causing extra scroll inside the container + was not pleasing to the eye  
# How

<!--
How did you build this feature or fix this bug and why?
-->
Made the custom padding to only be inline
# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Tested it manully 
before

![CleanShot 2023-01-20 at 20 50 39](https://user-images.githubusercontent.com/43112535/213778973-669e71a1-9fc5-4ff1-88c1-1a3fec19924b.gif)

after 

![CleanShot 2023-01-20 at 20 45 23](https://user-images.githubusercontent.com/43112535/213778937-d13225a7-04be-4fb5-8b0f-ed69edd0b236.gif)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
