### PR TITLE
[camera] Fix `Caused by java.lang.NoSuchMethodError: No interface method getOrDefault` on Android.

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `Caused by java.lang.NoSuchMethodError: No interface method getOrDefault` on Android.
+- Fix `Caused by java.lang.NoSuchMethodError: No interface method getOrDefault` on Android. ([#20921](https://github.com/expo/expo/pull/20921) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `Caused by java.lang.NoSuchMethodError: No interface method getOrDefault` on Android.
+
 ### 💡 Others
 
 ## 12.4.0 — 2022-11-30

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPictureAsyncTask.kt
@@ -67,7 +67,7 @@ class ResolveTakenPictureAsyncTask(
     get() = options[QUALITY_KEY]?.let {
       val requestedQuality = (it as Number).toDouble()
       (requestedQuality * 100).toInt()
-    } ?: DEFAULT_QUALITY * 100
+    } ?: (DEFAULT_QUALITY * 100)
 
   override fun doInBackground(vararg params: Void?): Bundle? {
     // handle SkipProcessing
@@ -93,7 +93,7 @@ class ResolveTakenPictureAsyncTask(
         var bitmap: Bitmap? = null
         var lastError: Error? = null
 
-        val maxDownsampling = ((options.getOrDefault("maxDownsampling", 1.0)) as Double).toInt()
+        val maxDownsampling = ((options["maxDownsampling"] as? Double) ?: 1.0).toInt()
         // If OOM exception was thrown, we try to use downsampling to recover.
         while (bitmapOptions.inSampleSize <= maxDownsampling) {
           try {


### PR DESCRIPTION
# Why

Fixes https://exponent-internal.slack.com/archives/C0238THKESC/p1674158274256649.

# Test Plan

- build and run NCL on Android with SDK 22