### PR TITLE
[core] remove boost dep and use boost from prefab

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - View-related DSL functions do not require providing the view's type in function parameters on Android. ([#20751](https://github.com/expo/expo/pull/20751) by [@lukmccall](https://github.com/lukmccall))
 - Add support for the `Long` type as function parameters on Android. ([#20787](https://github.com/expo/expo/pull/20787) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Added experimental support for building the function result from the object definition. ([#20864](https://github.com/expo/expo/pull/20864) by [@lukmccall](https://github.com/lukmccall))
+- Removed boost dependency which needs extra downloading on Android. ([#21000](https://github.com/expo/expo/pull/21000) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_CXX_STANDARD 17)
 set(PACKAGE_NAME "expo-modules-core")
 set(BUILD_DIR ${CMAKE_SOURCE_DIR}/build)
-set(ignoreMe "${PROJECT_BUILD_DIR} ${REACT_ANDROID_BUILD_DIR} ${REACT_ANDROID_DIR} ${HERMES_HEADER_DIR}")
+set(ignoreMe "${PROJECT_BUILD_DIR} ${REACT_ANDROID_BUILD_DIR} ${REACT_ANDROID_DIR} ${HERMES_HEADER_DIR} ${BOOST_VERSION}")
 
 string(APPEND CMAKE_CXX_FLAGS " -DREACT_NATIVE_TARGET_VERSION=${REACT_NATIVE_TARGET_VERSION}")
 
@@ -106,8 +106,6 @@ target_include_directories(
 
         # header only imports from turbomodule, e.g. CallInvokerHolder.h
         "${REACT_NATIVE_DIR}/ReactAndroid/src/main/jni/react/turbomodule"
-
-        "${BUILD_DIR}/third-party-ndk/boost/boost_${BOOST_VERSION}"
         "${COMMON_DIR}"
         "${SRC_DIR}/fabric"
 )

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -74,7 +74,6 @@ class LegacyReactNativeLibsExtractionPlugin implements Plugin<Project> {
     def reactProperties = new Properties()
     new File("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
     def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
-    def BOOST_VERSION = reactProperties.getProperty("BOOST_VERSION")
     def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_VERSION")
     def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
     def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -409,7 +409,9 @@ void nativeBuildDependsOn(project, dependsOnTask, buildTypesIncludes) {
 }
 
 afterEvaluate {
-  nativeBuildDependsOn(project, prepareBoost, null)
+  if (REACT_NATIVE_TARGET_VERSION < 71) {
+    nativeBuildDependsOn(project, prepareBoost, null)
+  }
   if (USE_HERMES) {
     nativeBuildDependsOn(project, prepareHermes, null)
     if (hasHermesProject && !prebuiltHermesCacheHit) {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -2,6 +2,8 @@
 
 #include "JavaReferencesCache.h"
 
+#include <vector>
+
 namespace expo {
 std::shared_ptr<JavaReferencesCache> JavaReferencesCache::instance() {
   static std::shared_ptr<JavaReferencesCache> singleton{new JavaReferencesCache};


### PR DESCRIPTION
# Why

react-native 0.71 ships boost in prefab artifacts, unfortunately, we use boost's container hash which is not published in prefab. that's why we still need to download boost manually. to speed up build time, we could remove the boost dependency and just use boost from prefab.

# How

- implement custom std::pair hash function for std::unordered_map. the hash function is referenced from boost.
- remove boost from build.gradle and CMakeLists.txt 

# Test Plan

- android tests passed
- bare-expo android

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
