### PR TITLE
[barcode][Android] Backport #18768 to versioned code

### DIFF
--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/barcodescanner/BarCodeScannerViewFinder.kt
@@ -99,10 +99,11 @@ internal class BarCodeScannerViewFinder(
 
   @Synchronized
   private fun startCamera() {
-    if (!isStarting) {
+    if (!isStarting && !isStopping) {
       isStarting = true
       try {
-        ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)?.run {
+        camera = ExpoBarCodeScanner.instance.acquireCameraInstance(cameraType)
+        camera?.run {
           val temporaryParameters = parameters
           // set autofocus
           val focusModes = temporaryParameters.supportedFocusModes


### PR DESCRIPTION
# Why

Why
This a follow-up to the https://github.com/expo/expo/issues/20947#issuecomment-1441137742.
Backports https://github.com/expo/expo/pull/18768 to SDK 48 branch to versioned code. 