### PR TITLE
[bare-expo] let android-emulator-runner cleanup the emulator

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -23,7 +23,7 @@
     "android:detox:build:debug": "detox build -c android.emu.debug",
     "android:detox:build:release": "detox build -c android.emu.release",
     "android:detox:test:debug": "detox test -c android.emu.debug",
-    "android:detox:test:release": "watchman watch-del-all; detox test -c android.emu.release --cleanup",
+    "android:detox:test:release": "watchman watch-del-all; detox test -c android.emu.release",
     "ios:detox:build:debug": "detox build -c ios.sim.debug",
     "ios:detox:build:release": "detox build -c ios.sim.release",
     "ios:detox:test:debug": "detox test -c ios.sim.debug",


### PR DESCRIPTION
# Why

fix android test-suite failures

# How

i noticed the detox tests are actually successful and it failed during terminating the emulator. this pr removes the emulator termination from detox and let the github action android-emulator-runner to do the cleanup.

# Test Plan

android test suite ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
