### PR TITLE
[docs] Fix typo in create-a-modal.mdx

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -340,7 +340,7 @@ Now, let's modify the **App.js** to:
 - Then, create an `isModalVisible` state variable with the `useState` hook. It has a default value of `false` to ensure that the modal is hidden until the user presses the button to open it.
 - Replace the comment in the `onAddSticker()` function to update the `isModalVisible` variable to `true` when the user presses the button. This will open the emoji picker.
 - Create a`onModalClose()` function to update the `isModalVisible` state variable.
-- Place the `<EmojiPicker>` component at the bottom of the `<App>` component, below the `<StatusBar>` component.
+- Place the `<EmojiPicker>` component at the bottom of the `<App>` component, above the `<StatusBar>` component.
 
 <SnackInline
 label="Create a modal"


### PR DESCRIPTION
# Why


I have seen a  issue - Modal Placement in "Create a Modal" #21403


# How


I have updated that specific line in  the doc as the code snippet given below


# Test Plan


I have crosschecked the other similar code snippet in the document , and also the the one , where the issue is pointed out and found out that there was a mistake in the document. And corrected it.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
