### PR TITLE
[exupdates][ios] Fix EXUpdatesDatabase.mergeAsset swift conversion

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
+++ b/packages/expo-updates/ios/EXUpdates/Database/EXUpdatesDatabase.m
@@ -102,7 +102,7 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
                           asset.url ? asset.url.absoluteString : [NSNull null],
                           asset.headers ?: [NSNull null],
                           asset.extraRequestHeaders ?: [NSNull null],
-                          asset.type,
+                          asset.type ?: [NSNull null],
                           asset.metadata ?: [NSNull null],
                           asset.downloadTime,
                           asset.filename,
@@ -182,12 +182,12 @@ static NSString * const EXUpdatesDatabaseStaticBuildDataKey = @"staticBuildData"
                       asset.key ?: [NSNull null],
                       asset.headers ?: [NSNull null],
                       asset.extraRequestHeaders ?: [NSNull null],
-                      asset.type,
+                      asset.type ?: [NSNull null],
                       asset.metadata ?: [NSNull null],
                       asset.downloadTime,
                       asset.filename,
                       asset.contentHash,
-                      asset.expectedHash,
+                      asset.expectedHash ?: [NSNull null],
                       asset.url ? asset.url.absoluteString : [NSNull null]
                       ]
               error:error];


### PR DESCRIPTION
# Why

This is failing in the e2e test (nice catch): https://expo.dev/accounts/expo-ci/projects/updates-e2e/builds/6ebac147-7a56-4198-9f97-32bc9fefac25

In this PR it was noticed: https://github.com/expo/expo/pull/21389

# How

I think this should fix asset stuff.

# Test Plan

Wait for e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
