### PR TITLE
[docs] Fix link on Expo Module API get started page

### DIFF
--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -48,5 +48,5 @@ Now that you've learned how to initialize a module and make simple changes to it
 <BoxLink
   title="Module API Reference"
   description="Outline for the Expo Module API and common patterns like sending events from native code to JavaScript."
-  href="/modules/native-module-tutorial"
+  href="/modules/module-api"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As reported internally, the two links are identical on https://docs.expo.dev/modules/get-started/ under "Next Steps".

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing the second link to redirect to Module API reference page: https://docs.expo.dev/modules/module-api/

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
