### PR TITLE
chore(prebuild-config): drop todo related to Expo config spec

### DIFF
--- a/packages/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/getAndroidSplashConfig.ts
+++ b/packages/@expo/prebuild-config/src/plugins/unversioned/expo-splash-screen/getAndroidSplashConfig.ts
@@ -46,7 +46,6 @@ export function getAndroidSplashConfig(
   return null;
 }
 
-// TODO: dark isn't supported in the Expo config spec yet.
 export function getAndroidDarkSplashConfig(
   config: Pick<ExpoConfig, 'splash' | 'android'>
 ): SplashScreenConfig | null {


### PR DESCRIPTION
# Why

Part of ENG-6837

Minor change, but good to keep code up to date.

# How

Removed the comment

# Test Plan

Docs change only 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
