### PR TITLE
[tools] Update check-packages to check for bundle files

### DIFF
--- a/tools/src/check-packages/checkPackageAsync.ts
+++ b/tools/src/check-packages/checkPackageAsync.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import logger from '../Logger';
 import { Package } from '../Packages';
-import checkBuildUniformityAsync from './checkBuildUniformityAsync';
+import checkUniformityAsync from './checkUniformityAsync';
 import runPackageScriptAsync from './runPackageScriptAsync';
 import { ActionOptions } from './types';
 
@@ -26,9 +26,15 @@ export default async function checkPackageAsync(
     if (options.build) {
       await runPackageScriptAsync(pkg, 'clean', args);
       await runPackageScriptAsync(pkg, 'build', args);
+      if (pkg.scripts.bundle) {
+        await runPackageScriptAsync(pkg, 'bundle', args);
+      }
 
       if (options.uniformityCheck) {
-        await checkBuildUniformityAsync(pkg);
+        await checkUniformityAsync(pkg, './build');
+        if (pkg.scripts.bundle) {
+          await checkUniformityAsync(pkg, '*bundle');
+        }
       }
     }
     if (options.test) {

--- a/tools/src/check-packages/checkUniformityAsync.ts
+++ b/tools/src/check-packages/checkUniformityAsync.ts
@@ -6,25 +6,24 @@ import { Package } from '../Packages';
 import { spawnAsync } from '../Utils';
 
 /**
- * Checks whether the state of build files is the same after running build script.
+ * Checks whether the state of files is the same after running a script.
  * @param pkg Package to check
+ * @param match Path or pattern of the files to match
  */
-export default async function checkBuildUniformityAsync(pkg: Package): Promise<void> {
-  const child = await spawnAsync('git', ['status', '--porcelain', './build'], {
+export default async function checkUniformityAsync(pkg: Package, match: string): Promise<void> {
+  const child = await spawnAsync('git', ['status', '--porcelain', match], {
     stdio: 'pipe',
     cwd: pkg.path,
   });
   const lines = child.stdout ? child.stdout.trim().split(/\r\n?|\n/g) : [];
 
   if (lines.length > 0) {
-    logger.error(`The following build files need to be rebuilt and committed:`);
+    logger.error(`The following files need to be rebuilt and committed:`);
     lines.map((line) => {
       const filePath = path.join(EXPO_DIR, line.replace(/^\s*\S+\s*/g, ''));
       logger.warn(path.relative(pkg.path, filePath));
     });
 
-    throw new Error(
-      `The build folder for ${pkg.packageName} has uncommitted changes after building.`
-    );
+    throw new Error(`${pkg.packageName} has uncommitted changes after building.`);
   }
 }


### PR DESCRIPTION
# Why

This PR is intended to prevent outdated JS bundles in `expo-dev-launcher` releases as happened on v2.1.4. Currently, there is no check to ensure that the bundles are up to date and we only check for the build folder. 

# How

This updates the `checkBuildUniformityAsync` function to be a bit more generic and accept an arbitrary path or pattern of the files to match, which can be used for both build folders and bundles.

# Test Plan

Modify some TS file inside `expo-dev-launcher, run `et check-packages -a` or `et check-packages expo-dev-laucher`

![image](https://user-images.githubusercontent.com/11707729/222804038-419ad5ec-5f6d-4dd1-8eb4-7f756a3f5434.png)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
