### PR TITLE
[core][ios] Fix URI with encoded `#` getting cut off

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed URI with encoded `#` getting cut off.
+- [iOS] Fixed URI with encoded `#` getting cut off. ([#21326](https://github.com/expo/expo/pull/21326) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed URI with encoded `#` getting cut off.
+
 ### 💡 Others
 
 ## 1.2.2 — 2023-02-14

--- a/packages/expo-modules-core/ios/Swift/Utilities.swift
+++ b/packages/expo-modules-core/ios/Swift/Utilities.swift
@@ -32,15 +32,29 @@ internal func toNSError(_ error: Error) -> NSError {
  Note that it encodes only characters that are not allowed in the url query and '#' that indicates the fragment part.
  */
 internal func percentEncodeUrlString(_ url: String) -> String? {
+  // URL contains '#' so it has a fragment part.
+  // We know that because that is the only allowed use case of the undecoded '#' symbol inside of the URL.
+  if (url.contains("#")) {
+    let urlParts = url.split(separator: "#")
+    
+    // Encodes the url without the fragment part. It'll leave the fragment part untounched.
+    guard let parsed = percentEncodeUrlStringWithoutFragmnet(String(urlParts[0])) else {
+      return nil
+    }
+    
+    // Concatenate encoded path with fragment.
+    return parsed + "#" + urlParts[1]
+  }
+  
+  return percentEncodeUrlStringWithoutFragmnet(url)
+}
+
+private func percentEncodeUrlStringWithoutFragmnet(_ url: String) -> String? {
   // The value may come unencoded or already encoded, so first we try to decode it.
   // `removingPercentEncoding` returns nil when the string contains an invalid percent-encoded sequence,
   // but that usually means the value came unencoded, so it falls back to the given string.
   let decodedString = url.removingPercentEncoding ?? url
 
-  // A `CharacterSet` with all query-allowed characters and the hash which is not allowed in the query,
-  // but it must stay unencoded to indicate the start of the url fragment part.
-  let allowedCharactersSet = CharacterSet.urlQueryAllowed.union(CharacterSet(charactersIn: "#"))
-
   // Do the percent encoding, but note that it may still return nil when it's not possible to encode for some reason.
-  return decodedString.addingPercentEncoding(withAllowedCharacters: allowedCharactersSet)
+  return decodedString.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
 }

--- a/packages/expo-modules-core/ios/Swift/Utilities.swift
+++ b/packages/expo-modules-core/ios/Swift/Utilities.swift
@@ -34,22 +34,22 @@ internal func toNSError(_ error: Error) -> NSError {
 internal func percentEncodeUrlString(_ url: String) -> String? {
   // URL contains '#' so it has a fragment part.
   // We know that because that is the only allowed use case of the undecoded '#' symbol inside of the URL.
-  if (url.contains("#")) {
+  if url.contains("#") {
     let urlParts = url.split(separator: "#")
-    
+
     // Encodes the url without the fragment part. It'll leave the fragment part untounched.
-    guard let parsed = percentEncodeUrlStringWithoutFragmnet(String(urlParts[0])) else {
+    guard let parsed = percentEncodeUrlStringWithoutFragment(String(urlParts[0])) else {
       return nil
     }
-    
+
     // Concatenate encoded path with fragment.
     return parsed + "#" + urlParts[1]
   }
-  
-  return percentEncodeUrlStringWithoutFragmnet(url)
+
+  return percentEncodeUrlStringWithoutFragment(url)
 }
 
-private func percentEncodeUrlStringWithoutFragmnet(_ url: String) -> String? {
+private func percentEncodeUrlStringWithoutFragment(_ url: String) -> String? {
   // The value may come unencoded or already encoded, so first we try to decode it.
   // `removingPercentEncoding` returns nil when the string contains an invalid percent-encoded sequence,
   // but that usually means the value came unencoded, so it falls back to the given string.

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -43,6 +43,17 @@ class ConvertiblesSpec: ExpoSpec {
         expect(url.absoluteString) == urlString
         expect(url.absoluteString.removingPercentEncoding) == "https://expo.dev/?param=🥓"
       }
+      
+      it("converts from url with encoded query containg the anchor") {
+        let query = "color=%230000ff"
+        let urlString = "https://expo.dev/?\(query)#anchor"
+        let url = try URL.convert(from: urlString)
+
+        expect(url.query) == query
+        expect(url.absoluteString) == urlString
+        expect(url.absoluteString.removingPercentEncoding) == "https://expo.dev/?color=#0000ff#anchor"
+        expect(url.fragment) == "anchor"
+      }
 
       it("converts from url containing percent character") {
         // The percent character alone requires percent-encoding to `%25`.


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/21321.

# How

In the previous implementation encoded `#` was mistakenly converted to the anchor separator. 

# Test Plan

- unit tests ✅
- https://github.com/trafficon/expo-image-search-params-bug ✅