### PR TITLE
Upgrade `react-native-shared-element@0.8.7` ➡️ `react-native-shared-element@0.8.8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `@react-native-community/slider` from `4.2.4` to `4.4.1`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))
 
 ### 🛠 Breaking changes
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -87,7 +87,7 @@
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
-    "react-native-shared-element": "0.8.7",
+    "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",
     "react-native-webview": "11.26.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
-    "react-native-shared-element": "0.8.7",
+    "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",
     "react-native-web": "~0.18.10",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,7 +96,7 @@
   "react-native-reanimated": "~2.14.0",
   "react-native-screens": "~3.19.0",
   "react-native-safe-area-context": "4.5.0",
-  "react-native-shared-element": "0.8.7",
+  "react-native-shared-element": "0.8.8",
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.5.0",
   "react-native-webview": "11.26.0",


### PR DESCRIPTION
# Why

Fixes ENG-7319

# How

Ran `et update-vendored-module --module react-native-shared-element --target expo-go --commit ff44d562af566f0eb61daddba683e088d4206378`

<details><summary>See output log</summary>

```bash
📥 Cloning react-native-shared-element#ff44d562af566f0eb61daddba683e088d4206378 from https://github.com/IjzerenHein/react-native-shared-element
‼️  Using legacy vendoring for platform ios

Cleaning up iOS files at Exponent/Versioned/Core/Api/Components/SharedElement ...

Copying iOS files ...
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementContent.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementContent.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementCornerRadii.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementCornerRadii.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementDelegate.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementNode.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementNode.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementNodeManager.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementNodeManager.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementStyle.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementStyle.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransition.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransition.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionItem.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionItem.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionManager.h
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTransitionManager.m
> ios/Exponent/Versioned/Core/Api/Components/SharedElement/RNSharedElementTypes.h

Updating pbxproj configuration ...
Saving updated pbxproj structure to the file Exponent.xcodeproj/project.pbxproj ...

Successfully updated iOS files, but please make sure Xcode project files are setup correctly in Exponent/Versioned/Core/Api/Components/SharedElement
‼️  Using legacy vendoring for platform android

Cleaning up Android files at expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement ...

Copying Android files ...
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementContent.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementDrawable.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementModule.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNode.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementNodeManager.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementPackage.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementStyle.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransition.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionItem.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTransitionManager.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementTypes.java
> android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/sharedelement/RNSharedElementView.java
✍️  Updating bundled native modules
✍️  Updating workspace dependencies
💪 Successfully updated react-native-shared-element


```

</details>

# Test Plan

## Android

> **Warning**
> Testing on Android is currently blocked by a reanimated related issue on `main`.
> `Can't find variable: setImmediate` - when opening `apps/native-component-list`

## iOS

> **Warning**
> Testing on iOS is currently blocked by a cocoapod issue on `main`.

<details><summary>Cocoapods error</summary>

```bash
[!] CocoaPods could not find compatible versions for pod "GoogleSignIn":
  In snapshot (Podfile.lock):
    GoogleSignIn (= 7.0.0)

  In Podfile:
    ABI46_0_0ExpoKit/Expo (from `./versioned-react-native/ABI46_0_0/Expo/ExpoKit`) was resolved to 46.0.0, which depends on
      GoogleSignIn
```

</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
