### PR TITLE
[image][ios] Process images concurrently off the main thread

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed possible freezes by processing images concurrently off the main thread. ([#21086](https://github.com/expo/expo/pull/21086) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 1.0.0-beta.5 — 2023-02-03

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -93,11 +93,11 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
 /**
  Resizes the animated image to fit in the given size and scale.
  */
-func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) -> UIImage {
+func resize(animatedImage image: UIImage, toSize size: CGSize, scale: Double) async -> UIImage {
   // For animated images, the `images` member is non-nil and represents an array of animation frames.
   if let images = image.images {
     // Resize each animation frame separately.
-    let resizedImages = images.map { image in
+    let resizedImages = await concurrentMap(images) { image in
       return resize(image: image, toSize: size, scale: scale)
     }
 
@@ -189,4 +189,39 @@ extension CGSize {
 func makeNSError(description: String) -> NSError {
   let userInfo = [NSLocalizedDescriptionKey: description]
   return NSError(domain: "expo.modules.image", code: 0, userInfo: userInfo)
+}
+
+// MARK: - Async helpers
+// TODO: Add helpers like these to the modules core eventually
+
+/**
+ Asynchronously maps the given sequence (sequentially).
+ */
+func asyncMap<ItemsType: Sequence, ResultType>(
+  _ items: ItemsType,
+  _ transform: (ItemsType.Element) async throws -> ResultType
+) async rethrows -> [ResultType] {
+  var values = [ResultType]()
+
+  for item in items {
+    try await values.append(transform(item))
+  }
+  return values
+}
+
+/**
+ Concurrently maps the given sequence.
+ */
+func concurrentMap<ItemsType: Sequence, ResultType>(
+  _ items: ItemsType,
+  _ transform: @escaping (ItemsType.Element) async throws -> ResultType
+) async rethrows -> [ResultType] {
+  let tasks = items.map { item in
+    Task {
+      try await transform(item)
+    }
+  }
+  return try await asyncMap(tasks) { task in
+    try await task.value
+  }
 }

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -197,10 +197,13 @@ public final class ImageView: ExpoView {
         scale: scale,
         contentFit: contentFit
       ).rounded(.up)
-      let image = processImage(image, idealSize: idealSize, scale: scale)
 
-      applyContentPosition(contentSize: idealSize, containerSize: frame.size)
-      renderImage(image)
+      Task {
+        let image = await processImage(image, idealSize: idealSize, scale: scale)
+
+        applyContentPosition(contentSize: idealSize, containerSize: frame.size)
+        renderImage(image)
+      }
     } else {
       displayPlaceholderIfNecessary()
     }
@@ -295,13 +298,13 @@ public final class ImageView: ExpoView {
     return SDImagePipelineTransformer(transformers: transformers)
   }
 
-  private func processImage(_ image: UIImage?, idealSize: CGSize, scale: Double) -> UIImage? {
+  private func processImage(_ image: UIImage?, idealSize: CGSize, scale: Double) async -> UIImage? {
     guard let image = image, !bounds.isEmpty else {
       return nil
     }
     // Downscale the image only when necessary
     if shouldDownscale(image: image, toSize: idealSize, scale: scale) {
-      return resize(animatedImage: image, toSize: idealSize, scale: scale)
+      return await resize(animatedImage: image, toSize: idealSize, scale: scale)
     }
     return image
   }


### PR DESCRIPTION
# Why

The UI might be freezing when showing many animated images at the same time. Opening the example added in #21085 caused a one-second freeze for me on iOS and that was also reported by the user on Discord.

# How

Used new Swift concurrency to run image processing concurrently and off the main thread

# Test Plan

- Example added in #21085 no longer freezes the UI on iOS
- Other examples with animated HEIC and WebP seem to render faster too