### PR TITLE
[go] disable remote debugging when running on hermes

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -472,6 +472,10 @@ abstract class ReactNativeActivity :
     if (devSettings != null) {
       devSettings.setField("exponentActivityId", activityId)
       if (devSettings.call("isRemoteJSDebugEnabled") as Boolean) {
+        if (manifest?.jsEngine == "hermes") {
+          // Disable remote debugging when running on Hermes
+          devSettings.call("setRemoteJSDebugEnabled", false)
+        }
         waitForReactAndFinishLoading()
       }
     }

--- a/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
+++ b/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDevSettings.m
@@ -30,4 +30,15 @@ NSString *const kRCTDevSettingHotLoadingEnabled = @"hotLoadingEnabled";
   return [super supportedEvents];
 }
 
+- (BOOL)isRemoteDebuggingAvailable
+{
+  NSString *bridgeDescription = [self.bridge valueForKey:@"_bridgeDescription"];
+  BOOL isHermesRuntime = [bridgeDescription containsString:@"HermesRuntime"];
+  if (isHermesRuntime) {
+    // Disable remote debugging when running on Hermes
+    return NO;
+  }
+  return [super isRemoteDebuggingAvailable];
+}
+
 @end


### PR DESCRIPTION
# Why

close ENG-7610

# How

the implementation is slightly different between android and ios. on ios, we could just disable remote debugging when changing to hermes and enable it when changing back to jsc. however, on android we just disable remote debugging when running on hermes. this is because the fact of we have override `EXDevSettings` on ios but no similar stuff on android.

# Test Plan

follow steps on ENG-7610

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
