### PR TITLE
[apps][go][templates] Bump AGP to 7.4.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dbFlowVersion = '4.2.4'
     buildToolsVersion = '33.0.0'
     kotlinVersion = '1.8.10'
-    gradlePluginVersion = '7.3.1'
+    gradlePluginVersion = '7.4.1'
     gradleDownloadTaskVersion = '5.0.1'
     repositoryUrl = "file:${System.env.HOME}/.m2/repository/"
 

--- a/apps/bare-expo/android/build.gradle
+++ b/apps/bare-expo/android/build.gradle
@@ -5,7 +5,7 @@ import groovy.json.JsonSlurper
 buildscript {
     ext {
         buildToolsVersion = '33.0.0'
-        gradlePluginVersion = '7.3.1'
+        gradlePluginVersion = '7.4.1'
         minSdkVersion = 21
         compileSdkVersion = 33
         targetSdkVersion = 33

--- a/apps/fabric-tester/android/build.gradle
+++ b/apps/fabric-tester/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.3.1')
+        classpath('com.android.tools.build:gradle:7.4.1')
         classpath('com.facebook.react:react-native-gradle-plugin')
     }
 }

--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.3.1')
+        classpath('com.android.tools.build:gradle:7.4.1')
         classpath('com.facebook.react:react-native-gradle-plugin')
     }
 }


### PR DESCRIPTION
# Why

AGP 7.3 does not support Kotlin 1.8 officially: https://developer.android.com/studio/write/kotlin-support
this seems to be the root cause of proguard issue because some kotlin `Metadata` is be stripped.

# How

bump AGP to 7.4.1

# Test Plan

- ci passed
- android versioned expo go + enable proguard + NCL image
- sdk 48 `expo-template-bare-minimum` app debug build
- sdk 48 `expo-template-bare-minimum` app release build
- sdk 48 `expo-template-bare-minimum` app release build with proguard

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
