### PR TITLE
[docs] add new Sidebar footer

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -5,7 +5,7 @@ import { css } from '@emotion/react';
 import { breakpoints, theme } from '@expo/styleguide';
 import * as React from 'react';
 
-import { SidebarHead } from '~/ui/components/Sidebar/SidebarHead';
+import { SidebarHead, SidebarFooter } from '~/ui/components/Sidebar';
 
 const STYLES_CONTAINER = css`
   width: 100%;
@@ -227,6 +227,7 @@ export default class DocumentationNestedScrollLayout extends React.Component<Pro
             <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
             <ScrollContainer ref={this.sidebarRef} scrollPosition={sidebarScrollPosition}>
               {sidebar}
+              <SidebarFooter />
             </ScrollContainer>
           </div>
           <div css={[STYLES_CENTER, isMobileMenuVisible && STYLES_HIDDEN]}>

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -7,7 +7,7 @@ import { Logo } from './Logo';
 import { ThemeSelector } from './ThemeSelector';
 
 import { Button } from '~/ui/components/Button';
-import { SidebarHead } from '~/ui/components/Sidebar';
+import { SidebarFooter, SidebarHead } from '~/ui/components/Sidebar';
 import { BOLD } from '~/ui/components/Text';
 
 type HeaderProps = {
@@ -60,6 +60,7 @@ export const Header = ({
         <div css={mobileSidebarStyle}>
           <SidebarHead sidebarActiveGroup={sidebarActiveGroup} />
           {sidebar}
+          <SidebarFooter />
         </div>
       )}
     </>

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/router';
 import { SidebarSingleEntry } from './SidebarSingleEntry';
 import { ArchiveIcon } from './icons/Archive';
 
+import { getPageSection } from '~/common/routes';
 import { customIconContainerStyle } from '~/ui/components/Sidebar/icons/styles';
 
 export const SidebarFooter = () => {
@@ -27,11 +28,11 @@ export const SidebarFooter = () => {
             <ArchiveIcon />
           </div>
         )}
-        isActive={pathname.startsWith('/archive')}
+        isActive={getPageSection(pathname) === 'archive'}
       />
       <SidebarSingleEntry
         href="https://snack.expo.dev"
-        title="Expo Snack (Playground)"
+        title="Expo Snack"
         Icon={SnackLogo}
         isExternal
       />

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/react';
+import {
+  spacing,
+  theme,
+  SnackLogo,
+  ChangelogIcon,
+  DiscordIcon,
+  MessageIcon,
+  iconSize,
+} from '@expo/styleguide';
+import { useRouter } from 'next/router';
+
+import { SidebarSingleEntry } from './SidebarSingleEntry';
+import { ArchiveIcon } from './icons/Archive';
+
+import { customIconContainerStyle } from '~/ui/components/Sidebar/icons/styles';
+
+export const SidebarFooter = () => {
+  const { pathname } = useRouter();
+  return (
+    <div css={sidebarFooterContainer}>
+      <SidebarSingleEntry
+        href="/archive"
+        title="Archive"
+        Icon={() => (
+          <div css={[customIconContainerStyle, { width: iconSize.sm }]}>
+            <ArchiveIcon />
+          </div>
+        )}
+        isActive={pathname.startsWith('/archive')}
+      />
+      <SidebarSingleEntry
+        href="https://snack.expo.dev"
+        title="Expo Snack (Playground)"
+        Icon={SnackLogo}
+        isExternal
+      />
+      <SidebarSingleEntry
+        href="https://chat.expo.dev"
+        title="Discord"
+        Icon={DiscordIcon}
+        isExternal
+      />
+      <SidebarSingleEntry
+        href="https://forums.expo.dev"
+        title="Forums"
+        Icon={MessageIcon}
+        isExternal
+      />
+      <SidebarSingleEntry
+        href="https://expo.dev/changelog"
+        title="Changelog"
+        Icon={ChangelogIcon}
+        isExternal
+      />
+    </div>
+  );
+};
+
+const sidebarFooterContainer = css({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: spacing[4],
+  borderTop: `1px solid ${theme.border.default}`,
+  background: theme.background.default,
+});

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -1,13 +1,13 @@
 import { css } from '@emotion/react';
 import { spacing, theme, PlanEnterpriseIcon, iconSize } from '@expo/styleguide';
-import * as React from 'react';
 
 import { APIIcon, APIInactiveIcon } from './icons/API';
 import { DocumentationIcon, DocumentationInactiveIcon } from './icons/Documentation';
 import { PreviewIcon, PreviewInactiveIcon } from './icons/Preview';
 
 import { shouldShowFeaturePreviewLink } from '~/constants/FeatureFlags.cjs';
-import { SidebarHeadEntry } from '~/ui/components/Sidebar/SidebarHeadEntry';
+import { SidebarSingleEntry } from '~/ui/components/Sidebar/SidebarSingleEntry';
+import { customIconContainerStyle } from '~/ui/components/Sidebar/icons/styles';
 
 type SidebarHeadProps = {
   sidebarActiveGroup: string;
@@ -16,17 +16,17 @@ type SidebarHeadProps = {
 export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
   return (
     <div css={sidebarHeadContainer}>
-      <SidebarHeadEntry
+      <SidebarSingleEntry
         href="/"
         title="Guides"
         Icon={sidebarActiveGroup === 'general' ? DocumentationIcon : DocumentationInactiveIcon}
         isActive={sidebarActiveGroup === 'general'}
       />
-      <SidebarHeadEntry
+      <SidebarSingleEntry
         href="/eas"
         title="Expo Application Services"
         Icon={() => (
-          <div css={easIconContainerStyle}>
+          <div css={customIconContainerStyle}>
             <PlanEnterpriseIcon
               color={sidebarActiveGroup === 'eas' ? theme.text.link : theme.icon.default}
               size={iconSize.sm}
@@ -35,14 +35,14 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
         )}
         isActive={sidebarActiveGroup === 'eas'}
       />
-      <SidebarHeadEntry
+      <SidebarSingleEntry
         href="/versions/latest"
         title="API Reference"
         Icon={sidebarActiveGroup === 'reference' ? APIIcon : APIInactiveIcon}
         isActive={sidebarActiveGroup === 'reference'}
       />
       {shouldShowFeaturePreviewLink() && (
-        <SidebarHeadEntry
+        <SidebarSingleEntry
           href="/feature-preview"
           title="Feature Preview"
           Icon={
@@ -63,13 +63,4 @@ const sidebarHeadContainer = css({
   padding: spacing[4],
   borderBottom: `1px solid ${theme.border.default}`,
   background: theme.background.default,
-});
-
-const easIconContainerStyle = css({
-  height: spacing[5],
-  width: spacing[5],
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  marginRight: spacing[2.5],
 });

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -1,18 +1,32 @@
 import { css } from '@emotion/react';
-import { borderRadius, spacing, theme, typography, iconSize } from '@expo/styleguide';
+import {
+  borderRadius,
+  spacing,
+  theme,
+  typography,
+  iconSize,
+  ArrowUpRightIcon,
+} from '@expo/styleguide';
 import { IconProps } from '@expo/styleguide/dist/types';
 import { ComponentType } from 'react';
 
 import { A } from '../Text';
 
-type SidebarHeadEntryProps = {
+type SidebarSingleEntryProps = {
   href: string;
   title: string;
-  isActive: boolean;
   Icon: ComponentType<IconProps>;
+  isActive?: boolean;
+  isExternal?: boolean;
 };
 
-export const SidebarHeadEntry = ({ href, title, isActive, Icon }: SidebarHeadEntryProps) => {
+export const SidebarSingleEntry = ({
+  href,
+  title,
+  Icon,
+  isActive = false,
+  isExternal = false,
+}: SidebarSingleEntryProps) => {
   return (
     <A href={href} css={[entryContainerStyle, isActive && activeEntryContainerStyle]} isStyled>
       <Icon
@@ -21,6 +35,9 @@ export const SidebarHeadEntry = ({ href, title, isActive, Icon }: SidebarHeadEnt
         width={iconSize.sm}
       />
       <span>{title}</span>
+      {isExternal && (
+        <ArrowUpRightIcon color={theme.icon.secondary} css={css({ marginLeft: 'auto' })} />
+      )}
     </A>
   );
 };

--- a/docs/ui/components/Sidebar/icons/Archive.tsx
+++ b/docs/ui/components/Sidebar/icons/Archive.tsx
@@ -3,23 +3,23 @@ import { IconProps } from '@expo/styleguide/dist/types';
 
 export const ArchiveIcon = ({ size = iconSize.sm }: IconProps) => {
   return (
-    <svg width={size} height={size} viewBox="0 0 15 16" fill="none">
+    <svg width={size} height={size} viewBox="0 0 16 13" fill="none">
       <path
-        d="M12.75 5.50537V13.0887H2.25V5.50537"
+        d="M13.727 4.05554V12H2.27246V4.05554"
         stroke={theme.icon.default}
         strokeWidth="1.16667"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
-        d="M13.9168 2.58875H1.0835V5.50541H13.9168V2.58875Z"
+        d="M15 1H1V4.05557H15V1Z"
         stroke={theme.icon.default}
         strokeWidth="1.16667"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
-        d="M6.33325 7.83875H8.66658"
+        d="M6.72705 6.5H7.99978H9.27251"
         stroke={theme.icon.default}
         strokeWidth="1.16667"
         strokeLinecap="round"

--- a/docs/ui/components/Sidebar/icons/Archive.tsx
+++ b/docs/ui/components/Sidebar/icons/Archive.tsx
@@ -1,0 +1,30 @@
+import { iconSize, theme } from '@expo/styleguide';
+import { IconProps } from '@expo/styleguide/dist/types';
+
+export const ArchiveIcon = ({ size = iconSize.sm }: IconProps) => {
+  return (
+    <svg width={size} height={size} viewBox="0 0 15 16" fill="none">
+      <path
+        d="M12.75 5.50537V13.0887H2.25V5.50537"
+        stroke={theme.icon.default}
+        strokeWidth="1.16667"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13.9168 2.58875H1.0835V5.50541H13.9168V2.58875Z"
+        stroke={theme.icon.default}
+        strokeWidth="1.16667"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.33325 7.83875H8.66658"
+        stroke={theme.icon.default}
+        strokeWidth="1.16667"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/docs/ui/components/Sidebar/icons/styles.ts
+++ b/docs/ui/components/Sidebar/icons/styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react';
+import { spacing } from '@expo/styleguide';
+
+export const customIconContainerStyle = css({
+  height: spacing[5],
+  width: spacing[5],
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  marginRight: spacing[2.5],
+});

--- a/docs/ui/components/Sidebar/index.ts
+++ b/docs/ui/components/Sidebar/index.ts
@@ -1,8 +1,9 @@
 export { Sidebar } from './Sidebar';
 export { SidebarCollapsible } from './SidebarCollapsible';
 export { SidebarGroup } from './SidebarGroup';
+export { SidebarFooter } from './SidebarFooter';
 export { SidebarHead } from './SidebarHead';
-export { SidebarHeadEntry } from './SidebarHeadEntry';
+export { SidebarSingleEntry } from './SidebarSingleEntry';
 export { SidebarLink } from './SidebarLink';
 export { SidebarSection } from './SidebarSection';
 export { SidebarTitle } from './SidebarTitle';


### PR DESCRIPTION
# Why

Fixes ENG-7433

# How

This PR add the new `Sidebar` footer which contains an URL for the non linked anywhere `Archive` section, as well as few  external links for Expo related stuff.

New footer is placed at the end of the scrollable part of the sidebar navigation.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

### Desktop
<img width="324" alt="Screenshot 2023-01-31 at 14 59 33" src="https://user-images.githubusercontent.com/719641/215787259-5b44ccb5-0cc4-4fa5-83d6-34d3b7fa3228.png">

### Mobile
<img width="430" alt="Screenshot 2023-01-31 at 15 01 28" src="https://user-images.githubusercontent.com/719641/215787096-2dbe14fd-d337-4d64-a904-b9ab0a54f02a.png">
