### PR TITLE
feat(cli): improve ios multi-scheme resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Improve multi-target iOS scheme resolution for `expo run:ios`.
+- Improve multi-target iOS scheme resolution for `expo run:ios`. ([#21240](https://github.com/expo/expo/pull/21240) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Improve multi-target iOS scheme resolution for `expo run:ios`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/InstallationProxyClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/InstallationProxyClient.ts
@@ -25,7 +25,31 @@ interface IPOptions {
   ApplicationsType?: 'Any';
   PackageType?: 'Developer';
   CFBundleIdentifier?: string;
-  ReturnAttributes?: ('CFBundleIdentifier' | 'CFBundleExecutable' | 'Container' | 'Path')[];
+
+  ReturnAttributes?: (
+    | 'CFBundleIdentifier'
+    | 'ApplicationDSID'
+    | 'ApplicationType'
+    | 'CFBundleExecutable'
+    | 'CFBundleDisplayName'
+    | 'CFBundleIconFile'
+    | 'CFBundleName'
+    | 'CFBundleShortVersionString'
+    | 'CFBundleSupportedPlatforms'
+    | 'CFBundleURLTypes'
+    | 'CodeInfoIdentifier'
+    | 'Container'
+    | 'Entitlements'
+    | 'HasSettingsBundle'
+    | 'IsUpgradeable'
+    | 'MinimumOSVersion'
+    | 'Path'
+    | 'SignerIdentity'
+    | 'UIDeviceFamily'
+    | 'UIFileSharingEnabled'
+    | 'UIStatusBarHidden'
+    | 'UISupportedInterfaceOrientations'
+  )[];
   BundleIDs?: string[];
   [key: string]: undefined | string | string[];
 }

--- a/packages/@expo/cli/src/run/ios/options/__tests__/resolveNativeScheme-test.ts
+++ b/packages/@expo/cli/src/run/ios/options/__tests__/resolveNativeScheme-test.ts
@@ -1,7 +1,7 @@
 import { IOSConfig } from '@expo/config-plugins';
 
 import { selectAsync } from '../../../../utils/prompts';
-import { promptOrQueryNativeSchemeAsync } from '../resolveNativeScheme';
+import { promptOrQueryNativeSchemeAsync, getDefaultNativeScheme } from '../resolveNativeScheme';
 
 const asMock = <T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> =>
   fn as jest.MockedFunction<T>;
@@ -16,6 +16,51 @@ jest.mock('@expo/config-plugins', () => {
       },
     },
   };
+});
+
+describe(getDefaultNativeScheme, () => {
+  it(`defaults to application scheme regardless of position in array`, () => {
+    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
+      // Ensure the wrong one is first...
+      { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
+      { name: 'foobar', osType: 'iOS', type: 'com.apple.product-type.application' },
+    ]);
+    expect(
+      getDefaultNativeScheme(
+        '/',
+        {
+          configuration: 'Debug',
+        },
+        {
+          name: 'foo',
+        }
+      )
+    ).toEqual({
+      name: 'foobar',
+      osType: 'iOS',
+      type: 'com.apple.product-type.application',
+    });
+  });
+  it(`uses only scheme if available even if no application scheme is available`, () => {
+    asMock(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj).mockReturnValueOnce([
+      { name: 'foobar2', osType: 'watchOS', type: 'com.apple.product-type.application.watchapp' },
+    ]);
+    expect(
+      getDefaultNativeScheme(
+        '/',
+        {
+          configuration: 'Debug',
+        },
+        {
+          name: 'foo',
+        }
+      )
+    ).toEqual({
+      name: 'foobar2',
+      osType: 'watchOS',
+      type: 'com.apple.product-type.application.watchapp',
+    });
+  });
 });
 
 describe(promptOrQueryNativeSchemeAsync, () => {

--- a/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
@@ -8,6 +8,8 @@ import { profile } from '../../../utils/profile';
 import { selectAsync } from '../../../utils/prompts';
 import { Options, ProjectInfo, XcodeConfiguration } from '../XcodeBuild.types';
 
+const debug = require('debug')('expo:run:ios:options:resolveNativeScheme') as typeof console.log;
+
 type NativeSchemeProps = {
   name: string;
   osType?: string;
@@ -66,7 +68,7 @@ export async function promptOrQueryNativeSchemeAsync(
 export function getDefaultNativeScheme(
   projectRoot: string,
   options: Pick<Options, 'configuration'>,
-  xcodeProject: ProjectInfo
+  xcodeProject: Pick<ProjectInfo, 'name'>
 ): NativeSchemeProps {
   // If the resolution failed then we should just use the first runnable scheme that
   // matches the provided configuration.
@@ -82,7 +84,7 @@ export function getDefaultNativeScheme(
     const scheme =
       resolvedSchemes.find(({ type }) => type === IOSConfig.Target.TargetType.APPLICATION) ??
       resolvedSchemes[0];
-    Log.debug(`Using default scheme: ${scheme.name}`);
+    debug(`Using default scheme: ${scheme.name}`);
     return scheme;
   }
 

--- a/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
+++ b/packages/@expo/cli/src/run/ios/options/resolveNativeScheme.ts
@@ -70,17 +70,26 @@ export function getDefaultNativeScheme(
 ): NativeSchemeProps {
   // If the resolution failed then we should just use the first runnable scheme that
   // matches the provided configuration.
-  const resolvedScheme = profile(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj)(
+  const resolvedSchemes = profile(IOSConfig.BuildScheme.getRunnableSchemesFromXcodeproj)(
     projectRoot,
     {
       configuration: options.configuration,
     }
-  )[0];
+  );
+
+  // If there are multiple schemes, then the default should be the application.
+  if (resolvedSchemes.length > 1) {
+    const scheme =
+      resolvedSchemes.find(({ type }) => type === IOSConfig.Target.TargetType.APPLICATION) ??
+      resolvedSchemes[0];
+    Log.debug(`Using default scheme: ${scheme.name}`);
+    return scheme;
+  }
 
   // If we couldn't find the scheme, then we'll guess at it,
   // this is needed for cases where the native code hasn't been generated yet.
-  if (resolvedScheme) {
-    return resolvedScheme;
+  if (resolvedSchemes[0]) {
+    return resolvedSchemes[0];
   }
   return {
     name: path.basename(xcodeProject.name, path.extname(xcodeProject.name)),


### PR DESCRIPTION
# Why

- Building app clips onto a native device will fail because the protocol appears to be unimplemented natively on-device.
- When an iOS project has multiple schemes, the default scheme should be the first application scheme if available. This prevents the addition of something like App Clips from breaking the default behavior.
