### PR TITLE
[expo-modules] Add tsconfig `paths` config to look for package definitions in the `/modules` directory

### DIFF
--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -11,7 +11,10 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "target": "ESNext"
+    "target": "ESNext",
+    "paths": {
+      "*": ["./modules/*"]
+    }
   },
 
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]


### PR DESCRIPTION
# Why

More description in:
https://github.com/expo/expo/pull/21460

# How

We just treat the `/modules` folder as an additional source of packages, and we adjust TS to correctly find types.

# Test Plan

Tested manually in bare expo.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
