### PR TITLE
[docs] PageTitle: adjust DOM for Algolia crawler

### DIFF
--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -11,10 +11,10 @@ type Props = {
 };
 
 export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props) => (
-  <H1>
+  <H1 crawlable={false}>
     {iconUrl && <img src={iconUrl} css={titleIconStyle} alt={`Expo ${title} icon`} />}
     {packageName && packageName.startsWith('expo-') && 'Expo '}
-    {title}
+    <span data-heading="true">{title}</span>
     {packageName && (
       <span css={linksContainerStyle}>
         {sourceCodeUrl && (

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -52,7 +52,7 @@ export const createPermalinkedComponent = (
 
 export function createTextComponent(Element: TextElement, textStyle?: SerializedStyles) {
   function TextComponent(props: TextComponentProps) {
-    const { testID, tag, weight: textWeight, theme: textTheme, ...rest } = props;
+    const { testID, tag, weight: textWeight, theme: textTheme, crawlable = true, ...rest } = props;
     const TextElementTag = tag ?? Element;
 
     return (
@@ -64,8 +64,8 @@ export function createTextComponent(Element: TextElement, textStyle?: Serialized
           textTheme && { color: theme.text[textTheme] },
         ]}
         data-testid={testID}
-        data-heading={CRAWLABLE_HEADINGS.includes(TextElementTag) || undefined}
-        data-text={CRAWLABLE_TEXT.includes(TextElementTag) || undefined}
+        data-heading={(crawlable && CRAWLABLE_HEADINGS.includes(TextElementTag)) || undefined}
+        data-text={(crawlable && CRAWLABLE_TEXT.includes(TextElementTag)) || undefined}
         {...rest}
       />
     );

--- a/docs/ui/components/Text/types.ts
+++ b/docs/ui/components/Text/types.ts
@@ -29,4 +29,5 @@ export type TextComponentProps = HTMLAttributes<
   weight?: TextWeight;
   theme?: TextTheme;
   tag?: `${TextElement}`;
+  crawlable?: boolean;
 };


### PR DESCRIPTION
# Why

Updates the structure and props on the new `PageTile` component to generate better results for Algolia crawler.

# How

Allow to make header non-crawlable, mark only page title as a heading for extraction. 

# Test Plan

DOM looks correct locally, but deploy and recrawl will fully verify this.
