### PR TITLE
[go] reversion sdk47 aar

### DIFF
--- a/android/versioned-abis/expoview-abi47_0_0/maven/host/exp/reactandroid-abi47_0_0/1.0.0/_remote.repositories
+++ b/android/versioned-abis/expoview-abi47_0_0/maven/host/exp/reactandroid-abi47_0_0/1.0.0/_remote.repositories
@@ -1,4 +1,4 @@
 #NOTE: This is a Maven Resolver internal implementation file, its format can be changed without prior notice.
-#Wed Oct 26 22:50:10 CST 2022
+#Tue Feb 28 12:06:16 CST 2023
 reactandroid-abi47_0_0-1.0.0.pom>=
 reactandroid-abi47_0_0-1.0.0.aar>=

--- a/android/versioned-abis/expoview-abi47_0_0/maven/host/exp/reactandroid-abi47_0_0/maven-metadata-local.xml
+++ b/android/versioned-abis/expoview-abi47_0_0/maven/host/exp/reactandroid-abi47_0_0/maven-metadata-local.xml
@@ -7,6 +7,6 @@
     <versions>
       <version>1.0.0</version>
     </versions>
-    <lastUpdated>20221026145010</lastUpdated>
+    <lastUpdated>20230228040616</lastUpdated>
   </versioning>
 </metadata>


### PR DESCRIPTION
# Why

fix android expo go crash on loading sdk 47 projects: https://play.google.com/console/u/0/developers/8143610498327843040/app/4973604790193188101/vitals/crashes/8b0d3cac46d64e9da55e67ee80c374c1/details?installedFrom=PLAY_STORE&days=28&versionCode=186

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 18198 >>> host.exp.exponent <<<

backtrace:
  #00  pc 0x0000000000091e90  [anon:libc_malloc]
  #01  pc 0x00000000000e8238  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libc++_shared.so
  #02  pc 0x00000000000e7e6c  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libc++_shared.so
  #03  pc 0x00000000000e3f50  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libc++_shared.so
  #04  pc 0x00000000000e3da4  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libc++_shared.so (__gxx_personality_v0+224)
  #05  pc 0x000000000009ccd8  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libreactnativejni_abi47_0_0.so
  #06  pc 0x000000000009d1e0  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libreactnativejni_abi47_0_0.so
  #07  pc 0x0000000000091ed0  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libreactnativejni_abi47_0_0.so (facebook::react::ModuleRegistry::getConfig(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)+2180)
  #08  pc 0x000000000001eacc  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjscexecutor_abi47_0_0.so (facebook::react::JSINativeModules::createModule(facebook::jsi::Runtime&, std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&)+256)
  #09  pc 0x000000000001e874  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjscexecutor_abi47_0_0.so (facebook::react::JSINativeModules::getModule(facebook::jsi::Runtime&, facebook::jsi::PropNameID const&)+312)
  #10  pc 0x000000000001b3a0  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjscexecutor_abi47_0_0.so (facebook::react::JSIExecutor::NativeModuleProxy::get(facebook::jsi::Runtime&, facebook::jsi::PropNameID const&)+296)
  #11  pc 0x0000000000023f8c  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjscexecutor_abi47_0_0.so
  #12  pc 0x0000000000259e28  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjsc.so
  #13  pc 0x000000000033942c  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjsc.so
  #14  pc 0x000000000023ed0c  /data/app/~~IjPGEd7tTs4f9NT7b3yhCw==/host.exp.exponent-8MkLYgGxpiz4fC7oGwXVkg==/split_config.arm64_v8a.apk!libjsc.so
```
# How

i cannot repro the crash locally from the current expo go 2.28.3, that's the main reason i didn't fix that on sdk 47. since the crash happens from the report. i think we should try to reversion sdk 47 aar as well.
the crash is coming from incompatible with ndk r21 <> r23. this pr tries to build sdk 47 aar based on ndk r23

# Test Plan

android versioned expo go + sdk 47 projects

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
