### PR TITLE
[go] Upgrade `@shopify/flash-list` to `1.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-community/slider` from `4.2.4` to `4.4.1`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))
 - Updated `@react-native-community/datetimepicker` from `6.5.2` to `6.7.3`. ([#20926](https://github.com/expo/expo/pull/20926) by [@byCedric](https://github.com/byCedric))
+- Updated `@shopify/flash-list` from `1.3.1` to `1.4.0`. ([#20927](https://github.com/expo/expo/pull/20927) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -655,7 +655,7 @@ PODS:
     - React-Core
   - RNDateTimePicker (6.7.3):
     - React-Core
-  - RNFlashList (1.3.1):
+  - RNFlashList (1.4.0):
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
@@ -1316,7 +1316,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDateTimePicker: 00247f26c34683c80be94207f488f6f13448586e
-  RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
+  RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: addc4900bf47882118d0a1b21747fa6705fa8cff
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -68,7 +68,7 @@
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",
-    "@shopify/flash-list": "1.3.1",
+    "@shopify/flash-list": "1.4.0",
     "expo": "~47.0.0-alpha.1",
     "expo-camera": "~13.0.0-beta.1",
     "expo-dev-client": "~2.0.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -54,7 +54,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@react-navigation/elements": "~1.3.6",
-    "@shopify/flash-list": "1.3.1",
+    "@shopify/flash-list": "1.4.0",
     "@shopify/react-native-skia": "0.1.171",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2094,7 +2094,7 @@ PODS:
     - React-perflogger (= 0.71.0)
   - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNFlashList (1.3.1):
+  - RNFlashList (1.4.0):
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
@@ -3639,7 +3639,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: ac80782d9d76ba2b0f709f4de0c427fe33c352dc
   ReactCommon: 20e38a9be5fe1341b5e422220877cc94034776ba
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
+  RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: 2757554a90c8eb038535bb1fce12c49cc027a934
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb

--- a/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
+++ b/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNFlashList",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "summary": "FlashList is a more performant FlatList replacement",
   "homepage": "https://shopify.github.io/flash-list/",
   "license": "MIT",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/flash-list.git",
-    "tag": "v1.3.1"
+    "tag": "v1.4.0"
   },
   "source_files": "ios/Sources/**/*",
   "requires_arc": true,

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -104,6 +104,6 @@
   "unimodules-app-loader": "~4.0.0",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.171",
-  "@shopify/flash-list": "1.3.1",
+  "@shopify/flash-list": "1.4.0",
   "@sentry/react-native": "4.9.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,12 +3210,12 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@shopify/flash-list@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.3.1.tgz#0bf5816028049a26fec09117ad70b761a8258a99"
-  integrity sha512-4Bse5zZ9xVRb7eU50kjK0nqKus5nXiqPNUcNKATI//rFvARxFqjhVDkaB18HKF9/8cxvtYgS4Rr9CUt1aZMMfQ==
+"@shopify/flash-list@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.4.0.tgz#cf299486ec9a7c97b7a8b1e8b6bf144a78141ed6"
+  integrity sha512-PvPOyk353LuETFnNA038+QaJsAFlCQ2TYC7DHP3YnYqTX72g2BM6qLoLsPaptXKuoXX+dinOo0MbEm7HDjTy1g==
   dependencies:
-    recyclerlistview "4.1.2"
+    recyclerlistview "4.2.0"
     tslib "2.4.0"
 
 "@shopify/react-native-skia@0.1.171":
@@ -16152,10 +16152,10 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
-recyclerlistview@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/recyclerlistview/-/recyclerlistview-4.1.2.tgz#3629c2faff13be3dc64bca82490e9a5efb2303aa"
-  integrity sha512-fvopyPoXaDY/RJGJKzroGYHgBAZoXlEdLw1D4PSi3isTRhyfbh0WNNuTyLfJSiz6ctZeb0J2ErPCInYcahFTlw==
+recyclerlistview@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/recyclerlistview/-/recyclerlistview-4.2.0.tgz#a140149aaa470c9787a1426452651934240d69ef"
+  integrity sha512-uuBCi0c+ggqHKwrzPX4Z/mJOzsBbjZEAwGGmlwpD/sD7raXixdAbdJ6BTcAmuWG50Cg4ru9p12M94Njwhr/27A==
   dependencies:
     lodash.debounce "4.0.8"
     prop-types "15.8.1"


### PR DESCRIPTION
# Why

Upgrades `@shopify/flash-list` to `1.4.0`
Closes ENG-7315.

# How

```
et update-vendored-module -m @shopify/flash-list -c 505eb70e7a885d48539ed89cb30aa48dbf81c57d
```

It was a simple upgrade because they didn't change anything in the native code. 

# Test Plan

- expo go with NCL ✅
