### PR TITLE
[jest-expo] use globalThis rather than global

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use the mocked `globalThis` rather than `global`. ([#21581](https://github.com/expo/expo/pull/21581) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 48.0.1 - 2023-02-21

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -11,8 +11,8 @@ const internalExpoModules = require('./internalExpoModules');
 
 // window isn't defined as of react-native 0.45+ it seems
 if (typeof window !== 'object') {
-  global.window = global;
-  global.window.navigator = {};
+  globalThis.window = global;
+  globalThis.window.navigator = {};
 }
 
 const mockImageLoader = {


### PR DESCRIPTION
# Why

fixes #21509

# How

replace `global` with `globalThis`

# Test Plan

- tbh i don't know how to test the global flow, let's see whether ci passed
- `et check-packages --all` to make sure no regression

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
