### PR TITLE
[docs] Update page titles for Expo Modules API for better search results

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Expo modules
-description: React Native project. Learn how to prepare your existing React Native project to install and use any Expo module.
+description: Learn how to prepare your existing React Native project to install and use any Expo module.
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -48,8 +48,6 @@ Once installation is complete, apply the changes from the following diffs to con
 
 <DiffBlock source="/static/diffs/expo-android.diff" />
 
-{/* <div style={{ marginTop: -10 }} /> */}
-
 ### Configuration for iOS
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Expo modules
-description: Learn how to prepare your project for installing and using any Expo module into an existing React Native project.
+description: React Native project. Learn how to prepare your existing React Native project to install and use any Expo module.
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -1,6 +1,6 @@
 ---
-title: Add Expo to an existing project
-description: Learn how to add Expo SDK to an existing React Native project.
+title: Install Expo modules
+description: Learn how to prepare your project for installing and using any Expo module into an existing React Native project.
 ---
 
 import InstallSection from '~/components/plugins/InstallSection';
@@ -44,13 +44,19 @@ The following instructions apply to installing the latest version of Expo module
 
 Once installation is complete, apply the changes from the following diffs to configure Expo modules in your project. This is expected to take about five minutes, and you may need to adapt it slightly depending on how customized your project is.
 
+### Configuration for Android
+
+<DiffBlock source="/static/diffs/expo-android.diff" />
+
+{/* <div style={{ marginTop: -10 }} /> */}
+
 ### Configuration for iOS
 
 <DiffBlock source="/static/diffs/expo-ios.diff" />
 
 Optionally, you can also add additional delegate methods to your **AppDelegate.mm**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.mm](https://github.com/expo/expo/blob/b7c0356c697ef2cf46388e5742d67b7b48adc97f/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L75-L102).
 
-Save all of your changes. In Xcode, update the iOS Deployment Target under `Target → Build Settings → Deployment` to `iOS 12.0`. The last step is to install the project's CocoaPods again in order to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the `Podfile`:
+Save all of your changes. In Xcode, update the iOS Deployment Target under `Target → Build Settings → Deployment` to `iOS 12.0`. The last step is to install the project's CocoaPods again to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the `Podfile`:
 
 <InstallSection
   packageName="expo"
@@ -63,14 +69,6 @@ Save all of your changes. In Xcode, update the iOS Deployment Target under `Targ
   ]}
   hideBareInstructions
 />
-
-<div style={{ marginTop: 50 }} />
-
-### Configuration for Android
-
-<DiffBlock source="/static/diffs/expo-android.diff" />
-
-<div style={{ marginTop: -10 }} />
 
 ## Usage
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -1,5 +1,6 @@
 ---
-title: Get started
+title: 'Expo Modules API: Get started'
+sidebar_title: Get started
 description: Learn about getting started with Expo modules API.
 ---
 

--- a/docs/pages/modules/overview.mdx
+++ b/docs/pages/modules/overview.mdx
@@ -1,5 +1,6 @@
 ---
-title: Overview
+title: 'Expo Modules API: Overview'
+sidebar_title: Overview
 description: An overview of the APIs and utilities provided by Expo to develop native modules.
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-7656

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated the "Overview" and "Get Started" Page titles in Expo Modules API section. Searching the term "Expo Modules" should show these results. Added the `sidebar_title` to not change the titles of the pages in the sidebar.
- Updated the page title for "Install Expo modules" to show in search result. Also, updated the description to signify what the page is about and re-positioned Android and iOS sections to follow [our writing styleguide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-android-ios-and-web).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="952" alt="CleanShot 2023-03-08 at 17 57 21@2x" src="https://user-images.githubusercontent.com/10234615/223713282-61052b28-740d-4418-a813-d70796f686cc.png">

<img width="1230" alt="CleanShot 2023-03-08 at 17 58 39@2x" src="https://user-images.githubusercontent.com/10234615/223713477-02595932-096b-4128-a637-9ead17cd4d79.png">

<img width="1232" alt="CleanShot 2023-03-08 at 17 58 52@2x" src="https://user-images.githubusercontent.com/10234615/223713518-647a98cf-c452-435b-ba01-d5c81bf5a113.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
