### PR TITLE
[ncl] Fix website build

### DIFF
--- a/apps/native-component-list/src/screens/PagerViewScreen.web.tsx
+++ b/apps/native-component-list/src/screens/PagerViewScreen.web.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { Text } from 'react-native';
+
+export default () => <Text>PagerView is not implemented on web</Text>;


### PR DESCRIPTION
# Why

On version 6.1.2 [react-native-pager-view ](https://github.com/callstack/react-native-pager-view) added some files that import code from `react-native` internal paths but that is not supported on react-native-web and is breaking our [Publish Native Component List Website & Update](https://github.com/expo/expo/actions/workflows/publish-demo.yml) workflow. Considering the fact that `react-native-pager-view`  never had web support ([issue #91](https://github.com/callstack/react-native-pager-view/issues/91)), we can just add a placeholder to the PagerView example on web

# How

Add a placeholder screen to NCL when accessing the PagerView example on web

![image](https://user-images.githubusercontent.com/11707729/214932845-7f7064d4-dda7-4ef9-b360-9543bfd4855d.png)


# Test Plan

```
cd apps/native-component-list/
yarn build:web 
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
