### PR TITLE
[create-expo-module] Only run pod install on macOS

### DIFF
--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import getenv from 'getenv';
+import os from 'os';
 import path from 'path';
 
 import { installDependencies } from './packageManager';
@@ -77,8 +78,12 @@ export async function createExampleApp(
 
   await newStep('Installing dependencies in the example app', async (step) => {
     await installDependencies(packageManager, appTargetPath);
-    await podInstall(appTargetPath);
-    step.succeed('Installed dependencies in the example app');
+    if (os.platform() === 'darwin') {
+      await podInstall(appTargetPath);
+      step.succeed('Installed dependencies in the example app');
+    } else {
+      step.succeed('Installed dependencies in the example app (skipped pod install)');
+    }
   });
 }
 

--- a/packages/create-expo-module/src/createExampleApp.ts
+++ b/packages/create-expo-module/src/createExampleApp.ts
@@ -82,7 +82,7 @@ export async function createExampleApp(
       await podInstall(appTargetPath);
       step.succeed('Installed dependencies in the example app');
     } else {
-      step.succeed('Installed dependencies in the example app (skipped pod install)');
+      step.succeed('Installed dependencies in the example app (skipped installing CocoaPods)');
     }
   });
 }


### PR DESCRIPTION
# Why

When you run create-expo-module, it always tries to run pod install, but it should only do it on macOS
https://github.com/expo/expo/issues/20950

# How

Only running pod install if `os.platform() === 'darwin'`

# Test Plan

If you want to test it, after the step completes, the message should be `'Installed dependencies in the example app'` on macOS and `'Installed dependencies in the example app (skipped pod install)'` otherwise

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
