### PR TITLE
[tools] fix ios versioning

### DIFF
--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.h
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.h
@@ -1,7 +1,8 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <ZXingObjC/ZXingObjCCore.h>
+
+@class ZXResult;
 
 @interface EXBarCodeScannerUtils : NSObject
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m
@@ -2,6 +2,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
+#import <ZXingObjC/ZXingObjCCore.h>
 #import <EXBarCodeScanner/EXBarCodeScannerUtils.h>
 
 @implementation EXBarCodeScannerUtils

--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -12,6 +12,7 @@ export type Podspec = {
   header_dir?: string;
   source_files: string | string[];
   exclude_files: string | string[];
+  public_header_files?: string | string[];
   preserve_paths: string | string[];
   compiler_flags: string;
   frameworks: string | string[];

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -217,7 +217,6 @@ async function generateVersionedReactNativeAsync(versionName: string): Promise<v
     'React-Core.podspec',
     'ReactCommon/ReactCommon.podspec',
     'ReactCommon/React-Fabric.podspec',
-    'ReactCommon/React-bridging.podspec',
     'ReactCommon/hermes/React-hermes.podspec',
     'sdks/hermes-engine/hermes-engine.podspec',
     'package.json',
@@ -250,6 +249,16 @@ async function generateVersionedReactNativeAsync(versionName: string): Promise<v
     jsSrcsDir: path.join(EXPO_DIR, RELATIVE_RN_PATH, 'Libraries'),
     keepIntermediateSchema: true,
   });
+  console.log(`Removing unused generated FBReactNativeSpecJSI files for 0.71`);
+  await Promise.all(
+    [
+      `${versionName}FBReactNativeSpecJSI.h`,
+      `${versionName}FBReactNativeSpecJSI-generated.cpp`,
+    ].map((file) => {
+      const filePath = path.join(versionedReactNativePath, 'codegen', 'ios', file);
+      return fs.remove(filePath);
+    })
+  );
 
   console.log(
     `Copying cpp libraries from ${chalk.magenta(path.join(RELATIVE_RN_PATH, 'ReactCommon'))} ...`
@@ -327,13 +336,16 @@ async function generateReactNativePodScriptAsync(
     'React-Core',
     'React-jsi',
     'ReactCommon/turbomodule/core',
+    'ReactCommon/turbomodule/bridging',
     'React-graphics',
     'React-rncore',
+    'hermes-engine',
+    'React-jsc',
   ];
 
   const reactNativePodScriptTransforms: StringTransform[] = [
     {
-      find: /\b(def (use_react_native|use_react_native_codegen))!/g,
+      find: /\b(def (use_react_native|use_react_native_codegen|setup_jsc))!/g,
       replaceWith: `$1_${versionName}!`,
     },
     {
@@ -374,17 +386,16 @@ async function generateReactNativePodScriptAsync(
     { find: /\b(React-Codegen)\b/g, replaceWith: `${versionName}$1` },
     { find: /(\$\(PODS_ROOT\)\/Headers\/Private\/)React-/g, replaceWith: `$1${versionName}React-` },
     {
-      find: new RegExp(
-        `["'](${reactCodegenDependencies.join('|')})["']:(\\s*\\[version\\],?)`,
-        'g'
-      ),
-      replaceWith: `"${versionName}$1":$2`,
+      find: /^\s+CodegenUtils\.clean_up_build_folder\(.+$/gm,
+      replaceWith: '',
     },
-    // hermes
+  ];
+
+  const hermesTransforms: StringTransform[] = [
     { find: /^\s+prepare_hermes[.\s\S]*abort unless prep_status == 0\n$/gm, replaceWith: '' },
     {
       find: new RegExp(
-        `^\\s*pod '${versionName}hermes-engine', :podspec => "#\\{react_native_path\\}\\/sdks\\/hermes\\/hermes-engine.podspec"`,
+        `^\\s*pod '${versionName}hermes-engine', :podspec => "#\\{react_native_path\\}\\/sdks\\/hermes-engine\\/hermes-engine.podspec"`,
         'gm'
       ),
       replaceWith: `
@@ -397,15 +408,39 @@ async function generateReactNativePodScriptAsync(
     { find: new RegExp(`\\b${versionName}(libevent)\\b`, 'g'), replaceWith: '$1' },
   ];
 
+  const commonMethodTransforms = [
+    'get_script_phases_with_codegen_discovery',
+    'get_script_phases_no_codegen_discovery',
+    'get_script_template',
+    'setup_jsc',
+    'setup_hermes',
+    'run_codegen',
+  ];
+
   const transforms: FileTransforms = {
     content: [
       ...reactNativePodScriptTransforms.map((stringTransform) => ({
         path: 'react_native_pods.rb',
         ...stringTransform,
       })),
+      ...hermesTransforms.map((stringTransform) => ({
+        paths: 'jsengine.rb',
+        ...stringTransform,
+      })),
       {
-        paths: ['react_native_pods.rb', 'script_phases.rb'],
-        find: /\b(get_script_phases_with_codegen_discovery|get_script_phases_no_codegen_discovery|get_script_template)\b/g,
+        paths: 'codegen_utils.rb',
+        find: new RegExp(`["'](${reactCodegenDependencies.join('|')})["']:(\\s*\\[\\],?)`, 'g'),
+        replaceWith: `"${versionName}$1":$2`,
+      },
+      {
+        paths: [
+          'react_native_pods.rb',
+          'script_phases.rb',
+          'jsengine.rb',
+          'codegen.rb',
+          'codegen_utils.rb',
+        ],
+        find: new RegExp(`\\b(${commonMethodTransforms.join('|')})\\b`, 'g'),
         replaceWith: `$1_${versionName}`,
       },
     ],
@@ -423,6 +458,11 @@ async function generateReactNativePodScriptAsync(
         keepFileMode: true,
       });
     })
+  );
+
+  await fs.copy(
+    path.join(EXPO_DIR, RELATIVE_RN_PATH, 'sdks', 'hermes-engine', 'hermes-utils.rb'),
+    path.join(versionedReactNativePath, 'sdks', 'hermes-engine', 'hermes-utils.rb')
   );
 }
 
@@ -707,6 +747,10 @@ use_react_native_${versionName}!(
   :hermes_enabled => true,
   :fabric_enabled => false,
 )
+setup_jsc_${versionName}!(
+  :react_native_path => './${relativeReactNativePath}',
+  :fabric_enabled => false,
+)
 
 pod '${getVersionedExpoKitPodName(versionName)}',
   :path => './${relativeExpoKitPath}',
@@ -958,6 +1002,12 @@ function getCppLibrariesToVersion() {
     },
     {
       libName: 'hermes',
+    },
+    {
+      libName: 'jsc',
+    },
+    {
+      libName: 'butter',
     },
   ];
 }
@@ -1326,6 +1376,12 @@ function _getReactNativeTransformRules(versionPrefix, reactPodName) {
     {
       flags: '-Ei',
       pattern: `s/(#import |__has_include\\()<(Expo|RNReanimated)/\\1<${versionPrefix}\\2/g`,
+    },
+    {
+      // Unprefix jsc dirname in JSCExecutorFactory.mm
+      paths: 'CxxBridge',
+      flags: '-Ei',
+      pattern: `s/(#import )<${versionPrefix}jsc\\/${versionPrefix}JSCRuntime\.h>/\\1<jsc\\/${versionPrefix}JSCRuntime.h>/g`,
     },
   ];
 }

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -68,8 +68,8 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
       {
         // Prefix `Expo*` frameworks in imports.
         paths: objcFilesPattern,
-        find: /#import <(Expo|EAS)(.*?)\//g,
-        replaceWith: `#import <${prefix}$1$2/`,
+        find: /#(import|include) <(Expo|EAS)(.*?)\//g,
+        replaceWith: `#$1 <${prefix}$2$3/`,
       },
       {
         paths: objcFilesPattern,
@@ -121,6 +121,11 @@ export function expoModulesTransforms(prefix: string): FileTransforms {
         paths: objcFilesPattern,
         find: /\bnamespace react(\s+[^=])/g,
         replaceWith: `namespace ${prefix}React$1`,
+      },
+      {
+        paths: objcFilesPattern,
+        find: /\b((include|import|__has_include).*\/)(JSCRuntime\.h)/g,
+        replaceWith: `$1${prefix}$3`,
       },
       {
         paths: 'EXGLImageUtils.cpp',

--- a/tools/src/versioning/ios/transforms/podspecTransforms.ts
+++ b/tools/src/versioning/ios/transforms/podspecTransforms.ts
@@ -47,20 +47,19 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         with: '$1 "DEFINES_MODULE" => "YES",',
       },
       {
+        // DEFINES_MODULE for swift integration
+        // Learn more: `packages/expo-modules-autolinking/scripts/ios/cocoapods/sandbox.rb`
+        paths: 'React-RCTAppDelegate.podspec',
+        replace: /("CLANG_CXX_LANGUAGE_STANDARD" => "c\+\+17")/g,
+        with: '$1, "DEFINES_MODULE" => "YES",',
+      },
+      {
         // Fixes HEADER_SEARCH_PATHS
         paths: ['React-Core.podspec', 'ReactCommon.podspec'],
         replace:
           /(Headers\/Private\/|Headers\/Public\/|_BUILD_DIR\)\/)(React-Core|React-bridging|React-hermes|hermes-engine)/g,
         with: `$1${versionName}$2`,
       },
-
-      // React-bridging
-      {
-        paths: 'React-bridging.podspec',
-        replace: /\bheader_mappings_dir\s*=\s*"."/,
-        with: 'header_mappings_dir    = "react/bridging"',
-      },
-
       // React-cxxreact
       {
         // Fixes excluding SampleCxxModule.* files
@@ -68,7 +67,17 @@ export function podspecTransforms(versionName: string): TransformPipeline {
         replace: /\.exclude_files(\s*=\s*["'])(SampleCxxModule\.\*)(["'])/g,
         with: `.exclude_files$1${versionName}$2$3`,
       },
-
+      {
+        // using jsc to expose jsi.h
+        paths: 'React-jsi.podspec',
+        replace: /^(\s+Pod::Spec.new do \|s\|.*)$/gm,
+        with: '\n# using jsc to expose jsi.h\njs_engine = :jsc$1',
+      },
+      {
+        paths: 'React-jsc.podspec',
+        replace: /\b(JSCRuntime\.)/g,
+        with: `${versionName}$1`,
+      },
       // Yoga
       {
         // Unprefixes inner directory for source_files

--- a/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/vendoredModulesTransforms.ts
@@ -121,6 +121,11 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           find: new RegExp(`${prefix}(REACT_NATIVE_MINOR_VERSION)`, 'g'),
           replaceWith: '$1',
         },
+        {
+          paths: 'RNReanimated.podspec.json',
+          find: /(REANIMATED_VERSION)/g,
+          replaceWith: `${prefix}$1`,
+        },
       ],
     },
     'react-native-gesture-handler': {
@@ -170,7 +175,7 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
     '@shopify/react-native-skia': {
       path: [
         {
-          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|SkiaUIView|SkiaPictureViewManager)/g,
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|SkiaUIView|SkiaPictureViewManager|SkiaDomViewManager)/g,
           replaceWith: `${prefix}$1`,
         },
       ],
@@ -181,8 +186,12 @@ export default function vendoredModulesTransformsFactory(prefix: string): Config
           replaceWith: `ReactCommon/${prefix}`,
         },
         {
-          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|RNJsi|SkiaUIView|SkiaPictureViewManager)/g,
+          find: /\b(DisplayLink|PlatformContext|SkiaDrawView|SkiaDrawViewManager|SkiaManager|RNJsi|SkiaUIView|SkiaPictureViewManager|SkiaDomViewManager)/g,
           replaceWith: `${prefix}$1`,
+        },
+        {
+          find: /RCT_EXPORT_MODULE\((SkiaDomView)\)/g,
+          replaceWith: `RCT_EXPORT_MODULE(${prefix}$1)`,
         },
         {
           // The module name in bridge should be unversioned `RNSkia`

--- a/tools/src/versioning/ios/unversionablePackages.json
+++ b/tools/src/versioning/ios/unversionablePackages.json
@@ -4,7 +4,6 @@
   "expo-dev-launcher",
   "expo-dev-menu",
   "expo-dev-menu-interface",
-  "expo-image",
   "expo-in-app-purchases",
   "expo-module-scripts",
   "expo-module-template",

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -127,6 +127,12 @@ function baseTransformsFactory(prefix: string): Required<FileTransforms> {
         },
       },
       {
+        // namespace ABI48_0_0React = ABI48_0_0facebook::react -> namespace ABI48_0_0React = ABI48_0_0facebook::ABI48_0_0React
+        // using namespace ABI48_0_0facebook::react -> using namespace ABI48_0_0facebook::ABI48_0_0React
+        find: /namespace ([\w\s=]+facebook)::react/g,
+        replaceWith: `namespace $1::${prefix}React`,
+      },
+      {
         // Objective-C only, see the comment in the rule below.
         paths: '*.{h,m,mm}',
         find: /r(eactTag|eactSubviews|eactSuperview|eactViewController|eactSetFrame|eactAddControllerToClosestParent|eactZIndex|eactLayoutDirection)/gi,


### PR DESCRIPTION
# Why

fix ios versioning after react-native 0.71 upgrade

# How

- [barcode-scanner] forward declaration for `ZXingObjC` to fix swift module build error from umbrella header in versioned code
- [tools] update transforms mainly for `React-jsc` dedicated pod and some upstream cocoapods changes

# Test Plan

- expo go versioning ci passed
- `et add-sdk -p ios -s 48.0.0` & versioned ios expo go + sdk 48 ncl smoke test

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
