### PR TITLE
Avoid using rawManifestJson in RTL support

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -269,7 +269,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (bool)_readSupportsRTLFromManifest:(EXManifestsManifest *)manifest
 {
-  return [[[[manifest rawManifestJSON] valueForKey:@"extra"] valueForKey: @"supportsRTL"] boolValue];
+  return [[[[manifest expoClientConfigRootObject] valueForKey:@"extra"] valueForKey: @"supportsRTL"] boolValue];
 }
 
 - (void)appStateDidBecomeActive


### PR DESCRIPTION
# Why

A tiny change to fix reading the key from the `manifest` extra field.
