### PR TITLE
[core][iOS] Fix expo modules aren't added to global

### DIFF
--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -43,8 +43,13 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
       appContext.reactBridge = bridge
 
       if bridge.responds(to: Selector(("runtime"))) {
+        // Getting the `runtime` on a different thread than JS is considered to be dangerous.
+        // However, we just checking if it exists. We don't do anything with it.
         let result = bridge.perform(Selector(("runtime")))
         if result == nil {
+          // When exporting expo modules using `extraModulesForBridge` (e.g. in Expo Go),
+          // the runtime won't be initiated before the bidge didSet method is called.
+          // Therefore, we need to wait for the main thread to complete its initialization by dispatching on it first.
           bridge.dispatchBlock({ [weak self] in
             guard let self = self, let bridge = self.appContext.reactBridge else {
               return

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -41,10 +41,10 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
   public var bridge: RCTBridge! {
     didSet {
       appContext.reactBridge = bridge
-      
+
       if bridge.responds(to: Selector(("runtime"))) {
         let result = bridge.perform(Selector(("runtime")))
-        if (result == nil) {
+        if result == nil {
           bridge.dispatchBlock({ [weak self] in
             guard let self = self, let bridge = self.appContext.reactBridge else {
               return
@@ -59,7 +59,7 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
           return
         }
       }
-      
+
       bridge.dispatchBlock({ [weak self] in
         guard let self = self, let bridge = self.appContext.reactBridge else {
           return

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -41,6 +41,25 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
   public var bridge: RCTBridge! {
     didSet {
       appContext.reactBridge = bridge
+      
+      if bridge.responds(to: Selector(("runtime"))) {
+        let result = bridge.perform(Selector(("runtime")))
+        if (result == nil) {
+          bridge.dispatchBlock({ [weak self] in
+            guard let self = self, let bridge = self.appContext.reactBridge else {
+              return
+            }
+            bridge.dispatchBlock({ [weak self] in
+              guard let self = self, let bridge = self.appContext.reactBridge else {
+                return
+              }
+              self.appContext.runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
+            }, queue: RCTJSThread)
+          }, queue: DispatchQueue.main)
+          return
+        }
+      }
+      
       bridge.dispatchBlock({ [weak self] in
         guard let self = self, let bridge = self.appContext.reactBridge else {
           return


### PR DESCRIPTION
# Why

Fixes https://www.notion.so/expo/iOS-Unversioned-QA-47e54e52912a4dfc9e4127cdb136e5a7?d=5791b37a93d245209352457d6d677358#399ef36c314643de8b633106ee652067.

# How

It has been discovered that jsiRuntime is null in the code at https://github.com/expo/expo/blob/720c844829c1916b7281377c0ec360ad5be049b2/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm#L32-L33

However, in a normal (non-test) scenario, it should have been set to the current runtime. This issue only occurs in Expo Go and is related to using extraModulesForBridge to add modules in the Go app, causing a change in the execution order and preventing the runtime from initializing when needed.


# Test Plan

- NCL with Expo Go and bare expo ✅ 