### PR TITLE
[docs] fix 404 on iOS push notification setup link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -263,7 +263,7 @@ Firebase Cloud Messaging credentials are required for all Android apps to receiv
 
 #### iOS
 
-To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](push-notifications/push-notifications-setup/#ios).
+To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](/push-notifications/push-notifications-setup/#ios).
 
 ### Expo config
 

--- a/docs/pages/versions/v45.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v45.0.0/sdk/notifications.mdx
@@ -170,7 +170,7 @@ Firebase Cloud Messaging credentials are required for all Android apps to receiv
 
 #### iOS
 
-To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](push-notifications/push-notifications-setup/#ios).
+To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](/push-notifications/push-notifications-setup/#ios).
 
 ### Expo config
 

--- a/docs/pages/versions/v46.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/notifications.mdx
@@ -170,7 +170,7 @@ Firebase Cloud Messaging credentials are required for all Android apps to receiv
 
 #### iOS
 
-To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](push-notifications/push-notifications-setup/#ios).
+To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](/push-notifications/push-notifications-setup/#ios).
 
 ### Expo config
 

--- a/docs/pages/versions/v47.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/notifications.mdx
@@ -170,7 +170,7 @@ Firebase Cloud Messaging credentials are required for all Android apps to receiv
 
 #### iOS
 
-To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](push-notifications/push-notifications-setup/#ios).
+To register your iOS device and automatically enable push notifications for your EAS Build, see [push notification setup](/push-notifications/push-notifications-setup/#ios).
 
 ### Expo config
 


### PR DESCRIPTION
# Why

<img width="765" alt="image" src="https://user-images.githubusercontent.com/8053974/216701227-e704c29d-a7ff-423d-b972-298b492a6d99.png">

This link (on `versions/[whatever]/sdk/notifications/`) was 404-ing, because it was trying to route within the SDK docs

# How

Added a slash

# Test Plan

Tried the link, it worked.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
