### PR TITLE
[ENG-7389][docs] update images documentation

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -176,7 +176,23 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-monterey-12.6-xcode-14.1` (alias `latest`)
+#### `macos-monterey-12.6-xcode-14.2` (alias `latest`)
+
+<Collapsible summary="Details">
+
+- macOS Monterey 12.6
+- Xcode 14.2 (14C18)
+- Node.js 16.18.1
+- Yarn 1.22.17
+- pnpm 7.27.0
+- npm 8.19.2
+- fastlane 2.211.0
+- CocoaPods 1.11.3
+- Ruby 2.7
+
+</Collapsible>
+
+#### `macos-monterey-12.6-xcode-14.1` (alias `default`)
 
 <Collapsible summary="Details">
 
@@ -192,7 +208,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.0` (alias `default`)
+#### `macos-monterey-12.6-xcode-14.0`
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7389/add-build-image-for-xcode-142

# How

Companion to https://github.com/expo/turtle-v2/pull/1209

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
