### PR TITLE
[file-system] fix unrecognized md5String selector crash

### DIFF
--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.h
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.h
@@ -37,9 +37,3 @@
         rejecter:(EXPromiseRejectBlock)reject;
 
 @end
-
-@interface NSData (EXFileSystem)
-
-- (NSString *)md5String;
-
-@end

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemAssetLibraryHandler.m
@@ -1,5 +1,6 @@
 
 #import <EXFileSystem/EXFileSystemAssetLibraryHandler.h>
+#import <EXFileSystem/NSData+EXFileSystem.h>
 
 #import <Photos/Photos.h>
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m
@@ -1,5 +1,6 @@
 
 #import <EXFileSystem/EXFileSystemLocalFileHandler.h>
+#import <EXFileSystem/NSData+EXFileSystem.h>
 
 @implementation EXFileSystemLocalFileHandler
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXSessionTasks/EXSessionDownloadTaskDelegate.m
@@ -1,7 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import <EXFileSystem/EXSessionDownloadTaskDelegate.h>
-#import <CommonCrypto/CommonDigest.h>
+#import <EXFileSystem/NSData+EXFileSystem.h>
 
 @interface EXSessionDownloadTaskDelegate ()
 
@@ -56,23 +56,9 @@
   result[@"uri"] = _localUrl.absoluteString;
   if (_shouldCalculateMd5) {
     NSData *data = [NSData dataWithContentsOfURL:_localUrl];
-    result[@"md5"] = EXNullIfNil([EXSessionDownloadTaskDelegate md5StringFromData:data]);
+    result[@"md5"] = [data md5String];
   }
   return result;
-}
-
-+ (nullable NSString *)md5StringFromData:(nullable NSData *)data
-{
-  if (!data) {
-    return nil;
-  }
-  unsigned char digest[CC_MD5_DIGEST_LENGTH];
-  CC_MD5(data.bytes, (CC_LONG)data.length, digest);
-  NSMutableString *md5 = [NSMutableString stringWithCapacity:2 * CC_MD5_DIGEST_LENGTH];
-  for (unsigned int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
-    [md5 appendFormat:@"%02x", digest[i]];
-  }
-  return md5;
 }
 
 @end

--- a/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.h
+++ b/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.h
@@ -1,0 +1,9 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+@interface NSData (EXFileSystem)
+
+- (NSString *)md5String;
+
+@end

--- a/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/NSData+EXFileSystem.m
@@ -1,0 +1,19 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import <EXFileSystem/NSData+EXFileSystem.h>
+#import <CommonCrypto/CommonDigest.h>
+
+@implementation NSData (EXFileSystem)
+
+- (NSString *)md5String
+{
+  unsigned char digest[CC_MD5_DIGEST_LENGTH];
+  CC_MD5(self.bytes, (CC_LONG) self.length, digest);
+  NSMutableString *md5 = [NSMutableString stringWithCapacity:2 * CC_MD5_DIGEST_LENGTH];
+  for (unsigned int i = 0; i < CC_MD5_DIGEST_LENGTH; ++i) {
+    [md5 appendFormat:@"%02x", digest[i]];
+  }
+  return md5;
+}
+
+@end


### PR DESCRIPTION
# Why

a crash happened when load an existing app in expo go twice

# How

the crash is from https://github.com/expo/expo/blob/c7b9eeeee589efda2c6b7da59ef97abd1b6413d7/packages/expo-file-system/ios/EXFileSystem/EXFileSystemLocalFileHandler.m#L20 which has declaration but not implementation.

this pr tries to revert #21317 and remove the strange duplicated md5String declaration inside EXFileSystem.h: https://github.com/expo/expo/blob/c7b9eeeee589efda2c6b7da59ef97abd1b6413d7/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.h#L41-L45 

adding necessary `#import <EXFileSystem/NSData+EXFileSystem.h>` to get the right fix.


# Test Plan

ios unit test ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
