### PR TITLE
[home] use hermes engine

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -16,13 +16,17 @@ import android.os.Bundle
 import android.os.Handler
 import android.util.Log
 import android.widget.Toast
+import com.facebook.hermes.reactexecutor.HermesExecutorFactory
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.LifecycleState
+import com.facebook.react.jscexecutor.JSCExecutorFactory
 import com.facebook.react.modules.network.ReactCookieJarContainer
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.facebook.react.shell.MainReactPackage
 import com.facebook.soloader.SoLoader
 import de.greenrobot.event.EventBus
@@ -258,6 +262,7 @@ class Kernel : KernelInterface() {
             .setApplication(applicationContext)
             .setCurrentActivity(activityContext)
             .setJSBundleFile(localBundlePath)
+            .setJavaScriptExecutorFactory(jsExecutorFactory)
             .addPackage(MainReactPackage())
             .addPackage(
               ExponentPackage.kernelExponentPackage(
@@ -360,6 +365,18 @@ class Kernel : KernelInterface() {
         throw Error("JSONObject failed to be converted to Bundle", e)
       }
       return bundle
+    }
+  private val jsExecutorFactory: JavaScriptExecutorFactory
+    get() {
+      val manifest = exponentManifest.getKernelManifest()
+      val appName = manifest.getName() ?: ""
+      val deviceName = AndroidInfoHelpers.getFriendlyDeviceName()
+
+      val jsEngineFromManifest = manifest.jsEngine
+      return if (jsEngineFromManifest == "hermes") HermesExecutorFactory() else JSCExecutorFactory(
+        appName,
+        deviceName
+      )
     }
 
   fun hasOptionsForManifestUrl(manifestUrl: String?): Boolean {

--- a/home/app.json
+++ b/home/app.json
@@ -38,6 +38,7 @@
     "kernel": {
       "iosManifestPath": "../ios/Exponent/Supporting/kernel-manifest.json",
       "androidManifestPath": "../android/app/src/main/assets/kernel-manifest.json"
-    }
+    },
+    "jsEngine": "hermes"
   }
 }

--- a/home/metro.config.js
+++ b/home/metro.config.js
@@ -1,6 +1,10 @@
 const { createMetroConfiguration } = require('expo-yarn-workspaces');
+const path = require('path');
 
 const baseConfig = createMetroConfiguration(__dirname);
+
+// To test home from Expo Go, the react-native js source is from our fork.
+const reactNativeRoot = path.join(__dirname, '..', 'react-native-lab', 'react-native');
 
 module.exports = {
   ...baseConfig,
@@ -21,5 +25,29 @@ module.exports = {
         return middleware(req, res, next);
       };
     },
+  },
+
+  resolver: {
+    ...baseConfig.resolver,
+    blockList: [
+      ...baseConfig.resolver.blockList,
+
+      // Because react-native versions may be different between node_modules/react-native and react-native-lab,
+      // metro and react-native cannot serve duplicated files from different paths.
+      // Assuming home only serves for Expo Go,
+      // the strategy here is to serve react-native imports from `react-native-lab/react-native` but not its transitive dependencies.
+      // That is not ideal but should work for most cases if the two react-native versions do not have too much difference.
+      // For example, `react-native-lab/react-native/node_modules/@react-native/polyfills` and `node_modules/@react-native/polyfills` may be different,
+      // the metro config will use the transitive dependency from `node_modules/@react-native/polyfills`.
+      /\bnode_modules\/react-native\//,
+      /\breact-native-lab\/react-native\/node_modules\b/,
+    ],
+  },
+  serializer: {
+    ...baseConfig.serializer,
+    getModulesRunBeforeMainModule: () => [
+      require.resolve(path.join(reactNativeRoot, 'Libraries/Core/InitializeCore')),
+    ],
+    getPolyfills: () => require(path.join(reactNativeRoot, 'rn-get-polyfills'))(),
   },
 };


### PR DESCRIPTION
# Why

close ENG-7162

# How

- [android] support hermes in loading home app
- [home] use hermes engine

# Test Plan

- unversioned android/ios expo go + local home + `console.log(globalThis.HermesInternal)`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
