### PR TITLE
[docs] Change ios request push address from deprecated

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -97,7 +97,7 @@ Here's how to construct the request:
 const http2 = require('http2');
 
 const client = http2.connect(
-  IS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.sandbox.push.apple.com'
+  IS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.development.push.apple.com'
 );
 
 const request = client.request({

--- a/docs/public/static/code/sendNotificationToAPNS.js
+++ b/docs/public/static/code/sendNotificationToAPNS.js
@@ -18,7 +18,7 @@ const token = jwt.sign(
 
 const IS_PRODUCTION = false; // TODO: your check
 const client = http2.connect(
-  IS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.sandbox.push.apple.com'
+  IS_PRODUCTION ? 'https://api.push.apple.com' : 'https://api.development.push.apple.com'
 );
 
 const deviceToken = 'device token grabbed cient-side';


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Expo docs and code still refer deprecated ios push address.
https://docs.expo.dev/push-notifications/sending-notifications-custom/#http2-connection

# How

<!--
How did you build this feature or fix this bug and why?
-->
Just changed request address.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I sent push by use that address

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
