### PR TITLE
[module-scripts] Remove jest-expo-enzyme reference from README

### DIFF
--- a/packages/expo-module-scripts/README.md
+++ b/packages/expo-module-scripts/README.md
@@ -144,7 +144,7 @@ Use the following scripts to interact with the plugin:
 
 ### 🤡 Jest
 
-The Jest preset extends [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) or [`jest-expo-enzyme`](https://github.com/expo/expo/tree/main/packages/jest-expo-enzyme) and adds proper TypeScript support and type declarations to the presets.
+The Jest preset extends [`jest-expo`](https://github.com/expo/expo/tree/main/packages/jest-expo) and adds proper TypeScript support and type declarations to the presets.
 
 **For unit testing API-based modules:**
 


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

The Jest section of the `expo-module-scripts` `README.md` was making reference to the now deprecated `jest-expo-enzyme` package which we no longer extend ([jest-preset.js](https://github.com/expo/expo/blob/main/packages/expo-module-scripts/jest-preset.js)). There is also the fact that this package has been moved to a different repo ([jest-expo-enzyme](https://github.com/expo/jest-expo-enzyme)) that is now archived, so I believe the best move here is to remove the reference of est-expo-enzyme from this document.

# How

Removed `jest-expo-enzyme` reference from the document 

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
