### PR TITLE
[ENG-7222][docs] add resource class related documentation for EAS Build

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -152,10 +152,10 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
-  - M1: 3.2GHz 8-Core M1, 16GB RAM [2020]
+  - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM [2020]
 - Build resources:
   - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM
-  - [`m1-medium`](eas-json/#resourceclass-2): 3 cores, 8 GB RAM
+  - [`m1-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -29,7 +29,7 @@ When selecting an image for the build you can use the full name provided below o
 
 ## Android build server configurations
 
-Android workers run on Google Cloud Compute Engine machines in an isolated environment. Every build gets its own dedicated VM instance:
+Android workers run on virtual machines in an isolated environment. Every build gets its own dedicated VM instance.
 
 - Build resources:
   - [`medium`](eas-json/#resourceclass-1): 4 CPU, 16 GB RAM ([`n2-standard-4`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -148,14 +148,14 @@ Android workers run on virtual machines in an isolated environment. Every build 
 
 ## iOS build server configurations
 
-iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM. We run a maximum of two builder VMs per one M1 host at the same time:
+iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM:
 
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM [2020]
 - Build resources:
-  - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM
-  - [`m1-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM
+  - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM, 2 builder VMs per host
+  - [`m1-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -29,9 +29,11 @@ When selecting an image for the build you can use the full name provided below o
 
 ## Android build server configurations
 
-Android workers run on Kubernetes in an isolated environment. Every build gets its own container running on a dedicated Kubernetes node:
+Android workers run on Google Cloud Compute Engine machines in an isolated environment. Every build gets its own dedicated VM instance:
 
-- Build resources: 4 CPU, 12 GB RAM
+- Build resources:
+  - [`medium`](eas-json/#resourceclass-1): 4 CPU, 16 GB RAM ([`n2-standard-4`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)
+  - [`large`](eas-json/#resourceclass-1): 8 CPU, 32 GB RAM ([`n2-standard-8`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)
 - [npm cache deployed with Kubernetes](caching/#javascript-dependencies)
 - [Maven cache deployed with Kubernetes](caching/#android-dependencies)
 - Global Gradle configuration in **~/.gradle/gradle.properties**:
@@ -151,9 +153,9 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - M1: 3.2GHz 8-Core M1, 16GB RAM [2020]
-- Build resource limits:
-  - Intel: 3 cores, 12 GB RAM
-  - M1: 3 cores, 8 GB RAM
+- Build resources:
+  - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM
+  - [`m1-medium`](eas-json/#resourceclass-2): 3 cores, 8 GB RAM
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -148,7 +148,7 @@ Android workers run on virtual machines in an isolated environment. Every build 
 
 ## iOS build server configurations
 
-iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM:
+iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM. We run a maximum of two builder VMs per one M1 host at the same time:
 
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -17,7 +17,10 @@ export default [
     name: 'resourceClass',
     enum: ['default', 'medium', 'large'],
     description: [
-      'The Android-specific resource class that will be used to run this build.',
+      'The Android-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#android-build-server-configurations)',
+      '- `default` maps to `medium`',
+      '',
+      'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -53,6 +53,7 @@ export default [
     enum: ['default', 'medium'],
     description: [
       'The resource class that will be used to run this build.',
+      'To see mapping for `default` and `medium` resource classes for each platform, see [Android-specific resource class field](eas-json/#resourceclass-1) and [iOS-specific resource class field](eas-json/#resourceclass-2) documentation.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -35,7 +35,11 @@ export default [
     name: 'resourceClass',
     enum: ['default', 'medium', 'm1-medium', 'intel-medium'],
     description: [
-      'The iOS-specific resource class that will be used to run this build.',
+      'The iOS-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#ios-build-server-configurations)',
+      '- `default` maps to `intel-medium`',
+      '- `medium` maps to `intel-medium`',
+      '',
+      'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
     ],
   },
   {


### PR DESCRIPTION
# Why

The resource class documentation wasn't properly updated in a while.

# How

Update information about resource classes used in EAS Build.

# Test Plan

Test locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
