### PR TITLE
[go][Android] Add support for new granular permissions on Android 13

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
@@ -142,6 +142,9 @@ class ScopedPermissionsRequester(private val experienceKey: ExperienceKey) {
       Manifest.permission.ACCESS_COARSE_LOCATION -> R.string.perm_coarse_location
       Manifest.permission.ACCESS_BACKGROUND_LOCATION -> R.string.perm_background_location
       Manifest.permission.READ_PHONE_STATE -> R.string.perm_read_phone_state
+      Manifest.permission.READ_MEDIA_IMAGES -> R.string.perm_read_media_images
+      Manifest.permission.READ_MEDIA_VIDEO -> R.string.perm_read_media_videos
+      Manifest.permission.READ_MEDIA_AUDIO -> R.string.perm_read_media_audio
       else -> -1
     }
   }

--- a/android/expoview/src/main/res/values/strings.xml
+++ b/android/expoview/src/main/res/values/strings.xml
@@ -28,6 +28,9 @@
   <string name="perm_coarse_location">coarse location</string>
   <string name="perm_background_location">background location</string>
   <string name="perm_read_phone_state">reading phone state</string>
+  <string name="perm_read_media_images">reading images from external storage</string>
+  <string name="perm_read_media_videos">reading videos from external storage</string>
+  <string name="perm_read_media_audio">reading audio files from external storage</string>
   <string name="perm_system_brightness">system brightness</string>
   <string name="default_notification_channel_group">Default</string>
   <string name="persistent_notification_channel_group">Expo</string>


### PR DESCRIPTION
# Why

Adds support for new granular permissions on Android 13 to the scoped permission code. 
This is a follow-up to 656a42b55a003bdd5da9ea5cb5c07188d8264a5e and 8d01b0f3e9cb5d9f26fa914626738f5b2a0f8f80.

# Test Plan

- NCL ✅