### PR TITLE
[barcode][Android] Backport `#18768` to SDK 46

### DIFF
--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -99,10 +99,11 @@ internal class BarCodeScannerViewFinder(
 
   @Synchronized
   private fun startCamera() {
-    if (!isStarting) {
+    if (!isStarting && !isStopping) {
       isStarting = true
       try {
-        ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)?.run {
+        camera = ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)
+        camera?.run {
           val temporaryParameters = parameters
           // set autofocus
           val focusModes = temporaryParameters.supportedFocusModes


### PR DESCRIPTION
# Why

This a follow-up to the https://github.com/expo/expo/issues/20947#issuecomment-1441137742.
Backports https://github.com/expo/expo/pull/18768 to SDK 46 branch to publish a new version of the barecode-scanner for older SDKs.
