### PR TITLE
[expo-updates] Improvements in E2E scripts

### DIFF
--- a/packages/expo-updates/e2e/__tests__/setup/create-updates-test.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-updates-test.js
@@ -1,0 +1,65 @@
+const path = require('path');
+
+const { initAsync } = require('./project');
+
+const repoRoot = process.env.EXPO_REPO_ROOT;
+const workingDir = path.resolve(repoRoot, '..');
+
+/*
+ * Change this to your own Expo account name
+ */
+const EXPO_ACCOUNT_NAME = 'myusername';
+
+/**
+ *
+ * This generates a project at the location TEST_PROJECT_ROOT,
+ * set up to use the latest bits from the current repo source,
+ * and can be used to test different expo-updates and EAS updates workflows.
+ */
+
+function transformAppJson(appJson, projectName, runtimeVersion) {
+  return {
+    expo: {
+      ...appJson.expo,
+      name: projectName,
+      runtimeVersion,
+      updates: {
+        ...appJson.expo.updates,
+        requestHeaders: {
+          'expo-channel-name': 'main',
+        },
+      },
+      android: {
+        ...appJson.expo.android,
+        package: `com.${EXPO_ACCOUNT_NAME}.${projectName}`,
+      },
+      ios: {
+        ...appJson.expo.ios,
+        bundleIdentifier: `com.${EXPO_ACCOUNT_NAME}.${projectName}`,
+      },
+    },
+  };
+}
+
+(async function () {
+  if (
+    !process.env.ARTIFACTS_DEST ||
+    !process.env.EXPO_REPO_ROOT ||
+    !process.env.UPDATES_HOST ||
+    !process.env.UPDATES_PORT
+  ) {
+    throw new Error(
+      'Missing one or more environment variables; see instructions in e2e/__tests__/setup/index.js'
+    );
+  }
+  const projectRoot = process.env.TEST_PROJECT_ROOT || path.join(workingDir, 'updates-e2e');
+  const localCliBin = path.join(repoRoot, 'packages/@expo/cli/build/bin/cli');
+  const runtimeVersion = '1.0.0';
+  await initAsync(projectRoot, {
+    repoRoot,
+    runtimeVersion,
+    localCliBin,
+    configureE2E: false,
+    transformAppJson,
+  });
+})();


### PR DESCRIPTION
# Why

- Ensure that setup scripts create project using latest code in repo
- Add new script to create a project suitable for local testing of developer workflows

# Test Plan

E2E tests should still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
