### PR TITLE
[expo-updates][Android] fix manifest generation for native debug for RN 0.71

### DIFF
--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -5,6 +5,8 @@ import org.gradle.util.GradleVersion
 
 def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
 
+def ex_updates_native_debug = System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1"
+
 // From a library project role to reference app project settings such as `targetName.toLowerCase().contains("release")`,
 // we extract the `appProject` from all projects here.
 // things like `config`, `buildDir`, and `applicationVariants`, we will reference from appProject.
@@ -60,7 +62,7 @@ def setupClosure = {
         commandLine(*nodeExecutableAndArgs, "$expoUpdatesDir/scripts/createManifest.js", "android", projectRoot, assetsDir, entryFile)
       }
 
-      enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release")
+      enabled config."bundleIn${targetName}" || targetName.toLowerCase().contains("release") || ex_updates_native_debug
     }
 
     def currentAssetsCopyTask = tasks.create(

--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -4,6 +4,14 @@ apply plugin: "com.facebook.react"
 import com.android.build.OutputFile
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
+def expoDebuggableVariants = ['debug']
+// Override `debuggableVariants` for expo-updates debugging
+if (System.getenv('EX_UPDATES_NATIVE_DEBUG') == "1") {
+  react {
+    expoDebuggableVariants = []
+  }
+}
+
 
 /**
  * This is the configuration block to customize your React Native Android app.
@@ -13,6 +21,7 @@ react {
     entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
     reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
     hermesCommand = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc"
+    debuggableVariants = expoDebuggableVariants
 
     /* Folders */
     //   The root of your project, i.e. where "package.json" lives. Default is '..'
@@ -61,13 +70,6 @@ react {
 // Override `hermesEnabled` by `expo.jsEngine`
 ext {
   hermesEnabled = (findProperty('expo.jsEngine') ?: "jsc") == "hermes"
-}
-
-// Override `debuggableVariants` for expo-updates debugging
-if (System.getenv('EX_UPDATES_NATIVE_DEBUG') == "1") {
-  react {
-    debuggableVariants = debuggableVariants.get().findAll { it != "debug" }
-  }
 }
 
 /**


### PR DESCRIPTION
# Why

After the upgrade to React Native 0.71, creating apps for native debugging of updates fails on Android, because the gradle build step to create the expo-updates embedded manifest is not executed.

# How

- Add a check for the `EX_UPDATES_NATIVE_DEBUG` environment variable in `create-manifest-android.gradle`, and enable the build step if that is detected
- Adjust the template `android/app/build.gradle` to set `react.debuggableVariants` correctly

# Test Plan

- Follow the steps in ENG-6078 to create an app set up for updates, and using the latest code from this branch
- Execute

```sh
export EX_UPDATES_NATIVE_DEBUG=1
cd android
./gradlew :app:installDebug
```

After these changes, the app will start normally, and updates will work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
