### PR TITLE
[cli] Simplify mainFields override in custom resolver (fix Metro 0.75 compatibility)

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -83,6 +83,7 @@ _This version does not introduce any user-facing changes._
 - Fix tests. ([#20510](https://github.com/expo/expo/pull/20510) by [@EvanBacon](https://github.com/EvanBacon))
 - Simplify the Xcode warnings. ([#20512](https://github.com/expo/expo/pull/20512) by [@EvanBacon](https://github.com/EvanBacon))
 - Simply Metro watch mode detection to `CI=true`, and log when disabled. ([#20939](https://github.com/expo/expo/pull/20939) by [@byCedric](https://github.com/byCedric))
+- Simplify `mainFields` override in custom resolver (fix Metro web 0.75 compatibility). ([#21039](https://github.com/expo/expo/pull/21039) by [@huntie](https://github.com/huntie))
 
 ## 0.4.10 - 2022-11-22
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -185,14 +185,18 @@ export function withExtendedResolver(
         return resolve(
           {
             ...context,
+            // @ts-expect-error: mainFields is not on type
+            mainFields,
             preferNativePlatform: platform !== 'web',
             resolveRequest: undefined,
 
             // Passing `mainFields` directly won't be considered
             // we need to extend the `getPackageMainPath` directly to
             // use platform specific `mainFields`.
+            // NOTE: This is no longer needed after Metro 0.75.0, where the above
+            // `mainFields` assignment is adequate.
             getPackageMainPath(packageJsonPath) {
-              // @ts-expect-error: mainFields is not on type
+              // @ts-expect-error: moduleCache is not on type
               const package_ = context.moduleCache.getPackage(packageJsonPath);
               return package_.getMain(mainFields);
             },


### PR DESCRIPTION
# Why

In today's major release of Metro, we've removed `getPackageMainPath` from the context object passed to custom resolvers, which will be a breaking change for Expo CLI.

> **[Breaking]**: Filter untyped context properties passed to custom resolvers. (https://github.com/facebook/metro/commit/cb01ec09c6a8df51f39d6b1419cbf173fa5abf4a)

This PR includes a suggested fix, ~~required once relevant Expo packages upgrade to Metro >= 0.75.0 (and not before)~~. This is because the same release updates `context.mainFields` to be load-bearing, which becomes usable as a replacement for this use case.

### Update (046b7ef) — safe to ship now, once tested

- The existing `getPackageMainPath` workaround is preserved, as @EvanBacon rightly noted that this can coexist and will be ignored by newer Metro versions.
- The time for the old workaround to be removed will be apparent after upgrading to a future Metro version/DefinitelyTyped version in which the updated `CustomResolutionContext` type no longer includes this field (we are in the process of updating our TS types and bringing them in-repo).

# Test Plan

**Not yet tested.** Requires validation when other Expo packages upgrade to Metro >= 0.75.0.
