### PR TITLE
[docs] Adds AppJS banner

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -13,6 +13,7 @@ import DocumentationSidebarRight, {
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
+import { AppJSBanner } from '~/ui/components/AppJSBanner';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { PageTitle } from '~/ui/components/PageTitle';
@@ -132,6 +133,7 @@ export default function DocumentationPage(props: Props) {
         )}
       </Head>
       <div css={STYLES_DOCUMENT}>
+        <AppJSBanner />
         {props.title && (
           <PageTitle
             title={props.title}

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -13,7 +13,6 @@ import DocumentationSidebarRight, {
 } from '~/components/DocumentationSidebarRight';
 import Head from '~/components/Head';
 import { usePageApiVersion } from '~/providers/page-api-version';
-import { AppJSBanner } from '~/ui/components/AppJSBanner';
 import { Footer } from '~/ui/components/Footer';
 import { Header } from '~/ui/components/Header';
 import { PageTitle } from '~/ui/components/PageTitle';
@@ -133,7 +132,6 @@ export default function DocumentationPage(props: Props) {
         )}
       </Head>
       <div css={STYLES_DOCUMENT}>
-        <AppJSBanner />
         {props.title && (
           <PageTitle
             title={props.title}

--- a/docs/package.json
+++ b/docs/package.json
@@ -33,6 +33,7 @@
     "@sentry/react": "^7.24.1",
     "@sentry/tracing": "^7.24.1",
     "cmdk": "^0.1.21",
+    "date-fns": "^2.29.3",
     "front-matter": "^4.0.2",
     "fs-extra": "^10.1.0",
     "github-slugger": "^1.3.0",

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
-import { spacing, breakpoints } from '@expo/styleguide-base';
+import { spacing, breakpoints, borderRadius } from '@expo/styleguide-base';
 import {
   ArrowUpRightIcon,
   ArrowRightIcon,
@@ -14,6 +14,7 @@ import type { PropsWithChildren } from 'react';
 import { Container, Row, ScreenClassProvider } from 'react-grid-system';
 
 import DocumentationPage from '~/components/DocumentationPage';
+import { AppJSBanner } from '~/ui/components/AppJSBanner';
 import { APIGridCell, CommunityGridCell, GridCell, HomeButton } from '~/ui/components/Home';
 import {
   APICameraIcon,
@@ -58,6 +59,7 @@ const Home = () => {
         <Description>
           Build one JavaScript/TypeScript project that runs natively on all your users' devices.
         </Description>
+        <AppJSBanner />
         <CellContainer>
           <Row>
             <GridCell xl={4} lg={12} css={quickStartCellStyle}>
@@ -311,6 +313,7 @@ const baseGradientStyle = css({
   width: '100%',
   height: '100%',
   position: 'absolute',
+  borderRadius: borderRadius.lg,
 });
 
 const quickStartCellStyle = css({

--- a/docs/ui/components/AppJSBanner/Background.tsx
+++ b/docs/ui/components/AppJSBanner/Background.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function Background() {
+  return (
+    <svg width="220" viewBox="0 0 180 91" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M66.4685 1.34497L39.5154 24.121C46.5154 38.121 60.0154 68.121 60.0154 68.121L23.0154 90.2211M8.77063 2.0617L120.224 19.383L179.5 1.80193M48.9083 2.0617L91.0154 41.621L1.51537 24.121L22.5082 2.0617M3.01537 72.121L23.0154 41.621L53.0154 81.621L23.0154 63.121L3.01537 72.121Z"
+        stroke="#3246CC"
+        strokeLinejoin="round"
+      />
+      <circle cx="52.5154" cy="81.121" r="2" fill="#8490E1" />
+      <circle cx="23.0597" cy="41.371" r="2" fill="#8490E1" />
+      <circle cx="39.5154" cy="24.121" r="2" fill="#8490E1" />
+      <circle cx="56.5154" cy="9.52374" r="2" fill="#8490E1" />
+      <circle cx="90.5154" cy="41.371" r="2" fill="#8490E1" />
+      <circle cx="119.555" cy="19.4351" r="2" fill="#8490E1" />
+      <circle cx="2.51537" cy="72.121" r="2" fill="#8490E1" />
+    </svg>
+  );
+}

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -1,20 +1,13 @@
 import { css } from '@emotion/react';
-import {
-  borderRadius,
-  breakpoints,
-  shadows,
-  spacing,
-  theme,
-  ArrowUpRightIcon,
-  iconSize,
-} from '@expo/styleguide';
+import { Button, theme, shadows } from '@expo/styleguide';
+import { ArrowUpRightIcon } from '@expo/styleguide-icons';
+import { borderRadius, breakpoints, spacing, iconSize } from '@expo/styleguide-base';
 import isBefore from 'date-fns/isBefore';
 import { useRouter } from 'next/router';
 import React from 'react';
 
 import { Background } from './Background';
 
-import { Button } from '~/ui/components/Button';
 import { CALLOUT, HEADLINE } from '~/ui/components/Text';
 
 export function AppJSBanner() {
@@ -28,8 +21,8 @@ export function AppJSBanner() {
   }
 
   return (
-    <div css={containerStyle}>
-      <div css={backgroundStyle}>
+    <div className='relative flex justify-between items-center bg-[#0019C1] py-4 px-6 rounded-md overflow-hidden gap-3 shadow-xs my-6 flex-wrap'>
+      <div className='absolute -top-1 -left-1'>
         <Background />
       </div>
       <div>
@@ -39,41 +32,16 @@ export function AppJSBanner() {
         </CALLOUT>
       </div>
       <Button
-        size="mini"
-        href="https://appjs.co"
+        size='xs'
+        href='https://appjs.co'
         openInNewTab
-        css={learnMoreButtonStyle}
-        iconRight={<ArrowUpRightIcon color="#0019C1" size={iconSize.sm} />}>
+        className='bg-palette-white text-[#0019C1] border-none'
+        rightSlot={<ArrowUpRightIcon className='icon-sm text-[#0019C1]' />}>
         Learn more
       </Button>
     </div>
   );
 }
-
-const containerStyle = css({
-  position: 'relative',
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  backgroundColor: '#0019C1',
-  padding: `${spacing[4]}px ${spacing[6]}px ${spacing[4]}px ${spacing[4]}px`,
-  borderRadius: borderRadius.md,
-  overflow: 'hidden',
-  gap: spacing[3],
-  boxShadow: shadows.xs,
-  marginTop: spacing[6],
-  marginBottom: spacing[6],
-
-  [`@media (max-width: ${breakpoints.medium}px)`]: {
-    flexWrap: 'wrap',
-  },
-});
-
-const backgroundStyle = css({
-  position: 'absolute',
-  top: -4,
-  left: -4,
-});
 
 const headlineStyle = css({
   position: 'relative',
@@ -84,9 +52,4 @@ const headlineStyle = css({
 const descriptionStyle = css({
   position: 'relative',
   color: '#CCD3FF',
-});
-
-const learnMoreButtonStyle = css({
-  backgroundColor: theme.palette.white,
-  color: '#0019C1',
 });

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
-import { Button, theme, shadows } from '@expo/styleguide';
+import { Button, theme } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
-import { borderRadius, breakpoints, spacing, iconSize } from '@expo/styleguide-base';
+import { spacing } from '@expo/styleguide-base';
 import isBefore from 'date-fns/isBefore';
 import { useRouter } from 'next/router';
 import React from 'react';

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -1,0 +1,78 @@
+import { css } from '@emotion/react';
+import { borderRadius, breakpoints, shadows, spacing, theme } from '@expo/styleguide';
+import isBefore from 'date-fns/isBefore';
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { Background } from './Background';
+
+import { Button } from '~/ui/components/Button';
+import { CALLOUT, HEADLINE } from '~/ui/components/Text';
+
+export function AppJSBanner() {
+  const router = useRouter();
+  const appJSConfEndDate = new Date('2023-05-10');
+  const showAppJSConfShoutout = isBefore(new Date(), appJSConfEndDate);
+  const isHomePage = router.pathname === '/';
+
+  if (!showAppJSConfShoutout || !isHomePage) {
+    return null;
+  }
+
+  return (
+    <div css={containerStyle}>
+      <div css={backgroundStyle}>
+        <Background />
+      </div>
+      <div>
+        <HEADLINE css={headlineStyle}>App.js Conf 2023</HEADLINE>
+        <CALLOUT css={descriptionStyle}>
+          An Expo &amp; React Native conference in Europe is back, May 10-12 in Kraków, Poland!
+        </CALLOUT>
+      </div>
+      <Button size="mini" href="https://appjs.co" openInNewTab css={learnMoreButtonStyle}>
+        Learn more
+      </Button>
+    </div>
+  );
+}
+
+const containerStyle = css({
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  backgroundColor: '#0019C1',
+  padding: `${spacing[4]}px ${spacing[6]}px ${spacing[4]}px ${spacing[4]}px`,
+  borderRadius: borderRadius.md,
+  overflow: 'hidden',
+  gap: spacing[3],
+  boxShadow: shadows.xs,
+  marginBottom: spacing[10],
+
+  [`@media (max-width: ${breakpoints.medium}px)`]: {
+    flexWrap: 'wrap',
+  },
+});
+
+const backgroundStyle = css({
+  position: 'absolute',
+  top: -4,
+  left: -4,
+});
+
+const headlineStyle = css({
+  position: 'relative',
+  color: theme.palette.white,
+  marginBottom: spacing[1],
+});
+
+const descriptionStyle = css({
+  position: 'relative',
+  color: '#CCD3FF',
+});
+
+const learnMoreButtonStyle = css({
+  backgroundColor: theme.palette.white,
+  color: '#0019C1',
+});

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -1,5 +1,13 @@
 import { css } from '@emotion/react';
-import { borderRadius, breakpoints, shadows, spacing, theme } from '@expo/styleguide';
+import {
+  borderRadius,
+  breakpoints,
+  shadows,
+  spacing,
+  theme,
+  ArrowUpRightIcon,
+  iconSize,
+} from '@expo/styleguide';
 import isBefore from 'date-fns/isBefore';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -30,7 +38,12 @@ export function AppJSBanner() {
           An Expo &amp; React Native conference in Europe is back, May 10-12 in Kraków, Poland!
         </CALLOUT>
       </div>
-      <Button size="mini" href="https://appjs.co" openInNewTab css={learnMoreButtonStyle}>
+      <Button
+        size="mini"
+        href="https://appjs.co"
+        openInNewTab
+        css={learnMoreButtonStyle}
+        iconRight={<ArrowUpRightIcon color="#0019C1" size={iconSize.sm} />}>
         Learn more
       </Button>
     </div>
@@ -48,7 +61,8 @@ const containerStyle = css({
   overflow: 'hidden',
   gap: spacing[3],
   boxShadow: shadows.xs,
-  marginBottom: spacing[10],
+  marginTop: spacing[6],
+  marginBottom: spacing[6],
 
   [`@media (max-width: ${breakpoints.medium}px)`]: {
     flexWrap: 'wrap',

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Button, theme } from '@expo/styleguide';
-import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { spacing } from '@expo/styleguide-base';
+import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import isBefore from 'date-fns/isBefore';
 import { useRouter } from 'next/router';
 import React from 'react';
@@ -21,8 +21,8 @@ export function AppJSBanner() {
   }
 
   return (
-    <div className='relative flex justify-between items-center bg-[#0019C1] py-4 px-6 rounded-md overflow-hidden gap-3 shadow-xs my-6 flex-wrap'>
-      <div className='absolute -top-1 -left-1'>
+    <div className="relative flex justify-between items-center bg-[#0019C1] py-4 px-6 rounded-md overflow-hidden gap-3 shadow-xs my-6 flex-wrap">
+      <div className="absolute -top-1 -left-1">
         <Background />
       </div>
       <div>
@@ -32,11 +32,11 @@ export function AppJSBanner() {
         </CALLOUT>
       </div>
       <Button
-        size='xs'
-        href='https://appjs.co'
+        size="xs"
+        href="https://appjs.co"
         openInNewTab
-        className='bg-palette-white text-[#0019C1] border-none'
-        rightSlot={<ArrowUpRightIcon className='icon-sm text-[#0019C1]' />}>
+        className="bg-palette-white text-[#0019C1] border-none"
+        rightSlot={<ArrowUpRightIcon className="icon-sm text-[#0019C1]" />}>
         Learn more
       </Button>
     </div>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2696,6 +2696,11 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+date-fns@^2.29.3:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
 debug@4, debug@4.3.4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"


### PR DESCRIPTION
# Why

I talked with Paulina about adding an App.js banner, to advertise it to Expo docs readers.

# How

- Adds the same component we had last year, but with updated information
- Adds the banner on the home page above the current content

# Screenshot

<img width="1348" alt="Screenshot 2023-03-08 at 11 31 11 AM" src="https://user-images.githubusercontent.com/6455018/223787161-f262d347-31f6-4f59-a1b5-2288e951e252.png">


# Test Plan

Make sure that the banner appears as it does in the screenshot above.
