### PR TITLE
[docs] fix typo on expo modules api documentation

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -222,7 +222,7 @@ Property("foo") {
 In the case of the mutable property, both the getter and the setter closure are needed (using the syntax below is also possible to declare a property with only a setter):
 
 - **name**: `String` — Name of the property that you'll use from JavaScript.
-- **getter**: `() -> ProperyType` — The closure to run when the getter for a property was called.
+- **getter**: `() -> PropertyType` — The closure to run when the getter for a property was called.
 - **setter**: `(newValue: PropertyType) -> void` — The closure to run when the setter for a property was called.
 
 <CodeBlocksTable>


### PR DESCRIPTION
# Why

To keep the docs consistent and grammatically correct

# How

I spelled the word Property correctly, because it was spelled wrong

# Test Plan

N/A

# Checklist


- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
