### PR TITLE
[core] Fix AppDelegateSubscriber broken on ios framework mode

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed convertible implementation for `URL` type to support unencoded UTF8 urls and file paths. ([#21139](https://github.com/expo/expo/pull/21139) by [@tsapeta](https://github.com/tsapeta))
+- Fixed AppDelegateSubscriber broken when running on iOS dynamic framework or static framework mode. ([#21206](https://github.com/expo/expo/pull/21206) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
+++ b/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.mm
@@ -42,7 +42,7 @@
   return _expoAppDelegate;
 }
 
-#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>)
+#if __has_include(<React-RCTAppDelegate/RCTAppDelegate.h>) || __has_include(<React_RCTAppDelegate/RCTAppDelegate.h>)
 
 - (UIView *)findRootView:(UIApplication *)application
 {


### PR DESCRIPTION
# Why

fixes #21161
close ENG-7549

# How

in ios framework mode, the search path to RCTAppDelegate is `<React_RCTAppDelegate/RCTAppDelegate.h>`. we did that in [EXAppDelegateWrapper.h](https://github.com/expo/expo/blob/610778d6105eb83d755a30f7de379e2df3f30527/packages/expo-modules-core/ios/AppDelegates/EXAppDelegateWrapper.h#L22) but not EXAppDelegateWrapper.mm. that's why our `application:didFinishLaunchingWithOptions:` doesn't be called and breaks expo-dev-launcher's auto setup.

# Test Plan

https://github.com/brentvatne/four-eight-repro-static + `npx expo run:ios` with this patch

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
