### PR TITLE
[go] Upgrade `react-native-screens` to `3.19.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.0`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo))
 - Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.171`. ([#20857](https://github.com/expo/expo/pull/20857) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Updated `react-native-screens` from `3.18.0` to `3.19.0`.
+- Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🛠 Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.0`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo))
 - Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.171`. ([#20857](https://github.com/expo/expo/pull/20857) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Updated `react-native-screens` from `3.18.0` to `3.19.0`.
 
 ### 🛠 Breaking changes
 
@@ -205,7 +206,7 @@ Package-specific changes not released in any SDK will be added here just before 
   - Added `bounds` property to the `BarCodeScanningResult`. ([#19519](https://github.com/expo/expo/pull/19519) by [@lukmccall](https://github.com/lukmccall))
 - **`expo-constants`**
   - Deprecated the unreliable `source-login-scripts.sh` and sourcing the Node.js binary path from `.xcode.env` and `.xcode.env.local`. ([#18330](https://github.com/expo/expo/pull/18330) by [@kudo](https://github.com/kudo))
-  - Fixed *with-node.sh* doesn't keep quotes when passing arguments to Node.js and caused build errors when there are spaces in target name. ([#18741](https://github.com/expo/expo/pull/18741) by [@kudo](https://github.com/kudo))
+  - Fixed _with-node.sh_ doesn't keep quotes when passing arguments to Node.js and caused build errors when there are spaces in target name. ([#18741](https://github.com/expo/expo/pull/18741) by [@kudo](https://github.com/kudo))
 - **`expo-cellular`**
   - Added missing permissions requester. ([#19633](https://github.com/expo/expo/pull/19633) by [@lukmccall](https://github.com/lukmccall))
 - **`expo-device`**

--- a/android/vendored/unversioned/react-native-screens/android/build.gradle
+++ b/android/vendored/unversioned/react-native-screens/android/build.gradle
@@ -103,11 +103,7 @@ repositories {
 }
 
 dependencies {
-    if (isNewArchitectureEnabled()) {
-        implementation project(":ReactAndroid")
-    } else {
-        implementation 'com.facebook.react:react-native:+'
-    }
+    implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.fragment:fragment:1.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'

--- a/android/vendored/unversioned/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/vendored/unversioned/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -156,6 +156,16 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
 
     override fun setSwipeDirection(view: Screen?, value: String?) = Unit
 
+    override fun setSheetAllowedDetents(view: Screen, value: String?) = Unit
+
+    override fun setSheetLargestUndimmedDetent(view: Screen, value: String?) = Unit
+
+    override fun setSheetGrabberVisible(view: Screen?, value: Boolean) = Unit
+
+    override fun setSheetCornerRadius(view: Screen?, value: Float) = Unit
+
+    override fun setSheetExpandsWhenScrolledToEdge(view: Screen?, value: Boolean) = Unit
+
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,

--- a/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -23,6 +23,21 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
+      case "sheetAllowedDetents":
+        mViewManager.setSheetAllowedDetents(view, (String) value);
+        break;
+      case "sheetLargestUndimmedDetent":
+        mViewManager.setSheetLargestUndimmedDetent(view, (String) value);
+        break;
+      case "sheetGrabberVisible":
+        mViewManager.setSheetGrabberVisible(view, value == null ? false : (boolean) value);
+        break;
+      case "sheetCornerRadius":
+        mViewManager.setSheetCornerRadius(view, value == null ? -1f : ((Double) value).floatValue());
+        break;
+      case "sheetExpandsWhenScrolledToEdge":
+        mViewManager.setSheetExpandsWhenScrolledToEdge(view, value == null ? false : (boolean) value);
+        break;
       case "customAnimationOnSwipe":
         mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);
         break;

--- a/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -14,6 +14,11 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSScreenManagerInterface<T extends View> {
+  void setSheetAllowedDetents(T view, @Nullable String value);
+  void setSheetLargestUndimmedDetent(T view, @Nullable String value);
+  void setSheetGrabberVisible(T view, boolean value);
+  void setSheetCornerRadius(T view, float value);
+  void setSheetExpandsWhenScrolledToEdge(T view, boolean value);
   void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, boolean value);
   void setHomeIndicatorHidden(T view, boolean value);

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -86,7 +86,7 @@
     "react-native-pager-view": "6.0.1",
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.18.0",
+    "react-native-screens": "~3.19.0",
     "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -148,7 +148,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.18.0",
+    "react-native-screens": "~3.19.0",
     "react-native-shared-element": "0.8.7",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",

--- a/apps/native-component-list/src/screens/Screens/container.tsx
+++ b/apps/native-component-list/src/screens/Screens/container.tsx
@@ -20,7 +20,7 @@ export class LazyTabs extends React.Component<{ renderScreen: (key: string) => J
   renderScreen = (key: string) => {
     const active = key === this.state.active ? 1 : 0;
     return (
-      <Screen style={StyleSheet.absoluteFill} key={key} active={active}>
+      <Screen style={StyleSheet.absoluteFill} key={key} activityState={active}>
         {this.props.renderScreen(key)}
       </Screen>
     );

--- a/apps/native-component-list/src/screens/Screens/nativeStack.tsx
+++ b/apps/native-component-list/src/screens/Screens/nativeStack.tsx
@@ -46,7 +46,6 @@ export class Stack extends Component<StackProps, StackState> {
         key={key}
         stackAnimation="fade"
         stackPresentation="push"
-        active={1}
         onDismissed={() => this.removeByKey(key)}>
         {this.props.renderScreen(key)}
       </Screen>

--- a/home/package.json
+++ b/home/package.json
@@ -64,7 +64,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.18.0",
+    "react-native-screens": "~3.19.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2125,7 +2125,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.18.0):
+  - RNScreens (3.19.0):
     - React-Core
     - React-RCTImage
   - RNSVG (13.4.0):
@@ -3642,7 +3642,7 @@ SPEC CHECKSUMS:
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
   RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
   RNReanimated: e7aeb0addbcc2c79dccb69bb176d079afbd5fd23
-  RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
+  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
   SDWebImageAVIFCoder: 5bf07409ab8a02f0a8e0ac976719b321d8fce209

--- a/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
+++ b/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNScreens",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "summary": "Native navigation primitives for your React Native app.",
   "description": "RNScreens - first incomplete navigation solution for your React Native app",
   "homepage": "https://github.com/software-mansion/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-screens.git",
-    "tag": "3.18.0"
+    "tag": "3.19.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "requires_arc": true,

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.h
@@ -19,6 +19,12 @@
 + (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
     (facebook::react::RNSScreenSwipeDirection)swipeDirection;
 
++ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
+    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents;
+
++ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
+    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent;
+
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.mm
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.mm
@@ -89,6 +89,32 @@
   }
 }
 
++ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
+    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents
+{
+  switch (allowedDetents) {
+    case facebook::react::RNSScreenSheetAllowedDetents::All:
+      return RNSScreenDetentTypeAll;
+    case facebook::react::RNSScreenSheetAllowedDetents::Large:
+      return RNSScreenDetentTypeLarge;
+    case facebook::react::RNSScreenSheetAllowedDetents::Medium:
+      return RNSScreenDetentTypeMedium;
+  }
+}
+
++ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
+    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent
+{
+  switch (detent) {
+    case facebook::react::RNSScreenSheetLargestUndimmedDetent::All:
+      return RNSScreenDetentTypeAll;
+    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Large:
+      return RNSScreenDetentTypeLarge;
+    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Medium:
+      return RNSScreenDetentTypeMedium;
+  }
+}
+
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
 {

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSEnums.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSEnums.h
@@ -57,3 +57,9 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
   RNSScreenStackHeaderSubviewTypeCenter,
   RNSScreenStackHeaderSubviewTypeSearchBar,
 };
+
+typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
+  RNSScreenDetentTypeMedium,
+  RNSScreenDetentTypeLarge,
+  RNSScreenDetentTypeAll,
+};

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSFullWindowOverlay.mm
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSFullWindowOverlay.mm
@@ -25,6 +25,38 @@
   return NO;
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  BOOL canReceiveTouchEvents = ([self isUserInteractionEnabled] && ![self isHidden]);
+  if (!canReceiveTouchEvents) {
+    return nil;
+  }
+
+  // `hitSubview` is the topmost subview which was hit. The hit point can
+  // be outside the bounds of `view` (e.g., if -clipsToBounds is NO).
+  UIView *hitSubview = nil;
+  BOOL isPointInside = [self pointInside:point withEvent:event];
+  if (![self clipsToBounds] || isPointInside) {
+    // Take z-index into account when calculating the touch target.
+    NSArray<UIView *> *sortedSubviews = [self reactZIndexSortedSubviews];
+
+    // The default behaviour of UIKit is that if a view does not contain a point,
+    // then no subviews will be returned from hit testing, even if they contain
+    // the hit point. By doing hit testing directly on the subviews, we bypass
+    // the strict containment policy (i.e., UIKit guarantees that every ancestor
+    // of the hit view will return YES from -pointInside:withEvent:). See:
+    //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
+    for (UIView *subview in [sortedSubviews reverseObjectEnumerator]) {
+      CGPoint convertedPoint = [subview convertPoint:point fromView:self];
+      hitSubview = [subview hitTest:convertedPoint withEvent:event];
+      if (hitSubview != nil) {
+        break;
+      }
+    }
+  }
+  return hitSubview;
+}
+
 @end
 
 @implementation RNSFullWindowOverlay {

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) RNSScreenStackPresentation stackPresentation;
 @property (nonatomic) RNSScreenSwipeDirection swipeDirection;
 @property (nonatomic) RNSScreenReplaceAnimation replaceAnimation;
+
 @property (nonatomic, retain) NSNumber *transitionDuration;
 @property (nonatomic, readonly) BOOL dismissed;
 @property (nonatomic) BOOL hideKeyboardOnSwipe;
@@ -74,7 +75,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 @property (nonatomic) BOOL statusBarHidden;
 @property (nonatomic) BOOL homeIndicatorHidden;
-#endif
+
+// Props controlling UISheetPresentationController
+@property (nonatomic) RNSScreenDetentType sheetAllowedDetents;
+@property (nonatomic) RNSScreenDetentType sheetLargestUndimmedDetent;
+@property (nonatomic) BOOL sheetGrabberVisible;
+@property (nonatomic) CGFloat sheetCornerRadius;
+@property (nonatomic) BOOL sheetExpandsWhenScrolledToEdge;
+#endif // !TARGET_OS_TV
 
 #ifdef RN_FABRIC_ENABLED
 // we recreate the behavior of `reactSetFrame` on new architecture
@@ -89,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy) RCTDirectEventBlock onWillDisappear;
 @property (nonatomic, copy) RCTDirectEventBlock onNativeDismissCancelled;
 @property (nonatomic, copy) RCTDirectEventBlock onTransitionProgress;
-#endif
+#endif // RN_FABRIC_ENABLED
 
 - (void)notifyFinishTransitioning;
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreenStackHeaderConfig.mm
@@ -460,7 +460,23 @@
   }
 
 #if !TARGET_OS_TV
-  if (config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize ||
+  // Fix for github.com/react-navigation/react-navigation/issues/11015
+  // It allows to hide back button title and use back button menu as normal.
+  // Back button display mode and back button menu are available since iOS 14.
+  if (@available(iOS 14.0, *)) {
+    // Make sure to set display mode to default.
+    // This line resets back button display mode - especially needed on the Fabric architecture.
+    navitem.backButtonDisplayMode = UINavigationItemBackButtonDisplayModeDefault;
+
+    NSString *trimmedBackTitle =
+        [config.backTitle stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+
+    // When an whitespace only back title is passed set back button mode to minimal.
+    if (config.backTitle != nil && [trimmedBackTitle length] == 0) {
+      navitem.backButtonDisplayMode = UINavigationItemBackButtonDisplayModeMinimal;
+    }
+  } else if (
+      config.backTitle != nil || config.backTitleFontFamily || config.backTitleFontSize ||
       config.disableBackButtonMenu) {
     RNSUIBarButtonItem *backBarButtonItem = [[RNSUIBarButtonItem alloc] initWithTitle:config.backTitle ?: prevItem.title
                                                                                 style:UIBarButtonItemStylePlain

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -32,7 +32,7 @@
     "glob": "^7.1.7",
     "react-native-gesture-handler": "~2.8.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.18.0",
+    "react-native-screens": "~3.19.0",
     "react-native-svg": "13.4.0",
     "sane": "^5.0.1"
   }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-native-maps": "1.3.2",
   "react-native-pager-view": "6.0.1",
   "react-native-reanimated": "~2.14.0",
-  "react-native-screens": "~3.18.0",
+  "react-native-screens": "~3.19.0",
   "react-native-safe-area-context": "4.5.0",
   "react-native-shared-element": "0.8.7",
   "react-native-svg": "13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15903,10 +15903,10 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@~3.18.0:
-  version "3.18.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.18.0.tgz#e10ec54d8b158d47f66dc6c9a81e5a042e33037d"
-  integrity sha512-ndnz5JPLMLq/ThCYQzAOT65x6B4bdKFH1GKckUdbxKrwINGItPRSUiAoVI7YYyOQOa4VYL4hF37rrx+AjgjtRg==
+react-native-screens@~3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.19.0.tgz#ec68685e04b074ebce4641b3a0ae7e2571629b75"
+  integrity sha512-Ehsmy7jr3H3j5pmN+/FqsAaIAD+k+xkcdePfLcg4rYRbN5X7fJPgaqhcmiCcZ0YxsU8ttsstP9IvRLNQuIkRRA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

Closes ENG-7311.

# How

```
et update-vendored-module -m react-native-screens -c '3.19.0'
```

# Test Plan

- expo go with NCL ✅