### PR TITLE
[manifests] fix sdkVersion parsing

### DIFF
--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.h
@@ -1,10 +1,11 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 #import <EXJSONUtils/NSDictionary+EXJSONUtils.h>
+#import <EXManifests/EXManifestsManifest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface EXManifestsBaseManifest : NSObject
+@interface EXManifestsBaseManifest : NSObject<EXManifestsManifestBehavior>
 
 @property (nonatomic, readonly, strong) NSDictionary* rawManifestJSON;
 

--- a/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
+++ b/packages/expo-manifests/ios/EXManifests/EXManifestsBaseManifest.m
@@ -312,7 +312,7 @@
 
 - (int)sdkMajorVersion
 {
-  NSString *sdkVersion = [self.expoClientConfigRootObject nullableStringForKey:@"sdkVersion"];
+  NSString *sdkVersion = [self sdkVersion];
   NSArray<NSString *> *components = [sdkVersion componentsSeparatedByString:@"."];
   if (components.count == 3) {
     return [components[0] intValue];


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/21266#discussion_r1111324708

# How

the sdkVersion parser varies between legacy manifest and new manifest. we should use the existing `sdkVersion` selector to get its version correctly.

# Test Plan

- ci passed
- expo go + eas update with `runtimeVersion.policy=sdkVersion`
- dev client + eas update with `runtimeVersion=1.0.0`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - not going to update changelog because #21266 does not publish yet
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
