### PR TITLE
Sort jest mock generation

### DIFF
--- a/apps/jest-expo-mock-generator/App.js
+++ b/apps/jest-expo-mock-generator/App.js
@@ -6,8 +6,7 @@ import React from 'react';
 import { Button, NativeModules, StyleSheet, Text, View } from 'react-native';
 import { v4 as uuidV4 } from 'uuid';
 
-// A workaround for `TypeError: Cannot read property 'now' of undefined` error.
-
+// A workaround for `TypeError: Cannot read property 'now' of undefined` error thrown from reanimated code.
 global.performance = {
   now: () => 0,
 };
@@ -26,7 +25,9 @@ if (!ExpoNativeModuleIntrospection) {
 const keysOrder = ['type', 'functionType', 'name', 'argumentsCount', 'key'];
 
 function isNumeric(str) {
-  if (typeof str != 'string') return false; // we only process strings!
+  if (typeof str !== 'string') {
+    return false; // we only process strings!
+  }
   return (
     !isNaN(str) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
     !isNaN(parseFloat(str))
@@ -67,15 +68,13 @@ const replacer = (_key, value) => {
 };
 
 export default class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
+  state = {};
+
   async componentDidMount() {
     const moduleSpecs = await _getExpoModuleSpecsAsync();
     const code = `module.exports = ${JSON.stringify(moduleSpecs, replacer)};`;
     await setStringAsync(code);
-    this.state.moduleSpecs = moduleSpecs;
+    this.setState({ moduleSpecs });
     const message = `
 
 ------------------------------COPY THE TEXT BELOW------------------------------

--- a/apps/jest-expo-mock-generator/App.js
+++ b/apps/jest-expo-mock-generator/App.js
@@ -1,9 +1,16 @@
 import mux from '@expo/mux';
+import { setStringAsync } from 'expo-clipboard';
 import Constants from 'expo-constants';
 import getInstallationIdAsync from 'expo/build/environment/getInstallationIdAsync';
 import React from 'react';
-import { NativeModules, StyleSheet, Text, View } from 'react-native';
+import { Button, NativeModules, StyleSheet, Text, View } from 'react-native';
 import { v4 as uuidV4 } from 'uuid';
+
+// A workaround for `TypeError: Cannot read property 'now' of undefined` error.
+
+global.performance = {
+  now: () => 0,
+};
 
 const logUrl = Constants.manifest.logUrl;
 const sessionId = uuidV4();
@@ -16,11 +23,59 @@ if (!ExpoNativeModuleIntrospection) {
   );
 }
 
+const keysOrder = ['type', 'functionType', 'name', 'argumentsCount', 'key'];
+
+function isNumeric(str) {
+  if (typeof str != 'string') return false; // we only process strings!
+  return (
+    !isNaN(str) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
+    !isNaN(parseFloat(str))
+  ); // ...and ensure strings of whitespace fail
+}
+
+const replacer = (_key, value) => {
+  if (value instanceof Object && !(value instanceof Array)) {
+    return Object.keys(value)
+      .sort(function (a, b) {
+        if (keysOrder.indexOf(a) !== -1 || keysOrder.indexOf(b) !== -1) {
+          return (
+            (keysOrder.includes(a) ? keysOrder.indexOf(a) : Infinity) -
+            (keysOrder.includes(b) ? keysOrder.indexOf(b) : Infinity)
+          );
+        } else {
+          return a.localeCompare(b);
+        }
+      })
+      .reduce((sorted, key) => {
+        sorted[key] = value[key];
+        return sorted;
+      }, {});
+  }
+  if (value instanceof Array) {
+    // sorts by numeric keys eg. { name: 'isAvailableAsync', argumentsCount: 0, key: 0 },
+    if (value?.[0]?.key && isNumeric(value?.[0]?.key)) {
+      return value.sort((a, b) => Number(a?.key) > Number(b?.key));
+    }
+    // sorts by string keys  eg. { name: 'getNetworkStateAsync', argumentsCount: 0, key: 'getNetworkStateAsync' },
+    if (value?.[0]?.key) {
+      return value.sort((a, b) => a?.key?.localeCompare?.(b?.key));
+    }
+    // sort other arrays
+    return value?.sort((a, b) => a?.localeCompare?.(b)) ?? value;
+  }
+  return value;
+};
+
 export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
   async componentDidMount() {
     const moduleSpecs = await _getExpoModuleSpecsAsync();
-    const code = `module.exports = ${JSON.stringify(moduleSpecs)};`;
-
+    const code = `module.exports = ${JSON.stringify(moduleSpecs, replacer)};`;
+    await setStringAsync(code);
+    this.state.moduleSpecs = moduleSpecs;
     const message = `
 
 ------------------------------COPY THE TEXT BELOW------------------------------
@@ -29,6 +84,8 @@ ${code}
 
 ------------------------------END OF TEXT TO COPY------------------------------
 
+THE TEXT WAS ALSO COPIED TO YOUR CLIPBOARD
+
 `;
     await _sendRawLogAsync(message, logUrl);
   }
@@ -36,10 +93,16 @@ ${code}
   render() {
     return (
       <View style={styles.container}>
-        <Text>
-          Check your console and copy the relevant logs into jest-expo/src/expoModules.js and format
-          it nicely with prettier
+        <Text style={{ fontWeight: '700' }}>
+          Your new jest mocks should now be:{'\n'}- In your clipboard{'\n'}- In your development
+          console.{'\n\n'}
+          Copy either one of the <Text style={{ backgroundColor: '#eee' }}>
+            module.exports
+          </Text>{' '}
+          line into <Text style={{ backgroundColor: '#eee' }}>jest-expo/src/expoModules.js</Text>{' '}
+          and format it nicely with prettier.
         </Text>
+        <Button onPress={() => setStringAsync(this.state.moduleSpecs)} title="Copy to clipboard" />
       </View>
     );
   }

--- a/apps/jest-expo-mock-generator/package.json
+++ b/apps/jest-expo-mock-generator/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@expo/mux": "^1.0.7",
     "expo": "~48.0.0-beta.0",
+    "expo-clipboard": "~4.1.1",
     "react": "18.2.0",
     "react-native": "0.71.3",
     "uuid": "^3.4.0"


### PR DESCRIPTION
# Why

To simplify figuring out jest mocks each release

# How

Auto copies the generated mocks to clipboard on iOS simulator.
Sorts keys and array values.
# Test Plan

Tested manually to see if it doesn't affect number of lines, only JSON order.

Can theoretically reorder arrays in mock values, but there's no such case yet, and I'm not sure if we should worry about it.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
