### PR TITLE
[home] Fix SafeAreaView brief layout flash

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-b7dc6f85d40e2ce2fba06a60b52171ce04d16ebb"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-eb0a60f4889b5ca0b41c57cac276c6b2e39a1eff"
 }

--- a/home/screens/HomeScreen/index.tsx
+++ b/home/screens/HomeScreen/index.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack';
 import { useCurrentTheme, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native';
 
 import { HomeScreenDataQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
@@ -51,7 +51,7 @@ export function HomeScreen(props: NavigationProps) {
   const { homeScreenData } = useInitialData();
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background.default }} edges={['top']}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background.default }}>
       <HomeScreenView
         theme={themeType}
         {...props}


### PR DESCRIPTION
# Why

Closes ENG-7608

This is one of the classic problems with `react-native-safe-area-context`, sometimes during the first mount of a SafeAreaView, the insets are not populated correctly.

# How

This PR replaces the `SafeAreaView` used on the Expo Go home screen  to use the component from `react-native` instead of `react-native-safe-area-context` 

# Test Plan
 
<table>
    <tr><th>After</th><th>Before</th></tr>
    <tr>
    <td>
        <video src="https://user-images.githubusercontent.com/11707729/220131398-99a52509-97fd-45ea-8b17-8a94554c889a.mov" />
   </td>
   <td>
   <video src="https://user-images.githubusercontent.com/11707729/220135027-5be9269d-d37a-4db4-a978-16aa563effad.mov" />  
    </td>
</tr>
    <tr>
<td>
 <video src="https://user-images.githubusercontent.com/11707729/220134838-5e636c9b-87cf-4e7b-89fb-34763c72f09a.mov" /> 
</td>
<td>
<video src="https://user-images.githubusercontent.com/11707729/220135212-85b7ca46-627f-4fdd-9227-c30bb992caeb.mov" />
</td></tr>
</table>








 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
