### PR TITLE
[go] fix crash on sdk 46 projects

### DIFF
--- a/android/versioned-abis/expoview-abi46_0_0/maven/host/exp/reactandroid-abi46_0_0/1.0.0/_remote.repositories
+++ b/android/versioned-abis/expoview-abi46_0_0/maven/host/exp/reactandroid-abi46_0_0/1.0.0/_remote.repositories
@@ -1,4 +1,4 @@
 #NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Fri Jul 15 14:52:02 CST 2022
+#Fri Feb 24 03:07:52 CST 2023
 reactandroid-abi46_0_0-1.0.0.pom>=
 reactandroid-abi46_0_0-1.0.0.aar>=

--- a/android/versioned-abis/expoview-abi46_0_0/maven/host/exp/reactandroid-abi46_0_0/maven-metadata-local.xml
+++ b/android/versioned-abis/expoview-abi46_0_0/maven/host/exp/reactandroid-abi46_0_0/maven-metadata-local.xml
@@ -7,6 +7,6 @@
     <versions>
       <version>1.0.0</version>
     </versions>
-    <lastUpdated>20220715065202</lastUpdated>
+    <lastUpdated>20230223190752</lastUpdated>
   </versioning>
 </metadata>

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/device/DeviceModule.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/expo/modules/device/DeviceModule.kt
@@ -62,7 +62,12 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
     "osInternalBuildId" to Build.ID,
     "osBuildFingerprint" to Build.FINGERPRINT,
     "platformApiLevel" to Build.VERSION.SDK_INT,
-    "deviceName" to Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
+    "deviceName" to run {
+      if (Build.VERSION.SDK_INT <= 31)
+        Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
+      else
+        Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME)
+    },
   )
 
   private val deviceYearClass: Int


### PR DESCRIPTION
# Why

close ENG-7651

# How

- add sdk-46 versioned aar which is built by ndk r23. this will solve the ndk r21 <> r23 incompatible issue
- backport expo-device fix for targetSdkVersion 33

# Test Plan

```sh
$ yarn create expo-app -t blank@sdk-46 sdk46
$ cd sdk46
$ npx expo start
# press 'a' key to load the app
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
