### PR TITLE
[expo-updates] E2E tests: graceful Detox failures

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Start converting to Swift. ([#21320](https://github.com/expo/expo/pull/21320), [#21329](https://github.com/expo/expo/pull/21329), [#21332](https://github.com/expo/expo/pull/21332), [#21391](https://github.com/expo/expo/pull/21391), [#21394](https://github.com/expo/expo/pull/21394), [#21450](https://github.com/expo/expo/pull/21450), [#21451](https://github.com/expo/expo/pull/21451), [#21467](https://github.com/expo/expo/pull/21467), [#21471](https://github.com/expo/expo/pull/21471), [#21478](https://github.com/expo/expo/pull/21478) by [@wschurman](https://github.com/wschurman))
 - Fix E2E rollback test and other improvements. ([#21389](https://github.com/expo/expo/pull/21389) by [@douglowder](https://github.com/douglowder))
 - Consolidate E2E tests. ([#21458](https://github.com/expo/expo/pull/21458) by [@douglowder](https://github.com/douglowder))
+- E2E tests: graceful Detox failures. ([#21520](https://github.com/expo/expo/pull/21520) by [@douglowder](https://github.com/douglowder))
 
 ## 0.16.1 — 2023-02-09
 

--- a/packages/expo-updates/e2e/README.md
+++ b/packages/expo-updates/e2e/README.md
@@ -65,6 +65,49 @@ eas init
 eas build --profile=updates_testing --platform=<android|ios>
 ```
 
+- Testing the EAS build locally:
+
+  - Ensure you have an emulator running named `pixel_4`
+  - Make the change below in `eas.json`:
+
+```diff
+--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
++++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
+@@ -15,7 +15,8 @@
+     "updates_testing": {
+       "env": {
+         "EX_UPDATES_NATIVE_DEBUG": "1",
+-        "NO_FLIPPER": "1"
++        "NO_FLIPPER": "1",
++        "LOCAL_TESTING": "1"
+       },
+       "android": {
+         "gradleCommand": ":app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release",
+```
+
+  - Clone the `eas-build` repo, and build it (`yarn`, `yarn build`)
+  - Set up the local EAS build environment as in this example:
+
+```
+#!/usr/bin/env bash
+
+export EAS_LOCAL_BUILD_HOME=<the eas-build directory that you just cloned above>
+
+export EAS_LOCAL_BUILD_PLUGIN_PATH=$EAS_LOCAL_BUILD_HOME/bin/eas-cli-local-build-plugin
+export EAS_LOCAL_BUILD_WORKINGDIR=$TMPDIR/eas-build-workingdir
+export EAS_LOCAL_BUILD_SKIP_CLEANUP=1
+export EAS_LOCAL_BUILD_ARTIFACTS_DIR=$TMPDIR/eas-build-workingdir/results
+
+rm -rf $EAS_LOCAL_BUILD_WORKINGDIR
+```
+
+  - Execute
+
+```bash
+eas init
+eas build --profile=updates_testing --platform=<android|ios> --local
+```
+
 ## Updates API test project:
 
 This creates a test project that allows you to exercise the Updates API features manually against EAS. The project is set up to use `expo-channel-name=main` as the EAS update request header.

--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
@@ -2,6 +2,10 @@
 
 set -eox pipefail
 
+if [[ "$LOCAL_TESTING" == "1" ]]; then
+  exit 0
+fi
+
 if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "updates_testing" ]]; then
   if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     sudo apt-get --quiet update --yes


### PR DESCRIPTION
# Why

- When updates E2E Detox tests fail on Android, the build hangs instead of immediately exiting gracefully.
- Root cause: the `set pipefail` in the on-success hook causes the hook to immediately exit when Detox fails, without shutting down the emulator first.

# How

- Modify the on-success hook to detect the Detox exit code, shut down the emulator, and then return the Detox exit code so that failure is handled correctly
- Added an optional `LOCAL_TESTING` environment variable that allows `eas build ... --local` to work correctly for debugging these files in future
- 
# Test Plan

- Added a temporary commit that will cause the updates E2E workflow to fail -- they should fail and not have to be canceled
- After removing the temporary commit, E2E should pass as usual
- 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
