### PR TITLE
[manifests] fix the default jsEngine for old sdks

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed default `expo.jsEngine` value when SDK is lower than 48. ([#21266](https://github.com/expo/expo/pull/21266) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.5.1 — 2023-02-09

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -169,8 +169,14 @@ abstract class Manifest(protected val json: JSONObject) {
 
   val jsEngine: String by lazy {
     val expoClientConfig = getExpoClientConfigRootObject()
-    expoClientConfig
-      ?.getNullable<JSONObject>("android")?.getNullable<String>("jsEngine") ?: expoClientConfig?.getNullable<String>("jsEngine") ?: "hermes"
+    var result = expoClientConfig
+      ?.getNullable<JSONObject>("android")?.getNullable<String>("jsEngine") ?: expoClientConfig?.getNullable<String>("jsEngine")
+    if (result == null) {
+      val sdkVersionComponents = getSDKVersion()?.split(".")
+      val sdkMajorVersion = if (sdkVersionComponents?.size == 3) sdkVersionComponents[0].toIntOrNull() else 0
+      result = if (sdkMajorVersion in 1..47) "jsc" else "hermes"
+    }
+    result
   }
 
   fun getIconUrl(): String? {

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
@@ -163,7 +163,12 @@
                                          ]];
   }
   if (!result) {
-    result = @"hermes";
+    int sdkMajorVersion = [self sdkMajorVersion];
+    if (sdkMajorVersion > 0 && sdkMajorVersion < 48) {
+      result = @"jsc";
+    } else {
+      result = @"hermes";
+    }
   }
   return result;
 }
@@ -303,6 +308,16 @@
     json = value;
   }
   return nil;
+}
+
+- (int)sdkMajorVersion
+{
+  NSString *sdkVersion = [self.expoClientConfigRootObject nullableStringForKey:@"sdkVersion"];
+  NSArray<NSString *> *components = [sdkVersion componentsSeparatedByString:@"."];
+  if (components.count == 3) {
+    return [components[0] intValue];
+  }
+  return 0;
 }
 
 @end


### PR DESCRIPTION
# Why

close ENG-7609

# How

since the manifest is unversioned code, we should set the default jsEngine based on sdk version

# Test Plan

- ci passed
- follow the steps at ENG-7609 to check the current jsEngine is jsc on a sdk 47 project

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
