### PR TITLE
[expo-updates][android] Fix versioned code

### DIFF
--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/updates/UpdatesModule.kt
@@ -10,13 +10,12 @@ import abi46_0_0.expo.modules.core.ModuleRegistryDelegate
 import abi46_0_0.expo.modules.core.Promise
 import abi46_0_0.expo.modules.core.interfaces.ExpoMethod
 import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.Launcher.LauncherCallback
+import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
-import expo.modules.updates.manifest.UpdateManifest
+import expo.modules.updates.loader.UpdateResponse
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
@@ -134,19 +133,29 @@ class UpdatesModule(
         updatesServiceLocal.embeddedUpdate
       )
       databaseHolder.releaseDatabase()
-      updatesServiceLocal.fileDownloader.downloadManifest(
+      updatesServiceLocal.fileDownloader.downloadRemoteUpdate(
         updatesServiceLocal.configuration,
         extraHeaders,
         context,
-        object : ManifestDownloadCallback {
+        object : RemoteUpdateDownloadCallback {
           override fun onFailure(message: String, e: Exception) {
             promise.reject("ERR_UPDATES_CHECK", message, e)
             Log.e(TAG, message, e)
           }
 
-          override fun onSuccess(updateManifest: UpdateManifest) {
-            val launchedUpdate = updatesServiceLocal.launchedUpdate
+          override fun onSuccess(updateResponse: UpdateResponse) {
+            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+
             val updateInfo = Bundle()
+
+            if (updateManifest == null) {
+              updateInfo.putBoolean("isAvailable", false)
+              promise.resolve(updateInfo)
+              return
+            }
+
+            val launchedUpdate = updatesServiceLocal.launchedUpdate
+
             if (launchedUpdate == null) {
               // this shouldn't ever happen, but if we don't have anything to compare
               // the new manifest to, let the user know an update is available
@@ -158,7 +167,7 @@ class UpdatesModule(
             if (updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
                 updateManifest.updateEntity,
                 launchedUpdate,
-                updateManifest.manifestFilters
+                updateResponse.responseHeaderData?.manifestFilters
               )
             ) {
               updateInfo.putBoolean("isAvailable", true)
@@ -215,24 +224,33 @@ class UpdatesModule(
               ) {
               }
 
-              override fun onUpdateManifestLoaded(updateManifest: UpdateManifest): Boolean {
-                return updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
-                  updateManifest.updateEntity,
-                  updatesServiceLocal.launchedUpdate,
-                  updateManifest.manifestFilters
+              override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+                val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
+                return Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
+                    updateManifest.updateEntity,
+                    updatesServiceLocal.launchedUpdate,
+                    updateResponse.responseHeaderData?.manifestFilters
+                  )
                 )
               }
 
-              override fun onSuccess(update: UpdateEntity?) {
+              override fun onSuccess(loaderResult: Loader.LoaderResult) {
                 databaseHolder.releaseDatabase()
                 val updateInfo = Bundle()
-                if (update == null) {
+
+                if (loaderResult.updateEntity == null) {
                   updateInfo.putBoolean("isNew", false)
                 } else {
                   updatesServiceLocal.resetSelectionPolicy()
                   updateInfo.putBoolean("isNew", true)
-                  updateInfo.putString("manifestString", update.manifest.toString())
+                  updateInfo.putString(
+                    "manifestString",
+                    loaderResult.updateEntity!!.manifest.toString()
+                  )
                 }
+
                 promise.resolve(updateInfo)
               }
             }

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/updates/UpdatesModule.kt
@@ -10,18 +10,17 @@ import abi47_0_0.expo.modules.core.ModuleRegistryDelegate
 import abi47_0_0.expo.modules.core.Promise
 import abi47_0_0.expo.modules.core.interfaces.ExpoMethod
 import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
+import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
-import expo.modules.updates.manifest.UpdateManifest
 import abi47_0_0.expo.modules.updates.logging.UpdatesErrorCode
 import abi47_0_0.expo.modules.updates.logging.UpdatesLogEntry
 import abi47_0_0.expo.modules.updates.logging.UpdatesLogReader
 import abi47_0_0.expo.modules.updates.logging.UpdatesLogger
 import java.util.Date
+import expo.modules.updates.loader.UpdateResponse
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
@@ -149,19 +148,29 @@ class UpdatesModule(
         updatesServiceLocal.embeddedUpdate
       )
       databaseHolder.releaseDatabase()
-      updatesServiceLocal.fileDownloader.downloadManifest(
+      updatesServiceLocal.fileDownloader.downloadRemoteUpdate(
         updatesServiceLocal.configuration,
         extraHeaders,
         context,
-        object : ManifestDownloadCallback {
+        object : RemoteUpdateDownloadCallback {
           override fun onFailure(message: String, e: Exception) {
             promise.reject("ERR_UPDATES_CHECK", message, e)
             Log.e(TAG, message, e)
           }
 
-          override fun onSuccess(updateManifest: UpdateManifest) {
-            val launchedUpdate = updatesServiceLocal.launchedUpdate
+          override fun onSuccess(updateResponse: UpdateResponse) {
+            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+
             val updateInfo = Bundle()
+
+            if (updateManifest == null) {
+              updateInfo.putBoolean("isAvailable", false)
+              promise.resolve(updateInfo)
+              return
+            }
+
+            val launchedUpdate = updatesServiceLocal.launchedUpdate
+
             if (launchedUpdate == null) {
               // this shouldn't ever happen, but if we don't have anything to compare
               // the new manifest to, let the user know an update is available
@@ -173,7 +182,7 @@ class UpdatesModule(
             if (updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
                 updateManifest.updateEntity,
                 launchedUpdate,
-                updateManifest.manifestFilters
+                updateResponse.responseHeaderData?.manifestFilters
               )
             ) {
               updateInfo.putBoolean("isAvailable", true)
@@ -230,24 +239,33 @@ class UpdatesModule(
               ) {
               }
 
-              override fun onUpdateManifestLoaded(updateManifest: UpdateManifest): Boolean {
-                return updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
-                  updateManifest.updateEntity,
-                  updatesServiceLocal.launchedUpdate,
-                  updateManifest.manifestFilters
+              override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+                val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
+                return Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
+                    updateManifest.updateEntity,
+                    updatesServiceLocal.launchedUpdate,
+                    updateResponse.responseHeaderData?.manifestFilters
+                  )
                 )
               }
 
-              override fun onSuccess(update: UpdateEntity?) {
+              override fun onSuccess(loaderResult: Loader.LoaderResult) {
                 databaseHolder.releaseDatabase()
                 val updateInfo = Bundle()
-                if (update == null) {
+
+                if (loaderResult.updateEntity == null) {
                   updateInfo.putBoolean("isNew", false)
                 } else {
                   updatesServiceLocal.resetSelectionPolicy()
                   updateInfo.putBoolean("isNew", true)
-                  updateInfo.putString("manifestString", update.manifest.toString())
+                  updateInfo.putString(
+                    "manifestString",
+                    loaderResult.updateEntity!!.manifest.toString()
+                  )
                 }
+
                 promise.resolve(updateInfo)
               }
             }

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/expo/modules/updates/UpdatesModule.kt
@@ -10,18 +10,17 @@ import abi48_0_0.expo.modules.core.ModuleRegistryDelegate
 import abi48_0_0.expo.modules.core.Promise
 import abi48_0_0.expo.modules.core.interfaces.ExpoMethod
 import expo.modules.updates.db.entity.AssetEntity
-import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.loader.FileDownloader.ManifestDownloadCallback
+import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
 import expo.modules.updates.loader.Loader
 import expo.modules.updates.loader.RemoteLoader
-import expo.modules.updates.manifest.UpdateManifest
 import abi48_0_0.expo.modules.updates.logging.UpdatesErrorCode
 import abi48_0_0.expo.modules.updates.logging.UpdatesLogEntry
 import abi48_0_0.expo.modules.updates.logging.UpdatesLogReader
 import abi48_0_0.expo.modules.updates.logging.UpdatesLogger
 import java.util.Date
+import expo.modules.updates.loader.UpdateResponse
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
@@ -150,19 +149,29 @@ class UpdatesModule(
         updatesServiceLocal.embeddedUpdate
       )
       databaseHolder.releaseDatabase()
-      updatesServiceLocal.fileDownloader.downloadManifest(
+      updatesServiceLocal.fileDownloader.downloadRemoteUpdate(
         updatesServiceLocal.configuration,
         extraHeaders,
         context,
-        object : ManifestDownloadCallback {
+        object : RemoteUpdateDownloadCallback {
           override fun onFailure(message: String, e: Exception) {
             promise.reject("ERR_UPDATES_CHECK", message, e)
             Log.e(TAG, message, e)
           }
 
-          override fun onSuccess(updateManifest: UpdateManifest) {
-            val launchedUpdate = updatesServiceLocal.launchedUpdate
+          override fun onSuccess(updateResponse: UpdateResponse) {
+            val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+
             val updateInfo = Bundle()
+
+            if (updateManifest == null) {
+              updateInfo.putBoolean("isAvailable", false)
+              promise.resolve(updateInfo)
+              return
+            }
+
+            val launchedUpdate = updatesServiceLocal.launchedUpdate
+
             if (launchedUpdate == null) {
               // this shouldn't ever happen, but if we don't have anything to compare
               // the new manifest to, let the user know an update is available
@@ -174,7 +183,7 @@ class UpdatesModule(
             if (updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
                 updateManifest.updateEntity,
                 launchedUpdate,
-                updateManifest.manifestFilters
+                updateResponse.responseHeaderData?.manifestFilters
               )
             ) {
               updateInfo.putBoolean("isAvailable", true)
@@ -231,24 +240,33 @@ class UpdatesModule(
               ) {
               }
 
-              override fun onUpdateManifestLoaded(updateManifest: UpdateManifest): Boolean {
-                return updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
-                  updateManifest.updateEntity,
-                  updatesServiceLocal.launchedUpdate,
-                  updateManifest.manifestFilters
+              override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): Loader.OnUpdateResponseLoadedResult {
+                val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+
+                return Loader.OnUpdateResponseLoadedResult(
+                  shouldDownloadManifestIfPresentInResponse = updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
+                    updateManifest.updateEntity,
+                    updatesServiceLocal.launchedUpdate,
+                    updateResponse.responseHeaderData?.manifestFilters
+                  )
                 )
               }
 
-              override fun onSuccess(update: UpdateEntity?) {
+              override fun onSuccess(loaderResult: Loader.LoaderResult) {
                 databaseHolder.releaseDatabase()
                 val updateInfo = Bundle()
-                if (update == null) {
+
+                if (loaderResult.updateEntity == null) {
                   updateInfo.putBoolean("isNew", false)
                 } else {
                   updatesServiceLocal.resetSelectionPolicy()
                   updateInfo.putBoolean("isNew", true)
-                  updateInfo.putString("manifestString", update.manifest.toString())
+                  updateInfo.putString(
+                    "manifestString",
+                    loaderResult.updateEntity!!.manifest.toString()
+                  )
                 }
+
                 promise.resolve(updateInfo)
               }
             }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -21,7 +21,7 @@ import java.util.Date
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
-
+import expo.modules.updates.UpdatesConfiguration
 /* ktlint-enable no-unused-imports */
 
 /**


### PR DESCRIPTION
# Why

#20275 and #21007 made changes to the shared (non-versioned) classes that the versioned module classes use. This is probably the most risky PR of the three if that can be believed, since we need to ensure that these previous modules don't have any breaking changes.

And guess what!! They totally do have a breaking change. I think. idk. Here's my analysis: https://github.com/expo/expo/pull/20275/files#r1106532674

# How

This backports to fix compilation but this doesn't fix the breakage.

# Test Plan

Compile.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
