### PR TITLE
[cli][dev-menu][go] add react devtools

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -562,6 +562,22 @@ abstract class ReactNativeActivity :
     }
   }
 
+  /**
+   * Emits events to `RCTNativeAppEventEmitter`
+   */
+  fun emitRCTNativeAppEvent(eventName: String, eventArgs: Map<String, String>?) {
+    try {
+      val nativeAppEventEmitter =
+        RNObject("com.facebook.react.modules.core.RCTNativeAppEventEmitter")
+      nativeAppEventEmitter.loadVersion(detachSdkVersion!!)
+      val emitter = reactInstanceManager.callRecursive("getCurrentReactContext")!!
+        .callRecursive("getJSModule", nativeAppEventEmitter.rnClass())
+      emitter?.call("emit", eventName, eventArgs)
+    } catch (e: Throwable) {
+      EXL.e(TAG, e)
+    }
+  }
+
   // for getting global permission
   override fun checkSelfPermission(permission: String): Int {
     return super.checkPermission(permission, Process.myPid(), Process.myUid())

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -144,6 +144,18 @@ object VersionedUtils {
     }
   }
 
+  private fun reconnectReactDevTools() {
+    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
+      FLog.e(
+        ReactConstants.TAG,
+        "Unable to get the current activity."
+      )
+    }
+    // Emit the `RCTDevMenuShown` for the app to reconnect react-devtools
+    // https://github.com/facebook/react-native/blob/22ba1e45c52edcc345552339c238c1f5ef6dfc65/Libraries/Core/setUpReactDevTools.js#L80
+    currentActivity.emitRCTNativeAppEvent("RCTDevMenuShown", null)
+  }
+
   private fun createPackagerCommandHelpers(): Map<String, RequestHandler> {
     // Attach listeners to the bundler's dev server web socket connection.
     // This enables tools to automatically reload the client remotely (i.e. in expo-cli).
@@ -163,6 +175,7 @@ object VersionedUtils {
             }
             "toggleElementInspector" -> toggleElementInspector()
             "togglePerformanceMonitor" -> togglePerformanceMonitor()
+            "reconnectReactDevTools" -> reconnectReactDevTools()
           }
         }
       }

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -510,6 +510,15 @@
   }
 }
 
+- (void)reconnectReactDevTools
+{
+  if ([self enablesDeveloperTools]) {
+    // Emit the `RCTDevMenuShown` for the app to reconnect react-devtools
+    // https://github.com/facebook/react-native/blob/22ba1e45c52edcc345552339c238c1f5ef6dfc65/Libraries/Core/setUpReactDevTools.js#L80
+    [self.reactBridge enqueueJSCall:@"RCTNativeAppEventEmitter.emit" args:@[@"RCTDevMenuShown"]];
+  }
+}
+
 - (void)toggleDevMenu
 {
   if ([EXEnvironment sharedEnvironment].isDetached) {
@@ -544,6 +553,8 @@
               [weakSelf toggleElementInspector];
             } else if ([name isEqualToString:@"togglePerformanceMonitor"]) {
               [weakSelf togglePerformanceMonitor];
+            } else if ([name isEqualToString:@"reconnectReactDevTools"]) {
+              [weakSelf reconnectReactDevTools];
             }
           }
         }

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add support for `compilerOptions.paths` aliases from `tsconfig.json` and `jsconfig.json` files to Metro. ([#21262](https://github.com/expo/expo/pull/21262) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce install prompt. ([#21264](https://github.com/expo/expo/pull/21264) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve multi-target iOS scheme resolution for `expo run:ios`. ([#21240](https://github.com/expo/expo/pull/21240) by [@EvanBacon](https://github.com/EvanBacon))
+- Added experimental react-devtools integration. ([#21462](https://github.com/expo/expo/pull/21462) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -95,7 +95,8 @@
     "terminal-link": "^2.1.1",
     "text-table": "^0.2.0",
     "url-join": "4.0.0",
-    "wrap-ansi": "^7.0.0"
+    "wrap-ansi": "^7.0.0",
+    "ws": "^8.12.1"
   },
   "taskr": {
     "requires": [

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -446,6 +446,13 @@ export abstract class BundlerDevServer {
     );
   }
 
+  public getReactDevToolsUrl(): string {
+    return new URL(
+      '_expo/react-devtools',
+      this.getUrlCreator().constructUrl({ scheme: 'http' })
+    ).toString();
+  }
+
   protected async getPlatformManagerAsync(platform: keyof typeof PLATFORM_MANAGERS) {
     if (!this.platformManagers[platform]) {
       const Manager = PLATFORM_MANAGERS[platform]();

--- a/packages/@expo/cli/src/start/server/ReactDevToolsProxy.ts
+++ b/packages/@expo/cli/src/start/server/ReactDevToolsProxy.ts
@@ -1,0 +1,77 @@
+import assert from 'assert';
+import { EventEmitter } from 'events';
+import WebSocket from 'ws';
+
+let serverInstance: WebSocket.WebSocketServer | null = null;
+
+const eventEmitter = new EventEmitter();
+
+/**
+ * Private command to support DevTools frontend reload.
+ *
+ * The react-devtools maintains state between frontend(webpage) and backend(app).
+ * If we reload the frontend without reloading the app, the react-devtools will stuck on incorrect state.
+ * We introduce this special reload command.
+ * As long as the frontend reload, we will close app's WebSocket connection and tell app to reconnect again.
+ */
+const RELOAD_COMMAND = 'Expo::RELOAD';
+
+/**
+ * Start the react-devtools WebSocket proxy server
+ */
+export async function startReactDevToolsProxyAsync(options?: { port: number }) {
+  if (serverInstance != null) {
+    return;
+  }
+
+  serverInstance = new WebSocket.WebSocketServer({ port: options?.port ?? 8097 });
+
+  serverInstance.on('connection', function connection(ws) {
+    ws.on('message', function message(rawData, isBinary) {
+      assert(!isBinary);
+      const data = rawData.toString();
+
+      if (data === RELOAD_COMMAND) {
+        closeAllOtherClients(ws);
+        eventEmitter.emit(RELOAD_COMMAND);
+        return;
+      }
+
+      serverInstance?.clients.forEach(function each(client) {
+        if (client !== ws && client.readyState === WebSocket.OPEN) {
+          client.send(data, { binary: isBinary });
+        }
+      });
+    });
+  });
+
+  serverInstance.on('close', function () {
+    serverInstance = null;
+  });
+}
+
+/**
+ * Close the WebSocket server
+ */
+export function closeReactDevToolsProxy() {
+  serverInstance?.close();
+  serverInstance = null;
+}
+
+/**
+ * add event listener from react-devtools frontend reload
+ */
+export function addReactDevToolsReloadListener(listener: (...args: any[]) => void) {
+  eventEmitter.addListener(RELOAD_COMMAND, listener);
+}
+
+/**
+ * Close all other WebSocket clients other than the current `self` client
+ */
+function closeAllOtherClients(self: WebSocket.WebSocket) {
+  serverInstance?.clients.forEach(function each(client) {
+    if (client !== self && client.readyState === WebSocket.OPEN) {
+      client.close();
+    }
+  });
+}

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -8,6 +8,7 @@ import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../Bun
 import { CreateFileMiddleware } from '../middleware/CreateFileMiddleware';
 import { HistoryFallbackMiddleware } from '../middleware/HistoryFallbackMiddleware';
 import { InterstitialPageMiddleware } from '../middleware/InterstitialPageMiddleware';
+import { ReactDevToolsPageMiddleware } from '../middleware/ReactDevToolsPageMiddleware';
 import {
   DeepLinkHandler,
   RuntimeRedirectMiddleware,
@@ -77,6 +78,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         scheme: options.location.scheme ?? null,
       }).getHandler()
     );
+    middleware.use(new ReactDevToolsPageMiddleware(this.projectRoot).getHandler());
 
     const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {
       onDeepLink: getDeepLinkHandler(this.projectRoot),

--- a/packages/@expo/cli/src/start/server/middleware/ReactDevToolsPageMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ReactDevToolsPageMiddleware.ts
@@ -1,0 +1,26 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+import { ExpoMiddleware } from './ExpoMiddleware';
+import { ServerRequest, ServerResponse } from './server.types';
+
+export const ReactDevToolsEndpoint = '/_expo/react-devtools';
+
+export class ReactDevToolsPageMiddleware extends ExpoMiddleware {
+  constructor(projectRoot: string) {
+    super(projectRoot, [ReactDevToolsEndpoint]);
+  }
+
+  async handleRequestAsync(req: ServerRequest, res: ServerResponse): Promise<void> {
+    const templatePath =
+      // Production: This will resolve when installed in the project.
+      resolveFrom.silent(this.projectRoot, 'expo/static/react-devtools-page/index.html') ??
+      // Development: This will resolve when testing locally.
+      path.resolve(__dirname, '../../../../../static/react-devtools-page/index.html');
+    const content = (await readFile(templatePath)).toString('utf-8');
+
+    res.setHeader('Content-Type', 'text/html');
+    res.end(content);
+  }
+}

--- a/packages/@expo/cli/static/react-devtools-page/index.html
+++ b/packages/@expo/cli/static/react-devtools-page/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>React DevTools</title>
+  <style>
+    html,
+    body {
+      width: 100vw;
+      height: 100vh;
+      padding: 0;
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+        Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    #hint {
+      margin: 1em;
+      font-size: 16px;
+    }
+
+    #root {
+      width: 100%;
+      height: 100%;
+    }
+
+  </style>
+</head>
+
+<body>
+  <noscript>
+    You need to enable JavaScript to run this app.
+  </noscript>
+  <div id="hint">Conntecting to ReactDevToolsProxy...</div>
+  <div id="root"></div>
+  <!--
+    JSPM Generator Import Map
+    Edit URL: https://generator.jspm.io/#U2NgYGBkDM0rySzJSU1hKEpNTC7RTUktK8nPzynWTc4vSnUw0TMy1zPSLy5JzEtJzMnPSwUAiUm0+zQA
+  -->
+  <script type="importmap">
+      {
+        "imports": {
+          "react-devtools-core/standalone": "https://ga.jspm.io/npm:react-devtools-core@4.27.2/standalone.js"
+        },
+        "scopes": {
+          "https://ga.jspm.io/": {
+            "buffer": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/buffer.js",
+            "child_process": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/child_process.js",
+            "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/crypto.js",
+            "events": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/events.js",
+            "fs": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/fs.js",
+            "http": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/http.js",
+            "https": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/https.js",
+            "net": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/net.js",
+            "path": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/path.js",
+            "process": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/process-production.js",
+            "stream": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/stream.js",
+            "tls": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/tls.js",
+            "url": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/url.js",
+            "util": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/util.js",
+            "vm": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/vm.js",
+            "zlib": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/zlib.js"
+          }
+        }
+      }
+    </script>
+
+  <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
+  <script async src="https://ga.jspm.io/npm:es-module-shims@1.5.1/dist/es-module-shims.js"
+    crossorigin="anonymous"></script>
+
+  <script type="module">
+    import { default as DevToolsUIWrapper } from "react-devtools-core/standalone";
+    const DevTools = DevToolsUIWrapper.default;
+
+    /**
+     * Private command to support DevTools frontend reload
+     */
+    const RELOAD_COMMAND = 'Expo::RELOAD';
+
+    function connectAsync(url) {
+      return new Promise((resolve, reject) => {
+        const ws = new WebSocket(url);
+
+        ws.addEventListener("open", () => {
+          resolve(ws);
+        });
+
+        ws.addEventListener("close", (e) => {
+          reject(e);
+        });
+
+        ws.addEventListener("error", (e) => {
+          reject(e);
+        });
+      });
+    }
+
+    async function delayAsync(timeMs) {
+      return new Promise((resolve) => setTimeout(resolve, timeMs));
+    }
+
+    async function connectAsyncWithRetries(url) {
+      while (true) {
+        try {
+          const ws = await connectAsync(url);
+          document.getElementById("hint").style.display = "none";
+          return ws;
+        } catch {
+          document.getElementById("hint").style.display = "block";
+          await delayAsync(5000);
+        }
+      }
+    }
+
+    async function main() {
+      const ws = await connectAsyncWithRetries("ws://localhost:8097");
+
+      ws.addEventListener("close", () => {
+        document.getElementById("hint").style.display = "block";
+        main();
+      });
+      DevTools.setContentDOMNode(document.getElementById("root"));
+      ws.send(RELOAD_COMMAND);
+      DevTools.connectToSocket(ws);
+    }
+
+    main();
+  </script>
+</body>
+
+</html>

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added experimental react-devtools integration. ([#21462](https://github.com/expo/expo/pull/21462) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/websockets/DevMenuCommandHandlersProvider.kt
@@ -3,6 +3,7 @@ package expo.modules.devmenu.websockets
 import android.util.Log
 import com.facebook.react.ReactInstanceManager
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.modules.core.RCTNativeAppEventEmitter
 import com.facebook.react.packagerconnection.NotificationOnlyHandler
 import expo.interfaces.devmenu.DevMenuManagerInterface
 import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
@@ -54,6 +55,11 @@ class DevMenuCommandHandlersProvider(
             devDelegate.togglePerformanceMonitor(activity)
           }
           "openJSInspector" -> devDelegate.openJSInspector()
+          "reconnectReactDevTools" -> {
+            // Emit the `RCTDevMenuShown` for the app to reconnect react-devtools
+            // https://github.com/facebook/react-native/blob/22ba1e45c52edcc345552339c238c1f5ef6dfc65/Libraries/Core/setUpReactDevTools.js#L80
+            instanceManager.currentReactContext?.getJSModule(RCTNativeAppEventEmitter::class.java)?.emit("RCTDevMenuShown", null)
+          }
           else -> Log.w("DevMenu", "Unknown command: $command")
         }
       }

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -53,6 +53,10 @@ class DevMenuPackagerConnectionHandler {
       devDelegate.toggleElementInsector()
     case "togglePerformanceMonitor":
       devDelegate.togglePerformanceMonitor()
+    case "reconnectReactDevTools":
+      // Emit the `RCTDevMenuShown` for the app to reconnect react-devtools
+      // https://github.com/facebook/react-native/blob/22ba1e45c52edcc345552339c238c1f5ef6dfc65/Libraries/Core/setUpReactDevTools.js#L80
+      bridge.enqueueJSCall("RCTNativeAppEventEmitter.emit", args: ["RCTDevMenuShown"])
     default:
       NSLog("Unknown command from packager: %@", command)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19551,10 +19551,10 @@ write-file-atomic@^4.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@>=7.4.6, ws@^8.11.0, ws@^8.3.0:
-  version "8.12.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.0.tgz#485074cc392689da78e1828a9ff23585e06cddd8"
-  integrity sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==
+ws@>=7.4.6, ws@^8.11.0, ws@^8.12.1, ws@^8.3.0:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 "ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7, ws@^7.0.0, ws@^7.5.1:
   version "7.5.7"
@@ -19567,11 +19567,6 @@ ws@^6.1.0, ws@^6.2.1, ws@^6.2.2:
   integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
-
-ws@^8.12.1:
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
-  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 xcode@^3.0.0, xcode@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19568,6 +19568,11 @@ ws@^6.1.0, ws@^6.2.1, ws@^6.2.2:
   dependencies:
     async-limiter "~1.0.0"
 
+ws@^8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
+
 xcode@^3.0.0, xcode@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/xcode/-/xcode-3.0.1.tgz#3efb62aac641ab2c702458f9a0302696146aa53c"


### PR DESCRIPTION
# Why

close ENG-7468
close ENG-7469

https://user-images.githubusercontent.com/46429/222129394-8c914e42-5264-432a-bdb1-00664c231114.mov



# How

- [cli] add websocket proxy to forward react-devtools events.
- [cli] add static page for react-devtools frontend. since react-devtools only ships commonjs format, this pr tries to use jspm to support it on browsers.
- [dev-menu][go] listen `reconnectDevTools` metro websocket event and send `RCTDevMenuShown` to js for app to reconnect devtools websocket

# Test Plan

manual test only. please let me know if there's any proper points to add unit tests

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
