### PR TITLE
[clipboard][Android] Fixed crash in clipboard listener on Android SDK <26

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crash in clipboard listener on Android SDK <26
+
 ### 💡 Others
 
 ## 4.1.1 — 2023-02-09

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed crash in clipboard listener on Android SDK <26
+- Fixed crash in clipboard listener on Android SDK <26 ([#21383](https://github.com/expo/expo/pull/21383) by [@frw](https://github.com/frw))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardModule.kt
@@ -170,10 +170,12 @@ class ClipboardModule : Module() {
       maybeClipboardManager.takeIf { isListening }
         ?.primaryClipDescription
         ?.let { clip ->
-          if (timestamp == clip.timestamp) {
-            return@OnPrimaryClipChangedListener
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (timestamp == clip.timestamp) {
+              return@OnPrimaryClipChangedListener
+            }
+            timestamp = clip.timestamp
           }
-          timestamp = clip.timestamp
 
           this@ClipboardModule.sendEvent(
             CLIPBOARD_CHANGED_EVENT_NAME,


### PR DESCRIPTION
# Why

On devices with Android versions below 8 (SDK 26), the changes in #19723 causes the app to crash whenever a string is copied due to using the `getTimestamp()` function that is only available on SDK 26 and above: https://developer.android.com/reference/android/content/ClipDescription#getTimestamp()

# How

Add a check to ensure `Build.VERSION.SDK_INT >= Build.VERSION_CODES.O` before calling `clip.timestamp`.

# Test Plan

Ran `yarn android` in `apps/bare-expo`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
