### PR TITLE
test(cli): wait until `socket.on('close')` is invoked in proxy test

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
@@ -1,5 +1,5 @@
 import { createInspectorDeviceClass } from '../device';
-import { InspectorHandler } from '../messages/types';
+import { InspectorHandler } from '../handlers/types';
 
 describe('ExpoInspectorDevice', () => {
   it('initializes with default handlers', () => {

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/proxy.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/proxy.test.ts
@@ -68,7 +68,7 @@ it('creates a new device when a client connects', async () => {
   const device = new WS(deviceWebSocketUrl);
 
   try {
-    await new Promise<void>((resolve) => device.on('open', resolve));
+    await new Promise((resolve) => device.on('open', resolve));
 
     expect(device.readyState).toBe(device.OPEN);
     expect(expoProxy.devices.size).toBe(1);
@@ -86,12 +86,15 @@ it('removes device when client disconnects', async () => {
   const device = new WS(deviceWebSocketUrl);
 
   try {
-    await new Promise<void>((resolve) => device.on('open', resolve));
+    await new Promise((resolve) => device.on('open', resolve));
     expect(expoProxy.devices.size).toBe(1);
 
     device.close();
 
-    await new Promise<void>((resolve) => device.on('close', resolve));
+    await new Promise((resolve) => device.on('close', resolve));
+    // Wait until the `socket.on('close')` handler is called in the proxy
+    await new Promise((resolve) => setTimeout(resolve));
+
     expect(expoProxy.devices.size).toBe(0);
   } finally {
     server.close();
@@ -109,7 +112,7 @@ it('accepts debugger connections when device is connected', async () => {
 
   try {
     deviceWs = new WS(deviceWebSocketUrl);
-    await new Promise<void>((resolve) => deviceWs?.on('open', resolve));
+    await new Promise((resolve) => deviceWs?.on('open', resolve));
 
     const device = expoProxy.devices.values().next().value;
     expect(device).toBeDefined();
@@ -117,7 +120,7 @@ it('accepts debugger connections when device is connected', async () => {
     const deviceDebugHandler = jest.spyOn(device, 'handleDebuggerConnection');
 
     debuggerWs = new WS(`${debuggerWebSocketUrl}?device=${device.id}&page=1`);
-    await new Promise<void>((resolve) => debuggerWs?.on('open', resolve));
+    await new Promise((resolve) => debuggerWs?.on('open', resolve));
 
     expect(debuggerWs.readyState).toBe(debuggerWs.OPEN);
     expect(deviceDebugHandler).toBeCalled();


### PR DESCRIPTION
# Why

It seems that the `socket.on('close')` callback is invoked after the assertion is made. This breaks the test in general.

# How

Unfortunately, only a set timeout works around this issue.

# Test Plan

See test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
