### PR TITLE
[android][document-picker] fix picking cancellation

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed cancellation type not being marked as a `Record` on Android.
+- Fixed cancellation type not being marked as a `Record` on Android. ([#21588](https://github.com/expo/expo/pull/21588) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed cancellation type not being marked as a `Record` on Android.
+
 ### 💡 Others
 
 ## 11.2.1 — 2023-02-09

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerModule.kt
@@ -52,6 +52,7 @@ class DocumentPickerModule : Module() {
       }
 
       val promise = pendingPromise!!
+      pendingPromise = null
 
       if (resultCode == Activity.RESULT_OK) {
         intent?.data?.let { uri ->
@@ -79,7 +80,6 @@ class DocumentPickerModule : Module() {
           DocumentPickerCancelled(type = "cancel")
         )
       }
-      pendingPromise = null
     }
   }
 

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
@@ -23,4 +23,4 @@ data class DocumentPickerResult(
 data class DocumentPickerCancelled(
   @Field
   val type: String
-)
+) : Record


### PR DESCRIPTION
# Why
fixes #21578

# How
Implement `Record` on `DocumentPickerCancelled`

# Test Plan
Tested in bare expo