### PR TITLE
[menu][iOS] Fixed `'jsc/JSCRuntime.h' file not found` when using JSC

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1236,7 +1236,7 @@ SPEC CHECKSUMS:
   Expo: 79deb55f33fab1b232232868a74713772943238d
   expo-dev-client: 504ebe5d4cfad59ce9b8463b12bf6d271d1b6c9c
   expo-dev-launcher: 222533abd5ac6cfc6bcdd64b1f697398068edb1d
-  expo-dev-menu: f28581ec401bea04b6fff4aa1228789972dbb746
+  expo-dev-menu: b8096bc6d7fd0e0ba0656bda4da41a640025ab91
   expo-dev-menu-interface: 6c82ae323c4b8724dead4763ce3ff24a2108bdb1
   ExpoAppleAuthentication: 7bd5e4150d59e8df37aa80b425850ae88adf9e65
   ExpoBattery: 678d2b710a8fc398c30258c4dc22c12340ee5411

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `'jsc/JSCRuntime.h' file not found` when using JSC on iOS.
+- Fixed `'jsc/JSCRuntime.h' file not found` when using JSC on iOS. ([#21246](https://github.com/expo/expo/pull/21246) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `'jsc/JSCRuntime.h' file not found` when using JSC on iOS.
+
 ### 💡 Others
 
 ## 2.1.1 — 2023-02-09

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -93,7 +93,7 @@ Pod::Spec.new do |s|
       "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     reanimated.xcconfig = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"$(PODS_ROOT)/Headers/Private/#{config[:react_native_common_dir]}\"",
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/glog\" \"$(PODS_ROOT)/#{folly_prefix}Folly\" \"${PODS_ROOT}/Headers/Public/React-hermes\" \"${PODS_ROOT}/Headers/Public/hermes-engine\" \"$(PODS_ROOT)/#{config[:react_native_common_dir]}\"",
                                  "OTHER_CFLAGS" => "$(inherited)" + " " + folly_flags
     }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/21233.
Closes ENG-7582.

# How

The path to the common dir of the RN was not set correctly. 

# Test Plan

- bare-expo ✅
- https://github.com/brentvatne/jsc-dev-client-48 ✅