### PR TITLE
[tools] Fix the review bot complaining about changes in the root changelog

### DIFF
--- a/tools/src/Constants.ts
+++ b/tools/src/Constants.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import * as Directories from './Directories';
 
 export const LOCAL_API_HOST = 'localhost:3000';
@@ -12,3 +14,7 @@ export const TEMPLATES_DIR = Directories.getTemplatesDir();
 export const PACKAGES_DIR = Directories.getPackagesDir();
 export const VERSIONED_RN_IOS_DIR = Directories.getVersionedReactNativeIosDir();
 export const REACT_NATIVE_SUBMODULE_DIR = Directories.getReactNativeSubmoduleDir();
+
+// Vendored dirs
+export const ANDROID_VENDORED_DIR = path.join(ANDROID_DIR, 'vendored');
+export const IOS_VENDORED_DIR = path.join(IOS_DIR, 'vendored');

--- a/tools/src/versioning/android/versionVendoredModules.ts
+++ b/tools/src/versioning/android/versionVendoredModules.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
-import { ANDROID_DIR } from '../../Constants';
+import { ANDROID_DIR, ANDROID_VENDORED_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { copyFileWithTransformsAsync, transformFilesAsync } from '../../Transforms';
 import { FileTransforms } from '../../Transforms.types';
@@ -14,8 +14,6 @@ import {
   exponentPackageTransforms,
   vendoredModulesTransforms,
 } from './transforms/vendoredModulesTransforms';
-
-const ANDROID_VENDORED_DIR = path.join(ANDROID_DIR, 'vendored');
 
 /**
  * Versions Android vendored modules.
@@ -65,7 +63,7 @@ export async function versionVendoredModulesAsync(
  * Prebuild shared libraries to jniLibs and cleanup CMakeLists.txt
  */
 async function maybePrebuildSharedLibsAsync(module: string, sdkNumber: number) {
-  const moduleRootDir = path.join(ANDROID_DIR, 'vendored', `sdk${sdkNumber}`, module, 'android');
+  const moduleRootDir = path.join(ANDROID_VENDORED_DIR, `sdk${sdkNumber}`, module, 'android');
   const cmakeFile = path.join(moduleRootDir, 'CMakeLists.txt');
   if (!fs.existsSync(cmakeFile)) {
     return;

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -4,14 +4,12 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
-import { IOS_DIR } from '../../Constants';
+import { IOS_VENDORED_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { copyFileWithTransformsAsync } from '../../Transforms';
 import { FileTransforms } from '../../Transforms.types';
 import { searchFilesAsync } from '../../Utils';
 import vendoredModulesTransforms from './transforms/vendoredModulesTransforms';
-
-const IOS_VENDORED_DIR = path.join(IOS_DIR, 'vendored');
 
 /**
  * Versions iOS vendored modules.


### PR DESCRIPTION
# Why

The review bot has a bug incorrectly complains about changing the wrong changelog when updating a vendored module

# How

Detect whether the PR changes the `ios/vendored` or `android/vendored` folders, in which case the bot will not complain about updating the root changelog.

# Test Plan

Tested it locally