### PR TITLE
[android] fix expo go build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 📚 3rd party library updates
 
-- Updated `@stripe/stripe-react-native` from `0.19.0` to `0.23.1`. ([#20964](https://github.com/expo/expo/pull/20964) by [@aleqsio](https://github.com/aleqsio))
+- Updated `@stripe/stripe-react-native` from `0.19.0` to `0.23.3`. ([#20964](https://github.com/expo/expo/pull/20964) by [@aleqsio](https://github.com/aleqsio), [#21117](https://github.com/expo/expo/pull/21117) by [@kudo](https://github.com/kudo))
 - Updated `react-native-webview` from `11.23.1` to `11.26.0`. ([#20933](https://github.com/expo/expo/pull/20933) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-gesture-handler` from `2.8.0` to `2.9.0`. ([#20930](https://github.com/expo/expo/pull/20930) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-shared-element` from `0.8.4` to `0.8.7`. ([#20593](https://github.com/expo/expo/pull/20593) by [@ijzerenhein](https://github.com/ijzerenhein))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     dbFlowVersion = '4.2.4'
     buildToolsVersion = '33.0.0'
-    kotlinVersion = '1.6.10'
+    kotlinVersion = '1.8.10'
     gradlePluginVersion = '7.3.1'
     gradleDownloadTaskVersion = '5.0.1'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
@@ -100,10 +100,6 @@ allprojects {
         .because("Building React Native from source")
     }
     // WHEN_DISTRIBUTING_REMOVE_TO_HERE
-
-    // Newer androidx.annotation:annotation use kotlin 1.8, we should stick on old version.
-    // Remove this when we upgrade kotlin to 1.8
-    resolutionStrategy.force("androidx.annotation:annotation:1.4.0")
   }
 }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/FinancialConnectionsSheetFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.*
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.createError
@@ -69,7 +69,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
       }
       is FinancialConnectionsSheetForTokenResult.Completed -> {
         promise.resolve(createTokenResult(result))
-        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
+        (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
       }
     }
   }
@@ -92,7 +92,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
               it.putMap("session", mapFromSession(result.financialConnectionsSession))
             }
         )
-        (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
+        (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.beginTransaction()?.remove(this)?.commitAllowingStateLoss()
       }
     }
   }
@@ -107,7 +107,7 @@ class FinancialConnectionsSheetFragment : Fragment() {
       stripeAccountId = stripeAccountId,
     )
 
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     } ?: run {
@@ -116,13 +116,13 @@ class FinancialConnectionsSheetFragment : Fragment() {
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayLauncherFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.*
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.createError
@@ -57,7 +57,7 @@ class GooglePayLauncherFragment : Fragment() {
       allowCreditCards = googlePayParams.getBooleanOr("allowCreditCards", true),
     )
 
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     } ?: run {
@@ -66,13 +66,13 @@ class GooglePayLauncherFragment : Fragment() {
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayRequestHelper.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/GooglePayRequestHelper.kt
@@ -2,7 +2,7 @@ package versioned.host.exp.exponent.modules.api.components.reactnativestripesdk
 
 import android.app.Activity
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -25,7 +25,7 @@ class GooglePayRequestHelper {
   companion object {
     internal const val LOAD_PAYMENT_DATA_REQUEST_CODE = 414243
 
-    internal fun createPaymentRequest(activity: AppCompatActivity, factory: GooglePayJsonFactory, googlePayParams: ReadableMap): Task<PaymentData> {
+    internal fun createPaymentRequest(activity: FragmentActivity, factory: GooglePayJsonFactory, googlePayParams: ReadableMap): Task<PaymentData> {
       val transactionInfo = buildTransactionInfo(googlePayParams)
       val merchantInfo = GooglePayJsonFactory.MerchantInfo(googlePayParams.getString("merchantName").orEmpty())
       val billingAddressParameters = buildBillingAddressParameters(googlePayParams.getMap("billingAddressConfig"))
@@ -90,7 +90,7 @@ class GooglePayRequestHelper {
       )
     }
 
-    internal fun createPaymentMethod(request: Task<PaymentData>, activity: AppCompatActivity) {
+    internal fun createPaymentMethod(request: Task<PaymentData>, activity: FragmentActivity) {
       AutoResolveHelper.resolveTask(
         request,
         activity,

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.*
@@ -107,7 +107,7 @@ class PaymentLauncherFragment(
     }
 
     private fun addFragment(fragment: PaymentLauncherFragment, context: ReactApplicationContext, promise: Promise) {
-      (context.currentActivity as? AppCompatActivity)?.let {
+      (context.currentActivity as? FragmentActivity)?.let {
         try {
           it.supportFragmentManager.beginTransaction()
             .add(fragment, TAG)
@@ -262,7 +262,8 @@ class PaymentLauncherFragment(
       StripeIntent.NextActionType.BlikAuthorize,
       StripeIntent.NextActionType.WeChatPayRedirect,
       StripeIntent.NextActionType.UpiAwaitNotification,
-      null -> false
+      StripeIntent.NextActionType.CashAppRedirect,
+      null, -> false
     }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetAppearance.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentSheetAppearance.kt
@@ -1,12 +1,13 @@
 package versioned.host.exp.exponent.modules.api.components.reactnativestripesdk
 
+import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.PaymentSheetAppearanceException
 import com.stripe.android.paymentsheet.PaymentSheet
 
-fun buildPaymentSheetAppearance(userParams: Bundle?, context: ReactContext): PaymentSheet.Appearance {
+fun buildPaymentSheetAppearance(userParams: Bundle?, context: Context): PaymentSheet.Appearance {
   val colorParams = userParams?.getBundle(PaymentSheetAppearanceKeys.COLORS)
   val lightColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.LIGHT) ?: colorParams
   val darkColorParams = colorParams?.getBundle(PaymentSheetAppearanceKeys.DARK) ?: colorParams
@@ -20,7 +21,7 @@ fun buildPaymentSheetAppearance(userParams: Bundle?, context: ReactContext): Pay
   )
 }
 
-private fun buildTypography(fontParams: Bundle?, context: ReactContext): PaymentSheet.Typography {
+private fun buildTypography(fontParams: Bundle?, context: Context): PaymentSheet.Typography {
   return PaymentSheet.Typography.default.copy(
     sizeScaleFactor = getFloatOr(fontParams, PaymentSheetAppearanceKeys.SCALE, PaymentSheet.Typography.default.sizeScaleFactor),
     fontResId = getFontResId(fontParams, PaymentSheetAppearanceKeys.FAMILY, PaymentSheet.Typography.default.fontResId, context)
@@ -65,7 +66,7 @@ private fun buildShapes(shapeParams: Bundle?): PaymentSheet.Shapes {
   )
 }
 
-private fun buildPrimaryButton(params: Bundle?, context: ReactContext): PaymentSheet.PrimaryButton {
+private fun buildPrimaryButton(params: Bundle?, context: Context): PaymentSheet.PrimaryButton {
   if (params == null) {
     return PaymentSheet.PrimaryButton()
   }
@@ -121,7 +122,7 @@ private fun getFloatOrNull(bundle: Bundle?, key: String): Float? {
 }
 
 @Throws(PaymentSheetAppearanceException::class)
-private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, context: ReactContext): Int? {
+private fun getFontResId(bundle: Bundle?, key: String, defaultValue: Int?, context: Context): Int? {
   val fontErrorPrefix = "Encountered an error when setting a custom font:"
   if (bundle?.containsKey(key) != true) {
     return defaultValue

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/StripeSdkModule.kt
@@ -4,7 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Parcelable
 import android.util.Log
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.addresssheet.AddressLauncherFragment
@@ -861,8 +861,8 @@ class StripeSdkModule(reactContext: ReactApplicationContext) : ReactContextBaseJ
    * Safely get and cast the current activity as an AppCompatActivity. If that fails, the promise
    * provided will be resolved with an error message instructing the user to retry the method.
    */
-  private fun getCurrentActivityOrResolveWithError(promise: Promise?): AppCompatActivity? {
-    (currentActivity as? AppCompatActivity)?.let {
+  private fun getCurrentActivityOrResolveWithError(promise: Promise?): FragmentActivity? {
+    (currentActivity as? FragmentActivity)?.let {
       return it
     }
     promise?.resolve(createMissingActivityError())

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/addresssheet/AddressLauncherFragment.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/addresssheet/AddressLauncherFragment.kt
@@ -5,8 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.utils.ErrorType
@@ -89,19 +89,19 @@ class AddressLauncherFragment : Fragment() {
       autocompleteCountries = autocompleteCountries,
     )
     this.callback = callback
-    (context.currentActivity as? AppCompatActivity)?.let {
+    (context.currentActivity as? FragmentActivity)?.let {
       attemptToCleanupPreviousFragment(it)
       commitFragmentAndStartFlow(it)
     }
   }
 
-  private fun attemptToCleanupPreviousFragment(currentActivity: AppCompatActivity) {
+  private fun attemptToCleanupPreviousFragment(currentActivity: FragmentActivity) {
     currentActivity.supportFragmentManager.beginTransaction()
       .remove(this)
       .commitAllowingStateLoss()
   }
 
-  private fun commitFragmentAndStartFlow(currentActivity: AppCompatActivity) {
+  private fun commitFragmentAndStartFlow(currentActivity: FragmentActivity) {
     try {
       currentActivity.supportFragmentManager.beginTransaction()
         .add(this, TAG)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/pushprovisioning/AddToWalletButtonManager.kt
@@ -1,15 +1,15 @@
 package versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.pushprovisioning
 
+import android.content.Context
 import com.bumptech.glide.Glide
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.bridge.ReactApplicationContext
 
 
-class AddToWalletButtonManager(applicationContext: ReactApplicationContext) : SimpleViewManager<AddToWalletButtonView?>() {
+class AddToWalletButtonManager(applicationContext: Context) : SimpleViewManager<AddToWalletButtonView?>() {
   private val requestManager = Glide.with(applicationContext)
   override fun getName() = "AddToWalletButton"
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/pushprovisioning/TapAndPayProxy.kt
@@ -83,34 +83,33 @@ object TapAndPayProxy {
     }
   }
 
-  private fun mapFromTokenInfo(token: Any?): WritableMap? {
-    if (token == null) {
-      return null
-    }
+  private fun mapFromTokenInfo(token: Any?): WritableMap {
     val result = WritableNativeMap()
-    try {
-      val tokenInfoClass = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo")
-      result.putString(
-        "id",
-        tokenInfoClass.getMethod("getIssuerTokenId").invoke(token) as String)
-      result.putString(
-        "cardLastFour",
-        tokenInfoClass.getMethod("getFpanLastFour").invoke(token) as String)
-      result.putString(
-        "issuer",
-        tokenInfoClass.getMethod("getIssuerName").invoke(token) as String)
-      result.putString(
-        "status",
-        mapFromTokenState(tokenInfoClass.getMethod("getTokenState").invoke(token) as Int))
-      result.putInt(
-        "network",
-        tokenInfoClass.getMethod("getNetwork").invoke(token) as Int)
-      result.putInt(
-        "serviceProvider",
-        tokenInfoClass.getMethod("getTokenServiceProvider").invoke(token) as Int)
-    } catch (e: Exception) {
-      Log.e(TAG,
-            "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
+    token?.let {
+      try {
+        val tokenInfoClass = Class.forName("com.google.android.gms.tapandpay.issuer.TokenInfo")
+        result.putString(
+          "id",
+          tokenInfoClass.getMethod("getIssuerTokenId").invoke(it) as String)
+        result.putString(
+          "cardLastFour",
+          tokenInfoClass.getMethod("getFpanLastFour").invoke(it) as String)
+        result.putString(
+          "issuer",
+          tokenInfoClass.getMethod("getIssuerName").invoke(it) as String)
+        result.putString(
+          "status",
+          mapFromTokenState(tokenInfoClass.getMethod("getTokenState").invoke(it) as Int))
+        result.putInt(
+          "network",
+          tokenInfoClass.getMethod("getNetwork").invoke(it) as Int)
+        result.putInt(
+          "serviceProvider",
+          tokenInfoClass.getMethod("getTokenServiceProvider").invoke(it) as Int)
+      } catch (e: Exception) {
+        Log.e(TAG,
+          "There was a problem finding the class com.google.android.gms.tapandpay.issuer.TokenInfo. Make sure you've included Google's TapAndPay dependency.")
+      }
     }
     return result
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Extensions.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Extensions.kt
@@ -3,8 +3,8 @@ package versioned.host.exp.exponent.modules.api.components.reactnativestripesdk.
 import android.content.Context
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 
@@ -25,7 +25,7 @@ fun View.hideSoftKeyboard() {
 }
 
 fun Fragment.removeFragment(context: ReactApplicationContext) {
-  (context.currentActivity as? AppCompatActivity)?.supportFragmentManager?.let {
+  (context.currentActivity as? FragmentActivity)?.supportFragmentManager?.let {
     if (it.findFragmentByTag(this.tag) != null) {
       it.beginTransaction().remove(this).commitAllowingStateLoss()
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
@@ -17,14 +17,12 @@ internal fun createResult(key: String, value: WritableMap): WritableMap {
 internal fun createCanAddCardResult(canAddCard: Boolean, status: String? = null, token: WritableMap? = null): WritableNativeMap {
   val result = WritableNativeMap()
   val details = WritableNativeMap()
+  result.putBoolean("canAddCard", canAddCard)
   if (status != null) {
-    result.putBoolean("canAddCard", false)
     details.putString("status", status)
-  } else {
-    result.putBoolean("canAddCard", canAddCard)
-    if (token != null) {
-      details.putMap("token", token)
-    }
+  }
+  if (token != null) {
+    details.putMap("token", token)
   }
   result.putMap("details", details)
   return result
@@ -484,7 +482,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
       return null
     }
   }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -22,3 +22,6 @@ reactNativeVersion=0.71.0
 
 # Use AppGlideModule from kernel
 excludeAppGlideModule=true
+
+# This version should align to stripe-react-native's settings when upgrade the vendoring module
+StripeSdk_stripeVersion=[20.19.2, 20.20.0[

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/Mappers.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/Mappers.kt
@@ -464,7 +464,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
       return null
     }
   }

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/Mappers.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/Mappers.kt
@@ -464,7 +464,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification, null -> {
       return null
     }
   }

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -278,6 +278,7 @@ class PaymentLauncherFragment(
       StripeIntent.NextActionType.BlikAuthorize,
       StripeIntent.NextActionType.WeChatPayRedirect,
       StripeIntent.NextActionType.UpiAwaitNotification,
+      StripeIntent.NextActionType.CashAppRedirect,
       null -> false
     }
   }

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -279,6 +279,7 @@ class PaymentLauncherFragment(
       StripeIntent.NextActionType.BlikAuthorize,
       StripeIntent.NextActionType.WeChatPayRedirect,
       StripeIntent.NextActionType.UpiAwaitNotification,
+      StripeIntent.NextActionType.CashAppRedirect,
       null -> false
     }
   }

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
@@ -483,7 +483,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
       return null
     }
   }

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
@@ -483,7 +483,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification, null -> {
       return null
     }
   }

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/PaymentLauncherFragment.kt
@@ -277,6 +277,7 @@ class PaymentLauncherFragment(
       StripeIntent.NextActionType.BlikAuthorize,
       StripeIntent.NextActionType.WeChatPayRedirect,
       StripeIntent.NextActionType.UpiAwaitNotification,
+      StripeIntent.NextActionType.CashAppRedirect,
       null -> false
     }
   }

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
@@ -511,7 +511,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification, null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
       return null
     }
   }

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/modules/api/components/reactnativestripesdk/utils/Mappers.kt
@@ -511,7 +511,7 @@ internal fun mapNextAction(type: NextActionType?, data: NextActionData?): Writab
     NextActionType.AlipayRedirect -> { // TODO: Can't access, private
       return null
     }
-    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification,  null -> {
+    NextActionType.CashAppRedirect, NextActionType.BlikAuthorize, NextActionType.UseStripeSdk, NextActionType.UpiAwaitNotification, null -> {
       return null
     }
   }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2919,7 +2919,7 @@ PODS:
     - StripePayments (= 23.3.0)
     - StripePaymentsUI (= 23.3.0)
     - StripeUICore (= 23.3.0)
-  - stripe-react-native (0.23.1):
+  - stripe-react-native (0.23.3):
     - React-Core
     - Stripe (~> 23.3.0)
     - StripeApplePay (~> 23.3.0)
@@ -4883,7 +4883,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
   SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
   Stripe: 8a2e7c77fc28bff1d0961a129fac0cb2ed91ddcb
-  stripe-react-native: 50d7148eac46ba2d93e669a5725712093fdd8b36
+  stripe-react-native: c71683ecc56c63eecbb7172c2f97c8ac737fa37c
   StripeApplePay: 7b7a5e10891d2ea428cf1a3a737a07fe874f7e7d
   StripeCore: 8122b0ffc76922ef0d3f3af3ecffd70c3bfabfc0
   StripeFinancialConnections: 84eba7226fb5fde44287c537dbc0b265ac90e2c4

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -8,7 +8,7 @@
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.4.8",
   "@react-native-segmented-control/segmented-control": "2.4.0",
-  "@stripe/stripe-react-native": "0.23.1",
+  "@stripe/stripe-react-native": "0.23.3",
   "expo-analytics-amplitude": "~11.3.0",
   "expo-app-auth": "~11.1.0",
   "expo-app-loader-provider": "~8.0.0",


### PR DESCRIPTION
# Why

fix expo go build error where kotlin 1.8 is incompatible with 1.6: https://github.com/expo/expo/actions/runs/4120016867/jobs/7114321156

# How

- the underlying module of stripe 0.23.1 ships kotlin 1.8 which is prebuilt as aar/jar on maven central. we have no way to downgrade its kotlin version but only to upgrade kotlin in whole android expo go.
- stripe 0.23.1 has a build error error and fixed at https://github.com/stripe/stripe-react-native/pull/1289. upgrade the vendoring module to 0.23.3.

# Test Plan

versioned android expo go + ncl launch test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
