### PR TITLE
[expo-updates] More E2E setup script changes

### DIFF
--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -5,7 +5,6 @@ To run the updates e2e tests locally, do the following:
 ```bash
 export EXPO_REPO_ROOT=/Users/me/myCode/expo
 export WORKING_DIR_ROOT=/Users/me/myCode/e2eworking
-export ARTIFACTS_DEST=$WORKING_DIR_ROOT/e2eartifacts
 export TEST_PROJECT_ROOT=$WORKING_DIR_ROOT/updates-e2e
 export UPDATES_HOST=localhost
 export UPDATES_PORT=4747

--- a/packages/expo-updates/e2e/__tests__/setup/create-eas-project-assets.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-eas-project-assets.js
@@ -18,12 +18,7 @@ const runtimeVersion = '1.0.0';
  */
 
 (async function () {
-  if (
-    !process.env.ARTIFACTS_DEST ||
-    !process.env.EXPO_REPO_ROOT ||
-    !process.env.UPDATES_HOST ||
-    !process.env.UPDATES_PORT
-  ) {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
     throw new Error(
       'Missing one or more environment variables; see instructions in e2e/__tests__/setup/index.js'
     );

--- a/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
@@ -22,12 +22,7 @@ const runtimeVersion = '1.0.0';
  */
 
 (async function () {
-  if (
-    !process.env.ARTIFACTS_DEST ||
-    !process.env.EXPO_REPO_ROOT ||
-    !process.env.UPDATES_HOST ||
-    !process.env.UPDATES_PORT
-  ) {
+  if (!process.env.EXPO_REPO_ROOT || !process.env.UPDATES_HOST || !process.env.UPDATES_PORT) {
     throw new Error(
       'Missing one or more environment variables; see instructions in e2e/__tests__/setup/index.js'
     );

--- a/packages/expo-updates/e2e/__tests__/setup/create-updates-test.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-updates-test.js
@@ -11,7 +11,6 @@ const workingDir = path.resolve(repoRoot, '..');
 const EXPO_ACCOUNT_NAME = 'myusername';
 
 /**
- *
  * This generates a project at the location TEST_PROJECT_ROOT,
  * set up to use the latest bits from the current repo source,
  * and can be used to test different expo-updates and EAS updates workflows.
@@ -42,12 +41,7 @@ function transformAppJson(appJson, projectName, runtimeVersion) {
 }
 
 (async function () {
-  if (
-    !process.env.ARTIFACTS_DEST ||
-    !process.env.EXPO_REPO_ROOT ||
-    !process.env.UPDATES_HOST ||
-    !process.env.UPDATES_PORT
-  ) {
+  if (!process.env.EXPO_REPO_ROOT) {
     throw new Error(
       'Missing one or more environment variables; see instructions in e2e/__tests__/setup/index.js'
     );


### PR DESCRIPTION
- Remove unneeded artifacts directory
- Add timestamps to package versions, to guarantee that dependencies come from latest repo code

# Test plan

Updates E2E tests will still work

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
