### PR TITLE
[core][ios] Fix `PhaseScriptExecution` failed with a nonzero exit code

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -222,8 +222,7 @@ module Expo
 
       function with_node() {
         # Start with a default
-        NODE_BINARY=$(command -v node)
-        export NODE_BINARY
+        export NODE_BINARY=$(command -v node)
 
         # Override the default with the global environment
         ENV_PATH="$PODS_ROOT/../.xcode.env"

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `PhaseScriptExecution failed with a nonzero exit code` caused by the failure of the `command -v node`.
-
 ### 💡 Others
 
 ## 1.2.3 - 2023-02-21

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `PhaseScriptExecution failed with a nonzero exit code` caused by the failure of the `command -v node`.
+
 ### 💡 Others
 
 ## 1.2.3 - 2023-02-21


### PR DESCRIPTION
# Why

Fixes `PhaseScriptExecution` failed with a nonzero exit code when the `command -v node` fails. 

# How

When the command -v node fails, the entire `expo-configure-project. sh` fails as well, due to the `set -e` setting, which terminates the script whenever any command exits with a non-zero status. The problem in our case is caused by the failure of the `command -v node`. However, by using `NODE_BINARY=$(command -v node)` in combination with the export function, the exit code will always be 0, regardless of whether or not the `command` fails.

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/9578601/220597218-f584c6a0-d5b9-4bc1-af42-4fb3ec95f156.png">

# Test Plan

- bare-expo ✅
- Expo Go ✅