### PR TITLE
[docs] drop decoration of API headers, add monospace font weight variant

### DIFF
--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#code-heading-depth-1"
     >
       <code
-        class="css-ma1quf-TextComponent"
+        class="css-13j9lyg-TextComponent"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/components/plugins/APIBox.tsx
+++ b/docs/components/plugins/APIBox.tsx
@@ -1,9 +1,13 @@
 import type { PropsWithChildren } from 'react';
 
-import { STYLES_APIBOX, STYLES_APIBOX_WRAPPER } from '~/components/plugins/api/APISectionUtils';
+import {
+  H3Code,
+  STYLES_APIBOX,
+  STYLES_APIBOX_WRAPPER,
+} from '~/components/plugins/api/APISectionUtils';
 import { PlatformName } from '~/types/common';
 import { PlatformTags } from '~/ui/components/Tag';
-import { H3 } from '~/ui/components/Text';
+import { MONOSPACE } from '~/ui/components/Text';
 
 type APIBoxProps = PropsWithChildren<{
   header?: string;
@@ -15,7 +19,11 @@ export const APIBox = ({ header, platforms, children, className }: APIBoxProps) 
   return (
     <div css={[STYLES_APIBOX, STYLES_APIBOX_WRAPPER]} className={className}>
       {platforms && <PlatformTags prefix="Only for:" platforms={platforms} />}
-      {header && <H3 tags={platforms}>{header}</H3>}
+      {header && (
+        <H3Code tags={platforms}>
+          <MONOSPACE weight="medium">{header}</MONOSPACE>
+        </H3Code>
+      )}
       {children}
     </div>
   );

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`APISection expo-apple-authentication 1`] = `
     </a>
   </h2>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -68,7 +68,7 @@ exports[`APISection expo-apple-authentication 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -338,7 +338,7 @@ for more details.
     </h2>
     <div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -356,7 +356,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 buttonStyle
@@ -423,7 +423,7 @@ for more details.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -441,7 +441,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 buttonType
@@ -508,7 +508,7 @@ for more details.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -526,7 +526,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 cornerRadius
@@ -601,7 +601,7 @@ for more details.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -619,7 +619,7 @@ for more details.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 onPress
@@ -696,7 +696,7 @@ in here.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -714,7 +714,7 @@ in here.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 style
@@ -948,7 +948,7 @@ properties.
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -966,7 +966,7 @@ properties.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             getCredentialStateAsync(user)
@@ -1213,7 +1213,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -1231,7 +1231,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -1347,7 +1347,7 @@ value depending on the state of the credential.
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -1365,7 +1365,7 @@ value depending on the state of the credential.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             refreshAsync(options)
@@ -1578,7 +1578,7 @@ refresh operation.
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -1596,7 +1596,7 @@ refresh operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             signInAsync(options)
@@ -1856,7 +1856,7 @@ sign-in operation.
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -1874,7 +1874,7 @@ sign-in operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             signOutAsync(options)
@@ -2168,7 +2168,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -2186,7 +2186,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             addRevokeListener(listener)
@@ -2380,7 +2380,7 @@ sign-out operation.
     </a>
   </h2>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -2398,7 +2398,7 @@ sign-out operation.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredential
@@ -2904,7 +2904,7 @@ developers.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -2922,7 +2922,7 @@ developers.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationFullName
@@ -3211,7 +3211,7 @@ may be
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -3229,7 +3229,7 @@ may be
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationRefreshOptions
@@ -3520,7 +3520,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -3538,7 +3538,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignInOptions
@@ -3850,7 +3850,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -3868,7 +3868,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationSignOutOptions
@@ -4089,7 +4089,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -4107,7 +4107,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             Subscription
@@ -4255,7 +4255,7 @@ OAuth 2.0 protocol
     </a>
   </h2>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -4273,7 +4273,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonStyle
@@ -4328,7 +4328,7 @@ OAuth 2.0 protocol
       .
     </p>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -4396,7 +4396,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -4464,7 +4464,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -4533,7 +4533,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -4551,7 +4551,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationButtonType
@@ -4606,7 +4606,7 @@ OAuth 2.0 protocol
       .
     </p>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -4674,7 +4674,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -4742,7 +4742,7 @@ OAuth 2.0 protocol
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <strong
         class="css-bvflvn-TextComponent"
@@ -4844,7 +4844,7 @@ OAuth 2.0 protocol
     </div>
   </div>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -4862,7 +4862,7 @@ OAuth 2.0 protocol
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationCredentialState
@@ -4969,7 +4969,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5031,7 +5031,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5093,7 +5093,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5155,7 +5155,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5218,7 +5218,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -5236,7 +5236,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationOperation
@@ -5273,7 +5273,7 @@ for more details.
       </a>
     </h3>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5341,7 +5341,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5403,7 +5403,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5465,7 +5465,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5528,7 +5528,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -5546,7 +5546,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationScope
@@ -5696,7 +5696,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5758,7 +5758,7 @@ for more details.
       </code>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -5821,7 +5821,7 @@ for more details.
     </div>
   </div>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -5839,7 +5839,7 @@ for more details.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             AppleAuthenticationUserDetectionStatus
@@ -5934,7 +5934,7 @@ for more details.
       </div>
     </blockquote>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -6002,7 +6002,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -6070,7 +6070,7 @@ for more details.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -6191,7 +6191,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </a>
   </h2>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -6209,7 +6209,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeScanner
@@ -6322,7 +6322,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
     </h2>
     <div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -6340,7 +6340,7 @@ exports[`APISection expo-barcode-scanner 1`] = `
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 barCodeTypes
@@ -6446,7 +6446,7 @@ minimize battery usage.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -6464,7 +6464,7 @@ minimize battery usage.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 onBarCodeScanned
@@ -6607,7 +6607,7 @@ data has been retrieved.
         <br />
       </div>
       <div
-        class="css-c22nmz"
+        class="css-11xr3cd"
       >
         <h3
           class="  css-6r23rc-TextComponent"
@@ -6625,7 +6625,7 @@ data has been retrieved.
               class="css-6n7j50"
             >
               <code
-                class="css-1qdx416-TextComponent"
+                class="css-s0csg4-TextComponent"
                 data-text="true"
               >
                 type
@@ -6863,7 +6863,7 @@ Same as
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -6881,7 +6881,7 @@ Same as
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             usePermissions(options)
@@ -7227,7 +7227,7 @@ This uses both
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -7245,7 +7245,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             BarCodeScanner.getPermissionsAsync()
@@ -7364,7 +7364,7 @@ This uses both
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -7382,7 +7382,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             BarCodeScanner.requestPermissionsAsync()
@@ -7523,7 +7523,7 @@ This uses both
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -7541,7 +7541,7 @@ This uses both
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             BarCodeScanner.scanFromURLAsync(url, barCodeTypes)
@@ -7859,7 +7859,7 @@ code.
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -7877,7 +7877,7 @@ code.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -8152,7 +8152,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8170,7 +8170,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeBounds
@@ -8317,7 +8317,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8335,7 +8335,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeEvent
@@ -8459,7 +8459,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8477,7 +8477,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeEventCallbackArguments
@@ -8581,7 +8581,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8599,7 +8599,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodePoint
@@ -8757,7 +8757,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8775,7 +8775,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeScannedCallback
@@ -8882,7 +8882,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -8900,7 +8900,7 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeScannerResult
@@ -9161,7 +9161,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -9179,7 +9179,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             BarCodeSize
@@ -9316,7 +9316,7 @@ you don't get this value.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -9334,7 +9334,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionHookOptions
@@ -9444,7 +9444,7 @@ you don't get this value.
     </a>
   </h2>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -9462,7 +9462,7 @@ you don't get this value.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -9499,7 +9499,7 @@ you don't get this value.
       </a>
     </h3>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -9567,7 +9567,7 @@ you don't get this value.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -9635,7 +9635,7 @@ you don't get this value.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -9756,7 +9756,7 @@ exports[`APISection expo-pedometer 1`] = `
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -9774,7 +9774,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             getPermissionsAsync()
@@ -9875,7 +9875,7 @@ exports[`APISection expo-pedometer 1`] = `
     <br />
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -9893,7 +9893,7 @@ exports[`APISection expo-pedometer 1`] = `
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             getStepCountAsync(start, end)
@@ -10186,7 +10186,7 @@ a start date that is more than seven days in the past returns only the available
     </blockquote>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -10204,7 +10204,7 @@ a start date that is more than seven days in the past returns only the available
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             isAvailableAsync()
@@ -10314,7 +10314,7 @@ available on this device.
     </p>
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -10332,7 +10332,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             requestPermissionsAsync()
@@ -10433,7 +10433,7 @@ available on this device.
     <br />
   </div>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -10451,7 +10451,7 @@ available on this device.
           class="css-6n7j50"
         >
           <code
-            class="css-1qdx416-TextComponent"
+            class="css-s0csg4-TextComponent"
             data-text="true"
           >
             watchStepCount(callback)
@@ -10698,7 +10698,7 @@ provided with a single argument that is
     </a>
   </h2>
   <div
-    class="css-c22nmz"
+    class="css-11xr3cd"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -10716,7 +10716,7 @@ provided with a single argument that is
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionResponse
@@ -10991,7 +10991,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -11009,7 +11009,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PedometerResult
@@ -11113,7 +11113,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -11131,7 +11131,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PedometerUpdateCallback
@@ -11244,7 +11244,7 @@ in order to enable/disable the permission.
     </div>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -11262,7 +11262,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionExpiration
@@ -11331,7 +11331,7 @@ in order to enable/disable the permission.
     </p>
   </div>
   <div
-    class="css-1h8tzv"
+    class="css-1fultt1"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -11349,7 +11349,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             Subscription
@@ -11497,7 +11497,7 @@ in order to enable/disable the permission.
     </a>
   </h2>
   <div
-    class="css-1kkk53e"
+    class="css-1gsbrid"
   >
     <h3
       class="  css-6r23rc-TextComponent"
@@ -11515,7 +11515,7 @@ in order to enable/disable the permission.
           class="css-6n7j50"
         >
           <code
-            class="css-4xa05b-TextComponent"
+            class="css-yd3r23-TextComponent"
             data-text="true"
           >
             PermissionStatus
@@ -11552,7 +11552,7 @@ in order to enable/disable the permission.
       </a>
     </h3>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -11620,7 +11620,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"
@@ -11688,7 +11688,7 @@ in order to enable/disable the permission.
       </p>
     </div>
     <div
-      class="css-c22nmz"
+      class="css-11xr3cd"
     >
       <h4
         class="  css-1gu5rqd-TextComponent"

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
 <div>
   <div
-    class="css-165e1mf-AppConfigProperty"
+    class="css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -123,7 +123,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     <div />
   </div>
   <div
-    class="css-165e1mf-AppConfigProperty"
+    class="css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -287,7 +287,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </details>
     <div>
       <div
-        class="css-165e1mf-AppConfigProperty"
+        class="css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -415,7 +415,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </details>
         <div>
           <div
-            class="css-165e1mf-AppConfigProperty"
+            class="css-c2t1qw-AppConfigProperty"
           >
             <p
               class="  css-1kfqm4n-TextComponent"
@@ -501,7 +501,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="css-165e1mf-AppConfigProperty"
+        class="css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -601,7 +601,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </div>
   </div>
   <div
-    class="css-165e1mf-AppConfigProperty"
+    class="css-c2t1qw-AppConfigProperty"
   >
     <p
       class="  css-1kfqm4n-TextComponent"
@@ -761,7 +761,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
     </blockquote>
     <div>
       <div
-        class="css-165e1mf-AppConfigProperty"
+        class="css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -845,7 +845,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         <div />
       </div>
       <div
-        class="css-165e1mf-AppConfigProperty"
+        class="css-c2t1qw-AppConfigProperty"
       >
         <p
           class="  css-1kfqm4n-TextComponent"
@@ -922,7 +922,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         </p>
         <div>
           <div
-            class="css-165e1mf-AppConfigProperty"
+            class="css-c2t1qw-AppConfigProperty"
           >
             <p
               class="  css-1kfqm4n-TextComponent"

--- a/docs/components/plugins/api/APISectionClasses.tsx
+++ b/docs/components/plugins/api/APISectionClasses.tsx
@@ -22,7 +22,7 @@ import {
   getCommentContent,
   BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionClassesProps = {
   data: GeneratedData[];
@@ -77,7 +77,7 @@ const renderClass = (clx: ClassDefinitionData, exposeInSidebar: boolean): JSX.El
       <APISectionDeprecationNote comment={comment} />
       <APISectionPlatformTags comment={comment} prefix="Only for:" />
       <H3Code tags={getTagNamesList(comment)}>
-        <CODE>{name}</CODE>
+        <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
       {(extendedTypes?.length || implementedTypes?.length) && (
         <P>

--- a/docs/components/plugins/api/APISectionComponents.tsx
+++ b/docs/components/plugins/api/APISectionComponents.tsx
@@ -15,7 +15,7 @@ import {
   H3Code,
   STYLES_ELEMENT_SPACING,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionComponentsProps = {
   data: GeneratedData[];
@@ -57,7 +57,7 @@ const renderComponent = (
     <div key={`component-definition-${resolvedName}`} css={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={extractedComment} />
       <H3Code tags={getTagNamesList(comment)}>
-        <CODE>{resolvedName}</CODE>
+        <MONOSPACE weight="medium">{resolvedName}</MONOSPACE>
       </H3Code>
       {resolvedType && resolvedTypeParameters && (
         <P css={STYLES_ELEMENT_SPACING}>

--- a/docs/components/plugins/api/APISectionConstants.tsx
+++ b/docs/components/plugins/api/APISectionConstants.tsx
@@ -9,7 +9,7 @@ import {
   STYLES_APIBOX,
   H3Code,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionConstantsProps = {
   data: ConstantDefinitionData[];
@@ -24,10 +24,10 @@ const renderConstant = (
     <APISectionDeprecationNote comment={comment} />
     <APISectionPlatformTags comment={comment} prefix="Only for:" />
     <H3Code tags={getTagNamesList(comment)}>
-      <CODE>
+      <MONOSPACE weight="medium">
         {apiName ? `${apiName}.` : ''}
         {name}
-      </CODE>
+      </MONOSPACE>
     </H3Code>
     {type && (
       <P>

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -11,7 +11,7 @@ import {
   STYLES_APIBOX_NESTED,
   H3Code,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, H4, CODE } from '~/ui/components/Text';
+import { H2, H4, CODE, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionEnumsProps = {
   data: EnumDefinitionData[];
@@ -35,7 +35,7 @@ const renderEnum = ({ name, children, comment }: EnumDefinitionData): JSX.Elemen
     <APISectionDeprecationNote comment={comment} />
     <APISectionPlatformTags comment={comment} prefix="Only for:" />
     <H3Code tags={getTagNamesList(comment)}>
-      <CODE>{name}</CODE>
+      <MONOSPACE weight="medium">{name}</MONOSPACE>
     </H3Code>
     <CommentTextBlock comment={comment} includePlatforms={false} />
     {children.sort(sortByValue).map((enumValue: EnumValueData) => (

--- a/docs/components/plugins/api/APISectionInterfaces.tsx
+++ b/docs/components/plugins/api/APISectionInterfaces.tsx
@@ -27,7 +27,7 @@ import {
   BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, P, CODE, DEMI } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE, DEMI, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionInterfacesProps = {
   data: InterfaceDefinitionData[];
@@ -122,7 +122,7 @@ const renderInterface = ({
       <APISectionDeprecationNote comment={comment} />
       <APISectionPlatformTags comment={comment} prefix="Only for:" />
       <H3Code tags={getTagNamesList(comment)}>
-        <CODE>{name}</CODE>
+        <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
       {extendedTypes?.length ? (
         <P css={STYLES_ELEMENT_SPACING}>

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -30,7 +30,7 @@ import {
   getCommentContent,
   BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, LI, UL, CODE } from '~/ui/components/Text';
+import { H2, LI, UL, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionMethodsProps = {
   data: (MethodDefinitionData | PropData)[];
@@ -66,9 +66,9 @@ export const renderMethod = (
           <APISectionDeprecationNote comment={comment} />
           <APISectionPlatformTags comment={comment} prefix="Only for:" />
           <HeaderComponent tags={getTagNamesList(comment)}>
-            <CODE css={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>
+            <MONOSPACE weight="medium" css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}>
               {getMethodName(method as MethodDefinitionData, apiName, name, parameters)}
-            </CODE>
+            </MONOSPACE>
           </HeaderComponent>
           {parameters && parameters.length > 0 && (
             <>

--- a/docs/components/plugins/api/APISectionNamespaces.tsx
+++ b/docs/components/plugins/api/APISectionNamespaces.tsx
@@ -18,7 +18,7 @@ import {
   getCommentContent,
   BoxSectionHeader,
 } from '~/components/plugins/api/APISectionUtils';
-import { H2, CODE } from '~/ui/components/Text';
+import { H2, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionNamespacesProps = {
   data: GeneratedData[];
@@ -43,7 +43,7 @@ const renderNamespace = (namespace: ClassDefinitionData, exposeInSidebar: boolea
     <div key={`class-definition-${name}`} css={STYLES_APIBOX}>
       <APISectionDeprecationNote comment={comment} />
       <H3Code tags={getTagNamesList(comment)}>
-        <CODE>{name}</CODE>
+        <MONOSPACE weight="medium">{name}</MONOSPACE>
       </H3Code>
       <CommentTextBlock comment={comment} />
       {returnComment && (

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -24,7 +24,7 @@ import {
   STYLES_SECONDARY,
   TypeDocKind,
 } from '~/components/plugins/api/APISectionUtils';
-import { CODE, H2, H3, H4, LI, P, UL } from '~/ui/components/Text';
+import { CODE, H2, H3, H4, LI, MONOSPACE, P, UL } from '~/ui/components/Text';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -119,7 +119,9 @@ export const renderProp = (
       <APISectionDeprecationNote comment={extractedComment} />
       <APISectionPlatformTags comment={comment} prefix="Only for:" />
       <HeaderComponent tags={getTagNamesList(comment)}>
-        <CODE css={!exposeInSidebar ? STYLES_NOT_EXPOSED_HEADER : undefined}>{name}</CODE>
+        <MONOSPACE weight="medium" css={!exposeInSidebar && STYLES_NOT_EXPOSED_HEADER}>
+          {name}
+        </MONOSPACE>
       </HeaderComponent>
       <P css={extractedComment && STYLES_ELEMENT_SPACING}>
         {flags?.isOptional && <span css={STYLES_SECONDARY}>Optional&emsp;&bull;&emsp;</span>}

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -28,7 +28,7 @@ import {
   getCommentContent,
 } from '~/components/plugins/api/APISectionUtils';
 import { Cell, Row, Table } from '~/ui/components/Table';
-import { H2, BOLD, P, CODE } from '~/ui/components/Text';
+import { H2, BOLD, P, CODE, MONOSPACE } from '~/ui/components/Text';
 
 export type APISectionTypesProps = {
   data: TypeGeneralData[];
@@ -115,10 +115,10 @@ const renderType = ({
         <APISectionDeprecationNote comment={comment} />
         <APISectionPlatformTags comment={comment} prefix="Only for:" />
         <H3Code tags={getTagNamesList(comment)}>
-          <CODE>
+          <MONOSPACE weight="medium">
             {name}
             {type.declaration.signatures ? '()' : ''}
-          </CODE>
+          </MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
         {type.declaration.children && renderTypeDeclarationTable(type.declaration)}
@@ -143,7 +143,7 @@ const renderType = ({
           <APISectionDeprecationNote comment={comment} />
           <APISectionPlatformTags comment={comment} prefix="Only for:" />
           <H3Code tags={getTagNamesList(comment)}>
-            <CODE>{name}</CODE>
+            <MONOSPACE weight="medium">{name}</MONOSPACE>
           </H3Code>
           <CommentTextBlock comment={comment} includePlatforms={false} />
           {type.type === 'intersection' ? (
@@ -173,7 +173,7 @@ const renderType = ({
           <APISectionDeprecationNote comment={comment} />
           <APISectionPlatformTags comment={comment} prefix="Only for:" />
           <H3Code tags={getTagNamesList(comment)}>
-            <CODE>{name}</CODE>
+            <MONOSPACE weight="medium">{name}</MONOSPACE>
           </H3Code>
           <CommentTextBlock comment={comment} includePlatforms={false} />
           <P>
@@ -195,7 +195,7 @@ const renderType = ({
         <APISectionDeprecationNote comment={comment} />
         <APISectionPlatformTags comment={comment} prefix="Only for:" />
         <H3Code tags={getTagNamesList(comment)}>
-          <CODE>{name}</CODE>
+          <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
         <div css={{ display: 'flex', gap: 8, marginBottom: 12 }}>
           <BOLD>Type: </BOLD>
@@ -210,7 +210,7 @@ const renderType = ({
         <APISectionDeprecationNote comment={comment} />
         <APISectionPlatformTags comment={comment} prefix="Only for:" />
         <H3Code tags={getTagNamesList(comment)}>
-          <CODE>{name}</CODE>
+          <MONOSPACE weight="medium">{name}</MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
         <P>
@@ -225,9 +225,9 @@ const renderType = ({
         <APISectionDeprecationNote comment={comment} />
         <APISectionPlatformTags comment={comment} prefix="Only for:" />
         <H3Code tags={getTagNamesList(comment)}>
-          <CODE>
+          <MONOSPACE weight="medium">
             {name}&lt;{type.checkType.name}&gt;
-          </CODE>
+          </MONOSPACE>
         </H3Code>
         <CommentTextBlock comment={comment} includePlatforms={false} />
         <P>

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -665,7 +665,7 @@ export const STYLES_APIBOX = css({
   overflowX: 'hidden',
 
   h3: {
-    marginBottom: spacing[2],
+    marginBottom: spacing[2.5],
   },
 
   'h2, h3, h4': {

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -21,7 +21,7 @@ export const regularFont = Inter({
   display: 'swap',
 });
 export const monospaceFont = Fira_Code({
-  weight: '400',
+  weight: ['400', '500'],
   display: 'swap',
 });
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -888,7 +888,8 @@ class LinearGradientModule : Module() {
 
 ## Guides
 
-<APIBox header="Sending events">
+<APIBox>
+### Sending events
 
 While JavaScript/TypeScript to Native communication is mostly covered by native functions, you might also want to let the JavaScript/TypeScript code know about certain system events, for example, when the clipboard content changes.
 
@@ -979,7 +980,8 @@ export function addClipboardListener(listener: (event) => void): Subscription {
 
 </APIBox>
 
-<APIBox header="View callbacks">
+<APIBox>
+### View callbacks
 
 Some events are connected to a certain view. For example, the touch event should be sent only to the underlying JavaScript view which was pressed. In that case, you can't use `sendEvent` described in [`Sending events`](#sending-events). The `expo-modules-core` introduces a view callbacks mechanism to handle view-bound events.
 

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -211,7 +211,7 @@ export const KBD = createTextComponent(
   TextElement.KBD,
   css([typography.utility.pre as CSSObject, kbdStyle])
 );
-export const MONOSPACE = createTextComponent(TextElement.CODE, css({ fontWeight: 500 }));
+export const MONOSPACE = createTextComponent(TextElement.CODE);
 
 const isExternalLink = (href?: string) => href?.includes('://');
 


### PR DESCRIPTION
# Why

The idea about clear monospace headers in API sections was around for a while, but with old font we were forced to only one weight from monospace font, now it's possible to alter that.

# How

This PR removes the inline code styling/appearance from the API section headers. Those changes also were ported for Expo Modules API docs for the consistency.

# Test Plan

Changes have been tested by running docs website locally. All lint checks and test are passing.

# Preview

<img width="1149" alt="Screenshot 2023-03-08 at 19 47 15" src="https://user-images.githubusercontent.com/719641/223967857-8687a667-592a-4cc3-b4b9-d907b39fd22b.png">
