### PR TITLE
[dev-launcher] Fix Dev Client crash when server URL is missing the protocol

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed dev client crash when server URL has no scheme. ([#21274](https://github.com/expo/expo/pull/21274) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 2.1.2 — 2023-02-17

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -65,11 +65,13 @@ public class EXDevLauncherURLHelper: NSObject {
 
   @objc
   public static func replaceEXPScheme(_ url: URL, to scheme: String) -> URL {
-    var components = URLComponents.init(url: url, resolvingAgainstBaseURL: false)!
-    if components.scheme == "exp" {
-      components.scheme = scheme
+    if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+      if components.scheme == "exp" {
+        components.scheme = scheme
+      }
+      return components.url!
     }
-    return components.url!
+    return url
   }
 
   @objc

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -65,13 +65,11 @@ public class EXDevLauncherURLHelper: NSObject {
 
   @objc
   public static func replaceEXPScheme(_ url: URL, to scheme: String) -> URL {
-    if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-      if components.scheme == "exp" {
-        components.scheme = scheme
-      }
-      return components.url!
+    var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    if components?.scheme == "exp" {
+      components?.scheme = scheme
     }
-    return url
+    return components?.url ?? url
   }
 
   @objc

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
@@ -5,9 +5,9 @@ import XCTest
 @testable import EXDevLauncher
 
 class EXDevLauncherURLHelperTests: XCTestCase {
-  
+
   let encodedUrlString = "http%3A%2F%2Flocalhost%3A8081"
-  
+
   func testIsDevLauncherURL() {
     let defaultUrl = "scheme://expo-development-client"
     XCTAssertTrue(EXDevLauncherURLHelper.isDevLauncherURL(URL(string: defaultUrl)))
@@ -22,28 +22,32 @@ class EXDevLauncherURLHelperTests: XCTestCase {
 
     let actual2 = EXDevLauncherURLHelper.replaceEXPScheme(URL(string: "http://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081")!, to: "scheme")
     XCTAssertEqual(URL(string: "http://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081"), actual2)
+
+    // should not crash if provided URL does not include scheme
+    let actual3 = EXDevLauncherURLHelper.replaceEXPScheme(URL(string: "192.168.0.12:19000")!, to: "scheme")
+    XCTAssertEqual(URL(string: "192.168.0.12:19000"), actual3)
   }
-  
+
   func testDevLauncherUrls() {
     // dev-client scheme with valid url param -> loadApp with specified url param
     expectDevLauncherUrlToEqual(input:"scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081%2Findex.bundle%3Fplatform%3Dios%26dev%3Dtrue",
                          expected:"http://localhost:8081/index.bundle?platform=ios&dev=true")
-    
+
     // non-dev-client scheme with valid url param -> defer loading to loaded app
     expectDevLauncherUrlToEqual(input: "scheme://not-dev-client/?url=\(encodedUrlString)",
                                 expected: "scheme://not-dev-client/?url=\(encodedUrlString)")
 
   }
-  
+
   func testDevLauncherUrlQueryParams() {
     let url = "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&updateMessage=123"
     let devLauncherUrl = EXDevLauncherUrl(URL(string:url)!)
     let queryParams = devLauncherUrl.queryParams
-    
+
     XCTAssertEqual(queryParams["updateMessage"], "123")
     XCTAssertEqual(queryParams["url"], "http://localhost:8081")
   }
-  
+
   //  HELPER
   func expectDevLauncherUrlToEqual(input: String, expected: String) {
     let devLauncherUrl = EXDevLauncherUrl(URL(string:input)!)


### PR DESCRIPTION
# Why

Closes ENG-7517

When calling `replaceEXPScheme` with an `url` that does not include a scheme, `URLComponents.init()` returns `nil` which was crashing the app because we were force-unwrapping the result with the `!` operator.

# How

This PR updates the `replaceEXPScheme` function to no longer force-unwrap and return the original `url` when `URLComponents.init()` returns `nil`, which is the approach already used for Android:
https://github.com/expo/expo/blob/98d90433bde67adbff25cdbfdc9e774ce1b4d205/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherURLHelper.kt#L5


One thing that we could do to improve the DX is to default the scheme of URLs provided to `loadApp` to `http`

# Test Plan

Tests using `bare-expo` with ` BOOL useDevClient = YES;` 
  

https://user-images.githubusercontent.com/11707729/219722351-7dabbae5-9ab3-45b5-a7a8-f9a64b911dfe.mov



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
