### PR TITLE
[core][ios] Fix convertible implementation for URL to support unencoded strings

### DIFF
--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -77,6 +77,7 @@ PODS:
     - React-Core/RCTWebSocket
     - React-CoreModules
     - React-cxxreact
+    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -77,7 +77,6 @@ PODS:
     - React-Core/RCTWebSocket
     - React-CoreModules
     - React-cxxreact
-    - React-jsc
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed convertible implementation for `URL` type to support unencoded UTF8 urls and file paths.
+
 ### 💡 Others
 
 ## 1.2.1 — 2023-02-09

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed convertible implementation for `URL` type to support unencoded UTF8 urls and file paths.
+- [iOS] Fixed convertible implementation for `URL` type to support unencoded UTF8 urls and file paths. ([#21139](https://github.com/expo/expo/pull/21139) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -13,11 +13,10 @@ import CoreGraphics
 
 extension URL: Convertible {
   public static func convert(from value: Any?) throws -> Self {
-    if let uri = value as? String, let url = URL(string: uri) {
-      // `URL(string:)` is an optional init but it doesn't imply it's a valid URL,
-      // so here we don't check for the correctness of the URL.
-      // If it has no scheme, we assume it was the file path.
-      return url.scheme != nil ? url : URL(fileURLWithPath: uri)
+    if let value = value as? String, let encodedValue = percentEncodeUrlString(value), let url = URL(string: encodedValue) {
+      // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
+      // Notice that it uses the decoded value as the file path doesn't have to be percent-encoded.
+      return url.scheme != nil ? url : URL(fileURLWithPath: value)
     }
     throw Conversions.ConvertingException<URL>(value)
   }

--- a/packages/expo-modules-core/ios/Swift/Utilities.swift
+++ b/packages/expo-modules-core/ios/Swift/Utilities.swift
@@ -26,3 +26,21 @@ internal func toNSError(_ error: Error) -> NSError {
   }
   return error as NSError
 }
+
+/**
+ Makes sure the url string is percent encoded. If the given string is already encoded, it's decoded first.
+ Note that it encodes only characters that are not allowed in the url query and '#' that indicates the fragment part.
+ */
+internal func percentEncodeUrlString(_ url: String) -> String? {
+  // The value may come unencoded or already encoded, so first we try to decode it.
+  // `removingPercentEncoding` returns nil when the string contains an invalid percent-encoded sequence,
+  // but that usually means the value came unencoded, so it falls back to the given string.
+  let decodedString = url.removingPercentEncoding ?? url
+
+  // A `CharacterSet` with all query-allowed characters and the hash which is not allowed in the query,
+  // but it must stay unencoded to indicate the start of the url fragment part.
+  let allowedCharactersSet = CharacterSet.urlQueryAllowed.union(CharacterSet(charactersIn: "#"))
+
+  // Do the percent encoding, but note that it may still return nil when it's not possible to encode for some reason.
+  return decodedString.addingPercentEncoding(withAllowedCharacters: allowedCharactersSet)
+}


### PR DESCRIPTION
# Why

Urls or file paths containing non-percent-encoded characters cannot be converted to `URL` type

# How

First we will try to decode the given url (with [`removingPercentEncoding`](https://developer.apple.com/documentation/foundation/nsstring/1409569-removingpercentencoding)) to normalize the url string to the unencoded format. Then we percent-encode characters not allowed in the url query component excluding the hash.

# Test Plan

Added new native unit tests covering some more use cases