### PR TITLE
[image] ImageProps extends ViewProps

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- `ImageProps` now extends `ViewProps`. ([#20942](https://github.com/expo/expo/pull/20942) by [@appden](https://github.com/appden))
+
 ### 💡 Others
 
 ## 1.0.0-beta.1 — 2023-01-20

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -1,4 +1,4 @@
-import { ImageStyle as RNImageStyle } from 'react-native';
+import { ImageStyle as RNImageStyle, ViewProps } from 'react-native';
 
 export type ImageSource = {
   /**
@@ -47,7 +47,7 @@ export type ImageStyle = RNImageStyle;
  * Some props are from React Native Image that Expo Image supports (more or less) for easier migration,
  * but all of them are deprecated and might be removed in the future.
  */
-export type ImageProps = {
+export interface ImageProps extends ViewProps {
   /** @hidden */
   style?: RNImageStyle | RNImageStyle[];
 


### PR DESCRIPTION
# Why

Without extending `ViewProps`, the prop types are missing important (but already supported) props, such as `children`, `onLayout`, `pointerEvents`, `nativeID`, `testID`, as well as the many accessibility and gesture-related props. All of these props are already supported since the native view inherits these capabilities.

# Test Plan

Verified many `ViewProps` work correctly on iOS with `Image`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
