### PR TITLE
[docs] Add note about SDK 45 & update verbiage in Customizing Metro

### DIFF
--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -130,21 +130,9 @@ See the list of all [default Uglify options](https://github.com/facebook/metro/b
 
 A useful way to debug your source code is by exploring the source maps with [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer).
 
-<Step label="1">
+To use it, run the following command:
 
-Install it with the following command in your project as a dev dependency:
-
-<Terminal cmd={['$ yarn add --dev react-native-bundle-visualizer']} />
-
-</Step>
-
-<Step label="2">
-
-To run it, use the following command:
-
-<Terminal cmd={['$ yarn add --dev npx react-native-bundle-visualizer']} />
-
-</Step>
+<Terminal cmd={['$ npx react-native-bundle-visualizer']} />
 
 This will show an interactive breakdown of what makes up your JavaScript bundle. Using this, you can find large packages that you may not have intended to bundle into your project. The smaller the bundle, the faster your app will start.
 
@@ -170,7 +158,7 @@ Universal Expo Metro is designed to be fully universal, meaning any web bundling
 | Bundle command   | `npx expo export`                | `npx expo export:web`  |
 | Output folder    | **dist**                         | **web-build**          |
 | Static folder    | **public**                       | **web**                |
-| Config file      | `metro.config.js`                | `webpack.config.js`    |
+| Config file      | **metro.config.js**              | **webpack.config.js**  |
 | Default config   | `@expo/metro-config`             | `@expo/webpack-config` |
 | Fast Refresh     | <PendingIcon /> (coming soon)    | <NoIcon />             |
 | Tree Shaking     | <NoIcon />                       | <YesIcon />            |

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -7,18 +7,28 @@ description: Learn about different Metro bundler configurations that can be cust
 
 import { Terminal } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Step } from '~/ui/components/Step';
 
-Expo CLI uses Metro during [`npx expo start`](/workflow/expo-cli#develop) and [`npx expo export`](/workflow/expo-cli#exporting) to bundle your JavaScript code and assets. Metro is built and optimized for React Native, and used for large scale applications such as Facebook and Instagram.
+Expo CLI uses Metro during [`npx expo start`](/workflow/expo-cli#develop) and [`npx expo export`](/workflow/expo-cli#exporting) to bundle your JavaScript code and assets. Metro is built and optimized for React Native, and used for large-scale applications such as Facebook and Instagram.
 
 ## Customizing
 
-You can customize the Metro bundler by creating a **metro.config.js** file at the root of your project. This file should export a [Metro configuration][metro-config] that extends [`expo/metro-config`][expo-metro-config]. You should import `expo/metro-config` instead of `@expo/metro-config` to ensure version consistency.
+You can customize the Metro bundler by creating a **metro.config.js** file at the root of your project. This file should export a [Metro configuration](https://facebook.github.io/metro/docs/configuration) that extends [`expo/metro-config`](https://github.com/expo/expo/tree/main/packages/@expo/metro-config). Import `expo/metro-config` instead of `@expo/metro-config` to ensure version consistency.
 
-Run the following to generate the template file:
+Run the following command to generate the template file:
 
 <Terminal cmd={['$ npx expo customize metro.config.js']} />
 
-The **metro.config.js** file looks something like this:
+<Collapsible summary="Using SDK 45 or below?">
+
+For SDK 45 or below, run the following command:
+
+<Terminal cmd={['$ npx expo customize:web']} />
+
+</Collapsible>
+
+The **metro.config.js** file looks as below:
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
@@ -28,11 +38,11 @@ const config = getDefaultConfig(__dirname);
 module.exports = config;
 ```
 
-To learn more, see [`metro.config.js` documentation](https://facebook.github.io/metro/docs/configuration).
+See [**metro.config.js** documentation](https://facebook.github.io/metro/docs/configuration) for more information.
 
 ## Assets
 
-Metro resolves files as either source code or assets. Source code is JavaScript, TypeScript, JSON, and other files used by your application. [Asset](/guides/assets) are images, fonts, and other files that should not be transformed by Metro. To accommodate large-scale codebases, Metro requires all extensions for both source code and assets to be explicitly defined before starting the bundler. This is done by adding the `resolver.sourceExts` and `resolver.assetExts` options to the Metro configuration. By default, the following extensions are included:
+Metro resolves files as either source code or assets. Source code is JavaScript, TypeScript, JSON, and other files used by your application. [Assets](/guides/assets) are images, fonts, and other files that should not be transformed by Metro. To accommodate large-scale codebases, Metro requires all extensions for both source code and assets to be explicitly defined before starting the bundler. This is done by adding the `resolver.sourceExts` and `resolver.assetExts` options to the Metro configuration. By default, the following extensions are included:
 
 - [`resolver.assetExts`](https://github.com/facebook/metro/blob/7028b7f51074f9ceef22258a8643d0f90de2388b/packages/metro-config/src/defaults/defaults.js#L15)
 - [`resolver.sourceExts`](https://github.com/facebook/metro/blob/7028b7f51074f9ceef22258a8643d0f90de2388b/packages/metro-config/src/defaults/defaults.js#L53)
@@ -58,23 +68,29 @@ module.exports = config;
 
 ## Minification
 
-Source code is optimized for readability and debugging. To optimize your application for performance, the source code is automatically minified when [compiling](/workflow/expo-cli#compiling) and [exporting](/workflow/expo-cli#exporting). You can also minify your code during development with `npx expo start --minify`. This is sometimes useful for testing production optimizations.
+The source code is optimized for readability and debugging. To optimize your application for performance, the source code is automatically minified when [compiling](/workflow/expo-cli#compiling) and [exporting](/workflow/expo-cli#exporting). You can also minify your code during development with `npx expo start --minify`. This is sometimes useful for testing production optimizations.
 
-By default, Metro uses `uglify-es` to minify code. According to [this benchmark](https://github.com/privatenumber/minification-benchmarks) `uglify` generally produces the smallest bundles, and is nearly the _slowest_ minifier. Here are some alternative minifiers you can use with Metro.
+By default, Metro uses `uglify-es` to minify code. According to [this benchmark](https://github.com/privatenumber/minification-benchmarks) `uglify` generally produces the smallest bundles, and is nearly the _slowest_ minifier. There are alternative minifiers you can use with Metro:
 
-### Minification: esbuild
+### esbuild
 
-You can use [`esbuild`](https://esbuild.github.io/) to minify exponentially faster than `uglify-es` and `terser`. Just follow this guide: [`metro-minify-esbuild` usage](https://github.com/EvanBacon/metro-minify-esbuild#usage).
+You can use [`esbuild`](https://esbuild.github.io/) to minify exponentially faster than `uglify-es` and `terser`. For more information, see [`metro-minify-esbuild` usage](https://github.com/EvanBacon/metro-minify-esbuild#usage).
 
-### Minification: Terser
+### Terser
 
 You can use [`terser`](https://github.com/terser/terser) instead of `uglify-es` to mangle and compress your project.
 
-First, install Terser in your project by running the following command:
+<Step label="1">
+
+Install Terser in your project by running the following command:
 
 <Terminal cmd={['$ yarn add --dev metro-minify-terser']} />
 
-Now set Terser as a minifier with `transformer.minifierPath`, and pass in [`terser` options](https://github.com/terser/terser#compress-options) via `transformer.minifierConfig`.
+</Step>
+
+<Step label="2">
+
+Set Terser as a minifier with `transformer.minifierPath`, and pass in [`terser` options](https://github.com/terser/terser#compress-options) via `transformer.minifierConfig`.
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
@@ -89,9 +105,13 @@ config.transformer.minifierConfig = {
 module.exports = config;
 ```
 
-### Minification: Uglify
+</Step>
 
-By default, Metro uses [`uglify-es`](https://github.com/mishoo/UglifyJS) to minify and compress your code. You can customize uglify by passing [options](https://github.com/mishoo/UglifyJS#compress-options) to `transformer.minifierConfig`. For example, if you want to remove all `console.log()` methods from your app in production, you can do the following:
+### Uglify
+
+By default, Metro uses [`uglify-es`](https://github.com/mishoo/UglifyJS) to minify and compress your code. You can customize `uglify` by passing [options](https://github.com/mishoo/UglifyJS#compress-options) to `transformer.minifierConfig`.
+
+For example, if you want to remove all `console.log()` methods from your app in production, you add the following to the **metro.config.js** file:
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
@@ -104,21 +124,37 @@ config.transformer.minifierConfig.compress.drop_console = true;
 module.exports = config;
 ```
 
-Here are all of the [default Uglify options](https://github.com/facebook/metro/blob/b629f44239bbb3414491755185cf19b5834b4b7a/packages/metro-config/src/defaults/index.js#L94-L111) applied in Metro bundler.
+See the list of all [default Uglify options](https://github.com/facebook/metro/blob/b629f44239bbb3414491755185cf19b5834b4b7a/packages/metro-config/src/defaults/index.js#L94-L111) applied in Metro bundler.
 
 ## Source map exploration
 
-A useful way to debug your source code is by exploring the source maps with [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer). Install it with `yarn add -D react-native-bundle-visualizer`, then run `npx react-native-bundle-visualizer`.
+A useful way to debug your source code is by exploring the source maps with [`react-native-bundle-visualizer`](https://github.com/IjzerenHein/react-native-bundle-visualizer).
 
-This will show you an interactive breakdown of what makes up your JavaScript bundle. Using this, you can find large packages that you may not have intended to bundle in your project. The smaller the bundle, the faster your app will start.
+<Step label="1">
+
+Install it with the following command in your project as a dev dependency:
+
+<Terminal cmd={['$ yarn add --dev react-native-bundle-visualizer']} />
+
+</Step>
+
+<Step label="2">
+
+To run it, use the following command:
+
+<Terminal cmd={['$ yarn add --dev npx react-native-bundle-visualizer']} />
+
+</Step>
+
+This will show an interactive breakdown of what makes up your JavaScript bundle. Using this, you can find large packages that you may not have intended to bundle into your project. The smaller the bundle, the faster your app will start.
 
 ## Web Support
 
-> **info** Metro web support is an experimental feature and only works with the [local Expo CLI](https://blog.expo.dev/new-versioned-expo-cli-cf6e10632656) and Expo SDK 46 or newer.
+> **info** Metro web support is an experimental feature and only works with the [local Expo CLI](/workflow/expo-cli) and Expo SDK 46 or newer.
 
-By default, Expo CLI uses webpack as the bundler on web platforms, this is because Metro historically did not support web. Using different bundlers across platforms leads to some critical divergence in how your app works across platforms. Features like Fast Refresh which work on native don't work on web, and important production functionality like assets are treated differently across bundlers.
+By default, Expo CLI uses webpack as the bundler on web platforms because Metro historically did not support web. Using different bundlers across platforms leads to some critical divergence in how an app works across platforms. Features such as Fast Refresh which works on native don't work on the web, and important production functionality such as assets are treated differently across bundlers.
 
-By utilizing Metro across all platforms you can have a more universal development experience. You also get to utilize shared cached chunks across platforms meaning faster iteration speed when working across platforms. Project upgrades can also be easier since there are less dependencies (`webpack`, `webpack-dev-server`) you need to update between versions.
+By utilizing Metro across all platforms you can have a more universal development experience. You also get to utilize shared cached chunks across platforms meaning faster iteration speed when working across platforms. Project upgrades can also be easier since there are fewer dependencies (`webpack`, `webpack-dev-server`) you need to update between versions.
 
 All Metro web features should be universal (bundling, static files, assets) making the DX easier to understand and faster across the app development process.
 
@@ -126,14 +162,14 @@ Learn once, bundle everywhere!
 
 ### Expo webpack vs. Expo Metro
 
-Universal Expo Metro is designed to be fully universal, meaning any web bundling features should also work on native too. Because of this we make some breaking changes between the two bundler implementations, carefully check the difference if you're moving from webpack to Metro.
+Universal Expo Metro is designed to be fully universal, meaning any web bundling features should also work on native too. Because of this, we make some breaking changes between the two bundler implementations, carefully check the difference if you're moving from webpack to Metro.
 
 | Feature          | Metro                            | webpack                |
 | ---------------- | -------------------------------- | ---------------------- |
 | Start command    | `npx expo start`                 | `npx expo start`       |
 | Bundle command   | `npx expo export`                | `npx expo export:web`  |
-| Output folder    | `dist/`                          | `web-build/`           |
-| Static folder    | `public/`                        | `web/`                 |
+| Output folder    | **dist**                         | **web-build**          |
+| Static folder    | **public**                       | **web**                |
 | Config file      | `metro.config.js`                | `webpack.config.js`    |
 | Default config   | `@expo/metro-config`             | `@expo/webpack-config` |
 | Fast Refresh     | <PendingIcon /> (coming soon)    | <NoIcon />             |
@@ -146,7 +182,7 @@ Note that aliases, resolution, and other bundler features are now universal acro
 
 ### Adding Web support to Metro
 
-To enable Metro web support, be sure to use Expo SDK 46 or newer, then modify your Expo config in **app.json**, or **app.config.js** to enable the feature using the `expo.web.bundler` field:
+To enable Metro web support, make sure your project is using Expo SDK 46 or newer. Then modify your [Expo config](/workflow/configuration) to enable the feature using the `expo.web.bundler` field:
 
 ```json app.json
 {
@@ -164,51 +200,42 @@ To start the development server run the following command:
 
 <Terminal cmd={['$ npx expo start --web']} />
 
-Or start normally and press <kbd>W</kbd> in the Terminal UI.
+Alternatively, press <kbd>W</kbd> in the Expo CLI terminal UI.
 
 #### Production
 
-> TL;DR: Use `npx expo export` instead of `npx expo export:web` or `expo build:web`.
+> **Tip** Use `npx expo export` instead of `npx expo export:web` or `expo build:web`.
 
-You can bundle the project for hosting just like you would for native:
+You can bundle the project for hosting as it is done for native:
 
 <Terminal cmd={['$ npx expo export']} />
 
-You should see something like this:
+In the terminal, after running the above command, you'll see a similar output as shown below:
 
 ```sh
-app $ npx expo export
+$ npx expo export
 Starting Metro Bundler
 iOS ./index.tsx ░░░░░░░░░░░░░░░░  4.0% (  8/132)
 Android ./index.tsx ░░░░░░░░░░░░░░░░  0.5% (  3/129)
 Web ./index.tsx ░░░░░░░░░░░░░░░░  4.0% ( 5/5
 ```
 
-You can skip bundling for all platforms by using the `--platform` flag:
+You can also skip bundling for other platforms by using the `--platform` flag:
 
 <Terminal cmd={['$ npx expo export --platform web']} />
 
-Your output will be found in the `dist` folder.
-
-The output can be tested locally by using the [Serve CLI](https://www.npmjs.com/package/serve).
+The output is found in the **dist** directory. To test it locally and see it will ork in production, use [Serve CLI](https://www.npmjs.com/package/serve).
 
 <Terminal cmd={['$ npx serve dist']} />
 
-You can deploy the website using any popular web host, follow any of the guides in [publishing websites](/distribution/publishing-websites/), just substitute the `web-build/` folder for the `dist/` folder.
+You can deploy the website using any popular web host by following a guide from [publishing websites](/distribution/publishing-websites), and substitute the **web-build** directory for **dist**.
 
 #### Static Files
 
-Expo's Metro implementation supports hosting static files from the dev server by putting them in the root **public/** directory, this is akin to many other web frameworks. In Expo webpack, we default to using the **web/** directory.
+Expo's Metro implementation supports hosting static files from the dev server by putting them in the root **public** directory. It is similar to many other web frameworks. In Expo webpack, the **web** directory is default.
 
-When exporting with `npx expo export`, we copy the contents of the **public/** directory into the **dist/** directory, meaning your app can expect to fetch these assets relative to the host URL.
+When exporting with `npx expo export`, the contents of the **public** directory are copied into the **dist/** directory. It means your app can expect to fetch these assets relative to the host URL. The most common example of this is the **public/favicon.ico** which is used by websites to render the tab icon.
 
-The most common example of this is the `public/favicon.ico` which is used by websites to render the tab icon.
+You can overwrite the default **index.html** in Metro web by creating a **public/index.html** file in your project.
 
-You can overwrite the default `index.html` in Metro web by creating a `public/index.html` file in your project.
-
-In the future, this will work universally across platforms with EAS Update hosting. Currently the feature is web-only based on the static host used for the native app, for example, the legacy Expo service updates does not support this feature.
-
-[expo-cli]: /workflow/expo-cli
-[metro]: https://facebook.github.io/metro
-[metro-config]: https://facebook.github.io/metro/docs/configuration
-[expo-metro-config]: https://github.com/expo/expo/tree/main/packages/@expo/metro-config
+In the future, this will work universally across platforms with EAS Update hosting. Currently, the feature is web-only based on the static host used for the native app, for example, the legacy Expo service updates do not support this feature.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Recently, @wodin shared a [forum post](https://forums.expo.dev/t/customize-metro-config-js-is-not-an-expo-command/69135?u=wodin) where a developer was confused by which command to use for project running on SDK 45 or lower.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a note for SDK 45 and lower to generate the **metro.config.js** file. It also updates overall verbiage and formatting to match our writing style guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
