### PR TITLE
[docs] Details on how to reset your Google Play Store App Signing Key

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -35,6 +35,29 @@ When you [upload your first release to Google Play](https://expo.fyi/first-andro
 
 If you currently manage your app signing key and want Google to manage it for you, see [Use app signing by Google Play](https://support.google.com/googleplay/android-developer/answer/9842756).
 
+#### Resetting your Google App Signing credentials 
+
+If you need to sync your expo keystore with Google, follow these steps:
+
+1. Run `eas credentials` 
+2. Select `Android` for the platform and the profile whose credentials you wish to download. 
+3. Select `credentials.json: Upload/Download credentials between EAS servers and your local json` 
+4. Select ` Download credentials from EAS to credentials.json`
+
+Your application's keystore should be kept private. **Under no circumstances should you check it in to your repository.** Debug keystores are the only exception because we don't use them for uploading apps to the Google Play Store.
+
+Once you've downloaded your credentials and the keystore, you must export it to the `pem` format so that you can submit it to Google. To do so:
+
+1. Find the key alias in your `credentials.json` file under the `keyAlias` key.
+2. Use `keytool` to export the certificate
+~~~
+keytool -export -rfc -alias {alias_from_step_1} -file {certificate_for_google.pem} -keystore {./path/to/keystore.jks}
+~~~
+
+Then, contact Google Support and request they change your key using [this support form](https://support.google.com/googleplay/android-developer/contact/key), attaching the `pem` file exported from the keystore.
+
+Once Google updates this on your account, builds created through `eas build` will be correctly signed as expected by the Google Play Store. Note that Google will set the validity start date of the new upload certificate to 72 hours in the future so you will have to wait before your first submission after performing this process.
+
 ## iOS
 
 The 3 primary iOS credentials, all of which are associated with your Apple Developer account, are:


### PR DESCRIPTION
Documents how to export your signing certificate from the expo keystore and update it on your Google Play Store settings for your app.

# Why

I had to do this since we had an old version of our app submitted in Google Play Store that used different keys than those managed by expo which so new versions of our app that used `eas build` were not able to be submitted.

# How

I was able to resolve this for myself and though it is a rare edge case, thought it'd be useful to provide those instructions for others.

# Test Plan
N/A just documentation.

# Checklist


- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
