### PR TITLE
[test-suite] fix video hanging

### DIFF
--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -417,7 +417,9 @@ export function test(t, { setPortalChild, cleanupPortal }) {
             instance.presentFullscreenPlayer().catch((error) => {
               presentationError = error;
             });
+            await waitFor(1000);
             await instance.dismissFullscreenPlayer();
+            await waitFor(1000);
           } catch (error) {
             dismissalError = error;
           }
@@ -434,8 +436,10 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         );
         let error = null;
         const presentationPromise = instance.presentFullscreenPlayer();
+        await waitFor(1000);
         try {
           await instance.dismissFullscreenPlayer();
+          await waitFor(1000);
         } catch (err) {
           error = err;
         }
@@ -451,8 +455,10 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         );
         let error = null;
         const presentationPromise = instance.presentFullscreenPlayer();
+        await waitFor(1000);
         try {
           await instance.presentFullscreenPlayer();
+          await waitFor(1000);
         } catch (err) {
           error = err;
         }
@@ -460,57 +466,6 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         await presentationPromise;
         await instance.dismissFullscreenPlayer();
       });
-
-      // NOTE(2018-10-17): Some of these tests are failing on iOS
-      const unreliablyIt = Platform.OS === 'ios' ? t.xit : t.it;
-
-      unreliablyIt(
-        'rejects all but the last request to change fullscreen mode before the video loads',
-        async () => {
-          // Adding second clause sometimes crashes the application,
-          // because by the time we call `present` second time,
-          // the video loads, so it handles the first request properly,
-          // rejects the second and it may reject the third request
-          // if it tries to be handled while the first presentation request
-          // is being handled.
-          let firstErrored = false;
-          // let secondErrored = false;
-          let thirdErrored = false;
-          // We're using remote source as this gives us time to request changes
-          // before the video loads.
-          const instance = await mountAndWaitFor(
-            <Video style={style} source={videoRemoteSource} />,
-            'ref'
-          );
-          instance.dismissFullscreenPlayer().catch(() => {
-            firstErrored = true;
-          });
-          // instance.presentFullscreenPlayer().catch(() => (secondErrored = true));
-          try {
-            await instance.dismissFullscreenPlayer();
-          } catch (_error) {
-            thirdErrored = true;
-          }
-
-          if (!firstErrored) {
-            // First present request finished too early so we cannot
-            // test this behavior at all. Normally I would put
-            // `t.pending` here, but as for the end of 2017 it doesn't work.
-          } else {
-            t.expect(firstErrored).toBe(true);
-            // t.expect(secondErrored).toBe(true);
-            t.expect(thirdErrored).toBe(false);
-          }
-          const pleaseDismiss = async () => {
-            try {
-              await instance.dismissFullscreenPlayer();
-            } catch {
-              pleaseDismiss();
-            }
-          };
-          await pleaseDismiss();
-        }
-      );
     });
 
     // Actually values 2.0 and -0.5 shouldn't be allowed, however at the moment


### PR DESCRIPTION
# Why

fix test suite video issues found in sdk48 android unversioned qa 

# How

- toggling fullscreen too fast may encounter issues, we should wait a little time.
- the `rejects all but the last request to change fullscreen mode before the video loads` is always failed and confused. dismissing a video view which is never presented would fail for sure. the code test will hang at the `pleaseDismiss` which is always failed and going into infinite loop.
 
# Test Plan

android unversioned expo go + test suite video

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
