### PR TITLE
[docs][modules] Fix example of record usage in Kotlin

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -607,7 +607,7 @@ class FileReadOptions : Record {
   val position: Int = 0
 
   @Field
-  val length: Int?
+  val length: Int? = null
 }
 
 // Now this record can be used as an argument of the functions or the view prop setters.


### PR DESCRIPTION
# Why

This's a follow-up to https://discord.com/channels/695411232856997968/1009056414028812299/1078082119668080650.

# How

I've decided to add `null` other than declaring those properties inside of the constructor. In my opinion, it is simpler and the same code can be used in the primary constructor. Where the declaration using contractor can't be used outside. 