### PR TITLE
[media-library][android] Support granular permissions on Android 13

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 🎉 New features
 
 - Migrated Android codebase to use the new Expo modules API. ([#20232](https://github.com/expo/expo/pull/20232) by [@alanhughes](https://github.com/alanjhughes))
+- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 🎉 New features
 
 - Migrated Android codebase to use the new Expo modules API. ([#20232](https://github.com/expo/expo/pull/20232) by [@alanhughes](https://github.com/alanjhughes))
-- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13.
+- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13. ([#20907](https://github.com/expo/expo/pull/20907) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-media-library/android/src/main/AndroidManifest.xml
+++ b/packages/expo-media-library/android/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 
 <manifest package="expo.modules.medialibrary" xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -2,6 +2,9 @@ package expo.modules.medialibrary
 
 import android.Manifest.permission.ACCESS_MEDIA_LOCATION
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_MEDIA_AUDIO
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
 import android.app.Activity
@@ -330,14 +333,10 @@ class MediaLibraryModule : Module() {
   }
 
   private val isMissingPermissions: Boolean
-    get() = appContext.permissions
-      ?.hasGrantedPermissions(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)
-      ?.not() ?: false
+    get() = hasReadPermissions()
 
   private val isMissingWritePermission: Boolean
-    get() = appContext.permissions
-      ?.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE)
-      ?.not() ?: false
+    get() = hasWritePermissions()
 
   @SuppressLint("InlinedApi")
   private fun getManifestPermissions(writeOnly: Boolean): Array<String> {
@@ -346,10 +345,30 @@ class MediaLibraryModule : Module() {
       Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
         MediaLibraryUtils.hasManifestPermission(context, ACCESS_MEDIA_LOCATION)
 
+    val shouldAddWriteExternalStorage =
+      Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
+        MediaLibraryUtils.hasManifestPermission(context, WRITE_EXTERNAL_STORAGE)
+
+    val shouldAddGranularPermissions =
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+        listOf(READ_MEDIA_AUDIO, READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
+          .all { MediaLibraryUtils.hasManifestPermission(context, it) }
+
     return listOfNotNull(
-      WRITE_EXTERNAL_STORAGE,
-      READ_EXTERNAL_STORAGE.takeIf { !writeOnly },
-      ACCESS_MEDIA_LOCATION.takeIf { shouldAddMediaLocationAccess }
+      WRITE_EXTERNAL_STORAGE.takeIf { shouldAddWriteExternalStorage },
+      READ_EXTERNAL_STORAGE.takeIf { !writeOnly && !shouldAddGranularPermissions },
+      ACCESS_MEDIA_LOCATION.takeIf { shouldAddMediaLocationAccess },
+      *getGranularPermissions(writeOnly, shouldAddGranularPermissions)
+    ).toTypedArray()
+  }
+
+  @SuppressLint("InlinedApi")
+  private fun getGranularPermissions(writeOnly: Boolean, shouldAdd: Boolean): Array<String> {
+    val addPermission = !writeOnly && shouldAdd
+    return listOfNotNull(
+      READ_MEDIA_IMAGES.takeIf { addPermission },
+      READ_MEDIA_VIDEO.takeIf { addPermission },
+      READ_MEDIA_AUDIO.takeIf { addPermission }
     ).toTypedArray()
   }
 
@@ -364,6 +383,28 @@ class MediaLibraryModule : Module() {
 
   private fun interface Action {
     fun runWithPermissions(permissionsWereGranted: Boolean)
+  }
+
+  private fun hasReadPermissions(): Boolean {
+    val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      arrayOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO)
+    } else {
+      arrayOf(READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)
+    }
+
+    return appContext.permissions
+      ?.hasGrantedPermissions(*permissions)
+      ?.not() ?: false
+  }
+
+  private fun hasWritePermissions(): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      false
+    } else {
+      appContext.permissions
+        ?.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE)
+        ?.not() ?: false
+    }
   }
 
   private fun runActionWithPermissions(assetsId: List<String>, action: Action) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -397,14 +397,12 @@ class MediaLibraryModule : Module() {
       ?.not() ?: false
   }
 
-  private fun hasWritePermissions(): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      false
-    } else {
-      appContext.permissions
-        ?.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE)
-        ?.not() ?: false
-    }
+  private fun hasWritePermissions() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    false
+  } else {
+    appContext.permissions
+      ?.hasGrantedPermissions(WRITE_EXTERNAL_STORAGE)
+      ?.not() ?: false
   }
 
   private fun runActionWithPermissions(assetsId: List<String>, action: Action) {


### PR DESCRIPTION
# Why
Android 13 added new [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) for accessing media files.

# How
Added support for requesting these permissions

# Test Plan
Tested on a physical device running android 13 and on emulators running android 9-13.
