### PR TITLE
[docs] Fix formatting and typos in various docs

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -275,6 +275,7 @@ const RENAMED_PAGES: Record<string, string> = {
   // Redirects for removed /archived pages
   '/archived/': '/archive/',
   '/versions/latest/expokit/eject/': '/archive/expokit/eject/',
+  '/expokit/eject/': '/archive/expokit/eject/',
 
   // Redirects for removed API docs based on Sentry
   '/versions/latest/sdk/facebook/': '/guides/authentication/',

--- a/docs/expo-dict.json
+++ b/docs/expo-dict.json
@@ -10,6 +10,7 @@
   "expo go": "Expo Go",
   "expo sdk": "Expo SDK",
   "ios simulator": "iOS Simulator",
+  "javascript core": "JavaScriptCore",
   "mac os": "macOS",
   "objective c": "Objective-C",
   "play store": "Play Store",

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -76,7 +76,10 @@ Save all of your changes. In Xcode, update the iOS Deployment Target under `Targ
 
 ### Verifying installation
 
-You can verify that installation was successful by logging a value from [expo-constants](/versions/latest/sdk/constants/). Run `expo install expo-constants`, then run `expo run:[android|ios]` and modify your app JavaScript code to add the following:
+You can verify that the installation was successful by logging a value from [`expo-constants`](/versions/latest/sdk/constants).
+
+- Run `expo install expo-constants`
+- Then, run `expo run:[android|ios]` and modify your app JavaScript code to add the following:
 
 ```js
 import Constants from 'expo-constants';
@@ -85,18 +88,18 @@ console.log(Constants.systemFonts);
 
 ### Using Expo SDK packages
 
-Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. Learn more in ["Using Libraries"](/workflow/using-libraries).
+Once the `expo` package is installed and configured in your project, you can use `expo install` to add any other Expo module from the SDK. See [Using Libraries](/workflow/using-libraries) for more information.
 
 ### Expo modules included in the `expo` package
 
 The following Expo modules are brought in as dependencies of the `expo` package:
 
-- [expo-application](/versions/latest/sdk/application.mdx) - Generates the installation id in remote logging in development. This module is optional and can be safely removed if you do not use `expo-dev-client`.
-- [expo-asset](/versions/latest/sdk/asset.mdx) - A JavaScript-only package that builds around `expo-file-system` and provides a common foundation for assets across all Expo modules.
-- [expo-constants](/versions/latest/sdk/constants.mdx) - Provides access to the manifest.
-- [expo-file-system](/versions/latest/sdk/filesystem.mdx) - Interact with the device file system. Used by `expo-asset` and many other Expo modules. Commonly used directly by developers in application code.
-- [expo-font](/versions/latest/sdk/font.mdx) - Load fonts at runtime. This module is optional and can be safely removed, however; it is recommended if you use `expo-dev-client` for development and it is required by `@expo/vector-icons`.
-- [expo-keep-awake](/versions/latest/sdk/keep-awake.mdx) - Prevents your device from going to sleep while developing your app. This module is optional and can be safely removed.
+- [`expo-application`](/versions/latest/sdk/application) - Generates the installation id in remote logging in development. This module is optional and can be safely removed if you do not use `expo-dev-client`.
+- [`expo-asset`](/versions/latest/sdk/asset) - A JavaScript-only package that builds around `expo-file-system` and provides a common foundation for assets across all Expo modules.
+- [`expo-constants`](/versions/latest/sdk/constants) - Provides access to the manifest.
+- [`expo-file-system`](/versions/latest/sdk/filesystem) - Interact with the device file system. Used by `expo-asset` and many other Expo modules. Commonly used directly by developers in application code.
+- [`expo-font`](/versions/latest/sdk/font) - Load fonts at runtime. This module is optional and can be safely removed, however; it is recommended if you use `expo-dev-client` for development and it is required by `@expo/vector-icons`.
+- [`expo-keep-awake`](/versions/latest/sdk/keep-awake) - Prevents your device from going to sleep while developing your app. This module is optional and can be safely removed.
 
 To exclude any of these modules, refer to the following guide on [excluding modules from autolinking](#excluding-specific-modules-from-autolinking).
 
@@ -104,7 +107,7 @@ To exclude any of these modules, refer to the following guide on [excluding modu
 
 If you need to exclude Expo modules that you are not using but they got installed by other dependencies, you can use the `expo.autolinking` field in **package.json**:
 
-```json
+```json package.json
 {
   "name": "...",
   "dependencies": {},
@@ -118,7 +121,7 @@ If you need to exclude Expo modules that you are not using but they got installe
 
 You can also exclude a specific platform by using `exclude` under the platform key:
 
-```json
+```json package.json
 {
   "name": "...",
   "dependencies": {},

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -6,7 +6,7 @@ description: Learn how to add expo-updates to an existing React Native project.
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 
-The `expo-updates` library fetches and manages updates received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates for projects using the expo-updates library.
+The `expo-updates` library fetches and manages updates received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates for projects using the `expo-updates` library.
 
 > If you are creating a new project, we recommend using `npx create-react-native-app` instead of `npx react-native init` because it will handle the following configuration for you automatically. It includes the `expo-updates` [config plugin](/guides/config-plugins), which will handle the following steps for you.
 

--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -11,7 +11,7 @@ The steps for configuring a bare React Native project are identical to the steps
 
 The `eas update:configure` will add two values to your project's app config.
 
-```json app.config
+```json app.json
 {
   "expo": {
     "runtimeVersion": "1.0.0",

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -65,17 +65,29 @@ The following will only work if you have an Apple account with Apple Developer E
 
 </Collapsible>
 
-## 2. Configure app signing
+</Step>
 
-### 2.1 Configure app signing credentials for Android
+<Step label="2">
+
+## Configure app signing
+
+<Step label="2.1">
+
+### Configure app signing credentials for Android
 
 Android does not restrict distribution of applications &mdash; the operating system is capable of installing any compatible **.apk** file. As a result, configuring app signing credentials for internal distribution is no different from other types of builds. The main benefit of using internal distribution, in this case, is to have an easily shareable URL to provide to testers for downloading the app.
 
-### 2.2 Configure app signing credentials for iOS
+</Step>
+
+<Step label="2.2">
+
+### Configure app signing credentials for iOS
 
 Apple restricts distribution of applications on iPhones and iPads, so we will need to build the app with an ad hoc provisioning profile that explicitly lists the devices on which the application can run.
 
 An alternative to ad hoc provisioning is enterprise provisioning, which requires a special Apple Developer membership that costs $299 USD per year. Enterprise provisioning allows you to run the application on any device without any sort of device registration.
+
+</Step>
 
 #### Setting up ad hoc provisioning
 
@@ -108,7 +120,11 @@ If so, make sure to point your **credentials.json** to an ad hoc or enterprise p
 
 </Collapsible>
 
-## 3. Run a build with the internal build profile
+</Step>
+
+<Step label="3">
+
+## Run a build with the internal build profile
 
 Now that we have set up our build profile and app signing, running a build for internal distribution is just like any other build.
 
@@ -124,15 +140,25 @@ Now that we have set up our build profile and app signing, running a build for i
 
 When the build completes, you will be given a URL that you can share with your team to download and install the app.
 
-## 4. Install and run the build
+</Step>
+
+<Step label="4">
+
+## Install and run the build
 
 Press the "Install" button on the build page and follow the instructions presented in the modal.
 
 If you're running iOS 16 or above and haven't yet turned on Developer Mode, you will need to [enable it](/guides/ios-developer-mode) before you can run your build. (This doesn't apply if you're using enterprise provisioning.)
 
-## 5. Automation on CI (optional)
+</Step>
+
+<Step label="5">
+
+## Automation on CI (optional)
 
 It's possible to run internal distribution builds non-interactively in CI using the `--non-interactive` flag; however, if you are using ad hoc provisioning on iOS you will not be able to add new devices to your provisioning profile when using this flag. After registering a device through `eas device:create`, you need to run `eas build` interactively and authenticate with Apple for EAS to add the device to your provisioning profile. [Learn more about triggering builds from CI](/build/building-on-ci).
+
+</Step>
 
 {/* (@dsokal) this is not implemented yet */}
 

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -5,6 +5,7 @@ description: Learn how EAS Build provides shareable URLs for your builds with yo
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Uploading your app to TestFlight and Google Play beta can be time-consuming (for example, waiting for the build to run through static analysis before becoming available to testers) and limiting (for example, TestFlight can only have one active build at a time). Both Android and iOS provide alternative mechanisms to distribute apps directly to testers, so they can download and install them to physical devices directly from a web browser as soon as the builds are completed.
 
@@ -14,11 +15,17 @@ EAS Build can help you with this by providing shareable URLs for your builds wit
 
 ## Setting up internal distribution
 
-The following steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](setup.mdx). It will only take a few minutes in total to: configure the project, add a couple of test iOS devices to a provisioning profile, and start builds for Android and iOS.
+The following steps will guide you through adding internal distribution to a project that is [already set up to build with EAS Build](setup.mdx). It will only take a few minutes in total to:
 
-## 1. Configure a build profile
+- Configure the project
+- Add a couple of test iOS devices to a provisioning profile
+- Start builds for Android and iOS
 
-Open up **eas.json** and add a new build profile for iOS and/or Android.
+<Step label="1">
+
+## Configure a build profile
+
+Open **eas.json** in your project. You can use the pre-configured `preview` profile or [create a new one](/build/eas-json/#build-profiles) for Android or iOS.
 
 ```json eas.json
 {
@@ -62,11 +69,11 @@ The following will only work if you have an Apple account with Apple Developer E
 
 ### 2.1 Configure app signing credentials for Android
 
-Android does not restrict distribution of applications &mdash; the operating system is capable of installing any compatible **.apk** file. As a result, configuring app signing credentials for internal distribution is no different from other types of builds. The main benefit of using internal distribution in this case is to have an easily shareable URL to provide to testers for downloading the app.
+Android does not restrict distribution of applications &mdash; the operating system is capable of installing any compatible **.apk** file. As a result, configuring app signing credentials for internal distribution is no different from other types of builds. The main benefit of using internal distribution, in this case, is to have an easily shareable URL to provide to testers for downloading the app.
 
 ### 2.2 Configure app signing credentials for iOS
 
-Apple restricts distribution of applications on iPhones and iPads, so we will need to build the app with an ad hoc provisioning profile that explicitly lists the devices that the application can run on.
+Apple restricts distribution of applications on iPhones and iPads, so we will need to build the app with an ad hoc provisioning profile that explicitly lists the devices on which the application can run.
 
 An alternative to ad hoc provisioning is enterprise provisioning, which requires a special Apple Developer membership that costs $299 USD per year. Enterprise provisioning allows you to run the application on any device without any sort of device registration.
 
@@ -80,7 +87,7 @@ Setting up ad hoc provisioning consists of two steps. In the first step, you'll 
 
 You can register new devices at any time, but builds that were created before the device was registered will not run on newly registered devices; only builds that are created after the device is registered will be installable.
 
-The next step is to generate or update the provisioning profile. When you proceed to running a build, you will be guided through this process.
+The next step is to generate or update the provisioning profile. When you proceed to run a build, you will be guided through this process.
 
 <Collapsible summary="Are you setting up enterprise provisioning?">
 
@@ -97,7 +104,7 @@ If you distribute your app both through enterprise provisioning and the App Stor
 
 <Collapsible summary="Are you using manual local credentials?">
 
-If so, make sure to point your **credentials.json** to an ad hoc or enterprise provisioning profile that you generate through the Apple Developer Portal (either update an existing **credentials.json** used for another type of distribution or replace it with a new one that points to the appropriate provisioning profile). Beware that EAS CLI does only a limited validation of your local credentials, and you will have to handle device UDID registration manually. Read more about [using local credentials](/app-signing/local-credentials.mdx).
+If so, make sure to point your **credentials.json** to an ad hoc or enterprise provisioning profile that you generate through the Apple Developer Portal (either update an existing **credentials.json** used for another type of distribution or replace it with a new one that points to the appropriate provisioning profile). Beware that EAS CLI does only a limited validation of your local credentials, and you will have to handle device UDID registration manually. Read more about [using local credentials](/app-signing/local-credentials).
 
 </Collapsible>
 
@@ -125,7 +132,7 @@ If you're running iOS 16 or above and haven't yet turned on Developer Mode, you 
 
 ## 5. Automation on CI (optional)
 
-It's possible to run internal distribution builds non-interactively in CI using the `--non-interactive` flag; however, if you are using ad hoc provisioning on iOS you will not be able to add new devices to your provisioning profile when using this flag. After registering a device through `eas device:create`, you need to run `eas build` interactively and authenticate with Apple in order for EAS to add the device to your provisioning profile. [Learn more about triggering builds from CI](/build/building-on-ci.mdx).
+It's possible to run internal distribution builds non-interactively in CI using the `--non-interactive` flag; however, if you are using ad hoc provisioning on iOS you will not be able to add new devices to your provisioning profile when using this flag. After registering a device through `eas device:create`, you need to run `eas build` interactively and authenticate with Apple for EAS to add the device to your provisioning profile. [Learn more about triggering builds from CI](/build/building-on-ci).
 
 {/* (@dsokal) this is not implemented yet */}
 

--- a/docs/pages/guides/config-plugins.mdx
+++ b/docs/pages/guides/config-plugins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Config Plugins
-description: Learn about config plugins, which are the Expo way of customizing the prebuild phase of an project.
+description: Learn about config plugins, which are the Expo way of customizing the prebuild phase of a project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -4,11 +4,11 @@ title: Icons
 
 import { SnackInline } from '~/ui/components/Snippet';
 
-As trendy as it is these days, not every app has to use emoji for all icons -- maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
+As trendy as it is these days, not every app has to use emoji for all icons &mdash; maybe you want to pull in a popular set through an icon font like FontAwesome, Glyphicons or Ionicons, or you just use some PNGs that you carefully picked out on [The Noun Project](https://thenounproject.com/). Let's look at how to do both of these approaches.
 
 ## @expo/vector-icons
 
-This library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets that you can browse at [icons.expo.fyi](https://icons.expo.fyi).
+This library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets that you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 
 In the example below, the component loads the `Ionicons` font, and renders a checkmark icon.
 
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-> As with [any custom font](using-custom-fonts.mdx#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. Read more on about [pre-loading and caching assets](preloading-and-caching-assets#pre-loading-and-caching-assets).
+> As with [any custom font](using-custom-fonts.mdx#using-custom-fonts) in Expo, you may want to preload icon fonts before rendering your app. The font object is available as a static property on the font component, so in the case above it is `Ionicons.font`, which evaluates to `{ionicons: require('path/to/ionicons.ttf')}`. Read more about [pre-loading and caching assets](preloading-and-caching-assets#pre-loading-and-caching-assets).
 
 ## Custom Icon Fonts
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -383,7 +383,7 @@ and wasn't killed by the user, however, this is ultimately decided by the OS, so
 
 Custom notification sounds are only supported when using [EAS Build](/build/introduction).
 
-To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file:
+To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file and then under the `sounds` key, provide an array of local paths to sound files that can be used as custom notification sounds. These local paths are local to your project.
 
 ```json app.json
 {

--- a/docs/pages/versions/v47.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/notifications.mdx
@@ -269,7 +269,7 @@ You can also set a custom notification color _per-notification_ directly in your
 
 Custom notification sounds are only supported when using [EAS Build](/build/introduction).
 
-To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file:
+To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file and then under the `sounds` key, provide an array of local paths to sound files that can be used as custom notification sounds. These local paths are local to your project.
 
 ```json app.json
 {

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -383,7 +383,7 @@ and wasn't killed by the user, however, this is ultimately decided by the OS, so
 
 Custom notification sounds are only supported when using [EAS Build](/build/introduction).
 
-To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file:
+To add custom push notification sounds to your app, add the `expo-notifications` plugin to your **app.json** file and then under the `sounds` key, provide an array of local paths to sound files that can be used as custom notification sounds. These local paths are local to your project.
 
 ```json app.json
 {


### PR DESCRIPTION
# Why & How

This PR:
- adds JavaScriptCore to expo-dict.json
- update verbiage on Internal distribution page
- update info about setting custom notifications sounds to make it clear the sound file should be local to the project
- fix typos and missing code syntax highlights
- add missing redirect as reported in Sentry

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
