### PR TITLE
[expo-updates] Fix E2E rollback test, other improvements

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Protocol 1 support and rollback test in E2E tests. ([#21197](https://github.com/expo/expo/pull/21197) by [@wschurman](https://github.com/wschurman), [@douglowder](https://github.com/douglowder))
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))
 - Start converting to Swift. ([#21320](https://github.com/expo/expo/pull/21320), [#21329](https://github.com/expo/expo/pull/21329), [#21332](https://github.com/expo/expo/pull/21332) by [@wschurman](https://github.com/wschurman))
+- Fix E2E rollback test and other improvements. ([#21389](https://github.com/expo/expo/pull/21389) by [@douglowder](https://github.com/douglowder))
 
 ## 0.16.1 — 2023-02-09
 

--- a/packages/expo-updates/e2e/fixtures/App-assets.tsx
+++ b/packages/expo-updates/e2e/fixtures/App-assets.tsx
@@ -34,10 +34,7 @@ async function readLogs() {
   }
 }
 
-async function fetchWithRetry(
-  url: RequestInfo,
-  body: string | undefined = undefined,
-) {
+async function fetchWithRetry(url: RequestInfo, body: string | undefined = undefined) {
   for (let i = 0; i < RETRY_COUNT; i++) {
     try {
       const response = await fetch(url, {
@@ -64,8 +61,7 @@ async function fetchWithRetry(
 
 async function readExpoInternal() {
   try {
-    const numFiles =
-      await NativeModulesProxy.ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
+    const numFiles = await NativeModulesProxy.ExpoUpdatesE2ETest.readInternalAssetsFolderAsync();
     await fetchWithRetry(
       `http://${HOSTNAME}:${PORT}/post`,
       JSON.stringify({
@@ -73,7 +69,7 @@ async function readExpoInternal() {
         success: true,
         updateId: Updates.updateId,
         numFiles,
-      }),
+      })
     );
   } catch (e: any) {
     await fetchWithRetry(
@@ -83,7 +79,7 @@ async function readExpoInternal() {
         success: false,
         updateId: Updates.updateId,
         error: e.message,
-      }),
+      })
     );
   }
 }
@@ -103,7 +99,7 @@ async function clearExpoInternal() {
         updateId: Updates.updateId,
         numFilesBefore,
         numFilesAfter,
-      }),
+      })
     );
   } catch (e: any) {
     await fetchWithRetry(
@@ -113,7 +109,7 @@ async function clearExpoInternal() {
         success: false,
         updateId: Updates.updateId,
         error: e.message,
-      }),
+      })
     );
   }
 }
@@ -121,9 +117,7 @@ async function clearExpoInternal() {
 export default function App() {
   useEffect(() => {
     const fetchResponseAsync = async () => {
-      const response = await fetchWithRetry(
-        `http://${HOSTNAME}:${PORT}/notify/test`,
-      );
+      const response = await fetchWithRetry(`http://${HOSTNAME}:${PORT}/notify/test`);
       const responseObj = (await response?.json()) || null;
       if (responseObj && responseObj.command) {
         switch (responseObj.command) {
@@ -145,6 +139,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Text>Open up App.js to start working on your app!</Text>
+      <Text>Notify resource = /notify/test</Text>
       <StatusBar style="auto" />
     </View>
   );

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -34,9 +34,7 @@ export default function App() {
     const fetchResponseAsync = async () => {
       for (let i = 0; i < RETRY_COUNT; i++) {
         try {
-          const response = await fetch(
-            `http://${HOSTNAME}:${PORT}/notify/test`,
-          );
+          const response = await fetch(`http://${HOSTNAME}:${PORT}/notify/test`);
           if (response.status === 200) {
             break;
           }
@@ -48,14 +46,13 @@ export default function App() {
       }
       await readLogs();
     };
-    fetchResponseAsync().catch((e) =>
-      console.warn(`Error in fetching response: ${e.message}`),
-    );
+    fetchResponseAsync().catch((e) => console.warn(`Error in fetching response: ${e.message}`));
   }, []);
 
   return (
     <View style={styles.container}>
       <Text>Open up App.js to start working on your app!</Text>
+      <Text>Notify resource = /notify/test</Text>
       <StatusBar style="auto" />
     </View>
   );

--- a/packages/expo-updates/e2e/fixtures/Updates-assets.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-assets.e2e.ts
@@ -189,10 +189,6 @@ describe('Asset deletion recovery', () => {
      * update runs, then clear assets from internal storage. When we relaunch the app,
      * DatabaseLauncher should re-download the missing assets and run the update as normal.
      */
-    if (platform === 'android') {
-      console.warn('Android is currently failing this test -- skipping');
-      return;
-    }
     jest.setTimeout(300000 * TIMEOUT_BIAS);
 
     /**

--- a/packages/expo-updates/e2e/fixtures/Updates-basic.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates-basic.e2e.ts
@@ -327,7 +327,7 @@ describe('', () => {
     }
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     const bundleFilename = 'bundle1.js';
-    const newNotifyString = 'test-update-1';
+    const newNotifyString = 'test-update-3';
     const hash = await Update.copyBundleToStaticFolder(
       projectRoot,
       bundleFilename,
@@ -337,7 +337,7 @@ describe('', () => {
     const manifest = Update.getUpdateManifestForBundleFilename(
       new Date(),
       hash,
-      'test-update-1-key',
+      'test-update-3-key',
       bundleFilename,
       []
     );
@@ -371,19 +371,14 @@ describe('', () => {
     await device.terminateApp();
     await device.launchApp();
     const thirdRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
+    await Server.waitForRequest(10000 * TIMEOUT_BIAS);
 
-    // give the app time to load the rollback in the background
-    await setTimeout(2000 * TIMEOUT_BIAS);
-
-    // restart the app so it will launch the rollback
+    // Restart the app so it will launch the rollback
     await device.terminateApp();
     await device.launchApp();
     const fourthRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     const rolledBackMessage = await Server.waitForRequest(10000 * TIMEOUT_BIAS);
-    //expect(rolledBackMessage).toBe('test');
-    console.warn(
-      `Rollback E2E not working until rolledBackMessage === 'test'. Actual value: '${rolledBackMessage}'`
-    );
+    expect(rolledBackMessage).toBe('test');
     expect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
     expect(secondRequest.headers['expo-embedded-update-id']).toEqual(
       firstRequest.headers['expo-embedded-update-id']

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
@@ -25,8 +25,15 @@ function findBundlePath(
   const testUpdateBundlesPath = path.join(projectRoot, 'test-update-bundles');
   const testUpdateBundlesJsonPath = path.join(testUpdateBundlesPath, 'test-updates.json');
   const testUpdateBundlesJson = require(testUpdateBundlesJsonPath);
-  const bundleUrl = testUpdateBundlesJson[notifyString][platform];
-  return path.join(testUpdateBundlesPath, bundleUrl);
+  const bundleJson = testUpdateBundlesJson[notifyString];
+  if (bundleJson) {
+    const bundleUrl = testUpdateBundlesJson[notifyString][platform];
+    return path.join(testUpdateBundlesPath, bundleUrl);
+  } else {
+    throw new Error(
+      `There is no bundle for notifyString = ${notifyString}. Please add this to the strings used to generate test bundles in 'project.js' (setupBasicAppAsync() or setupAssetsAppAsync())'`
+    );
+  }
 }
 
 /**

--- a/packages/expo-updates/e2e/setup/create-eas-project-assets.js
+++ b/packages/expo-updates/e2e/setup/create-eas-project-assets.js
@@ -26,5 +26,5 @@ const runtimeVersion = '1.0.0';
 
   await initAsync(projectRoot, { repoRoot, runtimeVersion, localCliBin });
 
-  await setupAssetsAppAsync(projectRoot, localCliBin);
+  await setupAssetsAppAsync(projectRoot, localCliBin, repoRoot);
 })();

--- a/packages/expo-updates/e2e/setup/create-eas-project-basic.js
+++ b/packages/expo-updates/e2e/setup/create-eas-project-basic.js
@@ -28,5 +28,5 @@ const runtimeVersion = '1.0.0';
 
   await initAsync(projectRoot, { repoRoot, runtimeVersion, localCliBin });
 
-  await setupBasicAppAsync(projectRoot, localCliBin);
+  await setupBasicAppAsync(projectRoot, localCliBin, repoRoot);
 })();

--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -102,7 +102,7 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
                           asset.url ? asset.url.absoluteString : [NSNull null],
                           asset.headers ?: [NSNull null],
                           asset.extraRequestHeaders ?: [NSNull null],
-                          asset.type,
+                          asset.type ?: [NSNull null],
                           asset.metadata ?: [NSNull null],
                           asset.downloadTime,
                           asset.filename,
@@ -182,12 +182,12 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
                       asset.key ?: [NSNull null],
                       asset.headers ?: [NSNull null],
                       asset.extraRequestHeaders ?: [NSNull null],
-                      asset.type,
+                      asset.type ?: [NSNull null],
                       asset.metadata ?: [NSNull null],
                       asset.downloadTime,
                       asset.filename,
                       asset.contentHash,
-                      asset.expectedHash,
+                      asset.expectedHash ?: [NSNull null],
                       asset.url ? asset.url.absoluteString : [NSNull null]
                       ]
               error:error];


### PR DESCRIPTION
# Why

- Test for new rollback directive not working on Android
- Difficult to visually see what updates were running when testing locally in iOS or Android

# How

- Fix the rollback test
- Add UI to the app markup showing which notify string is being used (and therefore which update is running)

# Test Plan

Updates E2E should pass, including rollback on Android

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
