### PR TITLE
feat(cli)!: set node and babel env for CLI commands

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, and run commands based on the input mode.
+- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode.
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, and run commands based on the input mode.
+
 ### 🎉 New features
 
 - Reduce install prompt. ([#21264](https://github.com/expo/expo/pull/21264) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode.
+- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode. ([#21337](https://github.com/expo/expo/pull/21337) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -17,6 +17,7 @@ export type Command = (argv?: string[]) => void;
 
 const commands: { [command: string]: () => Promise<Command> } = {
   // Add a new command here
+  // NOTE(EvanBacon): Ensure every bundler-related command sets `NODE_ENV` as expected for the command.
   'run:ios': () => import('../src/run/ios').then((i) => i.expoRunIos),
   'run:android': () => import('../src/run/android').then((i) => i.expoRunAndroid),
   start: () => import('../src/start').then((i) => i.expoStart),

--- a/packages/@expo/cli/src/config/configAsync.ts
+++ b/packages/@expo/cli/src/config/configAsync.ts
@@ -4,6 +4,7 @@ import util from 'util';
 
 import * as Log from '../log';
 import { CommandError } from '../utils/errors';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { profile } from '../utils/profile';
 
 type Options = {
@@ -31,6 +32,8 @@ export function logConfig(config: ExpoConfig | ProjectConfig) {
 }
 
 export async function configAsync(projectRoot: string, options: Options) {
+  setNodeEnv('development');
+
   if (options.type) {
     assert.match(options.type, /^(public|prebuild|introspect)$/);
   }

--- a/packages/@expo/cli/src/customize/customizeAsync.ts
+++ b/packages/@expo/cli/src/customize/customizeAsync.ts
@@ -1,11 +1,13 @@
 import { getConfig } from '@expo/config';
 
 import { findUpProjectRootOrAssert } from '../utils/findUp';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { queryAndGenerateAsync, selectAndGenerateAsync } from './generate';
 import { Options } from './resolveOptions';
 import { DestinationResolutionProps } from './templates';
 
 export async function customizeAsync(files: string[], options: Options, extras: any[]) {
+  setNodeEnv('development');
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo customize` from a subdirectory of the project.
   const projectRoot = findUpProjectRootOrAssert(process.cwd());

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -6,6 +6,7 @@ import { importCliSaveAssetsFromProject } from '../start/server/metro/resolveFro
 import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTemplate';
 import { copyAsync, ensureDirectoryAsync } from '../utils/dir';
 import { env } from '../utils/env';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { createBundlesAsync } from './createBundles';
 import { exportAssetsAsync } from './exportAssets';
 import { getPublicExpoManifestAsync } from './getPublicExpoManifest';
@@ -42,10 +43,7 @@ export async function exportAppAsync(
     dumpSourcemap,
   }: Pick<Options, 'dumpAssetmap' | 'dumpSourcemap' | 'dev' | 'clear' | 'outputDir' | 'platforms'>
 ): Promise<void> {
-  // Set the environment to production or development
-  // lots of tools use this to determine if they should run in a dev mode.
-  process.env.NODE_ENV = dev ? 'development' : 'production';
-  process.env.BABEL_ENV = dev ? 'development' : 'production';
+  setNodeEnv(dev ? 'development' : 'production');
 
   const exp = await getPublicExpoManifestAsync(projectRoot);
 

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -42,6 +42,11 @@ export async function exportAppAsync(
     dumpSourcemap,
   }: Pick<Options, 'dumpAssetmap' | 'dumpSourcemap' | 'dev' | 'clear' | 'outputDir' | 'platforms'>
 ): Promise<void> {
+  // Set the environment to production or development
+  // lots of tools use this to determine if they should run in a dev mode.
+  process.env.NODE_ENV = dev ? 'development' : 'production';
+  process.env.BABEL_ENV = dev ? 'development' : 'production';
+
   const exp = await getPublicExpoManifestAsync(projectRoot);
 
   const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -10,6 +10,7 @@ import {
 import { getVersionedDependenciesAsync } from '../start/doctor/dependencies/validateDependenciesVersions';
 import { groupBy } from '../utils/array';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { checkPackagesAsync } from './checkPackages';
 import { Options } from './resolveOptions';
 
@@ -18,6 +19,7 @@ export async function installAsync(
   options: Options & { projectRoot?: string },
   packageManagerArguments: string[] = []
 ) {
+  setNodeEnv('development');
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo install` from a subdirectory of the project.
   const projectRoot = options.projectRoot ?? findUpProjectRootOrAssert(process.cwd());

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -3,6 +3,7 @@ import { ModPlatform } from '@expo/config-plugins';
 
 import { installAsync } from '../install/installAsync';
 import { env } from '../utils/env';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { clearNodeModulesAsync } from '../utils/nodeModules';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';
@@ -57,6 +58,8 @@ export async function prebuildAsync(
     skipDependencyUpdate?: string[];
   }
 ): Promise<PrebuildResults | null> {
+  setNodeEnv('development');
+
   if (options.clean) {
     const { maybeBailOnGitStatusAsync } = await import('../utils/git');
     // Clean the project folders...

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { Log } from '../../log';
 import { assembleAsync, installAsync } from '../../start/platforms/android/gradle';
+import { setNodeEnv } from '../../utils/nodeEnv';
 import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
@@ -12,6 +13,9 @@ import { Options, ResolvedOptions, resolveOptionsAsync } from './resolveOptions'
 const debug = require('debug')('expo:run:android');
 
 export async function runAndroidAsync(projectRoot: string, { install, ...options }: Options) {
+  // TODO: Add support for setting as production.
+  setNodeEnv('development');
+
   await ensureNativeProjectAsync(projectRoot, { platform: 'android', install });
 
   const props = await resolveOptionsAsync(projectRoot, options);

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 import * as Log from '../../log';
 import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
+import { setNodeEnv } from '../../utils/nodeEnv';
 import { profile } from '../../utils/profile';
 import { getSchemesForIosAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
@@ -13,6 +14,8 @@ import { launchAppAsync } from './launchApp';
 import { resolveOptionsAsync } from './options/resolveOptions';
 
 export async function runIosAsync(projectRoot: string, options: Options) {
+  setNodeEnv(options.configuration === 'Release' ? 'production' : 'development');
+
   assertPlatform();
 
   const install = !!options.install;

--- a/packages/@expo/cli/src/run/startBundler.ts
+++ b/packages/@expo/cli/src/run/startBundler.ts
@@ -18,6 +18,11 @@ export async function startBundlerAsync(
     scheme?: string;
   }
 ): Promise<DevServerManager> {
+  // Apply the following side-effects for other tools to determine
+  // the current environment.
+  process.env.NODE_ENV = 'development';
+  process.env.BABEL_ENV = 'development';
+
   const options = {
     port,
     headless,

--- a/packages/@expo/cli/src/run/startBundler.ts
+++ b/packages/@expo/cli/src/run/startBundler.ts
@@ -18,11 +18,6 @@ export async function startBundlerAsync(
     scheme?: string;
   }
 ): Promise<DevServerManager> {
-  // Apply the following side-effects for other tools to determine
-  // the current environment.
-  process.env.NODE_ENV = 'development';
-  process.env.BABEL_ENV = 'development';
-
   const options = {
     port,
     headless,

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -11,6 +11,7 @@ import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { getIpAddress } from '../../../utils/ip';
+import { setNodeEnv } from '../../../utils/nodeEnv';
 import { choosePortAsync } from '../../../utils/port';
 import { createProgressBar } from '../../../utils/progress';
 import { ensureDotExpoProjectDirectoryInitialized } from '../../project/dotExpo';
@@ -345,7 +346,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       mode: options.mode,
       https: options.https,
     };
-    setMode(env.mode ?? 'development');
+    setNodeEnv(env.mode ?? 'development');
     // Check if the project has a webpack.config.js in the root.
     const projectWebpackConfig = this.getProjectConfigFilePath();
     let config: WebpackConfiguration;
@@ -383,11 +384,6 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       Log.error(`Could not clear ${mode} web cache directory: ${error.message}`);
     }
   }
-}
-
-function setMode(mode: 'development' | 'production' | 'test' | 'none'): void {
-  process.env.BABEL_ENV = mode;
-  process.env.NODE_ENV = mode;
 }
 
 export function getProjectWebpackConfigFilePath(projectRoot: string) {

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -69,6 +69,11 @@ export async function startAsync(
 ) {
   Log.log(chalk.gray(`Starting project at ${projectRoot}`));
 
+  // Set the environment to production or development
+  // lots of tools use this to determine if they should run in a dev mode.
+  process.env.NODE_ENV = options.dev ? 'development' : 'production';
+  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+
   const { exp, pkg } = profile(getConfig)(projectRoot);
 
   const platformBundlers = getPlatformBundlers(exp);

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -6,6 +6,7 @@ import getDevClientProperties from '../utils/analytics/getDevClientProperties';
 import { logEventAsync } from '../utils/analytics/rudderstackClient';
 import { installExitHooks } from '../utils/exit';
 import { isInteractive } from '../utils/interactive';
+import { setNodeEnv } from '../utils/nodeEnv';
 import { profile } from '../utils/profile';
 import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
 import { TypeScriptProjectPrerequisite } from './doctor/typescript/TypeScriptProjectPrerequisite';
@@ -69,10 +70,7 @@ export async function startAsync(
 ) {
   Log.log(chalk.gray(`Starting project at ${projectRoot}`));
 
-  // Set the environment to production or development
-  // lots of tools use this to determine if they should run in a dev mode.
-  process.env.NODE_ENV = options.dev ? 'development' : 'production';
-  process.env.BABEL_ENV = options.dev ? 'development' : 'production';
+  setNodeEnv(options.dev ? 'development' : 'production');
 
   const { exp, pkg } = profile(getConfig)(projectRoot);
 

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -1,0 +1,6 @@
+// Set the environment to production or development
+// lots of tools use this to determine if they should run in a dev mode.
+export function setNodeEnv(mode: 'development' | 'production') {
+  process.env.NODE_ENV = process.env.NODE_ENV || mode;
+  process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
+}


### PR DESCRIPTION
# Why

- User's may want to dynamically configure Metro or their Expo Config file to work differently when bundling for production environments, they can now do this by utilizing the standard `NODE_ENV` environment variable. We've been doing this with Webpack since it was introduced.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode.
- This can be overwritten by setting `NODE_ENV` and `BABEL_ENV` manually before running. `BABEL_ENV` will be set to `NODE_ENV` if defined.
- Most commands can safely default to assuming `development`.
- Only thing that this doesn't cover is `npx react-native bundle` and `npx react-native start` (building from Xcode/Android Studio). We'll need to change these commands in the future but it shouldn't be blocking for this PR.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
