### PR TITLE
Update react-native-screens to 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `react-native-reanimated` from `2.12.0` to `2.14.4`. ([#20798](https://github.com/expo/expo/pull/20798) by [@kudo](https://github.com/kudo), [#20990](https://github.com/expo/expo/pull/20990) by [@tsapeta](https://github.com/tsapeta))
 - Updated `@shopify/react-native-skia` from `0.1.157` to `0.1.172`. ([#20857](https://github.com/expo/expo/pull/20857), [#21014](https://github.com/expo/expo/pull/21014) by [@kudo](https://github.com/kudo))
 - Updated `react-native-safe-area-context` from `4.4.1` to `4.5.0`. ([#20899](https://github.com/expo/expo/pull/20899) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Updated `react-native-screens` from `3.18.0` to `3.19.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall))
+- Updated `react-native-screens` from `3.18.0` to `3.20.0`. ([#20938](https://github.com/expo/expo/pull/20938) by [@lukmccall](https://github.com/lukmccall), [#21186](https://github.com/expo/expo/pull/21186) by [@tsapeta](https://github.com/tsapeta))
 - Updated `react-native-pager-view` from `6.0.1` to `6.1.2`. ([#20932](https://github.com/expo/expo/pull/20932) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Updated `@react-native-community/slider` from `4.2.4` to `4.4.2`. ([#20903](https://github.com/expo/expo/pull/20903) by [@gabrieldonadel](https://github.com/gabrieldonadel), [#21055](https://github.com/expo/expo/pull/21055) by [@kudo](https://github.com/kudo))
 - Updated `react-native-shared-element` from `0.8.7` to `0.8.8`. ([#20929](https://github.com/expo/expo/pull/20929) by [@byCedric](https://github.com/byCedric))

--- a/android/vendored/unversioned/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
+++ b/android/vendored/unversioned/react-native-screens/android/src/main/java/com/swmansion/rnscreens/ScreenViewManager.kt
@@ -156,16 +156,6 @@ class ScreenViewManager : ViewGroupManager<Screen>(), RNSScreenManagerInterface<
 
     override fun setSwipeDirection(view: Screen?, value: String?) = Unit
 
-    override fun setSheetAllowedDetents(view: Screen, value: String?) = Unit
-
-    override fun setSheetLargestUndimmedDetent(view: Screen, value: String?) = Unit
-
-    override fun setSheetGrabberVisible(view: Screen?, value: Boolean) = Unit
-
-    override fun setSheetCornerRadius(view: Screen?, value: Float) = Unit
-
-    override fun setSheetExpandsWhenScrolledToEdge(view: Screen?, value: Boolean) = Unit
-
     override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
         return MapBuilder.of(
             ScreenDismissedEvent.EVENT_NAME,

--- a/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
+++ b/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerDelegate.java
@@ -23,21 +23,6 @@ public class RNSScreenManagerDelegate<T extends View, U extends BaseViewManagerI
   @Override
   public void setProperty(T view, String propName, @Nullable Object value) {
     switch (propName) {
-      case "sheetAllowedDetents":
-        mViewManager.setSheetAllowedDetents(view, (String) value);
-        break;
-      case "sheetLargestUndimmedDetent":
-        mViewManager.setSheetLargestUndimmedDetent(view, (String) value);
-        break;
-      case "sheetGrabberVisible":
-        mViewManager.setSheetGrabberVisible(view, value == null ? false : (boolean) value);
-        break;
-      case "sheetCornerRadius":
-        mViewManager.setSheetCornerRadius(view, value == null ? -1f : ((Double) value).floatValue());
-        break;
-      case "sheetExpandsWhenScrolledToEdge":
-        mViewManager.setSheetExpandsWhenScrolledToEdge(view, value == null ? false : (boolean) value);
-        break;
       case "customAnimationOnSwipe":
         mViewManager.setCustomAnimationOnSwipe(view, value == null ? false : (boolean) value);
         break;

--- a/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
+++ b/android/vendored/unversioned/react-native-screens/android/src/paper/java/com/facebook/react/viewmanagers/RNSScreenManagerInterface.java
@@ -14,11 +14,6 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
 
 public interface RNSScreenManagerInterface<T extends View> {
-  void setSheetAllowedDetents(T view, @Nullable String value);
-  void setSheetLargestUndimmedDetent(T view, @Nullable String value);
-  void setSheetGrabberVisible(T view, boolean value);
-  void setSheetCornerRadius(T view, float value);
-  void setSheetExpandsWhenScrolledToEdge(T view, boolean value);
   void setCustomAnimationOnSwipe(T view, boolean value);
   void setFullScreenSwipeEnabled(T view, boolean value);
   void setHomeIndicatorHidden(T view, boolean value);

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -721,7 +721,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.19.0):
+  - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
   - RNSharedElement (0.8.8):
@@ -1354,7 +1354,7 @@ SPEC CHECKSUMS:
   RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: addc4900bf47882118d0a1b21747fa6705fa8cff
-  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
+  RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSharedElement: 504fa28a235b12505b6daedbb452a9ec96809bd0
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "react-native-pager-view": "6.1.2",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.19.0",
+    "react-native-screens": "~3.20.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -148,7 +148,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.19.0",
+    "react-native-screens": "~3.20.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.4.0",
     "react-native-view-shot": "3.5.0",

--- a/home/package.json
+++ b/home/package.json
@@ -65,7 +65,7 @@
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.19.0",
+    "react-native-screens": "~3.20.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",
     "reanimated-bottom-sheet": "^1.0.0-alpha.18",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2897,7 +2897,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.19.0):
+  - RNScreens (3.20.0):
     - React-Core
     - React-RCTImage
   - RNSVG (13.4.0):
@@ -4876,7 +4876,7 @@ SPEC CHECKSUMS:
   RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNReanimated: 2757554a90c8eb038535bb1fce12c49cc027a934
-  RNScreens: ea4cd3a853063cda19a4e3c28d2e52180c80f4eb
+  RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
   SDWebImageAVIFCoder: 5bf07409ab8a02f0a8e0ac976719b321d8fce209

--- a/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
+++ b/ios/vendored/unversioned/react-native-screens/RNScreens.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNScreens",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "summary": "Native navigation primitives for your React Native app.",
   "description": "RNScreens - first incomplete navigation solution for your React Native app",
   "homepage": "https://github.com/software-mansion/react-native-screens",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-screens.git",
-    "tag": "3.19.0"
+    "tag": "3.20.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "requires_arc": true,

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.h
@@ -19,12 +19,6 @@
 + (RNSScreenSwipeDirection)RNSScreenSwipeDirectionFromCppEquivalent:
     (facebook::react::RNSScreenSwipeDirection)swipeDirection;
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
-    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents;
-
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
-    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent;
-
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance;
 

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.mm
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSConvert.mm
@@ -89,32 +89,6 @@
   }
 }
 
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromAllowedDetents:
-    (facebook::react::RNSScreenSheetAllowedDetents)allowedDetents
-{
-  switch (allowedDetents) {
-    case facebook::react::RNSScreenSheetAllowedDetents::All:
-      return RNSScreenDetentTypeAll;
-    case facebook::react::RNSScreenSheetAllowedDetents::Large:
-      return RNSScreenDetentTypeLarge;
-    case facebook::react::RNSScreenSheetAllowedDetents::Medium:
-      return RNSScreenDetentTypeMedium;
-  }
-}
-
-+ (RNSScreenDetentType)RNSScreenDetentTypeFromLargestUndimmedDetent:
-    (facebook::react::RNSScreenSheetLargestUndimmedDetent)detent
-{
-  switch (detent) {
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::All:
-      return RNSScreenDetentTypeAll;
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Large:
-      return RNSScreenDetentTypeLarge;
-    case facebook::react::RNSScreenSheetLargestUndimmedDetent::Medium:
-      return RNSScreenDetentTypeMedium;
-  }
-}
-
 + (NSDictionary *)gestureResponseDistanceDictFromCppStruct:
     (const facebook::react::RNSScreenGestureResponseDistanceStruct &)gestureResponseDistance
 {

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSEnums.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSEnums.h
@@ -57,9 +57,3 @@ typedef NS_ENUM(NSInteger, RNSScreenStackHeaderSubviewType) {
   RNSScreenStackHeaderSubviewTypeCenter,
   RNSScreenStackHeaderSubviewTypeSearchBar,
 };
-
-typedef NS_ENUM(NSInteger, RNSScreenDetentType) {
-  RNSScreenDetentTypeMedium,
-  RNSScreenDetentTypeLarge,
-  RNSScreenDetentTypeAll,
-};

--- a/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
+++ b/ios/vendored/unversioned/react-native-screens/ios/RNSScreen.h
@@ -75,13 +75,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) UIInterfaceOrientationMask screenOrientation;
 @property (nonatomic) BOOL statusBarHidden;
 @property (nonatomic) BOOL homeIndicatorHidden;
-
-// Props controlling UISheetPresentationController
-@property (nonatomic) RNSScreenDetentType sheetAllowedDetents;
-@property (nonatomic) RNSScreenDetentType sheetLargestUndimmedDetent;
-@property (nonatomic) BOOL sheetGrabberVisible;
-@property (nonatomic) CGFloat sheetCornerRadius;
-@property (nonatomic) BOOL sheetExpandsWhenScrolledToEdge;
 #endif // !TARGET_OS_TV
 
 #ifdef RN_FABRIC_ENABLED

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -32,7 +32,7 @@
     "glob": "^7.1.7",
     "react-native-gesture-handler": "~2.9.0",
     "react-native-safe-area-context": "4.5.0",
-    "react-native-screens": "~3.19.0",
+    "react-native-screens": "~3.20.0",
     "react-native-svg": "13.4.0",
     "sane": "^5.0.1"
   }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -92,7 +92,7 @@
   "react-native-maps": "1.3.2",
   "react-native-pager-view": "6.1.2",
   "react-native-reanimated": "~2.14.4",
-  "react-native-screens": "~3.19.0",
+  "react-native-screens": "~3.20.0",
   "react-native-safe-area-context": "4.5.0",
   "react-native-shared-element": "0.8.8",
   "react-native-svg": "13.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15740,10 +15740,10 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@~3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.19.0.tgz#ec68685e04b074ebce4641b3a0ae7e2571629b75"
-  integrity sha512-Ehsmy7jr3H3j5pmN+/FqsAaIAD+k+xkcdePfLcg4rYRbN5X7fJPgaqhcmiCcZ0YxsU8ttsstP9IvRLNQuIkRRA==
+react-native-screens@~3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.20.0.tgz#4d154177395e5541387d9a05bc2e12e54d2fb5b1"
+  integrity sha512-joWUKWAVHxymP3mL9gYApFHAsbd9L6ZcmpoZa6Sl3W/82bvvNVMqcfP7MeNqVCg73qZ8yL4fW+J/syusHleUgg==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
# Why

It solves https://github.com/software-mansion/react-native-screens/issues/1686 issue for Expo Go and SDK 48

# How

`et uvm -m react-native-screens -c 3.20.0` and made sure locks are updated

# Test Plan

Seems to work in Expo Go, but I'm waiting for Hirbod's confirmation if it solves the issue for him