### PR TITLE
[docs] fix import in android tutorial in Expo modules API

### DIFF
--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -382,6 +382,7 @@ import android.content.SharedPreferences
 import androidx.core.os.bundleOf
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.types.Enumerable
 
 class ExpoSettingsModule : Module() {
   override fun definition() = ModuleDefinition {


### PR DESCRIPTION
# Why

This PR is created because an import is missing from the Android Native Modules Enumerated type example

# How

While working on the tutorial, I figured out where the import was and added it to the documentation

# Test Plan

Just run the docs, go through the tutorial really quickly and make sure Android all works as expected 🙂

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
