### PR TITLE
[ENG-7204][docs] update CocoaPods Cache server documentation

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -76,7 +76,7 @@ Additionally, EAS Build runs a CocoaPods cache server that can speed up download
 
 The cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions that our cache server can't handle. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin. These are fetched directly from the CDN instead of being fetched through our cache server.
 
-This is expermiental feature which requires explicit opt-in. You can **enable** it by setting `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+This is an expermiental feature that requires explicit opt-in. You can **enable** it by setting the `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -95,7 +95,7 @@ This is expermiental feature which requires explicit opt-in. You can **enable** 
 }
 ```
 
-To explicitly disable using our CocoaPods cache server for your builds set `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"0"` in **eas.json**.
+To explicitly disable using our CocoaPods cache server for your builds, set the `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"0"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -72,7 +72,7 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 
 EAS Build caches the **Podfile.lock** file by default. This provides consistent results across managed app builds.
 
-Additionally, EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
+Additionally, EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs in most cases. It also makes the service more resilient to CocoaPods CDN outages.
 
 The cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions that our cache server can't handle. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin. These are fetched directly from the CDN instead of being fetched through our cache server.
 

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -70,13 +70,13 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 
 ## iOS dependencies
 
-EAS Build by default cache **Podfile.lock** file to provide consistent results across managed app builds.
+EAS Build caches the **Podfile.lock** file by default. This provides consistent results across managed app builds.
 
-Additionally EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
+Additionally, EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-Cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
+The cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions that our cache server can't handle. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin. These are fetched directly from the CDN instead of being fetched through our cache server.
 
-This is expermiental feature which requires explicit opt-in and can be **enabled** by setting `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+This is expermiental feature which requires explicit opt-in. You can **enable** it by setting `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -95,7 +95,7 @@ This is expermiental feature which requires explicit opt-in and can be **enabled
 }
 ```
 
-To explicitly disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+To explicitly disable using our CocoaPods cache server for your builds set `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"0"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -103,7 +103,7 @@ To explicitly disable using our CocoaPods cache server for your builds set `EAS_
   "build": {
     "production": {
       "env": {
-        "EAS_BUILD_DISABLE_COCOAPODS_CACHE": "1"
+        "EAS_BUILD_ENABLE_COCOAPODS_CACHE": "0"
         /* @hide ... */ /* @end */
       }
       /* @hide ... */ /* @end */

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -70,13 +70,32 @@ To disable using our Maven cache server for your builds set `EAS_BUILD_DISABLE_M
 
 ## iOS dependencies
 
-EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
+EAS Build by default cache **Podfile.lock** file to provide consistent results across managed app builds.
 
-Currently, EAS Build is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
+Additionally EAS Build runs a CocoaPods cache server that can speed up downloading iOS dependencies for your build jobs. It also makes the service more resilient to CocoaPods CDN outages.
 
-We also cache **Podfile.lock** to provide consistent results across managed app builds.
+Cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions which can't be handled by our cache server. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin and are fetched directly from CDN instead of being fetched through our cache server.
 
-To disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+This is expermiental feature which requires explicit opt-in and can be **enabled** by setting `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+
+{/* prettier-ignore */}
+```json eas.json
+{
+  "build": {
+    "production": {
+      "env": {
+        "EAS_BUILD_ENABLE_COCOAPODS_CACHE": "1"
+        /* @hide ... */ /* @end */
+      }
+      /* @hide ... */ /* @end */
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+To explicitly disable using our CocoaPods cache server for your builds set `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -76,7 +76,7 @@ Additionally, EAS Build runs a CocoaPods cache server that can speed up download
 
 The cache server is configured to cache almost all the pods served from the official CocoaPods CDN, minus a few exceptions that our cache server can't handle. These exceptions can be found on the [blacklist](https://github.com/expo/eas-build/blob/main/packages/cocoapods-nexus-plugin/lib/cocoapods_plugin.rb#L4) of our custom CocoaPods plugin. These are fetched directly from the CDN instead of being fetched through our cache server.
 
-This is an expermiental feature that requires explicit opt-in. You can **enable** it by setting the `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+This is an experimental feature that requires explicit opt-in. You can **enable** it by setting the `EAS_BUILD_ENABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7204/update-ios-dependencies-caching-docs-to-indicate-newish-opt-in

# How

Update iOS dependencies caching docs to indicate newish opt-in behavior of CocoaPods cache

# Test Plan

Test locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
