### PR TITLE
[github] Use --pretty online instead of %B to ensure commit message is on one line

### DIFF
--- a/.github/workflows/updates-e2e-android.yml
+++ b/.github/workflows/updates-e2e-android.yml
@@ -70,7 +70,7 @@ jobs:
       - name: 📦 Get artifacts path
         run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
       - name: 📦 Get commit message
-        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -c1000)" >> $GITHUB_ENV
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
         run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project

--- a/.github/workflows/updates-e2e-ios.yml
+++ b/.github/workflows/updates-e2e-ios.yml
@@ -70,7 +70,7 @@ jobs:
       - name: 📦 Get artifacts path
         run: mkdir -p artifact && echo "ARTIFACTS_DEST=$(pwd)/artifact" >> $GITHUB_ENV
       - name: 📦 Get commit message
-        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -c1000)" >> $GITHUB_ENV
+        run: echo "COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)" >> $GITHUB_ENV
       - name: 📦 Set test project location
         run: echo "TEST_PROJECT_ROOT=$GITHUB_WORKSPACE/updates-e2e" >> $GITHUB_ENV
       - name: 📦 Setup test project


### PR DESCRIPTION
# Why

Tests fail when commit message contains a newline. See: https://github.com/expo/expo/actions/runs/4178978878/jobs/7238402422 and https://stackoverflow.com/questions/68633485/github-action-invalid-environment-variable-format

# How

Use `--pretty=oneline` instead of printing the full commit message body.

# Test Plan

CI on this should run