### PR TITLE
[module-scripts] Fix broken config plugin link on README

### DIFF
--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -71,7 +71,7 @@ Besides, running `yarn prepare` script will also synchronize optional files from
 
 ### 🔌 Config Plugin
 
-To create a [config plugin](https://github.com/expo/expo-cli/blob/main/packages/config-plugins/README.md) that automatically configures your native code, you have two options:
+To create a [config plugin](https://github.com/expo/expo/blob/main/packages/@expo/config-plugins/README.md) that automatically configures your native code, you have two options:
 
 1. Create a `plugin` folder and write your plugin in TypeScript (recommended).
 2. Create an `app.plugin.js` file in the project root and write the plugin in pure Node.js-compliant JavaScript.


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

`expo-module-scripts` `README.md` was linking users to the old `config-plugin` inside the `expo-cli` repo 

# How

Update the link to point to the new `config plugin` location inside the expo package

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
