### PR TITLE
[dev-launcher] emits Expo(Network.receivedResponseBody) event

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherOkHttpInterceptor.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherOkHttpInterceptor.kt
@@ -12,6 +12,7 @@ class DevLauncherOkHttpInterceptor : Interceptor {
       DevLauncherNetworkLogger.instance.emitNetworkWillBeSent(request, requestId)
       val response = chain.proceed(request)
       DevLauncherNetworkLogger.instance.emitNetworkResponse(request, requestId, response)
+      DevLauncherNetworkLogger.instance.emitNetworkDidReceiveBody(requestId, response)
       return response
     }
     return chain.proceed(request)

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -102,6 +102,29 @@ public class EXDevLauncherNetworkLogger: NSObject {
       inspectorPackagerConn?.sendWrappedEventToAllPages(message)
     }
   }
+
+  /**
+   Emits our custom `Expo(Network.receivedResponseBody)` event
+   */
+  func emitNetworkDidReceiveBody(requestId: String, responseBody: Data, isText: Bool) {
+    let bodyString = isText
+      ? String(data: responseBody, encoding: .utf8)
+      : responseBody.base64EncodedString()
+    let params = [
+      "requestId": requestId,
+      "body": bodyString,
+      "base64Encoded": !isText
+    ] as [String: Any]
+    if let data = try? JSONSerialization.data(
+      withJSONObject: [
+        "method": "Expo(Network.receivedResponseBody)",
+        "params": params
+      ],
+      options: []
+    ), let message = String(data: data, encoding: .utf8) {
+      inspectorPackagerConn?.sendWrappedEventToAllPages(message)
+    }
+  }
 }
 
 extension URLSessionConfiguration {

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -199,6 +199,9 @@ public class EXDevLauncherNetworkLogger: NSObject {
 
   func emitNetworkResponse(request: URLRequest, requestId: String, response: HTTPURLResponse) {
   }
+
+  func emitNetworkDidReceiveBody(requestId: String, responseBody: Data, isText: Bool) {
+  }
 }
 
 #endif


### PR DESCRIPTION
# Why

send to network response body for #21449

# How

send network response body `Expo(Network.receivedResponseBody)` event

# Test Plan

based on #21449 to check the network response

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no new user faced change
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
