### PR TITLE
[docs] remove invalid graphql links resources on using graphql section

### DIFF
--- a/docs/pages/guides/using-graphql.mdx
+++ b/docs/pages/guides/using-graphql.mdx
@@ -101,7 +101,7 @@ In this section, we'll discuss the backbone of every GraphQL server: The GraphQL
 
 ### The Schema Definition Language (SDL)
 
-GraphQL has a [type system](http://graphql.org/learn/schema/#type-system) that’s used to define the capabilities of an API. These capabilities are written down in the GraphQL _schema_ using the syntax of the GraphQL [Schema Definition Language](https://blog.graph.cool/graphql-sdl-schema-definition-language-6755bcb9ce51) (SDL). Here’s what the `Post` type from our previous examples looks like:
+GraphQL has a [type system](http://graphql.org/learn/schema/#type-system) that’s used to define the capabilities of an API. These capabilities are written down in the GraphQL _schema_ using the syntax of the GraphQL [Schema Definition Language](https://www.apollographql.com/tutorials/lift-off-part1/03-schema-definition-language-sdl) (SDL). Here’s what the `Post` type from our previous examples looks like:
 
 ```graphql
 type Post {
@@ -139,9 +139,3 @@ You can read more about the core GraphQL constructs [here](https://www.howtograp
 
 Learn how to build a GraphQL server, check out this [tutorial](https://www.howtographql.com/graphql-js/0-introduction/).
 
-## Next Steps & Resources
-
-- **GraphQL server basics**: Check out this tutorial series about GraphQL servers:
-  - [GraphQL Server Basics (Part 1): The Schema](https://blog.graph.cool/graphql-server-basics-the-schema-ac5e2950214e)
-  - [GraphQL Server Basics (Part 2): The Network Layer](https://blog.graph.cool/graphql-server-basics-the-network-layer-51d97d21861)
-  - [GraphQL Server Basics (Part 3): Demystifying the info Argument in GraphQL Resolvers](https://blog.graph.cool/graphql-server-basics-demystifying-the-info-argument-in-graphql-resolvers-6f26249f613a)

--- a/docs/pages/guides/using-graphql.mdx
+++ b/docs/pages/guides/using-graphql.mdx
@@ -139,3 +139,9 @@ You can read more about the core GraphQL constructs [here](https://www.howtograp
 
 Learn how to build a GraphQL server, check out this [tutorial](https://www.howtographql.com/graphql-js/0-introduction/).
 
+## Next steps and resources
+
+**GraphQL server basics** &mdash; check out this tutorial series about GraphQL servers:
+  - [GraphQL Server Basics (Part 1): The Schema](https://www.prisma.io/blog/graphql-server-basics-the-schema-ac5e2950214e)
+  - [GraphQL Server Basics (Part 2): The Network Layer](https://www.prisma.io/blog/graphql-server-basics-the-network-layer-51d97d21861)
+  - [GraphQL Server Basics (Part 3): Demystifying the info Argument in GraphQL Resolvers](https://www.prisma.io/blog/graphql-server-basics-demystifying-the-info-argument-in-graphql-resolvers-6f26249f613a)


### PR DESCRIPTION
# Why
Remove all links from [blog graph cool](https://blog.graph.cool) on [using graphql section](https://docs.expo.dev/guides/using-graphql/#next-steps--resources)  since it cannot be accessed now, so it's better to remove it

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Remove all links that refer to [blog.graph.cool site](https://blog.graph.cool/)
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
