### PR TITLE
fix(cli): only check if `unstable_serverRoot` is defined

### DIFF
--- a/packages/@expo/cli/src/utils/analytics/getMetroProperties.ts
+++ b/packages/@expo/cli/src/utils/analytics/getMetroProperties.ts
@@ -27,7 +27,7 @@ export function getMetroProperties(
     resolverEnablePackageExports: metroConfig.resolver?.unstable_enablePackageExports, // boolean
 
     serverImportBundleSupport: metroConfig.server?.experimentalImportBundleSupport, // boolean
-    serverServerRoot: metroConfig.server?.unstable_serverRoot, // string | null
+    serverServerRoot: Boolean(metroConfig.server?.unstable_serverRoot) || undefined, // string | null
 
     transformerCollectDependenciesPath: metroConfig.transformer?.unstable_collectDependenciesPath, // string
     transformerDependencyMapReservedName:


### PR DESCRIPTION
# Why

We only need to check if this property is defined or not.

# How

Changed it into a boolean

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
