### PR TITLE
[image-picker][android] Support for granular permissions on Android 13

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13.
+- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13. ([#20908](https://github.com/expo/expo/pull/20908) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android 13.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <!-- Required for picking images from camera roll -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application>
       <activity

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -183,8 +183,7 @@ class ImagePickerModule : Module() {
       listOfNotNull(
         Manifest.permission.WRITE_EXTERNAL_STORAGE,
         Manifest.permission.READ_EXTERNAL_STORAGE.takeIf { !writeOnly }
-      )
-        .toTypedArray()
+      ).toTypedArray()
     }
 
   private fun ensureTargetActivityIsAvailable(options: ImagePickerOptions) {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -1,9 +1,12 @@
 package expo.modules.imagepicker
 
 import android.Manifest
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.OperationCanceledException
 import expo.modules.core.errors.ModuleNotFoundException
 import expo.modules.imagepicker.contracts.CameraContract
@@ -109,7 +112,7 @@ class ImagePickerModule : Module() {
   private lateinit var cropImageLauncher: AppContextActivityResultLauncher<CropImageContractOptions, ImagePickerContractResult>
 
   private val cacheDirectory: File
-    get() = appContext.cacheDirectory ?: throw ModuleNotFoundException("expo.modules.interfaces.filesystem.AppDirectories")
+    get() = appContext.cacheDirectory
 
   /**
    * Stores result for an operation that has been interrupted by the activity destruction.
@@ -171,10 +174,17 @@ class ImagePickerModule : Module() {
   // region Utils
 
   private fun getMediaLibraryPermissions(writeOnly: Boolean): Array<String> =
-    if (writeOnly) {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      listOfNotNull(
+        READ_MEDIA_IMAGES.takeIf { !writeOnly },
+        READ_MEDIA_VIDEO.takeIf { !writeOnly }
+      ).toTypedArray()
     } else {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+      listOfNotNull(
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.READ_EXTERNAL_STORAGE.takeIf { !writeOnly }
+      )
+        .toTypedArray()
     }
 
   private fun ensureTargetActivityIsAvailable(options: ImagePickerOptions) {
@@ -189,7 +199,13 @@ class ImagePickerModule : Module() {
 
     permissions.askForPermissions(
       { permissionsResponse ->
-        if (
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          if (permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED) {
+            continuation.resume(Unit)
+          } else {
+            continuation.resumeWithException(UserRejectedPermissionsException())
+          }
+        } else if (
           permissionsResponse[Manifest.permission.WRITE_EXTERNAL_STORAGE]?.status == PermissionsStatus.GRANTED &&
           permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED
         ) {
@@ -198,7 +214,8 @@ class ImagePickerModule : Module() {
           continuation.resumeWithException(UserRejectedPermissionsException())
         }
       },
-      Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA
+      Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU },
+      Manifest.permission.CAMERA
     )
   }
 


### PR DESCRIPTION
# Why
Add support for [granular permissions](https://developer.android.com/about/versions/13/behavior-changes-13) on Android that were preventing the camera from launching on devices running Android 13

# How
Added support for requesting these permissions

# Test Plan
Tested on a physical device running android 13.
