### PR TITLE
Webmanifest

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Clarified documentation for manifest value in web builds. ([#21318](https://github.com/expo/expo/pull/21318) by [@bradjones1](https://github.com/bradjones1))
+
 ### 💡 Others
 
 ## 14.2.1 — 2023-02-09

--- a/packages/expo-constants/src/Constants.types.ts
+++ b/packages/expo-constants/src/Constants.types.ts
@@ -79,6 +79,10 @@ export interface AndroidManifest {
   [key: string]: any;
 }
 
+/**
+ * The manifest for web builds is up to each app to specify via the
+ * `APP_MANIFEST` environment variable. No default manifest values are set.
+ */
 export interface WebManifest {
   [key: string]: any;
 }


### PR DESCRIPTION
# Why

The documentation is silent on the source of the manifest object for web builds. This was implemented at https://github.com/expo/expo/pull/3291 but it appears building up the actual manifest object is the developer's responsibility. (There's only an example app code update in the PR.)

# How

Added docblock to the type in the existing TS file, which feeds the online documentation pages.

# Test Plan

Manual review.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).