### PR TITLE
fix(html-elements): prevent converting in node_modules

### DIFF
--- a/packages/html-elements/CHANGELOG.md
+++ b/packages/html-elements/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- Prevent babel plugin from running on node_modules.
-- Prevent babel plugin from transforming `html` and `body` on web.
+- Prevent babel plugin from running on node_modules. ([#21594](https://github.com/expo/expo/pull/21594) by [@EvanBacon](https://github.com/EvanBacon))
+- Prevent babel plugin from transforming `html` and `body` on web. ([#21594](https://github.com/expo/expo/pull/21594) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/html-elements/CHANGELOG.md
+++ b/packages/html-elements/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- Prevent babel plugin from running on node_modules.
+- Prevent babel plugin from transforming `html` and `body` on web.
+
 ### 💡 Others
 
 ## 0.4.1 — 2023-02-09

--- a/packages/html-elements/babel.js
+++ b/packages/html-elements/babel.js
@@ -50,10 +50,26 @@ const elementToComponent = {
   // NOTE: head, meta, link should use some special component in the future.
 };
 
-module.exports = ({ types: t }, { expo }) => {
+function getPlatform(caller) {
+  return caller && caller.platform;
+}
+
+module.exports = ({ types: t, ...api }, { expo }) => {
+  const platform = api.caller(getPlatform);
+
   function replaceElement(path, state) {
+    // Not supported in node modules
+    if (/\/node_modules\//.test(state.filename)) {
+      return;
+    }
+
     const { name } = path.node.openingElement.name;
 
+    if (platform === 'web') {
+      if (['html', 'body'].includes(name)) {
+        return;
+      }
+    }
     // Replace element with @expo/html-elements
     const component = elementToComponent[name];
 

--- a/packages/html-elements/babel/__tests__/transform.test.js
+++ b/packages/html-elements/babel/__tests__/transform.test.js
@@ -15,6 +15,10 @@ const options = {
       },
     ],
   ],
+  caller: {
+    name: 'metro',
+    platform: 'ios',
+  },
   minified: false,
   plugins: [plugin],
   compact: false,
@@ -34,6 +38,35 @@ function App() {
   const { code } = babel.transform(sourceCode, options);
   expect(code).toMatchSnapshot();
   expect(code).not.toMatch(`@expo/html-elements`);
+});
+
+it(`Skips html and body on web`, () => {
+  const sourceCode = `
+function App() {
+  return <html><body>Test</body></html>;
+}`;
+  const { code } = babel.transform(sourceCode, {
+    ...options,
+    caller: {
+      ...options.caller,
+      platform: 'web',
+    },
+  });
+  expect(code).toMatch(`_jsx("html", { children: _jsx("body", { children: "Test" }) });`);
+  const { code: nativeCode } = babel.transform(sourceCode, options);
+  expect(nativeCode).toMatch(`_jsx(Div, { children: _jsx(Div, { children: "Test" }) });`);
+});
+
+it(`Skips conversion in node modules`, () => {
+  const sourceCode = `
+function App() {
+  return <a href="#">Link</a>;    
+}`;
+  const { code } = babel.transform(sourceCode, {
+    ...options,
+    filename: '/node_modules/foo/bar.js',
+  });
+  expect(code).not.toMatch(`import { A } from "@expo/html-elements";`);
 });
 
 it(`Converts basic link`, () => {


### PR DESCRIPTION
# Why

- Metro transpiles node_modules so we need to add this extra step to prevent targeting node modules.
- Web should skip converting html / body tags.
