### PR TITLE
[docs] Fix doc about building apk on EAS build

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -12,8 +12,8 @@ The default file format used when building Android apps with EAS Build is an [An
 To generate an **.apk**, modify the [**eas.json**](/build/eas-json.mdx) by adding one of the following properties in a build profile:
 
 - `developmentClient` to `true` (**default**)
-- `buildType` to `apk`
-- `gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces **.apk**
+- `android.buildType` to `apk`
+- `android.gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces **.apk**
 
 ```json eas.json
 {


### PR DESCRIPTION
# Why

This tripped me up recently (I put the fields top-level).

Closes ENG-7476.

# How

Specify that these are nested fields.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
