### PR TITLE
[docs] Fix typo in expo-contacts documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/contacts.mdx
+++ b/docs/pages/versions/unversioned/sdk/contacts.mdx
@@ -27,7 +27,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 ## Configuration in app.json/app.config.js
 
-You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-contacts` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 

--- a/docs/pages/versions/v48.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/contacts.mdx
@@ -27,7 +27,7 @@ On iOS, contacts have a multi-layered grouping system that you can also access t
 
 ## Configuration in app.json/app.config.js
 
-You can configure `expo-calendar` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
+You can configure `expo-contacts` using its built-in [config plugin](/guides/config-plugins) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`). The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
 
 <ConfigPluginExample>
 


### PR DESCRIPTION
# Why

This pull request fixes a typo in the expo-contacts documentation. The phrase "You can configure expo-calendar" should be changed to "You can configure expo-contacts". This is a small but important fix that will improve the accuracy of the documentation and make it easier for developers to use the library.

# How

The phrase "You can configure expo-calendar" was changed to "You can configure expo-contacts". 

# Test Plan
The application was built successfully

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
