### PR TITLE
[linear-gradient] fix crash when r8 enabled

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed crashes when R8 or Proguard is enabled. ([#21580](https://github.com/expo/expo/pull/21580) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 12.1.1 — 2023-02-09

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
@@ -10,6 +10,8 @@ import android.graphics.Shader;
 import android.util.TypedValue;
 import android.view.View;
 
+import androidx.annotation.Keep;
+
 public class LinearGradientView extends View {
   private final Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
   private Path mPathForBorderRadius;
@@ -22,6 +24,8 @@ public class LinearGradientView extends View {
   private int[] mSize = {0, 0};
   private float[] mBorderRadii = {0, 0, 0, 0, 0, 0, 0, 0};
 
+  // Keeps this primary constructor from Proguard/R8 for ViewDefinitionBuilder
+  @Keep
   public LinearGradientView(Context context) {
     super(context);
   }

--- a/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
+++ b/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java
@@ -9,8 +9,7 @@ import android.graphics.RectF;
 import android.graphics.Shader;
 import android.util.TypedValue;
 import android.view.View;
-
-import androidx.annotation.Keep;
+import expo.modules.core.interfaces.DoNotStrip;
 
 public class LinearGradientView extends View {
   private final Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
@@ -25,7 +24,7 @@ public class LinearGradientView extends View {
   private float[] mBorderRadii = {0, 0, 0, 0, 0, 0, 0, 0};
 
   // Keeps this primary constructor from Proguard/R8 for ViewDefinitionBuilder
-  @Keep
+  @DoNotStrip
   public LinearGradientView(Context context) {
     super(context);
   }


### PR DESCRIPTION
# Why

fixes #21562

# How

the code here will be stripped by R8: https://github.com/expo/expo/blob/4d234bbfb32b66b3944a0e652eda1e6c67287059/packages/expo-linear-gradient/android/src/main/java/expo/modules/lineargradient/LinearGradientView.java#L25-L27 and then our `ViewDefinitionBuilder` cannot find the primary constructor. this pr adds the keep annotation.

i didn't find a way to fix it systematically from expo-modules-core. let's address case by case and expo-linear-gradient first.


# Test Plan

https://github.com/GaelCO/repro_linearGradient with patch-package for the fix

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
