### PR TITLE
Document --example flag

### DIFF
--- a/docs/pages/get-started/create-a-new-app.mdx
+++ b/docs/pages/get-started/create-a-new-app.mdx
@@ -31,6 +31,8 @@ To initialize a new project, use [`create-expo-app`](/workflow/glossary-of-terms
 
 > **info** You can also use the `--template` option with the `create-expo-app` command. Run `npx create-expo-app --template` to see the list of available templates.
 
+> **info** You can also use the `--example` option with the `create-expo-app` command to scaffold your project based on an example from [the Examples repo](https://github.com/expo/examples/).
+
 ## Starting the development server
 
 Start the development server by running the following command:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `--example` flag for `create-expo-app` is undocumented.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I added a section to document the `--example` flag on the [Create a new app](https://docs.expo.dev/get-started/create-a-new-app/) docs page

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Check whether the documentation makes sense like this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# Related

Companion PR in the Expo Examples repo:

- https://github.com/expo/examples/pull/411

# Caveats

The `create-expo-app` CLI still does not have the documentation for the `--example` flag when showing the help via the `--help` flag:

```
$ npx create-expo-app --help
Usage: create-expo-app <path> [options]

Creates a new Expo project

Options:
  -V, --version         output the version number
  -y, --yes             Use the default options for creating a project
  --no-install          Skip installing npm packages or CocoaPods.
  -t, --template [pkg]  NPM template to use: blank, tabs, bare-minimum. Default: blank
  -h, --help            output usage information

  The package manager used for installing
  node modules is based on how you invoke the CLI:

   npm: npm create expo-app
  yarn: yarn create expo-app
  pnpm: pnpm create expo-app
```

There should probably be another PR done for this, maybe here cc @EvanBacon 

https://github.com/expo/expo/blob/5709b55bf2aa838dbd49fa5411a61fad679afd90/packages/%40expo/cli/src/prebuild/index.ts#L28-L45