### PR TITLE
[docs] Fix typo in screenshot tutorial page

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -91,7 +91,7 @@ export default function App() {
 }
 ```
 
-The `collapsible` prop is set to `false` in the above snippet because this `<View>` component is used to take a screenshot of the background image and the emoji sticker.
+The `collapsable` prop is set to `false` in the above snippet because this `<View>` component is used to take a screenshot of the background image and the emoji sticker.
 The rest of the contents of the app screen (such as buttons) are not part of the screenshot.
 
 ## Step 5: Capture a screenshot and save it


### PR DESCRIPTION
# Why

Found this while following the tutorial

# How

I replaced `collapsible` with `collapsable`, because thats the name of the prop

# Test Plan

not sure if needed

# Checklist

unsure how to fill this

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
