### PR TITLE
[android][ios] Upgrade react-native-gesture-handler to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
+- Updated `react-native-gesture-handler` from `2.8.0` to `2.9.0`. ([#20930](https://github.com/expo/expo/pull/20930) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-shared-element` from `0.8.4` to `0.8.7`. ([#20593](https://github.com/expo/expo/pull/20593) by [@ijzerenhein](https://github.com/ijzerenhein))
 - Updated `@react-native-async-storage/async-storage` from `1.17.3' to `1.17.11`. ([#20780](https://github.com/expo/expo/pull/20780) by [@kudo](https://github.com/kudo))
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.0`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo))

--- a/android/vendored/unversioned/react-native-gesture-handler/android/build.gradle
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/build.gradle
@@ -27,25 +27,33 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-static def findNodeModulePath(baseDir, packageName) {
-    def basePath = baseDir.toPath().normalize()
-    // Node's module resolution algorithm searches up to the root directory,
-    // after which the base path will be null
-    while (basePath) {
-        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
-        if (candidatePath.toFile().exists()) {
-            return candidatePath.toString()
-        }
-        basePath = basePath.getParent()
-    }
-    return null
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-def findNodeModulePath(packageName) {
-    // Don't start in the project dir, as its path ends with node_modules/react-native-gesture-handler/android
-    // we want to go two levels up, so we end up in the first_node modules and eventually
-    // search upwards if the package is not found there
-    return findNodeModulePath(projectDir.toPath().parent.parent.toFile(), packageName)
+def resolveReactNativeDirectory() {
+    def reactNativeLocation = safeExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+    if (reactNativeLocation != null) {
+        return file(reactNativeLocation)
+    }
+
+    // monorepo workaround
+    // react-native can be hoisted or in project's own node_modules
+    def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+    if (reactNativeFromProjectNodeModules.exists()) {
+        return reactNativeFromProjectNodeModules
+    }
+
+    def reactNativeFromNodeModulesWithReanimated = file("${projectDir}/../../react-native")
+    if (reactNativeFromNodeModulesWithReanimated.exists()) {
+        return reactNativeFromNodeModulesWithReanimated
+    }
+
+    throw new Exception(
+        "[react-native-gesture-handler] Unable to resolve react-native location in " +
+            "node_modules. You should add project extension property (in app/build.gradle) " +
+            "`REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+    )
 }
 
 if (isNewArchitectureEnabled()) {
@@ -56,10 +64,6 @@ apply plugin: 'kotlin-android'
 
 if (project == rootProject) {
     apply from: "spotless.gradle"
-}
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 // Check whether Reanimated 2.3 or higher is installed alongside Gesture Handler
@@ -95,6 +99,7 @@ def noMultipleInstancesAssertion() {
     Set<File> files = fileTree(rootDir.parent) {
         include "node_modules/**/react-native-gesture-handler/package.json"
         exclude "**/.yarn/**"
+        exclude "**/.pnpm/**"
     }.files
 
     if (files.size() > 1) {
@@ -104,7 +109,13 @@ def noMultipleInstancesAssertion() {
     }
 }
 
-def REACT_NATIVE_DIR = findNodeModulePath("react-native")
+def REACT_NATIVE_DIR = resolveReactNativeDirectory()
+
+def reactProperties = new Properties()
+file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
+def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 def assertionTask = task assertNoMultipleInstances {
     onlyIf { shouldAssertNoMultipleInstances() }
@@ -133,17 +144,25 @@ android {
         ndkVersion rootProject.ext.ndkVersion
     }
 
+    if (REACT_NATIVE_MINOR_VERSION >= 71) {
+        buildFeatures {
+            prefab true
+        }
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
+        buildConfigField "int", "REACT_NATIVE_MINOR_VERSION", REACT_NATIVE_MINOR_VERSION.toString()
+
         if (isNewArchitectureEnabled()) {
             var appProject = rootProject.allprojects.find {it.plugins.hasPlugin('com.android.application')}
             externalNativeBuild {
                 cmake {
-                    cppFlags "-O2 -frtti -fexceptions -Wall -Wno-unused-variable -fstack-protector-all"
+                    cppFlags "-O2", "-frtti", "-fexceptions", "-Wall", "-Werror", "-std=c++17"
                     arguments "-DAPP_BUILD_DIR=${appProject.buildDir}",
                         "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
                         "-DANDROID_STL=c++_shared"
@@ -200,10 +219,10 @@ def kotlin_version = safeExtGet('kotlinVersion', project.properties['RNGH_kotlin
 
 dependencies {
     //noinspection GradleDynamicVersion
-    if (isNewArchitectureEnabled()) {
-        implementation project(':ReactAndroid')
+    if (REACT_NATIVE_MINOR_VERSION >= 71) {
+        implementation "com.facebook.react:react-android" // version substituted by RNGP
     } else {
-        implementation 'com.facebook.react:react-native:+'
+        implementation 'com.facebook.react:react-native:+' // from node_modules
     }
 
     if (shouldUseCommonInterfaceFromReanimated()) {
@@ -216,21 +235,4 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-}
-
-if (isNewArchitectureEnabled()) {
-    // Resolves "LOCAL_SRC_FILES points to a missing file, Check that libfb.so exists or that its path is correct".
-    tasks.whenTaskAdded { task ->
-        if (task.name.contains("configureCMakeDebug")) {
-            rootProject.getTasksByName("packageReactNdkDebugLibs", true).forEach {
-                task.dependsOn(it)
-            }
-        }
-        // We want to add a dependency for both configureCMakeRelease and configureCMakeRelWithDebInfo
-        if (task.name.contains("configureCMakeRel")) {
-            rootProject.getTasksByName("packageReactNdkReleaseLibs", true).forEach {
-                task.dependsOn(it)
-            }
-        }
-    }
 }

--- a/android/vendored/unversioned/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -331,6 +331,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       // don't preform click when a child button is pressed (mainly to prevent sound effect of
       // a parent button from playing)
       return if (!isChildTouched() && soundResponder == this) {
+        tryFreeingResponder()
         soundResponder = null
         super.performClick()
       } else {

--- a/android/vendored/unversioned/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -538,7 +538,11 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         sendEventForReanimated(event)
       } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT) {
         // Animated with useNativeDriver: true
-        val event = RNGestureHandlerEvent.obtain(handler, handlerFactory)
+        val event = RNGestureHandlerEvent.obtain(
+          handler,
+          handlerFactory,
+          useTopPrefixedName = BuildConfig.REACT_NATIVE_MINOR_VERSION >= 71
+        )
         sendEventForNativeAnimatedEvent(event)
       } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API) {
         // JS function, Animated.event with useNativeDriver: false using old API

--- a/android/vendored/unversioned/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
@@ -3,57 +3,23 @@ cmake_minimum_required(VERSION 3.9.0)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-DFOLLY_NO_CONFIG=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_MOBILE=1 -DFOLLY_HAVE_RECVMMSG=1 -DFOLLY_HAVE_PTHREAD=1")
+
+set(REACT_ANDROID_DIR "${REACT_NATIVE_DIR}/ReactAndroid")
+
+include(${REACT_ANDROID_DIR}/cmake-utils/folly-flags.cmake)
+add_compile_options(${folly_FLAGS})
 
 add_library(gesturehandler
   SHARED
   cpp-adapter.cpp
 )
 
-set(REACT_ANDROID_DIR "${REACT_NATIVE_DIR}/ReactAndroid")
-set(REACT_COMMON_DIR "${REACT_NATIVE_DIR}/ReactCommon")
-set(REACT_NDK_EXPORT_DIR "${APP_BUILD_DIR}/react-ndk/exported")
-
-# copied from react-native/ReactAndroid/cmake-utils/Android-prebuilt.cmake
-
-## jsi
-add_library(jsi SHARED IMPORTED GLOBAL)
-set_target_properties(jsi
-        PROPERTIES
-        IMPORTED_LOCATION
-        ${REACT_NDK_EXPORT_DIR}/${ANDROID_ABI}/libjsi.so)
-target_include_directories(jsi INTERFACE ${REACT_COMMON_DIR}/jsi)
-
-## react_render_core
-add_library(react_render_core SHARED IMPORTED GLOBAL)
-set_target_properties(react_render_core
-        PROPERTIES
-        IMPORTED_LOCATION
-        ${REACT_NDK_EXPORT_DIR}/${ANDROID_ABI}/libreact_render_core.so)
-target_include_directories(react_render_core
-        INTERFACE
-        ${REACT_COMMON_DIR}
-        ${REACT_COMMON_DIR}/react/renderer/core)
-
-## react_render_uimanager
-add_library(react_render_uimanager SHARED IMPORTED GLOBAL)
-set_target_properties(react_render_uimanager
-        PROPERTIES
-        IMPORTED_LOCATION
-        ${REACT_NDK_EXPORT_DIR}/${ANDROID_ABI}/libreact_render_uimanager.so)
-target_include_directories(react_render_uimanager INTERFACE ${REACT_COMMON_DIR}/react/renderer/uimanager)
-
-target_include_directories(
-  gesturehandler
-  PRIVATE
-  "${REACT_ANDROID_DIR}/build/third-party-ndk/boost/boost_1_76_0"
-  "${REACT_ANDROID_DIR}/build/third-party-ndk/double-conversion"
-  "${REACT_ANDROID_DIR}/build/third-party-ndk/folly"
-)
+find_package(ReactAndroid REQUIRED CONFIG)
 
 target_link_libraries(
   gesturehandler
-  jsi
-  react_render_uimanager
-  react_render_core
+  ReactAndroid::react_render_core
+  ReactAndroid::react_render_uimanager
+  ReactAndroid::jsi
+  ReactAndroid::react_nativemodule_core
 )

--- a/android/vendored/unversioned/react-native-gesture-handler/android/src/main/jni/cpp-adapter.cpp
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/src/main/jni/cpp-adapter.cpp
@@ -6,8 +6,7 @@
 using namespace facebook;
 using namespace react;
 
-void decorateRuntime(jsi::Runtime &runtime)
-{
+void decorateRuntime(jsi::Runtime &runtime) {
   auto isFormsStackingContext = jsi::Function::createFromHostFunction(
       runtime,
       jsi::PropNameID::forAscii(runtime, "isFormsStackingContext"),
@@ -15,27 +14,31 @@ void decorateRuntime(jsi::Runtime &runtime)
       [](jsi::Runtime &runtime,
          const jsi::Value &thisValue,
          const jsi::Value *arguments,
-         size_t count) -> jsi::Value
-      {
-        if (!arguments[0].isObject())
-        {
+         size_t count) -> jsi::Value {
+        if (!arguments[0].isObject()) {
           return jsi::Value::null();
         }
 
-        auto shadowNode = arguments[0].asObject(runtime).getHostObject<ShadowNodeWrapper>(runtime)->shadowNode;
-        bool isFormsStackingContext = shadowNode->getTraits().check(ShadowNodeTraits::FormsStackingContext);
+        auto shadowNode = arguments[0]
+                              .asObject(runtime)
+                              .getHostObject<ShadowNodeWrapper>(runtime)
+                              ->shadowNode;
+        bool isFormsStackingContext = shadowNode->getTraits().check(
+            ShadowNodeTraits::FormsStackingContext);
 
         return jsi::Value(isFormsStackingContext);
       });
-  runtime.global().setProperty(runtime, "isFormsStackingContext", std::move(isFormsStackingContext));
+  runtime.global().setProperty(
+      runtime, "isFormsStackingContext", std::move(isFormsStackingContext));
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_swmansion_gesturehandler_react_RNGestureHandlerModule_decorateRuntime(JNIEnv *env, jobject clazz, jlong jsiPtr)
-{
+Java_com_swmansion_gesturehandler_react_RNGestureHandlerModule_decorateRuntime(
+    JNIEnv *env,
+    jobject clazz,
+    jlong jsiPtr) {
   jsi::Runtime *runtime = reinterpret_cast<jsi::Runtime *>(jsiPtr);
-  if (runtime)
-  {
+  if (runtime) {
     decorateRuntime(*runtime);
   }
 }

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -657,7 +657,7 @@ PODS:
     - React-Core
   - RNFlashList (1.3.1):
     - React-Core
-  - RNGestureHandler (2.8.0):
+  - RNGestureHandler (2.9.0):
     - React-Core
   - RNReanimated (2.14.0):
     - DoubleConversion
@@ -1317,7 +1317,7 @@ SPEC CHECKSUMS:
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDateTimePicker: 3f32aa2247836c12618d346113e5e82ea60ddd9c
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
-  RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
+  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: 3882aa3f7a30d3c74aa05d6c230399942690a043
   RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
   RNSharedElement: 14409838520c8b50850aa4d33e15d0b8afdf7052

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -82,7 +82,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.71.0",
-    "react-native-gesture-handler": "~2.8.0",
+    "react-native-gesture-handler": "~2.9.0",
     "react-native-pager-view": "6.0.1",
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -142,7 +142,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.71.0",
     "react-native-dropdown-picker": "^5.3.0",
-    "react-native-gesture-handler": "~2.8.0",
+    "react-native-gesture-handler": "~2.9.0",
     "react-native-maps": "1.3.2",
     "react-native-pager-view": "6.0.1",
     "react-native-paper": "^4.0.1",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.19",
     "react": "18.2.0",
     "react-native": "0.71.0",
-    "react-native-gesture-handler": "~2.8.0",
+    "react-native-gesture-handler": "~2.9.0",
     "sinon": "^7.1.1"
   },
   "devDependencies": {

--- a/home/package.json
+++ b/home/package.json
@@ -57,7 +57,7 @@
     "react": "18.2.0",
     "react-native": "0.71.0",
     "react-native-fade-in-image": "^1.6.1",
-    "react-native-gesture-handler": "~2.8.0",
+    "react-native-gesture-handler": "~2.9.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.3.2",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2096,7 +2096,7 @@ PODS:
     - React-Core
   - RNFlashList (1.3.1):
     - React-Core
-  - RNGestureHandler (2.8.0):
+  - RNGestureHandler (2.9.0):
     - React-Core
   - RNReanimated (2.14.0):
     - DoubleConversion
@@ -3640,7 +3640,7 @@ SPEC CHECKSUMS:
   ReactCommon: 20e38a9be5fe1341b5e422220877cc94034776ba
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
-  RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
+  RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: e7aeb0addbcc2c79dccb69bb176d079afbd5fd23
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
+++ b/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNGestureHandler",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-gesture-handler",
-    "tag": "2.8.0"
+    "tag": "2.9.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "requires_arc": true,

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNFlingHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNFlingHandler.m
@@ -2,12 +2,12 @@
 
 @interface RNBetterSwipeGestureRecognizer : UISwipeGestureRecognizer
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
 @implementation RNBetterSwipeGestureRecognizer {
-  __weak RNGestureHandler* _gestureHandler;
+  __weak RNGestureHandler *_gestureHandler;
   CGPoint _lastPoint; // location of the most recently updated touch, relative to the view
   bool _hasBegan; // whether the `BEGAN` event has been sent
 }
@@ -27,6 +27,7 @@
   _lastPoint = [[[touches allObjects] objectAtIndex:0] locationInView:_gestureHandler.recognizer.view];
   [_gestureHandler reset];
   [super touchesBegan:touches withEvent:event];
+  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 
   // self.numberOfTouches doesn't work for this because in case than one finger is required,
   // when holding one finger on the screen and tapping with the second one, numberOfTouches is equal
@@ -35,8 +36,6 @@
     [self triggerAction];
     _hasBegan = YES;
   }
-
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -73,7 +72,8 @@
   [super reset];
 }
 
-- (CGPoint)getLastLocation {
+- (CGPoint)getLastLocation
+{
   // I think keeping the location of only one touch is enough since it would be used to determine the direction
   // of the movement, and if it's wrong the recognizer fails anyway.
   // In case the location of all touches is required, touch events are the way to go
@@ -103,48 +103,50 @@
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    UISwipeGestureRecognizer *recognizer = (UISwipeGestureRecognizer *)_recognizer;
+  [super configure:config];
+  UISwipeGestureRecognizer *recognizer = (UISwipeGestureRecognizer *)_recognizer;
 
-    id prop = config[@"direction"];
-    if (prop != nil) {
-        recognizer.direction = [RCTConvert NSInteger:prop];
-    }
-    
+  id prop = config[@"direction"];
+  if (prop != nil) {
+    recognizer.direction = [RCTConvert NSInteger:prop];
+  }
+
 #if !TARGET_OS_TV
-    prop = config[@"numberOfPointers"];
-    if (prop != nil) {
-        recognizer.numberOfTouchesRequired = [RCTConvert NSInteger:prop];
-    }
+  prop = config[@"numberOfPointers"];
+  if (prop != nil) {
+    recognizer.numberOfTouchesRequired = [RCTConvert NSInteger:prop];
+  }
 #endif
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-    RNGestureHandlerState savedState = _lastState;
-    BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
-    _lastState = savedState;
-    
-    return shouldBegin;
+  RNGestureHandlerState savedState = _lastState;
+  BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
+  _lastState = savedState;
+
+  return shouldBegin;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(id)_recognizer
 {
-    // For some weird reason [recognizer locationInView:recognizer.view.window] returns (0, 0).
-    // To calculate the correct absolute position, first calculate the absolute position of the
-    // view inside the root view controller (https://stackoverflow.com/a/7448573) and then
-    // add the relative touch position to it.
-    
-    RNBetterSwipeGestureRecognizer *recognizer = (RNBetterSwipeGestureRecognizer *)_recognizer;
-    
-    CGPoint viewAbsolutePosition = [recognizer.view convertPoint:recognizer.view.bounds.origin toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
-    CGPoint locationInView = [recognizer getLastLocation];
-    
-    return [RNGestureHandlerEventExtraData
-            forPosition:locationInView
-            withAbsolutePosition:CGPointMake(viewAbsolutePosition.x + locationInView.x, viewAbsolutePosition.y + locationInView.y)
-            withNumberOfTouches:recognizer.numberOfTouches];
+  // For some weird reason [recognizer locationInView:recognizer.view.window] returns (0, 0).
+  // To calculate the correct absolute position, first calculate the absolute position of the
+  // view inside the root view controller (https://stackoverflow.com/a/7448573) and then
+  // add the relative touch position to it.
+
+  RNBetterSwipeGestureRecognizer *recognizer = (RNBetterSwipeGestureRecognizer *)_recognizer;
+
+  CGPoint viewAbsolutePosition =
+      [recognizer.view convertPoint:recognizer.view.bounds.origin
+                             toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
+  CGPoint locationInView = [recognizer getLastLocation];
+
+  return [RNGestureHandlerEventExtraData
+               forPosition:locationInView
+      withAbsolutePosition:CGPointMake(
+                               viewAbsolutePosition.x + locationInView.x, viewAbsolutePosition.y + locationInView.y)
+       withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNForceTouchHandler.m
@@ -11,7 +11,7 @@
 @property (nonatomic) CGFloat force;
 @property (nonatomic) BOOL feedbackOnActivation;
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
@@ -25,7 +25,7 @@ static const CGFloat defaultMinForce = 0.2;
 static const CGFloat defaultMaxForce = NAN;
 static const BOOL defaultFeedbackOnActivation = NO;
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
   if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
     _gestureHandler = gestureHandler;
@@ -45,7 +45,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
   }
   [super touchesBegan:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
-  
+
   _firstTouch = [touches anyObject];
   [self handleForceWithTouches:touches];
   self.state = UIGestureRecognizerStatePossible;
@@ -59,25 +59,27 @@ static const BOOL defaultFeedbackOnActivation = NO;
   }
   [super touchesMoved:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
-  
+
   [self handleForceWithTouches:touches];
-  
+
   if ([self shouldFail]) {
     self.state = UIGestureRecognizerStateFailed;
     return;
   }
-  
+
   if (self.state == UIGestureRecognizerStatePossible && [self shouldActivate]) {
     [self performFeedbackIfRequired];
     self.state = UIGestureRecognizerStateBegan;
   }
 }
 
-- (BOOL)shouldActivate {
+- (BOOL)shouldActivate
+{
   return (_force >= _minForce);
 }
 
-- (BOOL)shouldFail {
+- (BOOL)shouldFail
+{
   return TEST_MAX_IF_NOT_NAN(_force, _maxForce);
 }
 
@@ -113,11 +115,13 @@ static const BOOL defaultFeedbackOnActivation = NO;
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
 }
 
-- (void)handleForceWithTouches:(NSSet<UITouch *> *)touches {
+- (void)handleForceWithTouches:(NSSet<UITouch *> *)touches
+{
   _force = _firstTouch.force / _firstTouch.maximumPossibleForce;
 }
 
-- (void)reset {
+- (void)reset
+{
   [_gestureHandler.pointerTracker reset];
   [super reset];
   _force = 0;
@@ -140,7 +144,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
   [super resetConfig];
   RNForceTouchGestureRecognizer *recognizer = (RNForceTouchGestureRecognizer *)_recognizer;
-  
+
   recognizer.feedbackOnActivation = defaultFeedbackOnActivation;
   recognizer.maxForce = defaultMaxForce;
   recognizer.minForce = defaultMinForce;
@@ -162,12 +166,10 @@ static const BOOL defaultFeedbackOnActivation = NO;
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(RNForceTouchGestureRecognizer *)recognizer
 {
-  return [RNGestureHandlerEventExtraData
-          forForce: recognizer.force
-          forPosition:[recognizer locationInView:recognizer.view]
-          withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-          withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forForce:recognizer.force
+                                      forPosition:[recognizer locationInView:recognizer.view]
+                             withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+                              withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNLongPressHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNLongPressHandler.m
@@ -19,9 +19,9 @@
   uint64_t previousTime;
 }
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 - (void)handleGesture:(UIGestureRecognizer *)recognizer;
-- (NSUInteger) getDuration;
+- (NSUInteger)getDuration;
 
 @end
 
@@ -30,7 +30,7 @@
   CGPoint _initPosition;
 }
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
   if ((self = [super initWithTarget:self action:@selector(handleGesture:)])) {
     _gestureHandler = gestureHandler;
@@ -70,10 +70,11 @@
 {
   [super touchesMoved:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
-  
+
   CGPoint trans = [self translationInView];
-  if ((_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView])
-      || (TEST_MAX_IF_NOT_NAN(fabs(trans.y * trans.y + trans.x + trans.x), self.allowableMovement * self.allowableMovement))) {
+  if ((_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView]) ||
+      (TEST_MAX_IF_NOT_NAN(
+          fabs(trans.y * trans.y + trans.x + trans.x), self.allowableMovement * self.allowableMovement))) {
     self.enabled = NO;
     self.enabled = YES;
   }
@@ -96,25 +97,24 @@
   if (self.state == UIGestureRecognizerStateFailed) {
     [self triggerAction];
   }
-  
+
   [_gestureHandler.pointerTracker reset];
-  
+
   [super reset];
 }
 
 - (NSUInteger)getDuration
 {
   static mach_timebase_info_data_t sTimebaseInfo;
-  
+
   if (sTimebaseInfo.denom == 0) {
     mach_timebase_info(&sTimebaseInfo);
   }
-  
+
   return (NSUInteger)(((previousTime - startTime) * sTimebaseInfo.numer / (sTimebaseInfo.denom * 1000000)));
 }
 
 @end
-
 
 @implementation RNLongPressGestureHandler
 
@@ -130,7 +130,7 @@
 {
   [super resetConfig];
   UILongPressGestureRecognizer *recognizer = (UILongPressGestureRecognizer *)_recognizer;
-  
+
   recognizer.minimumPressDuration = 0.5;
   recognizer.allowableMovement = 10;
 }
@@ -139,12 +139,12 @@
 {
   [super configure:config];
   UILongPressGestureRecognizer *recognizer = (UILongPressGestureRecognizer *)_recognizer;
-  
+
   id prop = config[@"minDurationMs"];
   if (prop != nil) {
     recognizer.minimumPressDuration = [RCTConvert CGFloat:prop] / 1000.0;
   }
-  
+
   prop = config[@"maxDist"];
   if (prop != nil) {
     recognizer.allowableMovement = [RCTConvert CGFloat:prop];
@@ -165,21 +165,19 @@
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-  //same as TapGH, this needs to be unified when all handlers are updated
+  // same as TapGH, this needs to be unified when all handlers are updated
   RNGestureHandlerState savedState = _lastState;
   BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
   _lastState = savedState;
-  
+
   return shouldBegin;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer
 {
-    return [RNGestureHandlerEventExtraData
-            forPosition:[recognizer locationInView:recognizer.view]
-            withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-            withNumberOfTouches:recognizer.numberOfTouches
-            withDuration:[(RNBetterLongPressGestureRecognizer*)recognizer getDuration]];
+  return [RNGestureHandlerEventExtraData forPosition:[recognizer locationInView:recognizer.view]
+                                withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+                                 withNumberOfTouches:recognizer.numberOfTouches
+                                        withDuration:[(RNBetterLongPressGestureRecognizer *)recognizer getDuration]];
 }
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNManualHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNManualHandler.m
@@ -37,9 +37,8 @@
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
 
   if ([self shouldFail]) {
-    self.state = (self.state == UIGestureRecognizerStatePossible)
-      ? UIGestureRecognizerStateFailed
-      : UIGestureRecognizerStateCancelled;
+    self.state = (self.state == UIGestureRecognizerStatePossible) ? UIGestureRecognizerStateFailed
+                                                                  : UIGestureRecognizerStateCancelled;
 
     [self reset];
   }

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNNativeViewHandler.mm
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNNativeViewHandler.mm
@@ -27,37 +27,37 @@
 
 - (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
-    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
-        _gestureHandler = gestureHandler;
-    }
-    return self;
+  if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+    _gestureHandler = gestureHandler;
+  }
+  return self;
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
-    self.state = UIGestureRecognizerStateFailed;
-    [self reset];
+  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  self.state = UIGestureRecognizerStateFailed;
+  [self reset];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-    self.state = UIGestureRecognizerStateCancelled;
-    [self reset];
+  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  self.state = UIGestureRecognizerStateCancelled;
+  [self reset];
 }
 
--(void)reset
+- (void)reset
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
@@ -68,122 +68,126 @@
 #pragma mark RNNativeViewgestureHandler
 
 @implementation RNNativeViewGestureHandler {
-    BOOL _shouldActivateOnStart;
-    BOOL _disallowInterruption;
+  BOOL _shouldActivateOnStart;
+  BOOL _disallowInterruption;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        _recognizer = [[RNDummyGestureRecognizer alloc] initWithGestureHandler:self];
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+    _recognizer = [[RNDummyGestureRecognizer alloc] initWithGestureHandler:self];
+  }
+  return self;
 }
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    _shouldActivateOnStart = [RCTConvert BOOL:config[@"shouldActivateOnStart"]];
-    _disallowInterruption = [RCTConvert BOOL:config[@"disallowInterruption"]];
+  [super configure:config];
+  _shouldActivateOnStart = [RCTConvert BOOL:config[@"shouldActivateOnStart"]];
+  _disallowInterruption = [RCTConvert BOOL:config[@"disallowInterruption"]];
 }
 
 - (void)bindToView:(UIView *)view
 {
-    // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
-    // for properties like `disallowInterruption` to work.
-    if ([view isKindOfClass:[UIControl class]]) {
-        UIControl *control = (UIControl *)view;
-        [control addTarget:self action:@selector(handleTouchDown:forEvent:) forControlEvents:UIControlEventTouchDown];
-        [control addTarget:self action:@selector(handleTouchUpOutside:forEvent:) forControlEvents:UIControlEventTouchUpOutside];
-        [control addTarget:self action:@selector(handleTouchUpInside:forEvent:) forControlEvents:UIControlEventTouchUpInside];
-        [control addTarget:self action:@selector(handleDragExit:forEvent:) forControlEvents:UIControlEventTouchDragExit];
-        [control addTarget:self action:@selector(handleDragEnter:forEvent:) forControlEvents:UIControlEventTouchDragEnter];
-        [control addTarget:self action:@selector(handleTouchCancel:forEvent:) forControlEvents:UIControlEventTouchCancel];
-    } else {
-        [super bindToView:view];
-    }
+  // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
+  // for properties like `disallowInterruption` to work.
+  if ([view isKindOfClass:[UIControl class]]) {
+    UIControl *control = (UIControl *)view;
+    [control addTarget:self action:@selector(handleTouchDown:forEvent:) forControlEvents:UIControlEventTouchDown];
+    [control addTarget:self
+                  action:@selector(handleTouchUpOutside:forEvent:)
+        forControlEvents:UIControlEventTouchUpOutside];
+    [control addTarget:self
+                  action:@selector(handleTouchUpInside:forEvent:)
+        forControlEvents:UIControlEventTouchUpInside];
+    [control addTarget:self action:@selector(handleDragExit:forEvent:) forControlEvents:UIControlEventTouchDragExit];
+    [control addTarget:self action:@selector(handleDragEnter:forEvent:) forControlEvents:UIControlEventTouchDragEnter];
+    [control addTarget:self action:@selector(handleTouchCancel:forEvent:) forControlEvents:UIControlEventTouchCancel];
+  } else {
+    [super bindToView:view];
+  }
 
-    // We can restore default scrollview behaviour to delay touches to scrollview's children
-    // because gesture handler system can handle cancellation of scroll recognizer when JS responder
-    // is set
+  // We can restore default scrollview behaviour to delay touches to scrollview's children
+  // because gesture handler system can handle cancellation of scroll recognizer when JS responder
+  // is set
 #ifdef RN_FABRIC_ENABLED
-    if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
-        UIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
-        scrollView.delaysContentTouches = YES;
-    }
+  if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
+    UIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
+    scrollView.delaysContentTouches = YES;
+  }
 #else
-    if ([view isKindOfClass:[RCTScrollView class]]) {
-        // This part of the code is coupled with RN implementation of ScrollView native wrapper and
-        // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
-        // subview
-        UIScrollView *scrollView = [view.subviews objectAtIndex:0];
-        scrollView.delaysContentTouches = YES;
-    }
+  if ([view isKindOfClass:[RCTScrollView class]]) {
+    // This part of the code is coupled with RN implementation of ScrollView native wrapper and
+    // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
+    // subview
+    UIScrollView *scrollView = [view.subviews objectAtIndex:0];
+    scrollView.delaysContentTouches = YES;
+  }
 #endif // RN_FABRIC_ENABLED
 }
 
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self reset];
+  [self reset];
 
-    if (_disallowInterruption) {
-        // When `disallowInterruption` is set we cancel all gesture handlers when this UIControl
-        // gets DOWN event
-        for (UITouch *touch in [event allTouches]) {
-            for (UIGestureRecognizer *recogn in [touch gestureRecognizers]) {
-                recogn.enabled = NO;
-                recogn.enabled = YES;
-            }
-        }
+  if (_disallowInterruption) {
+    // When `disallowInterruption` is set we cancel all gesture handlers when this UIControl
+    // gets DOWN event
+    for (UITouch *touch in [event allTouches]) {
+      for (UIGestureRecognizer *recogn in [touch gestureRecognizers]) {
+        recogn.enabled = NO;
+        recogn.enabled = YES;
+      }
     }
+  }
 
-    [self sendEventsInState:RNGestureHandlerStateActive
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
+  [self sendEventsInState:RNGestureHandlerStateActive
+           forViewWithTag:sender.reactTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchUpOutside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateEnd
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
+  [self sendEventsInState:RNGestureHandlerStateEnd
+           forViewWithTag:sender.reactTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }
 
 - (void)handleTouchUpInside:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateEnd
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
+  [self sendEventsInState:RNGestureHandlerStateEnd
+           forViewWithTag:sender.reactTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleDragExit:(UIView *)sender forEvent:(UIEvent *)event
 {
-    // Pointer is moved outside of the view bounds, we cancel button when `shouldCancelWhenOutside` is set
-    if (self.shouldCancelWhenOutside) {
-        UIControl *control = (UIControl *)sender;
-        [control cancelTrackingWithEvent:event];
-        [self sendEventsInState:RNGestureHandlerStateEnd
-                 forViewWithTag:sender.reactTag
-                  withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
-    } else {
-        [self sendEventsInState:RNGestureHandlerStateActive
-                 forViewWithTag:sender.reactTag
-                  withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
-    }
+  // Pointer is moved outside of the view bounds, we cancel button when `shouldCancelWhenOutside` is set
+  if (self.shouldCancelWhenOutside) {
+    UIControl *control = (UIControl *)sender;
+    [control cancelTrackingWithEvent:event];
+    [self sendEventsInState:RNGestureHandlerStateEnd
+             forViewWithTag:sender.reactTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
+  } else {
+    [self sendEventsInState:RNGestureHandlerStateActive
+             forViewWithTag:sender.reactTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
+  }
 }
 
 - (void)handleDragEnter:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateActive
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
+  [self sendEventsInState:RNGestureHandlerStateActive
+           forViewWithTag:sender.reactTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES]];
 }
 
 - (void)handleTouchCancel:(UIView *)sender forEvent:(UIEvent *)event
 {
-    [self sendEventsInState:RNGestureHandlerStateCancelled
-             forViewWithTag:sender.reactTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
+  [self sendEventsInState:RNGestureHandlerStateCancelled
+           forViewWithTag:sender.reactTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO]];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNPanHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNPanHandler.m
@@ -26,11 +26,9 @@
 @property (nonatomic) CGFloat failOffsetYEnd;
 @property (nonatomic) CGFloat activateAfterLongPress;
 
-
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
-
 
 @implementation RNBetterPanGestureRecognizer {
   __weak RNGestureHandler *_gestureHandler;
@@ -38,7 +36,7 @@
   BOOL _hasCustomActivationCriteria;
 }
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
   if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
     _gestureHandler = gestureHandler;
@@ -96,9 +94,9 @@
   }
 #endif
   [super touchesBegan:touches withEvent:event];
-  [self triggerAction];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
-    
+  [self triggerAction];
+
   if (!isnan(_activateAfterLongPress)) {
     [self performSelector:@selector(activateAfterLongPress) withObject:nil afterDelay:_activateAfterLongPress];
   }
@@ -108,7 +106,7 @@
 {
   [super touchesMoved:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
-  
+
   if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
     self.state = UIGestureRecognizerStateFailed;
     return;
@@ -119,14 +117,14 @@
       // then UIGestureRecognizer's sate machine will only transition to
       // UIGestureRecognizerStateCancelled even if you set the state to
       // UIGestureRecognizerStateFailed here. Making the behavior explicit.
-      self.state = (self.state == UIGestureRecognizerStatePossible)
-      ? UIGestureRecognizerStateFailed
-      : UIGestureRecognizerStateCancelled;
+      self.state = (self.state == UIGestureRecognizerStatePossible) ? UIGestureRecognizerStateFailed
+                                                                    : UIGestureRecognizerStateCancelled;
       [self reset];
       return;
     }
   }
-  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible && [self shouldActivateUnderCustomCriteria]) {
+  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible &&
+      [self shouldActivateUnderCustomCriteria]) {
 #if !TARGET_OS_TV
     super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
     if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
@@ -160,10 +158,9 @@
 
 - (void)updateHasCustomActivationCriteria
 {
-  _hasCustomActivationCriteria = !isnan(_minDistSq)
-  || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq)
-  || !isnan(_activeOffsetXStart) || !isnan(_activeOffsetXEnd)
-  ||  !isnan(_activeOffsetYStart) || !isnan(_activeOffsetYEnd);
+  _hasCustomActivationCriteria = !isnan(_minDistSq) || !isnan(_minVelocityX) || !isnan(_minVelocityY) ||
+      !isnan(_minVelocitySq) || !isnan(_activeOffsetXStart) || !isnan(_activeOffsetXEnd) ||
+      !isnan(_activeOffsetYStart) || !isnan(_activeOffsetYEnd);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
@@ -174,7 +171,7 @@
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
     return YES;
   }
-    
+
   if (!isnan(_failOffsetXStart) && trans.x < _failOffsetXStart) {
     return YES;
   }
@@ -205,11 +202,11 @@
   if (!isnan(_activeOffsetYEnd) && trans.y > _activeOffsetYEnd) {
     return YES;
   }
-  
+
   if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(trans), _minDistSq)) {
     return YES;
   }
-  
+
   CGPoint velocity = [self velocityInView:self.view];
   if (TEST_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
     return YES;
@@ -220,7 +217,7 @@
   if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(velocity), _minVelocitySq)) {
     return YES;
   }
-  
+
   return NO;
 }
 
@@ -269,7 +266,7 @@
 {
   [super configure:config];
   RNBetterPanGestureRecognizer *recognizer = (RNBetterPanGestureRecognizer *)_recognizer;
-  
+
   APPLY_FLOAT_PROP(minVelocityX);
   APPLY_FLOAT_PROP(minVelocityY);
   APPLY_FLOAT_PROP(activeOffsetXStart);
@@ -284,7 +281,7 @@
 #if !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
   if (@available(iOS 13.4, *)) {
     bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
-    if(enableTrackpadTwoFingerGesture){
+    if (enableTrackpadTwoFingerGesture) {
       recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
     }
   }
@@ -292,19 +289,19 @@
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
   APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
 #endif
-    
+
   id prop = config[@"minDist"];
   if (prop != nil) {
     CGFloat dist = [RCTConvert CGFloat:prop];
     recognizer.minDistSq = dist * dist;
   }
-  
+
   prop = config[@"minVelocity"];
   if (prop != nil) {
     CGFloat velocity = [RCTConvert CGFloat:prop];
     recognizer.minVelocitySq = velocity * velocity;
   }
-    
+
   prop = config[@"activateAfterLongPress"];
   if (prop != nil) {
     recognizer.activateAfterLongPress = [RCTConvert CGFloat:prop] / 1000.0;
@@ -313,23 +310,22 @@
   [recognizer updateHasCustomActivationCriteria];
 }
 
-- (BOOL) gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
   RNGestureHandlerState savedState = _lastState;
   BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
   _lastState = savedState;
-  
+
   return shouldBegin;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPanGestureRecognizer *)recognizer
 {
-  return [RNGestureHandlerEventExtraData
-          forPan:[recognizer locationInView:recognizer.view]
-          withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-          withTranslation:[recognizer translationInView:recognizer.view.window]
-          withVelocity:[recognizer velocityInView:recognizer.view.window]
-          withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forPan:[recognizer locationInView:recognizer.view]
+                           withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+                                withTranslation:[recognizer translationInView:recognizer.view.window]
+                                   withVelocity:[recognizer velocityInView:recognizer.view.window]
+                            withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNPinchHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNPinchHandler.m
@@ -13,7 +13,7 @@
 #if !TARGET_OS_TV
 @interface RNBetterPinchRecognizer : UIPinchGestureRecognizer
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
@@ -74,22 +74,21 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
+  if ((self = [super initWithTag:tag])) {
 #if !TARGET_OS_TV
-        _recognizer = [[RNBetterPinchRecognizer alloc] initWithGestureHandler:self];
+    _recognizer = [[RNBetterPinchRecognizer alloc] initWithGestureHandler:self];
 #endif
-    }
-    return self;
+  }
+  return self;
 }
 
 #if !TARGET_OS_TV
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer
 {
-    return [RNGestureHandlerEventExtraData
-            forPinch:recognizer.scale
-            withFocalPoint:[recognizer locationInView:recognizer.view]
-            withVelocity:recognizer.velocity
-            withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forPinch:recognizer.scale
+                                   withFocalPoint:[recognizer locationInView:recognizer.view]
+                                     withVelocity:recognizer.velocity
+                              withNumberOfTouches:recognizer.numberOfTouches];
 }
 #endif
 

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNRotationHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNRotationHandler.m
@@ -11,7 +11,7 @@
 #if !TARGET_OS_TV
 @interface RNBetterRotationRecognizer : UIRotationGestureRecognizer
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
@@ -34,7 +34,6 @@
   }
   [_gestureHandler handleGesture:recognizer];
 }
-
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
@@ -73,24 +72,22 @@
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super initWithTag:tag])) {
-        #if !TARGET_OS_TV
-        _recognizer = [[RNBetterRotationRecognizer alloc] initWithGestureHandler:self];
-        #endif
-    }
-    return self;
+  if ((self = [super initWithTag:tag])) {
+#if !TARGET_OS_TV
+    _recognizer = [[RNBetterRotationRecognizer alloc] initWithGestureHandler:self];
+#endif
+  }
+  return self;
 }
 
 #if !TARGET_OS_TV
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIRotationGestureRecognizer *)recognizer
 {
-    return [RNGestureHandlerEventExtraData
-            forRotation:recognizer.rotation
-            withAnchorPoint:[recognizer locationInView:recognizer.view]
-            withVelocity:recognizer.velocity
-            withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forRotation:recognizer.rotation
+                                     withAnchorPoint:[recognizer locationInView:recognizer.view]
+                                        withVelocity:recognizer.velocity
+                                 withNumberOfTouches:recognizer.numberOfTouches];
 }
 #endif
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNTapHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/Handlers/RNTapHandler.m
@@ -12,8 +12,8 @@
 
 #import <React/RCTConvert.h>
 
-// RNBetterTapGestureRecognizer extends UIGestureRecognizer instead of UITapGestureRecognizer 
-// because the latter does not allow for parameters like maxDelay, maxDuration, minPointers, 
+// RNBetterTapGestureRecognizer extends UIGestureRecognizer instead of UITapGestureRecognizer
+// because the latter does not allow for parameters like maxDelay, maxDuration, minPointers,
 // maxDelta to be configured. Using our custom implementation of tap recognizer we are able
 // to support these.
 
@@ -27,7 +27,7 @@
 @property (nonatomic) CGFloat maxDeltaY;
 @property (nonatomic) NSInteger minPointers;
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
@@ -43,7 +43,7 @@ static const NSInteger defaultMinPointers = 1;
 static const CGFloat defaultMaxDelay = 0.2;
 static const NSTimeInterval defaultMaxDuration = 0.5;
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
   if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
     _gestureHandler = gestureHandler;
@@ -73,7 +73,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesBegan:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
-  
+
   if (_tapsSoFar == 0) {
     // this recognizer sends UNDETERMINED -> BEGAN state change event before gestureRecognizerShouldBegin
     // is called (it resets the gesture handler), making it send whatever the last known state as oldState
@@ -100,28 +100,29 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesMoved:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
-  
+
   NSInteger numberOfTouches = [touches count];
   if (numberOfTouches > _maxNumberOfTouches) {
     _maxNumberOfTouches = numberOfTouches;
   }
-  
+
   if (self.state != UIGestureRecognizerStatePossible) {
     return;
   }
-  
+
   if ([self shouldFailUnderCustomCriteria]) {
     self.state = UIGestureRecognizerStateFailed;
     [self triggerAction];
     [self reset];
     return;
   }
-  
+
   self.state = UIGestureRecognizerStatePossible;
   [self triggerAction];
 }
 
-- (CGPoint)translationInView {
+- (CGPoint)translationInView
+{
   CGPoint currentPosition = [self locationInView:self.view.window];
   return CGPointMake(currentPosition.x - _initPosition.x, currentPosition.y - _initPosition.y);
 }
@@ -133,7 +134,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
       return YES;
     }
   }
-  
+
   CGPoint trans = [self translationInView];
   if (TEST_MAX_IF_NOT_NAN(fabs(trans.x), _maxDeltaX)) {
     return YES;
@@ -151,7 +152,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesEnded:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
-  
+
   if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
     self.state = UIGestureRecognizerStateEnded;
     [self reset];
@@ -164,7 +165,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  
+
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
 }
@@ -186,7 +187,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 @end
 
 @implementation RNTapGestureHandler {
-    RNGestureHandlerEventExtraData * _lastData;
+  RNGestureHandlerEventExtraData *_lastData;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -201,7 +202,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super resetConfig];
   RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
-  
+
   recognizer.numberOfTaps = defaultNumberOfTaps;
   recognizer.minPointers = defaultMinPointers;
   recognizer.maxDeltaX = NAN;
@@ -215,22 +216,22 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super configure:config];
   RNBetterTapGestureRecognizer *recognizer = (RNBetterTapGestureRecognizer *)_recognizer;
-  
+
   APPLY_INT_PROP(numberOfTaps);
   APPLY_INT_PROP(minPointers);
   APPLY_FLOAT_PROP(maxDeltaX);
   APPLY_FLOAT_PROP(maxDeltaY);
-  
+
   id prop = config[@"maxDelayMs"];
   if (prop != nil) {
     recognizer.maxDelay = [RCTConvert CGFloat:prop] / 1000.0;
   }
-  
+
   prop = config[@"maxDurationMs"];
   if (prop != nil) {
     recognizer.maxDuration = [RCTConvert CGFloat:prop] / 1000.0;
   }
-  
+
   prop = config[@"maxDist"];
   if (prop != nil) {
     CGFloat dist = [RCTConvert CGFloat:prop];
@@ -240,12 +241,12 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer
 {
-    if (recognizer.state == UIGestureRecognizerStateEnded) {
-        return _lastData;
-    }
-    
-    _lastData = [super eventExtraData:recognizer];
+  if (recognizer.state == UIGestureRecognizerStateEnded) {
     return _lastData;
+  }
+
+  _lastData = [super eventExtraData:recognizer];
+  return _lastData;
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
@@ -257,9 +258,8 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   RNGestureHandlerState savedState = _lastState;
   BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
   _lastState = savedState;
-  
+
   return shouldBegin;
 }
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandler.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandler.h
@@ -1,35 +1,45 @@
 #import "RNGestureHandlerActionType.h"
-#import "RNGestureHandlerState.h"
 #import "RNGestureHandlerDirection.h"
 #import "RNGestureHandlerEvents.h"
 #import "RNGestureHandlerPointerTracker.h"
+#import "RNGestureHandlerState.h"
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 #import <React/RCTConvert.h>
+#import <UIKit/UIKit.h>
 
 #define VEC_LEN_SQ(pt) (pt.x * pt.x + pt.y * pt.y)
 #define TEST_MIN_IF_NOT_NAN(value, limit) \
-(!isnan(limit) && ((limit < 0 && value <= limit) || (limit >= 0 && value >= limit)))
+  (!isnan(limit) && ((limit < 0 && value <= limit) || (limit >= 0 && value >= limit)))
 
-#define TEST_MAX_IF_NOT_NAN(value, max) \
-(!isnan(max) && ((max < 0 && value < max) || (max >= 0 && value > max)))
+#define TEST_MAX_IF_NOT_NAN(value, max) (!isnan(max) && ((max < 0 && value < max) || (max >= 0 && value > max)))
 
-#define APPLY_PROP(recognizer, config, type, prop, propName) do { \
-id value = config[propName]; \
-if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
-} while(0)
+#define APPLY_PROP(recognizer, config, type, prop, propName) \
+  do {                                                       \
+    id value = config[propName];                             \
+    if (value != nil) {                                      \
+      recognizer.prop = [RCTConvert type:value];             \
+    }                                                        \
+  } while (0)
 
-#define APPLY_FLOAT_PROP(prop) do { APPLY_PROP(recognizer, config, CGFloat, prop, @#prop); } while(0)
-#define APPLY_INT_PROP(prop) do { APPLY_PROP(recognizer, config, NSInteger, prop, @#prop); } while(0)
-#define APPLY_NAMED_INT_PROP(prop, propName) do { APPLY_PROP(recognizer, config, NSInteger, prop, propName); } while(0)
+#define APPLY_FLOAT_PROP(prop)                              \
+  do {                                                      \
+    APPLY_PROP(recognizer, config, CGFloat, prop, @ #prop); \
+  } while (0)
+#define APPLY_INT_PROP(prop)                                  \
+  do {                                                        \
+    APPLY_PROP(recognizer, config, NSInteger, prop, @ #prop); \
+  } while (0)
+#define APPLY_NAMED_INT_PROP(prop, propName)                   \
+  do {                                                         \
+    APPLY_PROP(recognizer, config, NSInteger, prop, propName); \
+  } while (0)
 
 @protocol RNGestureHandlerEventEmitter
 
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event withActionType:(RNGestureHandlerActionType)actionType;
 
 @end
-
 
 @protocol RNRootViewGestureRecognizerDelegate <UIGestureRecognizerDelegate>
 
@@ -38,12 +48,11 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 
 @end
 
-
 @interface RNGestureHandler : NSObject <UIGestureRecognizerDelegate> {
-
-@protected UIGestureRecognizer *_recognizer;
-@protected RNGestureHandlerState _lastState;
-
+ @protected
+  UIGestureRecognizer *_recognizer;
+ @protected
+  RNGestureHandlerState _lastState;
 }
 
 + (nullable RNGestureHandler *)findGestureHandlerByRecognizer:(nonnull UIGestureRecognizer *)recognizer;
@@ -76,8 +85,6 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
-- (void)sendTouchEventInState:(RNGestureHandlerState)state
-                 forViewWithTag:(nonnull NSNumber *)reactTag;
+- (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(nonnull NSNumber *)reactTag;
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandler.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandler.m
@@ -11,84 +11,84 @@
 @property (nonatomic, readonly) RNGestureHandler *gestureHandler;
 @end
 
-
 @implementation UIGestureRecognizer (GestureHandler)
 
 - (RNGestureHandler *)gestureHandler
 {
-    id delegate = self.delegate;
-    if ([delegate isKindOfClass:[RNGestureHandler class]]) {
-        return (RNGestureHandler *)delegate;
-    }
-    return nil;
+  id delegate = self.delegate;
+  if ([delegate isKindOfClass:[RNGestureHandler class]]) {
+    return (RNGestureHandler *)delegate;
+  }
+  return nil;
 }
 
 @end
 
 typedef struct RNGHHitSlop {
-    CGFloat top, left, bottom, right, width, height;
+  CGFloat top, left, bottom, right, width, height;
 } RNGHHitSlop;
 
-static RNGHHitSlop RNGHHitSlopEmpty = { NAN, NAN, NAN, NAN, NAN, NAN };
+static RNGHHitSlop RNGHHitSlopEmpty = {NAN, NAN, NAN, NAN, NAN, NAN};
 
 #define RNGH_HIT_SLOP_GET(key) (prop[key] == nil ? NAN : [prop[key] doubleValue])
-#define RNGH_HIT_SLOP_IS_SET(hitSlop) (!isnan(hitSlop.left) || !isnan(hitSlop.right) || \
-                                        !isnan(hitSlop.top) || !isnan(hitSlop.bottom))
+#define RNGH_HIT_SLOP_IS_SET(hitSlop) \
+  (!isnan(hitSlop.left) || !isnan(hitSlop.right) || !isnan(hitSlop.top) || !isnan(hitSlop.bottom))
 #define RNGH_HIT_SLOP_INSET(key) (isnan(hitSlop.key) ? 0. : hitSlop.key)
 
-CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
-    rect.origin.x -= RNGH_HIT_SLOP_INSET(left);
-    rect.origin.y -= RNGH_HIT_SLOP_INSET(top);
+CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop)
+{
+  rect.origin.x -= RNGH_HIT_SLOP_INSET(left);
+  rect.origin.y -= RNGH_HIT_SLOP_INSET(top);
 
-    if (!isnan(hitSlop.width)) {
-        if (!isnan(hitSlop.right)) {
-            rect.origin.x = rect.size.width - hitSlop.width + RNGH_HIT_SLOP_INSET(right);
-        }
-        rect.size.width = hitSlop.width;
-    } else {
-        rect.size.width += (RNGH_HIT_SLOP_INSET(left) + RNGH_HIT_SLOP_INSET(right));
+  if (!isnan(hitSlop.width)) {
+    if (!isnan(hitSlop.right)) {
+      rect.origin.x = rect.size.width - hitSlop.width + RNGH_HIT_SLOP_INSET(right);
     }
-    if (!isnan(hitSlop.height)) {
-        if (!isnan(hitSlop.bottom)) {
-            rect.origin.y = rect.size.height - hitSlop.height + RNGH_HIT_SLOP_INSET(bottom);
-        }
-        rect.size.height = hitSlop.height;
-    } else {
-        rect.size.height += (RNGH_HIT_SLOP_INSET(top) + RNGH_HIT_SLOP_INSET(bottom));
+    rect.size.width = hitSlop.width;
+  } else {
+    rect.size.width += (RNGH_HIT_SLOP_INSET(left) + RNGH_HIT_SLOP_INSET(right));
+  }
+  if (!isnan(hitSlop.height)) {
+    if (!isnan(hitSlop.bottom)) {
+      rect.origin.y = rect.size.height - hitSlop.height + RNGH_HIT_SLOP_INSET(bottom);
     }
-    return rect;
+    rect.size.height = hitSlop.height;
+  } else {
+    rect.size.height += (RNGH_HIT_SLOP_INSET(top) + RNGH_HIT_SLOP_INSET(bottom));
+  }
+  return rect;
 }
 
 static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 @implementation RNGestureHandler {
-    RNGestureHandlerPointerTracker *_pointerTracker;
-    RNGestureHandlerState _state;
-    RNManualActivationRecognizer *_manualActivationRecognizer;
-    NSArray<NSNumber *> *_handlersToWaitFor;
-    NSArray<NSNumber *> *_simultaneousHandlers;
-    RNGHHitSlop _hitSlop;
-    uint16_t _eventCoalescingKey;
+  RNGestureHandlerPointerTracker *_pointerTracker;
+  RNGestureHandlerState _state;
+  RNManualActivationRecognizer *_manualActivationRecognizer;
+  NSArray<NSNumber *> *_handlersToWaitFor;
+  NSArray<NSNumber *> *_simultaneousHandlers;
+  RNGHHitSlop _hitSlop;
+  uint16_t _eventCoalescingKey;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
-    if ((self = [super init])) {
-        _pointerTracker = [[RNGestureHandlerPointerTracker alloc] initWithGestureHandler:self];
-        _tag = tag;
-        _lastState = RNGestureHandlerStateUndetermined;
-        _hitSlop = RNGHHitSlopEmpty;
-        _state = RNGestureHandlerStateBegan;
-        _manualActivationRecognizer = nil;
+  if ((self = [super init])) {
+    _pointerTracker = [[RNGestureHandlerPointerTracker alloc] initWithGestureHandler:self];
+    _tag = tag;
+    _lastState = RNGestureHandlerStateUndetermined;
+    _hitSlop = RNGHHitSlopEmpty;
+    _state = RNGestureHandlerStateBegan;
+    _manualActivationRecognizer = nil;
 
-        static dispatch_once_t onceToken;
-        dispatch_once(&onceToken, ^{
-            allGestureHandlers = [NSHashTable weakObjectsHashTable];
-        });
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      allGestureHandlers = [NSHashTable weakObjectsHashTable];
+    });
 
-        [allGestureHandlers addObject:self];
-    }
-    return self;
+    [allGestureHandlers addObject:self];
+  }
+  return self;
 }
 
 - (void)resetConfig
@@ -107,197 +107,201 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 - (void)configure:(NSDictionary *)config
 {
   [self resetConfig];
-    _handlersToWaitFor = [RCTConvert NSNumberArray:config[@"waitFor"]];
-    _simultaneousHandlers = [RCTConvert NSNumberArray:config[@"simultaneousHandlers"]];
+  _handlersToWaitFor = [RCTConvert NSNumberArray:config[@"waitFor"]];
+  _simultaneousHandlers = [RCTConvert NSNumberArray:config[@"simultaneousHandlers"]];
 
-    id prop = config[@"enabled"];
-    if (prop != nil) {
-        self.enabled = [RCTConvert BOOL:prop];
-    }
+  id prop = config[@"enabled"];
+  if (prop != nil) {
+    self.enabled = [RCTConvert BOOL:prop];
+  }
 
-    prop = config[@"shouldCancelWhenOutside"];
-    if (prop != nil) {
-        _shouldCancelWhenOutside = [RCTConvert BOOL:prop];
-    }
-  
-    prop = config[@"cancelsTouchesInView"];
-    if (prop != nil) {
-        _recognizer.cancelsTouchesInView = [RCTConvert BOOL:prop];
-    }
-    
-    prop = config[@"needsPointerData"];
-    if (prop != nil) {
-        _needsPointerData = [RCTConvert BOOL:prop];
-    }
-    
-    prop = config[@"manualActivation"];
-    if (prop != nil) {
-        self.manualActivation = [RCTConvert BOOL:prop];
-    }
+  prop = config[@"shouldCancelWhenOutside"];
+  if (prop != nil) {
+    _shouldCancelWhenOutside = [RCTConvert BOOL:prop];
+  }
 
-    prop = config[@"hitSlop"];
-    if ([prop isKindOfClass:[NSNumber class]]) {
-        _hitSlop.left = _hitSlop.right = _hitSlop.top = _hitSlop.bottom = [prop doubleValue];
-    } else if (prop != nil) {
-        _hitSlop.left = _hitSlop.right = RNGH_HIT_SLOP_GET(@"horizontal");
-        _hitSlop.top = _hitSlop.bottom = RNGH_HIT_SLOP_GET(@"vertical");
-        _hitSlop.left = RNGH_HIT_SLOP_GET(@"left");
-        _hitSlop.right = RNGH_HIT_SLOP_GET(@"right");
-        _hitSlop.top = RNGH_HIT_SLOP_GET(@"top");
-        _hitSlop.bottom = RNGH_HIT_SLOP_GET(@"bottom");
-        _hitSlop.width = RNGH_HIT_SLOP_GET(@"width");
-        _hitSlop.height = RNGH_HIT_SLOP_GET(@"height");
-        if (isnan(_hitSlop.left) && isnan(_hitSlop.right) && !isnan(_hitSlop.width)) {
-            RCTLogError(@"When width is set one of left or right pads need to be defined");
-        }
-        if (!isnan(_hitSlop.width) && !isnan(_hitSlop.left) && !isnan(_hitSlop.right)) {
-            RCTLogError(@"Cannot have all of left, right and width defined");
-        }
-        if (isnan(_hitSlop.top) && isnan(_hitSlop.bottom) && !isnan(_hitSlop.height)) {
-            RCTLogError(@"When height is set one of top or bottom pads need to be defined");
-        }
-        if (!isnan(_hitSlop.height) && !isnan(_hitSlop.top) && !isnan(_hitSlop.bottom)) {
-            RCTLogError(@"Cannot have all of top, bottom and height defined");
-        }
+  prop = config[@"cancelsTouchesInView"];
+  if (prop != nil) {
+    _recognizer.cancelsTouchesInView = [RCTConvert BOOL:prop];
+  }
+
+  prop = config[@"needsPointerData"];
+  if (prop != nil) {
+    _needsPointerData = [RCTConvert BOOL:prop];
+  }
+
+  prop = config[@"manualActivation"];
+  if (prop != nil) {
+    self.manualActivation = [RCTConvert BOOL:prop];
+  }
+
+  prop = config[@"hitSlop"];
+  if ([prop isKindOfClass:[NSNumber class]]) {
+    _hitSlop.left = _hitSlop.right = _hitSlop.top = _hitSlop.bottom = [prop doubleValue];
+  } else if (prop != nil) {
+    _hitSlop.left = _hitSlop.right = RNGH_HIT_SLOP_GET(@"horizontal");
+    _hitSlop.top = _hitSlop.bottom = RNGH_HIT_SLOP_GET(@"vertical");
+    _hitSlop.left = RNGH_HIT_SLOP_GET(@"left");
+    _hitSlop.right = RNGH_HIT_SLOP_GET(@"right");
+    _hitSlop.top = RNGH_HIT_SLOP_GET(@"top");
+    _hitSlop.bottom = RNGH_HIT_SLOP_GET(@"bottom");
+    _hitSlop.width = RNGH_HIT_SLOP_GET(@"width");
+    _hitSlop.height = RNGH_HIT_SLOP_GET(@"height");
+    if (isnan(_hitSlop.left) && isnan(_hitSlop.right) && !isnan(_hitSlop.width)) {
+      RCTLogError(@"When width is set one of left or right pads need to be defined");
     }
+    if (!isnan(_hitSlop.width) && !isnan(_hitSlop.left) && !isnan(_hitSlop.right)) {
+      RCTLogError(@"Cannot have all of left, right and width defined");
+    }
+    if (isnan(_hitSlop.top) && isnan(_hitSlop.bottom) && !isnan(_hitSlop.height)) {
+      RCTLogError(@"When height is set one of top or bottom pads need to be defined");
+    }
+    if (!isnan(_hitSlop.height) && !isnan(_hitSlop.top) && !isnan(_hitSlop.bottom)) {
+      RCTLogError(@"Cannot have all of top, bottom and height defined");
+    }
+  }
 }
 
 - (void)setEnabled:(BOOL)enabled
 {
-    _enabled = enabled;
-    self.recognizer.enabled = enabled;
+  _enabled = enabled;
+  self.recognizer.enabled = enabled;
 }
 
 - (void)bindToView:(UIView *)view
 {
-    view.userInteractionEnabled = YES;
-    self.recognizer.delegate = self;
-    [view addGestureRecognizer:self.recognizer];
-  
+  view.userInteractionEnabled = YES;
+  self.recognizer.delegate = self;
+  [view addGestureRecognizer:self.recognizer];
+
   [self bindManualActivationToView:view];
 }
 
 - (void)unbindFromView
 {
-    [self.recognizer.view removeGestureRecognizer:self.recognizer];
-    self.recognizer.delegate = nil;
-  
-    [self unbindManualActivation];
+  [self.recognizer.view removeGestureRecognizer:self.recognizer];
+  self.recognizer.delegate = nil;
+
+  [self unbindManualActivation];
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer
 {
-    return [RNGestureHandlerEventExtraData
-            forPosition:[recognizer locationInView:recognizer.view]
-            withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-            withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forPosition:[recognizer locationInView:recognizer.view]
+                                withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+                                 withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
-    // it may happen that the gesture recognizer is reset after it's been unbound from the view,
-    // it that recognizer tried to send event, the app would crash because the target of the event
-    // would be nil.
-    if (recognizer.view.reactTag == nil) {
-      return;
-    }
-    
-    _state = [self recognizerState];
-    [self handleGesture:recognizer inState:_state];
+  // it may happen that the gesture recognizer is reset after it's been unbound from the view,
+  // it that recognizer tried to send event, the app would crash because the target of the event
+  // would be nil.
+  if (recognizer.view.reactTag == nil) {
+    return;
+  }
+
+  _state = [self recognizerState];
+  [self handleGesture:recognizer inState:_state];
 }
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer inState:(RNGestureHandlerState)state
 {
-    _state = state;
-    RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
-    [self sendEventsInState:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];
+  _state = state;
+  RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
+  [self sendEventsInState:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];
 }
 
 - (void)sendEventsInState:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(RNGestureHandlerEventExtraData *)extraData
 {
-    if (state != _lastState) {
-        // don't send change events from END to FAILED or CANCELLED, this may happen when gesture is ended in `onTouchesUp` callback
-        if (_lastState == RNGestureHandlerStateEnd && (state == RNGestureHandlerStateFailed || state == RNGestureHandlerStateCancelled)) {
-            return;
-        }
-        
-        if (state == RNGestureHandlerStateActive) {
-            // Generate a unique coalescing-key each time the gesture-handler becomes active. All events will have
-            // the same coalescing-key allowing RCTEventDispatcher to coalesce RNGestureHandlerEvents when events are
-            // generated faster than they can be treated by JS thread
-            static uint16_t nextEventCoalescingKey = 0;
-            self->_eventCoalescingKey = nextEventCoalescingKey++;
-
-        } else if (state == RNGestureHandlerStateEnd && _lastState != RNGestureHandlerStateActive && !_manualActivation) {
-            id event = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
-                                                                  handlerTag:_tag
-                                                                       state:RNGestureHandlerStateActive
-                                                                   prevState:_lastState
-                                                                   extraData:extraData];
-            [self sendEvent:event];
-            _lastState = RNGestureHandlerStateActive;
-        }
-        id stateEvent = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
-                                                                   handlerTag:_tag
-                                                                        state:state
-                                                                    prevState:_lastState
-                                                                    extraData:extraData];
-        [self sendEvent:stateEvent];
-        _lastState = state;
+  if (state != _lastState) {
+    // don't send change events from END to FAILED or CANCELLED, this may happen when gesture is ended in `onTouchesUp`
+    // callback
+    if (_lastState == RNGestureHandlerStateEnd &&
+        (state == RNGestureHandlerStateFailed || state == RNGestureHandlerStateCancelled)) {
+      return;
     }
 
     if (state == RNGestureHandlerStateActive) {
-        id touchEvent = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag
-                                                             handlerTag:_tag
-                                                                  state:state
-                                                              extraData:extraData
-                                                          coalescingKey:self->_eventCoalescingKey];
-        [self sendEvent:touchEvent];
+      // Generate a unique coalescing-key each time the gesture-handler becomes active. All events will have
+      // the same coalescing-key allowing RCTEventDispatcher to coalesce RNGestureHandlerEvents when events are
+      // generated faster than they can be treated by JS thread
+      static uint16_t nextEventCoalescingKey = 0;
+      self->_eventCoalescingKey = nextEventCoalescingKey++;
+
+    } else if (state == RNGestureHandlerStateEnd && _lastState != RNGestureHandlerStateActive && !_manualActivation) {
+      id event = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
+                                                            handlerTag:_tag
+                                                                 state:RNGestureHandlerStateActive
+                                                             prevState:_lastState
+                                                             extraData:extraData];
+      [self sendEvent:event];
+      _lastState = RNGestureHandlerStateActive;
     }
+    id stateEvent = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
+                                                               handlerTag:_tag
+                                                                    state:state
+                                                                prevState:_lastState
+                                                                extraData:extraData];
+    [self sendEvent:stateEvent];
+    _lastState = state;
+  }
+
+  if (state == RNGestureHandlerStateActive) {
+    id touchEvent = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag
+                                                         handlerTag:_tag
+                                                              state:state
+                                                          extraData:extraData
+                                                      coalescingKey:self->_eventCoalescingKey];
+    [self sendEvent:touchEvent];
+  }
 }
 
 - (void)sendEvent:(RNGestureHandlerStateChange *)event
 {
-    [self.emitter sendEvent:event withActionType:self.actionType];
+  [self.emitter sendEvent:event withActionType:self.actionType];
 }
 
-- (void)sendTouchEventInState:(RNGestureHandlerState)state
-                 forViewWithTag:(NSNumber *)reactTag
+- (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(NSNumber *)reactTag
 {
   id extraData = [RNGestureHandlerEventExtraData forEventType:_pointerTracker.eventType
                                           withChangedPointers:_pointerTracker.changedPointersData
                                               withAllPointers:_pointerTracker.allPointersData
                                           withNumberOfTouches:_pointerTracker.trackedPointersCount];
-  id event = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag handlerTag:_tag state:state extraData:extraData coalescingKey:[_tag intValue]];
-  
+  id event = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag
+                                                  handlerTag:_tag
+                                                       state:state
+                                                   extraData:extraData
+                                               coalescingKey:[_tag intValue]];
+
   [self.emitter sendEvent:event withActionType:self.actionType];
 }
 
 - (RNGestureHandlerState)recognizerState
 {
-    switch (_recognizer.state) {
-        case UIGestureRecognizerStateBegan:
-        case UIGestureRecognizerStatePossible:
-            return RNGestureHandlerStateBegan;
-        case UIGestureRecognizerStateEnded:
-            return RNGestureHandlerStateEnd;
-        case UIGestureRecognizerStateFailed:
-            return RNGestureHandlerStateFailed;
-        case UIGestureRecognizerStateCancelled:
-            return RNGestureHandlerStateCancelled;
-        case UIGestureRecognizerStateChanged:
-            return RNGestureHandlerStateActive;
-    }
-    return RNGestureHandlerStateUndetermined;
+  switch (_recognizer.state) {
+    case UIGestureRecognizerStateBegan:
+    case UIGestureRecognizerStatePossible:
+      return RNGestureHandlerStateBegan;
+    case UIGestureRecognizerStateEnded:
+      return RNGestureHandlerStateEnd;
+    case UIGestureRecognizerStateFailed:
+      return RNGestureHandlerStateFailed;
+    case UIGestureRecognizerStateCancelled:
+      return RNGestureHandlerStateCancelled;
+    case UIGestureRecognizerStateChanged:
+      return RNGestureHandlerStateActive;
+  }
+  return RNGestureHandlerStateUndetermined;
 }
 
 - (RNGestureHandlerState)state
 {
-    // instead of mapping state of the recognizer directly, use value mapped when handleGesture was
-    // called, making it correct while awaiting for another handler failure
-    return _state;
+  // instead of mapping state of the recognizer directly, use value mapped when handleGesture was
+  // called, making it correct while awaiting for another handler failure
+  return _state;
 }
 
 #pragma mark Manual activation
@@ -312,7 +316,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 - (void)setManualActivation:(BOOL)manualActivation
 {
   _manualActivation = manualActivation;
-  
+
   if (manualActivation) {
     _manualActivationRecognizer = [[RNManualActivationRecognizer alloc] initWithGestureHandler:self];
 
@@ -343,135 +347,136 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 + (RNGestureHandler *)findGestureHandlerByRecognizer:(UIGestureRecognizer *)recognizer
 {
-    RNGestureHandler *handler = recognizer.gestureHandler;
-    if (handler != nil) {
-        return handler;
-    }
+  RNGestureHandler *handler = recognizer.gestureHandler;
+  if (handler != nil) {
+    return handler;
+  }
 
-    // We may try to extract "DummyGestureHandler" in case when "otherGestureRecognizer" belongs to
-    // a native view being wrapped with "NativeViewGestureHandler"
-    UIView *reactView = recognizer.view;
-    while (reactView != nil && reactView.reactTag == nil) {
-        reactView = reactView.superview;
-    }
+  // We may try to extract "DummyGestureHandler" in case when "otherGestureRecognizer" belongs to
+  // a native view being wrapped with "NativeViewGestureHandler"
+  UIView *reactView = recognizer.view;
+  while (reactView != nil && reactView.reactTag == nil) {
+    reactView = reactView.superview;
+  }
 
-    for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
-        if ([recognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-            return recognizer.gestureHandler;
-        }
+  for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
+    if ([recognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
+      return recognizer.gestureHandler;
     }
+  }
 
-    return nil;
+  return nil;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+    shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
-    if ([handler isKindOfClass:[RNNativeViewGestureHandler class]]) {
-        for (NSNumber *handlerTag in handler->_handlersToWaitFor) {
-            if ([_tag isEqual:handlerTag]) {
-                return YES;
-            }
-        }
-    }
-
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-    if ([_handlersToWaitFor count]) {
-        RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
-        if (handler != nil) {
-            for (NSNumber *handlerTag in _handlersToWaitFor) {
-                if ([handler.tag isEqual:handlerTag]) {
-                    return YES;
-                }
-            }
-        }
-    }
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
-{
-    if (_recognizer.state == UIGestureRecognizerStateBegan && _recognizer.state == UIGestureRecognizerStatePossible) {
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+  if ([handler isKindOfClass:[RNNativeViewGestureHandler class]]) {
+    for (NSNumber *handlerTag in handler->_handlersToWaitFor) {
+      if ([_tag isEqual:handlerTag]) {
         return YES;
+      }
     }
-    
+  }
+
+  return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  if ([_handlersToWaitFor count]) {
     RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
     if (handler != nil) {
-        if ([_simultaneousHandlers count]) {
-            for (NSNumber *handlerTag in _simultaneousHandlers) {
-                if ([handler.tag isEqual:handlerTag]) {
-                    return YES;
-                }
-            }
-        } else if (handler->_simultaneousHandlers) {
-            for (NSNumber *handlerTag in handler->_simultaneousHandlers) {
-                if ([self.tag isEqual:handlerTag]) {
-                    return YES;
-                }
-            }
+      for (NSNumber *handlerTag in _handlersToWaitFor) {
+        if ([handler.tag isEqual:handlerTag]) {
+          return YES;
         }
+      }
     }
-    return NO;
+  }
+  return NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  if (_recognizer.state == UIGestureRecognizerStateBegan && _recognizer.state == UIGestureRecognizerStatePossible) {
+    return YES;
+  }
+
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+  if (handler != nil) {
+    if ([_simultaneousHandlers count]) {
+      for (NSNumber *handlerTag in _simultaneousHandlers) {
+        if ([handler.tag isEqual:handlerTag]) {
+          return YES;
+        }
+      }
+    } else if (handler->_simultaneousHandlers) {
+      for (NSNumber *handlerTag in handler->_simultaneousHandlers) {
+        if ([self.tag isEqual:handlerTag]) {
+          return YES;
+        }
+      }
+    }
+  }
+  return NO;
 }
 
 - (void)reset
 {
-    // do not reset states while gesture is tracking pointers, as gestureRecognizerShouldBegin
-    // might be called after some pointers are down, and after state manipulation by the user.
-    // Pointer tracker calls this method when it resets, and in that case it no longer tracks
-    // any pointers, thus entering this if
-    if (!_needsPointerData || _pointerTracker.trackedPointersCount == 0) {
-        _lastState = RNGestureHandlerStateUndetermined;
-        _state = RNGestureHandlerStateBegan;
-    }
+  // do not reset states while gesture is tracking pointers, as gestureRecognizerShouldBegin
+  // might be called after some pointers are down, and after state manipulation by the user.
+  // Pointer tracker calls this method when it resets, and in that case it no longer tracks
+  // any pointers, thus entering this if
+  if (!_needsPointerData || _pointerTracker.trackedPointersCount == 0) {
+    _lastState = RNGestureHandlerStateUndetermined;
+    _state = RNGestureHandlerStateBegan;
+  }
 }
 
- - (BOOL)containsPointInView
- {
-     CGPoint pt = [_recognizer locationInView:_recognizer.view];
-     CGRect hitFrame = RNGHHitSlopInsetRect(_recognizer.view.bounds, _hitSlop);
-     return CGRectContainsPoint(hitFrame, pt);
- }
+- (BOOL)containsPointInView
+{
+  CGPoint pt = [_recognizer locationInView:_recognizer.view];
+  CGRect hitFrame = RNGHHitSlopInsetRect(_recognizer.view.bounds, _hitSlop);
+  return CGRectContainsPoint(hitFrame, pt);
+}
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-    if ([_handlersToWaitFor count]) {
-        for (RNGestureHandler *handler in [allGestureHandlers allObjects]) {
-            if (handler != nil
-                && (handler.state == RNGestureHandlerStateActive || handler->_recognizer.state == UIGestureRecognizerStateBegan)) {
-                for (NSNumber *handlerTag in _handlersToWaitFor) {
-                    if ([handler.tag isEqual:handlerTag]) {
-                        return NO;
-                    }
-                }
-            }
+  if ([_handlersToWaitFor count]) {
+    for (RNGestureHandler *handler in [allGestureHandlers allObjects]) {
+      if (handler != nil &&
+          (handler.state == RNGestureHandlerStateActive ||
+           handler->_recognizer.state == UIGestureRecognizerStateBegan)) {
+        for (NSNumber *handlerTag in _handlersToWaitFor) {
+          if ([handler.tag isEqual:handlerTag]) {
+            return NO;
+          }
         }
+      }
     }
+  }
 
-    [self reset];
-    return YES;
+  [self reset];
+  return YES;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {
-    // If hitSlop is set we use it to determine if a given gesture recognizer should start processing
-    // touch stream. This only works for negative values of hitSlop as this method won't be triggered
-    // unless touch startes in the bounds of the attached view. To acheve similar effect with positive
-    // values of hitSlop one should set hitSlop for the underlying view. This limitation is due to the
-    // fact that hitTest method is only available at the level of UIView
-    if (RNGH_HIT_SLOP_IS_SET(_hitSlop)) {
-        CGPoint location = [touch locationInView:gestureRecognizer.view];
-        CGRect hitFrame = RNGHHitSlopInsetRect(gestureRecognizer.view.bounds, _hitSlop);
-        return CGRectContainsPoint(hitFrame, location);
-    }
-    return YES;
+  // If hitSlop is set we use it to determine if a given gesture recognizer should start processing
+  // touch stream. This only works for negative values of hitSlop as this method won't be triggered
+  // unless touch startes in the bounds of the attached view. To acheve similar effect with positive
+  // values of hitSlop one should set hitSlop for the underlying view. This limitation is due to the
+  // fact that hitTest method is only available at the level of UIView
+  if (RNGH_HIT_SLOP_IS_SET(_hitSlop)) {
+    CGPoint location = [touch locationInView:gestureRecognizer.view];
+    CGRect hitFrame = RNGHHitSlopInsetRect(gestureRecognizer.view.bounds, _hitSlop);
+    return CGRectContainsPoint(hitFrame, location);
+  }
+  return YES;
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerActionType.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerActionType.h
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RNGestureHandlerActionType) {
-    RNGestureHandlerActionTypeReanimatedWorklet = 1, // Reanimated worklet
-    RNGestureHandlerActionTypeNativeAnimatedEvent, // Animated.event with useNativeDriver: true
-    RNGestureHandlerActionTypeJSFunctionOldAPI, // JS function or Animated.event with useNativeDriver: false using old RNGH API
-    RNGestureHandlerActionTypeJSFunctionNewAPI, // JS function or Animated.event with useNativeDriver: false using new RNGH API
+  RNGestureHandlerActionTypeReanimatedWorklet = 1, // Reanimated worklet
+  RNGestureHandlerActionTypeNativeAnimatedEvent, // Animated.event with useNativeDriver: true
+  RNGestureHandlerActionTypeJSFunctionOldAPI, // JS function or Animated.event with useNativeDriver: false using old
+                                              // RNGH API
+  RNGestureHandlerActionTypeJSFunctionNewAPI, // JS function or Animated.event with useNativeDriver: false using new
+                                              // RNGH API
 };

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerButton.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerButton.m
@@ -48,12 +48,12 @@
 
 - (BOOL)shouldHandleTouch:(UIView *)view
 {
-    if ([view isKindOfClass:[RNGestureHandlerButton class]]) {
-        RNGestureHandlerButton *button = (RNGestureHandlerButton *)view;
-        return button.userEnabled;
-    }
-    
-    return [view isKindOfClass:[UIControl class]] || [view.gestureRecognizers count] > 0;
+  if ([view isKindOfClass:[RNGestureHandlerButton class]]) {
+    RNGestureHandlerButton *button = (RNGestureHandlerButton *)view;
+    return button.userEnabled;
+  }
+
+  return [view isKindOfClass:[UIControl class]] || [view.gestureRecognizers count] > 0;
 }
 
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
@@ -67,12 +67,11 @@
 
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
-    UIView *inner = [super hitTest:point withEvent:event];
-    while (inner && ![self shouldHandleTouch:inner]) {
-        inner = inner.superview;
-    }
-    return inner;
+  UIView *inner = [super hitTest:point withEvent:event];
+  while (inner && ![self shouldHandleTouch:inner]) {
+    inner = inner.superview;
+  }
+  return inner;
 }
 
 @end
-

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerButtonManager.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerButtonManager.m
@@ -1,5 +1,5 @@
-#import "RNGestureHandlerButton.h"
 #import "RNGestureHandlerButtonManager.h"
+#import "RNGestureHandlerButton.h"
 
 @implementation RNGestureHandlerButtonManager
 
@@ -7,19 +7,20 @@ RCT_EXPORT_MODULE(RNGestureHandlerButton)
 
 RCT_CUSTOM_VIEW_PROPERTY(enabled, BOOL, RNGestureHandlerButton)
 {
-    view.userEnabled = json == nil ? YES : [RCTConvert BOOL: json];
+  view.userEnabled = json == nil ? YES : [RCTConvert BOOL:json];
 }
 #if !TARGET_OS_TV
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {
-  [view setExclusiveTouch: json == nil ? YES : [RCTConvert BOOL: json]];
+  [view setExclusiveTouch:json == nil ? YES : [RCTConvert BOOL:json]];
 }
 #endif
 RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)
 {
   if (json) {
     UIEdgeInsets hitSlopInsets = [RCTConvert UIEdgeInsets:json];
-    view.hitTestEdgeInsets = UIEdgeInsetsMake(-hitSlopInsets.top, -hitSlopInsets.left, -hitSlopInsets.bottom, -hitSlopInsets.right);
+    view.hitTestEdgeInsets =
+        UIEdgeInsetsMake(-hitSlopInsets.top, -hitSlopInsets.left, -hitSlopInsets.bottom, -hitSlopInsets.right);
   } else {
     view.hitTestEdgeInsets = defaultView.hitTestEdgeInsets;
   }
@@ -27,7 +28,7 @@ RCT_CUSTOM_VIEW_PROPERTY(hitSlop, UIEdgeInsets, RNGestureHandlerButton)
 
 - (UIView *)view
 {
-    return [RNGestureHandlerButton new];
+  return [RNGestureHandlerButton new];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerDirection.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerDirection.h
@@ -1,8 +1,8 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RNGestureHandlerDirection) {
-    RNGestureHandlerDirectionRight = 1,
-    RNGestureHandlerDirectionLeft = 2,
-    RNGestureHandlerDirectionUp = 4,
-    RNGestureHandlerDirectionDown = 8,
+  RNGestureHandlerDirectionRight = 1,
+  RNGestureHandlerDirectionLeft = 2,
+  RNGestureHandlerDirectionUp = 4,
+  RNGestureHandlerDirectionDown = 8,
 };

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerEvents.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerEvents.h
@@ -3,8 +3,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import "RNGestureHandlerState.h"
 #import "RNGHTouchEventType.h"
+#import "RNGestureHandlerState.h"
 
 @interface RNGestureHandlerEventExtraData : NSObject
 
@@ -48,11 +48,10 @@
 - (instancetype)initWithReactTag:(NSNumber *)reactTag
                       handlerTag:(NSNumber *)handlerTag
                            state:(RNGestureHandlerState)state
-                       extraData:(RNGestureHandlerEventExtraData*)extraData
+                       extraData:(RNGestureHandlerEventExtraData *)extraData
                    coalescingKey:(uint16_t)coalescingKey NS_DESIGNATED_INITIALIZER;
 
 @end
-
 
 @interface RNGestureHandlerStateChange : NSObject <RCTEvent>
 
@@ -60,6 +59,6 @@
                       handlerTag:(NSNumber *)handlerTag
                            state:(RNGestureHandlerState)state
                        prevState:(RNGestureHandlerState)prevState
-                       extraData:(RNGestureHandlerEventExtraData*)extraData NS_DESIGNATED_INITIALIZER;
+                       extraData:(RNGestureHandlerEventExtraData *)extraData NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerEvents.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerEvents.m
@@ -6,23 +6,23 @@
 
 - (instancetype)initWithData:(NSDictionary *)data;
 {
-    if ((self = [super init])) {
-        _data = data;
-    }
-    return self;
+  if ((self = [super init])) {
+    _data = data;
+  }
+  return self;
 }
 
 + (RNGestureHandlerEventExtraData *)forPosition:(CGPoint)position
                            withAbsolutePosition:(CGPoint)absolutePosition
                             withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{
-                           @"x": @(position.x),
-                           @"y": @(position.y),
-                           @"absoluteX": @(absolutePosition.x),
-                           @"absoluteY": @(absolutePosition.y),
-                           @"numberOfPointers": @(numberOfTouches)}];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"x" : @(position.x),
+    @"y" : @(position.y),
+    @"absoluteX" : @(absolutePosition.x),
+    @"absoluteY" : @(absolutePosition.y),
+    @"numberOfPointers" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forPosition:(CGPoint)position
@@ -30,15 +30,14 @@
                             withNumberOfTouches:(NSUInteger)numberOfTouches
                                    withDuration:(NSUInteger)duration
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{
-                           @"x": @(position.x),
-                           @"y": @(position.y),
-                           @"absoluteX": @(absolutePosition.x),
-                           @"absoluteY": @(absolutePosition.y),
-                           @"numberOfPointers": @(numberOfTouches),
-                           @"duration":@(duration)
-            }];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"x" : @(position.x),
+    @"y" : @(position.y),
+    @"absoluteX" : @(absolutePosition.x),
+    @"absoluteY" : @(absolutePosition.y),
+    @"numberOfPointers" : @(numberOfTouches),
+    @"duration" : @(duration)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forPan:(CGPoint)position
@@ -47,17 +46,17 @@
                               withVelocity:(CGPoint)velocity
                        withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{
-                           @"x": @(position.x),
-                           @"y": @(position.y),
-                           @"absoluteX": @(absolutePosition.x),
-                           @"absoluteY": @(absolutePosition.y),
-                           @"translationX": @(translation.x),
-                           @"translationY": @(translation.y),
-                           @"velocityX": SAFE_VELOCITY(velocity.x),
-                           @"velocityY": SAFE_VELOCITY(velocity.y),
-                           @"numberOfPointers": @(numberOfTouches)}];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"x" : @(position.x),
+    @"y" : @(position.y),
+    @"absoluteX" : @(absolutePosition.x),
+    @"absoluteY" : @(absolutePosition.y),
+    @"translationX" : @(translation.x),
+    @"translationY" : @(translation.y),
+    @"velocityX" : SAFE_VELOCITY(velocity.x),
+    @"velocityY" : SAFE_VELOCITY(velocity.y),
+    @"numberOfPointers" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forForce:(CGFloat)force
@@ -65,15 +64,14 @@
                         withAbsolutePosition:(CGPoint)absolutePosition
                          withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{
-                           @"x": @(position.x),
-                           @"y": @(position.y),
-                           @"absoluteX": @(absolutePosition.x),
-                           @"absoluteY": @(absolutePosition.y),
-                           @"force": @(force),
-                           @"numberOfPointers": @(numberOfTouches)}];
-  
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"x" : @(position.x),
+    @"y" : @(position.y),
+    @"absoluteX" : @(absolutePosition.x),
+    @"absoluteY" : @(absolutePosition.y),
+    @"force" : @(force),
+    @"numberOfPointers" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forPinch:(CGFloat)scale
@@ -81,13 +79,13 @@
                                 withVelocity:(CGFloat)velocity
                          withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{
-                           @"scale": @(scale),
-                           @"focalX": @(focalPoint.x),
-                           @"focalY": @(focalPoint.y),
-                           @"velocity": SAFE_VELOCITY(velocity),
-                           @"numberOfPointers": @(numberOfTouches)}];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"scale" : @(scale),
+    @"focalX" : @(focalPoint.x),
+    @"focalY" : @(focalPoint.y),
+    @"velocity" : SAFE_VELOCITY(velocity),
+    @"numberOfPointers" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forRotation:(CGFloat)rotation
@@ -95,12 +93,13 @@
                                    withVelocity:(CGFloat)velocity
                             withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{@"rotation": @(rotation),
-                           @"anchorX": @(anchorPoint.x),
-                           @"anchorY": @(anchorPoint.y),
-                           @"velocity": SAFE_VELOCITY(velocity),
-                           @"numberOfPointers": @(numberOfTouches)}];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"rotation" : @(rotation),
+    @"anchorX" : @(anchorPoint.x),
+    @"anchorY" : @(anchorPoint.y),
+    @"velocity" : SAFE_VELOCITY(velocity),
+    @"numberOfPointers" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forEventType:(RNGHTouchEventType)eventType
@@ -108,33 +107,31 @@
                                  withAllPointers:(NSArray<NSDictionary *> *)allPointers
                              withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    if (changedPointers == nil || allPointers == nil) {
-        changedPointers = @[];
-        allPointers = @[];
-        eventType = RNGHTouchEventTypeUndetermined;
-    }
-  
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{@"eventType": @(eventType),
-                         @"changedTouches": changedPointers,
-                         @"allTouches": allPointers,
-                         @"numberOfTouches": @(numberOfTouches)}];
+  if (changedPointers == nil || allPointers == nil) {
+    changedPointers = @[];
+    allPointers = @[];
+    eventType = RNGHTouchEventTypeUndetermined;
+  }
+
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{
+    @"eventType" : @(eventType),
+    @"changedTouches" : changedPointers,
+    @"allTouches" : allPointers,
+    @"numberOfTouches" : @(numberOfTouches)
+  }];
 }
 
 + (RNGestureHandlerEventExtraData *)forPointerInside:(BOOL)pointerInside
 {
-    return [[RNGestureHandlerEventExtraData alloc]
-            initWithData:@{@"pointerInside": @(pointerInside)}];
+  return [[RNGestureHandlerEventExtraData alloc] initWithData:@{@"pointerInside" : @(pointerInside)}];
 }
 
 @end
 
-
-@implementation RNGestureHandlerEvent
-{
-    NSNumber *_handlerTag;
-    RNGestureHandlerState _state;
-    RNGestureHandlerEventExtraData *_extraData;
+@implementation RNGestureHandlerEvent {
+  NSNumber *_handlerTag;
+  RNGestureHandlerState _state;
+  RNGestureHandlerEventExtraData *_extraData;
 }
 
 @synthesize viewTag = _viewTag;
@@ -146,56 +143,54 @@
                        extraData:(RNGestureHandlerEventExtraData *)extraData
                    coalescingKey:(uint16_t)coalescingKey
 {
-    if ((self = [super init])) {
-        _viewTag = reactTag;
-        _handlerTag = handlerTag;
-        _state = state;
-        _extraData = extraData;
-        _coalescingKey = coalescingKey;
-    }
-    return self;
+  if ((self = [super init])) {
+    _viewTag = reactTag;
+    _handlerTag = handlerTag;
+    _state = state;
+    _extraData = extraData;
+    _coalescingKey = coalescingKey;
+  }
+  return self;
 }
 
-RCT_NOT_IMPLEMENTED(- (instancetype)init)
+RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (NSString *)eventName
 {
-    return @"onGestureHandlerEvent";
+  return @"onGestureHandlerEvent";
 }
 
 - (BOOL)canCoalesce
 {
-    return YES;
+  return YES;
 }
 
 - (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent;
 {
-    return newEvent;
+  return newEvent;
 }
 
 + (NSString *)moduleDotMethod
 {
-    return @"RCTEventEmitter.receiveEvent";
+  return @"RCTEventEmitter.receiveEvent";
 }
 
 - (NSArray *)arguments
 {
-    NSMutableDictionary *body = [NSMutableDictionary dictionaryWithDictionary:_extraData.data];
-    [body setObject:_viewTag forKey:@"target"];
-    [body setObject:_handlerTag forKey:@"handlerTag"];
-    [body setObject:@(_state) forKey:@"state"];
-    return @[self.viewTag, @"onGestureHandlerEvent", body];
+  NSMutableDictionary *body = [NSMutableDictionary dictionaryWithDictionary:_extraData.data];
+  [body setObject:_viewTag forKey:@"target"];
+  [body setObject:_handlerTag forKey:@"handlerTag"];
+  [body setObject:@(_state) forKey:@"state"];
+  return @[ self.viewTag, @"onGestureHandlerEvent", body ];
 }
 
 @end
 
-
-@implementation RNGestureHandlerStateChange
-{
-    NSNumber *_handlerTag;
-    RNGestureHandlerState _state;
-    RNGestureHandlerState _prevState;
-    RNGestureHandlerEventExtraData *_extraData;
+@implementation RNGestureHandlerStateChange {
+  NSNumber *_handlerTag;
+  RNGestureHandlerState _state;
+  RNGestureHandlerState _prevState;
+  RNGestureHandlerEventExtraData *_extraData;
 }
 
 @synthesize viewTag = _viewTag;
@@ -207,49 +202,49 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                        prevState:(RNGestureHandlerState)prevState
                        extraData:(RNGestureHandlerEventExtraData *)extraData
 {
-    static uint16_t coalescingKey = 0;
-    if ((self = [super init])) {
-        _viewTag = reactTag;
-        _handlerTag = handlerTag;
-        _state = state;
-        _prevState = prevState;
-        _extraData = extraData;
-        _coalescingKey = coalescingKey++;
-    }
-    return self;
+  static uint16_t coalescingKey = 0;
+  if ((self = [super init])) {
+    _viewTag = reactTag;
+    _handlerTag = handlerTag;
+    _state = state;
+    _prevState = prevState;
+    _extraData = extraData;
+    _coalescingKey = coalescingKey++;
+  }
+  return self;
 }
 
-RCT_NOT_IMPLEMENTED(- (instancetype)init)
+RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (NSString *)eventName
 {
-    return @"onGestureHandlerStateChange";
+  return @"onGestureHandlerStateChange";
 }
 
 - (BOOL)canCoalesce
 {
-    // TODO: event coalescing
-    return NO;
+  // TODO: event coalescing
+  return NO;
 }
 
 - (id<RCTEvent>)coalesceWithEvent:(id<RCTEvent>)newEvent;
 {
-    return newEvent;
+  return newEvent;
 }
 
 + (NSString *)moduleDotMethod
 {
-    return @"RCTEventEmitter.receiveEvent";
+  return @"RCTEventEmitter.receiveEvent";
 }
 
 - (NSArray *)arguments
 {
-    NSMutableDictionary *body = [NSMutableDictionary dictionaryWithDictionary:_extraData.data];
-    [body setObject:_viewTag forKey:@"target"];
-    [body setObject:_handlerTag forKey:@"handlerTag"];
-    [body setObject:@(_state) forKey:@"state"];
-    [body setObject:@(_prevState) forKey:@"oldState"];
-    return @[self.viewTag, @"onGestureHandlerStateChange", body];
+  NSMutableDictionary *body = [NSMutableDictionary dictionaryWithDictionary:_extraData.data];
+  [body setObject:_viewTag forKey:@"target"];
+  [body setObject:_handlerTag forKey:@"handlerTag"];
+  [body setObject:@(_state) forKey:@"state"];
+  [body setObject:@(_prevState) forKey:@"oldState"];
+  return @[ self.viewTag, @"onGestureHandlerStateChange", body ];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerManager.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerManager.h
@@ -26,8 +26,7 @@
 
 - (void)dropAllGestureHandlers;
 
-- (void)handleSetJSResponder:(nonnull NSNumber *)viewTag
-        blockNativeResponder:(nonnull NSNumber *)blockNativeResponder;
+- (void)handleSetJSResponder:(nonnull NSNumber *)viewTag blockNativeResponder:(nonnull NSNumber *)blockNativeResponder;
 
 - (void)handleClearJSResponder;
 

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerModule.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerModule.h
@@ -1,8 +1,7 @@
-#import <React/RCTEventEmitter.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #import <React/RCTUIManager.h>
 
 @interface RNGestureHandlerModule : RCTEventEmitter <RCTBridgeModule>
 
 @end
-  

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerModule.mm
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerModule.mm
@@ -1,27 +1,27 @@
 #import "RNGestureHandlerModule.h"
 
-#import <React/RCTLog.h>
-#import <React/RCTViewManager.h>
 #import <React/RCTComponent.h>
+#import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
-#import <React/RCTUIManagerUtils.h>
 #import <React/RCTUIManagerObserverCoordinator.h>
+#import <React/RCTUIManagerUtils.h>
+#import <React/RCTViewManager.h>
 
 #ifdef RN_FABRIC_ENABLED
-#import <React/RCTBridge.h>
-#import <ReactCommon/RCTTurboModule.h>
 #import <React/RCTBridge+Private.h>
-#import <ReactCommon/CallInvoker.h>
-#import <React/RCTUtils.h>
+#import <React/RCTBridge.h>
 #import <React/RCTSurfacePresenter.h>
+#import <React/RCTUtils.h>
+#import <ReactCommon/CallInvoker.h>
+#import <ReactCommon/RCTTurboModule.h>
 
 #import <react/renderer/uimanager/primitives.h>
 #endif // RN_FABRIC_ENABLED
 
-#import "RNGestureHandlerState.h"
-#import "RNGestureHandlerDirection.h"
 #import "RNGestureHandler.h"
+#import "RNGestureHandlerDirection.h"
 #import "RNGestureHandlerManager.h"
+#import "RNGestureHandlerState.h"
 
 #import "RNGestureHandlerButton.h"
 #import "RNGestureHandlerStateManager.h"
@@ -43,46 +43,45 @@ using namespace react;
 
 typedef void (^GestureHandlerOperation)(RNGestureHandlerManager *manager);
 
-@implementation RNGestureHandlerModule
-{
-    RNGestureHandlerManager *_manager;
+@implementation RNGestureHandlerModule {
+  RNGestureHandlerManager *_manager;
 
-    // Oparations called after views have been updated.
-    NSMutableArray<GestureHandlerOperation> *_operations;
+  // Oparations called after views have been updated.
+  NSMutableArray<GestureHandlerOperation> *_operations;
 }
 
 RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+  return YES;
 }
 
 - (void)invalidate
 {
-    RNGestureHandlerManager *handlerManager = _manager;
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [handlerManager dropAllGestureHandlers];
-    });
-    
-    _manager = nil;
-    
+  RNGestureHandlerManager *handlerManager = _manager;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [handlerManager dropAllGestureHandlers];
+  });
+
+  _manager = nil;
+
 #ifdef RN_FABRIC_ENABLED
-    [self.bridge.surfacePresenter removeObserver:self];
+  [self.bridge.surfacePresenter removeObserver:self];
 #else
-    [self.bridge.uiManager.observerCoordinator removeObserver:self];
+  [self.bridge.uiManager.observerCoordinator removeObserver:self];
 #endif // RN_FABRIC_ENABLED
 }
 
 - (dispatch_queue_t)methodQueue
 {
-    // This module needs to be on the same queue as the UIManager to avoid
-    // having to lock `_operations` and `_preOperations` since `uiManagerWillFlushUIBlocks`
-    // will be called from that queue.
+  // This module needs to be on the same queue as the UIManager to avoid
+  // having to lock `_operations` and `_preOperations` since `uiManagerWillFlushUIBlocks`
+  // will be called from that queue.
 
-    // This is required as this module rely on having all the view nodes created before
-    // gesture handlers can be associated with them
-    return RCTGetUIManagerQueue();
+  // This is required as this module rely on having all the view nodes created before
+  // gesture handlers can be associated with them
+  return RCTGetUIManagerQueue();
 }
 
 #ifdef RN_FABRIC_ENABLED
@@ -92,13 +91,8 @@ void decorateRuntime(jsi::Runtime &runtime)
       runtime,
       jsi::PropNameID::forAscii(runtime, "isFormsStackingContext"),
       1,
-      [](jsi::Runtime &runtime,
-         const jsi::Value &thisValue,
-         const jsi::Value *arguments,
-         size_t count) -> jsi::Value
-      {
-        if (!arguments[0].isObject())
-        {
+      [](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *arguments, size_t count) -> jsi::Value {
+        if (!arguments[0].isObject()) {
           return jsi::Value::null();
         }
 
@@ -113,85 +107,96 @@ void decorateRuntime(jsi::Runtime &runtime)
 
 - (void)setBridge:(RCTBridge *)bridge
 {
-    [super setBridge:bridge];
+  [super setBridge:bridge];
 
-    _manager = [[RNGestureHandlerManager alloc]
-                initWithUIManager:bridge.uiManager
-                eventDispatcher:bridge.eventDispatcher];
-    _operations = [NSMutableArray new];
+  _manager = [[RNGestureHandlerManager alloc] initWithUIManager:bridge.uiManager
+                                                eventDispatcher:bridge.eventDispatcher];
+  _operations = [NSMutableArray new];
 
 #ifdef RN_FABRIC_ENABLED
-    [bridge.surfacePresenter addObserver:self];
+  [bridge.surfacePresenter addObserver:self];
 #else
-    [bridge.uiManager.observerCoordinator addObserver:self];
+  [bridge.uiManager.observerCoordinator addObserver:self];
 #endif // RN_FABRIC_ENABLED
 }
 
 #ifdef RN_FABRIC_ENABLED
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install) {
-    RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
-    auto runtime = (jsi::Runtime *)cxxBridge.runtime;
-    decorateRuntime(*runtime);
-    return @true;
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(install)
+{
+  RCTCxxBridge *cxxBridge = (RCTCxxBridge *)self.bridge;
+  auto runtime = (jsi::Runtime *)cxxBridge.runtime;
+  decorateRuntime(*runtime);
+  return @true;
 }
 #endif // RN_FABRIC_ENABLED
 
-RCT_EXPORT_METHOD(createGestureHandler:(nonnull NSString *)handlerName tag:(nonnull NSNumber *)handlerTag config:(NSDictionary *)config)
+RCT_EXPORT_METHOD(createGestureHandler
+                  : (nonnull NSString *)handlerName tag
+                  : (nonnull NSNumber *)handlerTag config
+                  : (NSDictionary *)config)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager createGestureHandler:handlerName tag:handlerTag config:config];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager createGestureHandler:handlerName tag:handlerTag config:config];
+  }];
 }
 
-RCT_EXPORT_METHOD(attachGestureHandler:(nonnull NSNumber *)handlerTag toViewWithTag:(nonnull NSNumber *)viewTag actionType:(nonnull NSNumber *)actionType)
+RCT_EXPORT_METHOD(attachGestureHandler
+                  : (nonnull NSNumber *)handlerTag toViewWithTag
+                  : (nonnull NSNumber *)viewTag actionType
+                  : (nonnull NSNumber *)actionType)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager attachGestureHandler:handlerTag toViewWithTag:viewTag withActionType:(RNGestureHandlerActionType)[actionType integerValue]];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager attachGestureHandler:handlerTag
+                    toViewWithTag:viewTag
+                   withActionType:(RNGestureHandlerActionType)[actionType integerValue]];
+  }];
 }
 
-RCT_EXPORT_METHOD(updateGestureHandler:(nonnull NSNumber *)handlerTag config:(NSDictionary *)config)
+RCT_EXPORT_METHOD(updateGestureHandler : (nonnull NSNumber *)handlerTag config : (NSDictionary *)config)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager updateGestureHandler:handlerTag config:config];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager updateGestureHandler:handlerTag config:config];
+  }];
 }
 
-RCT_EXPORT_METHOD(dropGestureHandler:(nonnull NSNumber *)handlerTag)
+RCT_EXPORT_METHOD(dropGestureHandler : (nonnull NSNumber *)handlerTag)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager dropGestureHandler:handlerTag];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager dropGestureHandler:handlerTag];
+  }];
 }
 
-RCT_EXPORT_METHOD(handleSetJSResponder:(nonnull NSNumber *)viewTag blockNativeResponder:(nonnull NSNumber *)blockNativeResponder)
+RCT_EXPORT_METHOD(handleSetJSResponder
+                  : (nonnull NSNumber *)viewTag blockNativeResponder
+                  : (nonnull NSNumber *)blockNativeResponder)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager handleSetJSResponder:viewTag blockNativeResponder:blockNativeResponder];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager handleSetJSResponder:viewTag blockNativeResponder:blockNativeResponder];
+  }];
 }
 
 RCT_EXPORT_METHOD(handleClearJSResponder)
 {
-    [self addOperationBlock:^(RNGestureHandlerManager *manager) {
-        [manager handleClearJSResponder];
-    }];
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager handleClearJSResponder];
+  }];
 }
 
 RCT_EXPORT_METHOD(flushOperations)
 {
-    if (_operations.count == 0) {
-        return;
-    }
+  if (_operations.count == 0) {
+    return;
+  }
 
-    NSArray<GestureHandlerOperation> *operations = _operations;
-    _operations = [NSMutableArray new];
+  NSArray<GestureHandlerOperation> *operations = _operations;
+  _operations = [NSMutableArray new];
 
-    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+  [self.bridge.uiManager
+      addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         for (GestureHandlerOperation operation in operations) {
-            operation(self->_manager);
+          operation(self->_manager);
         }
-    }];
+      }];
 }
 
 - (void)setGestureState:(int)state forHandler:(int)handlerTag
@@ -212,12 +217,12 @@ RCT_EXPORT_METHOD(flushOperations)
       handler.recognizer.state = UIGestureRecognizerStateEnded;
     }
   }
-  
+
   // if the gesture was set to finish, cancel all pointers it was tracking
   if (state == 1 || state == 3 || state == 5) {
     [handler.pointerTracker cancelPointers];
   }
-  
+
   // do not send state change event when activating because it bypasses
   // shouldRequireFailureOfGestureRecognizer
   if (state != 4) {
@@ -225,11 +230,11 @@ RCT_EXPORT_METHOD(flushOperations)
   }
 }
 
-#pragma mark -- Batch handling
+#pragma mark-- Batch handling
 
 - (void)addOperationBlock:(GestureHandlerOperation)operation
 {
-    [_operations addObject:operation];
+  [_operations addObject:operation];
 }
 
 #pragma mark - RCTSurfacePresenterObserver
@@ -238,18 +243,18 @@ RCT_EXPORT_METHOD(flushOperations)
 
 - (void)didMountComponentsWithRootTag:(NSInteger)rootTag
 {
-    RCTAssertMainQueue();
-    
-    if (_operations.count == 0) {
-        return;
-    }
+  RCTAssertMainQueue();
 
-    NSArray<GestureHandlerOperation> *operations = _operations;
-    _operations = [NSMutableArray new];
+  if (_operations.count == 0) {
+    return;
+  }
 
-    for (GestureHandlerOperation operation in operations) {
-        operation(self->_manager);
-    }
+  NSArray<GestureHandlerOperation> *operations = _operations;
+  _operations = [NSMutableArray new];
+
+  for (GestureHandlerOperation operation in operations) {
+    operation(self->_manager);
+  }
 }
 
 #else
@@ -263,18 +268,18 @@ RCT_EXPORT_METHOD(flushOperations)
 
 - (void)uiManagerWillPerformMounting:(RCTUIManager *)uiManager
 {
-    if (_operations.count == 0) {
-        return;
+  if (_operations.count == 0) {
+    return;
+  }
+
+  NSArray<GestureHandlerOperation> *operations = _operations;
+  _operations = [NSMutableArray new];
+
+  [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    for (GestureHandlerOperation operation in operations) {
+      operation(self->_manager);
     }
-
-    NSArray<GestureHandlerOperation> *operations = _operations;
-    _operations = [NSMutableArray new];
-
-    [uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        for (GestureHandlerOperation operation in operations) {
-            operation(self->_manager);
-        }
-    }];
+  }];
 }
 
 #endif // RN_FABRIC_ENABLED
@@ -283,30 +288,29 @@ RCT_EXPORT_METHOD(flushOperations)
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"onGestureHandlerEvent", @"onGestureHandlerStateChange"];
+  return @[ @"onGestureHandlerEvent", @"onGestureHandlerStateChange" ];
 }
 
 #pragma mark Module Constants
 
 - (NSDictionary *)constantsToExport
 {
-    return @{ @"State": @{
-                      @"UNDETERMINED": @(RNGestureHandlerStateUndetermined),
-                      @"BEGAN": @(RNGestureHandlerStateBegan),
-                      @"ACTIVE": @(RNGestureHandlerStateActive),
-                      @"CANCELLED": @(RNGestureHandlerStateCancelled),
-                      @"FAILED": @(RNGestureHandlerStateFailed),
-                      @"END": @(RNGestureHandlerStateEnd)
-                      },
-              @"Direction": @{
-                      @"RIGHT": @(RNGestureHandlerDirectionRight),
-                      @"LEFT": @(RNGestureHandlerDirectionLeft),
-                      @"UP": @(RNGestureHandlerDirectionUp),
-                      @"DOWN": @(RNGestureHandlerDirectionDown)
-                      }
-              };
+  return @{
+    @"State" : @{
+      @"UNDETERMINED" : @(RNGestureHandlerStateUndetermined),
+      @"BEGAN" : @(RNGestureHandlerStateBegan),
+      @"ACTIVE" : @(RNGestureHandlerStateActive),
+      @"CANCELLED" : @(RNGestureHandlerStateCancelled),
+      @"FAILED" : @(RNGestureHandlerStateFailed),
+      @"END" : @(RNGestureHandlerStateEnd)
+    },
+    @"Direction" : @{
+      @"RIGHT" : @(RNGestureHandlerDirectionRight),
+      @"LEFT" : @(RNGestureHandlerDirectionLeft),
+      @"UP" : @(RNGestureHandlerDirectionUp),
+      @"DOWN" : @(RNGestureHandlerDirectionDown)
+    }
+  };
 }
-
-
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerPointerTracker.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerPointerTracker.h
@@ -13,7 +13,7 @@
 @property (nonatomic) NSArray<NSDictionary *> *allPointersData;
 @property (nonatomic) int trackedPointersCount;
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerPointerTracker.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerPointerTracker.m
@@ -15,11 +15,11 @@
   _trackedPointersCount = 0;
   _changedPointersData = nil;
   _allPointersData = nil;
-  
+
   for (int i = 0; i < MAX_POINTERS_COUNT; i++) {
     _trackedPointers[i] = nil;
   }
-  
+
   return self;
 }
 
@@ -31,7 +31,7 @@
       return index;
     }
   }
-  
+
   return -1;
 }
 
@@ -43,7 +43,7 @@
       return index;
     }
   }
-  
+
   return -1;
 }
 
@@ -68,32 +68,34 @@
   return count;
 }
 
-- (NSDictionary *)extractPointerData:(int)index
-                            forTouch:(UITouch *)touch
+- (NSDictionary *)extractPointerData:(int)index forTouch:(UITouch *)touch
 {
   CGPoint relativePos = [touch locationInView:_gestureHandler.recognizer.view];
   CGPoint absolutePos = [touch locationInView:_gestureHandler.recognizer.view.window];
-  
-  return @{@"id": @(index),
-              @"x": @(relativePos.x),
-              @"y": @(relativePos.y),
-              @"absoluteX": @(absolutePos.x),
-              @"absoluteY": @(absolutePos.y)};
+
+  return @{
+    @"id" : @(index),
+    @"x" : @(relativePos.x),
+    @"y" : @(relativePos.y),
+    @"absoluteX" : @(absolutePos.x),
+    @"absoluteY" : @(absolutePos.y)
+  };
 }
 
-- (void)extractAllTouches {
+- (void)extractAllTouches
+{
   int registeredTouches = [self registeredTouchesCount];
 
   NSDictionary *data[registeredTouches];
   int nextIndex = 0;
-  
+
   for (int i = 0; i < MAX_POINTERS_COUNT; i++) {
     UITouch *touch = _trackedPointers[i];
     if (touch != nil) {
       data[nextIndex++] = [self extractPointerData:i forTouch:touch];
     }
   }
-  
+
   _allPointersData = [[NSArray alloc] initWithObjects:data count:registeredTouches];
 }
 
@@ -102,11 +104,11 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
-  
+
   _eventType = RNGHTouchEventTypePointerDown;
-  
+
   NSDictionary *data[touches.count];
-  
+
   for (int i = 0; i < [touches count]; i++) {
     UITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self registerTouch:touch];
@@ -116,7 +118,7 @@
 
     data[i] = [self extractPointerData:index forTouch:touch];
   }
-  
+
   _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
   // extract all touches last to include the ones that were just added
   [self extractAllTouches];
@@ -128,17 +130,17 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
-  
+
   _eventType = RNGHTouchEventTypePointerMove;
-  
+
   NSDictionary *data[touches.count];
-  
+
   for (int i = 0; i < [touches count]; i++) {
     UITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self findTouchIndex:touch];
     data[i] = [self extractPointerData:index forTouch:touch];
   }
-  
+
   _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
   [self extractAllTouches];
   [self sendEvent];
@@ -149,14 +151,14 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
-  
+
   // extract all touches first to include the ones that were just lifted
   [self extractAllTouches];
-  
+
   _eventType = RNGHTouchEventTypePointerUp;
-  
+
   NSDictionary *data[touches.count];
-  
+
   for (int i = 0; i < [touches count]; i++) {
     UITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self unregisterTouch:touch];
@@ -166,7 +168,7 @@
 
     data[i] = [self extractPointerData:index forTouch:touch];
   }
-  
+
   _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
   [self sendEvent];
 }
@@ -176,7 +178,7 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
-  
+
   [self reset];
 }
 
@@ -185,7 +187,7 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
-  
+
   if (_trackedPointersCount == 0) {
     // gesture has finished because all pointers were lifted, reset event type to send state change event
     _eventType = RNGHTouchEventTypeUndetermined;
@@ -195,7 +197,7 @@
     // we need to clear the pointers and send info about their cancellation
     [self cancelPointers];
   }
-  
+
   [_gestureHandler reset];
 }
 
@@ -203,13 +205,13 @@
 {
   // extract all touches first to include the ones that were just cancelled
   [self extractAllTouches];
-  
+
   int registeredTouches = [self registeredTouchesCount];
-  
+
   if (registeredTouches > 0) {
     int nextIndex = 0;
     NSDictionary *data[registeredTouches];
-    
+
     for (int i = 0; i < MAX_POINTERS_COUNT; i++) {
       UITouch *touch = _trackedPointers[i];
       if (touch != nil) {
@@ -217,7 +219,7 @@
         [self unregisterTouch:touch];
       }
     }
-    
+
     _eventType = RNGHTouchEventTypeCancelled;
     _changedPointersData = [[NSArray alloc] initWithObjects:data count:registeredTouches];
     [self sendEvent];
@@ -233,8 +235,9 @@
   if (!_gestureHandler.needsPointerData || _gestureHandler.recognizer.view.reactTag == nil) {
     return;
   }
-  
-  [_gestureHandler sendTouchEventInState:[_gestureHandler state] forViewWithTag:_gestureHandler.recognizer.view.reactTag];
+
+  [_gestureHandler sendTouchEventInState:[_gestureHandler state]
+                          forViewWithTag:_gestureHandler.recognizer.view.reactTag];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerRegistry.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerRegistry.h
@@ -12,7 +12,9 @@
 
 - (nullable RNGestureHandler *)handlerWithTag:(nonnull NSNumber *)handlerTag;
 - (void)registerGestureHandler:(nonnull RNGestureHandler *)gestureHandler;
-- (void)attachHandlerWithTag:(nonnull NSNumber *)handlerTag toView:(nonnull UIView *)view withActionType:(RNGestureHandlerActionType)actionType;
+- (void)attachHandlerWithTag:(nonnull NSNumber *)handlerTag
+                      toView:(nonnull UIView *)view
+              withActionType:(RNGestureHandlerActionType)actionType;
 - (void)dropHandlerWithTag:(nonnull NSNumber *)handlerTag;
 - (void)dropAllHandlers;
 

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerRegistry.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerRegistry.m
@@ -11,51 +11,53 @@
 #import <React/RCTAssert.h>
 
 @implementation RNGestureHandlerRegistry {
-    NSMutableDictionary<NSNumber *, RNGestureHandler *> *_handlers;
+  NSMutableDictionary<NSNumber *, RNGestureHandler *> *_handlers;
 }
 
 - (instancetype)init
 {
-    if ((self = [super init])) {
-        _handlers = [NSMutableDictionary new];
-    }
-    return self;
+  if ((self = [super init])) {
+    _handlers = [NSMutableDictionary new];
+  }
+  return self;
 }
 
 - (RNGestureHandler *)handlerWithTag:(NSNumber *)handlerTag
 {
-    return _handlers[handlerTag];
+  return _handlers[handlerTag];
 }
 
 - (void)registerGestureHandler:(RNGestureHandler *)gestureHandler
 {
-    _handlers[gestureHandler.tag] = gestureHandler;
+  _handlers[gestureHandler.tag] = gestureHandler;
 }
 
-- (void)attachHandlerWithTag:(NSNumber *)handlerTag toView:(UIView *)view withActionType:(RNGestureHandlerActionType)actionType
+- (void)attachHandlerWithTag:(NSNumber *)handlerTag
+                      toView:(UIView *)view
+              withActionType:(RNGestureHandlerActionType)actionType
 {
-    RNGestureHandler *handler = _handlers[handlerTag];
-    RCTAssert(handler != nil, @"Handler for tag %@ does not exists", handlerTag);
-    [handler unbindFromView];
-    handler.actionType = actionType;
-    [handler bindToView:view];
+  RNGestureHandler *handler = _handlers[handlerTag];
+  RCTAssert(handler != nil, @"Handler for tag %@ does not exists", handlerTag);
+  [handler unbindFromView];
+  handler.actionType = actionType;
+  [handler bindToView:view];
 }
 
 - (void)dropHandlerWithTag:(NSNumber *)handlerTag
 {
-    RNGestureHandler *handler = _handlers[handlerTag];
-    [handler unbindFromView];
-    [_handlers removeObjectForKey:handlerTag];
+  RNGestureHandler *handler = _handlers[handlerTag];
+  [handler unbindFromView];
+  [_handlers removeObjectForKey:handlerTag];
 }
 
 - (void)dropAllHandlers
 {
-    for (NSNumber* tag in _handlers) {
-        RNGestureHandler *handler = _handlers[tag];
-        [handler unbindFromView];
-    }
-    
-    [_handlers removeAllObjects];
+  for (NSNumber *tag in _handlers) {
+    RNGestureHandler *handler = _handlers[tag];
+    [handler unbindFromView];
+  }
+
+  [_handlers removeAllObjects];
 }
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerState.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerState.h
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RNGestureHandlerState) {
-    RNGestureHandlerStateUndetermined = 0,
-    RNGestureHandlerStateFailed,
-    RNGestureHandlerStateBegan,
-    RNGestureHandlerStateCancelled,
-    RNGestureHandlerStateActive,
-    RNGestureHandlerStateEnd,
+  RNGestureHandlerStateUndetermined = 0,
+  RNGestureHandlerStateFailed,
+  RNGestureHandlerStateBegan,
+  RNGestureHandlerStateCancelled,
+  RNGestureHandlerStateActive,
+  RNGestureHandlerStateEnd,
 };

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerStateManager.h
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNGestureHandlerStateManager.h
@@ -1,5 +1,5 @@
 @protocol RNGestureHandlerStateManager
 
--(void) setGestureState:(int)state forHandler:(int)handlerTag;
+- (void)setGestureState:(int)state forHandler:(int)handlerTag;
 
 @end

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNManualActivationRecognizer.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNManualActivationRecognizer.m
@@ -18,10 +18,10 @@
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
-    if (recognizer.state == UIGestureRecognizerStateBegan) {
-        self.state = UIGestureRecognizerStateEnded;
-        [self reset];
-    }
+  if (recognizer.state == UIGestureRecognizerStateBegan) {
+    self.state = UIGestureRecognizerStateEnded;
+    [self reset];
+  }
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -39,9 +39,9 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  
+
   _activePointers -= touches.count;
-  
+
   if (_activePointers == 0) {
     self.state = UIGestureRecognizerStateBegan;
   }
@@ -50,7 +50,7 @@
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  
+
   _activePointers = 0;
   [self reset];
 }
@@ -67,7 +67,7 @@
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
-shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+    shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
   return YES;
 }
@@ -80,7 +80,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
       return YES;
     }
   }
-  
+
   return NO;
 }
 

--- a/ios/vendored/unversioned/react-native-gesture-handler/ios/RNRootViewGestureRecognizer.m
+++ b/ios/vendored/unversioned/react-native-gesture-handler/ios/RNRootViewGestureRecognizer.m
@@ -16,39 +16,36 @@
 #import <React/RCTTouchHandler.h>
 #endif // RN_FABRIC_ENABLED
 
-
-@implementation RNRootViewGestureRecognizer
-{
-    BOOL _active;
+@implementation RNRootViewGestureRecognizer {
+  BOOL _active;
 }
 
 @dynamic delegate;
 
 - (instancetype)init
 {
-    if (self = [super init]) {
-        self.delaysTouchesEnded = NO;
-        self.delaysTouchesBegan = NO;
-    }
-    return self;
+  if (self = [super init]) {
+    self.delaysTouchesEnded = NO;
+    self.delaysTouchesBegan = NO;
+  }
+  return self;
 }
 
 - (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    // This method is used to implement "enabled" feature for gesture handlers. We enforce gesture
-    // recognizers that are connected with "disabled" handlers to wait for the root gesture
-    // recognizer to fail and this way we block them from acting.
-    RNGestureHandler *otherHandler = [RNGestureHandler
-                                      findGestureHandlerByRecognizer:otherGestureRecognizer];
-    if (otherHandler != nil && otherHandler.enabled == NO) {
-        return YES;
-    }
-    return NO;
+  // This method is used to implement "enabled" feature for gesture handlers. We enforce gesture
+  // recognizers that are connected with "disabled" handlers to wait for the root gesture
+  // recognizer to fail and this way we block them from acting.
+  RNGestureHandler *otherHandler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+  if (otherHandler != nil && otherHandler.enabled == NO) {
+    return YES;
+  }
+  return NO;
 }
 
 - (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer
 {
-    return ![preventedGestureRecognizer isKindOfClass:[
+  return ![preventedGestureRecognizer isKindOfClass:[
 #ifdef RN_FABRIC_ENABLED
         RCTSurfaceTouchHandler
 #else
@@ -59,46 +56,46 @@
 
 - (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer
 {
-    // When this method is called it means that one of handlers has activated, in this case we want
-    // to send an info to JS so that it cancells all JS responders
-    [self.delegate gestureRecognizer:preventingGestureRecognizer didActivateInViewWithTouchHandler:self.view];
-    return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
+  // When this method is called it means that one of handlers has activated, in this case we want
+  // to send an info to JS so that it cancells all JS responders
+  [self.delegate gestureRecognizer:preventingGestureRecognizer didActivateInViewWithTouchHandler:self.view];
+  return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    _active = YES;
-    self.state = UIGestureRecognizerStatePossible;
+  _active = YES;
+  self.state = UIGestureRecognizerStatePossible;
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    self.state = UIGestureRecognizerStatePossible;
+  self.state = UIGestureRecognizerStatePossible;
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    if (self.state == UIGestureRecognizerStateBegan || self.state == UIGestureRecognizerStateChanged) {
-        self.state = UIGestureRecognizerStateEnded;
-    } else {
-        self.state = UIGestureRecognizerStateFailed;
-    }
-    [self reset];
-    _active = NO;
+  if (self.state == UIGestureRecognizerStateBegan || self.state == UIGestureRecognizerStateChanged) {
+    self.state = UIGestureRecognizerStateEnded;
+  } else {
+    self.state = UIGestureRecognizerStateFailed;
+  }
+  [self reset];
+  _active = NO;
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    self.state = UIGestureRecognizerStateCancelled;
-    [self reset];
-    _active = NO;
+  self.state = UIGestureRecognizerStateCancelled;
+  [self reset];
+  _active = NO;
 }
 
 - (void)blockOtherRecognizers
 {
-    if (_active) {
-        self.state = UIGestureRecognizerStateBegan;
-    }
+  if (_active) {
+    self.state = UIGestureRecognizerStateBegan;
+  }
 }
 
 @end

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -30,7 +30,7 @@
     "esbuild": "^0.12.15",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
-    "react-native-gesture-handler": "~2.8.0",
+    "react-native-gesture-handler": "~2.9.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
     "react-native-svg": "13.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -89,7 +89,7 @@
   "react-native": "0.71.0",
   "react-native-web": "~0.18.10",
   "react-native-branch": "^5.4.0",
-  "react-native-gesture-handler": "~2.8.0",
+  "react-native-gesture-handler": "~2.9.0",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.3.2",
   "react-native-pager-view": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15812,10 +15812,10 @@ react-native-fade-in-image@^1.6.1:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.8.0.tgz#ef9857871c10663c95a51546225b6e00cd4740cf"
-  integrity sha512-poOSfz/w0IyD6Qwq7aaIRRfEaVTl1ecQFoyiIbpOpfNTjm2B1niY2FLrdVQIOtIOe+K9nH55Qal04nr4jGkHdQ==
+react-native-gesture-handler@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz#2f63812e523c646f25b9ad660fc6f75948e51241"
+  integrity sha512-a0BcH3Qb1tgVqUutc6d3VuWQkI1AM3+fJx8dkxzZs9t06qA27QgURYFoklpabuWpsUTzuKRpxleykp25E8m7tg==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
# Why

Upgrading vendored modules for SDK 48

# How

- `et uvm -m react-native-gesture-handler -c '2.9.0'`
- `et pods -f` to reinstall pods in Expo Go and BareExpo

# Test Plan

Tested in unversioned Expo Go with NCL app
