### PR TITLE
[android][image-picker] fix permissions

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 11.2.1 — 2023-02-09

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
-
 ### 💡 Others
 
 ## 11.2.1 — 2023-02-09

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix images unexpectedly being converted to `.png` when opening `.bmp` files and selecting any quality in `ImagePickerOptions`. ([#21361](https://github.com/expo/expo/pull/21361) by [@behenate](https://github.com/behenate))
+- Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -176,8 +176,8 @@ class ImagePickerModule : Module() {
   private fun getMediaLibraryPermissions(writeOnly: Boolean): Array<String> =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       listOfNotNull(
-        READ_MEDIA_IMAGES.takeIf { !writeOnly },
-        READ_MEDIA_VIDEO.takeIf { !writeOnly }
+        READ_MEDIA_IMAGES,
+        READ_MEDIA_VIDEO
       ).toTypedArray()
     } else {
       listOfNotNull(


### PR DESCRIPTION
# Why
Fixes an issue with `image-picker` where passing `writeOnly` would end up in an empty array of permissions causing an exception.

# How
Always fill the array with the necessary permissions

# Test Plan
All checks pass in bare expo
