### PR TITLE
[go][android] fix textinput crash in home

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -339,7 +339,7 @@ class Kernel : KernelInterface() {
 
   val reactRootView: ReactRootView
     get() {
-      val reactRootView: ReactRootView = ReactUnthemedRootView(context)
+      val reactRootView: ReactRootView = ReactUnthemedRootView(activityContext)
       reactRootView.startReactApplication(
         reactInstanceManager,
         KernelConstants.HOME_MODULE_NAME,


### PR DESCRIPTION
# Why

fix textinput crash on expo go home

```
                         E  FATAL EXCEPTION: main
                         E  Process: host.exp.exponent, PID: 14389
                         E  java.lang.ClassCastException: android.app.ContextImpl cannot be cast to android.app.Activity
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.getActivity(ReactRootView.java:22)
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.checkForKeyboardEvents(ReactRootView.java:62)
                         E      at com.facebook.react.ReactRootView$CustomGlobalLayoutListener.onGlobalLayout(ReactRootView.java:36)
                         E      at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:1061)
                         E      at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3352)
                         E      at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2286)
                         E      at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8948)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1231)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1239)
                         E      at android.view.Choreographer.doCallbacks(Choreographer.java:899)
                         E      at android.view.Choreographer.doFrame(Choreographer.java:832)
                         E      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1214)
                         E      at android.os.Handler.handleCallback(Handler.java:942)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at android.os.Looper.loopOnce(Looper.java:201)
                         E      at android.os.Looper.loop(Looper.java:288)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7898)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

close ENG-7643

# How

in the ReactRootView, the context is actually `MainApplication`, which is not quite correct. We should pass Activity to views instead.

# Test Plan

using Android 13 emulator to click textinput in expo go home 

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
