### PR TITLE
[expo-gl] Add support for GL_UNPACK_ALIGNMENT in pixelStorei

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- Add support for the `GL_UNPACK_ALIGNMENT` parameter in the `pixelStorei` method.
+- Add support for the `GL_UNPACK_ALIGNMENT` parameter in the `pixelStorei` method. ([#21212](https://github.com/expo/expo/pull/21212) by [@BanBart](https://github.com/BanBart))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
+- Add support for the `GL_UNPACK_ALIGNMENT` parameter in the `pixelStorei` method.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-gl/common/EXWebGLMethods.cpp
+++ b/packages/expo-gl/common/EXWebGLMethods.cpp
@@ -276,6 +276,13 @@ NATIVE_METHOD(pixelStorei) {
       ctx->unpackFLipY = ARG(1, GLboolean);
       break;
     }
+    case GL_UNPACK_ALIGNMENT: {
+      auto param = ARG(1, GLint);
+      ctx->addToNextBatch([=] {
+        glPixelStorei(GL_UNPACK_ALIGNMENT, param);
+      });
+      break;
+    }
     default:
       jsConsoleLog(runtime, { jsi::String::createFromUtf8(runtime, "EXGL: gl.pixelStorei() doesn't support this parameter yet!") });
   }


### PR DESCRIPTION
# Why

`GL_UNPACK_ALIGNMENT` parameter is essential in a commercial project in order to correctly draw an image.

# How

Added additional case block to the existing codebase.

# Test Plan

Verified in a commercial project. By applying `gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)` rendered image was correct.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
