### PR TITLE
[go] update @shopify/react-native-skia to 0.1.172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-shared-element` from `0.8.4` to `0.8.7`. ([#20593](https://github.com/expo/expo/pull/20593) by [@ijzerenhein](https://github.com/ijzerenhein))
 - Updated `@react-native-async-storage/async-storage` from `1.17.3' to `1.17.11`. ([#20780](https://github.com/expo/expo/pull/20780) by [@kudo](https://github.com/kudo))
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.4`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo), [#20990](https://github.com/expo/expo/pull/20990) by [@tsapeta](https://github.com/tsapeta))
-- Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.171`. ([#20857](https://github.com/expo/expo/pull/20857) by [@kudo](https://github.com/kudo))
+- Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.172`. ([#20857](https://github.com/expo/expo/pull/20857), [#21014](https://github.com/expo/expo/pull/21014) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkJsiViewApi.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkJsiViewApi.h
@@ -55,8 +55,8 @@ public:
     auto info = getEnsuredViewInfo(nativeId);
 
     std::lock_guard<std::mutex> lock(_mutex);
-    info->props.emplace(arguments[1].asString(runtime).utf8(runtime),
-                        RNJsi::JsiValueWrapper(runtime, arguments[2]));
+    info->props.insert_or_assign(arguments[1].asString(runtime).utf8(runtime),
+                                 RNJsi::JsiValueWrapper(runtime, arguments[2]));
 
     // Now let's see if we have a view that we can update
     if (info->view != nullptr) {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -55,7 +55,7 @@
     "@react-navigation/stack": "~6.3.2",
     "@react-navigation/elements": "~1.3.6",
     "@shopify/flash-list": "1.4.0",
-    "@shopify/react-native-skia": "0.1.171",
+    "@shopify/react-native-skia": "0.1.172",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~47.0.0-alpha.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1978,32 +1978,32 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-skia (0.1.171):
+  - react-native-skia (0.1.172):
     - React
     - React-callinvoker
     - React-Core
-    - react-native-skia/Api (= 0.1.171)
-    - react-native-skia/Jsi (= 0.1.171)
-    - react-native-skia/RNSkia (= 0.1.171)
-    - react-native-skia/SkiaHeaders (= 0.1.171)
-    - react-native-skia/Utils (= 0.1.171)
-  - react-native-skia/Api (0.1.171):
+    - react-native-skia/Api (= 0.1.172)
+    - react-native-skia/Jsi (= 0.1.172)
+    - react-native-skia/RNSkia (= 0.1.172)
+    - react-native-skia/SkiaHeaders (= 0.1.172)
+    - react-native-skia/Utils (= 0.1.172)
+  - react-native-skia/Api (0.1.172):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Jsi (0.1.171):
+  - react-native-skia/Jsi (0.1.172):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/RNSkia (0.1.171):
+  - react-native-skia/RNSkia (0.1.172):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/SkiaHeaders (0.1.171):
+  - react-native-skia/SkiaHeaders (0.1.172):
     - React
     - React-callinvoker
     - React-Core
-  - react-native-skia/Utils (0.1.171):
+  - react-native-skia/Utils (0.1.172):
     - React
     - React-callinvoker
     - React-Core
@@ -3622,7 +3622,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-skia: 571e20d8f275a305d5d30f17d4329862b852d65e
+  react-native-skia: ff2265fb802b2a3e1bf4a3c5a86d46936dd20354
   react-native-slider: a0d45ce5ea1be39f149954cae4367afff44d5a32
   react-native-webview: 994b9f8fbb504d6314dc40d83f94f27c6831b3bf
   React-perflogger: e5fc4149e9bbb972b8520277f3b23141faa47a36

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkJsiViewApi.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkJsiViewApi.h
@@ -55,8 +55,8 @@ public:
     auto info = getEnsuredViewInfo(nativeId);
 
     std::lock_guard<std::mutex> lock(_mutex);
-    info->props.emplace(arguments[1].asString(runtime).utf8(runtime),
-                        RNJsi::JsiValueWrapper(runtime, arguments[2]));
+    info->props.insert_or_assign(arguments[1].asString(runtime).utf8(runtime),
+                                 RNJsi::JsiValueWrapper(runtime, arguments[2]));
 
     // Now let's see if we have a view that we can update
     if (info->view != nullptr) {

--- a/ios/vendored/unversioned/@shopify/react-native-skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/ios/RNSkia-iOS/RNSkMetalCanvasProvider.mm
@@ -41,7 +41,7 @@ RNSkCanvasProvider(requestRedraw),
   _layer.opaque = false;
   _layer.contentsScale = _context->getPixelDensity();
   _layer.pixelFormat = MTLPixelFormatBGRA8Unorm;
-  _layer.contentsGravity = kCAGravityBottomRight;
+  _layer.contentsGravity = kCAGravityBottomLeft;
 }
 
 RNSkMetalCanvasProvider::~RNSkMetalCanvasProvider() {
@@ -73,6 +73,10 @@ void RNSkMetalCanvasProvider::renderToCanvas(const std::function<void(SkCanvas*)
   auto state = UIApplication.sharedApplication.applicationState;
   if (state == UIApplicationStateBackground || state == UIApplicationStateInactive)
   {
+    // Request a redraw in the next run loop callback
+    _requestRedraw();
+    // and don't draw now since it might cause errors in the metal renderer if 
+    // we try to render while in the background. (see above issue)
     return;
   }
   

--- a/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skia",
-  "version": "0.1.171",
+  "version": "0.1.172",
   "summary": "High-performance React Native Graphics using Skia",
   "description": "@shopify/react-native-skia",
   "homepage": "https://github.com/shopify/react-native-skia",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/react-native-skia/react-native-skia.git",
-    "tag": "0.1.171"
+    "tag": "0.1.172"
   },
   "requires_arc": true,
   "pod_target_xcconfig": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "sentry-expo": "~6.0.0",
   "unimodules-app-loader": "~4.0.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "0.1.171",
+  "@shopify/react-native-skia": "0.1.172",
   "@shopify/flash-list": "1.4.0",
   "@sentry/react-native": "4.9.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3218,15 +3218,15 @@
     recyclerlistview "4.2.0"
     tslib "2.4.0"
 
-"@shopify/react-native-skia@0.1.171":
-  version "0.1.171"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.171.tgz#70f00e178d3bc06d95535a82cbfbea2bd3723987"
-  integrity sha512-m/pSfc/xAlAqSIEzFsf82QJs3aRkq+Bn1xEJMPKWIZ8J4QDE6bGQ8MXy9/nM+89VYz1GjdYI2BKnCC3ZMjhT6Q==
+"@shopify/react-native-skia@0.1.172":
+  version "0.1.172"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.172.tgz#658fb9d90aebaf706d567c331d8bb125175431da"
+  integrity sha512-XpuertepKP/IlCc7Wq6qT+yfhGxSEekq7y+AfTuIVPTwWGEjF/aCAcwHE65zfLJDhjqswYZEk+O+T3XMA7MrwA==
   dependencies:
     "@types/pixelmatch" "^5.2.4"
     "@types/pngjs" "^6.0.1"
     "@types/ws" "^8.5.3"
-    canvaskit-wasm "0.36.1"
+    canvaskit-wasm "0.38.0"
     pixelmatch "^5.3.0"
     pngjs "^6.0.0"
     react-reconciler "^0.27.0"
@@ -6212,10 +6212,10 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001400:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001412.tgz#30f67d55a865da43e0aeec003f073ea8764d5d7c"
   integrity sha512-+TeEIee1gS5bYOiuf+PS/kp2mrXic37Hl66VY6EAfxasIk5fELTktK2oOezYed12H8w7jt3s512PpulQidPjwA==
 
-canvaskit-wasm@0.36.1:
-  version "0.36.1"
-  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.36.1.tgz#341df38ce7894a925064beaf9eeacbf7699c6633"
-  integrity sha512-6IHlBBc9zDQBTHiGuz4Rf0j/P/ulW24q/yW+QY517e7jwQoM0nJ1+L3h4wUpfC4eQrcpVPQY8ZFbqMbUCzDxTw==
+canvaskit-wasm@0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/canvaskit-wasm/-/canvaskit-wasm-0.38.0.tgz#83e6c46f3015c2ff3f6503157f47453af76a7be7"
+  integrity sha512-ZEG6lucpbQ4Ld+mY8C1Ng+PMLVP+/AX02jS0Sdl28NyMxuKSa9uKB8oGd1BYp1XWPyO2Jgr7U8pdyjJ/F3xR5Q==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Why

last chance to upgrade vendored react-native-skia to 0.1.172 for sdk 48

# How

- `et uvm -m @shopify/react-native-skia -c 0.1.172`

# Test Plan

unversioned android/ios expo go + skia ncl

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
