### PR TITLE
[image][Android] Fix `excludeAppGlideModule` property

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -59,7 +59,7 @@ android {
       java {
         if (safeExtGet("excludeAppGlideModule", false)) {
           srcDir "src"
-          exclude "**/ExpoImageAppGlideModule.java"
+          exclude "**/ExpoImageAppGlideModule.kt"
         }
       }
     }


### PR DESCRIPTION
# Why

Fixes the `excludeAppGlideModule` property that removes the glide app from the `expo-image` package.