### PR TITLE
[fingerprint] export diffFingerprintChangesAsync

### DIFF
--- a/packages/@expo/fingerprint/build/index.d.ts
+++ b/packages/@expo/fingerprint/build/index.d.ts
@@ -1,2 +1,2 @@
-export { createFingerprintAsync, createProjectHashAsync } from './Fingerprint';
+export * from './Fingerprint';
 export * from './Fingerprint.types';

--- a/packages/@expo/fingerprint/build/index.js
+++ b/packages/@expo/fingerprint/build/index.js
@@ -14,9 +14,6 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.createProjectHashAsync = exports.createFingerprintAsync = void 0;
-var Fingerprint_1 = require("./Fingerprint");
-Object.defineProperty(exports, "createFingerprintAsync", { enumerable: true, get: function () { return Fingerprint_1.createFingerprintAsync; } });
-Object.defineProperty(exports, "createProjectHashAsync", { enumerable: true, get: function () { return Fingerprint_1.createProjectHashAsync; } });
+__exportStar(require("./Fingerprint"), exports);
 __exportStar(require("./Fingerprint.types"), exports);
 //# sourceMappingURL=index.js.map

--- a/packages/@expo/fingerprint/build/index.js.map
+++ b/packages/@expo/fingerprint/build/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;;AAAA,6CAA+E;AAAtE,qHAAA,sBAAsB,OAAA;AAAE,qHAAA,sBAAsB,OAAA;AAEvD,sDAAoC"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;;;;;;;;;;;;;;;AAAA,gDAA8B;AAC9B,sDAAoC"}

--- a/packages/@expo/fingerprint/src/index.ts
+++ b/packages/@expo/fingerprint/src/index.ts
@@ -1,3 +1,2 @@
-export { createFingerprintAsync, createProjectHashAsync } from './Fingerprint';
-
+export * from './Fingerprint';
 export * from './Fingerprint.types';


### PR DESCRIPTION
# Why

the `diffFingerprintChangesAsync` is missing from exported function.

close ENG-7454

# How

export all functions

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
