### PR TITLE
[docs] expo-image is availabe with Expo SDK 48

### DIFF
--- a/docs/pages/versions/v48.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/image.mdx
@@ -42,7 +42,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 ## Installation
 
 > **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/) and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
-> It is available in Expo Go and Snack with Expo SDK 48.
+> It is available in Expo Go with Expo SDK 48 and not available with Snack yet.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v48.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/image.mdx
@@ -42,7 +42,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 ## Installation
 
 > **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/) and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
-> It is not available in Expo Go and Snack yet.
+> It is available in Expo Go and Snack with Expo SDK 48.
 
 <APIInstallSection />
 


### PR DESCRIPTION
# Why

officially roll out `expo-images` to the world.

# How

Following the instructions here https://blog.expo.dev/expo-sdk-48-ccb8302e231

# Test Plan

Here is a snack
https://snack.expo.dev/@flexbox/paranoid-pastry

here is another link to a random project
https://github.com/flexbox/react-native-bootcamp/pull/175

@dannyhw knows that it's working. 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
