### PR TITLE
[file-system][ios] Add utf-8 uri support

### DIFF
--- a/apps/native-component-list/src/screens/FileSystemScreen.tsx
+++ b/apps/native-component-list/src/screens/FileSystemScreen.tsx
@@ -233,6 +233,23 @@ export default class FileSystemScreen extends React.Component<object, State> {
     }
   };
 
+  _createUTF8Uri = async () => {
+    const folderName = '中文';
+    const folderUri = FileSystem.documentDirectory + folderName;
+
+    const dirInfo = await FileSystem.getInfoAsync(folderUri);
+    if (dirInfo.exists) {
+      await FileSystem.deleteAsync(folderUri);
+    }
+
+    await FileSystem.makeDirectoryAsync(folderUri);
+    const newDirInfo = await FileSystem.getInfoAsync(folderUri);
+
+    if (newDirInfo.exists && newDirInfo.isDirectory) {
+      alert(`${folderName} directory was successfully created`);
+    }
+  };
+
   _alertFreeSpace = async () => {
     const freeBytes = await FileSystem.getFreeDiskStorageAsync();
     alert(`${Math.round(freeBytes / 1024 / 1024)} MB available`);
@@ -335,6 +352,7 @@ export default class FileSystemScreen extends React.Component<object, State> {
         <ListButton onPress={this._readAsset} title="Read Asset" />
         <ListButton onPress={this._getInfoAsset} title="Get Info Asset" />
         <ListButton onPress={this._copyAndReadAsset} title="Copy and Read Asset" />
+        <ListButton onPress={this._createUTF8Uri} title="Create UTF-8 uri" />
         <ListButton onPress={this._alertFreeSpace} title="Alert free space" />
         {Platform.OS === 'android' && (
           <>

--- a/ios/versioned/sdk48/EXFileSystem/EXFileSystem/ABI48_0_0EXFileSystem.m
+++ b/ios/versioned/sdk48/EXFileSystem/EXFileSystem/ABI48_0_0EXFileSystem.m
@@ -179,11 +179,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(getInfoAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-  // no scheme provided in uri, handle as a local path and add 'file://' scheme
-  if (!uri.scheme) {
-    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
-  }
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],
@@ -208,11 +204,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(readAsStringAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-  // no scheme provided in uri, handle as a local path and add 'file://' scheme
-  if (!uri.scheme) {
-    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
-  }
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],
@@ -275,7 +267,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(writeAsStringAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't writable.", uri],
@@ -335,7 +327,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(deleteAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:[uri URLByAppendingPathComponent:@".."]] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't deletable.", uri],
@@ -472,7 +464,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(makeDirectoryAsync,
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
 
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Directory '%@' could not be created because the location isn't writable.", uri],
@@ -505,7 +497,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString] isDirectory:true];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't readable.", uri],
@@ -538,7 +530,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(downloadAsync,
                                 rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUri = [NSURL URLWithString:[localUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *localUri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:localUriString]];
   if (!([self checkIfFileDirExists:localUri.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", localUriString, [localUri.path stringByDeletingLastPathComponent]],
@@ -635,7 +627,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(uploadTaskStartAsync,
                                                options:(NSDictionary *)options
                                               rejecter:(ABI48_0_0EXPromiseRejectBlock)reject
 {
-  NSURL *fileUri = [NSURL URLWithString:[fileUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *fileUri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:fileUriString]];
   NSString *httpMethod = options[@"httpMethod"];
   ABI48_0_0EXFileSystemUploadType type = [self _getUploadTypeFrom:options[@"uploadType"]];
   if (![fileUri.scheme isEqualToString:@"file"]) {
@@ -702,7 +694,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
                                               rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUrl = [NSURL URLWithString:[fileUri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *localUrl = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:fileUri]];
   if (!([self checkIfFileDirExists:localUrl.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", fileUri, [localUrl.path stringByDeletingLastPathComponent]],
@@ -1010,6 +1002,15 @@ ABI48_0_0EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyn
 {
   NSString *dir = [path stringByDeletingLastPathComponent];
   return [self _checkIfFileExists:dir];
+}
+
+- (NSString *)removeFileSchemefromURIString:(NSString *)path
+{
+  if ([path hasPrefix:@"file:///"]) {
+    return [path substringFromIndex:7];
+  }
+
+  return [path copy];
 }
 
 #pragma mark - Class methods

--- a/ios/versioned/sdk48/EXFileSystem/EXFileSystem/ABI48_0_0EXFileSystem.m
+++ b/ios/versioned/sdk48/EXFileSystem/EXFileSystem/ABI48_0_0EXFileSystem.m
@@ -179,7 +179,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(getInfoAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
   if (!uri.scheme) {
     uri = [NSURL fileURLWithPath:uriString isDirectory:false];
@@ -208,7 +208,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(readAsStringAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
   if (!uri.scheme) {
     uri = [NSURL fileURLWithPath:uriString isDirectory:false];
@@ -275,7 +275,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(writeAsStringAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't writable.", uri],
@@ -335,7 +335,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(deleteAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:[uri URLByAppendingPathComponent:@".."]] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't deletable.", uri],
@@ -472,7 +472,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(makeDirectoryAsync,
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
 
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Directory '%@' could not be created because the location isn't writable.", uri],
@@ -505,7 +505,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     resolver:(ABI48_0_0EXPromiseResolveBlock)resolve
                     rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & ABI48_0_0EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't readable.", uri],
@@ -538,7 +538,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(downloadAsync,
                                 rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUri = [NSURL URLWithString:localUriString];
+  NSURL *localUri = [NSURL URLWithString:[localUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self checkIfFileDirExists:localUri.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", localUriString, [localUri.path stringByDeletingLastPathComponent]],
@@ -635,7 +635,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(uploadTaskStartAsync,
                                                options:(NSDictionary *)options
                                               rejecter:(ABI48_0_0EXPromiseRejectBlock)reject
 {
-  NSURL *fileUri = [NSURL URLWithString:fileUriString];
+  NSURL *fileUri = [NSURL URLWithString:[fileUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   NSString *httpMethod = options[@"httpMethod"];
   ABI48_0_0EXFileSystemUploadType type = [self _getUploadTypeFrom:options[@"uploadType"]];
   if (![fileUri.scheme isEqualToString:@"file"]) {
@@ -702,7 +702,7 @@ ABI48_0_0EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
                                               rejecter:(ABI48_0_0EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUrl = [NSURL URLWithString:fileUri];
+  NSURL *localUrl = [NSURL URLWithString:[fileUri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self checkIfFileDirExists:localUrl.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", fileUri, [localUrl.path stringByDeletingLastPathComponent]],

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add utf-8 uri support on iOS. ([#21098](https://github.com/expo/expo/pull/21098) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 15.2.0 — 2023-02-03

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -179,11 +179,7 @@ EX_EXPORT_METHOD_AS(getInfoAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-  // no scheme provided in uri, handle as a local path and add 'file://' scheme
-  if (!uri.scheme) {
-    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
-  }
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],
@@ -208,11 +204,7 @@ EX_EXPORT_METHOD_AS(readAsStringAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
-  // no scheme provided in uri, handle as a local path and add 'file://' scheme
-  if (!uri.scheme) {
-    uri = [NSURL fileURLWithPath:uriString isDirectory:false];
-  }
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't readable.", uri],
@@ -275,7 +267,7 @@ EX_EXPORT_METHOD_AS(writeAsStringAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't writable.", uri],
@@ -335,7 +327,7 @@ EX_EXPORT_METHOD_AS(deleteAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:[uri URLByAppendingPathComponent:@".."]] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't deletable.", uri],
@@ -472,7 +464,7 @@ EX_EXPORT_METHOD_AS(makeDirectoryAsync,
                     rejecter:(EXPromiseRejectBlock)reject)
 {
 
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Directory '%@' could not be created because the location isn't writable.", uri],
@@ -505,7 +497,7 @@ EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *uri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:uriString] isDirectory:true];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't readable.", uri],
@@ -538,7 +530,7 @@ EX_EXPORT_METHOD_AS(downloadAsync,
                                 rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUri = [NSURL URLWithString:[localUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *localUri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:localUriString]];
   if (!([self checkIfFileDirExists:localUri.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", localUriString, [localUri.path stringByDeletingLastPathComponent]],
@@ -635,7 +627,7 @@ EX_EXPORT_METHOD_AS(uploadTaskStartAsync,
                                                options:(NSDictionary *)options
                                               rejecter:(EXPromiseRejectBlock)reject
 {
-  NSURL *fileUri = [NSURL URLWithString:[fileUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *fileUri = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:fileUriString]];
   NSString *httpMethod = options[@"httpMethod"];
   EXFileSystemUploadType type = [self _getUploadTypeFrom:options[@"uploadType"]];
   if (![fileUri.scheme isEqualToString:@"file"]) {
@@ -702,7 +694,7 @@ EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
                                               rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUrl = [NSURL URLWithString:[fileUri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
+  NSURL *localUrl = [NSURL fileURLWithPath:[self removeFileSchemefromURIString:fileUri]];
   if (!([self checkIfFileDirExists:localUrl.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", fileUri, [localUrl.path stringByDeletingLastPathComponent]],
@@ -1010,6 +1002,15 @@ EX_EXPORT_METHOD_AS(getTotalDiskCapacityAsync, getTotalDiskCapacityAsyncWithReso
 {
   NSString *dir = [path stringByDeletingLastPathComponent];
   return [self _checkIfFileExists:dir];
+}
+
+- (NSString *)removeFileSchemefromURIString:(NSString *)path
+{
+  if ([path hasPrefix:@"file:///"]) {
+    return [path substringFromIndex:7];
+  }
+
+  return [path copy];
 }
 
 #pragma mark - Class methods

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -179,7 +179,7 @@ EX_EXPORT_METHOD_AS(getInfoAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
   if (!uri.scheme) {
     uri = [NSURL fileURLWithPath:uriString isDirectory:false];
@@ -208,7 +208,7 @@ EX_EXPORT_METHOD_AS(readAsStringAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   // no scheme provided in uri, handle as a local path and add 'file://' scheme
   if (!uri.scheme) {
     uri = [NSURL fileURLWithPath:uriString isDirectory:false];
@@ -275,7 +275,7 @@ EX_EXPORT_METHOD_AS(writeAsStringAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"File '%@' isn't writable.", uri],
@@ -335,7 +335,7 @@ EX_EXPORT_METHOD_AS(deleteAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:[uri URLByAppendingPathComponent:@".."]] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't deletable.", uri],
@@ -472,7 +472,7 @@ EX_EXPORT_METHOD_AS(makeDirectoryAsync,
                     rejecter:(EXPromiseRejectBlock)reject)
 {
 
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionWrite)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Directory '%@' could not be created because the location isn't writable.", uri],
@@ -505,7 +505,7 @@ EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURL *uri = [NSURL URLWithString:uriString];
+  NSURL *uri = [NSURL URLWithString:[uriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self permissionsForURI:uri] & EXFileSystemPermissionRead)) {
     reject(@"ERR_FILESYSTEM_NO_PERMISSIONS",
            [NSString stringWithFormat:@"Location '%@' isn't readable.", uri],
@@ -538,7 +538,7 @@ EX_EXPORT_METHOD_AS(downloadAsync,
                                 rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUri = [NSURL URLWithString:localUriString];
+  NSURL *localUri = [NSURL URLWithString:[localUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self checkIfFileDirExists:localUri.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", localUriString, [localUri.path stringByDeletingLastPathComponent]],
@@ -635,7 +635,7 @@ EX_EXPORT_METHOD_AS(uploadTaskStartAsync,
                                                options:(NSDictionary *)options
                                               rejecter:(EXPromiseRejectBlock)reject
 {
-  NSURL *fileUri = [NSURL URLWithString:fileUriString];
+  NSURL *fileUri = [NSURL URLWithString:[fileUriString stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   NSString *httpMethod = options[@"httpMethod"];
   EXFileSystemUploadType type = [self _getUploadTypeFrom:options[@"uploadType"]];
   if (![fileUri.scheme isEqualToString:@"file"]) {
@@ -702,7 +702,7 @@ EX_EXPORT_METHOD_AS(downloadResumableStartAsync,
                                               rejecter:(EXPromiseRejectBlock)reject)
 {
   NSURL *url = [NSURL URLWithString:urlString];
-  NSURL *localUrl = [NSURL URLWithString:fileUri];
+  NSURL *localUrl = [NSURL URLWithString:[fileUri stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
   if (!([self checkIfFileDirExists:localUrl.path])) {
     reject(@"ERR_FILESYSTEM_WRONG_DESTINATION",
            [NSString stringWithFormat:@"Directory for '%@' doesn't exist. Please make sure directory '%@' exists before calling downloadAsync.", fileUri, [localUrl.path stringByDeletingLastPathComponent]],


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/10476

# How

This PR updates all iOS local uri instances (NSURL) to parse them using percent-encoded characters when necessary, that way we're able to support paths like `fs.documentDirectory + "中文"`. This also updates 



# Test Plan

Added a new `Create UTF-8 uri` button to NCL so we can test this 

https://user-images.githubusercontent.com/11707729/217058407-3ff04176-2b72-43f9-803c-6a097f0a79ee.mov

 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
