### PR TITLE
[doc] Fix expo-updates doc typo

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -38,7 +38,7 @@ There are build-time configuration options that control the behavior of `expo-up
 
 On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and the provided values will override any value specified in **AndroidManifest.xml**.
 
-On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
+On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
 |--------------------------|---------------- | ------------------------------ | ------- | --------- |

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -38,7 +38,7 @@ There are build-time configuration options that control the behavior of `expo-up
 
 On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and the provided values will override any value specified in **AndroidManifest.xml**.
 
-On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
+On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
 
 | iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
 |--------------------------|---------------- | ------------------------------ | ------- | --------- |


### PR DESCRIPTION
# Why
when I tried to change release channel at runtime, I found this typo issue.  
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
update the doc
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
