### PR TITLE
[expo-media-library] Allow saving animated gifs

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix saving animated GIFs on iOS. ([#21549](https://github.com/expo/expo/pull/21549) by [@desi-ivanov](https://github.com/desi-ivanov))
+
 ### 💡 Others
 
 ## 15.2.1 — 2023-02-09

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -225,6 +225,11 @@ EX_EXPORT_METHOD_AS(saveToLibraryAsync,
   };
   
   if (assetType == PHAssetMediaTypeImage) {
+
+    if ([[assetUrl.pathExtension lowercaseString] isEqualToString:@"gif"]) {
+      return [delegate writeGIF:assetUrl withCallback:callback];
+    }
+
     UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:assetUrl]];
     if (image == nil) {
       return reject(@"E_FILE_IS_MISSING", [NSString stringWithFormat:@"Couldn't open file: %@. Make sure if this file exists.", localUri], nil);

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.h
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.h
@@ -11,4 +11,6 @@ typedef void(^EXSaveToLibraryCallback)(id asset, NSError *error);
 
 - (void)writeVideo:(NSString *)movieUrl withCallback:(EXSaveToLibraryCallback) callback;
 
+- (void)writeGIF:(NSURL *)gifUrl withCallback:(EXSaveToLibraryCallback)callback;
+
 @end

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXSaveToLibraryDelegate.m
@@ -28,6 +28,18 @@
                                       nil);
 }
 
+- (void)writeGIF:(NSURL *)gifUrl withCallback:(EXSaveToLibraryCallback) callback
+{
+  _callback = callback;
+  [[PHPhotoLibrary sharedPhotoLibrary] performChanges:^{
+    NSData *data = [NSData dataWithContentsOfURL:gifUrl];
+    PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+    [request addResourceWithType:PHAssetResourceTypePhoto data:data options:NULL];
+  } completionHandler:^(BOOL success, NSError *error) {
+    [self triggerCallback:nil withError:error];
+  }];
+}
+
 - (void)image:(UIImage*)image
         didFinishSavingWithError:(NSError *)error
         contextInfo:(void *)info


### PR DESCRIPTION
# Why

When saving animated GIFs on iOS with expo-media-library, the resulting images in the photo library are static. This PR fixes this issue 

# How
Use `PHAssetChangeRequest` instead of `UIImage.imageWithData`

# Test Plan

```typescript
import { StatusBar } from 'expo-status-bar';
import { Button, View, Image } from 'react-native';
import * as MediaLibrary from 'expo-media-library';
const gif = "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif";
export default function App() {
  const handleSave = () => {
    MediaLibrary.saveToLibraryAsync(gif).then(() => alert("Saved")).catch(console.error);
  }
  return (
    <View style={{ flex: 1, alignItems: "center", justifyContent: 'center' }}>
      <StatusBar style="auto" />
      <Image source={{ uri: gif }} style={{ width: 256, height: 256 }} />
      <Button onPress={handleSave} title="Save" />
    </View>
  );
}
```
## Without the fix

https://user-images.githubusercontent.com/20824840/222973879-837a94f2-02f5-4906-aa18-1c99b7849c46.mov

## With the fix

https://user-images.githubusercontent.com/20824840/222973888-bb8ab2a8-1574-4318-9efc-f2880d8917ec.mov

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
