### PR TITLE
[image][android] Fix crash on devices below api 28

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed a crash on iOS below 16.0 introduced by the Live Text interaction feature. ([#20987](https://github.com/expo/expo/pull/20987) by [@tsapeta](https://github.com/tsapeta))
+- Fixed a crash on Android where `isScreenReaderFocusable` crashes devices below api 28. ([#21012](https://github.com/expo/expo/pull/21012) by [@alanhughes](https://github.com/alanjhughes))
 
 ## 1.0.0-beta.2 — 2023-01-25
 


### PR DESCRIPTION
# Why
Crash reported by @BrodaNoel related to `isScreenReaderFocusable` being set on the view. This property is only available on API levels 28+. 

# How
Added a function that uses `ViewCompat` to allow the property to be set on devices back to API level 19

# Test Plan
Tested on devices below level 28, the crash does not occur. 
