### PR TITLE
[docs] Update app-credentials.mdx

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -48,7 +48,7 @@ This certificate will be used for all of your apps. If this certificate expires,
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts.
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts. Expo-created APN keys can be downloaded for your organization via [expo.dev](https://expo.dev).
 
 ### Provisioning Profiles
 

--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -48,7 +48,9 @@ This certificate will be used for all of your apps. If this certificate expires,
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts. Expo-created APN keys can be downloaded for your organization via [expo.dev](https://expo.dev).
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts. 
+
+> APN keys created by Expo can be downloaded on the [Expo website](https://expo.dev/accounts/[account]/settings/credentials).
 
 ### Provisioning Profiles
 


### PR DESCRIPTION
APN keys created via my Apple account can be downloaded only once. So when I head over to my Apple developer account, the Expo-created APN key showed up, but I was not able to download it. 

The Expo documentation misses information here that Expo-created APN keys can be downloaded via expo.dev . Open for your suggestions if it would e.g. be better to include this information elsewhere in this documentation because this also applies for e.g. distribution certificates, etc.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
