### PR TITLE
Add warning note to install-expo-modules docs

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -5,7 +5,7 @@ description: Learn how to add Expo SDK to an existing React Native project.
 
 import InstallSection from '~/components/plugins/InstallSection';
 import { DiffBlock } from '~/ui/components/Snippet';
-import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { YesIcon, NoIcon, WarningIcon } from '~/ui/components/DocIcons';
 
 > Are you migrating from `react-native-unimodules`? If yes, please refer to [the Expo modules migration guide](https://expo.fyi/expo-modules-migration).
 
@@ -30,6 +30,8 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 - <YesIcon small /> **When the command succeeds**, you will be able to add any Expo module in your app!
   Proceed to [Usage](#usage) for more information.
+
+- <WarningIcon small /> **If the command fails to find a valid react-native project**, after confirming you're running from the correct directory, remove package-lock.json and reinstall packages with yarn.
 
 - <NoIcon small /> **If the command fails**, please follow the manual installation instructions. Updating
   code programmatically can be tricky, and if your project deviates significantly from a default React


### PR DESCRIPTION
# Why

When following the docs for the command, I was originally hit with a warning that a valid project couldn't be found, which was fixed via transition from npm to yarn. Adding here to either add to the docs or trigger a reconfiguration of the command's functionality with either more descriptive messaging or an automatic check/fix process. 

It's also possible these steps served to trigger a smaller fix, such as just re-installing modules with either package manager. Some insight into what a valid project needs to look like for this command to work could also be helpful in the docs.

# How

Words

# Test Plan

Run command on bare react native project with npm vs yarn configurations

# Checklist

- [Y] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [Y] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [Y] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
