### PR TITLE
feat: support Hermes debugger on native when Metro web is running.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Support Hermes debugger on native when Metro web is running.
 - Skip uninstalling Expo Go when running in UNVERSIONED (internal). ([#20754](https://github.com/expo/expo/pull/20754) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Support Hermes debugger on native when Metro web is running.
+- Support Hermes debugger on native when Metro web is running. ([#21068](https://github.com/expo/expo/pull/21068) by [@EvanBacon](https://github.com/EvanBacon))
 - Skip uninstalling Expo Go when running in UNVERSIONED (internal). ([#20754](https://github.com/expo/expo/pull/20754) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -73,8 +73,13 @@ export class DevServerManagerActions {
       );
       return;
     }
-    for (const app of apps) {
-      openJsInspector(app);
+    try {
+      for (const app of apps) {
+        await openJsInspector(app);
+      }
+    } catch (error: any) {
+      Log.error('Failed to open JavaScript inspector. This is often an issue with Google Chrome.');
+      Log.exception(error);
     }
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
@@ -1,6 +1,35 @@
 import { parsePlatformHeader } from './resolvePlatform';
 import { ServerNext, ServerRequest, ServerResponse } from './server.types';
 
+const debug = require('debug')('expo:start:server:metro:historyFallback') as typeof console.log;
+
+const WS_DEVICE_URL = '/inspector/device';
+const WS_DEBUGGER_URL = '/inspector/debug';
+const PAGES_LIST_JSON_URL = '/json';
+const PAGES_LIST_JSON_URL_2 = '/json/list';
+const PAGES_LIST_JSON_VERSION_URL = '/json/version';
+
+export function isInspectorProxyRequest(req: ServerRequest) {
+  const ua = req.headers['user-agent'];
+  const url = req.url;
+
+  // This check is very fragile but it enables websites to use any of the
+  // endpoints below without triggering the inspector proxy.
+  if (!url || (ua && !ua.includes('node-fetch'))) {
+    // This optimizes for the inspector working over the endpoint being available on web.
+    // Web is less fragile.
+    return false;
+  }
+
+  return [
+    WS_DEVICE_URL,
+    WS_DEBUGGER_URL,
+    PAGES_LIST_JSON_URL,
+    PAGES_LIST_JSON_URL_2,
+    PAGES_LIST_JSON_VERSION_URL,
+  ].includes(url);
+}
+
 /**
  * Create a web-only middleware which redirects to the index middleware without losing the path component.
  * This is useful for things like React Navigation which need to render the index.html and then direct the user in-memory.
@@ -18,6 +47,10 @@ export class HistoryFallbackMiddleware {
       const platform = parsePlatformHeader(req);
 
       if (!platform || platform === 'web') {
+        if (isInspectorProxyRequest(req)) {
+          debug('Inspector proxy request:', req.url, 'UA:', req.headers['user-agent']);
+          return next();
+        }
         // Redirect unknown to the manifest handler while preserving the path.
         // This implements the HTML5 history fallback API.
         return this.indexMiddleware(req, res, next);

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
@@ -1,7 +1,65 @@
-import { HistoryFallbackMiddleware } from '../HistoryFallbackMiddleware';
+import { HistoryFallbackMiddleware, isInspectorProxyRequest } from '../HistoryFallbackMiddleware';
 import { ServerRequest } from '../server.types';
 
 const asRequest = (req: Partial<ServerRequest>) => req as ServerRequest;
+
+describe(isInspectorProxyRequest, () => {
+  it(`return true for no UA + known inspector endpoint`, () => {
+    expect(
+      isInspectorProxyRequest(
+        asRequest({
+          url: '/inspector/debug',
+          headers: {},
+        })
+      )
+    ).toBe(true);
+  });
+  it(`return true for node-fetch user-agent + known inspector endpoint`, () => {
+    expect(
+      isInspectorProxyRequest(
+        asRequest({
+          url: '/json/list',
+          headers: {
+            'user-agent': 'node-fetch',
+          },
+        })
+      )
+    ).toBe(true);
+  });
+  it(`return false for browser user-agent + known inspector endpoint`, () => {
+    expect(
+      isInspectorProxyRequest(
+        asRequest({
+          url: '/json/list',
+          headers: {
+            'user-agent':
+              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+          },
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+it(`skips requests to the Metro inspector proxy`, () => {
+  const indexMiddleware = jest.fn();
+  const middleware = new HistoryFallbackMiddleware(indexMiddleware).getHandler();
+
+  const next = jest.fn();
+  middleware(
+    asRequest({
+      url: '/json/list',
+      headers: {
+        'user-agent': 'node-fetch',
+      },
+    }),
+    {} as any,
+    next
+  );
+  // Redirects to middleware with URL intact.
+  expect(indexMiddleware).toBeCalledTimes(0);
+  expect(next).toBeCalledTimes(1);
+});
 
 it(`redirects to provided middleware on web with query parameter`, () => {
   const indexMiddleware = jest.fn();

--- a/packages/@expo/dev-server/src/middleware/createJsInspectorMiddleware.ts
+++ b/packages/@expo/dev-server/src/middleware/createJsInspectorMiddleware.ts
@@ -36,7 +36,19 @@ export default function createJsInspectorMiddleware(): NextHandleFunction {
       });
       res.end(data);
     } else if (req.method === 'POST' || req.method === 'PUT') {
-      openJsInspector(app);
+      try {
+        await openJsInspector(app);
+      } catch (error: any) {
+        // abort(Error: Command failed: osascript -e POSIX path of (path to application "google chrome")
+        // 15:50: execution error: Google Chrome got an error: Application isn’t running. (-600)
+
+        console.error(
+          chalk.red('Error launching JS inspector: ' + (error?.message ?? 'Unknown error occurred'))
+        );
+        res.writeHead(500);
+        res.end();
+        return;
+      }
       res.end();
     } else {
       res.writeHead(405);


### PR DESCRIPTION
# Why

Hermes debugger doesn't work when Metro web is enabled because the endpoints are being intercepted by the history fallback middleware.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Detect inspector proxy requests and skip returning the index.html.
- Add better error handling for Apple script failing to launch Chrome (which can sometimes happen when using chrome for web).

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added tests for endpoint logic
- `npx create-react-native-app -t with-router` `expo.jsEngine: hermes` -> open ios -> press `j` -> doesn't fail.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
