### PR TITLE
[core][Android] Expose `AppContext` from `KotlinInteropModuleRegistry`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -22,7 +22,7 @@ class KotlinInteropModuleRegistry(
   legacyModuleRegistry: expo.modules.core.ModuleRegistry,
   reactContext: WeakReference<ReactApplicationContext>
 ) {
-  internal val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
+  val appContext = AppContext(modulesProvider, legacyModuleRegistry, reactContext)
 
   private val registry: ModuleRegistry
     get() = appContext.registry


### PR DESCRIPTION
# Why

Exposes the app context from the `KotlinInteropModuleRegistry` class. It might be helpful to get access to other modules from the non-module. For instance, the dev-launcher or dev-menu should be able to access modules register on the delegate bridge. 