### PR TITLE
Close config file watchers to ensure process can exit.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Close config file watchers to ensure process can exit.
+- Close config file watchers to ensure process can exit. ([#21199](https://github.com/expo/expo/pull/21199) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix log format when modifying `tsconfig.json`. ([#21166](https://github.com/expo/expo/pull/21166) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `devDependencies` when running `npx expo install --fix`. ([#19344](https://github.com/expo/expo/pull/19344) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Close config file watchers to ensure process can exit.
 - Fix log format when modifying `tsconfig.json`. ([#21166](https://github.com/expo/expo/pull/21166) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `devDependencies` when running `npx expo install --fix`. ([#19344](https://github.com/expo/expo/pull/19344) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/src/export/createBundles.ts
+++ b/packages/@expo/cli/src/export/createBundles.ts
@@ -15,7 +15,7 @@ export type PublishOptions = {
 export async function createBundlesAsync(
   projectRoot: string,
   publishOptions: PublishOptions = {},
-  bundleOptions: { platforms: Platform[]; dev?: boolean; useDevServer: boolean }
+  bundleOptions: { platforms: Platform[]; dev?: boolean }
 ): Promise<Partial<Record<Platform, BundleOutput>>> {
   const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -61,7 +61,6 @@ export async function exportAppAsync(
     {
       platforms,
       dev,
-      useDevServer: true,
       // TODO: Disable source map generation if we aren't outputting them.
     }
   );

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -139,7 +139,7 @@ export abstract class BundlerDevServer {
       isNativeWebpack: this.name === 'webpack' && this.isTargetingNative(),
       privateKeyPath: options.privateKeyPath,
     });
-    return middleware;
+    return middleware.getHandler();
   }
 
   /** Start the dev server using settings defined in the start command. */

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -105,6 +105,8 @@ export abstract class BundlerDevServer {
   /** Manages the creation of dev server URLs. */
   protected urlCreator?: UrlCreator | null = null;
 
+  private notifier: FileNotifier | null = null;
+
   constructor(
     /** Project root folder. */
     public projectRoot: string,
@@ -137,7 +139,7 @@ export abstract class BundlerDevServer {
       isNativeWebpack: this.name === 'webpack' && this.isTargetingNative(),
       privateKeyPath: options.privateKeyPath,
     });
-    return middleware.getHandler();
+    return middleware;
   }
 
   /** Start the dev server using settings defined in the start command. */
@@ -215,8 +217,9 @@ export abstract class BundlerDevServer {
   protected abstract getConfigModuleIds(): string[];
 
   protected watchConfig() {
-    const notifier = new FileNotifier(this.projectRoot, this.getConfigModuleIds());
-    notifier.startObserving();
+    this.notifier?.stopObserving();
+    this.notifier = new FileNotifier(this.projectRoot, this.getConfigModuleIds());
+    this.notifier.startObserving();
   }
 
   /** Create ngrok instance and start the tunnel server. Exposed for testing. */
@@ -232,11 +235,7 @@ export abstract class BundlerDevServer {
   protected async startDevSessionAsync() {
     // This is used to make Expo Go open the project in either Expo Go, or the web browser.
     // Must come after ngrok (`startTunnelAsync`) setup.
-
-    if (this.devSession) {
-      this.devSession.stopNotifying();
-    }
-
+    this.devSession?.stopNotifying?.();
     this.devSession = new DevelopmentSession(
       this.projectRoot,
       // This URL will be used on external devices so the computer IP won't be relevant.
@@ -293,6 +292,9 @@ export abstract class BundlerDevServer {
 
   /** Stop the running dev server instance. */
   async stopAsync() {
+    // Stop file watching.
+    this.notifier?.stopObserving();
+
     // Stop the dev session timer and tell Expo API to remove dev session.
     await this.devSession?.closeAsync();
 

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -31,12 +31,14 @@ const BUNDLERS = {
 export class DevServerManager {
   private projectPrerequisites: ProjectPrerequisite[] = [];
 
+  private notifier: FileNotifier | null = null;
+
   constructor(
     public projectRoot: string,
     /** Keep track of the original CLI options for bundlers that are started interactively. */
     public options: BundlerStartOptions
   ) {
-    this.watchBabelConfig();
+    this.notifier = this.watchBabelConfig();
   }
 
   private watchBabelConfig() {
@@ -151,6 +153,7 @@ export class DevServerManager {
   /** Stop all servers including ADB. */
   async stopAsync(): Promise<void> {
     await Promise.allSettled([
+      this.notifier?.stopObserving(),
       // Stop all dev servers
       ...devServers.map((server) => server.stopAsync()),
       // Stop ADB

--- a/packages/@expo/cli/src/utils/FileNotifier.ts
+++ b/packages/@expo/cli/src/utils/FileNotifier.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { watchFile, StatWatcher } from 'fs';
+import { watchFile } from 'fs';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 

--- a/packages/@expo/cli/src/utils/FileNotifier.ts
+++ b/packages/@expo/cli/src/utils/FileNotifier.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { watchFile } from 'fs';
+import { watchFile, StatWatcher } from 'fs';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
@@ -10,6 +10,7 @@ const debug = require('debug')('expo:utils:fileNotifier') as typeof console.log;
 
 /** Observes and reports file changes. */
 export class FileNotifier {
+  private unsubscribe: (() => void) | null = null;
   constructor(
     /** Project root to resolve the module IDs relative to. */
     private projectRoot: string,
@@ -41,12 +42,16 @@ export class FileNotifier {
     return configPath;
   }
 
+  public stopObserving() {
+    this.unsubscribe?.();
+  }
+
   /** Watch the file and warn to reload the CLI if it changes. */
   public watchFile = memoize(this.startWatchingFile.bind(this));
 
   private startWatchingFile(filePath: string): string {
     const configName = path.relative(this.projectRoot, filePath);
-    watchFile(filePath, (cur: any, prev: any) => {
+    const listener = (cur: any, prev: any) => {
       if (prev.size || cur.size) {
         Log.log(
           `\u203A Detected a change in ${chalk.bold(
@@ -54,7 +59,14 @@ export class FileNotifier {
           )}. Restart the server to see the new results.` + (this.settings.additionalWarning || '')
         );
       }
-    });
+    };
+
+    const watcher = watchFile(filePath, listener);
+
+    this.unsubscribe = () => {
+      watcher.unref();
+    };
+
     return filePath;
   }
 }


### PR DESCRIPTION
# Why

This was a bug and now it's fixed.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Start and stop the dev server in `expo start`, this should now completely close and not hang open.