### PR TITLE
[barcode-scanner][Android] Fixed Android property name of BarCodeScannedEvent from boundingBox to bounds to match TypeScript definitions

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android property name of BarCodeScannedEvent from boundingBox to bounds to match TypeScript definitions
+- Fixed Android property name of BarCodeScannedEvent from boundingBox to bounds to match TypeScript definitions ([#21384](https://github.com/expo/expo/pull/21384) by [@frw](https://github.com/frw))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed Android property name of BarCodeScannedEvent from boundingBox to bounds to match TypeScript definitions
+
 ### 💡 Others
 
 ## 12.3.1 — 2023-02-09

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannedEvent.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannedEvent.kt
@@ -9,5 +9,5 @@ data class BarCodeScannedEvent(
   @Field val data: String,
   @Field val type: Int,
   @Field val cornerPoints: ArrayList<Bundle>,
-  @Field val boundingBox: Bundle
+  @Field val bounds: Bundle
 ) : Record

--- a/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
+++ b/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt
@@ -71,7 +71,7 @@ class BarCodeScannerView(
         data = barCode.value,
         type = barCode.type,
         cornerPoints = cornerPoints,
-        boundingBox = boundingBox
+        bounds = boundingBox
       )
     )
   }


### PR DESCRIPTION
# Why

TS type for `BarCodeScannerResult` contains `bounds`:
https://github.com/expo/expo/blob/9772ed8ebb879cde658c1f33949fd5b51bf04af9/packages/expo-barcode-scanner/src/BarCodeScanner.tsx#L74

And on iOS `bounds` is added to the payload:
https://github.com/expo/expo/blob/main/packages/expo-barcode-scanner/ios/EXBarCodeScanner/Utilities/EXBarCodeScannerUtils.m#L79

However, on Android the `bounds` payload is added as `boundingBox` instead:
https://github.com/expo/expo/blob/main/packages/expo-barcode-scanner/android/src/main/java/expo/modules/barcodescanner/BarCodeScannerView.kt#L74

Fixes #19998

# How

Renamed `boundingBox` to `bounds` in `BarCodeScannedEvent`.

# Test Plan

Ran `yarn android` in `apps/bare-expo`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
