### PR TITLE
[go] fix glide app module kapt issue for expo-image

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'kotlin-kapt'
+
 buildscript {
   // Simple helper that allows the root project to override versions declared by this library.
   ext.safeExtGet = { prop, fallback ->
@@ -152,6 +154,10 @@ dependencies {
   // expo-file-system
   implementation 'com.squareup.okhttp3:okhttp:3.10.0'
   implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
+
+  // expo-image
+  def GLIDE_VERSION = "4.13.2"
+  kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
 
   // Testing
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/android/app/src/main/java/host/exp/exponent/ExponentKernelImageAppGlideModule.kt
+++ b/android/app/src/main/java/host/exp/exponent/ExponentKernelImageAppGlideModule.kt
@@ -1,4 +1,4 @@
-package host.exp.exponent.modules
+package host.exp.exponent
 
 import android.content.Context
 import android.util.Log


### PR DESCRIPTION
# Why

close ENG-7642

# How

the kapt generated code for AppGlideModule should cover all versioned LibraryGlideModule. previously we put it inside **expoview**, so it includes the unversioned loaders only. this pr moves the AppGlideModule to **android/app**, so that kapt should able to generate modules from all versioned code.

this is the generated code in **app/build/generated/source/kapt/versionedDebug/com/bumptech/glide/GeneratedAppGlideModuleImpl.java**

```java
package com.bumptech.glide;

import abi48_0_0.expo.modules.image.blurhash.BlurhashModule;
import abi48_0_0.expo.modules.image.dataurls.Base64Module;
import abi48_0_0.expo.modules.image.okhttp.ExpoImageOkHttpClientGlideModule;
import abi48_0_0.expo.modules.image.svg.SVGModule;
import android.content.Context;
import android.util.Log;
import androidx.annotation.NonNull;
import com.bumptech.glide.integration.okhttp3.OkHttpLibraryGlideModule;
import host.exp.exponent.ExponentKernelImageAppGlideModule;
import java.util.Collections;
import java.util.Set;

@SuppressWarnings("deprecation")
final class GeneratedAppGlideModuleImpl extends GeneratedAppGlideModule {
  private final ExponentKernelImageAppGlideModule appGlideModule;

  public GeneratedAppGlideModuleImpl(Context context) {
    appGlideModule = new ExponentKernelImageAppGlideModule();
    if (Log.isLoggable("Glide", Log.DEBUG)) {
      Log.d("Glide", "Discovered AppGlideModule from annotation: host.exp.exponent.ExponentKernelImageAppGlideModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: abi48_0_0.expo.modules.image.blurhash.BlurhashModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: abi48_0_0.expo.modules.image.dataurls.Base64Module");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: abi48_0_0.expo.modules.image.okhttp.ExpoImageOkHttpClientGlideModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: abi48_0_0.expo.modules.image.svg.SVGModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: com.bumptech.glide.integration.okhttp3.OkHttpLibraryGlideModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: expo.modules.image.blurhash.BlurhashModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: expo.modules.image.dataurls.Base64Module");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: expo.modules.image.okhttp.ExpoImageOkHttpClientGlideModule");
      Log.d("Glide", "Discovered LibraryGlideModule from annotation: expo.modules.image.svg.SVGModule");
    }
  }

  @Override
  public void applyOptions(@NonNull Context context, @NonNull GlideBuilder builder) {
    appGlideModule.applyOptions(context, builder);
  }

  @Override
  public void registerComponents(@NonNull Context context, @NonNull Glide glide,
      @NonNull Registry registry) {
    new BlurhashModule().registerComponents(context, glide, registry);
    new Base64Module().registerComponents(context, glide, registry);
    new ExpoImageOkHttpClientGlideModule().registerComponents(context, glide, registry);
    new SVGModule().registerComponents(context, glide, registry);
    new OkHttpLibraryGlideModule().registerComponents(context, glide, registry);
    new expo.modules.image.blurhash.BlurhashModule().registerComponents(context, glide, registry);
    new expo.modules.image.dataurls.Base64Module().registerComponents(context, glide, registry);
    new expo.modules.image.okhttp.ExpoImageOkHttpClientGlideModule().registerComponents(context, glide, registry);
    new expo.modules.image.svg.SVGModule().registerComponents(context, glide, registry);
    appGlideModule.registerComponents(context, glide, registry);
  }

  @Override
  public boolean isManifestParsingEnabled() {
    return appGlideModule.isManifestParsingEnabled();
  }

  @Override
  @NonNull
  public Set<Class<?>> getExcludedModuleClasses() {
    return Collections.emptySet();
  }

  @Override
  @NonNull
  GeneratedRequestManagerFactory getRequestManagerFactory() {
    return new GeneratedRequestManagerFactory();
  }
}
```

# Test Plan

versioned expo go + https://github.com/brentvatne/expo-image-go-repro

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
