### PR TITLE
Add condition to enable Flipper in EAS env

### DIFF
--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -25,7 +25,7 @@ prepare_react_native_project!
 # }
 # ```
 flipper_config = FlipperConfiguration.disabled
-if ENV['NO_FLIPPER'] == "1" || ENV['CI'] then
+if ENV['NO_FLIPPER'] == "1" || (ENV['CI'] && !ENV['EAS_BUILD']) then
   # Explicitly disabled through environment variables
   flipper_config = FlipperConfiguration.disabled
 elsif podfile_properties.key?('ios.flipper') then

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -25,7 +25,7 @@ prepare_react_native_project!
 # }
 # ```
 flipper_config = FlipperConfiguration.disabled
-if ENV['NO_FLIPPER'] == "1" || (ENV['CI'] && !ENV['EAS_BUILD']) then
+if ENV['NO_FLIPPER'] == '1' then
   # Explicitly disabled through environment variables
   flipper_config = FlipperConfiguration.disabled
 elsif podfile_properties.key?('ios.flipper') then


### PR DESCRIPTION
# Why

When building an app that includes Flipper using `expo-build-properties`, Flipper was not included because the generated Podfile from expo bare template checks if the build happens on a CI. If thats the case, it disables Flipper. The problem is that an EAS build is considered to be on a CI, as the `CI` env variable is set to 1.

The issue is described in #21441

# How

To fix this, we add an extra check to verify that, if the CI env variable is set, we are in the context of an EAS build or not.

# Test Plan

- Create an expo app
- Install `expo-build-properties` and configure it to enable Flipper
- Run `expo prebuild -p ios`
- Submit the build to EAS

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
