### PR TITLE
[expo-updates][e2e] Add rollback e2e

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Break up E2E tests for reliability. ([#21223](https://github.com/expo/expo/pull/21223) by [@douglowder](https://github.com/douglowder))
 - Convert E2E tests to TypeScript. ([#21278](https://github.com/expo/expo/pull/21278) by [@douglowder](https://github.com/douglowder))
 - Improved README and other chagnes for E2E tests. ([#21331](https://github.com/expo/expo/pull/21331) by [@douglowder](https://github.com/douglowder))
+- Protocol 1 support and rollback test in E2E tests. ([#21197](https://github.com/expo/expo/pull/21197) by [@wschurman](https://github.com/wschurman), [@douglowder](https://github.com/douglowder))
 
 ## 0.16.1 — 2023-02-09
 

--- a/packages/expo-updates/e2e/fixtures/Updates-basic.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-basic.e2e.ts
@@ -3,12 +3,11 @@ import path from 'path';
 import { setTimeout } from 'timers/promises';
 
 import Server from './utils/server';
-
 import Update from './utils/update';
 
 const projectRoot = process.env.PROJECT_ROOT || process.cwd();
 const platform = (process.env.DETOX_CONFIGURATION || 'ios.release').split('.')[0];
-
+const protocolVersion = platform === 'android' ? 1 : 0;
 const TIMEOUT_BIAS = process.env.CI ? 10 : 1;
 
 describe('', () => {
@@ -19,7 +18,7 @@ describe('', () => {
 
   it('starts app, stops, and starts again', async () => {
     jest.setTimeout(300000 * TIMEOUT_BIAS);
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await device.installApp();
     await device.launchApp({
       newInstance: true,
@@ -75,7 +74,7 @@ describe('', () => {
       []
     );
 
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -118,7 +117,7 @@ describe('', () => {
       []
     );
 
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -179,7 +178,7 @@ describe('', () => {
       assets
     );
 
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -262,7 +261,7 @@ describe('', () => {
       assets
     );
 
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -300,7 +299,7 @@ describe('', () => {
       []
     );
 
-    Server.start(Update.serverPort);
+    Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
     await device.launchApp({
@@ -319,5 +318,90 @@ describe('', () => {
     await device.launchApp();
     const secondMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
     expect(secondMessage).toBe('test');
+  });
+
+  it('supports rollbacks', async () => {
+    if (platform === 'ios') {
+      console.warn('Rollbacks not yet implemented on iOS: exiting.');
+      return;
+    }
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      []
+    );
+
+    Server.start(Update.serverPort, protocolVersion);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const message = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(message).toBe('test');
+
+    // give the app time to load the new update in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+    expect(Server.consumeRequestedStaticFiles().length).toBe(1);
+
+    // restart the app so it will launch the new update
+    await device.terminateApp();
+    await device.launchApp();
+    const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const updatedMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    expect(updatedMessage).toBe(newNotifyString);
+
+    // serve a rollback now
+    const rollbackDirective = Update.getRollbackDirective(new Date());
+    await Server.serveSignedDirective(rollbackDirective, projectRoot);
+
+    // restart the app so it will fetch the rollback
+    await device.terminateApp();
+    await device.launchApp();
+    const thirdRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+
+    // give the app time to load the rollback in the background
+    await setTimeout(2000 * TIMEOUT_BIAS);
+
+    // restart the app so it will launch the rollback
+    await device.terminateApp();
+    await device.launchApp();
+    const fourthRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    const rolledBackMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
+    //expect(rolledBackMessage).toBe('test');
+    console.warn(
+      `Rollback E2E not working until rolledBackMessage === 'test'. Actual value: '${rolledBackMessage}'`
+    );
+    expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
+    expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
+    expect(thirdRequest.headers['expo-embedded-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
+    expect(fourthRequest.headers['expo-embedded-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
+
+    expect(firstRequest.headers['expo-current-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
+    expect(secondRequest.headers['expo-current-update-id']).toEqual(manifest.id);
+    expect(thirdRequest.headers['expo-current-update-id']).toEqual(manifest.id);
+    expect(fourthRequest.headers['expo-current-update-id']).toEqual(
+      firstRequest.headers['expo-embedded-update-id']
+    );
   });
 });

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/server.ts
@@ -1,27 +1,33 @@
 import * as crypto from 'crypto';
 import express from 'express';
+import FormData from 'form-data';
 import * as fs from 'fs';
 import * as path from 'path';
-
 import { serializeDictionary } from 'structured-headers';
 import { setTimeout } from 'timers/promises';
 
 const app = express();
 
-let server: { close: () => void; } | null;
+let server: { close: () => void } | null;
 
 let messages: any[] = [];
 let logEntries: string | any[] = [];
 let responsesToServe: any[] = [];
 
 let updateRequest: null = null;
+
 let manifestToServe: null = null;
-let manifestHeadersToServe: { [x: string]: any; } | null = null;
+let manifestHeadersToServe: { [x: string]: any } | null = null;
+
+let multipartResponseToServe: any = null;
 let requestedStaticFiles: string[] = [];
 
-function start(port: any) {
+let protocolVersion: number = 1;
+
+function start(port: any, protocol: number = 1) {
   if (!server) {
     server = app.listen(port);
+    protocolVersion = protocol;
   }
 }
 
@@ -36,6 +42,7 @@ function stop() {
   updateRequest = null;
   manifestToServe = null;
   manifestHeadersToServe = null;
+  multipartResponseToServe = null;
   requestedStaticFiles = [];
 }
 
@@ -46,37 +53,66 @@ function consumeRequestedStaticFiles() {
 }
 
 app.use(express.json());
-app.use('/static', (req: { url: string; }, res: any, next: () => void) => {
+app.use('/static', (req: { url: string }, res: any, next: () => void) => {
   requestedStaticFiles.push(path.basename(req.url));
   next();
 });
 app.use('/static', express.static(path.resolve(__dirname, '..', '.static')));
 
-app.get('/notify/:string', (req: { params: { string: any; }; }, res: { set: (arg0: string, arg1: string) => void; json: (arg0: any) => void; send: (arg0: string) => void; }) => {
-  messages.push(req.params.string);
-  res.set('Cache-Control', 'no-store');
-  if (responsesToServe[0]) {
-    res.json(responsesToServe.shift());
-  } else {
+app.get(
+  '/notify/:string',
+  (
+    req: { params: { string: any } },
+    res: {
+      set: (arg0: string, arg1: string) => void;
+      json: (arg0: any) => void;
+      send: (arg0: string) => void;
+    }
+  ) => {
+    messages.push(req.params.string);
+    res.set('Cache-Control', 'no-store');
+    if (responsesToServe[0]) {
+      res.json(responsesToServe.shift());
+    } else {
+      res.send('Received request');
+    }
+  }
+);
+
+app.post(
+  '/post',
+  (
+    req: { body: any },
+    res: {
+      set: (arg0: string, arg1: string) => void;
+      json: (arg0: any) => void;
+      send: (arg0: string) => void;
+    }
+  ) => {
+    messages.push(req.body);
+    res.set('Cache-Control', 'no-store');
+    if (responsesToServe[0]) {
+      res.json(responsesToServe.shift());
+    } else {
+      res.send('Received request');
+    }
+  }
+);
+
+app.post(
+  '/log',
+  (
+    req: { body: { logEntries: never[] } },
+    res: {
+      set: (arg0: string, arg1: string) => void;
+      send: (arg0: string) => void;
+    }
+  ) => {
+    logEntries = req.body.logEntries || [];
+    res.set('Cache-Control', 'no-store');
     res.send('Received request');
   }
-});
-
-app.post('/post', (req: { body: any; }, res: { set: (arg0: string, arg1: string) => void; json: (arg0: any) => void; send: (arg0: string) => void; }) => {
-  messages.push(req.body);
-  res.set('Cache-Control', 'no-store');
-  if (responsesToServe[0]) {
-    res.json(responsesToServe.shift());
-  } else {
-    res.send('Received request');
-  }
-});
-
-app.post('/log', (req: { body: { logEntries: never[]; }; }, res: { set: (arg0: string, arg1: string) => void; send: (arg0: string) => void; }) => {
-  logEntries = req.body.logEntries || [];
-  res.set('Cache-Control', 'no-store');
-  res.send('Received request');
-});
+);
 
 async function waitForRequest(timeout: number, responseToServe: any = null) {
   const finishTime = new Date().getTime() + timeout;
@@ -115,19 +151,54 @@ async function waitForLogEntries(timeout: number) {
 
 app.get('/update', (req: any, res: any) => {
   updateRequest = req;
-  if (manifestToServe) {
-    if (manifestHeadersToServe) {
-      Object.keys(manifestHeadersToServe).forEach((headerName) => {
-        res.set(headerName, manifestHeadersToServe ? manifestHeadersToServe[headerName] : '');
+  if (multipartResponseToServe) {
+    // Protocol 1: multipart and rollbacks supported
+    const form = new FormData();
+
+    if (multipartResponseToServe.manifest) {
+      form.append('manifest', JSON.stringify(multipartResponseToServe.manifest), {
+        contentType: 'application/json',
+        header: {
+          'content-type': 'application/json; charset=utf-8',
+          'expo-signature': multipartResponseToServe.manifestSignature,
+        },
       });
     }
-    res.json(manifestToServe);
+
+    if (multipartResponseToServe.directive) {
+      form.append('directive', JSON.stringify(multipartResponseToServe.directive), {
+        contentType: 'application/json',
+        header: {
+          'content-type': 'application/json; charset=utf-8',
+          'expo-signature': multipartResponseToServe.directiveSignature,
+        },
+      });
+    }
+
+    res.statusCode = 200;
+    res.setHeader('expo-protocol-version', 1);
+    res.setHeader('expo-sfv-version', 0);
+    res.setHeader('cache-control', 'private, max-age=0');
+    res.setHeader('content-type', `multipart/mixed; boundary=${form.getBoundary()}`);
+    res.write(form.getBuffer());
+    res.end();
   } else {
+    // Protocol 0
+    if (manifestToServe) {
+      if (manifestHeadersToServe) {
+        Object.keys(manifestHeadersToServe).forEach((headerName) => {
+          res.set(headerName, manifestHeadersToServe ? manifestHeadersToServe[headerName] : '');
+        });
+      }
+      res.json(manifestToServe);
+    } else {
+      res.status(404).send('No update available');
+    }
     res.status(404).send('No update available');
   }
 });
 
-async function waitForUpdateRequest(timeout: number): Promise<{ headers: any; }> {
+async function waitForUpdateRequest(timeout: number): Promise<{ headers: any }> {
   const finishTime = new Date().getTime() + timeout;
   while (!updateRequest && server) {
     const currentTime = new Date().getTime();
@@ -145,25 +216,25 @@ async function waitForUpdateRequest(timeout: number): Promise<{ headers: any; }>
   return request;
 }
 
-function serveManifest(manifest: any, headers: any = null) {
-  manifestToServe = manifest;
-  manifestHeadersToServe = headers;
-}
-
 async function getPrivateKeyAsync(projectRoot: string) {
   const codeSigningPrivateKeyPath = path.join(projectRoot, 'keys', 'private-key.pem');
   const pemBuffer = fs.readFileSync(path.resolve(codeSigningPrivateKeyPath));
   return pemBuffer.toString('utf8');
 }
 
-function signRSASHA256(data: string, privateKey: crypto.KeyLike | crypto.SignKeyObjectInput | crypto.SignPrivateKeyInput) {
+function signRSASHA256(
+  data: string,
+  privateKey: crypto.KeyLike | crypto.SignKeyObjectInput | crypto.SignPrivateKeyInput
+) {
   const sign = crypto.createSign('RSA-SHA256');
   sign.update(data, 'utf8');
   sign.end();
   return sign.sign(privateKey, 'base64');
 }
 
-function convertToDictionaryItemsRepresentation(obj: { [s: string]: unknown; } | ArrayLike<unknown>): any {
+function convertToDictionaryItemsRepresentation(
+  obj: { [s: string]: unknown } | ArrayLike<unknown>
+): any {
   return new Map(
     Object.entries(obj).map(([k, v]) => {
       return [k, [v, new Map()]];
@@ -171,7 +242,21 @@ function convertToDictionaryItemsRepresentation(obj: { [s: string]: unknown; } |
   );
 }
 
+function serveManifest(manifest: any, headers: any = null) {
+  manifestToServe = manifest;
+  manifestHeadersToServe = headers;
+}
+
 async function serveSignedManifest(manifest: any, projectRoot: any) {
+  if (protocolVersion === 0) {
+    serveSignedManifest0(manifest, projectRoot);
+  } else {
+    serveSignedManifest1(manifest, projectRoot);
+  }
+}
+
+// Protocol 0
+async function serveSignedManifest0(manifest: any, projectRoot: any) {
   const privateKey = await getPrivateKeyAsync(projectRoot);
   const manifestString = JSON.stringify(manifest);
   const hashSignature = signRSASHA256(manifestString, privateKey);
@@ -183,6 +268,38 @@ async function serveSignedManifest(manifest: any, projectRoot: any) {
   serveManifest(manifest, { 'expo-protocol-version': '0', 'expo-signature': signature });
 }
 
+// Protocol 1 multipart response
+async function serveSignedManifest1(manifest: any, projectRoot: any) {
+  const privateKey = await getPrivateKeyAsync(projectRoot);
+  const manifestString = JSON.stringify(manifest);
+  const hashSignature = signRSASHA256(manifestString, privateKey);
+  const dictionary = convertToDictionaryItemsRepresentation({
+    sig: hashSignature,
+    keyid: 'main',
+  });
+  const signature = serializeDictionary(dictionary);
+  multipartResponseToServe = {
+    manifest,
+    manifestSignature: signature,
+  };
+}
+
+// Protocol 1 directive response (including rollback)
+async function serveSignedDirective(directive: any, projectRoot: string) {
+  const privateKey = await getPrivateKeyAsync(projectRoot);
+  const directiveString = JSON.stringify(directive);
+  const hashSignature = signRSASHA256(directiveString, privateKey);
+  const dictionary = convertToDictionaryItemsRepresentation({
+    sig: hashSignature,
+    keyid: 'main',
+  });
+  const signature = serializeDictionary(dictionary);
+  multipartResponseToServe = {
+    directive,
+    directiveSignature: signature,
+  };
+}
+
 const Server = {
   start,
   stop,
@@ -191,6 +308,7 @@ const Server = {
   waitForUpdateRequest,
   serveManifest,
   serveSignedManifest,
+  serveSignedDirective,
   consumeRequestedStaticFiles,
 };
 

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
@@ -17,7 +17,11 @@ const urlForBundleFilename = (bundleFilename: any) =>
  * Find the pregenerated bundle corresponding to the string that is expected
  * in the responses for a given E2E test
  */
-function findBundlePath(projectRoot: string, platform: string | number, notifyString: string | number) {
+function findBundlePath(
+  projectRoot: string,
+  platform: string | number,
+  notifyString: string | number
+) {
   const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
   const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
   const testUpdateBundlesJson = require(testUpdateBundlesJsonPath);
@@ -32,7 +36,7 @@ function findAssets(projectRoot: string, platform: string | number) {
   const updatesPath = path.join(projectRoot, 'updates');
   const updatesJson = require(path.join(updatesPath, 'metadata.json'));
   const assets = updatesJson.fileMetadata[platform].assets;
-  return assets.map((asset: { path: string; ext: any; }) => {
+  return assets.map((asset: { path: string; ext: any }) => {
     return {
       path: path.join(updatesPath, asset.path),
       ext: asset.ext,
@@ -51,7 +55,12 @@ async function shaHash(filePath: PathLike) {
  * Copies a bundle to the location where the test server reads it,
  * and returns the SHA hash
  */
-async function copyBundleToStaticFolder(projectRoot: any, filename: string, notifyString: any, platform: any) {
+async function copyBundleToStaticFolder(
+  projectRoot: any,
+  filename: string,
+  notifyString: any,
+  platform: any
+) {
   await fs.mkdir(STATIC_FOLDER_PATH, { recursive: true });
   const bundleSrcPath = findBundlePath(projectRoot, platform, notifyString);
   const bundleDestPath = path.join(STATIC_FOLDER_PATH, filename);
@@ -73,7 +82,13 @@ async function copyAssetToStaticFolder(sourcePath: PathLike, filename: string) {
 /**
  * Common method used in all the tests to create valid update manifests
  */
-function getUpdateManifestForBundleFilename(date: { toISOString: () => string; }, hash: string, key: string, bundleFilename: string, assets: any[]) {
+function getUpdateManifestForBundleFilename(
+  date: { toISOString: () => string },
+  hash: string,
+  key: string,
+  bundleFilename: string,
+  assets: any[]
+) {
   return {
     id: crypto.randomUUID(),
     createdAt: date.toISOString(),
@@ -90,11 +105,24 @@ function getUpdateManifestForBundleFilename(date: { toISOString: () => string; }
   };
 }
 
+/**
+ * Common method used in all the tests to create valid rollback directives
+ */
+function getRollbackDirective(date: Date) {
+  return {
+    type: 'rollBackToEmbedded',
+    parameters: {
+      commitTime: date.toISOString(),
+    },
+  };
+}
+
 export default {
   copyBundleToStaticFolder,
   copyAssetToStaticFolder,
   findAssets,
   getUpdateManifestForBundleFilename,
+  getRollbackDirective,
   serverHost,
   serverPort,
 };

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -186,6 +186,7 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
         '@types/react-native': '~0.70.6',
         detox: '^19.12.1',
         express: '^4.18.2',
+        'form-data': '^4.0.0',
         jest: '^29.3.1',
         'jest-circus': '^29.3.1',
         'ts-jest': '^29.0.5',

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -57,6 +57,7 @@
     "@types/node-forge": "^1.0.0",
     "expo-module-scripts": "^3.0.0",
     "express": "^4.17.2",
+    "form-data": "^4.0.0",
     "fs-extra": "^9.1.0",
     "memfs": "^3.2.0"
   },


### PR DESCRIPTION
# Why

We need an e2e test for rollbacks since it couldn't be tested fully within the library tests.

Fixes ENG-7638.

# How

Add test.

# Test Plan

Run test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
