### PR TITLE
[ios][local-authentication] Fix incorrect nil check

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- On iOS, fix incorrect nil check when checking for `NSFaceIDUsageDescription` in the Info.plist.
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
-- On iOS, fix incorrect nil check when checking for `NSFaceIDUsageDescription` in the Info.plist.
+
+- On iOS, fix incorrect nil check when checking for `NSFaceIDUsageDescription` in the Info.plist. ([#21500](https://github.com/expo/expo/pull/21500) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
+++ b/packages/expo-local-authentication/ios/LocalAuthenticationModule.swift
@@ -58,7 +58,7 @@ public class LocalAuthenticationModule: Module {
     }
 
     AsyncFunction("authenticateAsync") { (options: LocalAuthenticationOptions, promise: Promise) -> Void in
-      var warningMessage: NSString?
+      var warningMessage: String?
       var reason = options.promptMessage
       var cancelLabel = options.cancelLabel
       var fallbackLabel = options.fallbackLabel
@@ -67,7 +67,7 @@ public class LocalAuthenticationModule: Module {
       if isFaceIdDevice() {
         let usageDescription = Bundle.main.object(forInfoDictionaryKey: "NSFaceIDUsageDescription")
 
-        if usageDescription != nil {
+        if usageDescription == nil {
           warningMessage = "FaceID is available but has not been configured. To enable FaceID, provide `NSFaceIDUsageDescription`."
         }
       }
@@ -84,7 +84,7 @@ public class LocalAuthenticationModule: Module {
 
       context.interactionNotAllowed = false
 
-      let policyForAuth: LAPolicy = disableDeviceFallback ? LAPolicy.deviceOwnerAuthenticationWithBiometrics : LAPolicy.deviceOwnerAuthentication
+      let policyForAuth = disableDeviceFallback ? LAPolicy.deviceOwnerAuthenticationWithBiometrics : LAPolicy.deviceOwnerAuthentication
 
       if disableDeviceFallback {
         if warningMessage != nil {


### PR DESCRIPTION
# Why
Closes #21496

# How
Reverse the nil check on `usageDescription` in `authenticateAsync`

# Test Plan
Tested in bare expo using a provided example
