### PR TITLE
[android][ios] Upgrade react-native-reanimated to 2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-gesture-handler` from `2.8.0` to `2.9.0`. ([#20930](https://github.com/expo/expo/pull/20930) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-shared-element` from `0.8.4` to `0.8.7`. ([#20593](https://github.com/expo/expo/pull/20593) by [@ijzerenhein](https://github.com/ijzerenhein))
 - Updated `@react-native-async-storage/async-storage` from `1.17.3' to `1.17.11`. ([#20780](https://github.com/expo/expo/pull/20780) by [@kudo](https://github.com/kudo))
-- Updated `react-native-reanimated` from `2.12.0` to `2.14.0`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo))
+- Updated `react-native-reanimated` from `2.12.0` to `2.14.4`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo), [#20990](https://github.com/expo/expo/pull/20990) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.171`. ([#20857](https://github.com/expo/expo/pull/20857) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))

--- a/android/vendored/unversioned/react-native-reanimated/android/CMakeLists.txt
+++ b/android/vendored/unversioned/react-native-reanimated/android/CMakeLists.txt
@@ -160,48 +160,54 @@ else()
         set (JSI_LIB "")
     else()
         find_library(
-                JSI_LIB
-                jsi
-                PATHS ${LIBRN_DIR}
-                NO_CMAKE_FIND_ROOT_PATH
+            JSI_LIB
+            jsi
+            PATHS ${LIBRN_DIR}
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH
         )
     endif()
 
     find_library(
-            GLOG_LIB
-            glog
-            PATHS ${LIBRN_DIR}
-            NO_CMAKE_FIND_ROOT_PATH
+        GLOG_LIB
+        glog
+        PATHS ${LIBRN_DIR}
+        NO_DEFAULT_PATH
+        NO_CMAKE_FIND_ROOT_PATH
     )
 
     find_library(
-            FBJNI_LIB
-            fbjni
-            PATHS ${LIBRN_DIR}
-            NO_CMAKE_FIND_ROOT_PATH
+        FBJNI_LIB
+        fbjni
+        PATHS ${LIBRN_DIR}
+        NO_DEFAULT_PATH
+        NO_CMAKE_FIND_ROOT_PATH
     )
 
     if(${REACT_NATIVE_MINOR_VERSION} LESS 69)
         find_library(
-                FOLLY_LIB
-                folly_json
-                PATHS ${LIBRN_DIR}
-                NO_CMAKE_FIND_ROOT_PATH
+            FOLLY_LIB
+            folly_json
+            PATHS ${LIBRN_DIR}
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH
         )
     else()
         find_library(
-                FOLLY_LIB
-                folly_runtime
-                PATHS ${LIBRN_DIR}
-                NO_CMAKE_FIND_ROOT_PATH
+            FOLLY_LIB
+            folly_runtime
+            PATHS ${LIBRN_DIR}
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH
         )
     endif()
 
     find_library(
-            REACTNATIVEJNI_LIB
-            reactnativejni
-            PATHS ${LIBRN_DIR}
-            NO_CMAKE_FIND_ROOT_PATH
+        REACTNATIVEJNI_LIB
+        reactnativejni
+        PATHS ${LIBRN_DIR}
+        NO_DEFAULT_PATH
+        NO_CMAKE_FIND_ROOT_PATH
     )
 
     target_link_libraries(
@@ -247,10 +253,11 @@ if(${JS_RUNTIME} STREQUAL "hermes")
             set(HERMES_EXECUTOR_LIB ReactAndroid::hermes_executor)
         else()
             find_library(
-                    HERMES_EXECUTOR_LIB
-                    hermes-executor-debug
-                    PATHS ${LIBRN_DIR}
-                    NO_CMAKE_FIND_ROOT_PATH
+                HERMES_EXECUTOR_LIB
+                hermes-executor-debug
+                PATHS ${LIBRN_DIR}
+                NO_DEFAULT_PATH
+                NO_CMAKE_FIND_ROOT_PATH
             )
         endif()
         target_link_libraries(
@@ -270,6 +277,7 @@ elseif(${JS_RUNTIME} STREQUAL "v8")
             V8EXECUTOR_LIB
             v8executor
             PATHS ${V8_SO_DIR}
+            NO_DEFAULT_PATH
             NO_CMAKE_FIND_ROOT_PATH
     )
     target_link_libraries(
@@ -282,10 +290,11 @@ elseif(${JS_RUNTIME} STREQUAL "jsc")
         set(JSEXECUTOR_LIB ReactAndroid::jscexecutor)
     else()
         find_library(
-                JSEXECUTOR_LIB
-                jscexecutor
-                PATHS ${LIBRN_DIR}
-                NO_CMAKE_FIND_ROOT_PATH
+            JSEXECUTOR_LIB
+            jscexecutor
+            PATHS ${LIBRN_DIR}
+            NO_DEFAULT_PATH
+            NO_CMAKE_FIND_ROOT_PATH
         )
     endif()
     target_link_libraries(${PACKAGE_NAME} ${JSEXECUTOR_LIB})

--- a/android/vendored/unversioned/react-native-reanimated/android/build.gradle
+++ b/android/vendored/unversioned/react-native-reanimated/android/build.gradle
@@ -208,7 +208,7 @@ file("$reactNativeRootDir/ReactAndroid/gradle.properties").withInputStream { rea
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 def REANIMATED_PACKAGE_BUILD = System.getenv("REANIMATED_PACKAGE_BUILD")
-def REANIMATED_VERSION = "2.14.0"
+def REANIMATED_VERSION = "2.14.4"
 def REANIMATED_MAJOR_VERSION = 2
 
 // for React Native <= 0.70
@@ -483,7 +483,7 @@ android {
         debug {
             externalNativeBuild {
                 cmake {
-                    if (JS_RUNTIME == "hermes") {
+                    if (JS_RUNTIME == "hermes" && !REANIMATED_PACKAGE_BUILD) {
                         arguments "-DHERMES_ENABLE_DEBUGGER=1"
                     } else {
                         arguments "-DHERMES_ENABLE_DEBUGGER=0"

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -659,7 +659,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
-  - RNReanimated (2.14.0):
+  - RNReanimated (2.14.4):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -1318,7 +1318,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 3f32aa2247836c12618d346113e5e82ea60ddd9c
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNReanimated: 3882aa3f7a30d3c74aa05d6c230399942690a043
+  RNReanimated: addc4900bf47882118d0a1b21747fa6705fa8cff
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSharedElement: 14409838520c8b50850aa4d33e15d0b8afdf7052
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "react-native": "0.71.0",
     "react-native-gesture-handler": "~2.9.0",
     "react-native-pager-view": "6.1.2",
-    "react-native-reanimated": "~2.14.0",
+    "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
     "react-native-shared-element": "0.8.8",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -146,7 +146,7 @@
     "react-native-maps": "1.3.2",
     "react-native-pager-view": "6.1.2",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.14.0",
+    "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
     "react-native-shared-element": "0.8.8",

--- a/home/package.json
+++ b/home/package.json
@@ -63,7 +63,7 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.3.2",
     "react-native-paper": "^4.0.1",
-    "react-native-reanimated": "~2.14.0",
+    "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.19.0",
     "react-redux": "^7.2.0",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2098,7 +2098,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
-  - RNReanimated (2.14.0):
+  - RNReanimated (2.14.4):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -3641,7 +3641,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNFlashList: 18d906a373da5ff16776e5013df9495d826edc7e
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
-  RNReanimated: e7aeb0addbcc2c79dccb69bb176d079afbd5fd23
+  RNReanimated: 2757554a90c8eb038535bb1fce12c49cc027a934
   RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593

--- a/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
+++ b/ios/vendored/unversioned/react-native-reanimated/RNReanimated.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNReanimated",
-  "version": "2.14.0",
+  "version": "2.14.4",
   "summary": "More powerful alternative to Animated library for React Native.",
   "description": "RNReanimated",
   "homepage": "https://github.com/software-mansion/react-native-reanimated",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-reanimated.git",
-    "tag": "2.14.0"
+    "tag": "2.14.4"
   },
   "source_files": [
     "ios/**/*.{mm,h,m}",
@@ -28,10 +28,10 @@
     "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Headers/Private/React-Core\" ",
     "FRAMEWORK_SEARCH_PATHS": "\"${PODS_CONFIGURATION_BUILD_DIR}/React-hermes\""
   },
-  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=70 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
+  "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=71 -Wno-comma -Wno-shorten-64-to-32 -Wno-documentation",
   "xcconfig": {
     "HEADER_SEARCH_PATHS": "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/RCT-Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"$(PODS_ROOT)/../../../../../../../../..${PODS_ROOT}/../../react-native-lab/react-native/ReactCommon\"",
-    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=70 -DREANIMATED_VERSION=2.14.0"
+    "OTHER_CFLAGS": "$(inherited) -DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32 -DREACT_NATIVE_MINOR_VERSION=71 -DREANIMATED_VERSION=2.14.4"
   },
   "requires_arc": true,
   "dependencies": {

--- a/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
+++ b/ios/vendored/unversioned/react-native-reanimated/ios/native/NativeProxy.mm
@@ -21,7 +21,11 @@
 #if __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>
 #else
-#import <jsi/JSCRuntime.h>
+#if REACT_NATIVE_MINOR_VERSION >= 71
+#include <jsc/JSCRuntime.h>
+#else
+#include <jsi/JSCRuntime.h>
+#endif // REACT_NATIVE_MINOR_VERSION
 #endif
 
 namespace reanimated {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,7 +93,7 @@
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.3.2",
   "react-native-pager-view": "6.1.2",
-  "react-native-reanimated": "~2.14.0",
+  "react-native-reanimated": "~2.14.4",
   "react-native-screens": "~3.19.0",
   "react-native-safe-area-context": "4.5.0",
   "react-native-shared-element": "0.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15878,10 +15878,10 @@ react-native-paper@^4.0.1:
     color "^3.1.2"
     react-native-iphone-x-helper "^1.3.1"
 
-react-native-reanimated@~2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.0.tgz#acc20d62ac4668afffb5bc749cf0a095e6c44239"
-  integrity sha512-WicflLAyXGveVLZCHLqxH4axkb1QoTLejsdb5WbjkMN0mEDHWQQly7BeKR7Ek0zzZnmcrChnNfMLGGW+X3uDkg==
+react-native-reanimated@~2.14.4:
+  version "2.14.4"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz#3fa3da4e7b99f5dfb28f86bcf24d9d1024d38836"
+  integrity sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
# Why

Reanimated was already upgraded to 2.14.0 in #20798 as part of RN upgrade, but in the meantime we've got 4 patch releases 😄 

# How

`et uvm -m react-native-reanimated -c 2.14.4`

# Test Plan

Expo Go and NCL seem to work on iOS and Android, except the well-known issue with `setImmediate`