### PR TITLE
fix(cli): auto-detect the TLS version based on current node version

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Send Exponent-Server header as JSON string for classic manifests. ([#20409](https://github.com/expo/expo/pull/20409) by [@byCedric](https://github.com/byCedric))
 - Use known Expo schemes when starting with dev clients. ([#20888](https://github.com/expo/expo/pull/20888) by [@byCedric](https://github.com/byCedric))
 - Fix sourcemap generation errors when exporting Hermes bundle. ([#21022](https://github.com/expo/expo/pull/21022) by [@kudo](https://github.com/kudo))
+- Avoid fixing secure Apple device socket connections to a single TLS method. ([#21169](https://github.com/expo/expo/pull/21169) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
@@ -96,7 +96,6 @@ export class ClientManager {
       const tlsOptions: tls.ConnectionOptions = {
         rejectUnauthorized: false,
         secureContext: tls.createSecureContext({
-          secureProtocol: 'TLSv1_method',
           cert: this.pairRecord.RootCertificate,
           key: this.pairRecord.RootPrivateKey,
         }),

--- a/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/ClientManager.ts
@@ -96,6 +96,11 @@ export class ClientManager {
       const tlsOptions: tls.ConnectionOptions = {
         rejectUnauthorized: false,
         secureContext: tls.createSecureContext({
+          // Avoid using `secureProtocol` fixing the socket to a single TLS version.
+          // Newer Node versions might not support older TLS versions.
+          // By using the default `minVersion` and `maxVersion` options,
+          // The socket will automatically use the appropriate TLS version.
+          // See: https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
           cert: this.pairRecord.RootCertificate,
           key: this.pairRecord.RootPrivateKey,
         }),

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -128,6 +128,11 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
       if (resp.EnableSessionSSL) {
         this.protocolClient.socket = new tls.TLSSocket(this.protocolClient.socket, {
           secureContext: tls.createSecureContext({
+            // Avoid using `secureProtocol` fixing the socket to a single TLS version.
+            // Newer Node versions might not support older TLS versions.
+            // By using the default `minVersion` and `maxVersion` options,
+            // The socket will automatically use the appropriate TLS version.
+            // See: https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
             cert: pairRecord.RootCertificate,
             key: pairRecord.RootPrivateKey,
           }),

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -128,7 +128,6 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
       if (resp.EnableSessionSSL) {
         this.protocolClient.socket = new tls.TLSSocket(this.protocolClient.socket, {
           secureContext: tls.createSecureContext({
-            secureProtocol: 'TLSv1_method',
             cert: pairRecord.RootCertificate,
             key: pairRecord.RootPrivateKey,
           }),


### PR DESCRIPTION
# Why

After debugging this issue https://github.com/byCedric/expo-monorepo-example/issues/84, it seems that we are having trouble with the internals of `expo run:ios`.

What's happening here are two major things:
1. Node 17+ is throwing an internal OpenSSL error when establishing a secure TLS connection to the iOS device. This is caused by the explicit `secureProtocol` option, which is set to `TLSv1_method`.
2. We don't have any error event handlers when opening (secure) sockets to iOS devices.

These two issues together result in `expo run:ios` not-installing the app on the device. Luckily, it does build the app. But, due to the missing error handlers, we are swallowing the underlying error and the installation part is [stuck on a promise](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/run/ios/appleDevice/AppleDevice.ts#L143) that will never be resolved.

Here is the chain that's getting blocked by issue 2 (caused by issue 1)
- `clientManager.getMobileImageMounterClient`
- `this.getServiceClient('com.apple.mobile.mobile_image_mounter', MobileImageMounterClient)`
- `lockdowndClient.startService(name)` is invoked (from `MobileImageMounterClient`)
- `LockdownProtocolClient.sendMessage` is invoked (with `StartService`, `com.apple.mobile.mobile_image_mounter`)
- `ProtocolClient.sendMessage` is invoked
  - Socket TLS handshake fails, but the `socket.on('error')` is not set. So the error is never received.

# How

- Removed the explicit `TLSv1_method` from `tls.createSecureContext`
- Added error handlers to surface underlying errors

After removing the fixed TLS method, it seems to use TLSv1.2 by default.

# Test Plan

Test `main` on Node 17+, while adding `enableTrace: true` and `socket.on('error', (error) => console.log(error));` to the changes I made
> This should fail with an internal socket/openssl error

Test this PR on Node 16, and Node 18
> This should NOT fail

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
