### PR TITLE
[docs] improves the migration guide

### DIFF
--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -111,6 +111,6 @@ Once published, you can see the update in the [Expo dashboard](https://expo.dev/
 
 ## Learn more
 
-The steps we described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features, which can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-eas-update-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) for your project and your team.
+The steps described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features. It can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-eas-update-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) for your project and your team.
 
 If you experience issues with migrating, check out our [debugging guide](/eas-update/debug-updates). If you have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -3,7 +3,6 @@ title: Migrating from Classic Updates to EAS Update
 description: A guide to help migrate from Classic Updates to EAS Update.
 ---
 
-import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -54,7 +53,8 @@ To ensure that updates are compatible with the underlying native code inside a b
 </Step>
 
 <Step label="3">
-To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels should replace any `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
+
+To allow updates to apply to builds built with EAS, update your EAS build profiles in **eas.json** to include `channel` properties. These channels replace `releaseChannel` properties. We find it convenient to name the `channel` after the profile's name. For instance, the `preview` profile has a `channel` named `"preview"` and the `production` profile has a `channel` named `"production"`.
 
 ```json eas.json
 {
@@ -84,34 +84,33 @@ To allow updates to apply to builds built with EAS, update your EAS build profil
 
 ## Create new builds
 
-The changes above affect the native code layer inside builds, which means you'll need to make new builds. Once your builds are complete, you'll be ready to develop an update and publish it.
+The changes above affect the native code layer inside builds, which means you'll need to make new builds to start sending updates. Once your builds are complete, you'll be ready to publish an update.
 
-## Publishing an update
+## Publish an update
 
 After making a change to your project locally, you're ready to publish an update, run:
 
 <Terminal
   cmd={[
-    '$ eas update --branch [branch-name] --message [message]',
+    '$ eas update --channel [channel-name] --message [message]',
     '',
     '# Example',
     '',
-    '$ eas update --branch production --message "Fixes typo"',
+    '$ eas update --channel production --message "Fixes typo"',
   ]}
-  cmdCopy="eas update --branch [branch-name] --message [message]"
+  cmdCopy="eas update --channel [channel-name] --message [message]"
 />
 
-EAS Update adds a new idea called a "branch". A branch is a list of updates, and it is mapped to a channel. In the diagram below, builds with a channel of "production" are linked to a branch named "production". By default, channels and branches of the same name are linked until changed. By default, this behaves like the Classic Updates service.
+Once published, you can see the update in the [Expo dashboard](https://expo.dev/accounts/[account]/projects/[project]/updates).
 
-<ImageSpotlight
-  alt={`Channel "production" linked to branch "production"`}
-  src="/static/images/eas-update/channel-branch.png"
-/>
+## Additional migration steps
 
-## Additional possible migration steps
-
-- Replace instances of `expo publish` with `eas update`. You can view all the options for publishing with `eas update --help`.
+- Replace instances of `expo publish` with `eas update` in scripts. You can view all the options for publishing with `eas update --help`.
 - If you have any code that references `Updates.releaseChannel` from the `expo-updates` library, replace them with `Updates.channel`.
 - Remove any code that references `Constants.manifest`. That will now always return `null`. If you're using SDK 46 or above, you can access most properties you'll need with `Constants.expoConfig` from the `expo-constants` library.
 
-If you run into issues or have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.
+## Learn more
+
+The steps we described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features, which can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-eas-update-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) with your project and your team.
+
+If you experience issues with migrating, check out our [debugging guide](/eas-update/debug-updates). If you have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -111,6 +111,6 @@ Once published, you can see the update in the [Expo dashboard](https://expo.dev/
 
 ## Learn more
 
-The steps we described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features, which can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-eas-update-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) with your project and your team.
+The steps we described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features, which can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-eas-update-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) for your project and your team.
 
 If you experience issues with migrating, check out our [debugging guide](/eas-update/debug-updates). If you have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.


### PR DESCRIPTION
# Why

We now have a `--channel` flag which is better suited for Classic Updates users. This change updates the migration guide to five Classic Updates users a nicer time when migrating.