### PR TITLE
[docs] add sdk 48 to upgrade walkthrough

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -8,6 +8,10 @@ description: Learn how to incrementally upgrade the Expo SDK version in your pro
 Expo maintains ~6 months of backward compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo Go app.
 However, you will still be able to publish updates via `eas update`, and build using `eas build`. Deprecations **will not** affect standalone apps you have in production.
 
+## SDK 48
+
+[Blog Post](https://blog.expo.dev/expo-sdk-48-ccb8302e231)
+
 ## SDK 47
 
 [Blog Post](https://blog.expo.dev/expo-sdk-47-a0f6f5c038af)
@@ -16,7 +20,7 @@ However, you will still be able to publish updates via `eas update`, and build u
 
 [Blog Post](https://blog.expo.dev/expo-sdk-46-c2a1655f63f7)
 
-## SDK 45
+## SDK 45 [DEPRECATED]
 
 [Blog Post](https://blog.expo.dev/expo-sdk-45-f4e332954a68)
 


### PR DESCRIPTION
# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
