### PR TITLE
partial revert: [templates] Remove config options that don't apply to templates

### DIFF
--- a/templates/expo-template-bare-minimum/app.json
+++ b/templates/expo-template-bare-minimum/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "HelloWorld",
     "slug": "expo-template-bare",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "assetBundlePatterns": ["**/*"]
   }
 }

--- a/templates/expo-template-blank-typescript/app.json
+++ b/templates/expo-template-blank-typescript/app.json
@@ -11,6 +11,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/templates/expo-template-blank/app.json
+++ b/templates/expo-template-blank/app.json
@@ -11,6 +11,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },

--- a/templates/expo-template-tabs/app.json
+++ b/templates/expo-template-tabs/app.json
@@ -12,6 +12,7 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true
     },


### PR DESCRIPTION
# Why

This partially reverts ff9831c03aafd8c1810dd644679301057e45c98a since there are still tools that rely upon this: https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/export/exportAssets.ts#L19

This will need to be cherry-picked into 48 since somehow the blame rev got in there.

# How

Revert portion of it.

# Test Plan

inspect

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
