### PR TITLE
[image][Android] Fix `No virtual method setScreenReaderFocusable`

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `No virtual method setScreenReaderFocusable` crash on Android.
+
 ### 💡 Others
 
 ## 1.0.0-beta.3 — 2023-01-30

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import com.bumptech.glide.Glide
@@ -124,7 +125,12 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
   internal var accessible: Boolean = false
     set(value) {
       field = value
-      activeView.isScreenReaderFocusable = value
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        activeView.isScreenReaderFocusable = value
+      } else {
+        activeView.isFocusable = value
+      }
     }
 
   internal var accessibilityLabel: String? = null
@@ -181,7 +187,11 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
     view.setBackgroundColor(backgroundColor)
     view.setTintColor(tintColor)
     view.isFocusable = isFocusableProp
-    view.isScreenReaderFocusable = accessible
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      view.isScreenReaderFocusable = accessible
+    } else {
+      view.isFocusable = accessible
+    }
     view.contentDescription = accessibilityLabel
     borderColor.forEachIndexed { index, (rgb, alpha) ->
       view.setBorderColor(index, rgb, alpha)


### PR DESCRIPTION
# Why

Fixes: https://discord.com/channels/695411232856997968/1067939185933160548/1069673146971603067

# How

It turns out that `setScreenReaderFocusable` isn't available across all supported SDKs. So I've fallback to the `isFocusable` property in those cases. The final effect should be the same. 

# Test Plan

- NCL ✅