### PR TITLE
[expo] bump sentry dependency versions

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,10 +96,10 @@
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.5.0",
   "react-native-webview": "11.26.0",
-  "sentry-expo": "~6.0.0",
+  "sentry-expo": "~6.1.0",
   "unimodules-app-loader": "~4.1.1",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.172",
   "@shopify/flash-list": "1.4.0",
-  "@sentry/react-native": "4.9.0"
+  "@sentry/react-native": "4.13.0"
 }


### PR DESCRIPTION
# Why

`sentry-expo@6.1.0` is released to support SDK 48. This version, along with its bumped `@sentry/react-native` version, should be the default version moving forward.

# How

Update version numbers in json.

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
