### PR TITLE
[docs] Update `expo-github-action` guides and examples

### DIFF
--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -18,7 +18,7 @@ Organizations can create Bot Users to take actions on resources owned by the Org
 
 You can use any tokens you have created to perform actions with the Expo CLI (other than signing in and out). To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
 
-If you are using GitHub Actions, [you can configure the `expo-token` property](https://github.com/expo/expo-github-action#configuration-options) to include this environment variable in all of the job steps.
+If you are using GitHub Actions, [you can configure the `token` property](https://github.com/expo/expo-github-action#configuration-options) to include this environment variable in all of the job steps.
 
 Common situations where access tokens are useful:
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -209,15 +209,14 @@ jobs:
     name: Install and build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: npm
       - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
-          expo-version: 5.x
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Install dependencies

--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -136,7 +136,7 @@ jobs:
           command: eas update --auto
 ```
 
-Although the code above is similar to the code in the previous example, there are a few differences. In this action, we changed the workflow event (`on`) to run every time a pull request is opened or updated. In the `update` job, we still set up Node, Expo's GitHub Action, and the dependencies using GitHub action's built in cache. But, instead of running `eas update --auto` ourselves, we let the [preview subaction](https://github.com/expo/expo-github-action/tree/main/preview#readme) run it for us. This will add a comment to the pull request with basic information about the update, and a QR code to scan the update.
+Although the code above is similar to the example in the previous section, there are a few differences. In this action, we changed the workflow event (`on`) to run every time a pull request is opened or updated. In the `update` job, we still set up Node, Expo's GitHub Action, and the dependencies using GitHub action's built-in cache. But, instead of running `eas update --auto` ourselves, we let the [preview subaction](https://github.com/expo/expo-github-action/tree/main/preview#readme) run it for us. This will add a comment to the pull request with basic information about the update and a QR code to scan the update.
 
 > Don't forget to add the `permissions` section to the job. This enables the job to add comments to the pull request.
 
@@ -144,9 +144,10 @@ Although the code above is similar to the code in the previous example, there ar
 
 <Step label="3">
 
-Finally, just like the previous example, we need to give the script above permission to run by providing an `EXPO_TOKEN` environment variable.
 
-If you already have done this, you can skip this step. Only one valid `EXPO_TOKEN` is required to authenticate GitHub Actions with your Expo account.
+You can skip this step if you have already set up `EXPO_TOKEN` in the previous section. Only one valid `EXPO_TOKEN` is required to authenticate GitHub Actions with your Expo account.
+
+If you haven't, you must give the script above permission to run by providing an `EXPO_TOKEN` environment variable.
 
 1.  Navigate to [https://expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens).
 2.  Click "Create" to create a new access token.

--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -1,7 +1,6 @@
 ---
 title: Using GitHub Actions
 description: Learn how to use GitHub Actions to automate publishing updates with EAS Update.
-hideTOC: true
 ---
 
 import { Step } from '~/ui/components/Step';
@@ -39,34 +38,22 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: yarn
 
-      - name: Setup Expo
-        uses: expo/expo-github-action@v7
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
         with:
-          expo-version: latest
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Find yarn cache
-        id: yarn-cache-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Restore cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: ${{ runner.os }}-yarn-
-
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install
 
       - name: Publish update
         run: eas update --auto
@@ -88,6 +75,87 @@ Finally, we need to give the script above permission to run by providing an `EXP
 6.  Make the secret's name "EXPO_TOKEN", then paste the access token in as the value.
 
 Your GitHub Action should be set up now. Whenever a developer merges code into the repo, this action will build an update and publish it, making it available to all of our devices with builds that have access to the EAS branch.
+
+> Some repositories or organizations might need to explicitly enable GitHub Workflows and allow third-party Actions.
+
+</Step>
+
+## Publish previews on pull requests
+
+Another common use case it to create a new update for every pull request. This allows you to test the changes in the pull request on a device before merging the code, and without having to start the project locally. Below are the steps to publish an update every time a pull request is opened:
+
+<Step label="1">
+
+Create a file path named **.github/workflows/preview.yml** at the root of your project.
+
+</Step>
+
+<Step label="2">
+
+Inside **preview.yml**, copy and paste the following snippet:
+
+```yaml
+name: preview
+on: pull_request
+
+jobs:
+  update:
+    name: EAS Update
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Create preview
+        uses: expo/expo-github-action/preview@v8
+        with:
+          command: eas update --auto
+```
+
+Although the code above is similar to the code in the previous example, there are a few differences. In this action, we changed the workflow event (`on`) to run every time a pull request is opened or updated. In the `update` job, we still set up Node, Expo's GitHub Action, and the dependencies using GitHub action's built in cache. But, instead of running `eas update --auto` ourselves, we let the [preview subaction](https://github.com/expo/expo-github-action/tree/main/preview#readme) run it for us. This will add a comment to the pull request with basic information about the update, and a QR code to scan the update.
+
+> Don't forget to add the `permissions` section to the job. This enables the job to add comments to the pull request.
+
+</Step>
+
+<Step label="3">
+
+Finally, just like the previous example, we need to give the script above permission to run by providing an `EXPO_TOKEN` environment variable.
+
+If you already have done this, you can skip this step. Only one valid `EXPO_TOKEN` is required to authenticate GitHub Actions with your Expo account.
+
+1.  Navigate to [https://expo.dev/settings/access-tokens](https://expo.dev/settings/access-tokens).
+2.  Click "Create" to create a new access token.
+3.  Copy the token generated.
+4.  Navigate to https://github.com/your-username/your-repo-name/settings/secrets/actions, replacing "your-username" and "your-repo-name" with your project's info.
+5.  Click "New repository secret"
+6.  Make the secret's name "EXPO_TOKEN", then paste the access token in as the value.
+
+Your GitHub Action should be set up now. Whenever a developer creates a pull request, this action will build an update and publish it, making it available to all reviewers with builds that have access to the EAS branch.
 
 > Some repositories or organizations might need to explicitly enable GitHub Workflows and allow third-party Actions.
 


### PR DESCRIPTION
# Why

`expo-github-action@v8` is finally released (see: https://twitter.com/cedricvanputten/status/1627732937008349186)

This introduces the preview QR code equivalent from `expo-github-actions/preview-comment` (classic updates) for EAS Update.

# How

- Updated Github workflows
- Added guide to set up previews for every pull request

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
