### PR TITLE
[expo-updates] E2E tests move to Hermes after 0.71.2

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Convert E2E tests to Hermes. ([#21065](https://github.com/expo/expo/pull/21065) by [@douglowder](https://github.com/douglowder))
+
 ## 0.16.0 — 2023-02-03
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -32,6 +32,7 @@ const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
  */
 describe('Asset deletion recovery', () => {
   afterEach(async () => {
+    await device.terminateApp();
     await device.uninstallApp();
     Server.stop();
   });
@@ -291,7 +292,7 @@ describe('Asset deletion recovery', () => {
      * Verify all the assets -- including the JS bundle from the update (which wasn't in the
      * embedded update) -- have been restored. Additionally verify from the server side that the
      * updated bundle was re-downloaded.
-r    */
+     */
     const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     if (!readAssetsMessage.success) {
       throw new Error(readAssetsMessage.error);

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -32,7 +32,6 @@ const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
  */
 describe('Asset deletion recovery', () => {
   afterEach(async () => {
-    await device.terminateApp();
     await device.uninstallApp();
     Server.stop();
   });

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -7,9 +7,9 @@ const {
   copyAssetToStaticFolder,
   copyBundleToStaticFolder,
   findAssets,
-  updateManifestForBundleFilename,
-  server_host,
-  server_port,
+  getUpdateManifestForBundleFilename,
+  serverHost,
+  serverPort,
 } = require('./utils/update');
 
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
@@ -41,7 +41,7 @@ describe('Asset deletion recovery', () => {
      * DatabaseLauncher should copy all the missing assets and run the update as normal.
      */
     jest.setTimeout(300000 * TIMEOUT_BIAS);
-    Server.start(server_port);
+    Server.start(serverPort);
 
     /**
      * Install the app and immediately send it a message to clear internal storage. Verify storage
@@ -122,7 +122,7 @@ describe('Asset deletion recovery', () => {
      * the missing assets and run the update as normal.
      */
     jest.setTimeout(300000 * TIMEOUT_BIAS);
-    Server.start(server_port);
+    Server.start(serverPort);
 
     /**
      * Install the app and immediately send it a message to clear internal storage. Verify storage
@@ -222,11 +222,11 @@ describe('Asset deletion recovery', () => {
           key,
           contentType: mimeType,
           fileExtension: asset.ext,
-          url: `http://${server_host}:${server_port}/static/${filename}`,
+          url: `http://${serverHost}:${serverPort}/static/${filename}`,
         };
       })
     );
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(),
       bundleHash,
       'test-assets-bundle',
@@ -237,7 +237,7 @@ describe('Asset deletion recovery', () => {
     /**
      * Install the app and launch it so that it downloads the new update we're hosting
      */
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({ newInstance: true });

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -190,127 +190,127 @@ describe('Asset deletion recovery', () => {
     // expect(readAssetsMessage.updateId).not.toEqual(clearAssetsMessage.updateId);
   });
 
-//   it('assets in a downloaded update deleted from internal storage should be re-copied or re-downloaded', async () => {
-//     /**
-//      * This test ensures we can (or at least try to) recover missing assets that originated from a
-//      * downloaded update, as opposed to assets originally copied from an embedded update (which
-//      * the previous 2 tests concern).
-//      *
-//      * To create this scenario, we launch an app, download an update with multiple assets
-//      * (including at least one -- the bundle -- not part of the embedded update), make sure the
-//      * update runs, then clear assets from internal storage. When we relaunch the app,
-//      * DatabaseLauncher should re-download the missing assets and run the update as normal.
-//      */
-//     jest.setTimeout(300000 * TIMEOUT_BIAS);
-// 
-//     /**
-//      * Prepare to host update manifest and assets from the test runner
-//      */
-//     const bundleFilename = 'bundle-assets.js';
-//     const newNotifyString = 'test-assets-1';
-//     const bundleHash = await copyBundleToStaticFolder(
-//       updateDistPath,
-//       bundleFilename,
-//       newNotifyString,
-//       platform
-//     );
-//     const { bundledAssets } = require(path.join(
-//       updateDistPath,
-//       exportedManifestFilename(platform)
-//     ));
-//     const assets = await Promise.all(
-//       bundledAssets.map(async (filename) => {
-//         const key = filename.replace('asset_', '').replace(/\.[^/.]+$/, '');
-//         const hash = await copyAssetToStaticFolder(
-//           path.join(updateDistPath, 'assets', key),
-//           filename
-//         );
-//         return {
-//           hash,
-//           key,
-//           contentType: 'image/jpg',
-//           fileExtension: '.jpg',
-//           url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${filename}`,
-//         };
-//       })
-//     );
-//     const manifest = {
-//       id: crypto.randomUUID(),
-//       createdAt: new Date().toISOString(),
-//       runtimeVersion: RUNTIME_VERSION,
-//       launchAsset: {
-//         hash: bundleHash,
-//         key: 'test-assets-bundle',
-//         contentType: 'application/javascript',
-//         url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
-//       },
-//       assets,
-//       metadata: {},
-//       extra: {},
-//     };
-// 
-//     /**
-//      * Install the app and launch it so that it downloads the new update we're hosting
-//      */
-//     Server.start(SERVER_PORT);
-//     await Server.serveSignedManifest(manifest, projectRoot);
-//     await device.installApp();
-//     await device.launchApp({ newInstance: true });
-//     await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
-//     const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     expect(message).toBe('test');
-// 
-//     // give the app time to load the new update in the background
-//     await setTimeout(2000 * TIMEOUT_BIAS);
-//     expect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
-// 
-//     /**
-//      * Stop and restart the app so it will launch the new update. Immediately send it a message to
-//      * clear internal storage while also verifying the new update is running.
-//      */
-//     await device.terminateApp();
-//     const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
-//       command: 'clearExpoInternal',
-//     });
-//     await device.launchApp({ newInstance: true });
-//     const updatedMessage = await promise;
-//     expect(updatedMessage).toBe(newNotifyString);
-// 
-//     /**
-//      * Verify that the assets were cleared correctly.
-//      */
-//     const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     if (!clearAssetsMessage.success) {
-//       throw new Error(clearAssetsMessage.error);
-//     }
-//     expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(4); // png, ttf, 2 JS bundles
-//     expect(clearAssetsMessage.numFilesAfter).toBe(0);
-//     expect(clearAssetsMessage.updateId).toEqual(manifest.id);
-// 
-//     /**
-//      * Stop and restart the app and immediately send it a message to read internal storage. Verify
-//      * that the new update is running (again).
-//      */
-//     await device.terminateApp();
-//     // set up promise before starting the app to ensure the correct response is sent
-//     const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
-//       command: 'readExpoInternal',
-//     });
-//     await device.launchApp({ newInstance: true });
-//     const updatedMessageAfterClearExpoInternal = await promise2;
-//     expect(updatedMessageAfterClearExpoInternal).toBe(newNotifyString);
-// 
-//     /**
-//      * Verify all the assets -- including the JS bundle from the update (which wasn't in the
-//      * embedded update) -- have been restored. Additionally verify from the server side that the
-//      * updated bundle was re-downloaded.
-// r    */
-//     const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     if (!readAssetsMessage.success) {
-//       throw new Error(readAssetsMessage.error);
-//     }
-//     expect(readAssetsMessage.numFiles).toEqual(manifest.assets.length + 1); // assets + JS bundle
-//     expect(readAssetsMessage.updateId).toEqual(manifest.id);
-//     expect(Server.consumeRequestedStaticFiles().length).toBe(1); // should have re-downloaded only the JS bundle; the rest should have been copied from the app binary
-//   });
+  it('assets in a downloaded update deleted from internal storage should be re-copied or re-downloaded', async () => {
+    /**
+     * This test ensures we can (or at least try to) recover missing assets that originated from a
+     * downloaded update, as opposed to assets originally copied from an embedded update (which
+     * the previous 2 tests concern).
+     *
+     * To create this scenario, we launch an app, download an update with multiple assets
+     * (including at least one -- the bundle -- not part of the embedded update), make sure the
+     * update runs, then clear assets from internal storage. When we relaunch the app,
+     * DatabaseLauncher should re-download the missing assets and run the update as normal.
+     */
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+
+    /**
+     * Prepare to host update manifest and assets from the test runner
+     */
+    const bundleFilename = 'bundle-assets.js';
+    const newNotifyString = 'test-assets-1';
+    const bundleHash = await copyBundleToStaticFolder(
+      updateDistPath,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const { bundledAssets } = require(path.join(
+      updateDistPath,
+      exportedManifestFilename(platform)
+    ));
+    const assets = await Promise.all(
+      bundledAssets.map(async (filename) => {
+        const key = filename.replace('asset_', '').replace(/\.[^/.]+$/, '');
+        const hash = await copyAssetToStaticFolder(
+          path.join(updateDistPath, 'assets', key),
+          filename
+        );
+        return {
+          hash,
+          key,
+          contentType: 'image/jpg',
+          fileExtension: '.jpg',
+          url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${filename}`,
+        };
+      })
+    );
+    const manifest = {
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+      runtimeVersion: RUNTIME_VERSION,
+      launchAsset: {
+        hash: bundleHash,
+        key: 'test-assets-bundle',
+        contentType: 'application/javascript',
+        url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
+      },
+      assets,
+      metadata: {},
+      extra: {},
+    };
+
+    /**
+     * Install the app and launch it so that it downloads the new update we're hosting
+     */
+    Server.start(SERVER_PORT);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({ newInstance: true });
+    await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(message).toBe('test');
+
+    // give the app time to load the new update in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
+
+    /**
+     * Stop and restart the app so it will launch the new update. Immediately send it a message to
+     * clear internal storage while also verifying the new update is running.
+     */
+    await device.terminateApp();
+    const promise = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'clearExpoInternal',
+    });
+    await device.launchApp({ newInstance: true });
+    const updatedMessage = await promise;
+    expect(updatedMessage).toBe(newNotifyString);
+
+    /**
+     * Verify that the assets were cleared correctly.
+     */
+    const clearAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!clearAssetsMessage.success) {
+      throw new Error(clearAssetsMessage.error);
+    }
+    expect(clearAssetsMessage.numFilesBefore).toBeGreaterThanOrEqual(4); // png, ttf, 2 JS bundles
+    expect(clearAssetsMessage.numFilesAfter).toBe(0);
+    expect(clearAssetsMessage.updateId).toEqual(manifest.id);
+
+    /**
+     * Stop and restart the app and immediately send it a message to read internal storage. Verify
+     * that the new update is running (again).
+     */
+    await device.terminateApp();
+    // set up promise before starting the app to ensure the correct response is sent
+    const promise2 = Server.waitForRequest(10000 * TIMEOUT_BIAS, {
+      command: 'readExpoInternal',
+    });
+    await device.launchApp({ newInstance: true });
+    const updatedMessageAfterClearExpoInternal = await promise2;
+    expect(updatedMessageAfterClearExpoInternal).toBe(newNotifyString);
+
+    /**
+     * Verify all the assets -- including the JS bundle from the update (which wasn't in the
+     * embedded update) -- have been restored. Additionally verify from the server side that the
+     * updated bundle was re-downloaded.
+r    */
+    const readAssetsMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    if (!readAssetsMessage.success) {
+      throw new Error(readAssetsMessage.error);
+    }
+    expect(readAssetsMessage.numFiles).toEqual(manifest.assets.length + 1); // assets + JS bundle
+    expect(readAssetsMessage.updateId).toEqual(manifest.id);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1); // should have re-downloaded only the JS bundle; the rest should have been copied from the app binary
+  });
 });

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-assets.e2e.js
@@ -1,10 +1,8 @@
-const crypto = require('crypto');
+const { device } = require('detox');
 const path = require('path');
 const { setTimeout } = require('timers/promises');
-const { device, beforeEach } = require('detox');
 
 const Server = require('./utils/server');
-
 const {
   copyAssetToStaticFolder,
   copyBundleToStaticFolder,

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -19,6 +19,7 @@ const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
 
 describe('', () => {
   afterEach(async () => {
+    await device.terminateApp();
     await device.uninstallApp();
     Server.stop();
   });
@@ -298,17 +299,6 @@ describe('', () => {
     await device.terminateApp();
     await device.launchApp();
     const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-
-    /**
-     * Check readLogEntriesAsync
-     */
-    const logEntries = await Server.waitForLogEntries(10000 * TIMEOUT_BIAS);
-    console.warn(
-      'Total number of log entries = ' +
-        logEntries.length +
-        '\n' +
-        JSON.stringify(logEntries, null, 2)
-    );
 
     expect(updatedMessage).toBe(newNotifyString);
   });

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -10,7 +10,6 @@ const SERVER_HOST = process.env.UPDATES_HOST;
 const SERVER_PORT = parseInt(process.env.UPDATES_PORT || '', 10);
 
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
-const updateDistPath = path.join(projectRoot, 'updates');
 const platform = process.env.DETOX_CONFIGURATION.split('.')[0];
 
 const RUNTIME_VERSION = '1.0.0';
@@ -63,65 +62,65 @@ describe('', () => {
     );
   });
 
-//   it('downloads and runs update, and updates current-update-id header', async () => {
-//     jest.setTimeout(300000 * TIMEOUT_BIAS);
-//     const bundleFilename = 'bundle1.js';
-//     const newNotifyString = 'test-update-1';
-//     const hash = await copyBundleToStaticFolder(
-//       updateDistPath,
-//       bundleFilename,
-//       newNotifyString,
-//       platform
-//     );
-//     const manifest = {
-//       id: crypto.randomUUID(),
-//       createdAt: new Date().toISOString(),
-//       runtimeVersion: RUNTIME_VERSION,
-//       launchAsset: {
-//         hash,
-//         key: 'test-update-1-key',
-//         contentType: 'application/javascript',
-//         url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
-//       },
-//       assets: [],
-//       metadata: {},
-//       extra: {},
-//     };
-// 
-//     Server.start(SERVER_PORT);
-//     await Server.serveSignedManifest(manifest, projectRoot);
-//     await device.installApp();
-//     await device.launchApp({
-//       newInstance: true,
-//     });
-//     const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
-//     const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     expect(message).toBe('test');
-// 
-//     // give the app time to load the new update in the background
-//     await setTimeout(2000 * TIMEOUT_BIAS);
-//     expect(Server.consumeRequestedStaticFiles().length).toBe(1);
-// 
-//     // restart the app so it will launch the new update
-//     await device.terminateApp();
-//     await device.launchApp();
-//     const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
-//     const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     expect(updatedMessage).toBe(newNotifyString);
-// 
-//     expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
-//     expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
-//       firstRequest.headers['expo-embedded-update-id']
-//     );
-//     expect(secondRequest.headers['expo-current-update-id']).toBeDefined();
-//     expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
-//   });
+  it('downloads and runs update, and updates current-update-id header', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = {
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+      runtimeVersion: RUNTIME_VERSION,
+      launchAsset: {
+        hash,
+        key: 'test-update-1-key',
+        contentType: 'application/javascript',
+        url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
+      },
+      assets: [],
+      metadata: {},
+      extra: {},
+    };
+
+    Server.start(SERVER_PORT);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(message).toBe('test');
+
+    // give the app time to load the new update in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1);
+
+    // restart the app so it will launch the new update
+    await device.terminateApp();
+    await device.launchApp();
+    const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(updatedMessage).toBe(newNotifyString);
+
+    expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
+    expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
+    expect(secondRequest.headers['expo-current-update-id']).toBeDefined();
+    expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
+  });
 
   it('does not run update with incorrect hash', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     const bundleFilename = 'bundle-invalid-hash.js';
     const newNotifyString = 'test-update-invalid-hash';
-    await copyBundleToStaticFolder(updateDistPath, bundleFilename, newNotifyString, platform);
+    await copyBundleToStaticFolder(projectRoot, bundleFilename, newNotifyString, platform);
     const hash = 'invalid-hash';
     const manifest = {
       id: crypto.randomUUID(),
@@ -165,7 +164,7 @@ describe('', () => {
     const bundleFilename = 'bundle2.js';
     const newNotifyString = 'test-update-2';
     const hash = await copyBundleToStaticFolder(
-      updateDistPath,
+      projectRoot,
       bundleFilename,
       newNotifyString,
       platform
@@ -230,7 +229,7 @@ describe('', () => {
      * Check readLogEntriesAsync
      */
     const logEntries = await Server.waitForLogEntries(10000 * TIMEOUT_BIAS);
-    console.debug(
+    console.warn(
       'Total number of log entries = ' +
         logEntries.length +
         '\n' +
@@ -251,76 +250,88 @@ describe('', () => {
      */
   });
 
-//   it('downloads and runs update with multiple assets', async () => {
-//     jest.setTimeout(300000 * TIMEOUT_BIAS);
-//     const bundleFilename = 'bundle2.js';
-//     const newNotifyString = 'test-update-2';
-//     const hash = await copyBundleToStaticFolder(
-//       updateDistPath,
-//       bundleFilename,
-//       newNotifyString,
-//       platform
-//     );
-//     const assets = await Promise.all(
-//       [
-//         'lubo-minar-j2RgHfqKhCM-unsplash.jpg',
-//         'niklas-liniger-zuPiCN7xekM-unsplash.jpg',
-//         'patrick-untersee-XJjsuuDwWas-unsplash.jpg',
-//       ].map(async (sourceFilename, index) => {
-//         const destinationFilename = `asset${index}.jpg`;
-//         const hash = await copyAssetToStaticFolder(
-//           path.join(__dirname, 'assets', sourceFilename),
-//           destinationFilename
-//         );
-//         return {
-//           hash,
-//           key: `asset${index}`,
-//           contentType: 'image/jpg',
-//           fileExtension: '.jpg',
-//           url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${destinationFilename}`,
-//         };
-//       })
-//     );
-//     const manifest = {
-//       id: crypto.randomUUID(),
-//       createdAt: new Date().toISOString(),
-//       runtimeVersion: RUNTIME_VERSION,
-//       launchAsset: {
-//         hash,
-//         key: 'test-update-2-key',
-//         contentType: 'application/javascript',
-//         url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
-//       },
-//       assets,
-//       metadata: {},
-//       extra: {},
-//     };
-// 
-//     Server.start(SERVER_PORT);
-//     await Server.serveSignedManifest(manifest, projectRoot);
-//     await device.installApp();
-//     await device.launchApp({
-//       newInstance: true,
-//     });
-//     const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     expect(message).toBe('test');
-// 
-//     // give the app time to load the new update in the background
-//     await setTimeout(2000 * TIMEOUT_BIAS);
-//     expect(Server.consumeRequestedStaticFiles().length).toBe(4);
-// 
-//     // restart the app so it will launch the new update
-//     await device.terminateApp();
-//     await device.launchApp();
-//     const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-//     expect(updatedMessage).toBe(newNotifyString);
-//   });
+  it('downloads and runs update with multiple assets', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle2.js';
+    const newNotifyString = 'test-update-2';
+    const hash = await copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const assets = await Promise.all(
+      [
+        'lubo-minar-j2RgHfqKhCM-unsplash.jpg',
+        'niklas-liniger-zuPiCN7xekM-unsplash.jpg',
+        'patrick-untersee-XJjsuuDwWas-unsplash.jpg',
+      ].map(async (sourceFilename, index) => {
+        const destinationFilename = `asset${index}.jpg`;
+        const hash = await copyAssetToStaticFolder(
+          path.join(__dirname, 'assets', sourceFilename),
+          destinationFilename
+        );
+        return {
+          hash,
+          key: `asset${index}`,
+          contentType: 'image/jpg',
+          fileExtension: '.jpg',
+          url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${destinationFilename}`,
+        };
+      })
+    );
+    const manifest = {
+      id: crypto.randomUUID(),
+      createdAt: new Date().toISOString(),
+      runtimeVersion: RUNTIME_VERSION,
+      launchAsset: {
+        hash,
+        key: 'test-update-2-key',
+        contentType: 'application/javascript',
+        url: `http://${SERVER_HOST}:${SERVER_PORT}/static/${bundleFilename}`,
+      },
+      assets,
+      metadata: {},
+      extra: {},
+    };
+
+    Server.start(SERVER_PORT);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(message).toBe('test');
+
+    // give the app time to load the new update in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(4);
+
+    // restart the app so it will launch the new update
+    await device.terminateApp();
+    await device.launchApp();
+    const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+
+    /**
+     * Check readLogEntriesAsync
+     */
+    const logEntries = await Server.waitForLogEntries(10000 * TIMEOUT_BIAS);
+    console.warn(
+      'Total number of log entries = ' +
+        logEntries.length +
+        '\n' +
+        JSON.stringify(logEntries, null, 2)
+    );
+
+    expect(updatedMessage).toBe(newNotifyString);
+  });
   // important for usage accuracy
   it('does not download any assets for an older update', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     const bundleFilename = 'bundle-old.js';
     const hash = await copyBundleToStaticFolder(
-      updateDistPath,
+      projectRoot,
       bundleFilename,
       'test-update-older',
       platform

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -6,9 +6,9 @@ const Server = require('./utils/server');
 const {
   copyAssetToStaticFolder,
   copyBundleToStaticFolder,
-  updateManifestForBundleFilename,
-  server_host,
-  server_port,
+  getUpdateManifestForBundleFilename,
+  serverHost,
+  serverPort,
 } = require('./utils/update');
 
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
@@ -24,7 +24,7 @@ describe('', () => {
 
   it('starts app, stops, and starts again', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
-    Server.start(server_port);
+    Server.start(serverPort);
     await device.installApp();
     await device.launchApp({
       newInstance: true,
@@ -47,7 +47,7 @@ describe('', () => {
 
   it('initial request includes correct update-id headers', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
-    Server.start(server_port);
+    Server.start(serverPort);
     await device.installApp();
     await device.launchApp({
       newInstance: true,
@@ -72,7 +72,7 @@ describe('', () => {
       newNotifyString,
       platform
     );
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(),
       hash,
       'test-update-1-key',
@@ -80,7 +80,7 @@ describe('', () => {
       []
     );
 
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -115,7 +115,7 @@ describe('', () => {
     const newNotifyString = 'test-update-invalid-hash';
     await copyBundleToStaticFolder(projectRoot, bundleFilename, newNotifyString, platform);
     const hash = 'invalid-hash';
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(),
       hash,
       'test-update-1-key',
@@ -123,7 +123,7 @@ describe('', () => {
       []
     );
 
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -172,11 +172,11 @@ describe('', () => {
           key: `asset${index}`,
           contentType: 'image/jpg',
           fileExtension: '.jpg',
-          url: `http://${server_host}:${server_port}/static/${destinationFilename}`,
+          url: `http://${serverHost}:${serverPort}/static/${destinationFilename}`,
         };
       })
     );
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(),
       hash,
       'test-update-2-key',
@@ -184,7 +184,7 @@ describe('', () => {
       assets
     );
 
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -255,11 +255,11 @@ describe('', () => {
           key: `asset${index}`,
           contentType: 'image/jpg',
           fileExtension: '.jpg',
-          url: `http://${server_host}:${server_port}/static/${destinationFilename}`,
+          url: `http://${serverHost}:${serverPort}/static/${destinationFilename}`,
         };
       })
     );
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(),
       hash,
       'test-update-2-key',
@@ -267,7 +267,7 @@ describe('', () => {
       assets
     );
 
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -297,7 +297,7 @@ describe('', () => {
       'test-update-older',
       platform
     );
-    const manifest = updateManifestForBundleFilename(
+    const manifest = getUpdateManifestForBundleFilename(
       new Date(Date.now() - 1000 * 60 * 60 * 24),
       hash,
       'test-update-old-key',
@@ -305,7 +305,7 @@ describe('', () => {
       []
     );
 
-    Server.start(server_port);
+    Server.start(serverPort);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -19,7 +19,6 @@ const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
 
 describe('', () => {
   afterEach(async () => {
-    await device.terminateApp();
     await device.uninstallApp();
     Server.stop();
   });

--- a/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/Updates-basic.e2e.js
@@ -1,4 +1,3 @@
-const crypto = require('crypto');
 const { device } = require('detox');
 const path = require('path');
 const { setTimeout } = require('timers/promises');
@@ -9,7 +8,7 @@ const {
   copyBundleToStaticFolder,
   updateManifestForBundleFilename,
   server_host,
-  server_port
+  server_port,
 } = require('./utils/update');
 
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
@@ -87,9 +86,7 @@ describe('', () => {
     await device.launchApp({
       newInstance: true,
     });
-    const firstRequest = await Server.waitForUpdateRequest(
-      10000 * TIMEOUT_BIAS
-    );
+    const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     expect(message).toBe('test');
 
@@ -100,9 +97,7 @@ describe('', () => {
     // restart the app so it will launch the new update
     await device.terminateApp();
     await device.launchApp();
-    const secondRequest = await Server.waitForUpdateRequest(
-      10000 * TIMEOUT_BIAS
-    );
+    const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     expect(updatedMessage).toBe(newNotifyString);
 
@@ -111,21 +106,14 @@ describe('', () => {
       firstRequest.headers['expo-embedded-update-id']
     );
     expect(secondRequest.headers['expo-current-update-id']).toBeDefined();
-    expect(secondRequest.headers['expo-current-update-id']).toEqual(
-      manifest.id
-    );
+    expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
   });
 
   it('does not run update with incorrect hash', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     const bundleFilename = 'bundle-invalid-hash.js';
     const newNotifyString = 'test-update-invalid-hash';
-    await copyBundleToStaticFolder(
-      projectRoot,
-      bundleFilename,
-      newNotifyString,
-      platform
-    );
+    await copyBundleToStaticFolder(projectRoot, bundleFilename, newNotifyString, platform);
     const hash = 'invalid-hash';
     const manifest = updateManifestForBundleFilename(
       new Date(),
@@ -180,9 +168,7 @@ describe('', () => {
         );
         return {
           hash:
-            index === 0
-              ? hash.substring(1, 2) + hash.substring(0, 1) + hash.substring(2)
-              : hash,
+            index === 0 ? hash.substring(1, 2) + hash.substring(0, 1) + hash.substring(2) : hash,
           key: `asset${index}`,
           contentType: 'image/jpg',
           fileExtension: '.jpg',

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/server.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/server.js
@@ -2,7 +2,7 @@ const crypto = require('crypto');
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const { Dictionary, serializeDictionary } = require('structured-headers');
+const { serializeDictionary } = require('structured-headers');
 const { setTimeout } = require('timers/promises');
 
 const app = express();
@@ -97,10 +97,13 @@ async function waitForRequest(timeout, responseToServe) {
 async function waitForLogEntries(timeout) {
   const finishTime = new Date().getTime() + timeout;
 
-  while (!logEntries.length) {
+  while (!logEntries.length && server) {
     const currentTime = new Date().getTime();
     if (currentTime >= finishTime) {
       throw new Error('Timed out waiting for message');
+    }
+    if (!server) {
+      throw new Error('Server killed while waiting for message');
     }
     await setTimeout(50);
   }
@@ -124,10 +127,13 @@ app.get('/update', (req, res) => {
 
 async function waitForUpdateRequest(timeout) {
   const finishTime = new Date().getTime() + timeout;
-  while (!updateRequest) {
+  while (!updateRequest && server) {
     const currentTime = new Date().getTime();
     if (currentTime >= finishTime) {
       throw new Error('Timed out waiting for update request');
+    }
+    if (!server) {
+      throw new Error('Server killed while waiting for update');
     }
     await setTimeout(50);
   }

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
@@ -5,10 +5,6 @@ const path = require('path');
 
 const STATIC_FOLDER_PATH = path.resolve(__dirname, '..', '.static');
 
-function exportedManifestFilename(platform) {
-  return 'metadata.json';
-}
-
 function findBundlePath(projectRoot, platform, notifyString) {
   const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
   const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
@@ -17,39 +13,47 @@ function findBundlePath(projectRoot, platform, notifyString) {
   return path.join(testUpdateBundlesPath, bundleUrl);
 }
 
-async function copyBundleToStaticFolder(projectRoot, filename, notifyString, platform) {
-  await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
-  const bundleSrcPath = findBundlePath(projectRoot, platform, notifyString);
-  const bundleDestPath = path.join(STATIC_FOLDER_PATH, filename);
-  await fs.copyFile(bundleSrcPath, bundleDestPath);
+function findAssets(projectRoot, platform) {
+  const updatesPath = path.join(projectRoot, 'updates');
+  const updatesJson = require(path.join(updatesPath, 'metadata.json'));
+  const assets = updatesJson.fileMetadata[platform].assets;
+  return assets.map(asset => {
+    return {
+      path: path.join(updatesPath, asset.path),
+      ext: asset.ext
+    };
+  });
+}
 
+async function shaHash(filePath) {
   const hash = crypto.createHash('sha256');
-  const stream = createReadStream(bundleDestPath);
+  const stream = createReadStream(filePath);
   return new Promise((resolve, reject) => {
     stream.on('error', (err) => reject(err));
     stream.on('data', (chunk) => hash.update(chunk));
     stream.on('end', () => resolve(hash.digest('base64url')));
   });
+}
+
+async function copyBundleToStaticFolder(projectRoot, filename, notifyString, platform) {
+  await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
+  const bundleSrcPath = findBundlePath(projectRoot, platform, notifyString);
+  const bundleDestPath = path.join(STATIC_FOLDER_PATH, filename);
+  await fs.copyFile(bundleSrcPath, bundleDestPath);
+  return await shaHash(bundleDestPath);
 }
 
 async function copyAssetToStaticFolder(sourcePath, filename) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   const destinationPath = path.join(STATIC_FOLDER_PATH, filename);
   await fs.copyFile(sourcePath, destinationPath);
-
-  const hash = crypto.createHash('sha256');
-  const stream = createReadStream(destinationPath);
-  return new Promise((resolve, reject) => {
-    stream.on('error', (err) => reject(err));
-    stream.on('data', (chunk) => hash.update(chunk));
-    stream.on('end', () => resolve(hash.digest('base64url')));
-  });
+  return await shaHash(destinationPath);
 }
 
 const Updates = {
   copyBundleToStaticFolder,
   copyAssetToStaticFolder,
-  exportedManifestFilename,
+  findAssets,
 };
 
 module.exports = Updates;

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
@@ -9,31 +9,30 @@ function exportedManifestFilename(platform) {
   return 'metadata.json';
 }
 
-function findBundlePath(updateDistPath, platform) {
-  const manifest = require(path.join(updateDistPath, exportedManifestFilename(platform)));
-  const bundleUrl = manifest.fileMetadata[platform].bundle;
-  return path.join(updateDistPath, bundleUrl);
+function findBundlePath(projectRoot, platform, notifyString) {
+  const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
+  const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
+  const testUpdateBundlesJson = require(testUpdateBundlesJsonPath);
+  const bundleUrl = testUpdateBundlesJson[notifyString][platform];
+  return path.join(testUpdateBundlesPath, bundleUrl);
 }
 
-async function copyBundleToStaticFolder(
-  updateDistPath,
-  filename,
-  notifyString,
-  platform
-) {
+async function copyBundleToStaticFolder(projectRoot, filename, notifyString, platform) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
-  let bundleString = await fs.readFile(findBundlePath(updateDistPath, platform), 'utf-8');
-  if (notifyString) {
-    bundleString = bundleString.replace('/notify/test', `/notify/${notifyString}`);
-  }
-  await fs.writeFile(path.join(STATIC_FOLDER_PATH, filename), bundleString, 'utf-8');
-  return crypto.createHash('sha256').update(bundleString, 'utf-8').digest('base64url');
+  const bundleSrcPath = findBundlePath(projectRoot, platform, notifyString);
+  const bundleDestPath = path.join(STATIC_FOLDER_PATH, filename);
+  await fs.copyFile(bundleSrcPath, bundleDestPath);
+
+  const hash = crypto.createHash('sha256');
+  const stream = createReadStream(bundleDestPath);
+  return new Promise((resolve, reject) => {
+    stream.on('error', (err) => reject(err));
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('base64url')));
+  });
 }
 
-async function copyAssetToStaticFolder(
-  sourcePath,
-  filename
-) {
+async function copyAssetToStaticFolder(sourcePath, filename) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   const destinationPath = path.join(STATIC_FOLDER_PATH, filename);
   await fs.copyFile(sourcePath, destinationPath);

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
@@ -4,16 +4,15 @@ const fs = require('fs/promises');
 const path = require('path');
 
 const STATIC_FOLDER_PATH = path.resolve(__dirname, '..', '.static');
-const EXPORT_PUBLIC_URL = 'https://u.expo.dev/dummy-url';
 
 function exportedManifestFilename(platform) {
-  return `${platform}-index.json`;
+  return 'metadata.json';
 }
 
 function findBundlePath(updateDistPath, platform) {
-  const classicManifest = require(path.join(updateDistPath, exportedManifestFilename(platform)));
-  const { bundleUrl } = classicManifest;
-  return path.join(updateDistPath, bundleUrl.replace(EXPORT_PUBLIC_URL, ''));
+  const manifest = require(path.join(updateDistPath, exportedManifestFilename(platform)));
+  const bundleUrl = manifest.fileMetadata[platform].bundle;
+  return path.join(updateDistPath, bundleUrl);
 }
 
 async function copyBundleToStaticFolder(

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/e2e/tests/utils/update.js
@@ -11,17 +11,21 @@ const server_port = parseInt(process.env.UPDATES_PORT || '', 10);
 const urlForBundleFilename = (bundleFilename) =>
   `http://${server_host}:${server_port}/static/${bundleFilename}`;
 
+/**
+ * Find the pregenerated bundle corresponding to the string that is expected
+ * in the responses for a given E2E test
+ */
 function findBundlePath(projectRoot, platform, notifyString) {
   const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
-  const testUpdateBundlesJsonPath = path.join(
-    testUpdateBundlesPath,
-    'test-updates.json'
-  );
+  const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
   const testUpdateBundlesJson = require(testUpdateBundlesJsonPath);
   const bundleUrl = testUpdateBundlesJson[notifyString][platform];
   return path.join(testUpdateBundlesPath, bundleUrl);
 }
 
+/**
+ * Returns all the assets in the updates bundle, both paths and file types
+ */
 function findAssets(projectRoot, platform) {
   const updatesPath = path.join(projectRoot, 'updates');
   const updatesJson = require(path.join(updatesPath, 'metadata.json'));
@@ -44,12 +48,11 @@ async function shaHash(filePath) {
   });
 }
 
-async function copyBundleToStaticFolder(
-  projectRoot,
-  filename,
-  notifyString,
-  platform
-) {
+/**
+ * Copies a bundle to the location where the test server reads it,
+ * and returns the SHA hash
+ */
+async function copyBundleToStaticFolder(projectRoot, filename, notifyString, platform) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   const bundleSrcPath = findBundlePath(projectRoot, platform, notifyString);
   const bundleDestPath = path.join(STATIC_FOLDER_PATH, filename);
@@ -57,6 +60,10 @@ async function copyBundleToStaticFolder(
   return await shaHash(bundleDestPath);
 }
 
+/**
+ * Copies an asset to the location where the test server reads it,
+ * and returns the SHA hash
+ */
 async function copyAssetToStaticFolder(sourcePath, filename) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   const destinationPath = path.join(STATIC_FOLDER_PATH, filename);
@@ -64,6 +71,9 @@ async function copyAssetToStaticFolder(sourcePath, filename) {
   return await shaHash(destinationPath);
 }
 
+/**
+ * Common method used in all the tests to create valid update manifests
+ */
 function updateManifestForBundleFilename(date, hash, key, bundleFilename, assets) {
   return {
     id: crypto.randomUUID(),
@@ -73,7 +83,7 @@ function updateManifestForBundleFilename(date, hash, key, bundleFilename, assets
       hash,
       key,
       contentType: 'application/javascript',
-      url: urlForBundleFilename(bundleFilename)
+      url: urlForBundleFilename(bundleFilename),
     },
     assets,
     metadata: {},

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -50,10 +50,10 @@ yarn
 if [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
   npx pod-install
 fi
-detox build --configuration $EAS_BUILD_PLATFORM.debug
+detox build --configuration $EAS_BUILD_PLATFORM.release
 
 # -- Execute Detox assets tests
-detox test --configuration $EAS_BUILD_PLATFORM.debug --headless 2>&1 | tee ./logs/detox-tests-assets.log
+detox test --configuration $EAS_BUILD_PLATFORM.release --headless 2>&1 | tee ./logs/detox-tests-assets.log
 
 
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -14,6 +14,7 @@ export UPDATES_PORT=4747
 export PROJECT_ROOT=$PWD
 
 export EX_UPDATES_NATIVE_DEBUG=1
+export NO_FLIPPER=1
 
 mkdir ./logs
 

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -13,6 +13,8 @@ export UPDATES_HOST=localhost
 export UPDATES_PORT=4747
 export PROJECT_ROOT=$PWD
 
+export EX_UPDATES_NATIVE_DEBUG=1
+
 mkdir ./logs
 
 

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-on-success.sh
@@ -34,7 +34,7 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
 fi
 
 # Basic tests
-detox test --configuration $EAS_BUILD_PLATFORM.release --headless 2>&1 | tee ./logs/detox-tests-basic.log
+detox test --configuration $EAS_BUILD_PLATFORM.debug --headless 2>&1 | tee ./logs/detox-tests-basic.log
 
 # -- Remove old files and directories
 rm -rf .detoxrc.json .expo .git .gitignore App.js android app.json assets babel.config.js certs dependencies e2e eas-hooks eas.json index.js ios keys metro.config.js node_modules package.json updates
@@ -47,10 +47,10 @@ yarn
 if [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
   npx pod-install
 fi
-detox build --configuration $EAS_BUILD_PLATFORM.release
+detox build --configuration $EAS_BUILD_PLATFORM.debug
 
 # -- Execute Detox assets tests
-detox test --configuration $EAS_BUILD_PLATFORM.release --headless 2>&1 | tee ./logs/detox-tests-assets.log
+detox test --configuration $EAS_BUILD_PLATFORM.debug --headless 2>&1 | tee ./logs/detox-tests-assets.log
 
 
 if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
@@ -29,8 +29,8 @@ if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "updates_tes
       pulseaudio \
       socat
 
-    sdkmanager --install "system-images;android-32;google_apis;x86_64"
-    avdmanager --verbose create avd --force --name "pixel_4" --device "pixel_4" --package "system-images;android-32;google_apis;x86_64"
+    sdkmanager --install "system-images;android-33;google_apis;x86_64"
+    avdmanager --verbose create avd --force --name "pixel_4" --device "pixel_4" --package "system-images;android-33;google_apis;x86_64"
   else
     brew tap wix/brew
     brew install applesimutils

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -eox pipefail
-npm i -g expo-cli
 
 if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "updates_testing" ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
@@ -19,7 +19,7 @@
       "android": {
         "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
         "withoutCredentials": true,
-        "resourceClass": "m1-medium"
+        "resourceClass": "large"
       },
       "ios": {
         "simulator": true,

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
@@ -19,7 +19,7 @@
       "android": {
         "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
         "withoutCredentials": true,
-        "resourceClass": "large"
+        "resourceClass": "m1-medium"
       },
       "ios": {
         "simulator": true,

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
@@ -13,14 +13,18 @@
       }
     },
     "updates_testing": {
+      "env": {
+        "EX_UPDATES_NATIVE_DEBUG": "1"
+      },
       "android": {
-        "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
+        "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",
         "withoutCredentials": true,
         "resourceClass": "large"
       },
       "ios": {
         "simulator": true,
-        "resourceClass": "m1-medium"
+        "resourceClass": "m1-medium",
+        "buildConfiguration": "Debug"
       },
       "distribution": "internal",
       "buildArtifactPaths": ["logs/*.log"]

--- a/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/__tests__/fixtures/project_files/eas.json
@@ -14,7 +14,8 @@
     },
     "updates_testing": {
       "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1"
+        "EX_UPDATES_NATIVE_DEBUG": "1",
+        "NO_FLIPPER": "1"
       },
       "android": {
         "gradleCommand": ":app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug",

--- a/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
@@ -32,7 +32,7 @@ const runtimeVersion = '1.0.0';
 
   await initAsync(projectRoot, { repoRoot, runtimeVersion, localCliBin });
 
-  await setupBasicAppAsync(projectRoot);
+  await setupBasicAppAsync(projectRoot, localCliBin);
 
   // Build assets project as a subdirectory in the project
   const assetsProjectRoot = path.join(process.env.TEST_PROJECT_ROOT, 'updates-e2e');

--- a/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
+++ b/packages/expo-updates/e2e/__tests__/setup/create-eas-project-basic.js
@@ -8,6 +8,9 @@ const repoRoot = process.env.EXPO_REPO_ROOT;
 const workingDir = path.resolve(repoRoot, '..');
 const runtimeVersion = '1.0.0';
 
+// Useful for local testing
+const skipAssetTestApp = process.env.EXPO_SKIP_ASSET_TEST_APP === '1';
+
 /**
  *
  * This generates a project at the location TEST_PROJECT_ROOT,
@@ -33,6 +36,10 @@ const runtimeVersion = '1.0.0';
   await initAsync(projectRoot, { repoRoot, runtimeVersion, localCliBin });
 
   await setupBasicAppAsync(projectRoot, localCliBin);
+
+  if (skipAssetTestApp) {
+    return;
+  }
 
   // Build assets project as a subdirectory in the project
   const assetsProjectRoot = path.join(process.env.TEST_PROJECT_ROOT, 'updates-e2e');

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -172,13 +172,6 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
       }
     : {};
 
-  const metroDependencies = {
-    metro: '0.71.1',
-    'metro-config': '0.71.1',
-    'metro-react-native-babel-preset': '0.71.1',
-    'metro-source-map': '0.71.1',
-  };
-
   // Remove the default Expo dependencies from create-expo-app
   let packageJson = JSON.parse(await fs.readFile(path.join(projectRoot, 'package.json'), 'utf-8'));
   for (const dependencyName of expoDependencyNames) {
@@ -199,12 +192,10 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
     },
     devDependencies: {
       ...extraDevDependencies,
-      ...metroDependencies,
       ...packageJson.devDependencies,
     },
     resolutions: {
       ...expoResolutions,
-      ...metroDependencies,
       ...packageJson.resolutions,
     },
   };
@@ -279,7 +270,7 @@ function transformAppJsonForE2E(appJson, projectName, runtimeVersion) {
       name: projectName,
       owner: 'expo-ci',
       runtimeVersion,
-      jsEngine: 'jsc',
+      jsEngine: 'hermes',
       plugins: ['expo-updates', '@config-plugins/detox'],
       android: { ...appJson.expo.android, package: 'dev.expo.updatese2e' },
       ios: { ...appJson.expo.ios, bundleIdentifier: 'dev.expo.updatese2e' },

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -387,14 +387,21 @@ async function initAsync(
   // We are done with template tarball
   await fs.rm(localTemplatePathName);
 
-  // Prebuild mangles the package.json expo dependency, fix it
-  // const packageJsonPath = path.resolve(projectRoot, 'package.json');
-  // let packageJsonString = await fs.readFile(packageJsonPath, 'utf-8');
-  // const packageJson = JSON.parse(packageJsonString);
+  // For now, we need to force the expo dependency to SDK 47,
+  // otherwise the legacy Expo CLI will not create update bundles correctly
+  // This can be removed once SDK 48 is live
+  const packageJsonPath = path.resolve(projectRoot, 'package.json');
+  let packageJsonString = await fs.readFile(packageJsonPath, 'utf-8');
+  const packageJson = JSON.parse(packageJsonString);
   // packageJson.dependencies.expo = packageJson.resolutions.expo;
-  // packageJsonString = JSON.stringify(packageJson, null, 2);
-  // await fs.rm(packageJsonPath);
-  // await fs.writeFile(packageJsonPath, packageJsonString, 'utf-8');
+  packageJson.dependencies.expo = '47.0.12';
+  packageJsonString = JSON.stringify(packageJson, null, 2);
+  await fs.rm(packageJsonPath);
+  await fs.writeFile(packageJsonPath, packageJsonString, 'utf-8');
+  await spawnAsync('yarn', [], {
+    cwd: projectRoot,
+    stdio: 'inherit',
+  });
 
   // enable proguard on Android
   await fs.appendFile(

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -10,7 +10,6 @@ const expoDependencyNames = [
   '@expo/config-plugins',
   '@expo/config-types',
   '@expo/dev-server',
-  'expo-asset',
   'expo-application',
   'expo-constants',
   'expo-eas-client',

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -414,11 +414,12 @@ async function initAsync(
   // We are done with template tarball
   await fs.rm(localTemplatePathName);
 
-  // Restore expo dependency after prebuild
+  // Restore expo dependencies after prebuild
   const packageJsonPath = path.resolve(projectRoot, 'package.json');
   let packageJsonString = await fs.readFile(packageJsonPath, 'utf-8');
   const packageJson = JSON.parse(packageJsonString);
   packageJson.dependencies.expo = packageJson.resolutions.expo;
+  packageJson.dependencies['expo-splash-screen'] = packageJson.resolutions['expo-splash-screen'];
   packageJsonString = JSON.stringify(packageJson, null, 2);
   await fs.rm(packageJsonPath);
   await fs.writeFile(packageJsonPath, packageJsonString, 'utf-8');

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -32,6 +32,11 @@ const expoDependencyNames = [
 const expoResolutions = {};
 const expoVersions = {};
 
+/**
+ * Executes `npm pack` on one of the Expo packages used in updates E2E
+ * Adds a dateTime stamp to the version to ensure that it is unique and that
+ * only this version will be used when yarn installs dependencies in the test app.
+ */
 async function packExpoDependency(repoRoot, projectRoot, destPath, dependencyName) {
   // Pack up the named Expo package into the destination folder
   const dependencyComponents = dependencyName.split('/');
@@ -128,6 +133,9 @@ async function copyCommonFixturesToProject(projectRoot, appJsFileName) {
   await fs.rm(projectFilesTarballPath);
 }
 
+/**
+ * Adds all the dependencies and other properties needed for the E2E test app
+ */
 async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
   // Create the project subfolder to hold NPM tarballs built from the current state of the repo
   const dependenciesPath = path.join(projectRoot, 'dependencies');
@@ -204,6 +212,10 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
   await fs.writeFile(path.join(projectRoot, 'package.json'), packageJsonString, 'utf-8');
 }
 
+/**
+ * Adds Detox modules to both iOS and Android expo-updates code.
+ * Returns a function that cleans up these changes to the repo once E2E setup is complete
+ */
 async function prepareLocalUpdatesModule(repoRoot) {
   // copy UpdatesE2ETest exported module into the local package
   const iosE2ETestModuleHPath = path.join(
@@ -286,6 +298,9 @@ async function prepareLocalUpdatesModule(repoRoot) {
   };
 }
 
+/**
+ * Modifies app.json in the E2E test app to add the properties we need
+ */
 function transformAppJsonForE2E(appJson, projectName, runtimeVersion) {
   return {
     ...appJson,
@@ -460,6 +475,13 @@ async function createUpdateBundleAsync(projectRoot, localCliBin) {
   });
 }
 
+/**
+ * Originally, the E2E tests would directly modify the text of the minified JS in update bundles
+ * when testing to make sure that the correct update was applied.
+ *
+ * Since Hermes bundles are bytecode and not readable JS, we instead pre-generate Hermes bundles
+ * corresponding to each test case, and save them in the `test-update-bundles` directory in the test app.
+ */
 async function createTestUpdateBundles(projectRoot, localCliBin, notifyStrings) {
   const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
   await fs.rm(testUpdateBundlesPath, { recursive: true, force: true });

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -541,6 +541,9 @@ async function setupAssetsAppAsync(projectRoot, localCliBin) {
   // export update for test server to host
   await createUpdateBundleAsync(projectRoot, localCliBin);
 
+  // create test bundles with different notify strings
+  await createTestUpdateBundles(projectRoot, localCliBin, ['test-assets-1']);
+
   // move exported update to "updates" directory for EAS testing
   await fs.rename(path.join(projectRoot, 'dist'), path.join(projectRoot, 'updates'));
 

--- a/packages/expo-updates/e2e/__tests__/setup/project.js
+++ b/packages/expo-updates/e2e/__tests__/setup/project.js
@@ -6,10 +6,11 @@ const path = require('path');
 const dirName = __dirname; /* eslint-disable-line */
 
 const expoDependencyNames = [
-  'expo',
+  // 'expo',
   '@expo/config-plugins',
   '@expo/config-types',
   '@expo/dev-server',
+  'expo-asset',
   'expo-application',
   'expo-constants',
   'expo-eas-client',
@@ -388,13 +389,13 @@ async function initAsync(
   await fs.rm(localTemplatePathName);
 
   // Prebuild mangles the package.json expo dependency, fix it
-  const packageJsonPath = path.resolve(projectRoot, 'package.json');
-  let packageJsonString = await fs.readFile(packageJsonPath, 'utf-8');
-  const packageJson = JSON.parse(packageJsonString);
-  packageJson.dependencies.expo = packageJson.resolutions.expo;
-  packageJsonString = JSON.stringify(packageJson, null, 2);
-  await fs.rm(packageJsonPath);
-  await fs.writeFile(packageJsonPath, packageJsonString, 'utf-8');
+  // const packageJsonPath = path.resolve(projectRoot, 'package.json');
+  // let packageJsonString = await fs.readFile(packageJsonPath, 'utf-8');
+  // const packageJson = JSON.parse(packageJsonString);
+  // packageJson.dependencies.expo = packageJson.resolutions.expo;
+  // packageJsonString = JSON.stringify(packageJson, null, 2);
+  // await fs.rm(packageJsonPath);
+  // await fs.writeFile(packageJsonPath, packageJsonString, 'utf-8');
 
   // enable proguard on Android
   await fs.appendFile(


### PR DESCRIPTION
# Why and How

- Switch E2E tests to use Hermes
- Remove metro dependencies needed for 0.71.0
- Discontinue use of deprecated global Expo CLI
- Generate test bundles ahead of time
- Test with both debug and release builds
- Do some refactoring and cleanup

# Test Plan

- Updates E2E should pass in CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
