### PR TITLE
[packages][expo-document-picker][types] Export DocumentResult's case

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ### 💡 Others
 
+
+## 11.2.2 — 2023-02-13
+
+### 💡 Others
+
+- Types on expo-document-picker now exports each `DocumentResult` case. ([#21190](https://github.com/expo/expo/pull/21190) by [@fmcalado](https://github.com/fmcalado))
+
 ## 11.2.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-document-picker/src/types.ts
+++ b/packages/expo-document-picker/src/types.ts
@@ -23,51 +23,56 @@ export type DocumentPickerOptions = {
   multiple?: boolean;
 };
 
-// @needsAudit @docsMissing
 /**
- * First object represents the result when the document pick has been cancelled.
- * The second one represents the successful document pick result.
+ * Represents the result when the document pick has been cancelled.
  */
-export type DocumentResult =
-  | {
-      /**
-       * Field indicating that the document pick has been cancelled.
-       */
-      type: 'cancel';
-    }
-  | {
-      /**
-       * Field indicating that the document pick has been successful.
-       */
-      type: 'success';
-      /**
-       * Document original name.
-       */
-      name: string;
-      /**
-       * Document size in bytes.
-       */
-      size?: number;
-      /**
-       * An URI to the local document file.
-       */
-      uri: string;
-      /**
-       * Document MIME type.
-       */
-      mimeType?: string;
-      /**
-       * Timestamp of last document modification.
-       */
-      lastModified?: number;
-      /**
-       * `File` object for the parity with web File API.
-       * @platform web
-       */
-      file?: File;
-      /**
-       * `FileList` object for the parity with web File API.
-       * @platform web
-       */
-      output?: FileList | null;
-    };
+export type DocumentResultCancel = {
+  /**
+   * Field indicating that the document pick has been cancelled.
+   */
+  type: 'cancel';
+};
+
+/**
+ * Represents the successful document pick result.
+ */
+export type DocumentResultSuccess = {
+  /**
+   * Field indicating that the document pick has been successful.
+   */
+  type: 'success';
+  /**
+   * Document original name.
+   */
+  name: string;
+  /**
+   * Document size in bytes.
+   */
+  size?: number;
+  /**
+   * An URI to the local document file.
+   */
+  uri: string;
+  /**
+   * Document MIME type.
+   */
+  mimeType?: string;
+  /**
+   * Timestamp of last document modification.
+   */
+  lastModified?: number;
+  /**
+   * `File` object for the parity with web File API.
+   * @platform web
+   */
+  file?: File;
+  /**
+   * `FileList` object for the parity with web File API.
+   * @platform web
+   */
+  output?: FileList | null;
+};
+
+// @needsAudit @docsMissing
+export type DocumentResult = DocumentResultCancel | DocumentResultSuccess;
+


### PR DESCRIPTION
# Why

Export DocumentResult type when cancelled and when succeed, so it can be used individually. Even though is possible to use Extract to extract each type, it feels more handy to have each type scenario exported

# How

 Separting the union into 2 types

