### PR TITLE
[core][ios] Fix automatic percent-encoding when converting to URL

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed jsc import when using use_frameworks ([#21479](https://github.com/expo/expo/pull/21479) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed coroutine functions crashing when invoked with more than 1 argument. ([#21635](https://github.com/expo/expo/pull/21635) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fix automatic percent-encoding when converting to the `URL` object. ([#21569](https://github.com/expo/expo/pull/21569) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -13,12 +13,34 @@ import CoreGraphics
 
 extension URL: Convertible {
   public static func convert(from value: Any?) throws -> Self {
-    if let value = value as? String, let encodedValue = percentEncodeUrlString(value), let url = URL(string: encodedValue) {
+    guard let value = value as? String else {
+      throw Conversions.ConvertingException<URL>(value)
+    }
+
+    // Try to construct the URL object from the string as it came in.
+    if let url = URL(string: value) {
       // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
-      // Notice that it uses the decoded value as the file path doesn't have to be percent-encoded.
       return url.scheme != nil ? url : URL(fileURLWithPath: value)
     }
-    throw Conversions.ConvertingException<URL>(value)
+
+    // File path doesn't need to be percent-encoded.
+    if isFileUrlPath(value) {
+      return URL(fileURLWithPath: value)
+    }
+
+    // If we get here, the string is not the file url and may require percent-encoding characters that are not URL-safe according to RFC 3986.
+    if let encodedValue = percentEncodeUrlString(value), let url = URL(string: encodedValue) {
+      return url.scheme != nil ? url : URL(fileURLWithPath: value)
+    }
+
+    // If it still fails to create the URL object, the string possibly contains characters that must be explicitly percent-encoded beforehand.
+    throw UrlContainsInvalidCharactersException()
+  }
+}
+
+internal class UrlContainsInvalidCharactersException: Exception {
+  override var reason: String {
+    return "Unable to create a URL object from the given string, make sure to percent-encode these characters: \(urlAllowedCharacters)"
   }
 }
 


### PR DESCRIPTION
# Why

Fixes #21405 
Fixes #21404 

# How

Changed the converter to iOS `URL` type to percent-encode only these characters that are not allowed in any part of the URL. This way we don't have to ensure the input url is decoded and thus `$2F` won't be decoded to `/`.

# Test Plan

- Updated native unit tests to cover this case
- Ensured that the example provided in #21405 works fine
- Checked blurhashes mentioned in #21404, all of them seem to work fine now