### PR TITLE
[docs] Update API reference docs to specify Config plugins & permission for various Expo packages

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -28,6 +28,22 @@ in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]
 The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
+<ConfigPluginExample>
+
+> This plugin is included automatically when installed.
+
+Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
+
+```json app.json
+{
+  "expo": {
+    "plugins": ["expo-apple-authentication"]
+  }
+}
+```
+
+</ConfigPluginExample>
+
 <ConfigReactNative>
 
 Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup)
@@ -46,22 +62,6 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
 
 </ConfigReactNative>
-
-<ConfigPluginExample>
-
-> This plugin is included automatically when installed.
-
-Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
-
-```json app.json
-{
-  "expo": {
-    "plugins": ["expo-apple-authentication"]
-  }
-}
-```
-
-</ConfigPluginExample>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -7,10 +7,16 @@ packageName: 'expo-av'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 The [`Audio.Sound`](audio.mdx) objects and [`Video`](video.mdx) components share a unified imperative API for media playback.
 
-Note that for `Video`, all of these operations are also available via props on the component, but we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
+Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
 Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
 
@@ -20,9 +26,50 @@ Try the [playlist example app](http://expo.dev/@community/playlist) (source code
 
 <APIInstallSection />
 
+## Configuration in app.json/app.config.js
+
+You can configure `expo-av` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-av",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-av` repository](https://github.com/expo/expo/tree/main/packages/expo-av#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
 ## Usage
 
-In this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -138,3 +185,17 @@ import { Audio, Video } from 'expo-av';
 ```
 
 <APISection packageName="expo-av" apiName="AV" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['RECORD_AUDIO']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -10,8 +10,10 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 
-**`expo-background-fetch`** provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
+`expo-background-fetch` provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -23,6 +25,14 @@ You can check out [the relevant GitHub issue](https://github.com/expo/expo/issue
 ## Installation
 
 <APIInstallSection />
+
+## Configuration
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-background-fetch` repository](https://github.com/expo/expo/tree/main/packages/expo-background-fetch#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -163,12 +173,6 @@ async function registerBackgroundFetchAsync() {
 }
 ```
 
-## Configuration
-
-In order to use `BackgroundFetch` API in standalone, bare apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.mdx#configuration-for-standalone-apps) for more details.
-
-On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
-
 ## API
 
 ```js
@@ -176,3 +180,15 @@ import * as BackgroundFetch from 'expo-background-fetch';
 ```
 
 <APISection packageName="expo-background-fetch" apiName="BackgroundFetch" />
+
+## Permissions
+
+### Android
+
+On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'WAKE_LOCK']} />
+
+### iOS
+
+To use `BackgroundFetch` API in standalone apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.mdx#configuration-for-standalone-apps) for more details.

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -7,8 +7,14 @@ packageName: 'expo-barcode-scanner'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
@@ -18,18 +24,59 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 > **info** Only one active `BarCodeScanner` preview is currently supported.
 
-When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
-so the following screens can use their own `BarCodeScanner` without any issue.
+When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component so the following screens can use their own `BarCodeScanner` without any issue.
 
 ## Installation
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-{/* TODO: Replace with config format from tracking-transparency */}
+You can configure `expo-barcode-scanner` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-Scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions.mdx#permissionscamera) permission. See the [usage example](#usage) below.
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-barcode-scanner",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access camera."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'cameraPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSCameraUsageDescription`](#permission-nscamerausagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your camera"',
+    },
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your mirophone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-barcode-scanner` repository](https://github.com/expo/expo/tree/main/packages/expo-barcode-scanner#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Supported formats
 
@@ -127,3 +174,17 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 ```
 
 <APISection packageName="expo-barcode-scanner" apiName="BarCodeScanner" />
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`:
+
+<AndroidPermissions permissions={['CAMERA']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCameraUsageDescription', 'NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/brightness.mdx
+++ b/docs/pages/versions/unversioned/sdk/brightness.mdx
@@ -7,7 +7,9 @@ packageName: 'expo-brightness'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 
 An API to get and set screen brightness.
 
@@ -18,6 +20,14 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <APIInstallSection />
+
+## Configuration
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -88,3 +98,15 @@ An error occurred when getting or setting the system brightness.
 ### `ERR_INVALID_ARGUMENT`
 
 An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -8,6 +8,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 Provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
@@ -17,12 +19,64 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-You must add the following permissions to your **app.json**.
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-- Android requires `READ_CALENDAR` & `WRITE_CALENDAR` inside the `expo.android.permissions` array.
-- iOS requires the `NSRemindersUsageDescription` key be added to `expo.ios.infoPlist` with a string value describing the reason for the permission request.
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-calendar",
+        {
+          "calendarPermission": "The app needs to access your calendar.",
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'calendarPermission',
+      platform: 'ios',
+      description: 'A string to set the NSCalendarsUsageDescription permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+    },
+    {
+      name: 'remindersPermission',
+      platform: 'ios',
+      description: 'A string to set the NSRemindersUsageDescription permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your reminders"',
+    },
+  ]}
+/>
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
+
+### iOS
+
+You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](versions/latest/config/app/#infoplist) object.
+
+<IOSPermissions
+  permissions={[
+    'NSCalendarsUsageDescription',
+    'NSRemindersUsageDescription',
+  ]}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -69,7 +69,7 @@ You must add the following permissions to your **app.json** inside the [`expo.an
 
 ### iOS
 
-You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](versions/latest/config/app/#infoplist) object.
+You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](/versions/latest/config/app/#infoplist) object.
 
 <IOSPermissions
   permissions={[

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -7,11 +7,15 @@ packageName: 'expo-calendar'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-Provides an API for interacting with the device's system calendars, events, reminders, and associated records.
+`expo-calendar` provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -32,7 +36,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
       [
         "expo-calendar",
         {
-          "calendarPermission": "The app needs to access your calendar.",
+          "calendarPermission": "The app needs to access your calendar."
         }
       ]
     ]
@@ -47,36 +51,23 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
     {
       name: 'calendarPermission',
       platform: 'ios',
-      description: 'A string to set the NSCalendarsUsageDescription permission message.',
+      description: 'A string to set the [`NSCalendarsUsageDescription`](#ios) permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your calendar"',
     },
     {
       name: 'remindersPermission',
       platform: 'ios',
-      description: 'A string to set the NSRemindersUsageDescription permission message.',
+      description: 'A string to set the [`NSRemindersUsageDescription`](#ios) permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your reminders"',
     },
   ]}
 />
 
-## Permissions
+<ConfigReactNative>
 
-### Android
+Learn how to configure the native projects in the [installation instructions in the `expo-calendar` repository](https://github.com/expo/expo/tree/main/packages/expo-calendar#installation-in-bare-react-native-projects).
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
-
-<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
-
-### iOS
-
-You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](/versions/latest/config/app/#infoplist) object.
-
-<IOSPermissions
-  permissions={[
-    'NSCalendarsUsageDescription',
-    'NSRemindersUsageDescription',
-  ]}
-/>
+</ConfigReactNative>
 
 ## Usage
 
@@ -151,3 +142,17 @@ import * as Calendar from 'expo-calendar';
 ```
 
 <APISection packageName="expo-calendar" apiName="Calendar" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCalendarsUsageDescription', 'NSRemindersUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -7,9 +7,15 @@ packageName: 'expo-camera'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
+`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 <PlatformsSection android ios web />
 
@@ -18,6 +24,52 @@ import { SnackInline} from '~/ui/components/Snippet';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-camera` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'cameraPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSCameraUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your camera"',
+    },
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSMicrophoneUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-camera` repository](https://github.com/expo/expo/tree/main/packages/expo-camera#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -122,3 +174,17 @@ import { Camera } from 'expo-camera';
 ```
 
 <APISection packageName="expo-camera" apiName="Camera" />
+
+## Permissions
+
+### Android
+
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCameraUsageDescription', 'NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/cellular.mdx
+++ b/docs/pages/versions/unversioned/sdk/cellular.mdx
@@ -7,14 +7,27 @@ packageName: 'expo-cellular'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
+`expo-cellular` provides information about the user's cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
 
 <PlatformsSection android emulator ios web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No permissions required_.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/cellular.mdx
+++ b/docs/pages/versions/unversioned/sdk/cellular.mdx
@@ -18,7 +18,7 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/unversioned/sdk/cellular.mdx
+++ b/docs/pages/versions/unversioned/sdk/cellular.mdx
@@ -7,7 +7,8 @@ packageName: 'expo-cellular'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-cellular` provides information about the user's cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
 
@@ -17,17 +18,13 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 <APIInstallSection />
 
-## Permissions
+## Configuration in app.json/app.config.js
 
-### Android
+<ConfigReactNative>
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
 
-<AndroidPermissions permissions={['READ_PHONE_STATE']} />
-
-### iOS
-
-_No permissions required_.
+</ConfigReactNative>
 
 ## API
 
@@ -42,3 +39,15 @@ import * as Cellular from 'expo-cellular';
 | Code                                         | Description                                                          |
 | -------------------------------------------- | -------------------------------------------------------------------- |
 | ERR_CELLULAR_GENERATION_UNKNOWN_NETWORK_TYPE | Unable to access network type or not connected to a cellular network |
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -7,8 +7,12 @@ packageName: 'expo-contacts'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-contacts` provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
@@ -34,7 +38,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
       [
         "expo-contacts",
         {
-          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts.",
+          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts."
         }
       ]
     ]
@@ -128,4 +132,4 @@ You must add the following permissions to your **app.json** inside the [`expo.an
 
 The following usage description keys are used by this library:
 
-<IOSPermissions permissions={[ 'NSContactsUsageDescription' ]} />
+<IOSPermissions permissions={['NSContactsUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -8,16 +8,58 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-contacts`** provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
+`expo-contacts` provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
 
-On iOS contacts have a multi-layered grouping system that you can also access through this API.
+On iOS, contacts have a multi-layered grouping system that you can also access through this API.
 
 <PlatformsSection android emulator ios simulator />
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-contacts",
+        {
+          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts.",
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'contactsPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSContactsUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your contacts"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-contacts` repository](https://github.com/expo/expo/tree/main/packages/expo-contacts#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -73,3 +115,17 @@ import * as Contacts from 'expo-contacts';
 ```
 
 <APISection packageName="expo-contacts" apiName="Contacts" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={[ 'NSContactsUsageDescription' ]} />

--- a/docs/pages/versions/unversioned/sdk/devicemotion.mdx
+++ b/docs/pages/versions/unversioned/sdk/devicemotion.mdx
@@ -7,14 +7,60 @@ packageName: 'expo-sensors'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { IOSPermissions } from '~/components/plugins/permissions';
 
-`DeviceMotion` from **`expo-sensors`** provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
+`DeviceMotion` from `expo-sensors` provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
 
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-sensors",
+        {
+          "motionPermission": "Allow $(PRODUCT_NAME) to access your device motion."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'motionPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSMotionUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your device motion"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-sensors` repository](https://github.com/expo/expo/tree/main/packages/expo-sensors#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## API
 
@@ -23,3 +69,11 @@ import { DeviceMotion } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-device-motion" />
+
+## Permissions
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSMotionUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -9,7 +9,6 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
-
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -62,7 +61,7 @@ If you want to enable [iCloud storage features][icloud-entitlement], set the `ex
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -91,7 +90,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
   ]}
 />
 
-## Using with expo-file-system
+## Using with `expo-file-system`
 
 When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -84,7 +84,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
       name: 'iCloudContainerEnvironment',
       platform: 'ios',
       description:
-        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
+        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/unversioned/sdk/document-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/document-picker.mdx
@@ -28,33 +28,6 @@ import Video from '~/components/plugins/Video';
 
 You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
-<ConfigReactNative>
-
-Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
-
-If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
-
-```xml
-<key>com.apple.developer.icloud-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.icloud-services</key>
-<array>
-    <string>CloudDocuments</string>
-</array>
-<key>com.apple.developer.ubiquity-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
-```
-
-Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
-
-</ConfigReactNative>
-
 <ConfigPluginExample>
 
 If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [Expo config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
@@ -89,6 +62,33 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
   ]}
 />
+
+<ConfigReactNative>
+
+Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
+
+If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
+
+```xml
+<key>com.apple.developer.icloud-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.icloud-services</key>
+<array>
+    <string>CloudDocuments</string>
+</array>
+<key>com.apple.developer.ubiquity-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
+```
+
+Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
+
+</ConfigReactNative>
 
 ## Using with `expo-file-system`
 

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -10,10 +10,9 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
+`expo-file-system` provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
 {/* TODO: update this image so we don't have to force a white background on it */}
 
@@ -197,18 +196,6 @@ app.listen(3000, () => {
 });
 ```
 
-## Permissions
-
-### Android
-
-The following permissions are added automatically through this library's `AndroidManifest.xml`.
-
-<AndroidPermissions permissions={['READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE', 'INTERNET']} />
-
-### iOS
-
-_No permissions required_.
-
 ## API
 
 ```js
@@ -254,3 +241,15 @@ In this table, you can see what type of URI can be handled by each method. For e
 | `createDownloadResumable` | Source:<br/>`http://`,<br/>`https://`<br/><br/>Destination:<br/>`file:///`                                                           | Source:<br/>`http://`,<br/>`https://`<br/><br/>Destination:<br/>`file://`                       |
 
 > On Android **no scheme** defaults to a bundled resource.
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE', 'INTERNET']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -79,7 +79,7 @@ try {
   console.error(e);
 }
 
-//To resume a download across app restarts, assuming the the DownloadResumable.savable() object was stored:
+//To resume a download across app restarts, assuming the DownloadResumable.savable() object was stored:
 const downloadSnapshotJson = await AsyncStorage.getItem('pausedDownload');
 const downloadSnapshot = JSON.parse(downloadSnapshotJson);
 const downloadResumable = new FileSystem.DownloadResumable(

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -29,7 +29,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -7,8 +7,14 @@ packageName: 'expo-local-authentication'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
+`expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -16,9 +22,46 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-On Android, this module requires permissions to access the biometric data for authentication purposes. The `USE_BIOMETRIC` and `USE_FINGERPRINT` permissions are automatically added.
+You can configure `expo-local-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "'Allow $(PRODUCT_NAME) to use Face ID."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'faceIDPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-local-authentication` repository](https://github.com/expo/expo/tree/main/packages/expo-local-authentication#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## API
 
@@ -27,3 +70,17 @@ import * as LocalAuthentication from 'expo-local-authentication';
 ```
 
 <APISection packageName="expo-local-authentication" apiName="LocalAuthentication" />
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`:
+
+<AndroidPermissions permissions={['USE_BIOMETRIC', 'USE_FINGERPRINT']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSFaceIDUsageDescription']} />

--- a/docs/pages/versions/unversioned/sdk/local-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/local-authentication.mdx
@@ -35,7 +35,7 @@ You can configure `expo-local-authentication` using its built-in [config plugin]
       [
         "expo-local-authentication",
         {
-          "faceIDPermission": "'Allow $(PRODUCT_NAME) to use Face ID."
+          "faceIDPermission": "Allow $(PRODUCT_NAME) to use Face ID."
         }
       ]
     ]
@@ -52,7 +52,7 @@ You can configure `expo-local-authentication` using its built-in [config plugin]
       platform: 'ios',
       description:
         'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message.',
-      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+      default: '"Allow $(PRODUCT_NAME) to use Face ID"',
     },
   ]}
 />

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -7,8 +7,13 @@ packageName: 'expo-location'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { AndroidPermissions } from '~/components/plugins/permissions';
+import { SnackInline } from '~/ui/components/Snippet';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -18,36 +23,67 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-### Android permissions
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-When you install the `expo-location` module, it automatically adds the following permissions:
+<ConfigPluginExample>
 
-- `ACCESS_COARSE_LOCATION`: for approximate device location
-- `ACCESS_FINE_LOCATION`: for precise device location
-- `FOREGROUND_SERVICE`: to subscribe to location updates while the app is in use
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to use your location."
+        }
+      ]
+    ]
+  }
+}
+```
 
-To use background location features, you must add the `ACCESS_BACKGROUND_LOCATION` in **app.json** and [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
+</ConfigPluginExample>
 
-<AndroidPermissions
-  permissions={[
-    'ACCESS_COARSE_LOCATION',
-    'ACCESS_FINE_LOCATION',
-    'FOREGROUND_SERVICE',
-    'ACCESS_BACKGROUND_LOCATION',
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'locationAlwaysAndWhenInUsePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationAlwaysAndWhenInUseUsageDescription`](#permission-nslocationalwaysandwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'locationAlwaysPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationAlwaysUsageDescription`](#permission-nslocationalwaysusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'isIosBackgroundLocationEnabled',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'isAndroidBackgroundLocationEnabled',
+      platform: 'android',
+      description:
+        'A string to set the [`ACCESS_BACKGROUND_LOCATION`](#permission-access_background_location) permission message.',
+      default: '',
+    },
   ]}
 />
 
-#### Excluding a permission
+<ConfigReactNative>
 
-> **Note**: Excluding a **required permission** from a module in your app can break the functionality corresponding to that permission. Always make sure to include all permissions a module is dependent on.
+Learn how to configure the native projects in the [installation instructions in the `expo-location` repository](https://github.com/expo/expo/tree/main/packages/expo-location#installation-in-bare-react-native-projects).
 
-When your Expo project doesn't benefit from having particular permission included, you can omit it. For example, if your application doesn't need access to the precise location, you can exclude the `ACCESS_FINE_LOCATION` permission.
-
-Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
-
-To learn more on how to exclude a permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+</ConfigReactNative>
 
 ### Background Location Methods
 
@@ -159,3 +195,46 @@ import * as Location from 'expo-location';
 ```
 
 <APISection packageName="expo-location" apiName="Location" />
+
+## Permissions
+
+### Android
+
+When you install the `expo-location` module, it automatically adds the following permissions:
+
+- `ACCESS_COARSE_LOCATION`: for approximate device location
+- `ACCESS_FINE_LOCATION`: for precise device location
+- `FOREGROUND_SERVICE`: to subscribe to location updates while the app is in use
+
+To use background location features, you must add the `ACCESS_BACKGROUND_LOCATION` in **app.json** and [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
+
+<AndroidPermissions
+  permissions={[
+    'ACCESS_COARSE_LOCATION',
+    'ACCESS_FINE_LOCATION',
+    'FOREGROUND_SERVICE',
+    'ACCESS_BACKGROUND_LOCATION',
+  ]}
+/>
+
+#### Excluding a permission
+
+> **Note**: Excluding a **required permission** from a module in your app can break the functionality corresponding to that permission. Always make sure to include all permissions a module is dependent on.
+
+When your Expo project doesn't benefit from having particular permission included, you can omit it. For example, if your application doesn't need access to the precise location, you can exclude the `ACCESS_FINE_LOCATION` permission.
+
+Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
+
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions
+  permissions={[
+    'NSLocationAlwaysAndWhenInUseUsageDescription',
+    'NSLocationAlwaysUsageDescription',
+    'NSLocationWhenInUseUsageDescription',
+  ]}
+/>

--- a/docs/pages/versions/unversioned/sdk/sensors.mdx
+++ b/docs/pages/versions/unversioned/sdk/sensors.mdx
@@ -7,6 +7,8 @@ packageName: 'expo-sensors'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-sensors` provides various APIs for accessing device sensors to measure motion, orientation, pressure, magnetic fields, ambient light, and step count.
 
@@ -15,14 +17,6 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Installation
 
 <APIInstallSection />
-
-### Configuration for Android
-
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
-
-If you need an update interval less than 200ms, you should:
-* add `android.permission.HIGH_SAMPLING_RATE_SENSORS` to [**app.json** `permissions` field](/versions/latest/config/app/#permissions)
-* or if you are using bare workflow, add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.
 
 ## API
 
@@ -40,6 +34,22 @@ import {
   Pedometer,
 } from 'expo-sensors';
 ```
+
+## Permissions
+
+### Android
+
+Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+
+If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-sensors` repository](https://github.com/expo/expo/tree/main/packages/expo-sensors#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Available sensors
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -26,7 +26,7 @@ Some features of this module are used by other modules under the hood. Here is a
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to test using [a development build](/development/introduction)
+`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to use a [development build](/development/introduction).
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so to use background features you will need to add appropriate keys to your **app.json** configuration.
 

--- a/docs/pages/versions/unversioned/sdk/task-manager.mdx
+++ b/docs/pages/versions/unversioned/sdk/task-manager.mdx
@@ -7,9 +7,10 @@ packageName: 'expo-task-manager'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-**`expo-task-manager`** provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
 Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
 
 - [Location](location.mdx)
@@ -25,30 +26,29 @@ Some features of this module are used by other modules under the hood. Here is a
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a development build](/development/introduction.mdx)
+`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to test using [a development build](/development/introduction)
 
-Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your **app.json** configuration.
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so to use background features you will need to add appropriate keys to your **app.json** configuration.
+
 Here is an example of an **app.json** configuration that enables background location and background fetch:
 
 ```json app.json
 {
   "expo": {
-    /* @hide ... */ /* @end */
     "ios": {
-      /* @hide ... */ /* @end */
       "infoPlist": {
-        /* @hide ... */ /* @end */
-        "UIBackgroundModes": [
-          "location",
-          "fetch"
-        ]
+        "UIBackgroundModes": ["location", "fetch"]
       }
     }
   }
 }
 ```
 
-For bare React Native apps, you need to add those keys manually. You can do it by clicking on your project in Xcode, then `Signing & Capabilities`, adding the `BackgroundMode` capability (if absent), and checking either `Location updates` or `Background fetch`, depending on your needs.
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-task-manager` repository](https://github.com/expo/expo/tree/main/packages/expo-task-manager#installation-in-bare-ios-react-native-project).
+
+</ConfigReactNative>
 
 ## Example
 
@@ -96,8 +96,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center'
-  }
+    justifyContent: 'center',
+  },
 });
 /* @end */
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 
 The expo-updates library allows you to programmatically control and respond to new updates made available to your app.
 
@@ -16,6 +17,35 @@ The expo-updates library allows you to programmatically control and respond to n
 ## Installation
 
 <APIInstallSection href="/bare/installing-updates/" />
+
+## Configuration in app.json/app.config.js
+
+The plugin is configured with the Expo account's username automatically when EAS CLI is used.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-updates",
+        {
+          "username": "account-username"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-updates` repository](https://github.com/expo/expo/tree/main/packages/expo-updates#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -31,29 +61,28 @@ Every custom updates server must implement the [Expo Updates protocol](https://d
 
 You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
 
-
 ### Configuration options
 
 There are build-time configuration options that control the behavior of `expo-updates`.
 
 On Android, these options are set as `meta-data` tags adjacent to the tags added during installation in the **AndroidManifest.xml** file. You can also define these options at runtime by passing a `Map` as the second parameter of `UpdatesController.initialize()`, and the provided values will override any value specified in **AndroidManifest.xml**.
 
-On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[UpdatesController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
+On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
-|--------------------------|---------------- | ------------------------------ | ------- | --------- |
-| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | <NoIcon />        |
-| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | <YesIcon />        |
-| `EXUpdatesRequestHeaders`| `requestHeaders`| `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | (none)  | <NoIcon />        |
-| `EXUpdatesSDKVersion`    | `sdkVersion`    | `expo.modules.updates.EXPO_SDK_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
-| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
-| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | <NoIcon />        |
-| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`)| <NoIcon />        |
-| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | <NoIcon />        |
-| `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | <NoIcon />        |
-| `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | <NoIcon />        |
-| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
-| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
+| iOS plist/dictionary key                                      | Android Map key                                      | Android meta-data name                                                          | Default                                                          | Required?                                                                                                |
+| ------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `EXUpdatesEnabled`                                            | `enabled`                                            | `expo.modules.updates.ENABLED`                                                  | `true`                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesURL`                                                | `updateUrl`                                          | `expo.modules.updates.EXPO_UPDATE_URL`                                          | (none)                                                           | <YesIcon />                                                                                              |
+| `EXUpdatesRequestHeaders`                                     | `requestHeaders`                                     | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY`                | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesSDKVersion`                                         | `sdkVersion`                                         | `expo.modules.updates.EXPO_SDK_VERSION`                                         | (none)                                                           | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
+| `EXUpdatesRuntimeVersion`                                     | `runtimeVersion`                                     | `expo.modules.updates.EXPO_RUNTIME_VERSION`                                     | (none)                                                           | (exactly one of `sdkVersion` or `runtimeVersion` is required)                                            |
+| `EXUpdatesReleaseChannel`                                     | `releaseChannel`                                     | `expo.modules.updates.EXPO_RELEASE_CHANNEL`                                     | `default`                                                        | <NoIcon />                                                                                               |
+| `EXUpdatesCheckOnLaunch`                                      | `checkOnLaunch`                                      | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`                             | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`) | <NoIcon />                                                                                               |
+| `EXUpdatesLaunchWaitMs`                                       | `launchWaitMs`                                       | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`                              | `0`                                                              | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningCertificate`                             | `codeSigningCertificate`                             | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                                 | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningMetadata`                                | `codeSigningMetadata`                                | `expo.modules.updates.CODE_SIGNING_METADATA`                                    | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false                                                            | <NoIcon />                                                                                               |
+| `EXUpdatesConfigCodeSigningAllowUnsignedManifests`            | `codeSigningAllowUnsignedManifests`                  | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS`                    | false                                                            | <NoIcon />                                                                                               |
 
 For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
 

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -9,7 +9,6 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
-
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -62,7 +61,7 @@ If you want to enable [iCloud storage features][icloud-entitlement], set the `ex
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -91,7 +90,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
   ]}
 />
 
-## Using with expo-file-system
+## Using with `expo-file-system`
 
 When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -84,7 +84,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
       name: 'iCloudContainerEnvironment',
       platform: 'ios',
       description:
-        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
+        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/document-picker.mdx
@@ -28,33 +28,6 @@ import Video from '~/components/plugins/Video';
 
 You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
-<ConfigReactNative>
-
-Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
-
-If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
-
-```xml
-<key>com.apple.developer.icloud-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.icloud-services</key>
-<array>
-    <string>CloudDocuments</string>
-</array>
-<key>com.apple.developer.ubiquity-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
-```
-
-Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
-
-</ConfigReactNative>
-
 <ConfigPluginExample>
 
 If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [Expo config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
@@ -89,6 +62,33 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
   ]}
 />
+
+<ConfigReactNative>
+
+Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
+
+If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
+
+```xml
+<key>com.apple.developer.icloud-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.icloud-services</key>
+<array>
+    <string>CloudDocuments</string>
+</array>
+<key>com.apple.developer.ubiquity-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
+```
+
+Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
+
+</ConfigReactNative>
 
 ## Using with `expo-file-system`
 

--- a/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
@@ -30,7 +30,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/filesystem.mdx
@@ -79,7 +79,7 @@ try {
   console.error(e);
 }
 
-//To resume a download across app restarts, assuming the the DownloadResumable.savable() object was stored:
+//To resume a download across app restarts, assuming the DownloadResumable.savable() object was stored:
 const downloadSnapshotJson = await AsyncStorage.getItem('pausedDownload');
 const downloadSnapshot = JSON.parse(downloadSnapshotJson);
 const downloadResumable = new FileSystem.DownloadResumable(

--- a/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/apple-authentication.mdx
@@ -28,6 +28,22 @@ in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]
 The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
+<ConfigPluginExample>
+
+> This plugin is included automatically when installed.
+
+Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
+
+```json app.json
+{
+  "expo": {
+    "plugins": ["expo-apple-authentication"]
+  }
+}
+```
+
+</ConfigPluginExample>
+
 <ConfigReactNative>
 
 Apps that don't use [EAS Build](/build/introduction) must [manually configure](/build-reference/ios-capabilities#manual-setup)
@@ -46,22 +62,6 @@ then be sure to add the following entitlements in your **ios/[app]/[app].entitle
 Also be sure to set `CFBundleAllowMixedLocalizations` to `true` in your **ios/[app]/Info.plist** to ensure the sign in button uses the device locale.
 
 </ConfigReactNative>
-
-<ConfigPluginExample>
-
-> This plugin is included automatically when installed.
-
-Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
-
-```json app.json
-{
-  "expo": {
-    "plugins": ["expo-apple-authentication"]
-  }
-}
-```
-
-</ConfigPluginExample>
 
 ## Usage
 

--- a/docs/pages/versions/v48.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/av.mdx
@@ -7,10 +7,16 @@ packageName: 'expo-av'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 The [`Audio.Sound`](audio.mdx) objects and [`Video`](video.mdx) components share a unified imperative API for media playback.
 
-Note that for `Video`, all of these operations are also available via props on the component, but we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
+Note that for `Video`, all of the operations are also available via props on the component. However, we recommend using this imperative playback API for most applications where finer control over the state of the video playback is needed.
 
 Try the [playlist example app](http://expo.dev/@community/playlist) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the playback API for both `Audio.Sound` and `Video`.
 
@@ -20,9 +26,50 @@ Try the [playlist example app](http://expo.dev/@community/playlist) (source code
 
 <APIInstallSection />
 
+## Configuration in app.json/app.config.js
+
+You can configure `expo-av` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-av",
+        {
+          "microphonePermission": "Allow $(PRODUCT_NAME) to access your microphone."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-av` repository](https://github.com/expo/expo/tree/main/packages/expo-av#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
+
 ## Usage
 
-In this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
+On this page, we reference operations on `playbackObject`s. Here is an example of obtaining access to the reference for both sound and video:
 
 ### Example: `Audio.Sound`
 
@@ -138,3 +185,17 @@ import { Audio, Video } from 'expo-av';
 ```
 
 <APISection packageName="expo-av" apiName="AV" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['RECORD_AUDIO']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/background-fetch.mdx
@@ -10,8 +10,10 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 import { PlatformTags } from '~/ui/components/Tag';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 
-**`expo-background-fetch`** provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
+`expo-background-fetch` provides an API to perform [background fetch](https://developer.apple.com/documentation/uikit/core_app/managing_your_app_s_life_cycle/preparing_your_app_to_run_in_the_background/updating_your_app_with_background_app_refresh) tasks, allowing you to run specific code periodically in the background to update your app. This module uses [TaskManager](task-manager.mdx) Native API under the hood.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -23,6 +25,14 @@ You can check out [the relevant GitHub issue](https://github.com/expo/expo/issue
 ## Installation
 
 <APIInstallSection />
+
+## Configuration
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-background-fetch` repository](https://github.com/expo/expo/tree/main/packages/expo-background-fetch#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -163,12 +173,6 @@ async function registerBackgroundFetchAsync() {
 }
 ```
 
-## Configuration
-
-In order to use `BackgroundFetch` API in standalone, bare apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.mdx#configuration-for-standalone-apps) for more details.
-
-On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
-
 ## API
 
 ```js
@@ -176,3 +180,15 @@ import * as BackgroundFetch from 'expo-background-fetch';
 ```
 
 <APISection packageName="expo-background-fetch" apiName="BackgroundFetch" />
+
+## Permissions
+
+### Android
+
+On Android, this module might listen when the device is starting up. It's necessary to continue working on tasks started with `startOnBoot`. It also keeps devices "awake" that are going idle and asleep fast, to improve reliability of the tasks. Because of this both the `RECEIVE_BOOT_COMPLETED` and `WAKE_LOCK` permissions are added automatically.
+
+<AndroidPermissions permissions={['RECEIVE_BOOT_COMPLETED', 'WAKE_LOCK']} />
+
+### iOS
+
+To use `BackgroundFetch` API in standalone apps on iOS, your app has to include background mode in the **Info.plist** file. See [background tasks configuration guide](task-manager.mdx#configuration-for-standalone-apps) for more details.

--- a/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
@@ -7,8 +7,14 @@ packageName: 'expo-barcode-scanner'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
@@ -18,18 +24,59 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 > **info** Only one active `BarCodeScanner` preview is currently supported.
 
-When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component
-so the following screens can use their own `BarCodeScanner` without any issue.
+When using navigation, the best practice is to unmount any previously rendered `BarCodeScanner` component so the following screens can use their own `BarCodeScanner` without any issue.
 
 ## Installation
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-{/* TODO: Replace with config format from tracking-transparency */}
+You can configure `expo-barcode-scanner` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-Scanning barcodes with the camera requires the [`Permission.CAMERA`](permissions.mdx#permissionscamera) permission. See the [usage example](#usage) below.
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-barcode-scanner",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access camera."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'cameraPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSCameraUsageDescription`](#permission-nscamerausagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your camera"',
+    },
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSMicrophoneUsageDescription`](#permission-nsmicrophoneusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your mirophone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-barcode-scanner` repository](https://github.com/expo/expo/tree/main/packages/expo-barcode-scanner#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Supported formats
 
@@ -127,3 +174,17 @@ import { BarCodeScanner } from 'expo-barcode-scanner';
 ```
 
 <APISection packageName="expo-barcode-scanner" apiName="BarCodeScanner" />
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`:
+
+<AndroidPermissions permissions={['CAMERA']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCameraUsageDescription', 'NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/brightness.mdx
@@ -7,7 +7,9 @@ packageName: 'expo-brightness'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions } from '~/components/plugins/permissions';
 
 An API to get and set screen brightness.
 
@@ -18,6 +20,14 @@ On Android, there is a global system-wide brightness setting, and each app has i
 ## Installation
 
 <APIInstallSection />
+
+## Configuration
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-brightness` repository](https://github.com/expo/expo/tree/main/packages/expo-brightness#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -88,3 +98,15 @@ An error occurred when getting or setting the system brightness.
 ### `ERR_INVALID_ARGUMENT`
 
 An invalid argument was passed. Only `BrightnessMode.MANUAL` or `BrightnessMode.AUTOMATIC` are allowed.
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['WRITE_SETTINGS']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/v48.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/calendar.mdx
@@ -8,6 +8,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 Provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
@@ -17,12 +19,64 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-You must add the following permissions to your **app.json**.
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-- Android requires `READ_CALENDAR` & `WRITE_CALENDAR` inside the `expo.android.permissions` array.
-- iOS requires the `NSRemindersUsageDescription` key be added to `expo.ios.infoPlist` with a string value describing the reason for the permission request.
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-calendar",
+        {
+          "calendarPermission": "The app needs to access your calendar.",
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'calendarPermission',
+      platform: 'ios',
+      description: 'A string to set the NSCalendarsUsageDescription permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+    },
+    {
+      name: 'remindersPermission',
+      platform: 'ios',
+      description: 'A string to set the NSRemindersUsageDescription permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your reminders"',
+    },
+  ]}
+/>
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
+
+### iOS
+
+You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](versions/latest/config/app/#infoplist) object.
+
+<IOSPermissions
+  permissions={[
+    'NSCalendarsUsageDescription',
+    'NSRemindersUsageDescription',
+  ]}
+/>
 
 ## Usage
 

--- a/docs/pages/versions/v48.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/calendar.mdx
@@ -69,7 +69,7 @@ You must add the following permissions to your **app.json** inside the [`expo.an
 
 ### iOS
 
-You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](versions/latest/config/app/#infoplist) object.
+You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](/versions/latest/config/app/#infoplist) object.
 
 <IOSPermissions
   permissions={[

--- a/docs/pages/versions/v48.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/calendar.mdx
@@ -7,11 +7,15 @@ packageName: 'expo-calendar'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-Provides an API for interacting with the device's system calendars, events, reminders, and associated records.
+`expo-calendar` provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -32,7 +36,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
       [
         "expo-calendar",
         {
-          "calendarPermission": "The app needs to access your calendar.",
+          "calendarPermission": "The app needs to access your calendar."
         }
       ]
     ]
@@ -47,36 +51,23 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
     {
       name: 'calendarPermission',
       platform: 'ios',
-      description: 'A string to set the NSCalendarsUsageDescription permission message.',
+      description: 'A string to set the [`NSCalendarsUsageDescription`](#ios) permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your calendar"',
     },
     {
       name: 'remindersPermission',
       platform: 'ios',
-      description: 'A string to set the NSRemindersUsageDescription permission message.',
+      description: 'A string to set the [`NSRemindersUsageDescription`](#ios) permission message.',
       default: '"Allow $(PRODUCT_NAME) to access your reminders"',
     },
   ]}
 />
 
-## Permissions
+<ConfigReactNative>
 
-### Android
+Learn how to configure the native projects in the [installation instructions in the `expo-calendar` repository](https://github.com/expo/expo/tree/main/packages/expo-calendar#installation-in-bare-react-native-projects).
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
-
-<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
-
-### iOS
-
-You can add the following permissions to your **app.json** inside the [`expo.ios.infoPlist`](/versions/latest/config/app/#infoplist) object.
-
-<IOSPermissions
-  permissions={[
-    'NSCalendarsUsageDescription',
-    'NSRemindersUsageDescription',
-  ]}
-/>
+</ConfigReactNative>
 
 ## Usage
 
@@ -151,3 +142,17 @@ import * as Calendar from 'expo-calendar';
 ```
 
 <APISection packageName="expo-calendar" apiName="Calendar" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CALENDAR', 'WRITE_CALENDAR']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCalendarsUsageDescription', 'NSRemindersUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/camera.mdx
@@ -7,9 +7,15 @@ packageName: 'expo-camera'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
+`expo-camera` provides a React component that renders a preview of the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. The component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together.
 
 <PlatformsSection android ios web />
 
@@ -18,6 +24,52 @@ import { SnackInline} from '~/ui/components/Snippet';
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-camera` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Allow $(PRODUCT_NAME) to access your camera."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'cameraPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSCameraUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your camera"',
+    },
+    {
+      name: 'microphonePermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSMicrophoneUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your microphone"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-camera` repository](https://github.com/expo/expo/tree/main/packages/expo-camera#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -122,3 +174,17 @@ import { Camera } from 'expo-camera';
 ```
 
 <APISection packageName="expo-camera" apiName="Camera" />
+
+## Permissions
+
+### Android
+
+This package automatically adds the `CAMERA` permission to your app. If you want to record videos with audio, you have to include the `RECORD_AUDIO` in your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['CAMERA', 'RECORD_AUDIO']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSCameraUsageDescription', 'NSMicrophoneUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/cellular.mdx
@@ -7,14 +7,27 @@ packageName: 'expo-cellular'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-cellular`** provides information about the user’s cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
+`expo-cellular` provides information about the user's cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
 
 <PlatformsSection android emulator ios web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No permissions required_.
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/cellular.mdx
@@ -18,7 +18,7 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v48.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/cellular.mdx
@@ -7,7 +7,8 @@ packageName: 'expo-cellular'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { AndroidPermissions } from '~/components/plugins/permissions';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-cellular` provides information about the user's cellular service provider, such as its unique identifier, cellular connection type, and whether it allows VoIP calls on its network.
 
@@ -17,17 +18,13 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 <APIInstallSection />
 
-## Permissions
+## Configuration in app.json/app.config.js
 
-### Android
+<ConfigReactNative>
 
-You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+Learn how to configure the native projects in the [installation instructions in the `expo-cellular` repository](https://github.com/expo/expo/tree/main/packages/expo-cellular#installation-in-bare-react-native-projects).
 
-<AndroidPermissions permissions={['READ_PHONE_STATE']} />
-
-### iOS
-
-_No permissions required_.
+</ConfigReactNative>
 
 ## API
 
@@ -42,3 +39,15 @@ import * as Cellular from 'expo-cellular';
 | Code                                         | Description                                                          |
 | -------------------------------------------- | -------------------------------------------------------------------- |
 | ERR_CELLULAR_GENERATION_UNKNOWN_NETWORK_TYPE | Unable to access network type or not connected to a cellular network |
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_PHONE_STATE']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/v48.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/contacts.mdx
@@ -7,8 +7,12 @@ packageName: 'expo-contacts'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { SnackInline } from '~/ui/components/Snippet';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
 `expo-contacts` provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
@@ -34,7 +38,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/guides/con
       [
         "expo-contacts",
         {
-          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts.",
+          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts."
         }
       ]
     ]
@@ -128,4 +132,4 @@ You must add the following permissions to your **app.json** inside the [`expo.an
 
 The following usage description keys are used by this library:
 
-<IOSPermissions permissions={[ 'NSContactsUsageDescription' ]} />
+<IOSPermissions permissions={['NSContactsUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/contacts.mdx
@@ -8,16 +8,58 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
+import { ConfigReactNative, ConfigPluginExample, ConfigPluginProperties } from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-contacts`** provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
+`expo-contacts` provides access to the device's system contacts, allowing you to get contact information as well as adding, editing, or removing contacts.
 
-On iOS contacts have a multi-layered grouping system that you can also access through this API.
+On iOS, contacts have a multi-layered grouping system that you can also access through this API.
 
 <PlatformsSection android emulator ios simulator />
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-contacts",
+        {
+          "contactsPermission": "Allow $(PRODUCT_NAME) to access your contacts.",
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'contactsPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSContactsUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your contacts"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-contacts` repository](https://github.com/expo/expo/tree/main/packages/expo-contacts#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -73,3 +115,17 @@ import * as Contacts from 'expo-contacts';
 ```
 
 <APISection packageName="expo-contacts" apiName="Contacts" />
+
+## Permissions
+
+### Android
+
+You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['READ_CONTACTS', 'WRITE_CONTACTS']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={[ 'NSContactsUsageDescription' ]} />

--- a/docs/pages/versions/v48.0.0/sdk/devicemotion.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/devicemotion.mdx
@@ -7,14 +7,60 @@ packageName: 'expo-sensors'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { IOSPermissions } from '~/components/plugins/permissions';
 
-`DeviceMotion` from **`expo-sensors`** provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
+`DeviceMotion` from `expo-sensors` provides access to the device motion and orientation sensors. All data is presented in terms of three axes that run through a device. According to portrait orientation: X runs from left to right, Y from bottom to top and Z perpendicularly through the screen from back to front.
 
 <PlatformsSection android emulator ios simulator web />
 
 ## Installation
 
 <APIInstallSection />
+
+## Configuration in app.json/app.config.js
+
+You can configure `DeviceMotion` from `expo-sensor` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-sensors",
+        {
+          "motionPermission": "Allow $(PRODUCT_NAME) to access your device motion."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'motionPermission',
+      platform: 'ios',
+      description: 'A string to set the [`NSMotionUsageDescription`](#ios) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your device motion"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-sensors` repository](https://github.com/expo/expo/tree/main/packages/expo-sensors#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## API
 
@@ -23,3 +69,11 @@ import { DeviceMotion } from 'expo-sensors';
 ```
 
 <APISection packageName="expo-device-motion" />
+
+## Permissions
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSMotionUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
@@ -9,7 +9,6 @@ import {
   ConfigPluginExample,
   ConfigPluginProperties,
 } from '~/components/plugins/ConfigSection';
-
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
@@ -62,7 +61,7 @@ If you want to enable [iCloud storage features][icloud-entitlement], set the `ex
 
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
-```json
+```json app.json
 {
   "expo": {
     "plugins": [
@@ -91,7 +90,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
   ]}
 />
 
-## Using with expo-file-system
+## Using with `expo-file-system`
 
 When using `expo-document-picker` with [`expo-file-system`](/versions/latest/sdk/filesystem/), it's not always possible for the file system to read the file immediately after the `expo-document-picker` picks it.
 

--- a/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
@@ -84,7 +84,7 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
       name: 'iCloudContainerEnvironment',
       platform: 'ios',
       description:
-        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
+        'Sets the iOS `com.apple.developer.icloud-container-environment` entitlement used for AdHoc iOS builds. Possible values: `Development`, `Production`. [Learn more](https://github.com/expo/eas-cli/issues/693).',
       default: 'undefined',
     },
   ]}

--- a/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/document-picker.mdx
@@ -28,33 +28,6 @@ import Video from '~/components/plugins/Video';
 
 You can configure `expo-document-picker` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
 
-<ConfigReactNative>
-
-Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
-
-If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
-
-```xml
-<key>com.apple.developer.icloud-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.icloud-services</key>
-<array>
-    <string>CloudDocuments</string>
-</array>
-<key>com.apple.developer.ubiquity-container-identifiers</key>
-<array>
-    <string>iCloud.dev.expo.my-app</string>
-</array>
-<key>com.apple.developer.ubiquity-kvstore-identifier</key>
-<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
-```
-
-Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
-
-</ConfigReactNative>
-
 <ConfigPluginExample>
 
 If you want to enable [iCloud storage features][icloud-entitlement], set the `expo.ios.usesIcloudStorage` key to `true` in the [Expo config](/workflow/configuration/) file as specified [configuration properties](/versions/latest/config/app/#usesicloudstorage).
@@ -89,6 +62,33 @@ Running [EAS Build](/build/introduction) locally will use [iOS capabilities sign
     },
   ]}
 />
+
+<ConfigReactNative>
+
+Apps that don't use [EAS Build](/build/introduction) and want [iCloud storage features][icloud-entitlement] must [manually configure](/build-reference/ios-capabilities#manual-setup) the [**iCloud service with CloudKit support**](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_icloud-container-environment) for their bundle identifier.
+
+If you enable the **iCloud** capability through the [Apple Developer Console](/build-reference/ios-capabilities#apple-developer-console), then be sure to add the following entitlements in your `ios/[app]/[app].entitlements` file (where `dev.expo.my-app` if your bundle identifier):
+
+```xml
+<key>com.apple.developer.icloud-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.icloud-services</key>
+<array>
+    <string>CloudDocuments</string>
+</array>
+<key>com.apple.developer.ubiquity-container-identifiers</key>
+<array>
+    <string>iCloud.dev.expo.my-app</string>
+</array>
+<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+<string>$(TeamIdentifierPrefix)dev.expo.my-app</string>
+```
+
+Apple Developer Console also requires an **iCloud Container** to be created. When registering the new container, you are asked to provide a description and identifier for the container. You may enter any name under the description. Under the identifier, add `iCloud.<your_bundle_identifier>` (same value used for `com.apple.developer.icloud-container-identifiers` and `com.apple.developer.ubiquity-container-identifiers` entitlements).
+
+</ConfigReactNative>
 
 ## Using with `expo-file-system`
 

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -10,10 +10,9 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-
 import { SnackInline } from '~/ui/components/Snippet';
 
-**`expo-file-system`** provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
+`expo-file-system` provides access to a file system stored locally on the device. Within Expo Go, each project has a separate file system and has no access to the file system of other Expo projects. However, it can save content shared by other projects to the local filesystem, as well as share local files with other projects. It is also capable of uploading and downloading files from network URLs.
 
 {/* TODO: update this image so we don't have to force a white background on it */}
 
@@ -197,18 +196,6 @@ app.listen(3000, () => {
 });
 ```
 
-## Permissions
-
-### Android
-
-The following permissions are added automatically through this library's `AndroidManifest.xml`.
-
-<AndroidPermissions permissions={['READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE', 'INTERNET']} />
-
-### iOS
-
-_No permissions required_.
-
 ## API
 
 ```js
@@ -254,3 +241,15 @@ In this table, you can see what type of URI can be handled by each method. For e
 | `createDownloadResumable` | Source:<br/>`http://`,<br/>`https://`<br/><br/>Destination:<br/>`file:///`                                                           | Source:<br/>`http://`,<br/>`https://`<br/><br/>Destination:<br/>`file://`                       |
 
 > On Android **no scheme** defaults to a bundled resource.
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`.
+
+<AndroidPermissions permissions={['READ_EXTERNAL_STORAGE', 'WRITE_EXTERNAL_STORAGE', 'INTERNET']} />
+
+### iOS
+
+_No permissions required_.

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -79,7 +79,7 @@ try {
   console.error(e);
 }
 
-//To resume a download across app restarts, assuming the the DownloadResumable.savable() object was stored:
+//To resume a download across app restarts, assuming the DownloadResumable.savable() object was stored:
 const downloadSnapshotJson = await AsyncStorage.getItem('pausedDownload');
 const downloadSnapshot = JSON.parse(downloadSnapshotJson);
 const downloadResumable = new FileSystem.DownloadResumable(

--- a/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/filesystem.mdx
@@ -29,7 +29,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v48.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/local-authentication.mdx
@@ -7,8 +7,14 @@ packageName: 'expo-local-authentication'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
 
-**`expo-local-authentication`** allows you to use FaceID and TouchID (iOS) or the Biometric Prompt (Android) to authenticate the user with a face or fingerprint scan.
+`expo-local-authentication` allows you to use the Biometric Prompt (Android) or FaceID and TouchID (iOS) to authenticate the user with a fingerprint or face scan.
 
 <PlatformsSection android emulator ios simulator />
 
@@ -16,9 +22,46 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-On Android, this module requires permissions to access the biometric data for authentication purposes. The `USE_BIOMETRIC` and `USE_FINGERPRINT` permissions are automatically added.
+You can configure `expo-local-authentication` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "'Allow $(PRODUCT_NAME) to use Face ID."
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'faceIDPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+    },
+  ]}
+/>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-local-authentication` repository](https://github.com/expo/expo/tree/main/packages/expo-local-authentication#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## API
 
@@ -27,3 +70,17 @@ import * as LocalAuthentication from 'expo-local-authentication';
 ```
 
 <APISection packageName="expo-local-authentication" apiName="LocalAuthentication" />
+
+## Permissions
+
+### Android
+
+The following permissions are added automatically through this library's `AndroidManifest.xml`:
+
+<AndroidPermissions permissions={['USE_BIOMETRIC', 'USE_FINGERPRINT']} />
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions permissions={['NSFaceIDUsageDescription']} />

--- a/docs/pages/versions/v48.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/local-authentication.mdx
@@ -35,7 +35,7 @@ You can configure `expo-local-authentication` using its built-in [config plugin]
       [
         "expo-local-authentication",
         {
-          "faceIDPermission": "'Allow $(PRODUCT_NAME) to use Face ID."
+          "faceIDPermission": "Allow $(PRODUCT_NAME) to use Face ID."
         }
       ]
     ]
@@ -52,7 +52,7 @@ You can configure `expo-local-authentication` using its built-in [config plugin]
       platform: 'ios',
       description:
         'A string to set the [`NSFaceIDUsageDescription`](#permission-nsfaceidusagedescription) permission message.',
-      default: '"Allow $(PRODUCT_NAME) to access your calendar"',
+      default: '"Allow $(PRODUCT_NAME) to use Face ID"',
     },
   ]}
 />

--- a/docs/pages/versions/v48.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/location.mdx
@@ -7,8 +7,13 @@ packageName: 'expo-location'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
-import { AndroidPermissions } from '~/components/plugins/permissions';
+import { SnackInline } from '~/ui/components/Snippet';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import {
+  ConfigReactNative,
+  ConfigPluginExample,
+  ConfigPluginProperties,
+} from '~/components/plugins/ConfigSection';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -18,36 +23,67 @@ import { AndroidPermissions } from '~/components/plugins/permissions';
 
 <APIInstallSection />
 
-## Configuration
+## Configuration in app.json/app.config.js
 
-### Android permissions
+You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
-When you install the `expo-location` module, it automatically adds the following permissions:
+<ConfigPluginExample>
 
-- `ACCESS_COARSE_LOCATION`: for approximate device location
-- `ACCESS_FINE_LOCATION`: for precise device location
-- `FOREGROUND_SERVICE`: to subscribe to location updates while the app is in use
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to use your location."
+        }
+      ]
+    ]
+  }
+}
+```
 
-To use background location features, you must add the `ACCESS_BACKGROUND_LOCATION` in **app.json** and [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
+</ConfigPluginExample>
 
-<AndroidPermissions
-  permissions={[
-    'ACCESS_COARSE_LOCATION',
-    'ACCESS_FINE_LOCATION',
-    'FOREGROUND_SERVICE',
-    'ACCESS_BACKGROUND_LOCATION',
+<ConfigPluginProperties
+  properties={[
+    {
+      name: 'locationAlwaysAndWhenInUsePermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationAlwaysAndWhenInUseUsageDescription`](#permission-nslocationalwaysandwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'locationAlwaysPermission',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationAlwaysUsageDescription`](#permission-nslocationalwaysusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'isIosBackgroundLocationEnabled',
+      platform: 'ios',
+      description:
+        'A string to set the [`NSLocationWhenInUseUsageDescription`](#permission-nslocationwheninuseusagedescription) permission message.',
+      default: '"Allow $(PRODUCT_NAME) to use your location"',
+    },
+    {
+      name: 'isAndroidBackgroundLocationEnabled',
+      platform: 'android',
+      description:
+        'A string to set the [`ACCESS_BACKGROUND_LOCATION`](#permission-access_background_location) permission message.',
+      default: '',
+    },
   ]}
 />
 
-#### Excluding a permission
+<ConfigReactNative>
 
-> **Note**: Excluding a **required permission** from a module in your app can break the functionality corresponding to that permission. Always make sure to include all permissions a module is dependent on.
+Learn how to configure the native projects in the [installation instructions in the `expo-location` repository](https://github.com/expo/expo/tree/main/packages/expo-location#installation-in-bare-react-native-projects).
 
-When your Expo project doesn't benefit from having particular permission included, you can omit it. For example, if your application doesn't need access to the precise location, you can exclude the `ACCESS_FINE_LOCATION` permission.
-
-Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
-
-To learn more on how to exclude a permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+</ConfigReactNative>
 
 ### Background Location Methods
 
@@ -159,3 +195,46 @@ import * as Location from 'expo-location';
 ```
 
 <APISection packageName="expo-location" apiName="Location" />
+
+## Permissions
+
+### Android
+
+When you install the `expo-location` module, it automatically adds the following permissions:
+
+- `ACCESS_COARSE_LOCATION`: for approximate device location
+- `ACCESS_FINE_LOCATION`: for precise device location
+- `FOREGROUND_SERVICE`: to subscribe to location updates while the app is in use
+
+To use background location features, you must add the `ACCESS_BACKGROUND_LOCATION` in **app.json** and [submit your app for review and request access to use the background location permission](https://support.google.com/googleplay/android-developer/answer/9799150?hl=en).
+
+<AndroidPermissions
+  permissions={[
+    'ACCESS_COARSE_LOCATION',
+    'ACCESS_FINE_LOCATION',
+    'FOREGROUND_SERVICE',
+    'ACCESS_BACKGROUND_LOCATION',
+  ]}
+/>
+
+#### Excluding a permission
+
+> **Note**: Excluding a **required permission** from a module in your app can break the functionality corresponding to that permission. Always make sure to include all permissions a module is dependent on.
+
+When your Expo project doesn't benefit from having particular permission included, you can omit it. For example, if your application doesn't need access to the precise location, you can exclude the `ACCESS_FINE_LOCATION` permission.
+
+Another example can be stated using [available location accuracies](#accuracy). Android defines the approximate location accuracy estimation within about 3 square kilometers, and the precise location accuracy estimation within about 50 meters. For example, if the location accuracy value is [Low](#low), you can exclude `ACCESS_FINE_LOCATION` permission. To learn more about levels of location accuracies, see [Android documentation](https://developer.android.com/training/location/permissions#accuracy).
+
+To learn more on how to exclude permission, see [Excluding Android permissions](/guides/permissions/#excluding-android-permissions).
+
+### iOS
+
+The following usage description keys are used by this library:
+
+<IOSPermissions
+  permissions={[
+    'NSLocationAlwaysAndWhenInUseUsageDescription',
+    'NSLocationAlwaysUsageDescription',
+    'NSLocationWhenInUseUsageDescription',
+  ]}
+/>

--- a/docs/pages/versions/v48.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/sensors.mdx
@@ -7,6 +7,8 @@ packageName: 'expo-sensors'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permissions';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
 `expo-sensors` provides various APIs for accessing device sensors to measure motion, orientation, pressure, magnetic fields, ambient light, and step count.
 
@@ -15,14 +17,6 @@ import { BoxLink } from '~/ui/components/BoxLink';
 ## Installation
 
 <APIInstallSection />
-
-### Configuration for Android
-
-Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
-
-If you need an update interval less than 200ms, you should:
-* add `android.permission.HIGH_SAMPLING_RATE_SENSORS` to [**app.json** `permissions` field](/versions/latest/config/app/#permissions)
-* or if you are using bare workflow, add `<uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>` to **AndroidManifest.xml**.
 
 ## API
 
@@ -40,6 +34,22 @@ import {
   Pedometer,
 } from 'expo-sensors';
 ```
+
+## Permissions
+
+### Android
+
+Starting in Android 12 (API level 31), the system has a 200ms limit for each sensor updates.
+
+If you need an update interval of less than 200ms, you must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
+
+<AndroidPermissions permissions={['HIGH_SAMPLING_RATE_SENSORS']} />
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-sensors` repository](https://github.com/expo/expo/tree/main/packages/expo-sensors#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Available sensors
 

--- a/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
@@ -26,7 +26,7 @@ Some features of this module are used by other modules under the hood. Here is a
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to test using [a development build](/development/introduction)
+`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to use a [development build](/development/introduction).
 
 Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so to use background features you will need to add appropriate keys to your **app.json** configuration.
 

--- a/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/task-manager.mdx
@@ -7,9 +7,10 @@ packageName: 'expo-task-manager'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 
-**`expo-task-manager`** provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
+`expo-task-manager` provides an API that allows you to manage long-running tasks, in particular those tasks that can run while your app is in the background.
 Some features of this module are used by other modules under the hood. Here is a list of Expo modules that use TaskManager:
 
 - [Location](location.mdx)
@@ -25,30 +26,29 @@ Some features of this module are used by other modules under the hood. Here is a
 
 ### Background modes on iOS
 
-`TaskManager` works out of the box in the Expo Go app on Android, but on iOS you'll need to test using [a development build](/development/introduction.mdx)
+`TaskManager` works out of the box in the Expo Go app on Android, however, on iOS, you'll need to test using [a development build](/development/introduction)
 
-Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so in order to use background features you will need to add appropriate keys to your **app.json** configuration.
+Standalone apps need some extra configuration: on iOS, each background feature requires a special key in `UIBackgroundModes` array in your **Info.plist** file. In standalone apps this array is empty by default, so to use background features you will need to add appropriate keys to your **app.json** configuration.
+
 Here is an example of an **app.json** configuration that enables background location and background fetch:
 
 ```json app.json
 {
   "expo": {
-    /* @hide ... */ /* @end */
     "ios": {
-      /* @hide ... */ /* @end */
       "infoPlist": {
-        /* @hide ... */ /* @end */
-        "UIBackgroundModes": [
-          "location",
-          "fetch"
-        ]
+        "UIBackgroundModes": ["location", "fetch"]
       }
     }
   }
 }
 ```
 
-For bare React Native apps, you need to add those keys manually. You can do it by clicking on your project in Xcode, then `Signing & Capabilities`, adding the `BackgroundMode` capability (if absent), and checking either `Location updates` or `Background fetch`, depending on your needs.
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-task-manager` repository](https://github.com/expo/expo/tree/main/packages/expo-task-manager#installation-in-bare-ios-react-native-project).
+
+</ConfigReactNative>
 
 ## Example
 
@@ -96,8 +96,8 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     alignItems: 'center',
-    justifyContent: 'center'
-  }
+    justifyContent: 'center',
+  },
 });
 /* @end */
 

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -8,6 +8,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 
 The expo-updates library allows you to programmatically control and respond to new updates made available to your app.
 
@@ -16,6 +17,35 @@ The expo-updates library allows you to programmatically control and respond to n
 ## Installation
 
 <APIInstallSection href="/bare/installing-updates/" />
+
+## Configuration in app.json/app.config.js
+
+The plugin is configured with the Expo account's username automatically when EAS CLI is used.
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-updates",
+        {
+          "username": "account-username"
+        }
+      ]
+    ]
+  }
+}
+```
+
+</ConfigPluginExample>
+
+<ConfigReactNative>
+
+Learn how to configure the native projects in the [installation instructions in the `expo-updates` repository](https://github.com/expo/expo/tree/main/packages/expo-updates#installation-in-bare-react-native-projects).
+
+</ConfigReactNative>
 
 ## Usage
 
@@ -31,7 +61,6 @@ Every custom updates server must implement the [Expo Updates protocol](https://d
 
 You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
 
-
 ### Configuration options
 
 There are build-time configuration options that control the behavior of `expo-updates`.
@@ -40,20 +69,20 @@ On Android, these options are set as `meta-data` tags adjacent to the tags added
 
 On iOS, these properties are set as keys in **Expo.plist** file. You can also set them at runtime by calling `[EXUpdatesAppController.sharedInstance setConfiguration:]` at any point before calling `start` or `startAndShowLaunchScreen`, and the values in this dictionary will override any values specified in **Expo.plist**.
 
-| iOS plist/dictionary key | Android Map key | Android meta-data name         | Default | Required? |
-|--------------------------|---------------- | ------------------------------ | ------- | --------- |
-| `EXUpdatesEnabled`       | `enabled`       | `expo.modules.updates.ENABLED` | `true`  | <NoIcon />        |
-| `EXUpdatesURL`           | `updateUrl`     | `expo.modules.updates.EXPO_UPDATE_URL` | (none)  | <YesIcon />        |
-| `EXUpdatesRequestHeaders`| `requestHeaders`| `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY` | (none)  | <NoIcon />        |
-| `EXUpdatesSDKVersion`    | `sdkVersion`    | `expo.modules.updates.EXPO_SDK_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
-| `EXUpdatesRuntimeVersion` | `runtimeVersion` | `expo.modules.updates.EXPO_RUNTIME_VERSION` | (none)  | (exactly one of `sdkVersion` or `runtimeVersion` is required) |
-| `EXUpdatesReleaseChannel` | `releaseChannel` | `expo.modules.updates.EXPO_RELEASE_CHANNEL` | `default` | <NoIcon />        |
-| `EXUpdatesCheckOnLaunch` | `checkOnLaunch` | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH` | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`)| <NoIcon />        |
-| `EXUpdatesLaunchWaitMs`  | `launchWaitMs`  | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS` | `0`     | <NoIcon />        |
-| `EXUpdatesCodeSigningCertificate` | `codeSigningCertificate` | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`    | (none)  | <NoIcon />        |
-| `EXUpdatesCodeSigningMetadata`    | `codeSigningMetadata`    | `expo.modules.updates.CODE_SIGNING_METADATA`       | (none)  | <NoIcon />        |
-| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false | <NoIcon />        |
-| `EXUpdatesConfigCodeSigningAllowUnsignedManifests` | `codeSigningAllowUnsignedManifests` | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS` | false | <NoIcon />        |
+| iOS plist/dictionary key                                      | Android Map key                                      | Android meta-data name                                                          | Default                                                          | Required?                                                                                                |
+| ------------------------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `EXUpdatesEnabled`                                            | `enabled`                                            | `expo.modules.updates.ENABLED`                                                  | `true`                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesURL`                                                | `updateUrl`                                          | `expo.modules.updates.EXPO_UPDATE_URL`                                          | (none)                                                           | <YesIcon />                                                                                              |
+| `EXUpdatesRequestHeaders`                                     | `requestHeaders`                                     | `expo.modules.updates.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY`                | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesSDKVersion`                                         | `sdkVersion`                                         | `expo.modules.updates.EXPO_SDK_VERSION`                                         | (none)                                                           | (exactly one of `sdkVersion` or `runtimeVersion` is required, Required for apps hosted on Expo's server) |
+| `EXUpdatesRuntimeVersion`                                     | `runtimeVersion`                                     | `expo.modules.updates.EXPO_RUNTIME_VERSION`                                     | (none)                                                           | (exactly one of `sdkVersion` or `runtimeVersion` is required)                                            |
+| `EXUpdatesReleaseChannel`                                     | `releaseChannel`                                     | `expo.modules.updates.EXPO_RELEASE_CHANNEL`                                     | `default`                                                        | <NoIcon />                                                                                               |
+| `EXUpdatesCheckOnLaunch`                                      | `checkOnLaunch`                                      | `expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH`                             | `ALWAYS` (`ALWAYS`, `NEVER`, `WIFI_ONLY`, `ERROR_RECOVERY_ONLY`) | <NoIcon />                                                                                               |
+| `EXUpdatesLaunchWaitMs`                                       | `launchWaitMs`                                       | `expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS`                              | `0`                                                              | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningCertificate`                             | `codeSigningCertificate`                             | `expo.modules.updates.CODE_SIGNING_CERTIFICATE`                                 | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningMetadata`                                | `codeSigningMetadata`                                | `expo.modules.updates.CODE_SIGNING_METADATA`                                    | (none)                                                           | <NoIcon />                                                                                               |
+| `EXUpdatesCodeSigningIncludeManifestResponseCertificateChain` | `codeSigningIncludeManifestResponseCertificateChain` | `expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN` | false                                                            | <NoIcon />                                                                                               |
+| `EXUpdatesConfigCodeSigningAllowUnsignedManifests`            | `codeSigningAllowUnsignedManifests`                  | `expo.modules.updates.CODE_SIGNING_ALLOW_UNSIGNED_MANIFESTS`                    | false                                                            | <NoIcon />                                                                                               |
 
 For a detailed explanation, see the [`expo-updates`](https://github.com/expo/expo/blob/main/packages/expo-updates/README.md) repository.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Closes ENG-2475
# How

<!--
How did you build this feature or fix this bug and why?
-->

By following instructions from this [notion doc](https://www.notion.so/expo/Config-plugin-and-permissions-docs-e0f5b8f5b98f4a6eb3ef279dcbd4de02) and updating the API references for packages listed. Changes backported for SDK 48.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
