### PR TITLE
[expo-modules] Add local modules path to expo-yarn-workspaces

### DIFF
--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -57,6 +57,11 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       // Include .cjs files
       sourceExts: [...defaultConfig.resolver.sourceExts, 'cjs'],
 
+      nodeModulesPaths: [
+        ...defaultConfig.resolver.nodeModulesPaths,
+        path.join(projectPath, 'modules'),
+      ],
+
       // Make the symlinked packages visible to Metro
       extraNodeModules,
 


### PR DESCRIPTION
# Why

More description in:
https://github.com/expo/expo/pull/21460

# How

We just treat the `/modules` folder as an additional source of packages.

# Test Plan

Tested manually in bare expo.
This has the potential to break existing configuration if someone has a `modules` folder with additional folders inside, if they try to import it, but i'd say we don't need to worry too much about this.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
