### PR TITLE
[docs]build a screen-fix component reference

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -440,7 +440,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        <Image source={PlaceholderImage} style={styles.image} />
+        <ImageViewer placeholderImageSource={PlaceholderImage} />
       </View>
       <View style={styles.footerContainer}>
         /* @info Add primary theme on the first button */


### PR DESCRIPTION
# Why

Documentation change: In previous steps of the tutorial, `<Image source={PlaceholderImage} style={styles.image} />` was already refactored to ` <ImageViewer placeholderImageSource={PlaceholderImage} />` but in the last example, it goes back again to `<Image source={PlaceholderImage} style={styles.image} />` causing an error for people updating only the updated fragments in the example.

Thank you.
