### PR TITLE
refactor(cli): move auto-ts install out of pr #20883

### DIFF
--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config';
+import chalk from 'chalk';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -17,12 +18,10 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
   /** Ensure a project that hasn't explicitly disabled web support has all the required packages for running in the browser. */
   async assertImplementation(): Promise<void> {
     if (env.EXPO_NO_TYPESCRIPT_SETUP) {
-      Log.warn('Skipping TypeScript setup: EXPO_NO_TYPESCRIPT_SETUP is enabled.');
-      return;
+      return Log.warn('Skipping TypeScript setup: EXPO_NO_TYPESCRIPT_SETUP is enabled.');
     }
-    debug('Ensuring TypeScript support is setup');
 
-    const tsConfigPath = path.join(this.projectRoot, 'tsconfig.json');
+    debug('Ensuring TypeScript support is setup');
 
     // Ensure the project is TypeScript before continuing.
     const intent = await this._getSetupRequirements();
@@ -34,7 +33,10 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
     await this._ensureDependenciesInstalledAsync();
 
     // Update the config
-    await updateTSConfigAsync({ tsConfigPath, isBootstrapping: intent.isBootstrapping });
+    await updateTSConfigAsync({
+      tsConfigPath: path.join(this.projectRoot, 'tsconfig.json'),
+      isBootstrapping: intent.isBootstrapping,
+    });
   }
 
   /** Exposed for testing. */
@@ -70,8 +72,8 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite {
       return await ensureDependenciesAsync(this.projectRoot, {
         exp,
         installMessage: `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`,
-        warningMessage:
-          "If you're not using TypeScript, please remove the TypeScript files from your project",
+        warningMessage: `If you're not using TypeScript, remove the TypeScript files from your project.`,
+        disableMessage: chalk`You can disable this setup with {bold EXPO_NO_TYPESCRIPT_SETUP}.`,
         requiredPackages: [
           // use typescript/package.json to skip node module cache issues when the user installs
           // the package and attempts to resolve the module in the same process.


### PR DESCRIPTION
# Why

Fixes ENG-7289

# How

- Pulled the updated code from #20883

# Test Plan

## With yarn

- `$ yarn create expo-app ./test-ts`
- `$ cd ./test-ts`
- `$ mv App.js App.tsx`
- `$ expod start`

<details><summary>This should show something like this screenshot</summary>

![image](https://user-images.githubusercontent.com/1203991/222198992-cebe95bf-4cbd-4663-b32b-899372a53839.png)

</details>

## With pnpm

- `$ pnpm create expo-app ./test-ts-pnpm`
- `$ cd ./test-ts-pnpm`
- `$ pnpm config --location project set node-linker hoisted`
- `$ pnpm install`
- `$ mv App.js App.tsx`
- `$ expod start`

## With npm

- `$ npm create expo-app ./test-ts-npm`
- `$ cd ./test-ts-npm`
- `$ mv App.js App.tsx`
- `expod start`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
