### PR TITLE
Don't overwrite EXPO_ROUTER_APP_ROOT if already set

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -166,7 +166,7 @@ export async function withMetroMultiPlatformAsync(
   platformBundlers: PlatformBundlers
 ) {
   // Auto pick App entry: this is injected with Babel.
-  process.env.EXPO_ROUTER_APP_ROOT = getAppRouterRelativeEntryPath(projectRoot);
+  process.env.EXPO_ROUTER_APP_ROOT = process.env.EXPO_ROUTER_APP_ROOT ?? getAppRouterRelativeEntryPath(projectRoot);
   process.env.EXPO_PROJECT_ROOT = process.env.EXPO_PROJECT_ROOT ?? projectRoot;
 
   if (platformBundlers.web === 'metro') {


### PR DESCRIPTION
# Why

Checking whether EXPO_ROUTER_APP_ROOT exists before setting it here would allow manually setting it when calling the CLI. This would allow choosing a different root folder than app/ for expo-router. I would like to use this way to specify a different folder when building an App Clip.