### PR TITLE
[av][ncl][go] fix audio and video qa issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Updated `@react-native-community/slider` from `4.2.4` to `4.4.1`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Updated `@react-native-community/slider` from `4.2.4` to `4.4.2`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel), [#21055](https://github.com/expo/expo/pull/21055) by [@kudo](https://github.com/kudo))
 - Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))
 - Updated `@react-native-community/datetimepicker` from `6.5.2` to `6.7.3`. ([#20926](https://github.com/expo/expo/pull/20926) by [@byCedric](https://github.com/byCedric))
 - Updated `@shopify/flash-list` from `1.3.1` to `1.4.0`. ([#20927](https://github.com/expo/expo/pull/20927) by [@lukmccall](https://github.com/lukmccall))

--- a/android/vendored/unversioned/@react-native-community/slider/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
+++ b/android/vendored/unversioned/@react-native-community/slider/android/src/oldarch/java/com/reactnativecommunity/slider/ReactSliderManager.java
@@ -43,12 +43,7 @@ public class ReactSliderManager extends SimpleViewManager<ReactSlider> {
                 reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
                   new ReactSliderEvent(
                     seekbar.getId(),
-                    slider.toRealProgress(progress), fromUser));
-              } else {
-                reactContext.getNativeModule(UIManagerModule.class).getEventDispatcher().dispatchEvent(
-                  new ReactSlidingCompleteEvent(
-                    seekbar.getId(),
-                    ((ReactSlider)seekbar).toRealProgress(seekbar.getProgress())));
+                    slider.toRealProgress(progress), true));
               }
             }
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -592,7 +592,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.4.0):
     - React-Core
-  - react-native-slider (4.4.1):
+  - react-native-slider (4.4.2):
     - React-Core
   - react-native-view-shot (3.5.0):
     - React-Core
@@ -1331,7 +1331,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
-  react-native-slider: a0d45ce5ea1be39f149954cae4367afff44d5a32
+  react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-view-shot: 792829857bbb23a9c8acdad9a640554bdee397a3
   react-native-webview: 994b9f8fbb504d6314dc40d83f94f27c6831b3bf
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.7",
-    "@react-native-community/slider": "4.4.1",
+    "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -44,7 +44,7 @@
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.7",
-    "@react-native-community/slider": "4.4.1",
+    "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",

--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -104,31 +104,31 @@ export default class AudioPlayer extends React.Component<Props, State> {
   };
 
   _playAsync = async () => {
-    this._sound!.playAsync();
+    this._sound?.playAsync();
   };
 
   _pauseAsync = async () => {
     this._clearJsiAudioSampleCallback();
-    this._sound!.pauseAsync();
+    this._sound?.pauseAsync();
   };
 
-  _replayAsync = async () => this._sound!.replayAsync();
+  _replayAsync = async () => this._sound?.replayAsync();
 
-  _setPositionAsync = async (position: number) => this._sound!.setPositionAsync(position);
+  _setPositionAsync = async (position: number) => this._sound?.setPositionAsync(position);
 
-  _setIsLoopingAsync = async (isLooping: boolean) => this._sound!.setIsLoopingAsync(isLooping);
+  _setIsLoopingAsync = async (isLooping: boolean) => this._sound?.setIsLoopingAsync(isLooping);
 
-  _setIsMutedAsync = async (isMuted: boolean) => this._sound!.setIsMutedAsync(isMuted);
+  _setIsMutedAsync = async (isMuted: boolean) => this._sound?.setIsMutedAsync(isMuted);
 
   _setVolumeAsync = async (volume: number, audioPan?: number) =>
-    this._sound!.setVolumeAsync(volume, audioPan);
+    this._sound?.setVolumeAsync(volume, audioPan);
 
   _setRateAsync = async (
     rate: number,
     shouldCorrectPitch: boolean,
     pitchCorrectionQuality = Audio.PitchCorrectionQuality.Low
   ) => {
-    await this._sound!.setRateAsync(rate, shouldCorrectPitch, pitchCorrectionQuality);
+    await this._sound?.setRateAsync(rate, shouldCorrectPitch, pitchCorrectionQuality);
   };
 
   _clearJsiAudioSampleCallback = () => {
@@ -174,7 +174,7 @@ export default class AudioPlayer extends React.Component<Props, State> {
           setRateAsync={this._setRateAsync}
           setIsMutedAsync={this._setIsMutedAsync}
           setVolume={this._setVolumeAsync}
-          extraIndicator={<JsiAudioBar isPlaying={this.state.isPlaying} sound={this._sound!} />}
+          extraIndicator={<JsiAudioBar isPlaying={this.state.isPlaying} sound={this._sound} />}
         />
       </View>
     );

--- a/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/AudioPlayer.tsx
@@ -159,7 +159,9 @@ export default class AudioPlayer extends React.Component<Props, State> {
       <View>
         <AndroidImplementationSelector
           onToggle={this._toggleAndroidImplementation}
-          title={`Use ${this._isMediaPlayerImplementation() ? 'SimpleExoPlayer' : 'MediaPlayer'}`}
+          title={`Current player: ${
+            this._isMediaPlayerImplementation() ? 'MediaPlayer' : 'SimpleExoPlayer'
+          }`}
           toggled={this._isMediaPlayerImplementation()}
         />
 

--- a/apps/native-component-list/src/screens/AV/JsiAudioBar.tsx
+++ b/apps/native-component-list/src/screens/AV/JsiAudioBar.tsx
@@ -17,7 +17,13 @@ import Colors from '../../constants/Colors';
 // TODO (barthap): Fix the root cause and normalize them between platforms
 const inputRange = Platform.OS === 'ios' ? [0, 0.3] : [0, 1];
 
-export function JsiAudioBar({ sound, isPlaying }: { sound: Audio.Sound; isPlaying: boolean }) {
+export function JsiAudioBar({
+  sound,
+  isPlaying,
+}: {
+  sound: Audio.Sound | undefined;
+  isPlaying: boolean;
+}) {
   const isJsiAudioSupported = React.useMemo(() => {
     try {
       // @ts-expect-error that method is private

--- a/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
+++ b/apps/native-component-list/src/screens/AV/VideoPlayer.tsx
@@ -86,7 +86,9 @@ export default function VideoPlayer(props: {
     <View>
       <AndroidImplementationSelector
         onToggle={toggleAndroidImplementation}
-        title={`Use ${isMediaPlayerImplementation() ? 'SimpleExoPlayer' : 'MediaPlayer'}`}
+        title={`Current player: ${
+          isMediaPlayerImplementation() ? 'MediaPlayer' : 'SimpleExoPlayer'
+        }`}
         toggled={isMediaPlayerImplementation()}
       />
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2032,7 +2032,7 @@ PODS:
     - React
     - React-callinvoker
     - React-Core
-  - react-native-slider (4.4.1):
+  - react-native-slider (4.4.2):
     - React-Core
   - react-native-webview (11.26.0):
     - React-Core
@@ -3661,7 +3661,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-skia: ff2265fb802b2a3e1bf4a3c5a86d46936dd20354
-  react-native-slider: a0d45ce5ea1be39f149954cae4367afff44d5a32
+  react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-webview: 994b9f8fbb504d6314dc40d83f94f27c6831b3bf
   React-perflogger: c7ccda3d1d1da837f7ff4e54e816022a6803ee87
   React-RCTActionSheet: 01c125aebbad462a24228f68c584c7a921d6c28e

--- a/ios/vendored/unversioned/@react-native-community/slider/react-native-slider.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/slider/react-native-slider.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-slider",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "summary": "React Native component used to select a single value from a range of values.",
   "license": "MIT",
   "authors": "react-native-community",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/callstack/react-native-slider.git",
-    "tag": "v4.4.1"
+    "tag": "v4.4.2"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "dependencies": {

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `HTMLMediaElement.play` and `HTMLMediaElement.pause` calls on the Web aren't properly awaited. ([#20439](https://github.com/expo/expo/pull/20439)) by [@zhigang1992](https://github.com/zhigang1992)
 - Added support for React Native 0.71.x. ([#20799](https://github.com/expo/expo/pull/20799) [#20832](https://github.com/expo/expo/pull/20832) by [@kudo](https://github.com/kudo))
+- Fixed JSI audio sampling buffer issues when using `SimpleExoPlayer` implementation on Android. ([#21055](https://github.com/expo/expo/pull/21055) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/src/main/java/expo/modules/av/player/PlayerData.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/player/PlayerData.java
@@ -9,11 +9,15 @@ import android.util.Log;
 import android.util.Pair;
 import android.view.Surface;
 
+import androidx.annotation.UiThread;
+
 import com.facebook.jni.HybridData;
+import com.facebook.react.bridge.UiThreadUtil;
 
 import expo.modules.core.Promise;
 import expo.modules.core.arguments.ReadableArguments;
 
+import java.lang.ref.WeakReference;
 import java.util.Map;
 
 import expo.modules.av.AVManagerInterface;
@@ -22,6 +26,7 @@ import expo.modules.av.AudioFocusNotAcquiredException;
 import expo.modules.av.progress.AndroidLooperTimeMachine;
 import expo.modules.av.progress.ProgressLooper;
 import expo.modules.core.interfaces.DoNotStrip;
+import expo.modules.core.interfaces.services.UIManager;
 import expo.modules.interfaces.permissions.PermissionsResponse;
 import expo.modules.interfaces.permissions.PermissionsStatus;
 
@@ -88,6 +93,7 @@ public abstract class PlayerData implements AudioEventHandler {
   final AVManagerInterface mAVModule;
   final Uri mUri;
   final Map<String, Object> mRequestHeaders;
+  private final WeakReference<UIManager> mUiManager;
 
   private ProgressLooper mProgressUpdater = new ProgressLooper(new AndroidLooperTimeMachine());
 
@@ -110,6 +116,7 @@ public abstract class PlayerData implements AudioEventHandler {
     mRequestHeaders = requestHeaders;
     mAVModule = avModule;
     mUri = uri;
+    mUiManager = new WeakReference<>(avModule.getModuleRegistry().getModule(UIManager.class));
 
     mHybridData = initHybrid();
   }
@@ -136,6 +143,13 @@ public abstract class PlayerData implements AudioEventHandler {
 //  @SuppressWarnings("unused")
   @DoNotStrip
   void setEnableSampleBufferCallback(boolean enable) {
+    if (!UiThreadUtil.isOnUiThread()) {
+      UiThreadUtil.runOnUiThread(() -> {
+        setEnableSampleBufferCallback(enable);
+      });
+      return;
+    }
+
     if (enable) {
       try {
         boolean hasRecordAudioPermission = mAVModule.hasAudioPermission();
@@ -166,7 +180,7 @@ public abstract class PlayerData implements AudioEventHandler {
           @Override
           public void onWaveFormDataCapture(Visualizer visualizer, byte[] bytes, int samplingRate) {
             if (mShouldPlay) {
-              sampleBufferCallback(bytes, getCurrentPositionSeconds());
+              emitSampleBufferEvent(bytes, getCurrentPositionSeconds());
             }
           }
 
@@ -205,6 +219,16 @@ public abstract class PlayerData implements AudioEventHandler {
       return new MediaPlayerData(avModule, context, uri, requestHeaders);
     } else {
       return new SimpleExoPlayerData(avModule, context, uri, uriOverridingExtension, requestHeaders);
+    }
+  }
+
+  @UiThread
+  private void emitSampleBufferEvent(final byte[] bytes, final double currentPositionSeconds) {
+    final UIManager uiManager = mUiManager.get();
+    if (uiManager != null) {
+      uiManager.runOnClientCodeQueueThread(() -> {
+        sampleBufferCallback(bytes, currentPositionSeconds);
+      });
     }
   }
 

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -4,7 +4,7 @@
   "@react-native-community/datetimepicker": "6.7.3",
   "@react-native-masked-view/masked-view": "0.2.8",
   "@react-native-community/netinfo": "9.3.7",
-  "@react-native-community/slider": "4.4.1",
+  "@react-native-community/slider": "4.4.2",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.4.8",
   "@react-native-segmented-control/segmented-control": "2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,10 +3044,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.7.tgz#92407f679f00bae005c785a9284e61d63e292b34"
   integrity sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==
 
-"@react-native-community/slider@4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.4.1.tgz#368faef3c2aac2097bbfda0a143283f3731a312c"
-  integrity sha512-CLzwZyLlWfDYN4xj6Wwqm+HisF6dd+rq9pk6Cp+Auw0bm4eb4GLQNc29ILh051xHMe5Dhrd9+NBrbvaEujevkA==
+"@react-native-community/slider@4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-4.4.2.tgz#1fea0eb3ae31841fe87bd6c4fc67569066e9cf4b"
+  integrity sha512-D9bv+3Vd2gairAhnRPAghwccgEmoM7g562pm8i4qB3Esrms5mggF81G3UvCyc0w3jjtFHh8dpQkfEoKiP0NW/Q==
 
 "@react-native-masked-view/masked-view@0.2.8":
   version "0.2.8"


### PR DESCRIPTION
# Why

fix audio and video issues from sdk48 android unversioned qa

# How

- [ncl] play position back-and-forth is actually from slider's [`onSlidingComplete` issue](https://github.com/callstack/react-native-slider/issues/487). this pr update the vendored slider to the latest version with a fix.
- [ncl] `setVolumeAsync` unhandled promise rejection: access `sound` when it's before starting (undefined).
- [av] also find a regression for SimpleExoPlayer jsi audio sampler which should access the player from main thread.

# Test Plan

- ci passed
- android unversioned expo go + ncl audio / video

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
