### PR TITLE
fix(cli): filter hermes native callframes from `Debugger.paused` messages

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeCompat.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeCompat.ts
@@ -1,7 +1,20 @@
 import type { Protocol } from 'devtools-protocol';
 import type { DebuggerInfo } from 'metro-inspector-proxy';
 
-import { CdpMessage, DebuggerRequest, DeviceResponse, InspectorHandler } from './types';
+import {
+  CdpMessage,
+  DebuggerRequest,
+  DeviceRequest,
+  DeviceResponse,
+  InspectorHandler,
+} from './types';
+
+/**
+ * "4294967295" is decimal for "0xffffffff", describing an invalid script id.
+ * @see https://github.com/facebook/hermes/issues/168#issuecomment-568809021
+ */
+const HERMES_INVALID_SCRIPT_ID = '4294967295';
+const HERMES_NATIVE_FUNCTION_NAME = '(native)';
 
 export class VscodeCompatHandler implements InspectorHandler {
   /** Keep track of device messages to intercept, by request id */
@@ -33,10 +46,10 @@ export class VscodeCompatHandler implements InspectorHandler {
     return false;
   }
 
-  onDeviceMessage(message: DeviceResponse<RuntimeGetProperties>) {
+  onDeviceMessage(message: DeviceResponse<RuntimeGetProperties> | DeviceRequest<DebuggerPaused>) {
     // Vscode doesn't seem to work nicely with missing `description` fields on `RemoteObject` instances.
     // See: https://github.com/microsoft/vscode-js-debug/issues/1583
-    if (this.interceptDeviceMessage.has(message.id)) {
+    if ('id' in message && this.interceptDeviceMessage.has(message.id)) {
       this.interceptDeviceMessage.delete(message.id);
 
       // Force-fully format the properties description to be an empty string
@@ -46,6 +59,16 @@ export class VscodeCompatHandler implements InspectorHandler {
           item.value.description = item.value.description ?? '';
         }
       }
+    }
+
+    // Hermes adds traces of JSI to the callFrames, which are refering to native code.
+    // It doesn't make sense to show these to the user, so we filter them out.
+    if ('method' in message && message.method === 'Debugger.paused') {
+      message.params.callFrames = message.params.callFrames.filter(
+        (frame) =>
+          frame.location.scriptId !== HERMES_INVALID_SCRIPT_ID &&
+          frame.functionName !== HERMES_NATIVE_FUNCTION_NAME
+      );
     }
 
     return false;
@@ -58,6 +81,9 @@ export type DebuggerGetPossibleBreakpoints = CdpMessage<
   Protocol.Debugger.GetPossibleBreakpointsRequest,
   Protocol.Debugger.GetPossibleBreakpointsResponse
 >;
+
+/** @see https://chromedevtools.github.io/devtools-protocol/v8/Debugger/#method-setBreakpoint */
+export type DebuggerPaused = CdpMessage<'Debugger.paused', Protocol.Debugger.PausedEvent, never>;
 
 /** @see https://chromedevtools.github.io/devtools-protocol/v8/Runtime/#method-getProperties */
 export type RuntimeGetProperties = CdpMessage<

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
@@ -1,5 +1,5 @@
-import { DeviceRequest } from '../types';
 import { DebuggerPaused, RuntimeGetProperties, VscodeCompatHandler } from '../VscodeCompat';
+import { DeviceRequest } from '../types';
 
 it('responds to `Debugger.getPossibleBreakpoints` with empty `locations`', () => {
   const handler = new VscodeCompatHandler();

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
@@ -1,4 +1,5 @@
-import { RuntimeGetProperties, VscodeCompatHandler } from '../VscodeCompat';
+import { DeviceRequest } from '../types';
+import { DebuggerPaused, RuntimeGetProperties, VscodeCompatHandler } from '../VscodeCompat';
 
 it('responds to `Debugger.getPossibleBreakpoints` with empty `locations`', () => {
   const handler = new VscodeCompatHandler();
@@ -64,4 +65,44 @@ it('mutates `Runtime.getProperties` device response with `description` propertie
   // Expect the descriptor values to be mutated
   expect(descriptors.result[0].value).toHaveProperty('description', '');
   expect(descriptors.result[1].value).toHaveProperty('description', 'Dont overwrite');
+});
+
+it('mutates `Debugger.paused` callFrames without Hermes native function frames', () => {
+  const handler = new VscodeCompatHandler();
+
+  // Copied from an actual `Debugger.paused` message, first one should be filtered
+  const message: DeviceRequest<DebuggerPaused> = {
+    method: 'Debugger.paused',
+    params: {
+      reason: 'debugCommand',
+      callFrames: [
+        {
+          callFrameId: '23',
+          functionName: '(native)',
+          location: { scriptId: '4294967295', lineNumber: 0 },
+          url: '',
+          this: { type: 'object', objectId: '48' },
+          scopeChain: [
+            { type: 'global', object: { type: 'object', className: 'Object', objectId: '47' } },
+          ],
+        },
+        {
+          callFrameId: '27',
+          functionName: 'callFunctionReturnFlushedQueue',
+          location: { scriptId: '3', lineNumber: 2571, columnNumber: 20 },
+          url: '',
+          this: { type: 'object', objectId: '56' },
+          scopeChain: [
+            { type: 'global', object: { type: 'object', className: 'Object', objectId: '55' } },
+          ],
+        },
+      ],
+    },
+  };
+
+  // This message should still be propagated, it should return `false`
+  expect(handler.onDeviceMessage(message)).toBe(false);
+  // Expect the first callFrame to be filtered
+  expect(message.params.callFrames).toHaveLength(1);
+  expect(message.params.callFrames[0]).toMatchObject({ callFrameId: '27' });
 });


### PR DESCRIPTION
# Why

We don't need to show `callFrames` which are not traceable.

before | after
--- | ---
<img alt="image" src="https://user-images.githubusercontent.com/1203991/223199631-fa5b5f25-733b-468d-b158-8e70b88c2b3d.png"> | <img alt="image" src="https://user-images.githubusercontent.com/1203991/223199486-22496281-3de7-4693-a47b-63ec168762c8.png">


> ℹ️ **FunFact**
> The Chrome DevTools already filters these out from the `callFrames`

# How

- Filter `callFrames` in the `Debugger.paused` event

# Test Plan

- See added test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
