### PR TITLE
[docs] use Markdown for Config Plugin properties descriptions

### DIFF
--- a/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
+++ b/docs/components/plugins/ConfigSection/ConfigPluginProperties.tsx
@@ -1,6 +1,8 @@
 import type { PropsWithChildren } from 'react';
+import ReactMarkdown from 'react-markdown';
 
 import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatformTags';
+import { mdComponents } from '~/components/plugins/api/APISectionUtils';
 import { Cell, HeaderCell, Row, Table, TableHead } from '~/ui/components/Table';
 import { P, CODE, H3 } from '~/ui/components/Text';
 
@@ -36,7 +38,7 @@ export const ConfigPluginProperties = ({ children, properties }: Props) => (
                   ]}
                 />
               )}
-              {property.description}
+              <ReactMarkdown components={mdComponents}>{property.description}</ReactMarkdown>
             </Cell>
           </Row>
         ))}

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -85,7 +85,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
       name: 'iCloudContainerEnvironment',
       platform: 'ios',
       description:
-        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. Learn more: https://github.com/expo/eas-cli/issues/693',
+        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -67,19 +67,19 @@ Learn how to configure the native projects in the [installation instructions in 
     {
       name: 'photosPermission',
       platform: 'ios',
-      description: 'A string to set the NSPhotoLibraryUsageDescription permission message.',
+      description: 'A string to set the `NSPhotoLibraryUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your photos"',
     },
     {
       name: 'cameraPermission',
       platform: 'ios',
-      description: 'A string to set the NSCameraUsageDescription permission message.',
+      description: 'A string to set the `NSCameraUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your camera"',
     },
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the NSMicrophoneUsageDescription permission message.',
+      description: 'A string to set the `NSMicrophoneUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/media-library.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library.mdx
@@ -68,14 +68,14 @@ Learn how to configure the native projects in the [installation instructions in 
       name: 'photosPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSPhotoLibraryUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSPhotoLibraryUsageDescription` permission message in **Info.plist**.',
       default: '"Allow $(PRODUCT_NAME) to access your photos."',
     },
     {
       name: 'savePhotosPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSPhotoLibraryAddUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSPhotoLibraryAddUsageDescription` permission message in **Info.plist**.',
       default: '"Allow $(PRODUCT_NAME) to save photos."',
     },
     {

--- a/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/unversioned/sdk/screen-orientation.mdx
@@ -75,7 +75,7 @@ You can configure `expo-screen-orientation` using its built-in [config plugin](/
       name: 'initialOrientation',
       platform: 'ios',
       description:
-        'Sets the iOS initial screen orientation. Options: `DEFAULT`, `ALL`, `PORTRAIT`, `PORTRAIT_UP`, `PORTRAIT_DOWN`, `LANDSCAPE`, `LANDSCAPE_LEFT`, `LANDSCAPE_RIGHT`',
+        'Sets the iOS initial screen orientation. Possible values: `DEFAULT`, `ALL`, `PORTRAIT`, `PORTRAIT_UP`, `PORTRAIT_DOWN`, `LANDSCAPE`, `LANDSCAPE_LEFT`, `LANDSCAPE_RIGHT`',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -67,7 +67,7 @@ Learn how to configure the native projects in the [installation instructions in 
       name: 'userTrackingPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSUserTrackingUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSUserTrackingUsageDescription` permission message in **Info.plist**.',
       default:
         '"Allow this app to collect app-related data that can be used for tracking you or your device."',
     },

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -85,7 +85,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
       name: 'iCloudContainerEnvironment',
       platform: 'ios',
       description:
-        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. Learn more: https://github.com/expo/eas-cli/issues/693',
+        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -67,19 +67,19 @@ Learn how to configure the native projects in the [installation instructions in 
     {
       name: 'photosPermission',
       platform: 'ios',
-      description: 'A string to set the NSPhotoLibraryUsageDescription permission message.',
+      description: 'A string to set the `NSPhotoLibraryUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your photos"',
     },
     {
       name: 'cameraPermission',
       platform: 'ios',
-      description: 'A string to set the NSCameraUsageDescription permission message.',
+      description: 'A string to set the `NSCameraUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your camera"',
     },
     {
       name: 'microphonePermission',
       platform: 'ios',
-      description: 'A string to set the NSMicrophoneUsageDescription permission message.',
+      description: 'A string to set the `NSMicrophoneUsageDescription` permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your microphone"',
     },
   ]}

--- a/docs/pages/versions/v47.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/media-library.mdx
@@ -68,14 +68,14 @@ Learn how to configure the native projects in the [installation instructions in 
       name: 'photosPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSPhotoLibraryUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSPhotoLibraryUsageDescription` permission message in **Info.plist**.',
       default: '"Allow $(PRODUCT_NAME) to access your photos."',
     },
     {
       name: 'savePhotosPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSPhotoLibraryAddUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSPhotoLibraryAddUsageDescription` permission message in **Info.plist**.',
       default: '"Allow $(PRODUCT_NAME) to save photos."',
     },
     {

--- a/docs/pages/versions/v47.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/screen-orientation.mdx
@@ -75,7 +75,7 @@ You can configure `expo-screen-orientation` using its built-in [config plugin](/
       name: 'initialOrientation',
       platform: 'ios',
       description:
-        'Sets the iOS initial screen orientation. Options: `DEFAULT`, `ALL`, `PORTRAIT`, `PORTRAIT_UP`, `PORTRAIT_DOWN`, `LANDSCAPE`, `LANDSCAPE_LEFT`, `LANDSCAPE_RIGHT`',
+        'Sets the iOS initial screen orientation. Possible values: `DEFAULT`, `ALL`, `PORTRAIT`, `PORTRAIT_UP`, `PORTRAIT_DOWN`, `LANDSCAPE`, `LANDSCAPE_LEFT`, `LANDSCAPE_RIGHT`',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v47.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/tracking-transparency.mdx
@@ -67,7 +67,7 @@ Learn how to configure the native projects in the [installation instructions in 
       name: 'userTrackingPermission',
       platform: 'ios',
       description:
-        'Sets the iOS `NSUserTrackingUsageDescription` permission message in Info.plist.',
+        'Sets the iOS `NSUserTrackingUsageDescription` permission message in **Info.plist**.',
       default:
         '"Allow this app to collect app-related data that can be used for tracking you or your device."',
     },


### PR DESCRIPTION
# Why

I have spotted that currently we render Config Plugin properties descriptions as a raw string, while we often use Markdown syntax in there:
* https://docs.expo.dev/versions/latest/sdk/document-picker/#configurable-properties

# How

Render Config Plugin properties descriptions as Markdown content, tweak the current description to match writing guide, backport changes to SDK 47 docs.

# Test Plan

The changes have been tested by running docs app locally.

Lint checks and tests are passing.

# Preview

<img width="1129" alt="Screenshot 2023-02-02 at 13 29 42" src="https://user-images.githubusercontent.com/719641/216325812-22b29d26-f47e-44cb-84a4-7896a9bc9a09.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
