### PR TITLE
feat(cli): add upgrade command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Implement new package manager API in CLI. ([#19343](https://github.com/expo/expo/pull/19343) by [@byCedric](https://github.com/byCedric))
 - Add `EXPO_USE_METRO_WORKSPACE_ROOT` to enable using the workspace root for serving files. ([#21088](https://github.com/expo/expo/pull/21088) by [@EvanBacon](https://github.com/EvanBacon))
+- Add `npx expo upgrade` command. ([#21195](https://github.com/expo/expo/pull/21195) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -26,6 +26,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
   'export:web': () => import('../src/export/web').then((i) => i.expoExportWeb),
 
   // Auxiliary commands
+  upgrade: () => import('../src/upgrade').then((i) => i.expoUpgrade),
   install: () => import('../src/install').then((i) => i.expoInstall),
   customize: () => import('../src/customize').then((i) => i.expoCustomize),
 
@@ -76,6 +77,7 @@ if (!isSubcommand && args['--help']) {
     register,
     start,
     install,
+    upgrade,
     export: _export,
     config,
     customize,
@@ -92,7 +94,7 @@ if (!isSubcommand && args['--help']) {
   {bold Commands}
     ${Object.keys({ start, export: _export, ...others }).join(', ')}
     ${Object.keys({ 'run:ios': runIos, 'run:android': runAndroid, prebuild }).join(', ')}
-    ${Object.keys({ install, customize, config }).join(', ')}
+    ${Object.keys({ install, upgrade, customize, config }).join(', ')}
     {dim ${Object.keys({ login, logout, whoami, register }).join(', ')}}
 
   {bold Options}

--- a/packages/@expo/cli/e2e/__tests__/index-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/index-test.ts
@@ -34,7 +34,7 @@ it('runs `npx expo --help`', async () => {
       Commands
         start, export, export:web
         run:ios, run:android, prebuild
-        install, customize, config
+        install, upgrade, customize, config
         login, logout, whoami, register
 
       Options

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -41,7 +41,7 @@ it('loads expected modules by default', async () => {
   ]);
 });
 
-it('runs `npx install install --help`', async () => {
+it('runs `npx expo install --help`', async () => {
   const results = await execute('install', '--help');
   expect(results.stdout).toMatchInlineSnapshot(`
     "

--- a/packages/@expo/cli/e2e/__tests__/upgrade-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/upgrade-test.ts
@@ -1,0 +1,107 @@
+/* eslint-env jest */
+import JsonFile from '@expo/json-file';
+import execa, { ExecaError } from 'execa';
+import fs from 'fs/promises';
+import klawSync from 'klaw-sync';
+import path from 'path';
+
+import {
+  execute,
+  projectRoot,
+  getLoadedModulesAsync,
+  bin,
+  setupTestProjectAsync,
+  installAsync,
+  setupTestSDK45ProjectAsync,
+} from './utils';
+
+const originalForceColor = process.env.FORCE_COLOR;
+const originalCI = process.env.CI;
+beforeAll(async () => {
+  await fs.mkdir(projectRoot, { recursive: true });
+  process.env.FORCE_COLOR = '0';
+  process.env.CI = '1';
+});
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
+  process.env.CI = originalCI;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(`require('../../build/src/upgrade').expoUpgrade`);
+  expect(modules).toStrictEqual([
+    '../node_modules/arg/index.js',
+    '../node_modules/chalk/node_modules/ansi-styles/index.js',
+    '../node_modules/chalk/source/index.js',
+    '../node_modules/chalk/source/util.js',
+    '../node_modules/has-flag/index.js',
+    '../node_modules/supports-color/index.js',
+    '@expo/cli/build/src/log.js',
+    '@expo/cli/build/src/upgrade/index.js',
+    '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/errors.js',
+  ]);
+});
+
+it('runs `npx expo upgrade --help`', async () => {
+  const results = await execute('upgrade', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "
+      Info
+        Upgrade the React project to a newer version of Expo. Does not update native code.
+
+      Usage
+        $ npx expo upgrade
+
+      Options
+        --sdk-version  Expo SDK version to upgrade to
+        --npm          Use npm to install dependencies. Default when package-lock.json exists
+        --yarn         Use Yarn to install dependencies. Default when yarn.lock exists
+        --pnpm         Use pnpm to install dependencies. Default when pnpm-lock.yaml exists
+        -h, --help     Usage info
+    "
+  `);
+});
+
+it(
+  'runs `npx expo upgrade --sdk-version 47`',
+  async () => {
+    const projectRoot = await setupTestSDK45ProjectAsync('basic-upgrade', 'with-outdated');
+    // `npx expo install expo-sms`
+    await execa('node', [bin, 'upgrade', '--sdk-version', '47'], { cwd: projectRoot });
+
+    // List output files with sizes for snapshotting.
+    // This is to make sure that any changes to the output are intentional.
+    // Posix path formatting is used to make paths the same across OSes.
+    const files = klawSync(projectRoot)
+      .map((entry) => {
+        if (entry.path.includes('node_modules') || !entry.stats.isFile()) {
+          return null;
+        }
+        return path.posix.relative(projectRoot, entry.path);
+      })
+      .filter(Boolean);
+
+    const pkg = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
+
+    // Added expected package
+    const pkgDependencies = pkg.dependencies as Record<string, string>;
+
+    // Removed all outdated packages
+    expect(pkgDependencies).toEqual({
+      '@react-native-async-storage/async-storage': '~1.17.3',
+      expo: '47.0.0',
+      'expo-auth-session': '^3.8.0',
+      'expo-random': '~13.0.0',
+      react: '18.1.0',
+      'react-native': '0.70.5',
+    });
+    expect(pkg.devDependencies).toEqual({
+      '@babel/core': '^7.12.9',
+    });
+
+    expect(files).toStrictEqual(['App.js', 'app.json', 'package.json', 'yarn.lock']);
+  },
+  // Could take 45s depending on how fast npm installs
+  60 * 1000
+);

--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -191,6 +191,24 @@ export async function setupTestProjectAsync(name: string, fixtureName: string): 
   return projectRoot;
 }
 
+/** For use in the upgrade tests */
+export async function setupTestSDK45ProjectAsync(
+  name: string,
+  fixtureName: string
+): Promise<string> {
+  // If you're testing this locally, you can set the projectRoot to a local project (you created with expo init) to save time.
+  const projectRoot = await createFromFixtureAsync(os.tmpdir(), {
+    dirName: name,
+    reuseExisting: false,
+    fixtureName,
+  });
+
+  // Many of the factors in this test are based on the expected SDK version that we're testing against.
+  const { exp } = getConfig(projectRoot, { skipPlugins: true });
+  expect(exp.sdkVersion).toBe('45.0.0');
+  return projectRoot;
+}
+
 /** Returns a list of loaded modules relative to the repo root. Useful for preventing lazy loading from breaking unexpectedly.   */
 export async function getLoadedModulesAsync(statement: string): Promise<string[]> {
   const repoRoot = path.join(__dirname, '../../../../');

--- a/packages/@expo/cli/e2e/fixtures/with-outdated/App.js
+++ b/packages/@expo/cli/e2e/fixtures/with-outdated/App.js
@@ -1,0 +1,3 @@
+import React from 'react';
+import { View } from 'react-native';
+export default () => <View />;

--- a/packages/@expo/cli/e2e/fixtures/with-outdated/app.json
+++ b/packages/@expo/cli/e2e/fixtures/with-outdated/app.json
@@ -1,0 +1,10 @@
+{
+    "expo": {
+        "android": {
+            "package": "com.example.minimal"
+        },
+        "ios": {
+            "bundleIdentifier": "com.example.minimal"
+        }
+    }
+}

--- a/packages/@expo/cli/e2e/fixtures/with-outdated/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-outdated/package.json
@@ -1,0 +1,14 @@
+{
+  "main": "node_modules/expo/AppEntry.js",
+  "dependencies": {
+    "expo": "~45.0.0",
+    "react": "18.0.0",
+    "react-native": "0.69.1",
+    "@react-native-community/async-storage": "1.12.1",
+    "expo-auth-session": "^3.8.0"
+  },
+  "devDependencies": {
+    "react-native-unimodules": "~0.14.10",
+    "@babel/core": "^7.12.9"
+  }
+}

--- a/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
@@ -5,7 +5,7 @@ import {
   logIncorrectDependencies,
 } from '../../start/doctor/dependencies/validateDependenciesVersions';
 import { confirmAsync } from '../../utils/prompts';
-import { checkPackagesAsync } from '../checkPackages';
+import { checkPackagesAsync, checkPackagesInternalAsync } from '../checkPackages';
 import { fixPackagesAsync } from '../installAsync';
 
 jest.mock('../../log');
@@ -103,13 +103,15 @@ describe(checkPackagesAsync, () => {
 
     asMock(getVersionedDependenciesAsync).mockResolvedValueOnce(issues);
 
-    await checkPackagesAsync('/', {
-      packages: ['react-native', 'expo'],
-      options: { fix: true },
-      // @ts-expect-error
-      packageManager: {},
-      packageManagerArguments: [],
-    });
+    expect(
+      await checkPackagesInternalAsync('/', {
+        packages: ['react-native', 'expo'],
+        options: { fix: true },
+        // @ts-expect-error
+        packageManager: {},
+        packageManagerArguments: [],
+      })
+    ).toEqual(true);
 
     expect(fixPackagesAsync).toBeCalledWith('/', {
       packageManager: {},

--- a/packages/@expo/cli/src/install/upgradeNew.ts
+++ b/packages/@expo/cli/src/install/upgradeNew.ts
@@ -1,0 +1,152 @@
+import { getConfig } from '@expo/config';
+import * as PackageManager from '@expo/package-manager';
+import chalk from 'chalk';
+import semver from 'semver';
+
+import { getVersionsAsync } from '../api/getVersions';
+import * as Log from '../log';
+import {
+  hasRequiredAndroidFilesAsync,
+  hasRequiredIOSFilesAsync,
+} from '../prebuild/clearNativeFolder';
+import { getRemoteVersionsForSdkAsync } from '../start/doctor/dependencies/getVersionedPackages';
+import { env } from '../utils/env';
+import { CommandError } from '../utils/errors';
+import { maybeBailOnGitStatusAsync } from '../utils/git';
+import { attemptModification } from '../utils/modifyConfigAsync';
+import { installAsync } from './installAsync';
+
+const debug = require('debug')('expo:upgrade') as typeof console.log;
+
+function formatSdkVersion(sdkVersionString: string) {
+  return semver.valid(semver.coerce(sdkVersionString) || '');
+}
+
+export async function upgradeAsync(
+  projectRoot: string,
+  { version: versionArgument }: { version?: string }
+) {
+  // Perform this early
+  const versionToInstall = versionArgument ? formatSdkVersion(versionArgument) : 'latest';
+
+  if (!versionToInstall && versionArgument) {
+    throw new CommandError(`Invalid version: ${versionArgument}`);
+  }
+
+  let projectConfig = getConfig(projectRoot);
+
+  const initialExpoVersion = projectConfig.exp.sdkVersion!;
+
+  if (versionArgument && semver.lt(versionArgument, initialExpoVersion)) {
+    throw new CommandError(
+      `Downgrading is not supported. (current: ${initialExpoVersion}, requested: ${versionArgument})`
+    );
+  }
+
+  debug(`Current Expo version: ${initialExpoVersion}`);
+
+  // Drop manual Expo SDK version from the config.
+  // Users have no reason to ever define this manually with versioned Expo CLI.
+  if (projectConfig.rootConfig.expo.sdkVersion) {
+    await attemptModification(
+      projectRoot,
+      {
+        sdkVersion: undefined,
+      },
+      { sdkVersion: undefined }
+    );
+  }
+
+  // Run this after all sanity checks.
+  if (await maybeBailOnGitStatusAsync()) {
+    return null;
+  }
+
+  // Do this first to ensure we have the latest versions locally
+  await getVersionsAsync({ skipCache: true });
+
+  const packageManager = PackageManager.createForProject(projectRoot, {
+    log: Log.log,
+    silent: false,
+  });
+
+  Log.log(`Installing: expo@${versionToInstall}`);
+
+  // Update Expo to the latest version.
+  await packageManager.installAsync([
+    // TODO: custom version
+    `expo@${versionToInstall}`,
+  ]);
+
+  Log.log(`Fixing known dependencies: npx expo install --fix`);
+
+  // Align dependencies with new Expo SDK version.
+  await installAsync([], {
+    projectRoot,
+    fix: true,
+    silent: false,
+  });
+
+  // Read config again to get the new SDK version and package.json.
+  projectConfig = getConfig(projectRoot);
+
+  const nextExpoVersion = projectConfig.exp.sdkVersion!;
+
+  const pkgsToInstall = [];
+  const pkgsToRemove = [];
+  if (projectConfig.pkg.dependencies?.['@react-native-community/async-storage']) {
+    //@react-native-async-storage/async-storage
+    pkgsToInstall.push('@react-native-async-storage/async-storage');
+    pkgsToRemove.push('@react-native-community/async-storage');
+  }
+
+  if (projectConfig.pkg.dependencies?.['expo-auth-session']) {
+    pkgsToInstall.push('expo-random');
+  }
+
+  if (pkgsToRemove.length) {
+    Log.log(`Removing packages: ${pkgsToRemove.join(', ')}`);
+    await packageManager.removeAsync(...pkgsToRemove);
+  }
+
+  if (pkgsToInstall.length) {
+    Log.log(`Adding packages: ${pkgsToInstall.join(', ')}`);
+    await installAsync(pkgsToInstall, {
+      projectRoot,
+      silent: false,
+    });
+  }
+
+  Log.log(chalk.greenBright`Project has been upgraded to Expo SDK ${nextExpoVersion}`);
+
+  const nextVersion = await getRemoteVersionsForSdkAsync({ sdkVersion: nextExpoVersion });
+  const initialVersion = await getRemoteVersionsForSdkAsync({ sdkVersion: initialExpoVersion });
+
+  if (nextVersion?.releaseNoteUrl) {
+    Log.log(
+      `Please refer to the release notes for information on any further required steps to update and information about breaking changes:`
+    );
+    Log.log(chalk.bold(nextVersion.releaseNoteUrl));
+  } else {
+    if (env.EXPO_BETA) {
+      Log.log(
+        chalk.gray`Release notes are not available for beta releases. Please refer to the CHANGELOG: https://github.com/expo/expo/blob/master/CHANGELOG.md.`
+      );
+    } else {
+      Log.log(
+        chalk.gray`Unable to find release notes for ${nextExpoVersion}, please try to find them on https://blog.expo.dev to learn more about other potentially important upgrade steps and breaking changes.`
+      );
+    }
+  }
+
+  if (
+    (await hasRequiredAndroidFilesAsync(projectRoot)) ||
+    (await hasRequiredIOSFilesAsync(projectRoot))
+  ) {
+    const upgradeHelperUrl = `https://react-native-community.github.io/upgrade-helper/?from=${initialVersion['react-native']}&to=${nextVersion['react-nativex']}`;
+
+    Log.log(
+      chalk`Native projects detected. Either upgrade automatically with {bold npx expo prebuild --clean} or manually by following the guide at: ${upgradeHelperUrl}.`
+    );
+  }
+}

--- a/packages/@expo/cli/src/upgrade/__tests__/upgradeAsync.test.ts
+++ b/packages/@expo/cli/src/upgrade/__tests__/upgradeAsync.test.ts
@@ -1,0 +1,30 @@
+import { getPackagesToModify } from '../upgradeAsync';
+
+describe(getPackagesToModify, () => {
+  it(`should remove deprecated packages`, () => {
+    const pkgJson = {
+      dependencies: {
+        'react-native-unimodules': '0.14.0',
+      },
+    };
+
+    const { remove, add } = getPackagesToModify(pkgJson);
+
+    expect(remove).toEqual(['react-native-unimodules']);
+    expect(add).toEqual([]);
+  });
+
+  it(`should add new packages`, () => {
+    const pkgJson = {
+      dependencies: {
+        '@react-native-community/async-storage': '1.13.2',
+        'expo-auth-session': '3.3.1',
+      },
+    };
+
+    const { remove, add } = getPackagesToModify(pkgJson);
+
+    expect(remove).toEqual(['@react-native-community/async-storage']);
+    expect(add).toEqual(['@react-native-async-storage/async-storage', 'expo-random']);
+  });
+});

--- a/packages/@expo/cli/src/upgrade/index.ts
+++ b/packages/@expo/cli/src/upgrade/index.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { CommandError } from '../utils/errors';
+
+export const expoUpgrade: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      '--sdk-version': String,
+      '--npm': Boolean,
+      '--pnpm': Boolean,
+      '--yarn': Boolean,
+      // Other options are parsed manually.
+      '--help': Boolean,
+      // Aliases
+      '-h': '--help',
+    },
+    argv
+  );
+
+  if (args['--help']) {
+    printHelp(
+      `Upgrade the React project to a newer version of Expo. Does not update native code.`,
+      `npx expo upgrade`,
+      [
+        `--sdk-version     Expo SDK version to upgrade to`,
+        chalk`--npm       Use npm to install dependencies. {dim Default when package-lock.json exists}`,
+        chalk`--yarn      Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
+        chalk`--pnpm      Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
+        `-h, --help  Usage info`,
+      ].join('\n')
+    );
+  }
+  const options = {
+    version: args['--sdk-version'],
+    npm: args['--npm'],
+    yarn: args['--yarn'],
+    pnpm: args['--pnpm'],
+  };
+
+  if ([options.npm, options.pnpm, options.yarn].filter(Boolean).length > 1) {
+    throw new CommandError('BAD_ARGS', 'Specify at most one of: --npm, --pnpm, --yarn');
+  }
+
+  const { upgradeAsync } = require('./upgradeAsync') as typeof import('./upgradeAsync');
+  const { logCmdError } = require('../utils/errors') as typeof import('../utils/errors');
+
+  return (async () => upgradeAsync(getProjectRoot(args), options))().catch(logCmdError);
+};

--- a/packages/@expo/cli/src/upgrade/index.ts
+++ b/packages/@expo/cli/src/upgrade/index.ts
@@ -25,11 +25,11 @@ export const expoUpgrade: Command = async (argv) => {
       `Upgrade the React project to a newer version of Expo. Does not update native code.`,
       `npx expo upgrade`,
       [
-        `--sdk-version     Expo SDK version to upgrade to`,
-        chalk`--npm       Use npm to install dependencies. {dim Default when package-lock.json exists}`,
-        chalk`--yarn      Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
-        chalk`--pnpm      Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
-        `-h, --help  Usage info`,
+        `--sdk-version  Expo SDK version to upgrade to`,
+        chalk`--npm          Use npm to install dependencies. {dim Default when package-lock.json exists}`,
+        chalk`--yarn         Use Yarn to install dependencies. {dim Default when yarn.lock exists}`,
+        chalk`--pnpm         Use pnpm to install dependencies. {dim Default when pnpm-lock.yaml exists}`,
+        `-h, --help     Usage info`,
       ].join('\n')
     );
   }

--- a/packages/@expo/cli/src/upgrade/upgradeAsync.ts
+++ b/packages/@expo/cli/src/upgrade/upgradeAsync.ts
@@ -1,0 +1,214 @@
+import { getConfig } from '@expo/config';
+import * as PackageManager from '@expo/package-manager';
+import chalk from 'chalk';
+import semver from 'semver';
+
+import { getVersionsAsync } from '../api/getVersions';
+import { checkPackagesInternalAsync } from '../install/checkPackages';
+import { installAsync } from '../install/installAsync';
+import * as Log from '../log';
+import {
+  hasRequiredAndroidFilesAsync,
+  hasRequiredIOSFilesAsync,
+} from '../prebuild/clearNativeFolder';
+import {
+  getCombinedKnownVersionsAsync,
+  getRemoteVersionsForSdkAsync,
+} from '../start/doctor/dependencies/getVersionedPackages';
+import { env } from '../utils/env';
+import { CommandError } from '../utils/errors';
+import { maybeBailOnGitStatusAsync } from '../utils/git';
+import { attemptModification } from '../utils/modifyConfigAsync';
+
+const debug = require('debug')('expo:upgrade') as typeof console.log;
+
+function formatSdkVersion(sdkVersionString: string) {
+  // Convert a value like 2 or 2.0 to 2.0.0
+  return semver.valid(semver.coerce(sdkVersionString, { loose: true }) || '');
+}
+
+export async function upgradeAsync(
+  projectRoot: string,
+  {
+    version: versionArgument,
+    ...options
+  }: { version?: string; npm?: boolean; yarn?: boolean; pnpm?: boolean }
+) {
+  // Perform this early
+  const versionToInstall = versionArgument ? formatSdkVersion(versionArgument) : 'latest';
+
+  debug(`Requested Expo version: ${versionToInstall}`);
+  if (!versionToInstall) {
+    throw new CommandError(`Invalid version: ${versionArgument}`);
+  }
+
+  let projectConfig = getConfig(projectRoot);
+
+  const initialPackages = {
+    ...projectConfig.pkg.dependencies,
+    ...projectConfig.pkg.devDependencies,
+  };
+
+  const initialExpoVersion = projectConfig.exp.sdkVersion!;
+
+  if (
+    // Allow downgrading for general testing
+    !env.EXPO_DEBUG &&
+    // Otherwise all downgrading is blocked
+    versionToInstall !== 'latest' &&
+    semver.lt(versionToInstall, initialExpoVersion)
+  ) {
+    throw new CommandError(
+      `Downgrading is not supported. (current: ${initialExpoVersion}, requested: ${versionToInstall})`
+    );
+  }
+
+  debug(`Current Expo version: ${initialExpoVersion}`);
+
+  // Drop manual Expo SDK version from the config.
+  // Users have no reason to ever define this manually with versioned Expo CLI.
+  if (projectConfig.rootConfig.expo.sdkVersion) {
+    await attemptModification(
+      projectRoot,
+      {
+        sdkVersion: undefined,
+      },
+      { sdkVersion: undefined }
+    );
+  }
+
+  // Run this after all sanity checks.
+  if (await maybeBailOnGitStatusAsync()) {
+    return;
+  }
+
+  // Do this first to ensure we have the latest versions locally
+  const versionData = await getVersionsAsync({ skipCache: true });
+
+  const initialVersion = await getRemoteVersionsForSdkAsync({ sdkVersion: initialExpoVersion });
+
+  const packageManager = PackageManager.createForProject(projectRoot, {
+    log: Log.log,
+    silent: false,
+    ...options,
+  });
+
+  // Do some evergreen upgrades
+
+  const pkgsToInstall = [];
+  const pkgsToRemove = [];
+
+  // Remove deprecated packages
+  ['react-native-unimodules'].forEach((pkg) => {
+    if (projectConfig.pkg.dependencies?.[pkg] || projectConfig.pkg.devDependencies?.[pkg]) {
+      pkgsToRemove.push(pkg);
+    }
+  });
+
+  if (projectConfig.pkg.dependencies?.['@react-native-community/async-storage']) {
+    //@react-native-async-storage/async-storage
+    pkgsToInstall.push('@react-native-async-storage/async-storage');
+    pkgsToRemove.push('@react-native-community/async-storage');
+  }
+
+  if (projectConfig.pkg.dependencies?.['expo-auth-session']) {
+    pkgsToInstall.push('expo-random');
+  }
+
+  if (pkgsToRemove.length) {
+    Log.log(`Removing packages: ${pkgsToRemove.join(', ')}`);
+    await packageManager.removeAsync(pkgsToRemove);
+  }
+
+  if (pkgsToInstall.length) {
+    Log.log(`Adding packages: ${pkgsToInstall.join(', ')}`);
+    await installAsync(pkgsToInstall, {
+      projectRoot,
+      silent: false,
+    });
+  }
+
+  // Now perform versioned work...
+
+  Log.log(`Upgrading Expo`);
+
+  // Update Expo to the latest version.
+  await packageManager.addAsync([
+    // TODO: custom version
+    `expo@${versionToInstall}`,
+  ]);
+
+  Log.log();
+  Log.log(chalk.bold`npx expo install --fix`);
+
+  // Align dependencies with new Expo SDK version.
+  await checkPackagesInternalAsync(projectRoot, {
+    packages: [],
+    options: { fix: true },
+    packageManager,
+    packageManagerArguments: [],
+  });
+
+  Log.log();
+
+  // Read config again to get the new SDK version and package.json.
+  projectConfig = getConfig(projectRoot);
+
+  const nextExpoVersion = projectConfig.exp.sdkVersion!;
+  const relatedVersionInfo = versionData.sdkVersions[nextExpoVersion];
+  Log.log(chalk.greenBright`Project has been upgraded to Expo SDK ${nextExpoVersion}`);
+
+  if (relatedVersionInfo?.releaseNoteUrl || env.EXPO_BETA) {
+    Log.log(
+      chalk`Release notes: {gray ${
+        relatedVersionInfo.releaseNoteUrl || 'https://github.com/expo/expo/blob/main/CHANGELOG.md'
+      }}`
+    );
+  } else {
+    Log.log(
+      chalk.red`Release notes: Not Found (this is a bug). Try checking https://blog.expo.dev`
+    );
+  }
+
+  Log.log();
+
+  // Print unknown packages
+
+  const nextVersion = await getCombinedKnownVersionsAsync({
+    projectRoot,
+    sdkVersion: nextExpoVersion,
+  });
+
+  const finalDependencies = {
+    ...projectConfig.pkg.dependencies,
+    ...projectConfig.pkg.devDependencies,
+  };
+
+  const unmodifiedDependencies = Object.keys(initialPackages).filter(
+    (key) => initialPackages[key] === finalDependencies[key] && key !== 'expo'
+  );
+
+  const unknownDependencies = unmodifiedDependencies.filter((key) => !nextVersion[key]);
+
+  if (unknownDependencies.length) {
+    Log.log(
+      chalk`{bold The following dependencies may need to be upgraded manually:}\n${unknownDependencies
+        .sort()
+        .join('\n')}`
+    );
+    Log.log();
+  }
+
+  // Print native info
+
+  if (
+    (await hasRequiredAndroidFilesAsync(projectRoot)) ||
+    (await hasRequiredIOSFilesAsync(projectRoot))
+  ) {
+    const upgradeHelperUrl = `https://react-native-community.github.io/upgrade-helper/?from=${initialVersion['react-native']}&to=${nextVersion['react-native']}`;
+
+    Log.log(
+      chalk`{yellow Native projects detected. Do one of the following:}\n- Automatically: {bold npx expo prebuild --clean} {gray Learn more: https://docs.expo.dev/workflow/prebuild/#clean}\n- Manually: {gray Learn more: ${upgradeHelperUrl}}`
+    );
+  }
+}

--- a/packages/@expo/cli/src/upgrade/upgradeAsync.ts
+++ b/packages/@expo/cli/src/upgrade/upgradeAsync.ts
@@ -95,8 +95,8 @@ export async function upgradeAsync(
 
   // Do some evergreen upgrades
 
-  const pkgsToInstall = [];
-  const pkgsToRemove = [];
+  const pkgsToInstall: string[] = [];
+  const pkgsToRemove: string[] = [];
 
   // Remove deprecated packages
   ['react-native-unimodules'].forEach((pkg) => {
@@ -133,10 +133,10 @@ export async function upgradeAsync(
   Log.log(`Upgrading Expo`);
 
   // Update Expo to the latest version.
-  await packageManager.addAsync([
+  await packageManager.addAsync(
     // TODO: custom version
-    `expo@${versionToInstall}`,
-  ]);
+    [`expo@${versionToInstall}`]
+  );
 
   Log.log();
   Log.log(chalk.bold`npx expo install --fix`);


### PR DESCRIPTION
# Why

- Migrate `expo-cli upgrade` to the local CLI.
- Concern: Does a command that upgrades itself make sense? It relies on unversioned or "global" data to work. We won't be able to update old versions if something goes wrong.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Mostly just runs the install command but with more curated options and different arguments.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- tbd