### PR TITLE
[docs] [tutorial] Update Platform differences to follow similar code conventions

### DIFF
--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -17,7 +17,7 @@ It allows taking a screenshot of any DOM node and turning it into a vector (SVG)
 
 Stop the development server and run the following command to install the library:
 
-<Terminal cmd={['$ npm install dom-to-image']} />
+<Terminal cmd={['$ npx expo install dom-to-image']} />
 
 After installing it, make sure to restart the development server and press <kbd>w</kbd> in the terminal.
 
@@ -81,21 +81,20 @@ const onSaveImageAsync = async () => {
       console.log(e);
     }
   } /* @info Add an else condition to run the logic when the current platform is the web. */else {
-    domtoimage
-      .toJpeg(imageRef.current, {
-          quality: 0.95,
-          width: 320,
-          height: 440,
-        })
-      .then(dataUrl => {
-        let link = document.createElement('a');
-        link.download = 'sticker-smash.jpeg';
-        link.href = dataUrl;
-        link.click();
-      })
-      .catch(e => {
-        console.log(e);
+    try {
+      const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+        quality: 0.95,
+        width: 320,
+        height: 440,
       });
+
+      let link = document.createElement('a');
+      link.download = 'sticker-smash.jpeg';
+      link.href = dataUrl;
+      link.click();
+    } catch (e) {
+      console.log(e);
+    }
   } /* @end */
 };
 ```

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -17,7 +17,7 @@ It allows taking a screenshot of any DOM node and turning it into a vector (SVG)
 
 Stop the development server and run the following command to install the library:
 
-<Terminal cmd={['$ npx expo install dom-to-image']} />
+<Terminal cmd={['$ npm install dom-to-image']} />
 
 After installing it, make sure to restart the development server and press <kbd>w</kbd> in the terminal.
 

--- a/docs/public/static/examples/unversioned/tutorial/08-run-on-web/App.js
+++ b/docs/public/static/examples/unversioned/tutorial/08-run-on-web/App.js
@@ -32,7 +32,7 @@ export default function App() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,      
+      allowsEditing: true,
       quality: 1,
     });
 
@@ -71,21 +71,20 @@ export default function App() {
         console.log(e);
       }
     } else {
-        domtoimage
-          .toJpeg(imageRef.current, {
-            quality: 0.95,
-            width: 320,
-            height: 440,
-          })
-          .then(dataUrl => {
-            let link = document.createElement('a');
-            link.download = 'sticker-smash.jpeg';
-            link.href = dataUrl;
-            link.click();
-          })
-          .catch(e => {
-            console.log(e);
-          });
+      try {
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          quality: 0.95,
+          width: 320,
+          height: 440,
+        });
+
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 
@@ -134,7 +133,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   imageContainer: {
-    flex:1, 
+    flex: 1,
     paddingTop: 58
   },
   footerContainer: {

--- a/docs/public/static/examples/v46.0.0/tutorial/08-run-on-web/App.js
+++ b/docs/public/static/examples/v46.0.0/tutorial/08-run-on-web/App.js
@@ -32,7 +32,7 @@ export default function App() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,      
+      allowsEditing: true,
       quality: 1,
     });
 
@@ -71,21 +71,20 @@ export default function App() {
         console.log(e);
       }
     } else {
-        domtoimage
-          .toJpeg(imageRef.current, {
-            quality: 0.95,
-            width: 320,
-            height: 440,
-          })
-          .then(dataUrl => {
-            let link = document.createElement('a');
-            link.download = 'sticker-smash.jpeg';
-            link.href = dataUrl;
-            link.click();
-          })
-          .catch(e => {
-            console.log(e);
-          });
+      try {
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          quality: 0.95,
+          width: 320,
+          height: 440,
+        });
+
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 
@@ -134,7 +133,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   imageContainer: {
-    flex:1, 
+    flex: 1,
     paddingTop: 58
   },
   footerContainer: {

--- a/docs/public/static/examples/v47.0.0/tutorial/08-run-on-web/App.js
+++ b/docs/public/static/examples/v47.0.0/tutorial/08-run-on-web/App.js
@@ -32,7 +32,7 @@ export default function App() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,      
+      allowsEditing: true,
       quality: 1,
     });
 
@@ -71,21 +71,20 @@ export default function App() {
         console.log(e);
       }
     } else {
-        domtoimage
-          .toJpeg(imageRef.current, {
-            quality: 0.95,
-            width: 320,
-            height: 440,
-          })
-          .then(dataUrl => {
-            let link = document.createElement('a');
-            link.download = 'sticker-smash.jpeg';
-            link.href = dataUrl;
-            link.click();
-          })
-          .catch(e => {
-            console.log(e);
-          });
+      try {
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          quality: 0.95,
+          width: 320,
+          height: 440,
+        });
+
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 
@@ -134,7 +133,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   imageContainer: {
-    flex:1, 
+    flex: 1,
     paddingTop: 58
   },
   footerContainer: {

--- a/docs/public/static/examples/v48.0.0/tutorial/08-run-on-web/App.js
+++ b/docs/public/static/examples/v48.0.0/tutorial/08-run-on-web/App.js
@@ -32,7 +32,7 @@ export default function App() {
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
-      allowsEditing: true,      
+      allowsEditing: true,
       quality: 1,
     });
 
@@ -71,21 +71,20 @@ export default function App() {
         console.log(e);
       }
     } else {
-        domtoimage
-          .toJpeg(imageRef.current, {
-            quality: 0.95,
-            width: 320,
-            height: 440,
-          })
-          .then(dataUrl => {
-            let link = document.createElement('a');
-            link.download = 'sticker-smash.jpeg';
-            link.href = dataUrl;
-            link.click();
-          })
-          .catch(e => {
-            console.log(e);
-          });
+      try {
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          quality: 0.95,
+          width: 320,
+          height: 440,
+        });
+
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+      } catch (e) {
+        console.log(e);
+      }
     }
   };
 
@@ -134,7 +133,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   imageContainer: {
-    flex:1, 
+    flex: 1,
     paddingTop: 58
   },
   footerContainer: {


### PR DESCRIPTION
# Why

- Update `platform-differences.md` to follow the same code convention of using `try/catch` with `await`
- Update terminal command to use `npx expo install` instead of `npm install`
- Ran `prettier` for file changes
- screenshot of new changes
![platform-differences](https://user-images.githubusercontent.com/11466401/221499363-2bbe0c71-c2eb-4789-8f1f-fce0659589c3.png)


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
