### PR TITLE
[tools] Selecting pull requests to label in the publish command

### DIFF
--- a/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
+++ b/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
@@ -13,6 +13,8 @@ import { selectPackagesToPublish } from './selectPackagesToPublish';
 // https://github.com/expo/expo/pulls?q=label:published
 const PUBLISHED_LABEL_NAME = 'published';
 
+const { green, blue, magenta, bold } = chalk;
+
 /**
  * Adds "published" label to pull requests mentioned in changelog entries.
  */
@@ -25,12 +27,13 @@ export const addPublishedLabelToPullRequests = new Task<TaskArgs>(
     if (!process.env.GITHUB_TOKEN) {
       logger.error(
         'Environment variable `%s` must be set to add labels to pull requests',
-        chalk.magenta('GITHUB_TOKEN')
+        magenta('GITHUB_TOKEN')
       );
       return;
     }
 
-    const pullRequestIds: number[] = [];
+    // A set of pull request IDs extracted from changelog entries
+    const pullRequestIds = new Set<number>();
 
     // Find all pull requests mentioned in changelogs
     for (const { changelogChanges } of parcels) {
@@ -40,71 +43,92 @@ export const addPublishedLabelToPullRequests = new Task<TaskArgs>(
         continue;
       }
       for (const entry of Object.values(versionChanges).flat()) {
-        const { pullRequests } = entry;
-        if (pullRequests && pullRequests.length > 0) {
-          pullRequestIds.push(...pullRequests);
-        }
+        entry.pullRequests?.forEach((pullRequestId) => {
+          pullRequestIds.add(pullRequestId);
+        });
       }
     }
 
-    if (pullRequestIds.length === 0) {
-      return;
-    }
-    const pullRequestIdsSet = new Set<number>(pullRequestIds);
-    const pullRequestsToLabel: GitHub.PullRequest[] = [];
-
-    logger.info(`\n🐙 List of published pull requests (${pullRequestIdsSet.size}):`);
-
-    // Request and log all published pull requests
-    for (const pullRequestId of pullRequestIdsSet) {
-      const pr = await GitHub.getPullRequestAsync(pullRequestId, true);
-
-      logger.log(`${linkToPullRequest(pr)}: ${chalk.bold(pr.title)}`);
-      pullRequestsToLabel.push(pr);
-    }
-
-    // Ask whether to continue adding the label to pull requests logged above
-    if (!(await shouldLabelPullRequestsAsync())) {
+    if (pullRequestIds.size === 0) {
       return;
     }
 
-    await runWithSpinner('Adding the label...', async (spinner) => {
-      // Finally add the label to each pull request
-      for (const pullRequest of pullRequestsToLabel) {
-        const hasLabel = pullRequest.labels.some((label) => label.name === PUBLISHED_LABEL_NAME);
+    // Request for pull request objects for the extracted IDs
+    // This needs to happen consecutively to reduce the risk of being rate-limited by GitHub
+    const pullRequests = await runWithSpinner(
+      'Requesting published pull requests from GitHub',
+      async () => {
+        const pullRequests: GitHub.PullRequest[] = [];
 
-        if (!hasLabel) {
+        for (const pullRequestId of pullRequestIds) {
+          const pullRequest = await GitHub.getPullRequestAsync(pullRequestId, true);
+          const hasLabel = pullRequest.labels.some((label) => label.name === PUBLISHED_LABEL_NAME);
+
+          if (!hasLabel) {
+            pullRequests.push(pullRequest);
+          }
+        }
+        return pullRequests;
+      },
+      'Loaded published pull requests from GitHub'
+    );
+
+    // Skip the rest if all pull requests already have the label
+    if (pullRequests.length === 0) {
+      logger.log('There are no pull requests that are not labeled already');
+      return;
+    }
+
+    // Select pull requests to mark as published
+    const pullRequestsToLabel = await selectPullRequestsToLabel(pullRequests);
+
+    // Finally, consecutively add the label to each pull request
+    await runWithSpinner(
+      'Adding the label to selected pull requests',
+      async () => {
+        for (const pullRequest of pullRequestsToLabel) {
           await GitHub.addIssueLabelsAsync(pullRequest.number, [PUBLISHED_LABEL_NAME]);
         }
-      }
-      spinner.succeed('Added the published label');
-    });
+      },
+      'Added the published label'
+    );
 
     logger.log();
   }
 );
 
 function linkToPullRequest(pr: GitHub.PullRequest): string {
-  return link(chalk.blue('#' + pr.number), pr.html_url);
+  return link(blue('#' + pr.number), pr.html_url);
+}
+
+function linkToAuthor(pr: GitHub.PullRequest): string {
+  const { user } = pr;
+  return user ? link(green('@' + user.login), user.html_url) : 'anonymous';
+}
+
+function formatPullRequest(pr: GitHub.PullRequest): string {
+  return `${linkToPullRequest(pr)}: ${bold(pr.title)} (by ${linkToAuthor(pr)})`;
 }
 
 /**
- * Prompts the user whether to add the label to pull requests.
+ * Prompts the user to select pull requests that should be labeled as published.
  */
-async function shouldLabelPullRequestsAsync(): Promise<boolean> {
-  if (process.env.CI) {
-    return true;
-  }
-  const { proceed } = await inquirer.prompt<{ proceed: boolean }>([
+async function selectPullRequestsToLabel(
+  pullRequests: GitHub.PullRequest[]
+): Promise<GitHub.PullRequest[]> {
+  const { selectedPullRequests } = await inquirer.prompt([
     {
-      type: 'confirm',
-      name: 'proceed',
-      prefix: '❔',
-      message: chalk.yellow(
-        `Do you want to add '${chalk.magenta(PUBLISHED_LABEL_NAME)}' label to these pull requests?`
-      ),
-      default: true,
+      type: 'checkbox',
+      name: 'selectedPullRequests',
+      message: 'Which pull requests do you want to label as published?\n',
+      choices: pullRequests.map((pr) => {
+        return {
+          name: formatPullRequest(pr),
+          value: pr,
+          checked: true,
+        };
+      }),
     },
   ]);
-  return proceed;
+  return selectedPullRequests as GitHub.PullRequest[];
 }


### PR DESCRIPTION
# Why

There are situations where we're publishing just one package from many that the PR touched, like bumping iOS minimum deployment target or Kotlin version.

# How

Instead of confirming to add the published label to all pull requests, let the user select which ones to label.

# Test Plan

<img width="872" alt="Screenshot 2023-01-30 at 00 11 57" src="https://user-images.githubusercontent.com/1714764/215364563-09368a74-e08c-4252-8872-4445368c4740.png">
