### PR TITLE
[image][ios] Fix a crash on iOS below 16.0

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a crash on iOS below 16.0 introduced by the Live Text interaction feature. ([#20987](https://github.com/expo/expo/pull/20987) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 1.0.0-beta.2 — 2023-01-25


### PR DESCRIPTION
# Why

Fix a crash reported by @brentvatne and @BrodaNoel that was happening on iOS below 16.0.

The problematic part was:

```swift
let imageAnalysisInteraction = {
  if #available(iOS 16.0, *) {
    return ImageAnalyzer.isSupported ? ImageAnalysisInteraction() : nil
  }
  return nil
}()
```

which, when evaluated, threw an `EXC_BAD_ACCESS` exception, probably because its return type is unknown and couldn't be inferred since it cannot return `ImageAnalysisInteraction` on iOS below 16.0

I wish we could just mark the property availability, but it's not possible for stored properties 🤷‍♂️ 

# How

Refactored the Live Text interaction feature a bit, so now it doesn't use this property at all.

# Test Plan

It's no longer crashing on my simulator with iOS 15.4. Also tested against new examples I added in #20988 