### PR TITLE
Upgrade `@react-native-community/datetimepicker@6.5.2` ➡️ `@react-native-community/datetimepicker@6.7.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `@react-native-community/slider` from `4.2.4` to `4.4.1`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))
-||||||| parent of 191cab1e3c (Add missing changelog entry)
 - Updated `@react-native-community/datetimepicker` from `6.5.2` to `6.7.3`. ([#20926](https://github.com/expo/expo/pull/20926) by [@byCedric](https://github.com/byCedric))
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `@react-native-community/slider` from `4.2.4` to `4.4.1`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))
+||||||| parent of 191cab1e3c (Add missing changelog entry)
+- Updated `@react-native-community/datetimepicker` from `6.5.2` to `6.7.3`. ([#20926](https://github.com/expo/expo/pull/20926) by [@byCedric](https://github.com/byCedric))
 
 ### 🛠 Breaking changes
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/Common.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/Common.java
@@ -1,12 +1,33 @@
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.util.TypedValue;
+import android.widget.Button;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
 import com.facebook.react.bridge.Promise;
 
+import java.util.Locale;
+
 public class Common {
+
+  public static final String POSITIVE = "positive";
+  public static final String NEUTRAL = "neutral";
+  public static final String NEGATIVE = "negative";
+  public static final String LABEL = "label";
+  public static final String TEXT_COLOR = "textColor";
 
   public static void dismissDialog(FragmentActivity activity, String fragmentTag, Promise promise) {
     if (activity == null) {
@@ -29,5 +50,93 @@ public class Common {
     } catch (Exception e) {
       promise.reject(e);
     }
+  }
+
+	public static int getDefaultDialogButtonTextColor(@NonNull Context activity) {
+		TypedValue typedValue = new TypedValue();
+		Resources.Theme theme = activity.getTheme();
+		theme.resolveAttribute(android.R.attr.textColorPrimary, typedValue, true);
+		@ColorRes int colorRes = (typedValue.resourceId != 0) ? typedValue.resourceId : typedValue.data;
+		@ColorInt int colorId = ContextCompat.getColor(activity, colorRes);
+		return colorId;
+	}
+
+	@NonNull
+	public static DialogInterface.OnShowListener setButtonTextColor(@NonNull Context activityContext, final AlertDialog dialog, final Bundle args, final boolean needsColorOverride) {
+    return new DialogInterface.OnShowListener() {
+      @Override
+      public void onShow(DialogInterface dialogInterface) {
+        // change text color only if custom color is set or if spinner mode is set
+        // because spinner suffers from https://github.com/react-native-datetimepicker/datetimepicker/issues/543
+
+        Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+        Button negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE);
+        Button neutralButton = dialog.getButton(AlertDialog.BUTTON_NEUTRAL);
+
+        int textColorPrimary = getDefaultDialogButtonTextColor(activityContext);
+        setTextColor(positiveButton, POSITIVE, args, needsColorOverride, textColorPrimary);
+        setTextColor(negativeButton, NEGATIVE, args, needsColorOverride, textColorPrimary);
+        setTextColor(neutralButton, NEUTRAL, args, needsColorOverride, textColorPrimary);
+      }
+    };
+	}
+
+  private static void setTextColor(Button button, String buttonKey, final Bundle args, final boolean needsColorOverride, int textColorPrimary) {
+    if (button == null) return;
+
+    Integer color = getButtonColor(args, buttonKey);
+    if (needsColorOverride || color != null) {
+      button.setTextColor(color != null ? color : textColorPrimary);
+    }
+  }
+
+  private static Integer getButtonColor(final Bundle args, String buttonKey) {
+    Bundle buttons = args.getBundle(RNConstants.ARG_DIALOG_BUTTONS);
+    if (buttons == null) {
+      return null;
+    }
+    Bundle buttonParams = buttons.getBundle(buttonKey);
+    if (buttonParams == null) {
+      return null;
+    }
+    // yes, this cast is safe. the color is passed as int from JS (RN.processColor)
+    int color = (int) buttonParams.getDouble(TEXT_COLOR, Color.TRANSPARENT);
+    if (color == Color.TRANSPARENT) {
+      return null;
+    }
+    return color;
+  }
+
+  public static RNTimePickerDisplay getDisplayTime(Bundle args) {
+    RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+    return display;
+  }
+
+  public static RNDatePickerDisplay getDisplayDate(Bundle args) {
+    RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
+    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
+      display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
+    }
+    return display;
+  }
+
+  public static void setButtonTitles(@NonNull Bundle args, AlertDialog dialog, DialogInterface.OnClickListener onNeutralButtonActionListener) {
+    Bundle buttons = args.getBundle(RNConstants.ARG_DIALOG_BUTTONS);
+    if (buttons == null) {
+      return;
+    }
+    setButtonLabel(buttons.getBundle(NEUTRAL), dialog, AlertDialog.BUTTON_NEUTRAL, onNeutralButtonActionListener);
+    setButtonLabel(buttons.getBundle(POSITIVE), dialog, AlertDialog.BUTTON_POSITIVE, (DialogInterface.OnClickListener) dialog);
+    setButtonLabel(buttons.getBundle(NEGATIVE), dialog, AlertDialog.BUTTON_NEGATIVE, (DialogInterface.OnClickListener) dialog);
+  }
+
+  private static void setButtonLabel(Bundle buttonConfig, AlertDialog dialog, int whichButton, DialogInterface.OnClickListener listener) {
+    if (buttonConfig == null || buttonConfig.getString(LABEL) == null) {
+      return;
+    }
+    dialog.setButton(whichButton, buttonConfig.getString(LABEL), listener);
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/KeepDateInRangeListener.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/KeepDateInRangeListener.java
@@ -1,0 +1,65 @@
+package versioned.host.exp.exponent.modules.api.components.datetimepicker;
+
+import android.os.Bundle;
+import android.widget.DatePicker;
+
+import androidx.annotation.NonNull;
+
+import java.util.Calendar;
+
+// fix for https://issuetracker.google.com/issues/169602180
+// TODO revisit day, month, year with timezoneoffset fixes
+public class KeepDateInRangeListener implements DatePicker.OnDateChangedListener {
+
+  private final Bundle args;
+
+  public KeepDateInRangeListener(@NonNull Bundle args) {
+    this.args = args;
+  }
+
+  @Override
+  public void onDateChanged(DatePicker view, int year, int month, int day) {
+    fixPotentialMaxDateBug(view, year, month, day);
+    fixPotentialMinDateBug(view, year, month, day);
+  }
+
+  private void fixPotentialMaxDateBug(DatePicker datePicker, int year, int month, int day) {
+    if (!isDateAfterMaxDate(args, year, month, day)) {
+      return;
+    }
+    Calendar maxDate = Calendar.getInstance();
+    maxDate.setTimeInMillis(args.getLong(RNConstants.ARG_MAXDATE));
+    datePicker.updateDate(maxDate.get(Calendar.YEAR), maxDate.get(Calendar.MONTH), maxDate.get(Calendar.DAY_OF_MONTH));
+  }
+
+  private void fixPotentialMinDateBug(DatePicker datePicker, int year, int month, int day) {
+    if (!isDateBeforeMinDate(args, year, month, day)) {
+      return;
+    }
+    Calendar c = Calendar.getInstance();
+    c.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+    datePicker.updateDate(c.get(Calendar.YEAR), c.get(Calendar.MONTH), c.get(Calendar.DAY_OF_MONTH));
+  }
+
+  public static boolean isDateAfterMaxDate(Bundle args, int year, int month, int day) {
+    if (!args.containsKey(RNConstants.ARG_MAXDATE)) {
+      return false;
+    }
+    Calendar maxDate = Calendar.getInstance();
+    maxDate.setTimeInMillis(args.getLong(RNConstants.ARG_MAXDATE));
+    return (year > maxDate.get(Calendar.YEAR) ||
+      (year == maxDate.get(Calendar.YEAR) && month > maxDate.get(Calendar.MONTH)) ||
+      (year == maxDate.get(Calendar.YEAR) && month == maxDate.get(Calendar.MONTH) && day > maxDate.get(Calendar.DAY_OF_MONTH)));
+  }
+
+  public static boolean isDateBeforeMinDate(Bundle args, int year, int month, int day) {
+    if (!args.containsKey(RNConstants.ARG_MINDATE)) {
+      return false;
+    }
+    Calendar minDate = Calendar.getInstance();
+    minDate.setTimeInMillis(args.getLong(RNConstants.ARG_MINDATE));
+    return (year < minDate.get(Calendar.YEAR) ||
+      (year == minDate.get(Calendar.YEAR) && month < minDate.get(Calendar.MONTH)) ||
+      (year == minDate.get(Calendar.YEAR) && month == minDate.get(Calendar.MONTH) && day < minDate.get(Calendar.DAY_OF_MONTH)));
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
@@ -34,7 +34,6 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
             RNTimePickerDisplay display
     ) {
         super(context, listener, hourOfDay, minute, is24HourView);
-		setCanceledOnTouchOutside(true);
         mTimePickerInterval = minuteInterval;
         mTimeSetListener = listener;
         mDisplay = display;
@@ -52,7 +51,6 @@ class MinuteIntervalSnappableTimePickerDialog extends TimePickerDialog {
             RNTimePickerDisplay display
     ) {
         super(context, theme, listener, hourOfDay, minute, is24HourView);
-		setCanceledOnTouchOutside(true);
         mTimePickerInterval = minuteInterval;
         mTimeSetListener = listener;
         mDisplay = display;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
@@ -1,5 +1,7 @@
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import android.app.TimePickerDialog;
+
 public final class RNConstants {
   public static final String ERROR_NO_ACTIVITY = "E_NO_ACTIVITY";
   public static final String ARG_VALUE = "value";
@@ -8,9 +10,7 @@ public final class RNConstants {
   public static final String ARG_INTERVAL = "minuteInterval";
   public static final String ARG_IS24HOUR = "is24Hour";
   public static final String ARG_DISPLAY = "display";
-  public static final String ARG_NEUTRAL_BUTTON_LABEL = "neutralButtonLabel";
-  public static final String ARG_POSITIVE_BUTTON_LABEL = "positiveButtonLabel";
-  public static final String ARG_NEGATIVE_BUTTON_LABEL = "negativeButtonLabel";
+  public static final String ARG_DIALOG_BUTTONS = "dialogButtons";
   public static final String ARG_TZOFFSET_MINS = "timeZoneOffsetInMinutes";
   public static final String ACTION_DATE_SET = "dateSetAction";
   public static final String ACTION_TIME_SET = "timeSetAction";
@@ -18,7 +18,7 @@ public final class RNConstants {
   public static final String ACTION_NEUTRAL_BUTTON = "neutralButtonAction";
 
   /**
-   * Minimum date supported by {@link DatePicker}, 01 Jan 1900
+   * Minimum date supported by {@link TimePickerDialog}, 01 Jan 1900
    */
   public static final long DEFAULT_MIN_DATE = -2208988800001l;
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,7 +7,9 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.getDisplayDate;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTextColor;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTitles;
 
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
@@ -38,12 +40,13 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   @Nullable
   private OnDismissListener mOnDismissListener;
   @Nullable
-  private static OnClickListener mOnNeutralButtonActionListener;
+  private OnClickListener mOnNeutralButtonActionListener;
 
+  @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     Bundle args = getArguments();
-    instance = createDialog(args, getActivity(), mOnDateSetListener);
+    instance = createDialog(args);
     return instance;
   }
 
@@ -57,62 +60,51 @@ public class RNDatePickerDialogFragment extends DialogFragment {
           Bundle args,
           Context activityContext,
           @Nullable OnDateSetListener onDateSetListener) {
-
     final RNDate date = new RNDate(args);
     final int year = date.year();
     final int month = date.month();
     final int day = date.day();
 
-    RNDatePickerDisplay display = RNDatePickerDisplay.DEFAULT;
+    RNDatePickerDisplay display = getDisplayDate(args);
 
     if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
       display = RNDatePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
     }
 
-    switch (display) {
-      case CALENDAR:
-      case SPINNER:
-        int theme = display == RNDatePickerDisplay.CALENDAR
-                ? R.style.CalendarDatePickerDialog
-                : R.style.SpinnerDatePickerDialog;
-        return new RNDismissableDatePickerDialog(
-                activityContext,
-                theme,
-                onDateSetListener,
-                year,
-                month,
-                day,
-                display
-        );
-      default:
-        return new RNDismissableDatePickerDialog(
-                activityContext,
-                onDateSetListener,
-                year,
-                month,
-                day,
-                display
-        );
+    if (display == RNDatePickerDisplay.SPINNER) {
+      return new RNDismissableDatePickerDialog(
+        activityContext,
+        R.style.SpinnerDatePickerDialog,
+        onDateSetListener,
+        year,
+        month,
+        day,
+        display
+      );
     }
+    return new RNDismissableDatePickerDialog(
+      activityContext,
+      onDateSetListener,
+      year,
+      month,
+      day,
+      display
+    );
   }
 
-  static DatePickerDialog createDialog(
-          Bundle args,
-          Context activityContext,
-          @Nullable OnDateSetListener onDateSetListener) {
-
+  private DatePickerDialog createDialog(Bundle args) {
+    Context activityContext = getActivity();
     final Calendar c = Calendar.getInstance();
 
-    DatePickerDialog dialog = getDialog(args, activityContext, onDateSetListener);
+    DatePickerDialog dialog = getDialog(args, activityContext, mOnDateSetListener);
 
-    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+    if (args != null) {
+      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+      if (activityContext != null) {
+        RNDatePickerDisplay display = getDisplayDate(args);
+        boolean needsColorOverride = display == RNDatePickerDisplay.SPINNER;
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
+      }
     }
 
     final DatePicker datePicker = dialog.getDatePicker();
@@ -147,6 +139,11 @@ public class RNDatePickerDialogFragment extends DialogFragment {
       datePicker.setMaxDate(c.getTimeInMillis() - getOffset(c, timeZoneOffsetInMilliseconds));
     }
 
+    if (args != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+      && (args.containsKey(RNConstants.ARG_MAXDATE) || args.containsKey(RNConstants.ARG_MINDATE))) {
+      datePicker.setOnDateChangedListener(new KeepDateInRangeListener(args));
+    }
+
     return dialog;
   }
 
@@ -168,7 +165,7 @@ public class RNDatePickerDialogFragment extends DialogFragment {
   }
 
   @Override
-  public void onDismiss(DialogInterface dialog) {
+  public void onDismiss(@NonNull DialogInterface dialog) {
     super.onDismiss(dialog);
     if (mOnDismissListener != null) {
       mOnDismissListener.onDismiss(dialog);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
@@ -7,6 +7,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.getDisplayDate;
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTextColor;
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTitles;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
@@ -14,7 +14,6 @@ import android.content.DialogInterface.OnClickListener;
 import android.os.Bundle;
 import android.widget.DatePicker;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
@@ -23,6 +22,10 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.dismissDialog;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.KeepDateInRangeListener.isDateAfterMaxDate;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.KeepDateInRangeListener.isDateBeforeMinDate;
+
+import java.util.Calendar;
 
 /**
  * {@link NativeModule} that allows JS to show a native date picker dialog and get called back when
@@ -46,10 +49,12 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
   private class DatePickerDialogListener implements OnDateSetListener, OnDismissListener, OnClickListener {
 
     private final Promise mPromise;
+    private final Bundle mArgs;
     private boolean mPromiseResolved = false;
 
-    public DatePickerDialogListener(final Promise promise) {
+    public DatePickerDialogListener(final Promise promise, Bundle arguments) {
       mPromise = promise;
+      mArgs = arguments;
     }
 
     @Override
@@ -60,6 +65,27 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
         result.putInt("year", year);
         result.putInt("month", month);
         result.putInt("day", day);
+
+        // https://issuetracker.google.com/issues/169602180
+        // TODO revisit day, month, year with timezoneoffset fixes
+        if (isDateAfterMaxDate(mArgs, year, month, day)) {
+          Calendar maxDate = Calendar.getInstance();
+          maxDate.setTimeInMillis(mArgs.getLong(RNConstants.ARG_MAXDATE));
+
+          result.putInt("year", maxDate.get(Calendar.YEAR));
+          result.putInt("month", maxDate.get(Calendar.MONTH) );
+          result.putInt("day", maxDate.get(Calendar.DAY_OF_MONTH));
+        }
+
+        if (isDateBeforeMinDate(mArgs, year, month, day)) {
+          Calendar minDate = Calendar.getInstance();
+          minDate.setTimeInMillis(mArgs.getLong(RNConstants.ARG_MINDATE));
+
+          result.putInt("year", minDate.get(Calendar.YEAR));
+          result.putInt("month", minDate.get(Calendar.MONTH) );
+          result.putInt("day", minDate.get(Calendar.DAY_OF_MONTH));
+        }
+
         mPromise.resolve(result);
         mPromiseResolved = true;
       }
@@ -117,7 +143,7 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
    *                dismiss, year, month and date are undefined.
    */
   @ReactMethod
-  public void open(@Nullable final ReadableMap options, final Promise promise) {
+  public void open(final ReadableMap options, final Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
@@ -134,18 +160,16 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
         RNDatePickerDialogFragment oldFragment =
                 (RNDatePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
 
-        if (oldFragment != null && options != null) {
+        if (oldFragment != null) {
           oldFragment.update(createFragmentArguments(options));
           return;
         }
 
         RNDatePickerDialogFragment fragment = new RNDatePickerDialogFragment();
 
-        if (options != null) {
-          fragment.setArguments(createFragmentArguments(options));
-        }
+        fragment.setArguments(createFragmentArguments(options));
 
-        final DatePickerDialogListener listener = new DatePickerDialogListener(promise);
+        final DatePickerDialogListener listener = new DatePickerDialogListener(promise, createFragmentArguments(options));
         fragment.setOnDismissListener(listener);
         fragment.setOnDateSetListener(listener);
         fragment.setOnNeutralButtonActionListener(listener);
@@ -168,14 +192,8 @@ public class RNDatePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
     }
-    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
     }
     if (options.hasKey(RNConstants.ARG_TZOFFSET_MINS) && !options.isNull(RNConstants.ARG_TZOFFSET_MINS)) {
       args.putLong(RNConstants.ARG_TZOFFSET_MINS, (long) options.getDouble(RNConstants.ARG_TZOFFSET_MINS));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
@@ -11,7 +11,6 @@ package versioned.host.exp.exponent.modules.api.components.datetimepicker;
  * Date picker display options.
  */
 public enum RNDatePickerDisplay {
-  CALENDAR,
   SPINNER,
   DEFAULT
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
@@ -40,7 +40,6 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int dayOfMonth,
       RNDatePickerDisplay display) {
     super(context, callback, year, monthOfYear, dayOfMonth);
-	setCanceledOnTouchOutside(true);
     fixSpinner(context, year, monthOfYear, dayOfMonth, display);
   }
 
@@ -53,7 +52,6 @@ public class RNDismissableDatePickerDialog extends DatePickerDialog {
       int dayOfMonth,
       RNDatePickerDisplay display) {
     super(context, theme, callback, year, monthOfYear, dayOfMonth);
-	setCanceledOnTouchOutside(true);
     fixSpinner(context, year, monthOfYear, dayOfMonth, display);
   }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,6 +8,8 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
+import host.exp.expoview.R;
+
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.getDisplayTime;
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTextColor;
 import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTitles;

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
@@ -8,7 +8,9 @@
 
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
-import host.exp.expoview.R;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.getDisplayTime;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTextColor;
+import static versioned.host.exp.exponent.modules.api.components.datetimepicker.Common.setButtonTitles;
 
 import android.app.Dialog;
 import android.app.TimePickerDialog;
@@ -24,8 +26,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
-import java.util.Locale;
-
 @SuppressWarnings("ValidFragment")
 public class RNTimePickerDialogFragment extends DialogFragment {
   private TimePickerDialog instance;
@@ -35,13 +35,13 @@ public class RNTimePickerDialogFragment extends DialogFragment {
   @Nullable
   private OnDismissListener mOnDismissListener;
   @Nullable
-  private static OnClickListener mOnNeutralButtonActionListener;
+  private OnClickListener mOnNeutralButtonActionListener;
 
   @NonNull
   @Override
   public Dialog onCreateDialog(Bundle savedInstanceState) {
     final Bundle args = getArguments();
-    instance = createDialog(args, getActivity(), mOnTimeSetListener);
+    instance = createDialog(args);
     return instance;
   }
 
@@ -59,28 +59,21 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     final int hour = date.hour();
     final int minute = date.minute();
     boolean is24hour = DateFormat.is24HourFormat(activityContext);
+    if (args != null) {
+      is24hour = args.getBoolean(RNConstants.ARG_IS24HOUR, DateFormat.is24HourFormat(activityContext));
+    }
 
     int minuteInterval = RNConstants.DEFAULT_TIME_PICKER_INTERVAL;
     if (args != null && MinuteIntervalSnappableTimePickerDialog.isValidMinuteInterval(args.getInt(RNConstants.ARG_INTERVAL))) {
       minuteInterval = args.getInt(RNConstants.ARG_INTERVAL);
     }
 
-    RNTimePickerDisplay display = RNTimePickerDisplay.DEFAULT;
-    if (args != null && args.getString(RNConstants.ARG_DISPLAY, null) != null) {
-      display = RNTimePickerDisplay.valueOf(args.getString(RNConstants.ARG_DISPLAY).toUpperCase(Locale.US));
-    }
+    RNTimePickerDisplay display = getDisplayTime(args);
 
-    if (args != null) {
-      is24hour = args.getBoolean(RNConstants.ARG_IS24HOUR, DateFormat.is24HourFormat(activityContext));
-    }
-
-    if (display == RNTimePickerDisplay.CLOCK || display == RNTimePickerDisplay.SPINNER) {
-        int theme = display == RNTimePickerDisplay.CLOCK
-              ? R.style.ClockTimePickerDialog
-              : R.style.SpinnerTimePickerDialog;
+    if (display == RNTimePickerDisplay.SPINNER) {
         return new RNDismissableTimePickerDialog(
                 activityContext,
-                theme,
+				R.style.SpinnerTimePickerDialog,
                 onTimeSetListener,
                 hour,
                 minute,
@@ -100,20 +93,17 @@ public class RNTimePickerDialogFragment extends DialogFragment {
     );
   }
 
-  static TimePickerDialog createDialog(
-          Bundle args, Context activityContext,
-          @Nullable OnTimeSetListener onTimeSetListener) {
+  private TimePickerDialog createDialog(Bundle args) {
+    Context activityContext = getActivity();
+    TimePickerDialog dialog = getDialog(args, activityContext, mOnTimeSetListener);
 
-    TimePickerDialog dialog = getDialog(args, activityContext, onTimeSetListener);
-
-    if (args != null && args.containsKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEUTRAL, args.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL), mOnNeutralButtonActionListener);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_POSITIVE, args.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL), dialog);
-    }
-    if (args != null && args.containsKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      dialog.setButton(DialogInterface.BUTTON_NEGATIVE, args.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL), dialog);
+    if (args != null) {
+      setButtonTitles(args, dialog, mOnNeutralButtonActionListener);
+      if (activityContext != null) {
+        RNTimePickerDisplay display = getDisplayTime(args);
+        boolean needsColorOverride = display == RNTimePickerDisplay.SPINNER;
+        dialog.setOnShowListener(setButtonTextColor(activityContext, dialog, args, needsColorOverride));
+      }
     }
     return dialog;
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
@@ -20,7 +20,6 @@ import android.os.Bundle;
 import android.widget.TimePicker;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
@@ -94,8 +93,7 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void open(@Nullable final ReadableMap options, final Promise promise) {
-
+  public void open(final ReadableMap options, final Promise promise) {
     FragmentActivity activity = (FragmentActivity) getCurrentActivity();
     if (activity == null) {
       promise.reject(
@@ -113,16 +111,14 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
         RNTimePickerDialogFragment oldFragment =
                 (RNTimePickerDialogFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG);
 
-        if (oldFragment != null && options != null) {
+        if (oldFragment != null) {
           oldFragment.update(createFragmentArguments(options));
           return;
         }
 
         RNTimePickerDialogFragment fragment = new RNTimePickerDialogFragment();
 
-        if (options != null) {
-          fragment.setArguments(createFragmentArguments(options));
-        }
+        fragment.setArguments(createFragmentArguments(options));
 
         final TimePickerDialogListener listener = new TimePickerDialogListener(promise);
         fragment.setOnDismissListener(listener);
@@ -144,14 +140,8 @@ public class RNTimePickerDialogModule extends ReactContextBaseJavaModule {
     if (options.hasKey(RNConstants.ARG_DISPLAY) && !options.isNull(RNConstants.ARG_DISPLAY)) {
       args.putString(RNConstants.ARG_DISPLAY, options.getString(RNConstants.ARG_DISPLAY));
     }
-    if (options.hasKey(RNConstants.ARG_NEUTRAL_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEUTRAL_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL, options.getString(RNConstants.ARG_NEUTRAL_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_POSITIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_POSITIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_POSITIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_POSITIVE_BUTTON_LABEL));
-    }
-    if (options.hasKey(RNConstants.ARG_NEGATIVE_BUTTON_LABEL) && !options.isNull(RNConstants.ARG_NEGATIVE_BUTTON_LABEL)) {
-      args.putString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL, options.getString(RNConstants.ARG_NEGATIVE_BUTTON_LABEL));
+    if (options.hasKey(RNConstants.ARG_DIALOG_BUTTONS) && !options.isNull(RNConstants.ARG_DIALOG_BUTTONS)) {
+      args.putBundle(RNConstants.ARG_DIALOG_BUTTONS, Arguments.toBundle(options.getMap(RNConstants.ARG_DIALOG_BUTTONS)));
     }
     if (options.hasKey(RNConstants.ARG_INTERVAL) && !options.isNull(RNConstants.ARG_INTERVAL)) {
       args.putInt(RNConstants.ARG_INTERVAL, options.getInt(RNConstants.ARG_INTERVAL));

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
@@ -12,7 +12,6 @@ package versioned.host.exp.exponent.modules.api.components.datetimepicker;
  * Date picker display options.
  */
 public enum RNTimePickerDisplay {
-  CLOCK,
   SPINNER,
   DEFAULT
 }

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@babel/runtime": "^7.14.0",
     "@react-native-async-storage/async-storage": "1.17.11",
-    "@react-native-community/datetimepicker": "6.5.2",
+    "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-community/slider": "4.4.1",
     "@react-native-masked-view/masked-view": "0.2.8",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "1.17.11",
-    "@react-native-community/datetimepicker": "6.5.2",
+    "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-community/slider": "4.4.1",
     "@react-native-masked-view/masked-view": "0.2.8",

--- a/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
+++ b/apps/native-component-list/src/screens/DateTimePickerScreen.tsx
@@ -57,8 +57,8 @@ const MODE_VALUES = Platform.select({
 })! as ['date', 'time', 'datetime', 'countdown'];
 const DISPLAY_VALUES = Platform.select({
   ios: ['default', 'spinner', 'compact', 'inline'],
-  android: ['default', 'spinner', 'clock', 'calendar'],
-})! as ['default', 'spinner', 'clock', 'calendar'];
+  android: ['default', 'spinner'],
+})! as ['default', 'spinner'];
 const MINUTE_INTERVALS = [1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30];
 
 // This example is a refactored copy from https://github.com/react-native-community/react-native-datetimepicker/tree/master/example
@@ -68,17 +68,16 @@ const DateTimePickerScreen = () => {
   // Sat, 13 Nov 2021 10:00:00 GMT (local: Saturday, November 13, 2021 11:00:00 AM GMT+01:00)
   const sourceMoment = moment.unix(1636797600);
   const sourceDate = sourceMoment.local().toDate();
-  const [show, setShow] = useState(true);
+  const [show, setShow] = useState(false);
   const [date, setDate] = useState<Date>(sourceDate);
   const [mode, setMode] = useState<'date' | 'time' | 'datetime' | 'countdown'>(MODE_VALUES[0]);
   const [textColor, setTextColor] = useState<string | undefined>();
   const [accentColor, setAccentColor] = useState<string | undefined>();
-  const [display, setDisplay] = useState<'default' | 'spinner' | 'clock' | 'calendar'>(
-    DISPLAY_VALUES[0]
-  );
+  const [display, setDisplay] = useState<'default' | 'spinner'>(DISPLAY_VALUES[0]);
   const [interval, setMinInterval] = useState(1);
   const [neutralButtonLabel, setNeutralButtonLabel] = useState<string | undefined>();
   const [disabled, setDisabled] = useState(false);
+  const [neutralButtonPressed, setNeutralButtonPressed] = useState<boolean>(false);
 
   const scrollRef = useRef<ScrollView>(null);
 
@@ -88,8 +87,10 @@ const DateTimePickerScreen = () => {
     }
     const currentDate = selectedDate || date;
     if (event.type === 'neutralButtonPressed') {
-      setDate(new Date(0));
+      setNeutralButtonPressed(true);
+      setDate(new Date());
     } else {
+      setNeutralButtonPressed(false);
       setDate(currentDate);
     }
   };
@@ -175,22 +176,15 @@ const DateTimePickerScreen = () => {
             </>
           )}
           {Platform.OS === 'android' && (
-            <>
-              <View style={styles.header}>
-                <ThemedText style={styles.textLabel}>neutralButtonLabel (android only)</ThemedText>
-                <ThemedTextInput
-                  value={neutralButtonLabel}
-                  onChangeText={setNeutralButtonLabel}
-                  placeholder="neutralButtonLabel"
-                  testID="neutralButtonLabelTextInput"
-                />
-              </View>
-              <View style={styles.header}>
-                <ThemedText style={styles.textLabel}>
-                  [android] show and dismiss picker after 3 secs
-                </ThemedText>
-              </View>
-            </>
+            <View style={styles.header}>
+              <ThemedText style={styles.textLabel}>neutralButtonLabel (android only)</ThemedText>
+              <ThemedTextInput
+                value={neutralButtonLabel}
+                onChangeText={setNeutralButtonLabel}
+                placeholder="neutralButtonLabel"
+                testID="neutralButtonLabelTextInput"
+              />
+            </View>
           )}
           <View style={[styles.button, { flexDirection: 'row', justifyContent: 'space-around' }]}>
             <Button
@@ -202,10 +196,23 @@ const DateTimePickerScreen = () => {
             />
             <Button testID="hidePicker" onPress={() => setShow(false)} title="Hide picker!" />
           </View>
-          <View style={[styles.header, { flexDirection: 'row', justifyContent: 'space-around' }]}>
+          <View
+            style={[
+              styles.header,
+              {
+                flexDirection: 'column',
+                justifyContent: 'space-around',
+                alignContent: 'space-around',
+              },
+            ]}>
             <ThemedText testID="dateText" style={styles.dateTimeText}>
               {moment(date).format('MM/DD/YYYY  HH:mm')}
             </ThemedText>
+            {neutralButtonPressed && (
+              <ThemedText testID="neutralButtonPressed" style={styles.dateTimeText}>
+                Neutral button was pressed, date changed to now.
+              </ThemedText>
+            )}
           </View>
           {show && (
             <DateTimePicker
@@ -219,7 +226,9 @@ const DateTimePickerScreen = () => {
               style={styles.iOsPicker}
               textColor={textColor || undefined}
               accentColor={accentColor || undefined}
-              neutralButtonLabel={neutralButtonLabel}
+              neutralButton={
+                neutralButtonLabel ? { label: neutralButtonLabel, textColor: 'grey' } : undefined
+              }
               disabled={disabled}
             />
           )}

--- a/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
+++ b/ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m
@@ -43,7 +43,8 @@ static YGSize RNDateTimePickerShadowViewMeasure(YGNodeRef node, float width, YGM
     if (@available(iOS 14.0, *)) {
       [shadowPickerView.picker setPreferredDatePickerStyle:shadowPickerView.displayIOS];
     }
-    size = [shadowPickerView.picker sizeThatFits:UILayoutFittingCompressedSize];
+	size = [shadowPickerView.picker sizeThatFits:UILayoutFittingCompressedSize];
+	size.width += 10;
   });
   
   return (YGSize){

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^13.0.0",
   "@react-native-async-storage/async-storage": "1.17.11",
-  "@react-native-community/datetimepicker": "6.5.2",
+  "@react-native-community/datetimepicker": "6.7.3",
   "@react-native-masked-view/masked-view": "0.2.8",
   "@react-native-community/netinfo": "9.3.7",
   "@react-native-community/slider": "4.4.1",


### PR DESCRIPTION
# Why

Fixes ENG-7318

# How

Ran `et update-vendored-module --module @react-native-community/datetimepicker --target expo-go --commit 5d174d097d2821911b73b5e308520f9e028b8348`

<details><summary>See log output</summary>

```bash
📥 Cloning @react-native-community/datetimepicker#5d174d097d2821911b73b5e308520f9e028b8348 from https://github.com/react-native-community/react-native-datetimepicker.git
‼️  Using legacy vendoring for platform ios
NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

Cleaning up iOS files at Exponent/Versioned/Core/Api/Components/DateTimePicker ...

Copying iOS files ...
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePicker.m
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerManager.m
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.h
> ios/Exponent/Versioned/Core/Api/Components/DateTimePicker/RNDateTimePickerShadowView.m

Updating pbxproj configuration ...
Saving updated pbxproj structure to the file Exponent.xcodeproj/project.pbxproj ...

Successfully updated iOS files, but please make sure Xcode project files are setup correctly in Exponent/Versioned/Core/Api/Components/DateTimePicker
‼️  Using legacy vendoring for platform android
NOTE: In Expo, native Android styles are prefixed with ReactAndroid. Please ensure that resourceNames used for grabbing style of dialogs are being resolved properly.

Cleaning up Android files at expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker ...

Copying Android files ...
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/Common.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/KeepDateInRangeListener.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/MinuteIntervalSnappableTimePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/ReflectionHelper.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNConstants.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDate.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogFragment.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDialogModule.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDatePickerDisplay.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableDatePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDismissableTimePickerDialog.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogFragment.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDialogModule.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNTimePickerDisplay.java
✍️  Updating bundled native modules
✍️  Updating workspace dependencies
💪 Successfully updated @react-native-community/datetimepicker
```

</details>

# Test Plan

## Android

After changing:
- Add 1global.setImmediate = function(){};` -> to fix reanimated issue
- Change `@shopify/flash-list` (vendored SDK 46 and 47 code) `androidx.annotation:annotation:+` to `androidx.annotation:annotation:1.2.0`

I managed to test the date time picker on Android. Dropped a few test features that weren't used, or are removed.
- The "open and hide dialog after 3 seconds" -> had no logic connected, was mostly confusing
- Dropped `clock` and `calendar` (which is `default` now) enums.
- Updated `neutralButtonLabel` -> `neutralButton`

## iOS

> **Warning**
> Testing on iOS is currently blocked by building issues.

<details><summary>Build errors</summary>

![image](https://user-images.githubusercontent.com/1203991/215162429-a4f57b50-5040-4321-9af7-8da21b6a2da5.png)

</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
