### PR TITLE
[ios][dev-menu] fix reload crash when dev-menu turned off

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
+
 ### 💡 Others
 
 ## 2.1.2 — 2023-02-17

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -5,7 +5,7 @@ open class DevMenuModule: NSObject {
   deinit {
     // cleanup registered callbacks when the bridge is deallocated to prevent these leaking into other (potentially unrelated) bridges
     if ExpoDevMenuReactDelegateHandler.enableAutoSetup == true {
-        DevMenuManager.shared.registeredCallbacks = []
+      DevMenuManager.shared.registeredCallbacks = []
     }
   }
   

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -4,9 +4,9 @@
 open class DevMenuModule: NSObject {
   deinit {
     // cleanup registered callbacks when the bridge is deallocated to prevent these leaking into other (potentially unrelated) bridges
-      if (ExpoDevMenuReactDelegateHandler.enableAutoSetup == true) {
-          DevMenuManager.shared.registeredCallbacks = []
-      }
+    if ExpoDevMenuReactDelegateHandler.enableAutoSetup == true {
+        DevMenuManager.shared.registeredCallbacks = []
+    }
   }
   
   // MARK: JavaScript API

--- a/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuModule.swift
@@ -4,7 +4,9 @@
 open class DevMenuModule: NSObject {
   deinit {
     // cleanup registered callbacks when the bridge is deallocated to prevent these leaking into other (potentially unrelated) bridges
-    DevMenuManager.shared.registeredCallbacks = []
+      if (ExpoDevMenuReactDelegateHandler.enableAutoSetup == true) {
+          DevMenuManager.shared.registeredCallbacks = []
+      }
   }
   
   // MARK: JavaScript API


### PR DESCRIPTION
# Why

When Expo-dev-menu is turned off from AppDelegate.m using:
```
     ExpoDevMenuReactDelegateHandler.enableAutoSetup = NO;
```
The application crashes when we try to use bare react-native reload.


# How

I noticed that Expo-dev-menu does not need to be setup if an app has explcitly requested for its disabling.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
1. Disable auto setup of expo-dev-menu by adding: `ExpoDevMenuReactDelegateHandler.enableAutoSetup = NO;` in your AppDelegate.m
2. Launch bare-expo app.
3. Try to reload via "r" or via Shake gesture -> "Reload".
4. You will see a crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
