### PR TITLE
[tools] Fix publishing packages to NPM using OTP

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -82,6 +82,7 @@ export async function publishPackageAsync(
   }
   await spawnAsync('npm', args, {
     cwd: packageDir,
+    stdio: 'inherit',
   });
 }
 

--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -75,6 +75,12 @@ export async function publishPackageAsync(
   tagName: string = 'latest',
   dryRun: boolean = false
 ): Promise<void> {
+  // check if two factor auth is required for publishing
+  const npmProfile = await spawnJSONCommandAsync<{
+    tfa: { mode: string };
+  }>('npm', ['profile', 'get', '--json']);
+  const requiresOTP = npmProfile?.tfa?.mode === 'auth-and-writes';
+
   const args = ['publish', '--tag', tagName, '--access', 'public'];
 
   if (dryRun) {
@@ -82,7 +88,7 @@ export async function publishPackageAsync(
   }
   await spawnAsync('npm', args, {
     cwd: packageDir,
-    stdio: 'inherit',
+    stdio: requiresOTP ? 'inherit' : undefined,
   });
 }
 

--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import glob from 'glob-promise';
 
-import { spawnAsync, spawnJSONCommandAsync } from './Utils';
+import { spawnAsync, spawnJSONCommandAsync, SpawnOptions } from './Utils';
 
 export const EXPO_DEVELOPERS_TEAM_NAME = 'expo:developers';
 
@@ -29,6 +29,16 @@ export type PackageViewType = null | {
   [key: string]: unknown;
 };
 
+export type ProfileType = null | {
+  name: string;
+  email: string;
+  tfa: {
+    pending: boolean;
+    mode: string;
+  };
+  [key: string]: unknown;
+};
+
 /**
  * Runs `npm view` for package with given name. Returns null if package is not published yet.
  */
@@ -42,6 +52,17 @@ export async function getPackageViewAsync(
       version ? `${packageName}@${version}` : packageName,
       '--json',
     ]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Runs `npm profile get`. Returns null if user is not authenticated.
+ */
+export async function getProfileAsync(): Promise<ProfileType> {
+  try {
+    return await spawnJSONCommandAsync('npm', ['profile', 'get', '--json']);
   } catch {
     return null;
   }
@@ -73,14 +94,9 @@ export async function downloadPackageTarballAsync(
 export async function publishPackageAsync(
   packageDir: string,
   tagName: string = 'latest',
-  dryRun: boolean = false
+  dryRun: boolean = false,
+  spawnOptions: SpawnOptions = {}
 ): Promise<void> {
-  // check if two factor auth is required for publishing
-  const npmProfile = await spawnJSONCommandAsync<{
-    tfa: { mode: string };
-  }>('npm', ['profile', 'get', '--json']);
-  const requiresOTP = npmProfile?.tfa?.mode === 'auth-and-writes';
-
   const args = ['publish', '--tag', tagName, '--access', 'public'];
 
   if (dryRun) {
@@ -88,7 +104,7 @@ export async function publishPackageAsync(
   }
   await spawnAsync('npm', args, {
     cwd: packageDir,
-    stdio: requiresOTP ? 'inherit' : undefined,
+    ...spawnOptions,
   });
 }
 

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -24,6 +24,10 @@ export const publishPackages = new Task<TaskArgs>(
 
     const gitHead = await Git.getHeadCommitHashAsync();
 
+    // check if two factor auth is required for publishing
+    const npmProfile = await Npm.getProfileAsync();
+    const requiresOTP = npmProfile?.tfa?.mode === 'auth-and-writes';
+
     for (const { pkg, state } of parcels) {
       const packageJsonPath = path.join(pkg.path, 'package.json');
 
@@ -37,7 +41,9 @@ export const publishPackages = new Task<TaskArgs>(
       await JsonFile.setAsync(packageJsonPath, 'gitHead', gitHead);
 
       // Publish the package.
-      await Npm.publishPackageAsync(pkg.path, options.tag, options.dry);
+      await Npm.publishPackageAsync(pkg.path, options.tag, options.dry, {
+        stdio: requiresOTP ? 'inherit' : undefined,
+      });
 
       // Delete `gitHead` from `package.json` – no need to clutter it.
       await JsonFile.deleteKeyAsync(packageJsonPath, 'gitHead');


### PR DESCRIPTION
# Why

When you have set up a security key for your NPM account and attempt to publish a package, an OTP (One-Time Password) code is required to be entered. However, if you use the `et publish` command, the process fails immediately without allowing you to input the OTP code. This is because the user does not have direct access to the child process input.

![image](https://user-images.githubusercontent.com/11707729/221936211-8053d612-2c64-4568-9dcb-292b8df0d158.png)


# How

This PR updates the `publishPackageAsync` function to use the `stdio: 'inherit'` parameter so the user is able to interact with the `npm` command and input the OTP code

# Test Plan

run `et publish`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
