### PR TITLE
[linking] Add 3.3.1 release to changelog

### DIFF
--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -24,6 +24,12 @@ _This version does not introduce any user-facing changes._
 
 - Fix link in README that was incorrectly pointing to to expo-asset. ([#20616](https://github.com/expo/expo/pull/20616) by [@stereoplegic](https://github.com/stereoplegic))
 
+## 3.3.1 — 2023-02-27
+
+### 🐛 Bug fixes
+
+- Fixed crash when calling `Linking.removeEventListener` and added warning about `Linking.removeEventListener` being removed from react-native. ([#21371](https://github.com/expo/expo/pull/21371) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 3.2.3 — 2022-10-25
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

We release expo-linking@3.3.1 from the sdk-47 branch (https://github.com/expo/expo/commit/55a17ff7de9f5cdf674a6949b61745c4df10f832) and now we need to update the change log on main to include the version 3.3.1

# How

Manually update the expo-linking `CHANGELOG.md` file

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
