### PR TITLE
[core] reference folly build flags from folly-flags.cmake

### DIFF
--- a/packages/expo-modules-core/android/CMakeLists.txt
+++ b/packages/expo-modules-core/android/CMakeLists.txt
@@ -112,13 +112,12 @@ target_include_directories(
 
 # linking
 
+include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
+
 target_compile_options(
         ${PACKAGE_NAME}
-        PRIVATE -DFOLLY_NO_CONFIG=1
-        -DFOLLY_HAVE_CLOCK_GETTIME=1
-        -DFOLLY_HAVE_MEMRCHR=1
-        -DFOLLY_USE_LIBCPP=1
-        -DFOLLY_MOBILE=1
+        PRIVATE
+        ${folly_FLAGS}
 )
 
 target_link_libraries(

--- a/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
+++ b/packages/expo-modules-core/android/src/fabric/CMakeLists.txt
@@ -9,13 +9,11 @@ add_library(fabric STATIC
   ${SOURCES}
 )
 
+include("${REACT_NATIVE_DIR}/ReactAndroid/cmake-utils/folly-flags.cmake")
+
 target_compile_options(fabric PRIVATE
   "-std=c++17"
-  -DFOLLY_NO_CONFIG=1
-  -DFOLLY_HAVE_CLOCK_GETTIME=1
-  -DFOLLY_HAVE_MEMRCHR=1
-  -DFOLLY_USE_LIBCPP=1
-  -DFOLLY_MOBILE=1
+  ${folly_FLAGS}
 )
 
 find_package(ReactAndroid REQUIRED CONFIG)


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/20470#discussion_r1048789381
close ENG-7083

# How

reference folly build flags from `folly-flags.cmake` shipped in react-native 0.71 

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
