### PR TITLE
[docs] Add a guide on How to build a config plugin and an Expo module

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -115,6 +115,7 @@ const general = [
     makePage('modules/get-started.mdx'),
     makePage('modules/native-module-tutorial.mdx'),
     makePage('modules/native-view-tutorial.mdx'),
+    makePage('modules/config-plugin-and-native-module-tutorial.mdx'),
     makePage('modules/existing-library.mdx'),
     makePage('modules/module-api.mdx'),
     makePage('modules/android-lifecycle-listeners.mdx'),

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -186,14 +186,7 @@ At the root of your project, run `npm run build plugin` to start the TypeScript 
 
 Now when running `npx expo prebuild` inside our **example** folder we should see our 'my custom plugin’ console.log statement in the terminal.
 
-<Terminal
-  cmd={[
-    '# Run this in the root of the project to start the TypeScript compiler',
-    '$ npm run build plugin',
-    '$ cd example',
-    '$ npx expo prebuild --clean',
-  ]}
-/>
+<Terminal cmd={['$ cd example', '$ npx expo prebuild --clean']} />
 
 To inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper [`mods` provided by `expo/config-plugins`](/guides/config-plugins/#mod-plugins), which makes it easy to modify native files. In our example, we will use two of them, `withAndroidManifest` and `withInfoPlist`.
 

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -103,6 +103,7 @@ Now let's run the example project to make sure everything is working. Start the 
 />
 
 In another terminal window, compile and run the example app:
+
 <Terminal
   cmdCopy="cd example && npx expo run:ios"
   cmd={[
@@ -135,7 +136,7 @@ However, there are a few considerations that we should follow when writing confi
 - Plugins should be synchronous and their return value should be serializable, except for any `mods` that are added.
 - `plugins` are always invoked when the config is read by the `expo/config` method `getConfig`. However, `mods` are only invoked during the "syncing" phase of `npx expo prebuild`.
 
-Although not required, we can use [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts) to make plugin development easier — it provides a recommended default configuration for TypeScript and Jest. For more information, see [config plugins guide](https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin).
+> Although not required, we can use [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts) to make plugin development easier — it provides a recommended default configuration for TypeScript and Jest. For more information, see [config plugins guide](https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin).
 
 Let's start by creating our plugin with this minimal boilerplate. This will create a **plugin** folder where we will write the plugin in TypeScript and add a **app.plugin.js** file in the project root, which will be the entry file for the plugin.
 
@@ -271,8 +272,6 @@ Now with the plugin ready to be used, let's update the example app to pass our A
   }
 }
 ```
-
-This tells the example app to use our custom plugin, and passes in the API key as a configuration option.
 
 After making this change, we can test that the plugin is working correctly by running the command `npx expo prebuild --clean` inside the **example** folder. This will execute our plugin and update native files, injecting "MY_CUSTOM_API_KEY" into **AndroidManifest.xml** and **Info.plist**. You can verify this by checking the contents of **example/android/app/src/main/AndroidManifest.xml**.
 

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -1,0 +1,342 @@
+---
+title: 'Tutorial: Create a module with a config plugin'
+sidebar_title: Create a module with a config plugin
+description: A tutorial on creating a native module with a config plugin using Expo modules API.
+---
+
+import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { PlatformTag } from '~/ui/components/Tag';
+import { APIBox } from '~/components/plugins/APIBox';
+import { Terminal } from '~/ui/components/Snippet';
+
+Config plugins allow you to customize native iOS and Android projects when they are generated with `npx expo prebuild`. This is often useful to add properties in native config files, to copy assets to native projects, and even for advanced configurations such as adding an app extension target. As an app developer, this can be useful to apply customizations that are not exposed in the default **app.json** configuration. As a library author, this allows you to automatically configure native projects for the developers using your library.
+
+In this guide, we will walk you through the process of creating a new config plugin from scratch, and show you how to read custom values injected into **AndroidManifest.xml** and **Info.plist** by your plugin from an Expo module.
+
+## 1. Initialize a module
+
+Let's start a new project using `create-expo-module` which will initialize a new Expo module project with scaffolding for iOS, Android, and TypeScript, along with an example project to interact with the module from within an app. You can do that by running the following command:
+
+<Terminal cmd={['$ npx create-expo-module expo-native-configuration']} />
+
+In this guide we will use the name `expo-native-configuration`/`ExpoNativeConfiguration` but you can name it whatever you like.
+
+## 2. Set up our workspace
+
+In our example we won't need the view module included by `create-expo-module`, so we can clean up the default module a little bit with the following command:
+
+<Terminal
+  cmdCopy="cd expo-native-configuration && rm ios/ExpoNativeConfigurationView.swift && rm android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationView.kt && rm src/ExpoNativeConfigurationView.tsx src/ExpoNativeConfiguration.types.ts && rm src/ExpoNativeConfigurationView.web.tsx src/ExpoNativeConfigurationModule.web.ts"
+  cmd={[
+    '$ cd expo-native-configuration',
+    '$ rm ios/ExpoNativeConfigurationView.swift',
+    '$ rm android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationView.kt',
+    '$ rm src/ExpoNativeConfigurationView.tsx src/ExpoNativeConfiguration.types.ts',
+    '$ rm src/ExpoNativeConfigurationView.web.tsx src/ExpoNativeConfigurationModule.web.ts',
+  ]}
+/>
+
+We also need to find the following files and replace them with the provided minimal boilerplate:
+
+```swift ios/ExpoNativeConfigurationModule.swift
+import ExpoModulesCore
+
+public class ExpoNativeConfigurationModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoNativeConfiguration")
+
+    Function("getApiKey") { () -> String in
+      "api-key"
+    }
+  }
+}
+```
+
+```kotlin android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt
+package expo.modules.nativeconfiguration
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class ExpoNativeConfigurationModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("ExpoNativeConfiguration")
+
+    Function("getApiKey") {
+      return@Function "api-key"
+    }
+  }
+}
+```
+
+```typescript src/index.ts
+import ExpoNativeConfigurationModule from './ExpoNativeConfigurationModule';
+
+export function getApiKey(): string {
+  return ExpoNativeConfigurationModule.getApiKey();
+}
+```
+
+```typescript example/App.tsx
+import * as ExpoNativeConfiguration from 'expo-native-configuration';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Api key: {ExpoNativeConfiguration.getApiKey()}</Text>
+    </View>
+  );
+}
+```
+
+## 3. Run the example project
+
+Now let's run the example project to make sure everything is working. We'll need to start the TypeScript compiler to watch for changes and rebuild the module JavaScript, and separately in another terminal window we will compile and run the example app.
+
+<Terminal
+  cmdCopy="npm run build"
+  cmd={[
+    '# Run this in the root of the project to start the TypeScript compiler',
+    '$ npm run build',
+  ]}
+/>
+
+<Terminal
+  cmdCopy="cd example && npx expo run:ios"
+  cmd={[
+    '$ cd example',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+  ]}
+/>
+
+We should see a screen with a text saying `Api key: api-key`. Now let's develop the plugin to inject our custom API key.
+
+## 4. Creating a new config plugin
+
+With all that set up, we can now start developing our new config plugin. Plugins are synchronous functions that accept an `ExpoConfig` and return a modified `ExpoConfig`. By convention, these functions are prefixed by the word `with` , and in this guide, we will name our plugin `withMyApiKey` — however, you can name it whatever you like, as long as it follows this pattern.
+
+Here is an example of what a basic config plugin function would look like:
+
+```javascript
+const withMyApiKey = config => {
+  return config;
+};
+```
+
+Additionally, you can use `mods`, async functions that modify native project files, such as source code or configuration (plist, xml) files. The `mods` object is different from the rest of the Expo config because it doesn't get serialized after the initial reading, this means you can use it to perform actions *during* code generation.
+
+With that said there are a few considerations that we should follow when writing config plugins:
+
+- Plugins should be synchronous and their return value should be serializable, except for any `mods` that are added.
+- `plugins` are always invoked when the config is read by the `expo/config` method `getConfig`. However, `mods` are only invoked during the "syncing" phase of `npx expo prebuild`.
+
+Although not required, we can use [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts) to make plugin development easier — it provides a recommended default configuration for TypeScript and Jest. Refer to the [config plugins guide](https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin) for more information.
+
+Let's start by creating our plugin with this minimal boilerplate. This will create a **plugin** folder where we will write our plugin in TypeScript and add a **app.plugin.js** file in the project root which will be the entry file for the plugin.
+
+1. Create a **plugin/tsconfig.json** file
+
+   ```json plugin/tsconfig.json
+   {
+     "extends": "expo-module-scripts/tsconfig.plugin",
+     "compilerOptions": {
+       "outDir": "build",
+       "rootDir": "src"
+     },
+     "include": ["./src"],
+     "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+   }
+   ```
+
+2. Create a **plugin/src/index.ts** file for our plugin
+
+   ```typescript plugin/src/index.ts
+   import { ConfigPlugin } from 'expo/config-plugins';
+
+   const withMyApiKey: ConfigPlugin = config => {
+     console.log('my custom plugin');
+     return config;
+   };
+
+   export default withMyApiKey;
+   ```
+
+3. Finally, create an **app.plugin.js** file in the root directory. That will configure the entry file for our plugin
+
+   ```javascript app.plugin.js
+   module.exports = require('./plugin/build');
+   ```
+
+With that set, we can already run `npm run build plugin` to start the Typescript compiler in watch mode. The only thing left to configure is our example project to use our plugin. We can achieve this by adding the following line to the **example/app.json** file.
+
+```json example/app.json
+{
+  "expo": {
+    ...
+    "plugins": ["../app.plugin.js"]
+  }
+}
+```
+
+Now when running `npx expo prebuild` inside our **example** folder we should see our 'my custom plugin’ console.log statement in the terminal.
+
+<Terminal
+  cmd={[
+    '# Run this in the root of the project to start the TypeScript compiler',
+    '$ npm run build plugin',
+    '$ cd example',
+    '$ npx expo prebuild --clean',
+  ]}
+/>
+
+In order to inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper `mods` provided by `expo/config-plugins` which makes it easy to modify native files. You can check the full list [here](https://docs.expo.dev/guides/config-plugins/#mod-plugins). In our example, we are going to use two of them, `withInfoPlist` and `withAndroidManifest`.
+
+As the name suggests `withInfoPlist` allows us to read and modify **Info.plist** values. Using the `modResults` property we can add custom values as demonstrated in the code snippet below:
+
+```typescript
+const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
+  config = withInfoPlist(config, config => {
+    config.modResults['MY_CUSTOM_API_KEY'] = apiKey;
+    return config;
+  });
+
+  return config;
+};
+```
+
+Similarly, we can use the `withAndroidManifest` to modify the **AndroidManifest.xml** file. In this case, we will utilize `AndroidConfig` helpers to add a meta data item to the main application:
+
+```typescript
+const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
+  config = withAndroidManifest(config, config => {
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+    AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+      mainApplication,
+      'MY_CUSTOM_API_KEY',
+      apiKey
+    );
+    return config;
+  });
+
+  return config;
+};
+```
+
+By merging everything into a single function, we can create our custom plugin. The final code would look like this:
+
+```typescript plugin/src/index.ts
+import {
+  withInfoPlist,
+  withAndroidManifest,
+  AndroidConfig,
+  ConfigPlugin,
+} from 'expo/config-plugins';
+
+const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
+  config = withInfoPlist(config, config => {
+    config.modResults['MY_CUSTOM_API_KEY'] = apiKey;
+    return config;
+  });
+
+  config = withAndroidManifest(config, config => {
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+    AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+      mainApplication,
+      'MY_CUSTOM_API_KEY',
+      apiKey
+    );
+    return config;
+  });
+
+  return config;
+};
+
+export default withMyApiKey;
+```
+
+Now with the plugin ready to be used we can update the example app to pass our API key to the plugin. To do so we need to update the following line on **example/app.json**
+
+```json example/app.json
+{
+  "expo": {
+    ...
+    "plugins": [["../app.plugin.js", { "apiKey": "custom_secret_api" }]]
+  }
+}
+```
+
+This tells the example app to use our custom plugin, and passes in the API key as a configuration option.
+
+After making this change, we can test that the plugin is working correctly by running the command `npx expo prebuild --clean` inside the **example** folder. This will execute our plugin and update native files, injecting "MY_CUSTOM_API_KEY" into **AndroidManifest.xml** and **Info.plist**. You can verify this by checking the contents of **example/android/app/src/main/AndroidManifest.xml**.
+
+## 5. Reading native values from the module
+
+Now let's make our native module read the fields we added to **AndroidManifest.xml** and **Info.plist**. This can be done by using platform-specific methods to access the contents of these files.
+
+On iOS we can read the content of an **Info.plist** property by using the `Bundle.main.object(forInfoDictionaryKey:  "")` instance Method. To read the `"MY_CUSTOM_API_KEY"` value that we added earlier, we can update the **ios/ExpoNativeConfigurationModule.swift** file as follows:
+
+```swift ios/ExpoNativeConfigurationModule.swift
+import ExpoModulesCore
+
+public class ExpoNativeConfigurationModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("ExpoNativeConfiguration")
+
+    Function("getApiKey") {
+     return Bundle.main.object(forInfoDictionaryKey: "MY_CUSTOM_API_KEY") as? String
+    }
+  }
+}
+```
+
+On Android, we can access metadata information from the **AndroidManifest.xml** file using the `packageManager` class. To read the `"MY_CUSTOM_API_KEY"` value, we need to update the **android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt** file as follows:
+
+```kotlin android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt
+package expo.modules.nativeconfiguration
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import android.content.pm.PackageManager
+
+class ExpoNativeConfigurationModule() : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("ExpoNativeConfiguration")
+
+    Function("getApiKey") {
+      val applicationInfo = appContext?.reactContext?.packageManager?.getApplicationInfo(appContext?.reactContext?.packageName.toString(), PackageManager.GET_META_DATA)
+
+      return@Function applicationInfo?.metaData?.getString("MY_CUSTOM_API_KEY")
+    }
+  }
+}
+```
+
+## 6. Running your module
+
+With our native modules reading the fields we added to the native files we can now run the example app and access our custom API key through the `ExamplePlugin.getApiKey()`
+function.
+
+<Terminal
+  cmdCopy="cd example && npx expo run:ios"
+  cmd={[
+    '$ cd example',
+    '# execute our plugin and update native files',
+    '$ npx expo prebuild',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+  ]}
+/>
+
+## Next steps
+
+Congratulations, you have created a simple yet non-trivial config plugin that interacts with an Expo module for iOS and Android!
+
+If you want to challenge yourself and make the plugin more versatile we leave this exercise open to the reader, try modifying the plugin to allow for any arbitrary set of config keys/values to be passed in and adding the functionality to allow for reading of arbitrary keys from the module.

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -36,7 +36,7 @@ In our example, we won't need the view module included by `create-expo-module`. 
   ]}
 />
 
-We also need to find the following files and replace them with the provided minimal boilerplate:
+We also need to find **ExpoNativeConfigurationModule.swift**, **ExpoNativeConfigurationModule.kt**, **src/index.ts** and **example/App.tsx** and replace them with the provided minimal boilerplate:
 
 ```swift ios/ExpoNativeConfigurationModule.swift
 import ExpoModulesCore

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -84,7 +84,7 @@ import { Text, View } from 'react-native';
 export default function App() {
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Api key: {ExpoNativeConfiguration.getApiKey()}</Text>
+      <Text>API key: {ExpoNativeConfiguration.getApiKey()}</Text>
     </View>
   );
 }
@@ -113,7 +113,7 @@ Now let's run the example project to make sure everything is working. We'll need
   ]}
 />
 
-We should see a screen with a text saying `Api key: api-key`. Now let's develop the plugin to inject our custom API key.
+We should see a screen with a text saying `API key: api-key`. Now let's develop the plugin to inject our custom API key.
 
 ## 4. Creating a new config plugin
 
@@ -171,7 +171,7 @@ Let's start by creating our plugin with this minimal boilerplate. This will crea
    module.exports = require('./plugin/build');
    ```
 
-With that set, we can already run `npm run build plugin` to start the Typescript compiler in watch mode. The only thing left to configure is our example project to use our plugin. We can achieve this by adding the following line to the **example/app.json** file.
+With that set, we can already run `npm run build plugin` to start the TypeScript compiler in watch mode. The only thing left to configure is our example project to use our plugin. We can achieve this by adding the following line to the **example/app.json** file.
 
 ```json example/app.json
 {

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -9,21 +9,21 @@ import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 
-Config plugins allow you to customize native iOS and Android projects when they are generated with `npx expo prebuild`. This is often useful to add properties in native config files, to copy assets to native projects, and even for advanced configurations such as adding an app extension target. As an app developer, this can be useful to apply customizations that are not exposed in the default **app.json** configuration. As a library author, this allows you to automatically configure native projects for the developers using your library.
+Config plugins allow you to customize native Android and iOS projects when they are generated with `npx expo prebuild`. It is often useful to add properties in native config files, to copy assets to native projects, and for advanced configurations such as adding an app extension target. As an app developer, applying customizations not exposed in the default [Expo config](/workflow/configuration) can be helpful. As a library author, it allows you to configure native projects for the developers using your library automatically.
 
-In this guide, we will walk you through the process of creating a new config plugin from scratch, and show you how to read custom values injected into **AndroidManifest.xml** and **Info.plist** by your plugin from an Expo module.
+This guide will walk you through creating a new config plugin from scratch and show you how to read custom values injected into **AndroidManifest.xml** and **Info.plist** by your plugin from an Expo module.
 
 ## 1. Initialize a module
 
-Let's start a new project using `create-expo-module` which will initialize a new Expo module project with scaffolding for iOS, Android, and TypeScript, along with an example project to interact with the module from within an app. You can do that by running the following command:
+Start by initializing a new Expo module project using `create-expo-module`, which will provide scaffolding for Android, iOS, and TypeScript. It will also provide an example project to interact with the module from within an app. Run the following command to initialize it:
 
 <Terminal cmd={['$ npx create-expo-module expo-native-configuration']} />
 
-In this guide we will use the name `expo-native-configuration`/`ExpoNativeConfiguration` but you can name it whatever you like.
+We will use the name `expo-native-configuration`/`ExpoNativeConfiguration` for the project. You can name it whatever you like.
 
 ## 2. Set up our workspace
 
-In our example we won't need the view module included by `create-expo-module`, so we can clean up the default module a little bit with the following command:
+In our example, we won't need the view module included by `create-expo-module`. Let's clean up the default module a little bit with the following command:
 
 <Terminal
   cmdCopy="cd expo-native-configuration && rm ios/ExpoNativeConfigurationView.swift && rm android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationView.kt && rm src/ExpoNativeConfigurationView.tsx src/ExpoNativeConfiguration.types.ts && rm src/ExpoNativeConfigurationView.web.tsx src/ExpoNativeConfigurationModule.web.ts"
@@ -92,7 +92,7 @@ export default function App() {
 
 ## 3. Run the example project
 
-Now let's run the example project to make sure everything is working. We'll need to start the TypeScript compiler to watch for changes and rebuild the module JavaScript, and separately in another terminal window we will compile and run the example app.
+Now let's run the example project to make sure everything is working. Start the TypeScript compiler to watch for changes and rebuild the module JavaScript.
 
 <Terminal
   cmdCopy="npm run build"
@@ -102,6 +102,7 @@ Now let's run the example project to make sure everything is working. We'll need
   ]}
 />
 
+In another terminal window, compile and run the example app:
 <Terminal
   cmdCopy="cd example && npx expo run:ios"
   cmd={[
@@ -117,9 +118,9 @@ We should see a screen with a text saying `API key: api-key`. Now let's develop 
 
 ## 4. Creating a new config plugin
 
-With all that set up, we can now start developing our new config plugin. Plugins are synchronous functions that accept an `ExpoConfig` and return a modified `ExpoConfig`. By convention, these functions are prefixed by the word `with` , and in this guide, we will name our plugin `withMyApiKey` — however, you can name it whatever you like, as long as it follows this pattern.
+Let's start developing our new config plugin. Plugins are synchronous functions that accept an `ExpoConfig` and return a modified `ExpoConfig`. By convention, these functions are prefixed by the word `with`. We will name our plugin `withMyApiKey`. Feel free to call it whatever you like, as long as it follows the convention.
 
-Here is an example of what a basic config plugin function would look like:
+Here is an example of how a basic config plugin function looks:
 
 ```javascript
 const withMyApiKey = config => {
@@ -127,18 +128,18 @@ const withMyApiKey = config => {
 };
 ```
 
-Additionally, you can use `mods`, async functions that modify native project files, such as source code or configuration (plist, xml) files. The `mods` object is different from the rest of the Expo config because it doesn't get serialized after the initial reading, this means you can use it to perform actions *during* code generation.
+Additionally, you can use `mods`, which are async functions that modify files in native projects such as source code or configuration (plist, xml) files. The `mods` object is different from the rest of the Expo config because it doesn't get serialized after the initial reading. This means you can use it to perform actions *during* code generation.
 
-With that said there are a few considerations that we should follow when writing config plugins:
+However, there are a few considerations that we should follow when writing config plugins:
 
 - Plugins should be synchronous and their return value should be serializable, except for any `mods` that are added.
 - `plugins` are always invoked when the config is read by the `expo/config` method `getConfig`. However, `mods` are only invoked during the "syncing" phase of `npx expo prebuild`.
 
-Although not required, we can use [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts) to make plugin development easier — it provides a recommended default configuration for TypeScript and Jest. Refer to the [config plugins guide](https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin) for more information.
+Although not required, we can use [`expo-module-scripts`](https://www.npmjs.com/package/expo-module-scripts) to make plugin development easier — it provides a recommended default configuration for TypeScript and Jest. For more information, see [config plugins guide](https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin).
 
-Let's start by creating our plugin with this minimal boilerplate. This will create a **plugin** folder where we will write our plugin in TypeScript and add a **app.plugin.js** file in the project root which will be the entry file for the plugin.
+Let's start by creating our plugin with this minimal boilerplate. This will create a **plugin** folder where we will write the plugin in TypeScript and add a **app.plugin.js** file in the project root, which will be the entry file for the plugin.
 
-1. Create a **plugin/tsconfig.json** file
+1. Create a **plugin/tsconfig.json** file:
 
    ```json plugin/tsconfig.json
    {
@@ -152,7 +153,7 @@ Let's start by creating our plugin with this minimal boilerplate. This will crea
    }
    ```
 
-2. Create a **plugin/src/index.ts** file for our plugin
+2. Create a **plugin/src/index.ts** file for our plugin:
 
    ```typescript plugin/src/index.ts
    import { ConfigPlugin } from 'expo/config-plugins';
@@ -165,13 +166,13 @@ Let's start by creating our plugin with this minimal boilerplate. This will crea
    export default withMyApiKey;
    ```
 
-3. Finally, create an **app.plugin.js** file in the root directory. That will configure the entry file for our plugin
+3. Finally, create an **app.plugin.js** file in the root directory. That will configure the entry file for our plugin:
 
    ```javascript app.plugin.js
    module.exports = require('./plugin/build');
    ```
 
-With that set, we can already run `npm run build plugin` to start the TypeScript compiler in watch mode. The only thing left to configure is our example project to use our plugin. We can achieve this by adding the following line to the **example/app.json** file.
+At the root of your project, run `npm run build plugin` to start the TypeScript compiler in watch mode. The only thing left to configure is our example project to use our plugin. We can achieve this by adding the following line to the **example/app.json** file.
 
 ```json example/app.json
 {
@@ -193,9 +194,9 @@ Now when running `npx expo prebuild` inside our **example** folder we should see
   ]}
 />
 
-In order to inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper `mods` provided by `expo/config-plugins` which makes it easy to modify native files. You can check the full list [here](https://docs.expo.dev/guides/config-plugins/#mod-plugins). In our example, we are going to use two of them, `withInfoPlist` and `withAndroidManifest`.
+To inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper [`mods` provided by `expo/config-plugins`](/guides/config-plugins/#mod-plugins), which makes it easy to modify native files. In our example, we will use two of them, `withAndroidManifest` and `withInfoPlist`.
 
-As the name suggests `withInfoPlist` allows us to read and modify **Info.plist** values. Using the `modResults` property we can add custom values as demonstrated in the code snippet below:
+As the name suggests, `withInfoPlist` allows us to read and modify **Info.plist** values. Using the `modResults` property, we can add custom values as demonstrated in the code snippet below:
 
 ```typescript
 const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
@@ -208,7 +209,7 @@ const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
 };
 ```
 
-Similarly, we can use the `withAndroidManifest` to modify the **AndroidManifest.xml** file. In this case, we will utilize `AndroidConfig` helpers to add a meta data item to the main application:
+Similarly, we can use `withAndroidManifest` to modify the **AndroidManifest.xml** file. In this case, we will utilize `AndroidConfig` helpers to add a meta data item to the main application:
 
 ```typescript
 const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
@@ -227,7 +228,7 @@ const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
 };
 ```
 
-By merging everything into a single function, we can create our custom plugin. The final code would look like this:
+We can create our custom plugin by merging everything into a single function:
 
 ```typescript plugin/src/index.ts
 import {
@@ -260,7 +261,7 @@ const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
 export default withMyApiKey;
 ```
 
-Now with the plugin ready to be used we can update the example app to pass our API key to the plugin. To do so we need to update the following line on **example/app.json**
+Now with the plugin ready to be used, let's update the example app to pass our API key to the plugin as a configuration option. Modify the `"plugins"` field in **example/app.json** as shown below:
 
 ```json example/app.json
 {
@@ -279,7 +280,7 @@ After making this change, we can test that the plugin is working correctly by ru
 
 Now let's make our native module read the fields we added to **AndroidManifest.xml** and **Info.plist**. This can be done by using platform-specific methods to access the contents of these files.
 
-On iOS we can read the content of an **Info.plist** property by using the `Bundle.main.object(forInfoDictionaryKey:  "")` instance Method. To read the `"MY_CUSTOM_API_KEY"` value that we added earlier, we can update the **ios/ExpoNativeConfigurationModule.swift** file as follows:
+On iOS, we can read the content of an **Info.plist** property by using the `Bundle.main.object(forInfoDictionaryKey:  "")` instance Method. To read the `"MY_CUSTOM_API_KEY"` value that we added earlier, update the **ios/ExpoNativeConfigurationModule.swift** file:
 
 ```swift ios/ExpoNativeConfigurationModule.swift
 import ExpoModulesCore
@@ -295,7 +296,7 @@ public class ExpoNativeConfigurationModule: Module {
 }
 ```
 
-On Android, we can access metadata information from the **AndroidManifest.xml** file using the `packageManager` class. To read the `"MY_CUSTOM_API_KEY"` value, we need to update the **android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt** file as follows:
+On Android, we can access metadata information from the **AndroidManifest.xml** file using the `packageManager` class. To read the `"MY_CUSTOM_API_KEY"` value, update the **android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt** file:
 
 ```kotlin android/src/main/java/expo/modules/nativeconfiguration/ExpoNativeConfigurationModule.kt
 package expo.modules.nativeconfiguration
@@ -319,8 +320,7 @@ class ExpoNativeConfigurationModule() : Module() {
 
 ## 6. Running your module
 
-With our native modules reading the fields we added to the native files we can now run the example app and access our custom API key through the `ExamplePlugin.getApiKey()`
-function.
+With our native modules reading the fields we added to the native files, we can now run the example app and access our custom API key through the `ExamplePlugin.getApiKey()` function.
 
 <Terminal
   cmdCopy="cd example && npx expo run:ios"
@@ -337,6 +337,6 @@ function.
 
 ## Next steps
 
-Congratulations, you have created a simple yet non-trivial config plugin that interacts with an Expo module for iOS and Android!
+Congratulations, you have created a simple yet non-trivial config plugin that interacts with an Expo module for Android and iOS!
 
-If you want to challenge yourself and make the plugin more versatile we leave this exercise open to the reader, try modifying the plugin to allow for any arbitrary set of config keys/values to be passed in and adding the functionality to allow for reading of arbitrary keys from the module.
+If you want to challenge yourself and make the plugin more versatile we leave this exercise open to you. Try modifying the plugin to allow for any arbitrary set of config keys/values to be passed in and adding the functionality to allow for the reading of arbitrary keys from the module.


### PR DESCRIPTION
# Why

Closes ENG-6060

# How

This PR adds a "Create a module with a config plugin" to the Expo Modules API docs 

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
