### PR TITLE
[image][ios] Don't emit onProgress event when the asset size is unknown

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed `You can't start or clear loads in RequestListener or Target callbacks` on Android. ([#21192](https://github.com/expo/expo/pull/21192) by [@lukmccall](https://github.com/lukmccall))
 - Fixed SVGs are not rendered in the release mode on Android. ([#21214](https://github.com/expo/expo/pull/21214) by [@lukmccall](https://github.com/lukmccall))
-- Stop sending `onProgress` event when the asset size is unknown which led to diving by zero and a crash.
+- Stop sending `onProgress` event when the asset size is unknown which led to diving by zero and a crash. ([#21215](https://github.com/expo/expo/pull/21215) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `You can't start or clear loads in RequestListener or Target callbacks` on Android. ([#21192](https://github.com/expo/expo/pull/21192) by [@lukmccall](https://github.com/lukmccall))
 - Fixed SVGs are not rendered in the release mode on Android. ([#21214](https://github.com/expo/expo/pull/21214) by [@lukmccall](https://github.com/lukmccall))
+- Stop sending `onProgress` event when the asset size is unknown which led to diving by zero and a crash.
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -151,6 +151,11 @@ public final class ImageView: ExpoView {
   // MARK: - Loading
 
   private func imageLoadProgress(_ receivedSize: Int, _ expectedSize: Int, _ imageUrl: URL?) {
+    // Don't send the event when the expected size is unknown (it's usually -1 or 0 when called for the first time).
+    if expectedSize <= 0 {
+      return
+    }
+
     // Photos library requester emits the progress as a double `0...1` that we map to `0...100` int in `PhotosLoader`.
     // When that loader is used, we don't have any information about the sizes in bytes, so we only send the `progress` param.
     let isPhotoLibraryAsset = isPhotoLibraryAssetUrl(imageUrl)


### PR DESCRIPTION
# Why

Fixes #21207 
Closes ENG-7095

# How

In the progress completion block, the expected size of the asset can sometimes be `-1` or `0`. On Android we already ignore all calls with the expected size lower or equal to zero, so this PR aims to fix the difference between platforms and also the case when `0` could lead to dividing by zero and then of course a crash.

# Test Plan

The example provided in #21207 doesn't crash with this change
