### PR TITLE
[ios][intent-launcher] Fix attempting to import module on iOS.

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix attempting to import module on iOS.
+- Fix attempting to import module on iOS. ([#21185](https://github.com/expo/expo/pull/21185) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix attempting to import module on iOS.
+
 ### 💡 Others
 
 ## 10.5.1 — 2023-02-09
@@ -68,7 +70,7 @@ _This version does not introduce any user-facing changes._
 
 - Replace the stand-alone action constant strings with String Enum named `ActivityAction`. ([#14070](https://github.com/expo/expo/pull/14070) by [@Simek](https://github.com/Simek))
 
-```diff
+````diff
 - IntentLauncher.ACTION_* // ACTION_ACCESSIBILITY_SETTINGS
 + IntentLauncher.ActivityAction.* // ActivityAction.ACCESSIBILITY_SETTINGS
 ```## 9.1.0 — 2021-06-16
@@ -107,6 +109,8 @@ _This version does not introduce any user-facing changes._
 ## 8.2.0 — 2020-05-27
 
 *This version does not introduce any user-facing changes.*
-``````
+````
+
+```
 
 ```

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -70,7 +70,7 @@ _This version does not introduce any user-facing changes._
 
 - Replace the stand-alone action constant strings with String Enum named `ActivityAction`. ([#14070](https://github.com/expo/expo/pull/14070) by [@Simek](https://github.com/Simek))
 
-````diff
+```diff
 - IntentLauncher.ACTION_* // ACTION_ACCESSIBILITY_SETTINGS
 + IntentLauncher.ActivityAction.* // ActivityAction.ACCESSIBILITY_SETTINGS
 ```## 9.1.0 — 2021-06-16
@@ -109,8 +109,6 @@ _This version does not introduce any user-facing changes._
 ## 8.2.0 — 2020-05-27
 
 *This version does not introduce any user-facing changes.*
-````
-
-```
+``````
 
 ```

--- a/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.d.ts
+++ b/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.d.ts
@@ -1,0 +1,3 @@
+declare const _default: {};
+export default _default;
+//# sourceMappingURL=ExpoIntentLauncher.ios.d.ts.map

--- a/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.d.ts.map
+++ b/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ExpoIntentLauncher.ios.d.ts","sourceRoot":"","sources":["../src/ExpoIntentLauncher.ios.ts"],"names":[],"mappings":";AAAA,wBAAkB"}

--- a/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.js
+++ b/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.js
@@ -1,0 +1,2 @@
+export default {};
+//# sourceMappingURL=ExpoIntentLauncher.ios.js.map

--- a/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.js.map
+++ b/packages/expo-intent-launcher/build/ExpoIntentLauncher.ios.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"ExpoIntentLauncher.ios.js","sourceRoot":"","sources":["../src/ExpoIntentLauncher.ios.ts"],"names":[],"mappings":"AAAA,eAAe,EAAE,CAAC","sourcesContent":["export default {};\n"]}

--- a/packages/expo-intent-launcher/src/ExpoIntentLauncher.ios.ts
+++ b/packages/expo-intent-launcher/src/ExpoIntentLauncher.ios.ts
@@ -1,0 +1,1 @@
+export default {};


### PR DESCRIPTION
# Why
Intent launcher is an android only module
Closes #21181 

# How
Added `ExpoIntentLauncher.ios.ts` that exports an empty object

# Test Plan
Recreated the provided reproduction and installed the library. The crash is prevented on iOS and works as expected on Android
