### PR TITLE
[templates] Remove config options that don't apply to templates

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -2,7 +2,6 @@
   "expo": {
     "name": "HelloWorld",
     "slug": "expo-template-bare",
-    "version": "1.0.0",
-    "assetBundlePatterns": ["**/*"]
+    "version": "1.0.0"
   }
 }

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -11,17 +11,13 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "updates": {
-      "fallbackToCacheTimeout": 0
-    },
-    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#FFFFFF"
+        "backgroundColor": "#ffffff"
       }
     },
     "web": {

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -11,17 +11,13 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "updates": {
-      "fallbackToCacheTimeout": 0
-    },
-    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#FFFFFF"
+        "backgroundColor": "#ffffff"
       }
     },
     "web": {

--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -12,10 +12,6 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "updates": {
-      "fallbackToCacheTimeout": 0
-    },
-    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
# Why

Users should config updates when they install it, we shouldn't include updates config in app templates that don't have expo-updates installed.

# How

Straightforward - remove config from templates. My main concern about this is that we may not be asking people to include the `fallbackToCacheTimeout` setting when setting up EAS Update, and without it, I'm not sure what the expected behavior is for updates right now (I believe it will block loading the app for some number of seconds while fetching update?). I also don't know if we tell people to use `assetBundlePatterns` or how important that is.

# Test Plan

--

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
