### PR TITLE
[docs] Fix typo in create-a-modal tutorial page

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -102,7 +102,7 @@ Let's break down the layout of the option buttons we will implement in this chap
   containerStyle={{ marginBottom: 10 }}
 />
 
-It contains a parent `<View>` with three buttons aligned in a row. The button in the middle with the plus icon (+) will open the model and is styled differently than the other two buttons.
+It contains a parent `<View>` with three buttons aligned in a row. The button in the middle with the plus icon (+) will open the modal and is styled differently than the other two buttons.
 
 Inside the **components** directory, create a new file called **CircleButton.js** with the following code:
 


### PR DESCRIPTION
# Why

Found this while following the tutorial

# How

I replaced `model` with `modal`

# Test Plan

not sure if needed

# Checklist

unsure how to fill this

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
