### PR TITLE
[docs][image] Add a table with supported image formats

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { Terminal } from '~/ui/components/Snippet';
+import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 **`expo-image`** is a cross-platform React component that loads and renders images.
 
@@ -22,6 +23,20 @@ import { Terminal } from '~/ui/components/Snippet';
 - Uses performant [`SDWebImage`](https://github.com/SDWebImage/SDWebImage) and [`Glide`](https://github.com/bumptech/glide) under the hood
 
 <PlatformsSection android emulator ios simulator web />
+
+#### Supported image formats
+
+| Format | Android | iOS | Web |
+|:---:|:---:|:---:|:---:|
+| WebP | <YesIcon /> | <YesIcon /> | <YesIcon /> [~96% adoption](https://caniuse.com/webp) |
+| PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
+| AVIF | <YesIcon /> | <YesIcon /> | <PendingIcon /> [~79% adoption](https://caniuse.com/avif) |
+| HEIC | <YesIcon /> | <YesIcon /> | <NoIcon /> [not adopted yet](https://caniuse.com/heif) |
+| JPEG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
+| GIF | <YesIcon /> | <YesIcon /> | <YesIcon /> |
+| SVG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
+| ICO | <YesIcon /> | <YesIcon /> | <YesIcon /> |
+| ICNS | <NoIcon /> | <YesIcon /> | <NoIcon /> |
 
 ## Installation
 


### PR DESCRIPTION
# Why

Something important that was missing

# How

Added a table with supported formats. For Web I also added links to `caniuse.com` so people can easily check out in more details

# Test Plan

<img width="1126" alt="Screenshot 2023-01-25 at 22 02 49" src="https://user-images.githubusercontent.com/1714764/214722773-940b73e9-0669-4197-a28d-88265e6f7004.png">
