### PR TITLE
[docs] Rename "Debugging" section titles to be more meaningful for various docs pages

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -91,7 +91,7 @@ The unsupported capabilities either don't support iOS, or they don't have a corr
 
 Merchant IDs, App Groups, and CloudKit Containers can all be automatically registered and assigned to your app. These assignments require Apple cookies authentication (running locally) as the official App Store Connect API does not support these operations.
 
-## Debugging
+## Debugging iOS capabilities
 
 You can run `EXPO_DEBUG=1 eas build` to get more detailed logs regarding the capability syncing.
 

--- a/docs/pages/development/use-development-builds.mdx
+++ b/docs/pages/development/use-development-builds.mdx
@@ -43,7 +43,7 @@ If you launch the development build from your device's Home screen, you will see
 
 If a bundler is detected on your local network, or if you've signed in to an Expo account in both Expo CLI and your development build, you can connect to it directly from this screen. Otherwise, you can connect by scanning the QR code displayed by the Expo CLI.
 
-## Debugging
+## Debugging a development build
 
 When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> or <kbd>Ctrl</kbd> + <kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, any debugging functionality you need, or switch to a different version of your app.
 

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -154,15 +154,15 @@ If we've made builds and updates with EAS, we can view the state of our project 
 
 The EAS website has a page that shows the current state of our apps. We can view it at [https://expo.dev/accounts/[account]/projects/[project]/deployments](https://expo.dev/accounts/[account]/projects/[project]/deployments).
 
-## Debugging
+## Debugging EAS Update
 
-After verifying expo-updates and EAS Update configurations, we can move on to debugging how our project is interacting with updates.
+After verifying `expo-updates` and EAS Update configurations, we can move on to debugging how our project is interacting with updates.
 
 ### In-app debugging
 
 The expo-updates library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause.
 
-We can write the following code then make a simulator build of our project to see if there are errors fetching updates:
+We can write the following code and then make a simulator build of our project to see if there are errors fetching updates:
 
 ```jsx
 import { View, Button } from 'react-native';

--- a/docs/pages/guides/config-plugins.mdx
+++ b/docs/pages/guides/config-plugins.mdx
@@ -262,7 +262,7 @@ The following default mods are provided by the mod compiler for common file mani
 > Always opt towards using application code to modify application code, that is, [Expo Modules][emc] native API.
 
 | Android mod                       |    Dangerous    | Description                                                                                               |
-|-----------------------------------|:---------------:|-----------------------------------------------------------------------------------------------------------|
+| --------------------------------- | :-------------: | --------------------------------------------------------------------------------------------------------- |
 | `mods.android.manifest`           |        -        | Modify the **android/app/src/main/AndroidManifest.xml** as JSON (parsed with [`xml2js`][xml2js]).         |
 | `mods.android.strings`            |        -        | Modify the **android/app/src/main/res/values/strings.xml** as JSON (parsed with [`xml2js`][xml2js]).      |
 | `mods.android.colors`             |        -        | Modify the **android/app/src/main/res/values/colors.xml** as JSON (parsed with [`xml2js`][xml2js]).       |
@@ -276,7 +276,7 @@ The following default mods are provided by the mod compiler for common file mani
 | `mods.android.settingsGradle`     | <WarningIcon /> | Modify the **android/settings.gradle** as a string.                                                       |
 
 | iOS mod                      |    Dangerous    | Description                                                                                                                         |
-|------------------------------|:---------------:|-------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | :-------------: | ----------------------------------------------------------------------------------------------------------------------------------- |
 | `mods.ios.infoPlist`         |        -        | Modify the **ios/&lt;name&gt;/Info.plist** as JSON (parsed with [`@expo/plist`][expo-plist]).                                       |
 | `mods.ios.entitlements`      |        -        | Modify the **ios/&lt;name&gt;/&lt;product-name&gt;.entitlements** as JSON (parsed with [`@expo/plist`][expo-plist]).                |
 | `mods.ios.expoPlist`         |        -        | Modify the **ios/&lt;ame&gt;/Expo.plist** as JSON (Expo updates config for iOS) (parsed with [`@expo/plist`][expo-plist]).          |
@@ -297,7 +297,7 @@ Instead you should use the helper mods provided by `expo/config-plugins`:
 #### Android
 
 | Android mod                       | Mod plugin               |    Dangerous    |
-|-----------------------------------|--------------------------|:---------------:|
+| --------------------------------- | ------------------------ | :-------------: |
 | `mods.android.manifest`           | `withAndroidManifest`    |        -        |
 | `mods.android.strings`            | `withStringsXml`         |        -        |
 | `mods.android.colors`             | `withAndroidColors`      |        -        |
@@ -313,7 +313,7 @@ Instead you should use the helper mods provided by `expo/config-plugins`:
 #### iOS
 
 | iOS mod                      | Mod plugin              |    Dangerous    |
-|------------------------------|-------------------------|:---------------:|
+| ---------------------------- | ----------------------- | :-------------: |
 | `mods.ios.infoPlist`         | `withInfoPlist`         |        -        |
 | `mods.ios.entitlements`      | `withEntitlementsPlist` |        -        |
 | `mods.ios.expoPlist`         | `withExpoPlist`         |        -        |
@@ -551,6 +551,7 @@ Use the following dependencies in a library that provides a config plugin:
 
 The `expo/config-plugins` and `expo/config` packages are re-exported from the `expo` package.
 
+{/* prettier-ignore */}
 ```js
 const { /* @hide ...*//* @end */ } = require('expo/config-plugins');
 const { /* @hide ...*//* @end */ } = require('expo/config');
@@ -572,6 +573,7 @@ import { ExpoConfig, ConfigContext } from 'expo/config';
 
 For SDK 46 and lower, import the `@expo/config-plugins` package directly. This is installed automatically by the `expo` package, but not re-exported as it is in SDK 47 and higher.
 
+{/* prettier-ignore */}
 ```js
 const { /* @hide ...*//* @end */ } = require('@expo/config-plugins');
 ```
@@ -753,7 +755,7 @@ export default createRunOncePlugin(
 - **Split up plugins by platform**: For example — `withIosSplash`, `withAndroidSplash`. This makes using the `--platform` flag in `expo prebuild` a bit easier to follow in `EXPO_DEBUG` mode.
 - **Unit test your plugin**: Write Jest tests for complex modifications. If your plugin requires access to the filesystem,
   use a mock system (we strongly recommend [`memfs`][memfs]), you can see examples of this in the [`expo-notifications`](https://github.com/expo/expo/blob/fc3fb2e81ad3a62332fa1ba6956c1df1c3186464/packages/expo-notifications/plugin/src/__tests__/withNotificationsAndroid-test.ts#L34) plugin tests.
-  - Notice the root [\*\*/\_\_mocks\_\_/\*\*/*](https://github.com/expo/expo/tree/main/packages/expo-notifications/plugin/__mocks__) folder and [**plugin/jest.config.js**](https://github.com/expo/expo/tree/main/packages/expo-notifications/plugin/jest.config.js).
+  - Notice the root [\*\*/\_\_mocks\_\_/\*\*/\*](https://github.com/expo/expo/tree/main/packages/expo-notifications/plugin/__mocks__) folder and [**plugin/jest.config.js**](https://github.com/expo/expo/tree/main/packages/expo-notifications/plugin/jest.config.js).
 - A TypeScript plugin is always better than a JavaScript plugin. Check out the [`expo-module-script` plugin][ems-plugin] tooling for more info.
 - Do not modify the `sdkVersion` via a config plugin, this can break commands like `expo install` and cause other unexpected issues.
 
@@ -913,7 +915,7 @@ By re-running `expo prebuild -p` (`eas build -p android`, or `expo run:ios`) the
 
 As you can see from the example, we rely heavily on application code (expo-modules-core) to interact with application code (the native project). This ensures that our config plugins are safe and reliable, hopefully for a very long time!
 
-## Debugging
+## Debugging config plugins
 
 You can debug config plugins by running `EXPO_DEBUG=1 expo prebuild`. If `EXPO_DEBUG` is enabled, the plugin stack logs will be printed,
 these are useful for viewing which mods ran, and in what order they ran in.

--- a/docs/pages/workflow/snack.mdx
+++ b/docs/pages/workflow/snack.mdx
@@ -10,21 +10,21 @@ Creating a shareable and runnable code example should be quick and easy. Without
 
 Snack solves precisely that problem. It's an open-source platform for running React Native apps in the browser. You can write React Native code and run it directly in the browser or Expo Go. When you want to share the code, save it and share the URL, or embed it on your website, like in the [React Native](http://reactnative.dev/) and [React Navigation](https://reactnavigation.org/) documentation sites.
 
-## Let's get started
+## Get started
 
 Head over to [https://snack.expo.dev](https://snack.expo.dev) and start typing! On the right, you'll see the preview of the changes you make. By going to the "Android" or "iOS" tabs, you can preview it on a simulator directly in the browser. To open it on your device, go to the "My Device" tab and open it in the Expo Go app.
 
-## Adding a library
+## Add a library
 
 You can add any library that works in a managed Expo project, like [`expo-camera`](/versions/latest/sdk/camera.mdx) or [`React Navigation`](https://reactnavigation.org). Add the import in the file that you want, and Snack will prompt you to install that dependency. You can also specify the exact version by adding it to your **package.json** file.
 
 > **warning** Not all React Native libraries will work on Snack. First, [the same constraints](/workflow/using-libraries.mdx) that apply to the Expo managed workflow apply here. Second, Snack bundles the code differently than Expo CLI and React Native CLI, so in some cases libraries that work locally on your machine will fail to load in Snack.
 
-## Saving and sharing code
+## Save and share code
 
 You can always share the code you just created. Save the Snack on your Expo account, and share the link. Anyone with that link can view, fork and edit, and share it as another Snack. Saved Snacks will appear for your account under the Profile tab in the Expo Go app.
 
-## Embed it on your website
+## Embed Snack on your website
 
 Snacks can also be embedded as "live" code previews, like the [React Native docs](https://reactnative.dev/docs/intro-react#your-first-component). Either share a link with the embedded code or use [the embed script](https://github.com/expo/snack/blob/main/docs/embedding-snacks.mdx) for the live preview. If you use [Docusaurus](https://docusaurus.io/), check out the [remark-snackplayer plugin](https://github.com/facebook/react-native-website/tree/master/plugins/remark-snackplayer).
 
@@ -58,10 +58,10 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Debugging your code
+## Debugging code in Snack
 
-All logs from the web and mobile device previews are visible in toolbar below the editor. To inspect the logs, click on bottom toolbar and go to the "Logs" tab. While it's possible to view logs, it is not possible to connect a JavaScript debugger in Snack, you will need to download your project and run it with `expo-cli` in order to do this. Press the download button in the header bar on the right to download the project to your machine.
+All logs from the web and mobile device previews are visible in the toolbar below the editor. To inspect the logs, click on the bottom toolbar and go to the "Logs" tab. While it's possible to view logs, it is not possible to connect a JavaScript debugger in Snack, you will need to download your project and run it with [Expo CLI](/workflow/expo-cli/) to do this. Press the download button in the header bar on the right to download the project to your machine.
 
 ## Static analysis
 
-ESLint and TypeScript are integrated with Snack. When making a syntax error or just a typo, you will be warned about the error. TypeScript will give you autocompletion as well. Right click your **App.js** file in the file browser on the left side of the editor and choose "Rename to App.tsx" to enable TypeScript.
+ESLint and TypeScript are integrated with Snack. When making a syntax error or just a typo, you will be warned about the error. TypeScript will give you auto-completion as well. Right-click your **App.js** file in the file browser on the left side of the editor and choose **Rename to App.tsx** to enable TypeScript.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-7581
Also, a follow up for #21564 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated section titles in various pages that just refer "Debugging" to be more descriptive. Also, this should improve the search results.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
