### PR TITLE
[image][Android] Fix SVGs are not rendered in the release mode

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed SVGs are not rendered in the release mode on Android.
+
 ### 💡 Others
 
 ## 1.0.0-rc.0 — 2023-02-09

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed SVGs are not rendered in the release mode on Android.
+- Fixed SVGs are not rendered in the release mode on Android. ([#21214](https://github.com/expo/expo/pull/21214) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ResourceIdHelper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ResourceIdHelper.kt
@@ -1,0 +1,47 @@
+package expo.modules.image
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.Uri
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
+import java.util.*
+
+object ResourceIdHelper {
+  private val idMap = mutableMapOf<String, Int>()
+
+  @SuppressLint("DiscouragedApi")
+  private fun getResourceRawId(context: Context, name: String): Int {
+    if (name.isEmpty()) {
+      return -1
+    }
+
+    val normalizedName = name.lowercase(Locale.ROOT).replace("-", "_")
+    synchronized(this) {
+      val id = idMap[normalizedName]
+      if (id != null) {
+        return id
+      }
+
+      return context
+        .resources
+        .getIdentifier(normalizedName, "raw", context.packageName)
+        .also {
+          idMap[normalizedName] = it
+        }
+    }
+  }
+
+  fun getResourceUri(context: Context, name: String): Uri? {
+    val drawableUri = ResourceDrawableIdHelper.getInstance().getResourceDrawableUri(context, name)
+    if (drawableUri != null && drawableUri != Uri.EMPTY) {
+      return drawableUri
+    }
+
+    val resId = getResourceRawId(context, name)
+    return if (resId > 0) {
+      Uri.Builder().scheme("res").path(resId.toString()).build()
+    } else {
+      null
+    }
+  }
+}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -7,12 +7,12 @@ import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.load.model.LazyHeaders
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.signature.ApplicationVersionSignature
-import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
 import expo.modules.image.GlideBlurhashModel
 import expo.modules.image.GlideModel
 import expo.modules.image.GlideRawModel
 import expo.modules.image.GlideUriModel
 import expo.modules.image.GlideUrlModel
+import expo.modules.image.ResourceIdHelper
 import expo.modules.image.okhttp.GlideUrlWithCustomCacheKey
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
@@ -141,7 +141,7 @@ data class SourceMap(
   }
 
   private fun computeLocalUri(stringUri: String, context: Context): Uri? {
-    return ResourceDrawableIdHelper.getInstance().getResourceDrawableUri(context, stringUri)
+    return ResourceIdHelper.getResourceUri(context, stringUri)
   }
 
   internal val pixelCount: Double


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/21162.

# How

React Native's default method for decoding asset names only checks the drawable folder, which means URIs for SVGs located in the raw path are not properly converted. To solve this issue, I created a helper function that searches for assets in both the drawable and raw paths.

# Test Plan

- [peterlazar1993/expo-image-svg-bug](https://github.com/peterlazar1993/expo-image-svg-bug)
