### PR TITLE
Update ImageProps for strictOptionalPropertyTypes

### DIFF
--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -62,7 +62,7 @@ export interface ImageProps extends ViewProps {
    * When provided as an array of sources, the source that fits best into the container size and is closest to the screen scale
    * will be chosen. In this case it is important to provide `width`, `height` and `scale` properties.
    */
-  source?: ImageSource | string | number | ImageSource[] | string[] | null;
+  source?: ImageSource | string | number | ImageSource[] | string[] | null | undefined;
 
   /**
    * An image to display while loading the proper image and no image has been displayed yet or the source is unset.


### PR DESCRIPTION
When using strictOptionalPropertyTypes option in TS you must explicity add `| undefined` to optional fields in objects. This is because a property may be present but undefined (exists in Object.keys() or hasOwnProperty) which may cause different behavior from the property being missing entirely. This aligns the behavior with react-native's built in Image source prop.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
