### PR TITLE
[dev-launcher] Fix AppProviders not receiving initial data

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed dev client crash when server URL has no scheme. ([#21274](https://github.com/expo/expo/pull/21274) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fixed dev client not showing logged user and initial data. ([#21425](https://github.com/expo/expo/pull/21425) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/bundle/App.tsx
+++ b/packages/expo-dev-launcher/bundle/App.tsx
@@ -26,8 +26,8 @@ type LauncherAppProps = object;
 
 export function App(props: LauncherAppProps) {
   return (
-    <LoadInitialData loader={<Splash />}>
-      <View style={{ direction: 'ltr', flex: 1 }}>
+    <View style={{ direction: 'ltr', flex: 1 }}>
+      <LoadInitialData loader={<Splash />}>
         <AppProviders>
           <Stack.Navigator
             initialRouteName="Main"
@@ -44,8 +44,8 @@ export function App(props: LauncherAppProps) {
             <Stack.Screen name="Crash Report" component={CrashReportScreen} />
           </Stack.Navigator>
         </AppProviders>
-      </View>
-    </LoadInitialData>
+      </LoadInitialData>
+    </View>
   );
 }
 


### PR DESCRIPTION
# Why

Closes ENG-7615

# How

The `LoadInitialData` component only injects props to its immediate child, when we added a `View` around the `AppProviders` component and thus now the immediate child of  `LoadInitialData`, we stopped injecting all the 8 initial props expected by `AppProviders`, this was causing the app to behave as if the cache was cleared every time

# Test Plan

Run bare-expo using `useDevClient = YES` and `export EX_DEV_LAUNCHER_URL=http://localhost:8090 && pod install`

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
