### PR TITLE
[ncl] Add example with a list of GIFs

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageGifsScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageGifsScreen.tsx
@@ -1,0 +1,65 @@
+import { Image } from 'expo-image';
+import { Dimensions, ScrollView, StyleSheet, View } from 'react-native';
+
+const GIF_SOURCES = [
+  'https://media2.giphy.com/media/Q6WPVzFU8LcBWWgQE1/giphy.gif',
+  'https://media3.giphy.com/media/cfuL5gqFDreXxkWQ4o/giphy.gif',
+  'https://media3.giphy.com/media/l3q2AMoPRflHphYM8/giphy.gif',
+  'https://media4.giphy.com/media/IXqRaInRqGMfK/giphy.gif',
+  'https://media1.giphy.com/media/HMSLfCl5BsXoQ/giphy.gif',
+  'https://media1.giphy.com/media/YRtLgsajXrz1FNJ6oy/giphy.gif',
+  'https://media1.giphy.com/media/1HKaikaFqDt7i/giphy.gif',
+  'https://media2.giphy.com/media/5tSvsYJl4T4fC/giphy.gif',
+  'https://media1.giphy.com/media/5aCiXMnPl1cli/giphy.gif',
+  'https://media1.giphy.com/media/rgAd7jWyJyo8M/giphy.gif',
+  'https://media2.giphy.com/media/11quO2C07Sh2oM/giphy.gif',
+  'https://media1.giphy.com/media/BTWVWzYoNyYzm/giphy.gif',
+  'https://media4.giphy.com/media/12HZukMBlutpoQ/giphy.gif',
+  'https://media1.giphy.com/media/13CoXDiaCcCoyk/giphy.gif',
+  'https://media4.giphy.com/media/jTnGaiuxvvDNK/giphy.gif',
+  'https://media1.giphy.com/media/3o6Zt481isNVuQI1l6/giphy.gif',
+  'https://media3.giphy.com/media/l0ExdMHUDKteztyfe/giphy.gif',
+  'https://media4.giphy.com/media/5gXYzsVBmjIsw/giphy.gif',
+];
+
+const ITEMS_GAP = 12;
+const COLUMNS_COUNT = 3;
+
+const WINDOW_SIZE = Dimensions.get('window');
+const IMAGE_SIZE = Math.ceil((WINDOW_SIZE.width - ITEMS_GAP * (COLUMNS_COUNT + 1)) / COLUMNS_COUNT);
+
+function renderRow(_: any, row: number) {
+  function renderImage(_: any, column: number) {
+    const gifIndex = row * COLUMNS_COUNT + column;
+    const uri = GIF_SOURCES[gifIndex];
+
+    return <Image key={column} style={styles.image} source={uri} cachePolicy="none" />;
+  }
+
+  return (
+    <View key={row} style={styles.row}>
+      {Array(COLUMNS_COUNT).fill(0).map(renderImage)}
+    </View>
+  );
+}
+
+export default function ImageGifsScreen() {
+  const rowsCount = Math.ceil(GIF_SOURCES.length / COLUMNS_COUNT);
+
+  return <ScrollView>{Array(rowsCount).fill(0).map(renderRow)}</ScrollView>;
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: ITEMS_GAP,
+    marginTop: ITEMS_GAP,
+    paddingHorizontal: ITEMS_GAP,
+  },
+  image: {
+    flex: 1,
+    height: IMAGE_SIZE,
+    borderRadius: 12,
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -83,6 +83,13 @@ export const ImageScreens = [
       return optionalRequire(() => require('./ImageCacheKeyScreen'));
     },
   },
+  {
+    name: 'List of GIFs',
+    route: 'image/gifs',
+    getComponent() {
+      return optionalRequire(() => require('./ImageGifsScreen'));
+    },
+  },
 ];
 
 if (Platform.OS === 'ios') {


### PR DESCRIPTION
# Why

Rendering GIFs is a bit more problematic – they consume a lot of memory if not downscaled, but downscaling may take more time because each frame is downscaled separately. With a separate example rendering many GIFs we can easily detect some unexpected behavior (no UI freezes, no out of memory crashes).

# How

Added a new demo screen with a list of GIFs from Giphy

> **Note**
> In the future, when needed, we can easily add a switch to change between `.gif` and `.webp` extension as Giphy supports both under the same rest part of the URL

# Test Plan

![IMG_8EBB71300F17-1](https://user-images.githubusercontent.com/1714764/216731918-9a539ccd-f76a-415a-861b-31ca524429d3.jpg)
