### PR TITLE
[core][ios] Fix jsc import when using use_frameworks

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed jsc import when using use_frameworks
+
 ### 💡 Others
 
 ## 1.2.3 - 2023-02-21

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed jsc import when using use_frameworks
+- [iOS] Fixed jsc import when using use_frameworks ([#21479](https://github.com/expo/expo/pull/21479) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -7,6 +7,9 @@
 #elif __has_include(<React-jsc/JSCRuntime.h>)
 // react-native@>=0.71 has a specific React-jsc pod
 #import <React-jsc/JSCRuntime.h>
+// use_frameworks! transforms the dash to underscore
+#elif __has_include(<React_jsc/JSCRuntime.h>)
+#import <React_jsc/JSCRuntime.h>
 #else
 #import <jsi/JSCRuntime.h>
 #endif
@@ -176,7 +179,7 @@ static NSString *mainObjectPropertyName = @"expo";
     }];
   } catch (jsi::JSIException &error) {
     NSString *reason = [NSString stringWithUTF8String:error.what()];
-    
+
     @throw [NSException exceptionWithName:@"ScriptEvaluationException" reason:reason userInfo:@{
       @"message": reason
     }];


### PR DESCRIPTION
# Why

iOS projects using `use_frameworks!` along with JSC are broken on SDK 48

Closes https://github.com/expo/expo/issues/21461


# How

This PR adds an additional import check for `<React_jsc/JSCRuntime.h>` inside `EXJavaScriptRuntime.mm` as when in framework mode dashes are replaced with underscores.

# Test Plan

Update bare-expo `Podfile.properties.json` to

```
{
  "expo.jsEngine": "jsc",
  "ios.useFrameworks": "static"
}
```

and build the app 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
