### PR TITLE
[docs] More descriptive "Debugging" page titles

### DIFF
--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Debugging
+title: Debugging EAS Update
 description: Learn how to debug EAS Update.
 ---
 

--- a/docs/pages/workflow/debugging.mdx
+++ b/docs/pages/workflow/debugging.mdx
@@ -1,5 +1,5 @@
 ---
-title: Debugging
+title: Debugging Runtime Issues
 description: Learn about different techniques and tools available to debug your Expo project.
 ---
 


### PR DESCRIPTION
# Why

These are my top go-to's for support, but it's difficult to tell which "Debugging" article is for what. I've finally evolved enough muscle memory to generally remember that the one for runtime errors is on top, but some extra visual clarity would be welcome.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/8053974/223174916-69254b4c-990e-4f41-9deb-306006dd774d.png">


# How
Updated the titles. All ears for better suggestions.

# Test Plan
Looked at each page, saw the title was updated. I have no idea how make updated search results show when testing.
