### PR TITLE
[autolinking] Suppress node warnings about deprecated exports mapping

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Suppress node warnings about deprecated exports mapping in 3rd-party dependencies.
+
 ## 1.1.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Suppress node warnings about deprecated exports mapping in 3rd-party dependencies.
+- Suppress node warnings about deprecated exports mapping in 3rd-party dependencies. ([#21222](https://github.com/expo/expo/pull/21222) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.1.1 — 2023-02-09
 

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -108,6 +108,7 @@ class ExpoAutolinkingManager {
   static private String[] convertOptionsToCommandArgs(String command, Map options) {
     String[] args = [
       'node',
+      '--no-warnings',
       '--eval',
       'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
       '--',

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -133,6 +133,7 @@ module Expo
 
       args = [
         'node',
+        '--no-warnings',
         '--eval',
         'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
         command_name,

--- a/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
@@ -12,6 +12,7 @@ module Expo
     public def run!
       args = [
         'node',
+        '--no-warnings',
         '--eval',
         'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
         'patch-react-imports',


### PR DESCRIPTION
# Why

Running `pod install` produces warnings from node:

<img width="865" alt="Screenshot 2023-02-14 at 19 11 55" src="https://user-images.githubusercontent.com/1714764/218878555-9842f08b-5187-4d05-aad8-840217e9273a.png">

# How

Added `--no-warnings` flag to all node commands we execute from Ruby and Gradle

# Test Plan

- tbd