### PR TITLE
[docs] adds  steps required for email / phone links

### DIFF
--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -47,6 +47,24 @@ There are some URL schemes for core functionality that exist on every platform. 
 | `tel`            | Open phone app, eg: `tel:+123456789`          |
 | `sms`            | Open SMS app, eg: `sms:+123456789`            |
 
+On newer Android versions, you may have to include the appropriate queries in your `AndroidManifest.xml` to open links (ideally via a config plugin). For example, the following:
+
+```xml
+<manifest>
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.SENDTO"/>
+      <data android:scheme="mailto"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.DIAL"/>
+    </intent>
+  </queries>
+</manifest>
+```
+
+Enables linking to the phone and email app.
+
 ### Custom URL schemes
 
 If you know the custom scheme for another app you can link to it. Some services provide documentation for deep linking, for example the [Lyft deep linking documentation](https://developer.lyft.com/v1/docs/deeplinking) describes how to link directly to a specific pickup location and destination:

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -77,7 +77,6 @@ module.exports = withAndroidQueries;
 
 You can then [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) in your project's app config. This example plugin will enable linking to phone and email apps.
 
-
 ### Custom URL schemes
 
 If you know the custom scheme for another app you can link to it. Some services provide documentation for deep linking, for example the [Lyft deep linking documentation](https://developer.lyft.com/v1/docs/deeplinking) describes how to link directly to a specific pickup location and destination:

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -77,7 +77,6 @@ module.exports = withAndroidQueries;
 
 You can then [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) in your project's app config. This example plugin will enable linking to phone and email apps.
 
-Enables linking to the phone and email app.
 
 ### Custom URL schemes
 

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -47,21 +47,35 @@ There are some URL schemes for core functionality that exist on every platform. 
 | `tel`            | Open phone app, eg: `tel:+123456789`          |
 | `sms`            | Open SMS app, eg: `sms:+123456789`            |
 
-On newer Android versions, you may have to include the appropriate queries in your `AndroidManifest.xml` to open links (ideally via a config plugin). For example, the following:
+On newer Android versions, include the appropriate queries in the **AndroidManifest.xml** to open links. This can be done by [creating a config plugin](/config-plugins/plugins-and-mods/#create-a-plugin). For example:
 
-```xml
-<manifest>
-  <queries>
-    <intent>
-      <action android:name="android.intent.action.SENDTO"/>
-      <data android:scheme="mailto"/>
-    </intent>
-    <intent>
-      <action android:name="android.intent.action.DIAL"/>
-    </intent>
-  </queries>
-</manifest>
+```js my-plugin.js
+const { withAndroidManifest } = require("@expo/config-plugins");
+
+const withAndroidQueries = (config) => {
+  return withAndroidManifest(config, (config) => {
+    config.modResults.manifest.queries = [
+      {
+        intent: [
+          {
+            action: [{ $: { "android:name": "android.intent.action.SENDTO" } }],
+            data: [{ $: { "android:scheme": "mailto" } }],
+          },
+          {
+            action: [{ $: { "android:name": "android.intent.action.DIAL" } }],
+          },
+        ],
+      },
+    ];
+
+    return config;
+  });
+};
+
+module.exports = withAndroidQueries;
 ```
+
+You can then [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) in your project's app config. This example plugin will enable linking to phone and email apps.
 
 Enables linking to the phone and email app.
 

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -47,7 +47,7 @@ There are some URL schemes for core functionality that exist on every platform. 
 | `tel`            | Open phone app, eg: `tel:+123456789`          |
 | `sms`            | Open SMS app, eg: `sms:+123456789`            |
 
-On newer Android versions, include the appropriate queries in the **AndroidManifest.xml** to open links. This can be done by [creating a config plugin](/config-plugins/plugins-and-mods/#create-a-plugin). For example:
+On newer Android versions, include the appropriate queries in the **AndroidManifest.xml** to open links. This can be done by [creating a config plugin](/config-plugins/plugins-and-mods/#create-a-plugin). For example, the config plugin below will enable linking to phone and email apps:
 
 ```js my-plugin.js
 const { withAndroidManifest } = require("@expo/config-plugins");
@@ -75,7 +75,7 @@ const withAndroidQueries = (config) => {
 module.exports = withAndroidQueries;
 ```
 
-You can then [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) in your project's app config. This example plugin will enable linking to phone and email apps.
+You can then [import the custom config plugin](/config-plugins/plugins-and-mods/#import-a-plugin) in your project's app config.
 
 ### Custom URL schemes
 


### PR DESCRIPTION
# Why

Current linking docs don't mention some necessary configuration for enabling linking to email / phone etc on newer Android versions. See https://github.com/facebook/react-native/issues/30909

# How

Added necessary docs.

# Open questions

- Should we create a link to a config plugin in the docs?
- OR we can add an optional config plugin to `expo-linking` to make this a lot easier