### PR TITLE
[exupdates][ios] More swift rename cleanup

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -27,6 +27,7 @@
 - iOS: Decrease access control on classes and remove unnecessary objc attributes. ([#21597](https://github.com/expo/expo/pull/21597) by [@wschurman](https://github.com/wschurman))
 - iOS: Replace reachability code with library for wifi detection. ([#21598](https://github.com/expo/expo/pull/21598) by [@wschurman](https://github.com/wschurman))
 - iOS: Clean up and rename code signing classes. ([#21600](https://github.com/expo/expo/pull/21600) by [@wschurman](https://github.com/wschurman))
+- iOS: Rename classes to be more swifty. ([#21620](https://github.com/expo/expo/pull/21620), [#21622](https://github.com/expo/expo/pull/21622) by [@wschurman](https://github.com/wschurman))
 - Fix E2E rollback test and other improvements. ([#21389](https://github.com/expo/expo/pull/21389) by [@douglowder](https://github.com/douglowder))
 - Consolidate E2E tests. ([#21458](https://github.com/expo/expo/pull/21458) by [@douglowder](https://github.com/douglowder))
 - E2E tests: graceful Detox failures. ([#21520](https://github.com/expo/expo/pull/21520) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncher.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public typealias EXUpdatesAppLauncherCompletionBlock = (Error?, Bool) -> Void
+public typealias AppLauncherCompletionBlock = (Error?, Bool) -> Void
 
 /**
  * Protocol through which an update can be launched from disk. Classes that implement this protocol

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
@@ -5,12 +5,12 @@
 import Foundation
 
 /**
- * Implementation of EXUpdatesAppLauncher which always uses the update embedded in the application
+ * Implementation of AppLauncher which always uses the update embedded in the application
  * package, avoiding SQLite and the expo-updates file store entirely.
  *
  * This is only used in rare cases when the database/file system is corrupt or otherwise
  * inaccessible, but we still want to avoid crashing. The exported property `isEmergencyLaunch` on
- * EXUpdatesModule should be `true` whenever this class is used.
+ * UpdatesModule should be `true` whenever this class is used.
  */
 @objc(EXUpdatesAppLauncherNoDatabase)
 @objcMembers

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -11,16 +11,16 @@ public typealias AppLauncherUpdateCompletionBlock = (Error?, Update?) -> Void
 public typealias AppLauncherQueryCompletionBlock = (Error?, [UUID]?) -> Void
 
 /**
- * Implementation of EXUpdatesAppLauncher that uses the SQLite database and expo-updates file store
+ * Implementation of AppLauncher that uses the SQLite database and expo-updates file store
  * as the source of updates.
  *
- * Uses the EXUpdatesSelectionPolicy to choose an update from SQLite to launch, then ensures that
+ * Uses the SelectionPolicy to choose an update from SQLite to launch, then ensures that
  * the update is safe and ready to launch (i.e. all the assets that SQLite expects to be stored on
  * disk are actually there).
  *
  * This class also includes failsafe code to attempt to re-download any assets unexpectedly missing
  * from disk (since it isn't necessarily safe to just revert to an older update in this case).
- * Distinct from the EXUpdatesAppLoader classes, though, this class does *not* make any major
+ * Distinct from the AppLoader classes, though, this class does *not* make any major
  * modifications to the database; its role is mostly to read the database and ensure integrity with
  * the file system.
  *
@@ -43,7 +43,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
   private let database: UpdatesDatabase
   private let directory: URL
   public private(set) var completionQueue: DispatchQueue
-  public private(set) var completion: EXUpdatesAppLauncherCompletionBlock?
+  public private(set) var completion: AppLauncherCompletionBlock?
 
   private var launchAssetError: Error?
 
@@ -130,9 +130,9 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
 
   public func launchUpdate(
     withSelectionPolicy selectionPolicy: SelectionPolicy,
-    completion: @escaping EXUpdatesAppLauncherCompletionBlock
+    completion: @escaping AppLauncherCompletionBlock
   ) {
-    precondition(self.completion == nil, "EXUpdatesAppLauncher:launchUpdateWithSelectionPolicy:successBlock should not be called twice on the same instance")
+    precondition(self.completion == nil, "AppLauncher:launchUpdateWithSelectionPolicy:completion should not be called twice on the same instance")
     self.completion = completion
 
     if launchedUpdate == nil {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -140,7 +140,7 @@ public class AppLoader: NSObject {
         }
 
         // swiftlint:disable:next line_length
-        NSLog("EXUpdatesAppLoader: Loaded an update with the same ID but a different scopeKey than one we already have on disk. This is a server error. Overwriting the scopeKey and loading the existing update.")
+        NSLog("AppLoader: Loaded an update with the same ID but a different scopeKey than one we already have on disk. This is a server error. Overwriting the scopeKey and loading the existing update.")
       }
 
       if let existingUpdate = existingUpdate,

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -16,7 +16,7 @@ public protocol AppLoaderTaskDelegate: AnyObject {
    * a remote load if it decides the cached update is not runnable. Returning NO from this
    * callback will force a remote load, overriding the timeout and configuration settings for
    * whether or not to check for a remote update. Returning YES from this callback will make
-   * EXUpdatesAppLoaderTask proceed as usual.
+   * AppLoaderTask proceed as usual.
    */
   func appLoaderTask(_: AppLoaderTask, didLoadCachedUpdate update: Update) -> Bool
   func appLoaderTask(_: AppLoaderTask, didStartLoadingUpdate update: Update)
@@ -41,16 +41,16 @@ public enum BackgroundUpdateStatus: Int {
  * Controlling class that handles the complex logic that needs to happen each time the app is cold
  * booted. From a high level, this class does the following:
  *
- * - Immediately starts an instance of EXUpdatesEmbeddedAppLoader to load the embedded update into
+ * - Immediately starts an instance of EmbeddedAppLoader to load the embedded update into
  *   SQLite. This does nothing if SQLite already has the embedded update or a newer one, but we have
  *   to do this on each cold boot, as we have no way of knowing if a new build was just installed
  *   (which could have a new embedded update).
  * - If the app is configured for automatic update downloads (most apps), starts a timer based on
- *   the `launchWaitMs` value in EXUpdatesConfig.
+ *   the `launchWaitMs` value in UpdatesConfig.
  * - Again if the app is configured for automatic update downloads, starts an instance of
- *   EXUpdatesRemoteAppLoader to check for and download a new update if there is one.
+ *   RemoteAppLoader to check for and download a new update if there is one.
  * - Once the download succeeds, fails, or the timer runs out (whichever happens first), creates an
- *   instance of EXUpdatesAppLauncherWithDatabase and signals that the app is ready to be launched
+ *   instance of AppLauncherWithDatabase and signals that the app is ready to be launched
  *   with the newest update available locally at that time (which may not be the newest update if
  *   the download is still in progress).
  * - If the download succeeds or fails after this point, fires a callback which causes an event to
@@ -107,7 +107,7 @@ public final class AppLoaderTask: NSObject {
   public func start() {
     guard config.isEnabled else {
       // swiftlint:disable:next line_length
-      let errorMessage = "EXUpdatesAppLoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling EXUpdatesAppLoaderTask, or enable updates in the configuration."
+      let errorMessage = "AppLoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling AppLoaderTask, or enable updates in the configuration."
       logger.error(message: errorMessage, code: .updateFailedToLoad)
       delegateQueue.async {
         self.delegate?.appLoaderTask(
@@ -124,7 +124,7 @@ public final class AppLoaderTask: NSObject {
 
     guard config.updateUrl != nil else {
       // swiftlint:disable:next line_length
-      let errorMessage = "EXUpdatesAppLoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use EXUpdatesAppLoaderTask to load updates."
+      let errorMessage = "AppLoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use AppLoaderTask to load updates."
       logger.error(message: errorMessage, code: .updateFailedToLoad)
       delegateQueue.async {
         self.delegate?.appLoaderTask(
@@ -209,7 +209,7 @@ public final class AppLoaderTask: NSObject {
               domain: AppLoaderTask.ErrorDomain,
               code: 1031,
               userInfo: [
-                NSLocalizedDescriptionKey: "EXUpdatesAppLoaderTask encountered an unexpected error and could not launch an update."
+                NSLocalizedDescriptionKey: "AppLoaderTask encountered an unexpected error and could not launch an update."
               ]
             )
           )
@@ -283,7 +283,7 @@ public final class AppLoaderTask: NSObject {
             filters: manifestFilters
           ) {
             // launchedUpdate is nil because we don't yet have one, and it doesn't matter as we won't
-            // be sending an HTTP request from EXUpdatesEmbeddedAppLoader
+            // be sending an HTTP request from EmbeddedAppLoader
             self.embeddedAppLoader = EmbeddedAppLoader(
               config: self.config,
               database: self.database,

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
- * Subclass of EXUpdatesAppLoader which handles copying the embedded update's assets into the
+ * Subclass of AppLoader which handles copying the embedded update's assets into the
  * expo-updates cache location.
  *
  * Rather than launching the embedded update directly from its location in the app bundle/apk, we
@@ -28,7 +28,7 @@ public final class EmbeddedAppLoader: AppLoader {
   public static let EXUpdatesBareEmbeddedBundleFilename = "main"
   public static let EXUpdatesBareEmbeddedBundleFileType = "jsbundle"
 
-  private static let EXUpdatesEmbeddedAppLoaderErrorDomain = "EXUpdatesEmbeddedAppLoader"
+  private static let ErrorDomain = "EXUpdatesEmbeddedAppLoader"
 
   private static var embeddedManifestInternal: Update?
   public static func embeddedManifest(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> Update? {
@@ -108,7 +108,7 @@ public final class EmbeddedAppLoader: AppLoader {
   ) {
     guard let embeddedManifest = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database) else {
       errorBlock(NSError(
-        domain: EmbeddedAppLoader.EXUpdatesEmbeddedAppLoaderErrorDomain,
+        domain: EmbeddedAppLoader.ErrorDomain,
         code: 1008,
         userInfo: [
           NSLocalizedDescriptionKey: "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
@@ -163,6 +163,6 @@ public final class EmbeddedAppLoader: AppLoader {
     success successBlock: @escaping AppLoaderSuccessBlock,
     error errorBlock: @escaping AppLoaderErrorBlock
   ) {
-    preconditionFailure("Should not call EXUpdatesEmbeddedAppLoader#loadUpdateFromUrl")
+    preconditionFailure("Should not call EmbeddedAppLoader#loadUpdateFromUrl")
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /**
- * Subclass of EXUpdatesAppLoader which handles downloading updates from a remote server.
+ * Subclass of AppLoader which handles downloading updates from a remote server.
  */
 internal final class RemoteAppLoader: AppLoader {
   private static let ErrorDomain = "EXUpdatesRemoteAppLoader"

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -8,7 +8,7 @@ import EXUpdatesInterface
 
 /**
  * Main entry point to expo-updates in development builds with expo-dev-client. Singleton that still
- * makes use of EXUpdatesAppController for keeping track of updates state, but provides capabilities
+ * makes use of AppController for keeping track of updates state, but provides capabilities
  * that are not usually exposed but that expo-dev-client needs (launching and downloading a specific
  * update by URL, allowing dynamic configuration, introspecting the database).
  *

--- a/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
+++ b/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
@@ -186,16 +186,16 @@ public final class ErrorRecovery: NSObject {
 
     switch nextTask {
     case .waitForRemoteUpdate:
-      logger.info(message: "EXUpdatesErrorRecovery: attempting to fetch a new update, waiting")
+      logger.info(message: "ErrorRecovery: attempting to fetch a new update, waiting")
       waitForRemoteLoaderToFinish()
     case .launchNew:
-      logger.info(message: "EXUpdatesErrorRecovery: launching a new update")
+      logger.info(message: "ErrorRecovery: launching a new update")
       tryRelaunchFromCache()
     case .launchCached:
-      logger.info(message: "EXUpdatesErrorRecovery: launching a cached update")
+      logger.info(message: "ErrorRecovery: launching a cached update")
       tryRelaunchFromCache()
     case .crash:
-      logger.error(message: "EXUpdatesErrorRecovery: could not recover from error, crashing", code: .updateFailedToLoad)
+      logger.error(message: "ErrorRecovery: could not recover from error, crashing", code: .updateFailedToLoad)
       crash()
     }
   }
@@ -325,7 +325,7 @@ public final class ErrorRecovery: NSObject {
     }
     // wait 10s before unsetting error handlers; even though we won't try to relaunch if our handlers
     // are triggered after now, we still want to give the app a reasonable window of time to start the
-    // EXUpdatesErrorRecoveryTaskWaitForRemoteUpdate task and check for a new update is there is one
+    // ErrorRecoveryTaskWaitForRemoteUpdate task and check for a new update is there is one
     errorRecoveryQueue.asyncAfter(deadline: DispatchTime.now() + .seconds(10)) {
       self.unsetRCTErrorHandlers()
     }
@@ -388,7 +388,7 @@ public final class ErrorRecovery: NSObject {
         return
       }
 
-      self.logger.error(message: "EXUpdatesErrorRecovery fatal exception: \(serializedError)", code: .jsRuntimeError)
+      self.logger.error(message: "ErrorRecovery fatal exception: \(serializedError)", code: .jsRuntimeError)
       let data = serializedError.data(using: .utf8)!
       let errorLogFile = ErrorRecovery.errorLogFile()
       if FileManager.default.fileExists(atPath: errorLogFile.path) {

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -20,7 +20,7 @@ internal final class UpdatesNotInitializedException: Exception {
   }
 
   override var reason: String {
-    "The updates module controller has not been properly initialized. If you're in development mode, you cannot use this method. Otherwise, make sure you have called EXUpdatesAppController.sharedInstance.start()"
+    "The updates module controller has not been properly initialized. If you're in development mode, you cannot use this method. Otherwise, make sure you have called AppController.sharedInstance.start()"
   }
 }
 
@@ -30,6 +30,6 @@ internal final class UpdatesReloadException: Exception {
   }
 
   override var reason: String {
-    "Could not reload application. Ensure you have set the `bridge` property of EXUpdatesAppController."
+    "Could not reload application. Ensure you have set the `bridge` property of AppController."
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesAppDelegateSubscriber.swift
@@ -5,7 +5,7 @@ import EXUpdatesInterface
 
 /**
  * Used only in development builds with expo-dev-client; completes the auto-setup for development
- * builds with the expo-updates integration by passing a reference to EXUpdatesDevLauncherController
+ * builds with the expo-updates integration by passing a reference to DevLauncherController
  * over to the registry, which expo-dev-client can access.
  */
 public final class ExpoUpdatesAppDelegateSubscriber: ExpoAppDelegateSubscriber {

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -74,7 +74,7 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     return self.deferredRootView
   }
 
-  // MARK: EXUpdatesAppControllerDelegate implementations
+  // MARK: AppControllerDelegate implementations
 
   public func appController(_ appController: AppController, didStartWithSuccess success: Bool) {
     guard let reactDelegate = self.reactDelegate else {

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicyFilterAware.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /**
- * An EXUpdatesLauncherSelectionPolicy which chooses an update to launch based on the manifest
+ * A LauncherSelectionPolicy which chooses an update to launch based on the manifest
  * filters provided by the server. If multiple updates meet the criteria, the newest one (using
  * `commitTime` for ordering) is chosen, but the manifest filters are always taken into account
  * before the `commitTime`.

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicySingleUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LauncherSelectionPolicySingleUpdate.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /**
- * A trivial EXUpdatesLauncherSelectionPolicy that will choose a single predetermined update to launch.
+ * A trivial LauncherSelectionPolicy that will choose a single predetermined update to launch.
  */
 @objc(EXUpdatesLauncherSelectionPolicySingleUpdate)
 @objcMembers

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicyFilterAware.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /**
- * An EXUpdatesLoaderSelectionPolicy which decides whether or not to load an update, taking filters into
+ * A LoaderSelectionPolicy which decides whether or not to load an update, taking filters into
  * account. Returns true (should load the update) if we don't have an existing newer update that
  * matches the given manifest filters.
  *

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyDevelopmentClient.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyDevelopmentClient.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /**
- * An EXUpdatesReaperSelectionPolicy which keeps a predefined maximum number of updates across all scopes,
+ * A ReaperSelectionPolicy which keeps a predefined maximum number of updates across all scopes,
  * and, once that number is surpassed, selects the updates least recently accessed (and then least
  * recently published) to delete. Ignores filters and scopes.
  *
@@ -24,7 +24,7 @@ public final class ReaperSelectionPolicyDevelopmentClient: NSObject, ReaperSelec
     if maxUpdatesToKeep <= 0 {
       NSException.init(
         name: .invalidArgumentException,
-        reason: "Cannot initiailize EXUpdatesReaperSelectionPolicy with maxUpdatesToKeep <= 0"
+        reason: "Cannot initiailize ReaperSelectionPolicy with maxUpdatesToKeep <= 0"
       )
       .raise()
     }
@@ -53,7 +53,7 @@ public final class ReaperSelectionPolicyDevelopmentClient: NSObject, ReaperSelec
           // avoid infinite loop
           NSException.init(
             name: .internalInconsistencyException,
-            reason: "Multiple updates with the same ID were passed into EXUpdatesReaperSelectionPolicyDevelopmentClient"
+            reason: "Multiple updates with the same ID were passed into ReaperSelectionPolicyDevelopmentClient"
           )
           .raise()
         }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
@@ -3,7 +3,7 @@
 import Foundation
 
 /**
- * An EXUpdatesReaperSelectionPolicy which chooses which updates to delete taking into account manifest filters
+ * A ReaperSelectionPolicy which chooses which updates to delete taking into account manifest filters
  * originating from the server. If an older update is available, it will choose to keep one older
  * update in addition to the one currently running, preferring updates that match the same filters
  * if available.

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicy.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicy.swift
@@ -16,7 +16,7 @@ import Foundation
  * The three methods are individually pluggable to allow for different behavior of specific parts of
  * the module in different situations. For example, in a development client, our policy for
  * retaining and deleting updates is different than in a release build, so we use a different
- * implementation of EXUpdatesReaperSelectionPolicy.
+ * implementation of ReaperSelectionPolicy.
  *
  * Importantly (and non-trivially), expo-updates must be able to make all these determinations
  * without talking to any server. This is because the embedded update can change at any time,

--- a/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
@@ -63,7 +63,7 @@ internal final class BareUpdate: Update {
     if update.runtimeVersion.contains(",") {
       let exception = NSException(
         name: NSExceptionName.internalInconsistencyException,
-        reason: "Should not be initializing EXUpdatesBareUpdate in an environment with multiple runtime versions.",
+        reason: "Should not be initializing BareUpdate in an environment with multiple runtime versions.",
         userInfo: [:]
       )
       exception.raise()

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -10,7 +10,7 @@ import ExpoModulesCore
  * and updates state, along with methods to check for and download new updates, reload with the
  * newest downloaded update applied, and read/clear native log entries.
  *
- * Communicates with the updates hub (EXUpdatesAppController in most apps, EXAppLoaderExpoUpdates in
+ * Communicates with the updates hub (AppController in most apps, EXAppLoaderExpoUpdates in
  * Expo Go and legacy standalone apps) via EXUpdatesService, an internal module which is overridden
  * by EXUpdatesBinding, a scoped module, in Expo Go.
  */

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -134,7 +134,7 @@ public final class UpdatesUtils: NSObject {
   internal static func purgeUpdatesLogsOlderThanOneDay() {
     UpdatesLogReader().purgeLogEntries { error in
       if let error = error {
-        NSLog("EXUpdatesUtils: error in purgeOldUpdatesLogs: %@", error.localizedDescription)
+        NSLog("UpdatesUtils: error in purgeOldUpdatesLogs: %@", error.localizedDescription)
       }
     }
   }


### PR DESCRIPTION
# Why

This mostly corrects docblocks referencing old class names.

# How

Correct.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
