### PR TITLE
fix(cli): simplify Metro watch mode and communicate when disabled

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Do not show `error.stack` for `ConfigError`s. ([#19248](https://github.com/expo/expo/pull/19248) by [@Simek](https://github.com/Simek))
 - Fix tests. ([#20510](https://github.com/expo/expo/pull/20510) by [@EvanBacon](https://github.com/EvanBacon))
 - Simplify the Xcode warnings. ([#20512](https://github.com/expo/expo/pull/20512) by [@EvanBacon](https://github.com/EvanBacon))
+- Simply Metro watch mode detection to `CI=true`, and log when disabled. ([#20939](https://github.com/expo/expo/pull/20939) by [@byCedric](https://github.com/byCedric))
 
 ## 0.4.10 - 2022-11-22
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/instantiateMetro.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/instantiateMetro.test.ts
@@ -1,0 +1,31 @@
+import { Log } from '../../../../log';
+import { isWatchEnabled } from '../instantiateMetro';
+
+jest.mock('../../../../log');
+
+describe(isWatchEnabled, () => {
+  const originalValue = process.env.CI;
+
+  beforeEach(() => {
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    process.env.CI = originalValue;
+  });
+
+  it('is enabled without CI', () => {
+    expect(isWatchEnabled()).toBe(true);
+  });
+
+  it('is enabled with CI=false', () => {
+    process.env.CI = 'false';
+    expect(isWatchEnabled()).toBe(true);
+  });
+
+  it('is disabled with CI=true', () => {
+    process.env.CI = 'true';
+    expect(isWatchEnabled()).toBe(false);
+    expect(Log.log).toHaveBeenCalledWith(expect.stringContaining('Metro is running in CI mode'));
+  });
+});

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -1,9 +1,12 @@
 import { getConfig } from '@expo/config';
 import { MetroDevServerOptions } from '@expo/dev-server';
+import chalk from 'chalk';
 import http from 'http';
 import Metro from 'metro';
 import { Terminal } from 'metro-core';
 
+import { Log } from '../../../log';
+import { env } from '../../../utils/env';
 import { createDevServerMiddleware } from '../middleware/createDevServerMiddleware';
 import { getPlatformBundlers } from '../platformBundlers';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
@@ -76,6 +79,8 @@ export async function instantiateMetroAsync(
   const server = await Metro.runServer(metroConfig, {
     hmrEnabled: true,
     websocketEndpoints,
+    // @ts-expect-error Property was added in 0.73.4, remove this statement when updating Metro
+    watch: isWatchEnabled(),
   });
 
   if (attachToServer) {
@@ -98,4 +103,18 @@ export async function instantiateMetroAsync(
       messageSocket: messageSocketEndpoint,
     };
   }
+}
+
+/**
+ * Simplify and communicate if Metro is running without watching file updates,.
+ * Exposed for testing.
+ */
+export function isWatchEnabled() {
+  if (env.CI) {
+    Log.log(
+      chalk`Metro is running in CI mode, reloads are disabled. Remove {bold CI=true} to enable watch mode.`
+    );
+  }
+
+  return !env.CI;
 }


### PR DESCRIPTION
# Why

Fixes ENG-7089

# How

Because this option is only exposed through `Metro.runServer`, I added the override in `@expo/cli`. Alternative, we could add a custom Metro config option to move this to the config itself, however, that would create a significant diversion of the normal Metro config.

> **Note**
> We could add a Metro version check and disable the warning, but I think it's safe to skip that and leave it in for older Metro versions. It's not really synced, but if the message pops up, it's very very likely Metro actually is running without watch.

# Test Plan

See added tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
