### PR TITLE
Fix crash when reloading app while expo-av video is playing

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash when reloading app while expo-av video is playing. ([#21118](https://github.com/expo/expo/pull/21118) by [@janicduplessis](https://github.com/janicduplessis))
+
 ### 💡 Others
 
 ## 1.2.0 — 2023-02-03

--- a/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
@@ -76,7 +76,7 @@ private func createEventSetter(eventName: String, bridge: RCTBridge?) -> RCTProp
     installEventDispatcher(forEvent: eventName, onView: target) { [weak target] (body: [String: Any]) in
       if let target = target {
         let componentEvent = RCTComponentEvent(name: eventName, viewTag: target.reactTag, body: body)
-        bridge?.eventDispatcher().send(componentEvent)
+        bridge?.eventDispatcher()?.send(componentEvent)
       }
     }
   }


### PR DESCRIPTION
# Why

Seems like eventDispatcher can be null while app is reloading, so if events are still being dispatched it could cause a crash. This repros consistently for me when using expo-av, which I assume sends lots of video progress events.

# How

Don't send the event if eventDispatched is null

# Test Plan

Tested in an app that this stops the crash from happening.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
