### PR TITLE
[android][go] fix broken reanimated layout animation

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoTurboPackage.kt
@@ -20,6 +20,7 @@ import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.systrace.Systrace
 import com.swmansion.reanimated.ReanimatedModule
+import com.swmansion.reanimated.ReanimatedUIManagerFactory
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.experience.ReactNativeActivity
 import host.exp.exponent.kernel.KernelConstants
@@ -113,7 +114,7 @@ class ExpoTurboPackage(
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "createUIManagerModule")
     val minTimeLeftInFrameForNonBatchedOperationMs = -1
     return try {
-      ReanimatedUIManager(
+      ReanimatedUIManagerFactory.create(
         reactContext,
         reactInstanceManager.getOrCreateViewManagers(reactContext),
         minTimeLeftInFrameForNonBatchedOperationMs

--- a/android/vendored/sdk48/react-native-reanimated/android/src/reactNativeVersionPatch/ReanimatedUIManager/latest/com/swmansion/reanimated/ReanimatedUIManagerFactory.java
+++ b/android/vendored/sdk48/react-native-reanimated/android/src/reactNativeVersionPatch/ReanimatedUIManager/latest/com/swmansion/reanimated/ReanimatedUIManagerFactory.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class ReanimatedUIManagerFactory {
 
-  static UIManagerModule create(ReactApplicationContext reactContext, List<ViewManager> viewManagers, int minTimeLeftInFrameForNonBatchedOperationMs) {
+  public static UIManagerModule create(ReactApplicationContext reactContext, List<ViewManager> viewManagers, int minTimeLeftInFrameForNonBatchedOperationMs) {
     ViewManagerRegistry viewManagerRegistry = new ViewManagerRegistry(viewManagers);
 
     UIManagerModule uiManagerModule =

--- a/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReanimatedUIManager/latest/com/swmansion/reanimated/ReanimatedUIManagerFactory.java
+++ b/android/vendored/unversioned/react-native-reanimated/android/src/reactNativeVersionPatch/ReanimatedUIManager/latest/com/swmansion/reanimated/ReanimatedUIManagerFactory.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class ReanimatedUIManagerFactory {
 
-  static UIManagerModule create(ReactApplicationContext reactContext, List<ViewManager> viewManagers, int minTimeLeftInFrameForNonBatchedOperationMs) {
+  public static UIManagerModule create(ReactApplicationContext reactContext, List<ViewManager> viewManagers, int minTimeLeftInFrameForNonBatchedOperationMs) {
     ViewManagerRegistry viewManagerRegistry = new ViewManagerRegistry(viewManagers);
 
     UIManagerModule uiManagerModule =

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/ExpoTurboPackage.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/ExpoTurboPackage.kt
@@ -16,6 +16,7 @@ import abi48_0_0.com.facebook.react.module.model.ReactModuleInfoProvider
 import abi48_0_0.com.facebook.react.modules.intent.IntentModule
 import abi48_0_0.com.facebook.react.turbomodule.core.interfaces.TurboModule
 import abi48_0_0.com.facebook.react.uimanager.ReanimatedUIManager
+import abi48_0_0.com.swmansion.reanimated.ReanimatedUIManagerFactory
 import abi48_0_0.com.facebook.react.uimanager.UIManagerModule
 import abi48_0_0.com.facebook.react.uimanager.ViewManager
 import abi48_0_0.com.facebook.systrace.Systrace
@@ -113,7 +114,7 @@ class ExpoTurboPackage(
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "createUIManagerModule")
     val minTimeLeftInFrameForNonBatchedOperationMs = -1
     return try {
-      ReanimatedUIManager(
+      ReanimatedUIManagerFactory.create(
         reactContext,
         reactInstanceManager.getOrCreateViewManagers(reactContext),
         minTimeLeftInFrameForNonBatchedOperationMs

--- a/tools/src/vendoring/config/expoGoConfig.ts
+++ b/tools/src/vendoring/config/expoGoConfig.ts
@@ -199,6 +199,12 @@ const config: VendoringTargetConfig = {
               find: /"\$\{BUILD_DIR\}\/.+\/libhermes\.so"/g,
               replaceWith: `hermes-engine::libhermes`,
             },
+            {
+              // expose `ReanimatedUIManagerFactory.create` publicly
+              paths: 'ReanimatedUIManagerFactory.java',
+              find: /((?<!public )static UIManagerModule create\()/g,
+              replaceWith: 'public $1',
+            },
           ],
         },
       },


### PR DESCRIPTION
# Why

fixes #21505

# How

reanimated 2.14 requires to use the `ReanimatedUIManagerFactory.create()` for uimanager binding: https://github.com/software-mansion/react-native-reanimated/blob/fa5dc5271f49895339e0669b4f10d111e1c64e34/android/src/main/java/com/swmansion/reanimated/ReanimatedPackage.java#L76

# Test Plan

versioned android expo go + ncl reanimated

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
