### PR TITLE
[Android] Bump kotlin version to `1.8.10`

### DIFF
--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         targetSdkVersion = 33
         // Some dependencies still expect supportLibVersion to be defined
         supportLibVersion = "29.0.0"
-        kotlinVersion = '1.6.10'
+        kotlinVersion = '1.8.10'
         // for expo-dev-client
         expoUpdatesVersion = null
 

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -43,7 +43,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -33,7 +33,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-clipboard/android/build.gradle
+++ b/packages/expo-clipboard/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -170,7 +170,7 @@ configurations.all {
   resolutionStrategy.eachDependency { DependencyResolveDetails details ->
     def requested = details.requested
     if (requested.group == 'org.jetbrains.kotlin') {
-      details.useVersion safeExtGet('kotlinVersion', '1.6.10')
+      details.useVersion safeExtGet('kotlinVersion', '1.8.10')
     }
   }
 }

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -80,7 +80,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-error-recovery/android/build.gradle
+++ b/packages/expo-error-recovery/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -43,7 +43,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -91,7 +91,9 @@ dependencies {
   testImplementation 'org.mockito:mockito-core:1.10.19'
   testImplementation 'io.mockk:mockk:1.12.3'
 
-  androidTestImplementation 'org.amshove.kluent:kluent-android:1.68'
+  androidTestImplementation('org.amshove.kluent:kluent-android:1.72') {
+    exclude group: 'org.jetbrains.kotlin'
+  }
   androidTestImplementation 'androidx.test:runner:1.4.0'
   androidTestImplementation 'androidx.test:core:1.4.0'
   androidTestImplementation 'androidx.test:rules:1.4.0'

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -4,7 +4,7 @@ class KotlinExpoModulesCorePlugin implements Plugin<Project> {
       project.ext.kotlinVersion = {
         project.rootProject.ext.has("kotlinVersion")
             ? project.rootProject.ext.get("kotlinVersion")
-            : "1.6.10"
+            : "1.8.10"
       }
     }
   }

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-navigation-bar/android/build.gradle
+++ b/packages/expo-navigation-bar/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-store-review/android/build.gradle
+++ b/packages/expo-store-review/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-system-ui/android/build.gradle
+++ b/packages/expo-system-ui/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -52,7 +52,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.6.10")
+      ext.safeExtGet("kotlinVersion", "1.8.10")
     }
   }
 


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/pull/21117#discussion_r1100709414.

# How

Bumped the default kotlin version to `1.8.10`.
I'll add a changelog entry later. 

# Test Plan

- expo-go with NCL ✅
- bare-expo with NCL ✅