### PR TITLE
[docs] Search: fix text selection color in input

### DIFF
--- a/docs/ui/components/CommandMenu/styles.ts
+++ b/docs/ui/components/CommandMenu/styles.ts
@@ -64,10 +64,6 @@ export const commandMenuStyles = css`
     &::placeholder {
       color: ${theme.icon.secondary};
     }
-
-    &::selection {
-      color: ${theme.palette.white};
-    }
   }
 
   [cmdk-item] {


### PR DESCRIPTION
# Why

Fixes ENG-7391

Brent has spotted small regression after the styleguide color changes, let's fix it.

# How

Remove custom CMDK selection color (previous default selection shade was darker and more vibrant, so we were always need to use white font).

# Test Plan

The change has been tested by running docs app locally.

# Preview

<img width="743" alt="Screenshot 2023-01-30 at 11 10 54" src="https://user-images.githubusercontent.com/719641/215449596-eb403726-27e6-4d35-b9e9-b3ec81ec0949.png">
