### PR TITLE
[docs] UI tweaks and corrections

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -121,12 +121,12 @@ const STYLES_SCROLL_CONTAINER = css`
 
   /* Handle */
   ::-webkit-scrollbar-thumb {
-    background: ${theme.background.element};
+    background: ${theme.palette.gray5};
   }
 
   /* Handle on hover */
   ::-webkit-scrollbar-thumb:hover {
-    background: ${theme.background.hover};
+    background: ${theme.palette.gray6};
   }
 
   @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -105,7 +105,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       <strong
@@ -115,7 +115,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </strong>
        
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         React.Element
@@ -130,7 +130,7 @@ exports[`APISection expo-apple-authentication 1`] = `
       </code>
     </p>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       This component displays the proprietary "Sign In with Apple" / "Continue with Apple" button on
@@ -141,7 +141,7 @@ available via the provided properties.
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       You should only attempt to render this if 
@@ -150,7 +150,7 @@ available via the provided properties.
         href="#isavailableasync"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.isAvailableAsync()
@@ -159,7 +159,7 @@ available via the provided properties.
       
 resolves to 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         true
@@ -167,7 +167,7 @@ resolves to
       . This component will render nothing if it is not available, and you will get
 a warning in development mode (
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         __DEV__ === true
@@ -177,12 +177,12 @@ a warning in development mode (
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       The properties of this component extend from 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         View
@@ -190,21 +190,21 @@ a warning in development mode (
       ; however, you should not attempt to set
 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         backgroundColor
       </code>
        or 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         borderRadius
       </code>
        with the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         style
@@ -212,7 +212,7 @@ a warning in development mode (
        property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         buttonStyle
@@ -220,7 +220,7 @@ the App Store Guidelines. Instead, you should use the
        property to choose one of the
 predefined color styles and the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         cornerRadius
@@ -231,7 +231,7 @@ button.
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Make sure to attach height and width via the style props as without these styles, the button will
@@ -266,7 +266,7 @@ not appear on the screen.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -356,7 +356,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 buttonStyle
@@ -393,7 +393,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -403,7 +403,7 @@ for more details.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <a
@@ -415,11 +415,12 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           The Apple-defined color scheme to use to display the button.
         </p>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -440,7 +441,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 buttonType
@@ -477,7 +478,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -487,7 +488,7 @@ for more details.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <a
@@ -499,11 +500,12 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           The type of button text to display ("Sign In with Apple" vs. "Continue with Apple").
         </p>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -524,7 +526,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 cornerRadius
@@ -561,7 +563,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -576,26 +578,27 @@ for more details.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             number
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           The border radius to use when rendering the button. This works similarly to
 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             style.borderRadius
           </code>
            in other Views.
         </p>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -616,7 +619,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 onPress
@@ -653,7 +656,7 @@ for more details.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -663,7 +666,7 @@ for more details.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             (
@@ -672,7 +675,7 @@ for more details.
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           The method to call when the user presses the button. You should call 
@@ -681,7 +684,7 @@ for more details.
             href="#isavailableasync"
           >
             <code
-              class="css-zmv3vl-TextComponent"
+              class="css-23wgco-TextComponent"
               data-text="true"
             >
               AppleAuthentication.signInAsync
@@ -690,6 +693,7 @@ for more details.
           
 in here.
         </p>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -710,7 +714,7 @@ in here.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 style
@@ -747,7 +751,7 @@ in here.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -762,7 +766,7 @@ in here.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             StyleProp
@@ -803,19 +807,19 @@ in here.
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           The custom style to apply to the button. Should not include 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             backgroundColor
           </code>
            or 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             borderRadius
@@ -823,6 +827,7 @@ in here.
           
 properties.
         </p>
+        <br />
       </div>
       <h3
         class="  css-6r23rc-TextComponent"
@@ -879,7 +884,7 @@ properties.
           data-text="true"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <a
@@ -961,7 +966,7 @@ properties.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -1043,7 +1048,7 @@ properties.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -1053,7 +1058,7 @@ properties.
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The unique identifier for the user whose credential state you'd like to check.
@@ -1063,7 +1068,7 @@ This should come from the user field of an
                   href="#appleauthenticationcredentialstate"
                 >
                   <code
-                    class="css-zmv3vl-TextComponent"
+                    class="css-23wgco-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationCredential
@@ -1078,7 +1083,7 @@ This should come from the user field of an
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Queries the current state of a user credential, to determine if it is still valid or if it has been revoked.
@@ -1116,7 +1121,7 @@ This should come from the user field of an
         
 
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -1130,57 +1135,12 @@ This should come from the user field of an
 
       </div>
     </blockquote>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -1207,7 +1167,7 @@ This should come from the user field of an
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -1233,7 +1193,7 @@ This should come from the user field of an
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1242,7 +1202,7 @@ This should come from the user field of an
         href="#appleauthenticationcredentialstate"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredentialState
@@ -1271,7 +1231,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -1308,62 +1268,17 @@ value depending on the state of the credential.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Determine if the current device's operating system supports Apple authentication.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-1"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-1"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -1390,7 +1305,7 @@ value depending on the state of the credential.
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -1411,19 +1326,19 @@ value depending on the state of the credential.
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A promise that fulfills with 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         true
       </code>
        if the system supports Apple authentication, and 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         false
@@ -1450,7 +1365,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             refreshAsync(options)
@@ -1532,7 +1447,7 @@ value depending on the state of the credential.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1547,7 +1462,7 @@ value depending on the state of the credential.
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An 
@@ -1556,7 +1471,7 @@ value depending on the state of the credential.
                   href="#appleauthenticationrefreshoptions"
                 >
                   <code
-                    class="css-zmv3vl-TextComponent"
+                    class="css-23wgco-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationRefreshOptions
@@ -1571,63 +1486,18 @@ value depending on the state of the credential.
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An operation that refreshes the logged-in user’s credentials.
 Calling this method will show the sign in modal before actually refreshing the user credentials.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-2"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-2"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -1654,7 +1524,7 @@ Calling this method will show the sign in modal before actually refreshing the u
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -1680,7 +1550,7 @@ Calling this method will show the sign in modal before actually refreshing the u
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -1689,7 +1559,7 @@ Calling this method will show the sign in modal before actually refreshing the u
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -1698,7 +1568,7 @@ Calling this method will show the sign in modal before actually refreshing the u
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         ERR_REQUEST_CANCELED
@@ -1726,7 +1596,7 @@ refresh operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             signInAsync(options)
@@ -1814,7 +1684,7 @@ refresh operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -1829,7 +1699,7 @@ refresh operation.
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An optional 
@@ -1838,7 +1708,7 @@ refresh operation.
                   href="#appleauthenticationsigninoptions"
                 >
                   <code
-                    class="css-zmv3vl-TextComponent"
+                    class="css-23wgco-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationSignInOptions
@@ -1853,7 +1723,7 @@ refresh operation.
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Sends a request to the operating system to initiate the Apple authentication flow, which will
@@ -1862,7 +1732,7 @@ present a modal to the user over your app and allow them to sign in.
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       You can request access to the user's full name and email address in this method, which allows you
@@ -1872,7 +1742,7 @@ of these options at runtime.
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Additionally, you will only receive Apple Authentication Credentials the first time users sign
@@ -1891,7 +1761,7 @@ You can use
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential.user
@@ -1900,57 +1770,12 @@ You can use
        to identify
 the user, since this remains the same for apps released by the same developer.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-3"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-3"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -1977,7 +1802,7 @@ the user, since this remains the same for apps released by the same developer.
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -2003,7 +1828,7 @@ the user, since this remains the same for apps released by the same developer.
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2012,7 +1837,7 @@ the user, since this remains the same for apps released by the same developer.
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -2021,7 +1846,7 @@ the user, since this remains the same for apps released by the same developer.
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         ERR_REQUEST_CANCELED
@@ -2049,7 +1874,7 @@ sign-in operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             signOutAsync(options)
@@ -2131,7 +1956,7 @@ sign-in operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -2146,7 +1971,7 @@ sign-in operation.
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An 
@@ -2155,7 +1980,7 @@ sign-in operation.
                   href="#appleauthenticationsignoutoptions"
                 >
                   <code
-                    class="css-zmv3vl-TextComponent"
+                    class="css-23wgco-TextComponent"
                     data-text="true"
                   >
                     AppleAuthenticationSignOutOptions
@@ -2170,7 +1995,7 @@ sign-in operation.
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An operation that ends the authenticated session.
@@ -2179,7 +2004,7 @@ Calling this method will show the sign in modal before actually signing the user
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       It is not recommended to use this method to sign out the user as it works counterintuitively.
@@ -2190,7 +2015,7 @@ from using
         href="./#signinasync"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           signInAsync
@@ -2202,7 +2027,7 @@ from using
         href="./#refreshasync"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           refreshAsync
@@ -2210,57 +2035,12 @@ from using
       </a>
        methods.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-4"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-4"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -2287,7 +2067,7 @@ from using
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -2313,7 +2093,7 @@ from using
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A promise that fulfills with an 
@@ -2322,7 +2102,7 @@ from using
         href="#appleauthenticationcredential"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationCredential
@@ -2331,7 +2111,7 @@ from using
       
 object after a successful authentication, and rejects with 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         ERR_REQUEST_CANCELED
@@ -2406,7 +2186,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2488,7 +2268,7 @@ sign-out operation.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -2506,57 +2286,12 @@ sign-out operation.
       </table>
     </div>
     <br />
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-5"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-5"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -2583,7 +2318,7 @@ sign-out operation.
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -2663,7 +2398,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2700,7 +2435,7 @@ sign-out operation.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       The object type returned from a successful call to 
@@ -2709,7 +2444,7 @@ sign-out operation.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -2722,7 +2457,7 @@ sign-out operation.
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -2734,7 +2469,7 @@ sign-out operation.
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -2772,7 +2507,7 @@ which contains all of the pertinent user and credential information.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -2841,7 +2576,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2857,13 +2592,13 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   user
@@ -2888,7 +2623,7 @@ the app's server counterpart. Unlike
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2904,12 +2639,12 @@ the app's server counterpart. Unlike
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The user's email address. Might not be present if you didn't request the 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   EMAIL
@@ -2937,7 +2672,7 @@ an Apple domain.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -2958,26 +2693,26 @@ an Apple domain.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The user's name. May be 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                  or contain 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                  values if you didn't request the 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   FULL_NAME
@@ -3004,7 +2739,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3020,7 +2755,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A JSON Web Token (JWT) that securely communicates information about the user to your app.
@@ -3043,7 +2778,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3058,7 +2793,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A value that indicates whether the user appears to the system to be a real person.
@@ -3081,7 +2816,7 @@ your app.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3097,12 +2832,12 @@ your app.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that your app provided as 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   state
@@ -3111,7 +2846,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   state
@@ -3119,7 +2854,7 @@ avoid replay attacks. If you did not provide
                  when making the sign-in request, this field
 will be 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
@@ -3144,7 +2879,7 @@ will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -3154,7 +2889,7 @@ will be
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An identifier associated with the authenticated user. You can use this to check if the user is
@@ -3187,7 +2922,7 @@ developers.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -3224,13 +2959,13 @@ developers.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         null
@@ -3283,7 +3018,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3317,7 +3052,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3351,7 +3086,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3385,7 +3120,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3419,7 +3154,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3453,7 +3188,7 @@ may be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <span>
@@ -3494,7 +3229,7 @@ may be
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3531,7 +3266,7 @@ may be
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3540,7 +3275,7 @@ may be
         href="#appleauthenticationrefreshasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.refreshAsync()
@@ -3578,7 +3313,7 @@ You must include the ID string of the user whose credentials you'd like to refre
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -3653,7 +3388,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -3669,14 +3404,14 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
@@ -3685,14 +3420,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   []
@@ -3723,7 +3458,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -3733,7 +3468,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -3768,7 +3503,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -3803,7 +3538,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3840,7 +3575,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -3849,7 +3584,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -3887,7 +3622,7 @@ None of these options are required.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -3962,7 +3697,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -3972,7 +3707,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is used to prevent replay attacks. See more information on this in the
@@ -4011,7 +3746,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -4027,14 +3762,14 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
@@ -4043,14 +3778,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   null
                 </code>
                 . Defaults to 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   []
@@ -4081,7 +3816,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -4091,7 +3826,7 @@ requests they will be
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4133,7 +3868,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -4170,7 +3905,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       The options you can supply when making a call to 
@@ -4179,7 +3914,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationsignoutasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signOutAsync()
@@ -4217,7 +3952,7 @@ You must include the ID string of the user to sign out.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -4292,7 +4027,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -4302,7 +4037,7 @@ for more details.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An arbitrary string that is returned unmodified in the corresponding credential after a
@@ -4337,7 +4072,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -4372,7 +4107,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             Subscription
@@ -4454,7 +4189,7 @@ OAuth 2.0 protocol
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -4538,7 +4273,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonStyle
@@ -4575,7 +4310,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An enum whose values control which pre-defined color scheme to use when rendering an 
@@ -4584,7 +4319,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationButton
@@ -4611,7 +4346,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               WHITE
@@ -4648,13 +4383,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         White button with black text.
@@ -4679,7 +4414,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               WHITE_OUTLINE
@@ -4716,13 +4451,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         White button with a black outline and black text.
@@ -4747,7 +4482,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               BLACK
@@ -4784,13 +4519,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         Black button with white text.
@@ -4816,7 +4551,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonType
@@ -4853,7 +4588,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An enum whose values control which pre-defined text to use when rendering an 
@@ -4862,7 +4597,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationappleauthenticationbutton"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthenticationButton
@@ -4889,7 +4624,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               SIGN_IN
@@ -4926,13 +4661,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         "Sign in with Apple"
@@ -4957,7 +4692,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               CONTINUE
@@ -4994,13 +4729,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         "Continue with Apple"
@@ -5058,7 +4793,7 @@ OAuth 2.0 protocol
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               SIGN_UP
@@ -5095,13 +4830,13 @@ OAuth 2.0 protocol
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         "Sign up with Apple"
@@ -5127,7 +4862,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -5164,7 +4899,7 @@ OAuth 2.0 protocol
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An enum whose values specify state of the credential when checked with 
@@ -5173,7 +4908,7 @@ OAuth 2.0 protocol
         href="#appleauthenticationgetcredentialstateasyncuser"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.getCredentialStateAsync()
@@ -5210,7 +4945,7 @@ OAuth 2.0 protocol
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -5252,7 +4987,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               REVOKED
@@ -5289,7 +5024,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5314,7 +5049,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               AUTHORIZED
@@ -5351,7 +5086,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -5376,7 +5111,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               NOT_FOUND
@@ -5413,7 +5148,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -5438,7 +5173,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               TRANSFERRED
@@ -5475,7 +5210,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -5501,7 +5236,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationOperation
@@ -5556,7 +5291,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               IMPLICIT
@@ -5593,13 +5328,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         An operation that depends on the particular kind of credential provider.
@@ -5624,7 +5359,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               LOGIN
@@ -5661,7 +5396,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -5686,7 +5421,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               REFRESH
@@ -5723,7 +5458,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -5748,7 +5483,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               LOGOUT
@@ -5785,7 +5520,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -5811,7 +5546,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationScope
@@ -5848,7 +5583,7 @@ for more details.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An enum whose values specify scopes you can request when calling 
@@ -5857,7 +5592,7 @@ for more details.
         href="#appleauthenticationsigninasyncoptions"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           AppleAuthentication.signInAsync()
@@ -5898,7 +5633,7 @@ for more details.
         
 
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Note that it is possible that you will not be granted all of the scopes which you request.
@@ -5937,7 +5672,7 @@ You will still need to handle null values for any fields you request.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -5979,7 +5714,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               FULL_NAME
@@ -6016,7 +5751,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -6041,7 +5776,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               EMAIL
@@ -6078,7 +5813,7 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6104,7 +5839,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             AppleAuthenticationUserDetectionStatus
@@ -6141,7 +5876,7 @@ for more details.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An enum whose values specify the system's best guess for how likely the current user is a real person.
@@ -6175,7 +5910,7 @@ for more details.
         class="css-1m74yfi-Callout"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <strong
@@ -6217,7 +5952,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               UNSUPPORTED
@@ -6254,13 +5989,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         The system does not support this determination and there is no data.
@@ -6285,7 +6020,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               UNKNOWN
@@ -6322,13 +6057,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         The system has not determined whether the user might be a real person.
@@ -6353,7 +6088,7 @@ for more details.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               LIKELY_REAL
@@ -6390,13 +6125,13 @@ for more details.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         The user appears to be a real person.
@@ -6474,7 +6209,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeScanner
@@ -6511,7 +6246,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       <strong
@@ -6521,7 +6256,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
       </strong>
        
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         React.
@@ -6605,7 +6340,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 barCodeTypes
@@ -6642,7 +6377,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -6657,19 +6392,19 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             string[]
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           An array of bar code types. Usage: 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             BarCodeScanner.Constants.BarCodeType.&lt;codeType&gt;
@@ -6677,7 +6412,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
            where
 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             codeType
@@ -6696,18 +6431,19 @@ minimize battery usage.
         
 
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           For example: 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
           </code>
           .
         </p>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -6728,7 +6464,7 @@ minimize battery usage.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6765,7 +6501,7 @@ minimize battery usage.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -6780,7 +6516,7 @@ minimize battery usage.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <a
@@ -6792,7 +6528,7 @@ minimize battery usage.
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           A callback that is invoked when a bar code has been successfully scanned. The callback is
@@ -6838,7 +6574,7 @@ provided with an
             
 
             <p
-              class="css-1oym3r-TextComponent"
+              class="css-hnkmoy-TextComponent"
               data-text="true"
             >
               <strong
@@ -6848,14 +6584,14 @@ provided with an
               </strong>
                Passing 
               <code
-                class="css-zmv3vl-TextComponent"
+                class="css-23wgco-TextComponent"
                 data-text="true"
               >
                 undefined
               </code>
                to the 
               <code
-                class="css-zmv3vl-TextComponent"
+                class="css-23wgco-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6868,6 +6604,7 @@ data has been retrieved.
 
           </div>
         </blockquote>
+        <br />
       </div>
       <div
         class="css-c22nmz"
@@ -6888,7 +6625,7 @@ data has been retrieved.
               class="css-6n7j50"
             >
               <code
-                class="css-1oape9q-TextComponent"
+                class="css-1qdx416-TextComponent"
                 data-text="true"
               >
                 type
@@ -6925,7 +6662,7 @@ data has been retrieved.
           </a>
         </h3>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           <span
@@ -6940,7 +6677,7 @@ data has been retrieved.
           </span>
            
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <span>
@@ -6963,7 +6700,7 @@ data has been retrieved.
             </span>
              
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               Type.back
@@ -6971,26 +6708,26 @@ data has been retrieved.
           </span>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Camera facing. Use one of 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             BarCodeScanner.Constants.Type
           </code>
           . Use either 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             Type.front
           </code>
            or 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             Type.back
@@ -6998,13 +6735,14 @@ data has been retrieved.
           .
 Same as 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             Camera.Constants.Type
           </code>
           .
         </p>
+        <br />
       </div>
       <h3
         class="  css-6r23rc-TextComponent"
@@ -7061,7 +6799,7 @@ Same as
           data-text="true"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             <a
@@ -7143,7 +6881,7 @@ Same as
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             usePermissions(options)
@@ -7231,7 +6969,7 @@ Same as
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -7258,36 +6996,32 @@ Same as
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Check or request permissions for the barcode scanner.
 This uses both 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         requestPermissionAsync
       </code>
        and 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         getPermissionsAsync
       </code>
        to interact with the permissions.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        Example
-      </h4>
-    </div>
+      Example
+    </p>
     <pre>
       <pre
         class="css-1tmj8fm"
@@ -7361,57 +7095,12 @@ This uses both
         </code>
       </pre>
     </pre>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -7438,7 +7127,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           [
@@ -7556,7 +7245,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             BarCodeScanner.getPermissionsAsync()
@@ -7593,62 +7282,17 @@ This uses both
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Checks user's permissions for accessing the camera.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-1"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-1"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -7675,7 +7319,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -7701,7 +7345,7 @@ This uses both
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7710,7 +7354,7 @@ This uses both
         href="#permissionresponse"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           PermissionResponse
@@ -7738,7 +7382,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             BarCodeScanner.requestPermissionsAsync()
@@ -7775,7 +7419,7 @@ This uses both
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Asks the user to grant permissions for accessing the camera.
@@ -7783,76 +7427,31 @@ This uses both
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       On iOS this will require apps to specify the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         NSCameraUsageDescription
       </code>
        entry in the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         Info.plist
       </code>
       .
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-2"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-2"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -7879,7 +7478,7 @@ This uses both
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -7905,7 +7504,7 @@ This uses both
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Return a promise that fulfills to an object of type 
@@ -7914,7 +7513,7 @@ This uses both
         href="#permissionresponse"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           PermissionResponse
@@ -7942,7 +7541,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             BarCodeScanner.scanFromURLAsync(url, barCodeTypes)
@@ -8024,7 +7623,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -8034,7 +7633,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 URL to get the image from.
@@ -8063,7 +7662,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string[]
@@ -8073,7 +7672,7 @@ This uses both
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 An array of bar code types. Defaults to all supported bar code types on
@@ -8112,7 +7711,7 @@ the platform.
                   
 
                   <p
-                    class="css-1oym3r-TextComponent"
+                    class="css-hnkmoy-TextComponent"
                     data-text="true"
                   >
                     <strong
@@ -8133,62 +7732,17 @@ the platform.
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Scan bar codes from the image given by the URL.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-3"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-3"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -8215,7 +7769,7 @@ the platform.
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -8242,12 +7796,12 @@ the platform.
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       A possibly empty array of objects of the 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         BarCodeScannerResult
@@ -8323,7 +7877,7 @@ code.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -8360,63 +7914,17 @@ code.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#permissionresponse--properties"
-        >
-          <span
-            class="css-s3qkfm"
-            id="permissionresponse--properties"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            PermissionResponse
-             Properties
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      PermissionResponse Properties
+    </p>
     <div
       class="css-1uyflf8-Table"
     >
@@ -8463,7 +7971,7 @@ code.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8473,7 +7981,7 @@ code.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -8498,7 +8006,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8513,7 +8021,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -8536,7 +8044,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -8546,7 +8054,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -8569,7 +8077,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8584,7 +8092,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -8662,7 +8170,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeBounds
@@ -8744,7 +8252,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8759,7 +8267,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The origin point of the bounding box.
@@ -8782,7 +8290,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -8797,7 +8305,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The size of the bounding box.
@@ -8827,7 +8335,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeEvent
@@ -8864,11 +8372,11 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-yszm2s-TextComponent"
+      class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         <a
@@ -8934,7 +8442,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -8969,7 +8477,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -9051,7 +8559,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9091,7 +8599,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodePoint
@@ -9128,7 +8636,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Those coordinates are represented in the coordinate space of the barcode source (e.g. when you
@@ -9180,7 +8688,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -9190,12 +8698,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   x
@@ -9220,7 +8728,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -9230,12 +8738,12 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   y
@@ -9267,7 +8775,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -9351,7 +8859,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-kzvbfm-TextComponent"
+                  class="css-4xa05b-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -9392,7 +8900,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeScannerResult
@@ -9474,7 +8982,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9489,7 +8997,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The 
@@ -9502,7 +9010,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  object.
 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   bounds
@@ -9510,7 +9018,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
                  in some case will be representing an empty rectangle.
 Moreover, 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   bounds
@@ -9536,7 +9044,7 @@ For some types, they will represent the area used by the scanner.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -9552,27 +9060,27 @@ For some types, they will represent the area used by the scanner.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Corner points of the bounding box.
 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   cornerPoints
                 </code>
                  is not always available and may be empty. On iOS, for 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   code39
                 </code>
                  and 
                 <code
-                  class="css-zmv3vl-TextComponent"
+                  class="css-23wgco-TextComponent"
                   data-text="true"
                 >
                   pdf417
@@ -9598,7 +9106,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -9608,7 +9116,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The information encoded in the bar code.
@@ -9631,7 +9139,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string
@@ -9641,7 +9149,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The barcode type.
@@ -9671,7 +9179,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             BarCodeSize
@@ -9753,7 +9261,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -9763,7 +9271,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The height value.
@@ -9786,7 +9294,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -9796,7 +9304,7 @@ you don't get this value.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 The width value.
@@ -9826,7 +9334,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionHookOptions
@@ -9863,14 +9371,14 @@ you don't get this value.
       </a>
     </h3>
     <p
-      class="css-yszm2s-TextComponent"
+      class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           PermissionHookBehavior
@@ -9879,7 +9387,7 @@ you don't get this value.
       </span>
       <span>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           Options
@@ -9954,7 +9462,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -10009,7 +9517,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               DENIED
@@ -10046,13 +9554,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User has denied the permission.
@@ -10077,7 +9585,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               GRANTED
@@ -10114,13 +9622,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User has granted the permission.
@@ -10145,7 +9653,7 @@ you don't get this value.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               UNDETERMINED
@@ -10182,13 +9690,13 @@ you don't get this value.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -10266,7 +9774,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             getPermissionsAsync()
@@ -10303,62 +9811,17 @@ exports[`APISection expo-pedometer 1`] = `
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Checks user's permissions for accessing pedometer.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -10385,7 +9848,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -10430,7 +9893,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -10512,7 +9975,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10529,7 +9992,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A date indicating the start of the range over which to measure steps.
@@ -10552,7 +10015,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -10569,7 +10032,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A date indicating the end of the range over which to measure steps.
@@ -10581,62 +10044,17 @@ exports[`APISection expo-pedometer 1`] = `
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Get the step count between two dates.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-1"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-1"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -10663,7 +10081,7 @@ exports[`APISection expo-pedometer 1`] = `
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -10689,7 +10107,7 @@ exports[`APISection expo-pedometer 1`] = `
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Returns a promise that fulfills with a 
@@ -10698,7 +10116,7 @@ exports[`APISection expo-pedometer 1`] = `
         href="#pedometerresult"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           PedometerResult
@@ -10709,7 +10127,7 @@ exports[`APISection expo-pedometer 1`] = `
     
 
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       As 
@@ -10756,7 +10174,7 @@ exports[`APISection expo-pedometer 1`] = `
         
 
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Only the past seven days worth of data is stored and available for you to retrieve. Specifying
@@ -10786,7 +10204,7 @@ a start date that is more than seven days in the past returns only the available
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -10823,62 +10241,17 @@ a start date that is more than seven days in the past returns only the available
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Returns whether the pedometer is enabled on the device.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-2"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-2"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -10905,7 +10278,7 @@ a start date that is more than seven days in the past returns only the available
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -10926,12 +10299,12 @@ a start date that is more than seven days in the past returns only the available
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Returns a promise that fulfills with a 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         boolean
@@ -10959,7 +10332,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -10996,62 +10369,17 @@ available on this device.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Asks the user to grant permissions for accessing pedometer.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-3"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-3"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -11078,7 +10406,7 @@ available on this device.
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -11123,7 +10451,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1oape9q-TextComponent"
+            class="css-1qdx416-TextComponent"
             data-text="true"
           >
             watchStepCount(callback)
@@ -11205,7 +10533,7 @@ available on this device.
               class="css-zstkv9-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11220,7 +10548,7 @@ available on this device.
               class="css-zstkv9-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A callback that is invoked when new step count data is available. The callback is
@@ -11230,7 +10558,7 @@ provided with a single argument that is
                   href="#pedometerresult"
                 >
                   <code
-                    class="css-zmv3vl-TextComponent"
+                    class="css-23wgco-TextComponent"
                     data-text="true"
                   >
                     PedometerResult
@@ -11245,62 +10573,17 @@ provided with a single argument that is
     </div>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Subscribe to pedometer updates.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#returns-4"
-        >
-          <span
-            class="css-s3qkfm"
-            id="returns-4"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            Returns
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      Returns
+    </p>
     <ul
       class="css-1c9clym-TextComponent"
     >
@@ -11327,7 +10610,7 @@ provided with a single argument that is
           />
         </svg>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           <a
@@ -11341,7 +10624,7 @@ provided with a single argument that is
     </ul>
     <br />
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Returns a 
@@ -11350,7 +10633,7 @@ provided with a single argument that is
         href="#subscription"
       >
         <code
-          class="css-zmv3vl-TextComponent"
+          class="css-23wgco-TextComponent"
           data-text="true"
         >
           Subscription
@@ -11359,7 +10642,7 @@ provided with a single argument that is
        that enables you to call
 
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         remove()
@@ -11433,7 +10716,7 @@ provided with a single argument that is
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -11470,63 +10753,17 @@ provided with a single argument that is
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       An object obtained by permissions get and request functions.
     </p>
-    <div
-      class="css-10kkd4f"
+    <p
+      class="css-1eksndl-BoxSectionHeader"
+      data-text="true"
     >
-      <h4
-        class="  css-1gu5rqd-TextComponent"
-        data-heading="true"
-      >
-        <a
-          class="css-1y48vg3"
-          href="#permissionresponse--properties"
-        >
-          <span
-            class="css-s3qkfm"
-            id="permissionresponse--properties"
-          />
-          <span
-            class="css-6n7j50"
-          >
-            PermissionResponse
-             Properties
-          </span>
-          <span
-            class="css-1eysgws"
-          >
-            <svg
-              aria-label="permalink"
-              class="anchor-icon"
-              fill="none"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-              <path
-                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
-                stroke="#9B9B9B"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-              />
-            </svg>
-          </span>
-        </a>
-      </h4>
-    </div>
+      PermissionResponse Properties
+    </p>
     <div
       class="css-1uyflf8-Table"
     >
@@ -11573,7 +10810,7 @@ provided with a single argument that is
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11583,7 +10820,7 @@ provided with a single argument that is
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Indicates if user can be asked again for specific permission.
@@ -11608,7 +10845,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11623,7 +10860,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Determines time when the permission expires.
@@ -11646,7 +10883,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -11656,7 +10893,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 A convenience boolean that indicates if the permission is granted.
@@ -11679,7 +10916,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 <a
@@ -11694,7 +10931,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Determines the status of the permission.
@@ -11772,7 +11009,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PedometerResult
@@ -11854,7 +11091,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 number
@@ -11864,7 +11101,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <p
-                class="css-1oym3r-TextComponent"
+                class="css-hnkmoy-TextComponent"
                 data-text="true"
               >
                 Number of steps taken between the given dates.
@@ -11894,7 +11131,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11933,7 +11170,7 @@ in order to enable/disable the permission.
     </h3>
     <div>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         Callback function providing event result as an argument.
@@ -11984,7 +11221,7 @@ in order to enable/disable the permission.
                 class="css-zstkv9-Cell"
               >
                 <code
-                  class="css-kzvbfm-TextComponent"
+                  class="css-4xa05b-TextComponent"
                   data-text="true"
                 >
                   <a
@@ -12025,7 +11262,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionExpiration
@@ -12062,20 +11299,20 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Permission expiration time. Currently, all permissions are granted permanently.
     </p>
     <p
-      class="css-yszm2s-TextComponent"
+      class="css-1kfqm4n-TextComponent"
       data-text="true"
     >
       Acceptable values are:
        
       <span>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           'never'
@@ -12084,7 +11321,7 @@ in order to enable/disable the permission.
       </span>
       <span>
         <code
-          class="css-kzvbfm-TextComponent"
+          class="css-4xa05b-TextComponent"
           data-text="true"
         >
           number
@@ -12112,7 +11349,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             Subscription
@@ -12194,7 +11431,7 @@ in order to enable/disable the permission.
               class="css-18p3734-Cell"
             >
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 () =&gt;
@@ -12278,7 +11515,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -12333,7 +11570,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               DENIED
@@ -12370,13 +11607,13 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User has denied the permission.
@@ -12401,7 +11638,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               GRANTED
@@ -12438,13 +11675,13 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User has granted the permission.
@@ -12469,7 +11706,7 @@ in order to enable/disable the permission.
             class="css-6n7j50"
           >
             <code
-              class="css-kzvbfm-TextComponent"
+              class="css-4xa05b-TextComponent"
               data-text="true"
             >
               UNDETERMINED
@@ -12506,13 +11743,13 @@ in order to enable/disable the permission.
         </a>
       </h4>
       <code
-        class="css-7rjo46-TextComponent"
+        class="css-1s1f2t0-TextComponent"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"
       </code>
       <p
-        class="css-1oym3r-TextComponent"
+        class="css-hnkmoy-TextComponent"
         data-text="true"
       >
         User hasn't granted or denied the permission yet.
@@ -12525,7 +11762,7 @@ in order to enable/disable the permission.
 exports[`APISection no data 1`] = `
 <div>
   <p
-    class="css-yszm2s-TextComponent"
+    class="css-1kfqm4n-TextComponent"
     data-text="true"
   >
     No API data file found, sorry!

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     class="css-165e1mf-AppConfigProperty"
   >
     <p
-      class="  css-yszm2s-TextComponent"
+      class="  css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <a
@@ -21,7 +21,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-cj6ctd-PropertyName"
+            class="css-ter5io-PropertyName"
             data-text="true"
           >
             name
@@ -63,14 +63,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         string
       </code>
     </p>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Name of your app.
@@ -113,7 +113,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-b8vpa7-Collapsible"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Edit the 'Display Name' field in Xcode
@@ -126,7 +126,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     class="css-165e1mf-AppConfigProperty"
   >
     <p
-      class="  css-yszm2s-TextComponent"
+      class="  css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <a
@@ -141,7 +141,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-cj6ctd-PropertyName"
+            class="css-ter5io-PropertyName"
             data-text="true"
           >
             androidNavigationBar
@@ -183,14 +183,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         object
       </code>
     </p>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Configuration for the bottom navigation bar on Android.
@@ -233,7 +233,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-b8vpa7-Collapsible"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Set this property using AppConstants.java.
@@ -278,7 +278,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-b8vpa7-Collapsible"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Set this property using just Xcode
@@ -290,7 +290,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-165e1mf-AppConfigProperty"
       >
         <p
-          class="  css-yszm2s-TextComponent"
+          class="  css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <a
@@ -305,7 +305,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-cj6ctd-PropertyName"
+                class="css-ter5io-PropertyName"
                 data-text="true"
               >
                 visible
@@ -347,7 +347,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             enum
@@ -363,7 +363,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Determines how and when the navigation bar is shown.
@@ -406,7 +406,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-b8vpa7-Collapsible"
           >
             <p
-              class="css-1oym3r-TextComponent"
+              class="css-hnkmoy-TextComponent"
               data-text="true"
             >
               Set this property using Xcode.
@@ -418,7 +418,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-165e1mf-AppConfigProperty"
           >
             <p
-              class="  css-yszm2s-TextComponent"
+              class="  css-1kfqm4n-TextComponent"
               data-text="true"
             >
               <a
@@ -433,7 +433,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-6n7j50"
                 >
                   <code
-                    class="css-cj6ctd-PropertyName"
+                    class="css-ter5io-PropertyName"
                     data-text="true"
                   >
                     always
@@ -475,7 +475,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 boolean
@@ -491,7 +491,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </code>
             </p>
             <p
-              class="css-1oym3r-TextComponent"
+              class="css-hnkmoy-TextComponent"
               data-text="true"
             >
               Test sub-sub-property
@@ -504,7 +504,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-165e1mf-AppConfigProperty"
       >
         <p
-          class="  css-yszm2s-TextComponent"
+          class="  css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <a
@@ -519,7 +519,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-cj6ctd-PropertyName"
+                class="css-ter5io-PropertyName"
                 data-text="true"
               >
                 backgroundColor
@@ -561,7 +561,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             string
@@ -577,7 +577,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           Specifies the background color of the navigation bar.
@@ -585,12 +585,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         
 
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           6 character long hex color string, eg: 
           <code
-            class="css-zmv3vl-TextComponent"
+            class="css-23wgco-TextComponent"
             data-text="true"
           >
             '#000000'
@@ -604,7 +604,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     class="css-165e1mf-AppConfigProperty"
   >
     <p
-      class="  css-yszm2s-TextComponent"
+      class="  css-1kfqm4n-TextComponent"
       data-text="true"
     >
       <a
@@ -619,7 +619,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-cj6ctd-PropertyName"
+            class="css-ter5io-PropertyName"
             data-text="true"
           >
             intentFilters
@@ -661,14 +661,14 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     >
       Type: 
       <code
-        class="css-kzvbfm-TextComponent"
+        class="css-4xa05b-TextComponent"
         data-text="true"
       >
         array
       </code>
     </p>
     <p
-      class="css-1oym3r-TextComponent"
+      class="css-hnkmoy-TextComponent"
       data-text="true"
     >
       Configuration for setting an array of custom intent filters in Android manifest.
@@ -711,7 +711,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-b8vpa7-Collapsible"
       >
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           This is set in AndroidManifest.xml directly.
@@ -752,7 +752,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Example
         </strong>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           [{  "autoVerify": true,  "data": {"host": "*.example.com"  }  }]
@@ -764,7 +764,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-165e1mf-AppConfigProperty"
       >
         <p
-          class="  css-yszm2s-TextComponent"
+          class="  css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <a
@@ -779,7 +779,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-cj6ctd-PropertyName"
+                class="css-ter5io-PropertyName"
                 data-text="true"
               >
                 autoVerify
@@ -821,7 +821,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             boolean
@@ -837,7 +837,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </p>
         <p
-          class="css-1oym3r-TextComponent"
+          class="css-hnkmoy-TextComponent"
           data-text="true"
         >
           You may also use an intent filter to set your app as the default handler for links
@@ -848,7 +848,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         class="css-165e1mf-AppConfigProperty"
       >
         <p
-          class="  css-yszm2s-TextComponent"
+          class="  css-1kfqm4n-TextComponent"
           data-text="true"
         >
           <a
@@ -863,7 +863,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-cj6ctd-PropertyName"
+                class="css-ter5io-PropertyName"
                 data-text="true"
               >
                 data
@@ -905,7 +905,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="css-kzvbfm-TextComponent"
+            class="css-4xa05b-TextComponent"
             data-text="true"
           >
             array || object
@@ -925,7 +925,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             class="css-165e1mf-AppConfigProperty"
           >
             <p
-              class="  css-yszm2s-TextComponent"
+              class="  css-1kfqm4n-TextComponent"
               data-text="true"
             >
               <a
@@ -940,7 +940,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   class="css-6n7j50"
                 >
                   <code
-                    class="css-cj6ctd-PropertyName"
+                    class="css-ter5io-PropertyName"
                     data-text="true"
                   >
                     host
@@ -982,7 +982,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="css-kzvbfm-TextComponent"
+                class="css-4xa05b-TextComponent"
                 data-text="true"
               >
                 string

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -106,7 +106,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
       <CommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>
-          <BoxSectionHeader text="Returns" exposeInSidebar={exposeInSidebar} />
+          <BoxSectionHeader text="Returns" />
           <ReactMarkdown components={mdComponents}>
             {getCommentContent(returnComment.content)}
           </ReactMarkdown>

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -11,7 +11,6 @@ import { APISectionPlatformTags } from '~/components/plugins/api/APISectionPlatf
 import { renderProp } from '~/components/plugins/api/APISectionProps';
 import {
   CommentTextBlock,
-  getAPISectionHeader,
   H3Code,
   getTagData,
   getTagNamesList,
@@ -19,11 +18,11 @@ import {
   resolveTypeName,
   STYLES_APIBOX,
   STYLES_APIBOX_NESTED,
-  STYLES_NESTED_SECTION_HEADER,
   TypeDocKind,
   getCommentContent,
+  BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, H4, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE } from '~/ui/components/Text';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
@@ -66,7 +65,6 @@ const remapClass = (clx: ClassDefinitionData) => {
 
 const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.Element => {
   const { name, comment, type, extendedTypes, children, implementedTypes, isSensor } = clx;
-  const Header = getAPISectionHeader(exposeInSidebar);
 
   const properties = children?.filter(isProp);
   const methods = children
@@ -108,9 +106,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
       <CommentTextBlock comment={comment} includePlatforms={false} />
       {returnComment && (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>Returns</H4>
-          </div>
+          <BoxSectionHeader text="Returns" exposeInSidebar={exposeInSidebar} />
           <ReactMarkdown components={mdComponents}>
             {getCommentContent(returnComment.content)}
           </ReactMarkdown>
@@ -118,9 +114,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
       )}
       {properties?.length ? (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <Header>{name} Properties</Header>
-          </div>
+          <BoxSectionHeader text={`${name} Properties`} exposeInSidebar={exposeInSidebar} />
           <div>
             {properties.map(property =>
               renderProp(property, property?.defaultValue, exposeInSidebar)
@@ -130,9 +124,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
       ) : null}
       {methods?.length && (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <Header>{name} Methods</Header>
-          </div>
+          <BoxSectionHeader text={`${name} Methods`} exposeInSidebar={exposeInSidebar} />
           {methods.map(method => renderMethod(method, { exposeInSidebar }))}
         </>
       )}

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -19,15 +19,15 @@ import {
   resolveTypeName,
   renderDefaultValue,
   STYLES_APIBOX,
-  STYLES_NESTED_SECTION_HEADER,
   getTagNamesList,
   STYLES_APIBOX_NESTED,
   STYLES_ELEMENT_SPACING,
   H3Code,
   getCommentContent,
+  BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, H4, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE, DEMI } from '~/ui/components/Text';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
@@ -46,7 +46,7 @@ const renderInterfaceComment = (
     return (
       <>
         {parameters?.length ? parameters.map(param => renderParamRow(param)) : null}
-        <BOLD>Returns: </BOLD>
+        <DEMI>Returns</DEMI>
         <CODE>{resolveTypeName(type)}</CODE>
         {signatureComment && (
           <>
@@ -126,7 +126,7 @@ const renderInterface = ({
       </H3Code>
       {extendedTypes?.length ? (
         <P css={STYLES_ELEMENT_SPACING}>
-          <BOLD>Extends: </BOLD>
+          <DEMI>Extends: </DEMI>
           {extendedTypes.map(extendedType => (
             <CODE key={`extend-${extendedType.name}`}>{resolveTypeName(extendedType)}</CODE>
           ))}
@@ -135,17 +135,13 @@ const renderInterface = ({
       <CommentTextBlock comment={comment} includePlatforms={false} />
       {interfaceMethods.length ? (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>{name} Methods</H4>
-          </div>
+          <BoxSectionHeader text={`${name} Methods`} />
           {interfaceMethods.map(method => renderMethod(method, { exposeInSidebar: false }))}
         </>
       ) : undefined}
       {interfaceFields.length ? (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>{name} Properties</H4>
-          </div>
+          <BoxSectionHeader text={`${name} Properties`} />
           <Table>
             <ParamsTableHeadRow />
             <tbody>{interfaceFields.map(renderInterfacePropertyRow)}</tbody>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -22,15 +22,15 @@ import {
   resolveTypeName,
   STYLES_APIBOX,
   STYLES_APIBOX_NESTED,
-  STYLES_NESTED_SECTION_HEADER,
   STYLES_NOT_EXPOSED_HEADER,
   TypeDocKind,
   H3Code,
   H4Code,
   getTagData,
   getCommentContent,
+  BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, H4, LI, UL, CODE } from '~/ui/components/Text';
+import { H2, LI, UL, CODE } from '~/ui/components/Text';
 
 export type APISectionMethodsProps = {
   data: (MethodDefinitionData | PropData)[];
@@ -79,9 +79,7 @@ export const renderMethod = (
           <CommentTextBlock comment={comment} includePlatforms={false} />
           {resolveTypeName(type) !== 'undefined' && (
             <>
-              <div css={STYLES_NESTED_SECTION_HEADER}>
-                <H4>Returns</H4>
-              </div>
+              <BoxSectionHeader text="Returns" />
               <UL css={STYLES_NO_BULLET_LIST}>
                 <LI>
                   <UndoIcon

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -9,17 +9,16 @@ import { APISectionDeprecationNote } from '~/components/plugins/api/APISectionDe
 import { renderMethod } from '~/components/plugins/api/APISectionMethods';
 import {
   CommentTextBlock,
-  getAPISectionHeader,
   getTagData,
   getTagNamesList,
   mdComponents,
   STYLES_APIBOX,
-  STYLES_NESTED_SECTION_HEADER,
   TypeDocKind,
   H3Code,
   getCommentContent,
+  BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, H4, CODE } from '~/ui/components/Text';
+import { H2, CODE } from '~/ui/components/Text';
 
 export type APISectionNamespacesProps = {
   data: GeneratedData[];
@@ -34,7 +33,6 @@ const isMethod = (child: PropData, allowOverwrites: boolean = false) =>
 
 const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolean): JSX.Element => {
   const { name, comment, children } = namespace;
-  const Header = getAPISectionHeader(exposeInSidebar);
 
   const methods = children
     ?.filter(child => isMethod(child))
@@ -50,9 +48,7 @@ const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolea
       <CommentTextBlock comment={comment} />
       {returnComment && (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <H4>Returns</H4>
-          </div>
+          <BoxSectionHeader text="Returns" />
           <ReactMarkdown components={mdComponents}>
             {getCommentContent(returnComment.content)}
           </ReactMarkdown>
@@ -60,9 +56,7 @@ const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolea
       )}
       {methods?.length ? (
         <>
-          <div css={STYLES_NESTED_SECTION_HEADER}>
-            <Header>{name} Methods</Header>
-          </div>
+          <BoxSectionHeader text={`${name} Methods`} exposeInSidebar={exposeInSidebar} />
           {methods.map(method => renderMethod(method, { exposeInSidebar }))}
         </>
       ) : undefined}

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -133,6 +133,7 @@ export const renderProp = (
         ) : null}
       </P>
       <CommentTextBlock comment={extractedComment} includePlatforms={false} />
+      <br />
     </div>
   );
 };

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -37,7 +37,11 @@ import {
   RawH4,
   UL,
   createPermalinkedComponent,
+  DEMI,
+  CALLOUT,
+  createTextComponent,
 } from '~/ui/components/Text';
+import { TextElement } from '~/ui/components/Text/types';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -408,6 +412,29 @@ export const ParamsTableHeadRow = () => (
   </TableHead>
 );
 
+const InheritPermalink = createPermalinkedComponent(
+  createTextComponent(
+    TextElement.SPAN,
+    css({ fontSize: 'inherit', fontWeight: 'inherit', color: 'inherit' })
+  ),
+  { baseNestingLevel: 2 }
+);
+
+export const BoxSectionHeader = ({
+  text,
+  exposeInSidebar,
+}: {
+  text: string;
+  exposeInSidebar?: boolean;
+}) => {
+  const TextWrapper = exposeInSidebar ? InheritPermalink : Fragment;
+  return (
+    <CALLOUT theme="secondary" weight="medium" css={STYLES_NESTED_SECTION_HEADER}>
+      <TextWrapper>{text}</TextWrapper>
+    </CALLOUT>
+  );
+};
+
 export const renderParams = (parameters: MethodParamData[]) => (
   <Table>
     <ParamsTableHeadRow />
@@ -421,7 +448,7 @@ export const listParams = (parameters: MethodParamData[]) =>
 export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue && defaultValue !== '...' ? (
     <div css={defaultValueContainerStyle}>
-      <BOLD>Default:</BOLD> <CODE>{defaultValue}</CODE>
+      <DEMI>Default:</DEMI> <CODE>{defaultValue}</CODE>
     </div>
   ) : undefined;
 
@@ -571,9 +598,7 @@ export const CommentTextBlock = ({
           <BOLD>Example</BOLD>
         </div>
       ) : (
-        <div css={STYLES_NESTED_SECTION_HEADER}>
-          <RawH4>Example</RawH4>
-        </div>
+        <BoxSectionHeader text="Example" />
       )}
       <ReactMarkdown components={mdComponents}>{getCommentContent(example.content)}</ReactMarkdown>
     </Fragment>
@@ -611,9 +636,6 @@ export const CommentTextBlock = ({
     </>
   );
 };
-
-export const getAPISectionHeader = (exposeInSidebar?: boolean) =>
-  exposeInSidebar ? createPermalinkedComponent(RawH4, { baseNestingLevel: 2 }) : H4;
 
 const getMonospaceHeader = (element: ComponentType<any>) => {
   const level = parseInt(element?.displayName?.replace(/\D/g, '') ?? '0', 10);

--- a/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
+++ b/docs/components/plugins/api/__snapshots__/APISectionUtils.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`APISectionUtils.CommentTextBlock component basic comment 1`] = `
 <div>
   <p
-    class="css-1oym3r-TextComponent"
+    class="css-hnkmoy-TextComponent"
     data-text="true"
   >
     This is the basic comment.
@@ -47,7 +47,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
   </div>
   <br />
   <p
-    class="css-1oym3r-TextComponent"
+    class="css-hnkmoy-TextComponent"
     data-text="true"
   >
     Gets the referrer URL of the installed app with the 
@@ -58,7 +58,7 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
       target="_blank"
     >
       <code
-        class="css-zmv3vl-TextComponent"
+        class="css-23wgco-TextComponent"
         data-text="true"
       >
         Install Referrer API
@@ -67,16 +67,12 @@ exports[`APISectionUtils.CommentTextBlock component comment with example 1`] = `
     
 from the Google Play Store. In practice, the referrer URL may not be a complete, absolute URL.
   </p>
-  <div
-    class="css-10kkd4f"
+  <p
+    class="css-1eksndl-BoxSectionHeader"
+    data-text="true"
   >
-    <h4
-      class="css-1gu5rqd-TextComponent"
-      data-heading="true"
-    >
-      Example
-    </h4>
-  </div>
+    Example
+  </p>
   <pre>
     <pre
       class="css-1tmj8fm"

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -314,9 +314,13 @@ const preview = [
 ];
 
 const archive = [
-  makeSection('Archive', [makeGroup('Archive', [makePage('archive/index.mdx')])], {
-    expanded: true,
-  }),
+  makeGroup('Archive', [makePage('archive/index.mdx')]),
+  makeGroup('Miscellaneous', [
+    makePage('archive/adhoc-builds.mdx'),
+    makePage('archive/expo-cli.mdx'),
+    makePage('archive/notification-channels.mdx'),
+    makePage('archive/glossary.mdx'),
+  ]),
   makeSection(
     'Classic Updates',
     [
@@ -343,12 +347,6 @@ const archive = [
       expanded: true,
     }
   ),
-  makeGroup('Miscellaneous', [
-    makePage('archive/adhoc-builds.mdx'),
-    makePage('archive/expo-cli.mdx'),
-    makePage('archive/notification-channels.mdx'),
-    makePage('archive/glossary.mdx'),
-  ]),
 ];
 
 const featurePreview = [];

--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -28,21 +28,21 @@ export const globalExtras = css`
   }
 
   ::-webkit-scrollbar-thumb {
-    background: ${theme.background.element};
+    background: ${theme.palette.gray5};
     border-radius: 10px;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background: ${theme.background.hover};
+    background: ${theme.palette.gray6};
   }
 
-  html[data-expo-theme='light'] div[class*='SnippetContent'] {
+  div[class*='Terminal'] > div {
     ::-webkit-scrollbar-thumb {
-      background: ${darkTheme.background.hover};
+      background: ${darkTheme.icon.quaternary};
     }
 
     ::-webkit-scrollbar-thumb:hover {
-      background: ${darkTheme.icon.secondary};
+      background: ${darkTheme.icon.tertiary};
     }
   }
 

--- a/docs/ui/components/Button/Button.tsx
+++ b/docs/ui/components/Button/Button.tsx
@@ -56,7 +56,7 @@ const buttonThemes: Record<ButtonTheme, Theme> = {
     color: styleguideTheme.button.quaternary.text,
   },
   ghost: {
-    backgroundColor: styleguideTheme.button.secondary.background,
+    backgroundColor: 'transparent',
     color: styleguideTheme.button.secondary.text,
     border: `1px solid ${styleguideTheme.button.secondary.border}`,
   },

--- a/docs/ui/components/CommandMenu/styles.ts
+++ b/docs/ui/components/CommandMenu/styles.ts
@@ -149,7 +149,7 @@ export const commandMenuStyles = css`
     padding: ${spacing[8]}px 0;
   }
 
-  html[data-expo-theme='dark'] {
+  html.dark-theme {
     [cmdk-item] mark {
       background: ${theme.palette.blue5};
 

--- a/docs/ui/components/Header/ThemeSelector.tsx
+++ b/docs/ui/components/Header/ThemeSelector.tsx
@@ -64,7 +64,7 @@ const selectStyle = css`
   align-items: center;
   justify-content: center;
   height: 36px;
-  color: transparent;
+  color: ${theme.text.default};
   line-height: 1.3;
   padding: 0;
   width: 50px;
@@ -77,6 +77,7 @@ const selectStyle = css`
   appearance: none;
   background-color: ${theme.background.default};
   cursor: pointer;
+  text-indent: -9999px;
 
   @media screen and (max-width: ${(breakpoints.medium + breakpoints.large) / 2}px) {
     width: auto;

--- a/docs/ui/components/Layout/LayoutScroll.tsx
+++ b/docs/ui/components/Layout/LayoutScroll.tsx
@@ -47,12 +47,12 @@ const scrollStyle = css({
   },
   // Handle
   '::-webkit-scrollbar-thumb': {
-    backgroundColor: theme.background.element,
+    backgroundColor: theme.palette.gray5,
     borderRadius: '10px',
   },
   // Handle on hover
   '::-webkit-scrollbar-thumb:hover': {
-    backgroundColor: theme.background.hover,
+    backgroundColor: theme.palette.gray6,
   },
 });
 

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -25,7 +25,8 @@ const headerStyle = css`
   display: flex;
   padding: 0 0 0 16px;
   justify-content: space-between;
-  min-height: 42px;
+  height: 42px;
+  overflow: hidden;
 `;
 
 const headerDarkStyle = css`
@@ -35,9 +36,14 @@ const headerDarkStyle = css`
 `;
 
 const headerTitleStyle = css`
+  height: 42px;
   line-height: 42px !important;
   user-select: none;
   font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding-right: 16px;
 `;
 
 const headerActionsStyle = css`

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -77,6 +77,7 @@ export function createTextComponent(Element: TextElement, textStyle?: Serialized
 const baseTextStyle = css({
   ...typography.body.paragraph,
   color: theme.text.default,
+  wordBreak: 'break-word',
 });
 
 const link = css({

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -77,7 +77,6 @@ export function createTextComponent(Element: TextElement, textStyle?: Serialized
 const baseTextStyle = css({
   ...typography.body.paragraph,
   color: theme.text.default,
-  wordBreak: 'break-word',
 });
 
 const link = css({
@@ -117,6 +116,7 @@ const codeStyle = css({
   borderColor: theme.border.secondary,
   borderRadius: borderRadius.sm,
   verticalAlign: 'initial',
+  wordBreak: 'unset',
 });
 
 export const kbdStyle = css({
@@ -176,6 +176,12 @@ const h5Style = {
   ...codeInHeaderStyle,
 };
 
+const paragraphStyle = {
+  strong: {
+    wordBreak: 'break-word',
+  },
+};
+
 export const H1 = createTextComponent(TextElement.H1, css(h1Style));
 export const RawH2 = createTextComponent(TextElement.H2, css(h2Style));
 export const H2 = createPermalinkedComponent(RawH2, { baseNestingLevel: 2 });
@@ -186,7 +192,7 @@ export const H4 = createPermalinkedComponent(RawH4, { baseNestingLevel: 4 });
 export const RawH5 = createTextComponent(TextElement.H5, css(h5Style));
 export const H5 = createPermalinkedComponent(RawH5, { baseNestingLevel: 5 });
 
-export const P = createTextComponent(TextElement.P);
+export const P = createTextComponent(TextElement.P, css(paragraphStyle as CSSObject));
 export const CODE = createTextComponent(
   TextElement.CODE,
   css([typography.utility.inlineCode, codeStyle])


### PR DESCRIPTION
# Why

This PR solves small regression on Windows with theme selector after the latest header update.

Additionally, I have address few other small issues or inconsistence spotted in docs UI. 

# How

The following chnages have been made:
* fix theme selector options text color
* unify the colors of scrollbars and make them a bit more visible
* fix not working overwrites based on old theme DOM indicator (leading to incorrect scrollbars in Terminal component)
* fix Snippets header text overflow 
* fix Snippets copy button background overflow
* ensure that length, styled text can wrap correctly on narrow viewports
* small reogranization of Archive navigation
* unification of nested section headers in APISection

# Test Plan

The changes have been tested by running docs website locally.

# Preview

<img width="1153" alt="Screenshot 2023-02-23 at 11 29 03" src="https://user-images.githubusercontent.com/719641/220883298-2910c663-c260-4c96-a865-e609079a887d.png">

<img width="1142" alt="Screenshot 2023-02-23 at 12 25 39" src="https://user-images.githubusercontent.com/719641/220893159-4aba51a5-dee6-4ce0-ba62-46391aa62a78.png">
