### PR TITLE
[ncl] fix reanimated setImmediate issue

### DIFF
--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -1,4 +1,5 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
+const path = require('path');
 
 const baseConfig = createMetroConfiguration(__dirname);
 
@@ -6,6 +7,9 @@ if (process.env.EXPO_USE_EXOTIC) {
   // Use the custom transformer when exotic is enabled.
   baseConfig.transformer.babelTransformerPath = require.resolve('./metro.transformer.js');
 }
+
+// To test NCL from Expo Go, the react-native js source is from our fork.
+const reactNativeRoot = path.join(__dirname, '..', '..', 'react-native-lab', 'react-native');
 
 module.exports = {
   ...baseConfig,
@@ -41,8 +45,15 @@ module.exports = {
       // That is not ideal but should work for most cases if the two react-native versions do not have too much difference.
       // For example, `react-native-lab/react-native/node_modules/@react-native/polyfills` and `node_modules/@react-native/polyfills` may be different,
       // the metro config will use the transitive dependency from `node_modules/@react-native/polyfills`.
-      /\bnode_modules\/react-native\/\b/,
+      /\bnode_modules\/react-native\//,
       /\breact-native-lab\/react-native\/node_modules\b/,
     ],
+  },
+  serializer: {
+    ...baseConfig.serializer,
+    getModulesRunBeforeMainModule: () => [
+      require.resolve(path.join(reactNativeRoot, 'Libraries/Core/InitializeCore')),
+    ],
+    getPolyfills: () => require(path.join(reactNativeRoot, 'rn-get-polyfills'))(),
   },
 };


### PR DESCRIPTION
# Why

fix the reanimated `setImmediate` not defined issue on NCL.

# How

the root cause is that react-native's InitializeCore does not setup correctly. on NCL, the InitializeCore should be bundled from `react-native-lab/react-native/Libraries/Core/InitializeCore.js` but not `node_modules/react-native/Libraries/Core/InitializeCore.js`. however, it was [bundled from node_modules](https://github.com/expo/expo/blob/6a2669892a35943c45fb2ad89d476be646d87659/packages/%40expo/metro-config/src/ExpoMetroConfig.ts#L189-L195), so that InitializeCore does not setup correctly.

the pr tries to setup InitializeCore from react-native-lab

# Test Plan

- `wget -O 1.bundle 'http://localhost:19000/index.bundle?platform=ios&dev=true&minify=false&app=com.reproduce&modulesOnly=false&runModule=true'` + `tail -4 1.bundle` and check there are two `__r()`
- unversioned ios expo go + ncl

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
