### PR TITLE
[device][ios] Added support for desktop detection

### DIFF
--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- On iOS added support for deviceType detection of Desktop on MacOS, checking for Catalyst and iPad app running on Mac. ([#21636](https://github.com/expo/expo/pull/21636) by [@robertherber](https://github.com/robertherber))
+
 ### 🐛 Bug fixes
 
 - Fixed Device.getDeviceTypeAsync() returning TABLET on some devices. ([#21325](https://github.com/expo/expo/pull/21325) by [@behenate](https://github.com/behenate))

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -40,7 +40,7 @@ public class DeviceModule: Module {
 
 func getDeviceType() -> Int {
   // if it's a macOS Catalyst app
-  if (ProcessInfo.processInfo.isMacCatalystApp) {
+  if ProcessInfo.processInfo.isMacCatalystApp {
     return DeviceType.desktop.rawValue
   }
 

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -40,13 +40,13 @@ public class DeviceModule: Module {
 
 func getDeviceType() -> Int {
   // if it's a macOS Catalyst app
-  if ((ProcessInfo.processInfo.isMacCatalystApp)) {
+  if (ProcessInfo.processInfo.isMacCatalystApp) {
     return DeviceType.desktop.rawValue
   }
-  
+
   // if it's built for iPad running on a Mac
   if #available(iOS 14.0, *) {
-    if (ProcessInfo.processInfo.isiOSAppOnMac) {
+    if ProcessInfo.processInfo.isiOSAppOnMac {
       return DeviceType.desktop.rawValue
     }
   }

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -3,109 +3,109 @@ import UIKit
 import MachO
 
 public class DeviceModule: Module {
-    public func definition() -> ModuleDefinition {
-        Name("ExpoDevice")
+  public func definition() -> ModuleDefinition {
+    Name("ExpoDevice")
 
-        Constants([
-            "isDevice": isDevice(),
-            "brand": "Apple",
-            "manufacturer": "Apple",
-            "modelId": UIDevice.modelIdentifier,
-            "modelName": UIDevice.DeviceMap.modelName,
-            "deviceYearClass": UIDevice.DeviceMap.deviceYearClass,
-            "totalMemory": ProcessInfo.processInfo.physicalMemory,
-            "osName": UIDevice.current.systemName,
-            "osVersion": UIDevice.current.systemVersion,
-            "osBuildId": osBuildId(),
-            "osInternalBuildId": osBuildId(),
-            "deviceName": UIDevice.current.name,
-            "supportedCpuArchitectures": cpuArchitectures()
-        ])
+    Constants([
+      "isDevice": isDevice(),
+      "brand": "Apple",
+      "manufacturer": "Apple",
+      "modelId": UIDevice.modelIdentifier,
+      "modelName": UIDevice.DeviceMap.modelName,
+      "deviceYearClass": UIDevice.DeviceMap.deviceYearClass,
+      "totalMemory": ProcessInfo.processInfo.physicalMemory,
+      "osName": UIDevice.current.systemName,
+      "osVersion": UIDevice.current.systemVersion,
+      "osBuildId": osBuildId(),
+      "osInternalBuildId": osBuildId(),
+      "deviceName": UIDevice.current.name,
+      "supportedCpuArchitectures": cpuArchitectures()
+    ])
 
-        AsyncFunction("getDeviceTypeAsync") { () -> Int in
-            return getDeviceType()
-        }
-
-        AsyncFunction("getUptimeAsync") { () -> Double in
-            let uptimeMs: Double = ProcessInfo.processInfo.systemUptime * 1000
-
-            return uptimeMs
-        }
-
-        AsyncFunction("isRootedExperimentalAsync") { () -> Bool in
-            return UIDevice.current.isJailbroken
-        }
+    AsyncFunction("getDeviceTypeAsync") { () -> Int in
+      return getDeviceType()
     }
+
+    AsyncFunction("getUptimeAsync") { () -> Double in
+      let uptimeMs: Double = ProcessInfo.processInfo.systemUptime * 1000
+
+      return uptimeMs
+    }
+
+    AsyncFunction("isRootedExperimentalAsync") { () -> Bool in
+      return UIDevice.current.isJailbroken
+    }
+  }
 }
 
 func getDeviceType() -> Int {
-    // if it's a macOS Catalyst app
-    if (ProcessInfo.processInfo.isMacCatalystApp) {
-        return DeviceType.desktop.rawValue
+  // if it's a macOS Catalyst app
+  if ((ProcessInfo.processInfo.isMacCatalystApp)) {
+    return DeviceType.desktop.rawValue
+  }
+  
+  // if it's built for iPad running on a Mac
+  if #available(iOS 14.0, *) {
+    if (ProcessInfo.processInfo.isiOSAppOnMac) {
+      return DeviceType.desktop.rawValue
     }
+  }
 
-    // if it's built for iPad running on a Mac
-    if #available(iOS 14.0, *) {
-        if ProcessInfo.processInfo.isiOSAppOnMac {
-            return DeviceType.desktop.rawValue
-        }
-    }
-
-    switch UIDevice.current.userInterfaceIdiom {
+  switch UIDevice.current.userInterfaceIdiom {
     case UIUserInterfaceIdiom.phone:
-        return DeviceType.phone.rawValue
+      return DeviceType.phone.rawValue
     case UIUserInterfaceIdiom.pad:
-        return DeviceType.tablet.rawValue
+      return DeviceType.tablet.rawValue
     case UIUserInterfaceIdiom.tv:
-        return DeviceType.tv.rawValue
+      return DeviceType.tv.rawValue
     default:
-        return DeviceType.unknown.rawValue
-    }
+      return DeviceType.unknown.rawValue
+  }
 }
 
 func isDevice() -> Bool {
-    #if targetEnvironment(simulator)
-    return false
-    #else
-    return true
-    #endif
+  #if targetEnvironment(simulator)
+  return false
+  #else
+  return true
+  #endif
 }
 
 func osBuildId() -> String? {
-    #if os(tvOS)
-    return nil
-    #else
-    // Credit: https://stackoverflow.com/a/65858410
-    var mib: [Int32] = [CTL_KERN, KERN_OSVERSION]
-    let namelen = UInt32(MemoryLayout.size(ofValue: mib) / MemoryLayout.size(ofValue: mib[0]))
-    var bufferSize = 0
+  #if os(tvOS)
+  return nil
+  #else
+  // Credit: https://stackoverflow.com/a/65858410
+  var mib: [Int32] = [CTL_KERN, KERN_OSVERSION]
+  let namelen = UInt32(MemoryLayout.size(ofValue: mib) / MemoryLayout.size(ofValue: mib[0]))
+  var bufferSize = 0
 
-    // Get the size for the buffer
-    sysctl(&mib, namelen, nil, &bufferSize, nil, 0)
+  // Get the size for the buffer
+  sysctl(&mib, namelen, nil, &bufferSize, nil, 0)
 
-    var buildBuffer = [UInt8](repeating: 0, count: bufferSize)
-    let result = sysctl(&mib, namelen, &buildBuffer, &bufferSize, nil, 0)
+  var buildBuffer = [UInt8](repeating: 0, count: bufferSize)
+  let result = sysctl(&mib, namelen, &buildBuffer, &bufferSize, nil, 0)
 
-    if result >= 0 && bufferSize > 0 {
-        return String(bytesNoCopy: &buildBuffer, length: bufferSize - 1, encoding: .utf8, freeWhenDone: false)
-    }
+  if result >= 0 && bufferSize > 0 {
+    return String(bytesNoCopy: &buildBuffer, length: bufferSize - 1, encoding: .utf8, freeWhenDone: false)
+  }
 
-    return nil
-    #endif
+  return nil
+  #endif
 }
 
 func cpuArchitectures() -> [String]? {
-    // Credit: https://stackoverflow.com/a/70134518
-    guard let archRaw = NXGetLocalArchInfo().pointee.name else {
-        return nil
-    }
-    return [String(cString: archRaw)]
+  // Credit: https://stackoverflow.com/a/70134518
+  guard let archRaw = NXGetLocalArchInfo().pointee.name else {
+    return nil
+  }
+  return [String(cString: archRaw)]
 }
 
 enum DeviceType: Int {
-    case unknown = 0
-    case phone = 1
-    case tablet = 2
-    case desktop = 3
-    case tv = 4
+  case unknown = 0
+  case phone = 1
+  case tablet = 2
+  case desktop = 3
+  case tv = 4
 }

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -23,16 +23,7 @@ public class DeviceModule: Module {
     ])
 
     AsyncFunction("getDeviceTypeAsync") { () -> Int in
-      switch UIDevice.current.userInterfaceIdiom {
-      case UIUserInterfaceIdiom.phone:
-        return DeviceType.phone.rawValue
-      case UIUserInterfaceIdiom.pad:
-        return DeviceType.tablet.rawValue
-      case UIUserInterfaceIdiom.tv:
-        return DeviceType.tv.rawValue
-      default:
-        return DeviceType.unknown.rawValue
-      }
+      return getDeviceType()
     }
 
     AsyncFunction("getUptimeAsync") { () -> Double in
@@ -44,6 +35,31 @@ public class DeviceModule: Module {
     AsyncFunction("isRootedExperimentalAsync") { () -> Bool in
       return UIDevice.current.isJailbroken
     }
+  }
+}
+
+func getDeviceType() -> Int {
+  // if it's a macOS Catalyst app
+  if ((ProcessInfo.processInfo.isMacCatalystApp)) {
+    return DeviceType.desktop.rawValue
+  }
+  
+  // if it's built for iPad running on a Mac
+  if #available(iOS 14.0, *) {
+    if (ProcessInfo.processInfo.isiOSAppOnMac) {
+      return DeviceType.desktop.rawValue
+    }
+  }
+
+  switch UIDevice.current.userInterfaceIdiom {
+    case UIUserInterfaceIdiom.phone:
+      return DeviceType.phone.rawValue
+    case UIUserInterfaceIdiom.pad:
+      return DeviceType.tablet.rawValue
+    case UIUserInterfaceIdiom.tv:
+      return DeviceType.tv.rawValue
+    default:
+      return DeviceType.unknown.rawValue
   }
 }
 

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -3,109 +3,109 @@ import UIKit
 import MachO
 
 public class DeviceModule: Module {
-  public func definition() -> ModuleDefinition {
-    Name("ExpoDevice")
+    public func definition() -> ModuleDefinition {
+        Name("ExpoDevice")
 
-    Constants([
-      "isDevice": isDevice(),
-      "brand": "Apple",
-      "manufacturer": "Apple",
-      "modelId": UIDevice.modelIdentifier,
-      "modelName": UIDevice.DeviceMap.modelName,
-      "deviceYearClass": UIDevice.DeviceMap.deviceYearClass,
-      "totalMemory": ProcessInfo.processInfo.physicalMemory,
-      "osName": UIDevice.current.systemName,
-      "osVersion": UIDevice.current.systemVersion,
-      "osBuildId": osBuildId(),
-      "osInternalBuildId": osBuildId(),
-      "deviceName": UIDevice.current.name,
-      "supportedCpuArchitectures": cpuArchitectures()
-    ])
+        Constants([
+            "isDevice": isDevice(),
+            "brand": "Apple",
+            "manufacturer": "Apple",
+            "modelId": UIDevice.modelIdentifier,
+            "modelName": UIDevice.DeviceMap.modelName,
+            "deviceYearClass": UIDevice.DeviceMap.deviceYearClass,
+            "totalMemory": ProcessInfo.processInfo.physicalMemory,
+            "osName": UIDevice.current.systemName,
+            "osVersion": UIDevice.current.systemVersion,
+            "osBuildId": osBuildId(),
+            "osInternalBuildId": osBuildId(),
+            "deviceName": UIDevice.current.name,
+            "supportedCpuArchitectures": cpuArchitectures()
+        ])
 
-    AsyncFunction("getDeviceTypeAsync") { () -> Int in
-      return getDeviceType()
+        AsyncFunction("getDeviceTypeAsync") { () -> Int in
+            return getDeviceType()
+        }
+
+        AsyncFunction("getUptimeAsync") { () -> Double in
+            let uptimeMs: Double = ProcessInfo.processInfo.systemUptime * 1000
+
+            return uptimeMs
+        }
+
+        AsyncFunction("isRootedExperimentalAsync") { () -> Bool in
+            return UIDevice.current.isJailbroken
+        }
     }
-
-    AsyncFunction("getUptimeAsync") { () -> Double in
-      let uptimeMs: Double = ProcessInfo.processInfo.systemUptime * 1000
-
-      return uptimeMs
-    }
-
-    AsyncFunction("isRootedExperimentalAsync") { () -> Bool in
-      return UIDevice.current.isJailbroken
-    }
-  }
 }
 
 func getDeviceType() -> Int {
-  // if it's a macOS Catalyst app
-  if ((ProcessInfo.processInfo.isMacCatalystApp)) {
-    return DeviceType.desktop.rawValue
-  }
-  
-  // if it's built for iPad running on a Mac
-  if #available(iOS 14.0, *) {
-    if (ProcessInfo.processInfo.isiOSAppOnMac) {
-      return DeviceType.desktop.rawValue
+    // if it's a macOS Catalyst app
+    if (ProcessInfo.processInfo.isMacCatalystApp) {
+        return DeviceType.desktop.rawValue
     }
-  }
 
-  switch UIDevice.current.userInterfaceIdiom {
+    // if it's built for iPad running on a Mac
+    if #available(iOS 14.0, *) {
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return DeviceType.desktop.rawValue
+        }
+    }
+
+    switch UIDevice.current.userInterfaceIdiom {
     case UIUserInterfaceIdiom.phone:
-      return DeviceType.phone.rawValue
+        return DeviceType.phone.rawValue
     case UIUserInterfaceIdiom.pad:
-      return DeviceType.tablet.rawValue
+        return DeviceType.tablet.rawValue
     case UIUserInterfaceIdiom.tv:
-      return DeviceType.tv.rawValue
+        return DeviceType.tv.rawValue
     default:
-      return DeviceType.unknown.rawValue
-  }
+        return DeviceType.unknown.rawValue
+    }
 }
 
 func isDevice() -> Bool {
-  #if targetEnvironment(simulator)
-  return false
-  #else
-  return true
-  #endif
+    #if targetEnvironment(simulator)
+    return false
+    #else
+    return true
+    #endif
 }
 
 func osBuildId() -> String? {
-  #if os(tvOS)
-  return nil
-  #else
-  // Credit: https://stackoverflow.com/a/65858410
-  var mib: [Int32] = [CTL_KERN, KERN_OSVERSION]
-  let namelen = UInt32(MemoryLayout.size(ofValue: mib) / MemoryLayout.size(ofValue: mib[0]))
-  var bufferSize = 0
+    #if os(tvOS)
+    return nil
+    #else
+    // Credit: https://stackoverflow.com/a/65858410
+    var mib: [Int32] = [CTL_KERN, KERN_OSVERSION]
+    let namelen = UInt32(MemoryLayout.size(ofValue: mib) / MemoryLayout.size(ofValue: mib[0]))
+    var bufferSize = 0
 
-  // Get the size for the buffer
-  sysctl(&mib, namelen, nil, &bufferSize, nil, 0)
+    // Get the size for the buffer
+    sysctl(&mib, namelen, nil, &bufferSize, nil, 0)
 
-  var buildBuffer = [UInt8](repeating: 0, count: bufferSize)
-  let result = sysctl(&mib, namelen, &buildBuffer, &bufferSize, nil, 0)
+    var buildBuffer = [UInt8](repeating: 0, count: bufferSize)
+    let result = sysctl(&mib, namelen, &buildBuffer, &bufferSize, nil, 0)
 
-  if result >= 0 && bufferSize > 0 {
-    return String(bytesNoCopy: &buildBuffer, length: bufferSize - 1, encoding: .utf8, freeWhenDone: false)
-  }
+    if result >= 0 && bufferSize > 0 {
+        return String(bytesNoCopy: &buildBuffer, length: bufferSize - 1, encoding: .utf8, freeWhenDone: false)
+    }
 
-  return nil
-  #endif
+    return nil
+    #endif
 }
 
 func cpuArchitectures() -> [String]? {
-  // Credit: https://stackoverflow.com/a/70134518
-  guard let archRaw = NXGetLocalArchInfo().pointee.name else {
-    return nil
-  }
-  return [String(cString: archRaw)]
+    // Credit: https://stackoverflow.com/a/70134518
+    guard let archRaw = NXGetLocalArchInfo().pointee.name else {
+        return nil
+    }
+    return [String(cString: archRaw)]
 }
 
 enum DeviceType: Int {
-  case unknown = 0
-  case phone = 1
-  case tablet = 2
-  case desktop = 3
-  case tv = 4
+    case unknown = 0
+    case phone = 1
+    case tablet = 2
+    case desktop = 3
+    case tv = 4
 }

--- a/packages/expo-device/ios/DeviceModule.swift
+++ b/packages/expo-device/ios/DeviceModule.swift
@@ -52,14 +52,14 @@ func getDeviceType() -> Int {
   }
 
   switch UIDevice.current.userInterfaceIdiom {
-    case UIUserInterfaceIdiom.phone:
-      return DeviceType.phone.rawValue
-    case UIUserInterfaceIdiom.pad:
-      return DeviceType.tablet.rawValue
-    case UIUserInterfaceIdiom.tv:
-      return DeviceType.tv.rawValue
-    default:
-      return DeviceType.unknown.rawValue
+  case UIUserInterfaceIdiom.phone:
+    return DeviceType.phone.rawValue
+  case UIUserInterfaceIdiom.pad:
+    return DeviceType.tablet.rawValue
+  case UIUserInterfaceIdiom.tv:
+    return DeviceType.tv.rawValue
+  default:
+    return DeviceType.unknown.rawValue
   }
 }
 

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -1,261 +1,261 @@
 import UIKit
 
 struct ExpoDeviceType {
-  let modelName: String
-  let deviceYearClass: Int?
+    let modelName: String
+    let deviceYearClass: Int?
 }
 
 public extension UIDevice {
-  // Credit: https://stackoverflow.com/a/26962452
-  static let modelIdentifier: String = {
-    var systemInfo = utsname()
-    uname(&systemInfo)
-    let machineMirror = Mirror(reflecting: systemInfo.machine)
-    let identifier = machineMirror.children.reduce("") { identifier, element in
-      guard let value = element.value as? Int8, value != 0 else {
+    // Credit: https://stackoverflow.com/a/26962452
+    static let modelIdentifier: String = {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else {
+                return identifier
+            }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+
         return identifier
-      }
-      return identifier + String(UnicodeScalar(UInt8(value)))
+    }()
+
+    // swiftlint:disable function_body_length closure_body_length
+    static internal let DeviceMap: ExpoDeviceType = {
+        func mapToDevice(identifier: String) -> ExpoDeviceType {
+            let currentYear = Calendar(identifier: .gregorian).dateComponents([.year], from: Date()).year
+
+            #if os(iOS)
+            switch identifier {
+            case "iPod7,1":
+                return ExpoDeviceType(modelName: "iPod touch (6th generation)", deviceYearClass: 2015)
+            case "iPod9,1":
+                return ExpoDeviceType(modelName: "iPod touch (7th generation)", deviceYearClass: 2019)
+            case "iPhone6,1", "iPhone6,2":
+                return ExpoDeviceType(modelName: "iPhone 5s", deviceYearClass: 2013)
+            case "iPhone7,1":
+                return ExpoDeviceType(modelName: "iPhone 6 Plus", deviceYearClass: 2014)
+            case "iPhone7,2":
+                return ExpoDeviceType(modelName: "iPhone 6", deviceYearClass: 2014)
+            case "iPhone8,1":
+                return ExpoDeviceType(modelName: "iPhone 6s", deviceYearClass: 2015)
+            case "iPhone8,2":
+                return ExpoDeviceType(modelName: "iPhone 6s Plus", deviceYearClass: 2015)
+            case "iPhone9,1", "iPhone9,3":
+                return ExpoDeviceType(modelName: "iPhone 7", deviceYearClass: 2016)
+            case "iPhone9,2", "iPhone9,4":
+                return ExpoDeviceType(modelName: "iPhone 7 Plus", deviceYearClass: 2016)
+            case "iPhone10,1", "iPhone10,4":
+                return ExpoDeviceType(modelName: "iPhone 8", deviceYearClass: 2017)
+            case "iPhone10,2", "iPhone10,5":
+                return ExpoDeviceType(modelName: "iPhone 8 Plus", deviceYearClass: 2017)
+            case "iPhone10,3", "iPhone10,6":
+                return ExpoDeviceType(modelName: "iPhone X", deviceYearClass: 2017)
+            case "iPhone11,2":
+                return ExpoDeviceType(modelName: "iPhone XS", deviceYearClass: 2018)
+            case "iPhone11,4", "iPhone11,6":
+                return ExpoDeviceType(modelName: "iPhone XS Max", deviceYearClass: 2018)
+            case "iPhone11,8":
+                return ExpoDeviceType(modelName: "iPhone XR", deviceYearClass: 2018)
+            case "iPhone12,1":
+                return ExpoDeviceType(modelName: "iPhone 11", deviceYearClass: 2019)
+            case "iPhone12,3":
+                return ExpoDeviceType(modelName: "iPhone 11 Pro", deviceYearClass: 2019)
+            case "iPhone12,5":
+                return ExpoDeviceType(modelName: "iPhone 11 Pro Max", deviceYearClass: 2019)
+            case "iPhone13,1":
+                return ExpoDeviceType(modelName: "iPhone 12 mini", deviceYearClass: 2020)
+            case "iPhone13,2":
+                return ExpoDeviceType(modelName: "iPhone 12", deviceYearClass: 2020)
+            case "iPhone13,3":
+                return ExpoDeviceType(modelName: "iPhone 12 Pro", deviceYearClass: 2020)
+            case "iPhone13,4":
+                return ExpoDeviceType(modelName: "iPhone 12 Pro Max", deviceYearClass: 2020)
+            case "iPhone14,4":
+                return ExpoDeviceType(modelName: "iPhone 13 mini", deviceYearClass: 2021)
+            case "iPhone14,5":
+                return ExpoDeviceType(modelName: "iPhone 13", deviceYearClass: 2021)
+            case "iPhone14,2":
+                return ExpoDeviceType(modelName: "iPhone 13 Pro", deviceYearClass: 2021)
+            case "iPhone14,3":
+                return ExpoDeviceType(modelName: "iPhone 13 Pro Max", deviceYearClass: 2021)
+            case "iPhone14,7":
+                return ExpoDeviceType(modelName: "iPhone 14", deviceYearClass: 2022)
+            case "iPhone14,8":
+                return ExpoDeviceType(modelName: "iPhone 14 Plus", deviceYearClass: 2022)
+            case "iPhone15,2":
+                return ExpoDeviceType(modelName: "iPhone 14 Pro", deviceYearClass: 2022)
+            case "iPhone15,3":
+                return ExpoDeviceType(modelName: "iPhone 14 Pro Max", deviceYearClass: 2022)
+            case "iPhone8,4":
+                return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
+            case "iPhone12,8":
+                return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
+            case "iPhone14,6":
+                return ExpoDeviceType(modelName: "iPhone SE (3rd generation)", deviceYearClass: 2022)
+            case "iPad6,11", "iPad6,12":
+                return ExpoDeviceType(modelName: "iPad (5th generation)", deviceYearClass: 2017)
+            case "iPad7,5", "iPad7,6":
+                return ExpoDeviceType(modelName: "iPad (6th generation)", deviceYearClass: 2018)
+            case "iPad7,11", "iPad7,12":
+                return ExpoDeviceType(modelName: "iPad (7th generation)", deviceYearClass: 2019)
+            case "iPad11,6", "iPad11,7":
+                return ExpoDeviceType(modelName: "iPad (8th generation)", deviceYearClass: 2020)
+            case "iPad12,1", "iPad12,2":
+                return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
+            case "iPad4,1", "iPad4,2", "iPad4,3":
+                return ExpoDeviceType(modelName: "iPad Air", deviceYearClass: 2013)
+            case "iPad5,3", "iPad5,4":
+                return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
+            case "iPad11,3", "iPad11,4":
+                return ExpoDeviceType(modelName: "iPad Air (3rd generation)", deviceYearClass: 2019)
+            case "iPad13,1", "iPad13,2":
+                return ExpoDeviceType(modelName: "iPad Air (4th generation)", deviceYearClass: 2020)
+            case "iPad13,16", "iPad13,17":
+                return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
+            case "iPad4,4", "iPad4,5", "iPad4,6":
+                return ExpoDeviceType(modelName: "iPad mini 2", deviceYearClass: 2013)
+            case "iPad4,7", "iPad4,8", "iPad4,9":
+                return ExpoDeviceType(modelName: "iPad mini 3", deviceYearClass: 2014)
+            case "iPad5,1", "iPad5,2":
+                return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
+            case "iPad11,1", "iPad11,2":
+                return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
+            case "iPad14,1", "iPad14,2":
+                return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
+            case "iPad6,3", "iPad6,4":
+                return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
+            case "iPad7,3", "iPad7,4":
+                return ExpoDeviceType(modelName: "iPad Pro (10.5-inch)", deviceYearClass: 2017)
+            case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4":
+                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (1st generation)", deviceYearClass: 2018)
+            case "iPad8,9", "iPad8,10":
+                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (2nd generation)", deviceYearClass: 2020)
+            case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
+                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
+            case "iPad6,7", "iPad6,8":
+                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
+            case "iPad7,1", "iPad7,2":
+                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (2nd generation)", deviceYearClass: 2017)
+            case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":
+                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (3rd generation)", deviceYearClass: 2018)
+            case "iPad8,11", "iPad8,12":
+                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (4th generation)", deviceYearClass: 2020)
+            case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":
+                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
+            case "AppleTV5,3":
+                return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
+            case "AppleTV6,2":
+                return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
+            case "i386", "x86_64", "arm64":
+                return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
+            default:
+                return ExpoDeviceType(modelName: identifier, deviceYearClass: currentYear)
+            }
+            #elseif os(tvOS)
+            switch identifier {
+            case "AppleTV5,3":
+                return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
+            case "AppleTV6,2":
+                return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
+            case "i386", "x86_64":
+                return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
+            default:
+                return identifier
+            }
+            #endif
+        }
+
+        return mapToDevice(identifier: modelIdentifier)
+    }()
+    // swiftlint:enable function_body_length closure_body_length
+
+    // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
+    var isSimulator: Bool {
+        return TARGET_OS_SIMULATOR != 0
     }
 
-    return identifier
-  }()
+    var isJailbroken: Bool {
+        if UIDevice.current.isSimulator {
+            return false
+        }
 
-  // swiftlint:disable function_body_length closure_body_length
-  static internal let DeviceMap: ExpoDeviceType = {
-    func mapToDevice(identifier: String) -> ExpoDeviceType {
-      let currentYear = Calendar(identifier: .gregorian).dateComponents([.year], from: Date()).year
+        let jailbroken = JailbreakHelper.hasCydiaInstalled() || JailbreakHelper.doesContainSuspiciousApps() ||
+            JailbreakHelper.doesSuspiciousSystemPathExist() || JailbreakHelper.canEditSystemFiles()
 
-      #if os(iOS)
-      switch identifier {
-      case "iPod7,1":
-        return ExpoDeviceType(modelName: "iPod touch (6th generation)", deviceYearClass: 2015)
-      case "iPod9,1":
-        return ExpoDeviceType(modelName: "iPod touch (7th generation)", deviceYearClass: 2019)
-      case "iPhone6,1", "iPhone6,2":
-        return ExpoDeviceType(modelName: "iPhone 5s", deviceYearClass: 2013)
-      case "iPhone7,1":
-        return ExpoDeviceType(modelName: "iPhone 6 Plus", deviceYearClass: 2014)
-      case "iPhone7,2":
-        return ExpoDeviceType(modelName: "iPhone 6", deviceYearClass: 2014)
-      case "iPhone8,1":
-        return ExpoDeviceType(modelName: "iPhone 6s", deviceYearClass: 2015)
-      case "iPhone8,2":
-        return ExpoDeviceType(modelName: "iPhone 6s Plus", deviceYearClass: 2015)
-      case "iPhone9,1", "iPhone9,3":
-        return ExpoDeviceType(modelName: "iPhone 7", deviceYearClass: 2016)
-      case "iPhone9,2", "iPhone9,4":
-        return ExpoDeviceType(modelName: "iPhone 7 Plus", deviceYearClass: 2016)
-      case "iPhone10,1", "iPhone10,4":
-        return ExpoDeviceType(modelName: "iPhone 8", deviceYearClass: 2017)
-      case "iPhone10,2", "iPhone10,5":
-        return ExpoDeviceType(modelName: "iPhone 8 Plus", deviceYearClass: 2017)
-      case "iPhone10,3", "iPhone10,6":
-        return ExpoDeviceType(modelName: "iPhone X", deviceYearClass: 2017)
-      case "iPhone11,2":
-        return ExpoDeviceType(modelName: "iPhone XS", deviceYearClass: 2018)
-      case "iPhone11,4", "iPhone11,6":
-        return ExpoDeviceType(modelName: "iPhone XS Max", deviceYearClass: 2018)
-      case "iPhone11,8":
-        return ExpoDeviceType(modelName: "iPhone XR", deviceYearClass: 2018)
-      case "iPhone12,1":
-        return ExpoDeviceType(modelName: "iPhone 11", deviceYearClass: 2019)
-      case "iPhone12,3":
-        return ExpoDeviceType(modelName: "iPhone 11 Pro", deviceYearClass: 2019)
-      case "iPhone12,5":
-        return ExpoDeviceType(modelName: "iPhone 11 Pro Max", deviceYearClass: 2019)
-      case "iPhone13,1":
-        return ExpoDeviceType(modelName: "iPhone 12 mini", deviceYearClass: 2020)
-      case "iPhone13,2":
-        return ExpoDeviceType(modelName: "iPhone 12", deviceYearClass: 2020)
-      case "iPhone13,3":
-        return ExpoDeviceType(modelName: "iPhone 12 Pro", deviceYearClass: 2020)
-      case "iPhone13,4":
-        return ExpoDeviceType(modelName: "iPhone 12 Pro Max", deviceYearClass: 2020)
-      case "iPhone14,4":
-        return ExpoDeviceType(modelName: "iPhone 13 mini", deviceYearClass: 2021)
-      case "iPhone14,5":
-        return ExpoDeviceType(modelName: "iPhone 13", deviceYearClass: 2021)
-      case "iPhone14,2":
-        return ExpoDeviceType(modelName: "iPhone 13 Pro", deviceYearClass: 2021)
-      case "iPhone14,3":
-        return ExpoDeviceType(modelName: "iPhone 13 Pro Max", deviceYearClass: 2021)
-      case "iPhone14,7":
-        return ExpoDeviceType(modelName: "iPhone 14", deviceYearClass: 2022)
-      case "iPhone14,8":
-        return ExpoDeviceType(modelName: "iPhone 14 Plus", deviceYearClass: 2022)
-      case "iPhone15,2":
-        return ExpoDeviceType(modelName: "iPhone 14 Pro", deviceYearClass: 2022)
-      case "iPhone15,3":
-        return ExpoDeviceType(modelName: "iPhone 14 Pro Max", deviceYearClass: 2022)
-      case "iPhone8,4":
-        return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
-      case "iPhone12,8":
-        return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
-      case "iPhone14,6":
-        return ExpoDeviceType(modelName: "iPhone SE (3rd generation)", deviceYearClass: 2022)
-      case "iPad6,11", "iPad6,12":
-        return ExpoDeviceType(modelName: "iPad (5th generation)", deviceYearClass: 2017)
-      case "iPad7,5", "iPad7,6":
-        return ExpoDeviceType(modelName: "iPad (6th generation)", deviceYearClass: 2018)
-      case "iPad7,11", "iPad7,12":
-        return ExpoDeviceType(modelName: "iPad (7th generation)", deviceYearClass: 2019)
-      case "iPad11,6", "iPad11,7":
-        return ExpoDeviceType(modelName: "iPad (8th generation)", deviceYearClass: 2020)
-      case "iPad12,1", "iPad12,2":
-        return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
-      case "iPad4,1", "iPad4,2", "iPad4,3":
-        return ExpoDeviceType(modelName: "iPad Air", deviceYearClass: 2013)
-      case "iPad5,3", "iPad5,4":
-        return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
-      case "iPad11,3", "iPad11,4":
-        return ExpoDeviceType(modelName: "iPad Air (3rd generation)", deviceYearClass: 2019)
-      case "iPad13,1", "iPad13,2":
-        return ExpoDeviceType(modelName: "iPad Air (4th generation)", deviceYearClass: 2020)
-      case "iPad13,16", "iPad13,17":
-        return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
-      case "iPad4,4", "iPad4,5", "iPad4,6":
-        return ExpoDeviceType(modelName: "iPad mini 2", deviceYearClass: 2013)
-      case "iPad4,7", "iPad4,8", "iPad4,9":
-        return ExpoDeviceType(modelName: "iPad mini 3", deviceYearClass: 2014)
-      case "iPad5,1", "iPad5,2":
-        return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
-      case "iPad11,1", "iPad11,2":
-        return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
-      case "iPad14,1", "iPad14,2":
-        return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
-      case "iPad6,3", "iPad6,4":
-        return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
-      case "iPad7,3", "iPad7,4":
-        return ExpoDeviceType(modelName: "iPad Pro (10.5-inch)", deviceYearClass: 2017)
-      case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4":
-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (1st generation)", deviceYearClass: 2018)
-      case "iPad8,9", "iPad8,10":
-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (2nd generation)", deviceYearClass: 2020)
-      case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
-        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
-      case "iPad6,7", "iPad6,8":
-        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
-      case "iPad7,1", "iPad7,2":
-        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (2nd generation)", deviceYearClass: 2017)
-      case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":
-        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (3rd generation)", deviceYearClass: 2018)
-      case "iPad8,11", "iPad8,12":
-        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (4th generation)", deviceYearClass: 2020)
-      case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":
-        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
-      case "AppleTV5,3":
-        return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
-      case "AppleTV6,2":
-        return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
-      case "i386", "x86_64", "arm64":
-        return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
-      default:
-        return ExpoDeviceType(modelName: identifier, deviceYearClass: currentYear)
-      }
-      #elseif os(tvOS)
-      switch identifier {
-      case "AppleTV5,3":
-        return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
-      case "AppleTV6,2":
-        return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
-      case "i386", "x86_64":
-        return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
-      default:
-        return identifier
-      }
-      #endif
+        return jailbroken
     }
-
-    return mapToDevice(identifier: modelIdentifier)
-  }()
-  // swiftlint:enable function_body_length closure_body_length
-
-  // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
-  var isSimulator: Bool {
-    return TARGET_OS_SIMULATOR != 0
-  }
-
-  var isJailbroken: Bool {
-    if UIDevice.current.isSimulator {
-      return false
-    }
-
-    let jailbroken = JailbreakHelper.hasCydiaInstalled() || JailbreakHelper.doesContainSuspiciousApps() ||
-    JailbreakHelper.doesSuspiciousSystemPathExist() || JailbreakHelper.canEditSystemFiles()
-
-    return jailbroken
-  }
 }
 
 // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
 private struct JailbreakHelper {
-  static func hasCydiaInstalled() -> Bool {
-    if let url = URL(string: "cydia://") {
-      return UIApplication.shared.canOpenURL(url)
+    static func hasCydiaInstalled() -> Bool {
+        if let url = URL(string: "cydia://") {
+            return UIApplication.shared.canOpenURL(url)
+        }
+        return false
     }
-    return false
-  }
 
-  static func doesContainSuspiciousApps() -> Bool {
-    for path in suspiciousAppsPathToCheck where FileManager.default.fileExists(atPath: path) {
-      return true
+    static func doesContainSuspiciousApps() -> Bool {
+        for path in suspiciousAppsPathToCheck where FileManager.default.fileExists(atPath: path) {
+            return true
+        }
+        return false
     }
-    return false
-  }
 
-  static func doesSuspiciousSystemPathExist() -> Bool {
-    for path in suspiciousSystemPathsToCheck where FileManager.default.fileExists(atPath: path) {
-      return true
+    static func doesSuspiciousSystemPathExist() -> Bool {
+        for path in suspiciousSystemPathsToCheck where FileManager.default.fileExists(atPath: path) {
+            return true
+        }
+        return false
     }
-    return false
-  }
 
-  static func canEditSystemFiles() -> Bool {
-    let jailbreakText = "Developer Insider"
-    do {
-      try jailbreakText.write(toFile: jailbreakText, atomically: true, encoding: .utf8)
-      return true
-    } catch {
-      return false
+    static func canEditSystemFiles() -> Bool {
+        let jailbreakText = "Developer Insider"
+        do {
+            try jailbreakText.write(toFile: jailbreakText, atomically: true, encoding: .utf8)
+            return true
+        } catch {
+            return false
+        }
     }
-  }
 
-  /**
-   Add more paths here to check for jail break
-   */
-  static var suspiciousAppsPathToCheck: [String] {
-    return [
-      "/Applications/Cydia.app",
-      "/Applications/blackra1n.app",
-      "/Applications/FakeCarrier.app",
-      "/Applications/Icy.app",
-      "/Applications/IntelliScreen.app",
-      "/Applications/MxTube.app",
-      "/Applications/RockApp.app",
-      "/Applications/SBSettings.app",
-      "/Applications/WinterBoard.app"
-    ]
-  }
+    /**
+     Add more paths here to check for jail break
+     */
+    static var suspiciousAppsPathToCheck: [String] {
+        return [
+            "/Applications/Cydia.app",
+            "/Applications/blackra1n.app",
+            "/Applications/FakeCarrier.app",
+            "/Applications/Icy.app",
+            "/Applications/IntelliScreen.app",
+            "/Applications/MxTube.app",
+            "/Applications/RockApp.app",
+            "/Applications/SBSettings.app",
+            "/Applications/WinterBoard.app"
+        ]
+    }
 
-  static var suspiciousSystemPathsToCheck: [String] {
-    return [
-      "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
-      "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
-      "/private/var/lib/apt",
-      "/private/var/lib/apt/",
-      "/private/var/lib/cydia",
-      "/private/var/mobile/Library/SBSettings/Themes",
-      "/private/var/stash",
-      "/private/var/tmp/cydia.log",
-      "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
-      "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
-      "/usr/bin/sshd",
-      "/usr/libexec/sftp-server",
-      "/usr/sbin/sshd",
-      "/etc/apt",
-      "/bin/bash",
-      "/Library/MobileSubstrate/MobileSubstrate.dylib"
-    ]
-  }
+    static var suspiciousSystemPathsToCheck: [String] {
+        return [
+            "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+            "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+            "/private/var/lib/apt",
+            "/private/var/lib/apt/",
+            "/private/var/lib/cydia",
+            "/private/var/mobile/Library/SBSettings/Themes",
+            "/private/var/stash",
+            "/private/var/tmp/cydia.log",
+            "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+            "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+            "/usr/bin/sshd",
+            "/usr/libexec/sftp-server",
+            "/usr/sbin/sshd",
+            "/etc/apt",
+            "/bin/bash",
+            "/Library/MobileSubstrate/MobileSubstrate.dylib"
+        ]
+    }
 }

--- a/packages/expo-device/ios/UIDevice.swift
+++ b/packages/expo-device/ios/UIDevice.swift
@@ -1,261 +1,261 @@
 import UIKit
 
 struct ExpoDeviceType {
-    let modelName: String
-    let deviceYearClass: Int?
+  let modelName: String
+  let deviceYearClass: Int?
 }
 
 public extension UIDevice {
-    // Credit: https://stackoverflow.com/a/26962452
-    static let modelIdentifier: String = {
-        var systemInfo = utsname()
-        uname(&systemInfo)
-        let machineMirror = Mirror(reflecting: systemInfo.machine)
-        let identifier = machineMirror.children.reduce("") { identifier, element in
-            guard let value = element.value as? Int8, value != 0 else {
-                return identifier
-            }
-            return identifier + String(UnicodeScalar(UInt8(value)))
-        }
-
+  // Credit: https://stackoverflow.com/a/26962452
+  static let modelIdentifier: String = {
+    var systemInfo = utsname()
+    uname(&systemInfo)
+    let machineMirror = Mirror(reflecting: systemInfo.machine)
+    let identifier = machineMirror.children.reduce("") { identifier, element in
+      guard let value = element.value as? Int8, value != 0 else {
         return identifier
-    }()
-
-    // swiftlint:disable function_body_length closure_body_length
-    static internal let DeviceMap: ExpoDeviceType = {
-        func mapToDevice(identifier: String) -> ExpoDeviceType {
-            let currentYear = Calendar(identifier: .gregorian).dateComponents([.year], from: Date()).year
-
-            #if os(iOS)
-            switch identifier {
-            case "iPod7,1":
-                return ExpoDeviceType(modelName: "iPod touch (6th generation)", deviceYearClass: 2015)
-            case "iPod9,1":
-                return ExpoDeviceType(modelName: "iPod touch (7th generation)", deviceYearClass: 2019)
-            case "iPhone6,1", "iPhone6,2":
-                return ExpoDeviceType(modelName: "iPhone 5s", deviceYearClass: 2013)
-            case "iPhone7,1":
-                return ExpoDeviceType(modelName: "iPhone 6 Plus", deviceYearClass: 2014)
-            case "iPhone7,2":
-                return ExpoDeviceType(modelName: "iPhone 6", deviceYearClass: 2014)
-            case "iPhone8,1":
-                return ExpoDeviceType(modelName: "iPhone 6s", deviceYearClass: 2015)
-            case "iPhone8,2":
-                return ExpoDeviceType(modelName: "iPhone 6s Plus", deviceYearClass: 2015)
-            case "iPhone9,1", "iPhone9,3":
-                return ExpoDeviceType(modelName: "iPhone 7", deviceYearClass: 2016)
-            case "iPhone9,2", "iPhone9,4":
-                return ExpoDeviceType(modelName: "iPhone 7 Plus", deviceYearClass: 2016)
-            case "iPhone10,1", "iPhone10,4":
-                return ExpoDeviceType(modelName: "iPhone 8", deviceYearClass: 2017)
-            case "iPhone10,2", "iPhone10,5":
-                return ExpoDeviceType(modelName: "iPhone 8 Plus", deviceYearClass: 2017)
-            case "iPhone10,3", "iPhone10,6":
-                return ExpoDeviceType(modelName: "iPhone X", deviceYearClass: 2017)
-            case "iPhone11,2":
-                return ExpoDeviceType(modelName: "iPhone XS", deviceYearClass: 2018)
-            case "iPhone11,4", "iPhone11,6":
-                return ExpoDeviceType(modelName: "iPhone XS Max", deviceYearClass: 2018)
-            case "iPhone11,8":
-                return ExpoDeviceType(modelName: "iPhone XR", deviceYearClass: 2018)
-            case "iPhone12,1":
-                return ExpoDeviceType(modelName: "iPhone 11", deviceYearClass: 2019)
-            case "iPhone12,3":
-                return ExpoDeviceType(modelName: "iPhone 11 Pro", deviceYearClass: 2019)
-            case "iPhone12,5":
-                return ExpoDeviceType(modelName: "iPhone 11 Pro Max", deviceYearClass: 2019)
-            case "iPhone13,1":
-                return ExpoDeviceType(modelName: "iPhone 12 mini", deviceYearClass: 2020)
-            case "iPhone13,2":
-                return ExpoDeviceType(modelName: "iPhone 12", deviceYearClass: 2020)
-            case "iPhone13,3":
-                return ExpoDeviceType(modelName: "iPhone 12 Pro", deviceYearClass: 2020)
-            case "iPhone13,4":
-                return ExpoDeviceType(modelName: "iPhone 12 Pro Max", deviceYearClass: 2020)
-            case "iPhone14,4":
-                return ExpoDeviceType(modelName: "iPhone 13 mini", deviceYearClass: 2021)
-            case "iPhone14,5":
-                return ExpoDeviceType(modelName: "iPhone 13", deviceYearClass: 2021)
-            case "iPhone14,2":
-                return ExpoDeviceType(modelName: "iPhone 13 Pro", deviceYearClass: 2021)
-            case "iPhone14,3":
-                return ExpoDeviceType(modelName: "iPhone 13 Pro Max", deviceYearClass: 2021)
-            case "iPhone14,7":
-                return ExpoDeviceType(modelName: "iPhone 14", deviceYearClass: 2022)
-            case "iPhone14,8":
-                return ExpoDeviceType(modelName: "iPhone 14 Plus", deviceYearClass: 2022)
-            case "iPhone15,2":
-                return ExpoDeviceType(modelName: "iPhone 14 Pro", deviceYearClass: 2022)
-            case "iPhone15,3":
-                return ExpoDeviceType(modelName: "iPhone 14 Pro Max", deviceYearClass: 2022)
-            case "iPhone8,4":
-                return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
-            case "iPhone12,8":
-                return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
-            case "iPhone14,6":
-                return ExpoDeviceType(modelName: "iPhone SE (3rd generation)", deviceYearClass: 2022)
-            case "iPad6,11", "iPad6,12":
-                return ExpoDeviceType(modelName: "iPad (5th generation)", deviceYearClass: 2017)
-            case "iPad7,5", "iPad7,6":
-                return ExpoDeviceType(modelName: "iPad (6th generation)", deviceYearClass: 2018)
-            case "iPad7,11", "iPad7,12":
-                return ExpoDeviceType(modelName: "iPad (7th generation)", deviceYearClass: 2019)
-            case "iPad11,6", "iPad11,7":
-                return ExpoDeviceType(modelName: "iPad (8th generation)", deviceYearClass: 2020)
-            case "iPad12,1", "iPad12,2":
-                return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
-            case "iPad4,1", "iPad4,2", "iPad4,3":
-                return ExpoDeviceType(modelName: "iPad Air", deviceYearClass: 2013)
-            case "iPad5,3", "iPad5,4":
-                return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
-            case "iPad11,3", "iPad11,4":
-                return ExpoDeviceType(modelName: "iPad Air (3rd generation)", deviceYearClass: 2019)
-            case "iPad13,1", "iPad13,2":
-                return ExpoDeviceType(modelName: "iPad Air (4th generation)", deviceYearClass: 2020)
-            case "iPad13,16", "iPad13,17":
-                return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
-            case "iPad4,4", "iPad4,5", "iPad4,6":
-                return ExpoDeviceType(modelName: "iPad mini 2", deviceYearClass: 2013)
-            case "iPad4,7", "iPad4,8", "iPad4,9":
-                return ExpoDeviceType(modelName: "iPad mini 3", deviceYearClass: 2014)
-            case "iPad5,1", "iPad5,2":
-                return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
-            case "iPad11,1", "iPad11,2":
-                return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
-            case "iPad14,1", "iPad14,2":
-                return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
-            case "iPad6,3", "iPad6,4":
-                return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
-            case "iPad7,3", "iPad7,4":
-                return ExpoDeviceType(modelName: "iPad Pro (10.5-inch)", deviceYearClass: 2017)
-            case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4":
-                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (1st generation)", deviceYearClass: 2018)
-            case "iPad8,9", "iPad8,10":
-                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (2nd generation)", deviceYearClass: 2020)
-            case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
-                return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
-            case "iPad6,7", "iPad6,8":
-                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
-            case "iPad7,1", "iPad7,2":
-                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (2nd generation)", deviceYearClass: 2017)
-            case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":
-                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (3rd generation)", deviceYearClass: 2018)
-            case "iPad8,11", "iPad8,12":
-                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (4th generation)", deviceYearClass: 2020)
-            case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":
-                return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
-            case "AppleTV5,3":
-                return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
-            case "AppleTV6,2":
-                return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
-            case "i386", "x86_64", "arm64":
-                return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
-            default:
-                return ExpoDeviceType(modelName: identifier, deviceYearClass: currentYear)
-            }
-            #elseif os(tvOS)
-            switch identifier {
-            case "AppleTV5,3":
-                return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
-            case "AppleTV6,2":
-                return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
-            case "i386", "x86_64":
-                return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
-            default:
-                return identifier
-            }
-            #endif
-        }
-
-        return mapToDevice(identifier: modelIdentifier)
-    }()
-    // swiftlint:enable function_body_length closure_body_length
-
-    // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
-    var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0
+      }
+      return identifier + String(UnicodeScalar(UInt8(value)))
     }
 
-    var isJailbroken: Bool {
-        if UIDevice.current.isSimulator {
-            return false
-        }
+    return identifier
+  }()
 
-        let jailbroken = JailbreakHelper.hasCydiaInstalled() || JailbreakHelper.doesContainSuspiciousApps() ||
-            JailbreakHelper.doesSuspiciousSystemPathExist() || JailbreakHelper.canEditSystemFiles()
+  // swiftlint:disable function_body_length closure_body_length
+  static internal let DeviceMap: ExpoDeviceType = {
+    func mapToDevice(identifier: String) -> ExpoDeviceType {
+      let currentYear = Calendar(identifier: .gregorian).dateComponents([.year], from: Date()).year
 
-        return jailbroken
+      #if os(iOS)
+      switch identifier {
+      case "iPod7,1":
+        return ExpoDeviceType(modelName: "iPod touch (6th generation)", deviceYearClass: 2015)
+      case "iPod9,1":
+        return ExpoDeviceType(modelName: "iPod touch (7th generation)", deviceYearClass: 2019)
+      case "iPhone6,1", "iPhone6,2":
+        return ExpoDeviceType(modelName: "iPhone 5s", deviceYearClass: 2013)
+      case "iPhone7,1":
+        return ExpoDeviceType(modelName: "iPhone 6 Plus", deviceYearClass: 2014)
+      case "iPhone7,2":
+        return ExpoDeviceType(modelName: "iPhone 6", deviceYearClass: 2014)
+      case "iPhone8,1":
+        return ExpoDeviceType(modelName: "iPhone 6s", deviceYearClass: 2015)
+      case "iPhone8,2":
+        return ExpoDeviceType(modelName: "iPhone 6s Plus", deviceYearClass: 2015)
+      case "iPhone9,1", "iPhone9,3":
+        return ExpoDeviceType(modelName: "iPhone 7", deviceYearClass: 2016)
+      case "iPhone9,2", "iPhone9,4":
+        return ExpoDeviceType(modelName: "iPhone 7 Plus", deviceYearClass: 2016)
+      case "iPhone10,1", "iPhone10,4":
+        return ExpoDeviceType(modelName: "iPhone 8", deviceYearClass: 2017)
+      case "iPhone10,2", "iPhone10,5":
+        return ExpoDeviceType(modelName: "iPhone 8 Plus", deviceYearClass: 2017)
+      case "iPhone10,3", "iPhone10,6":
+        return ExpoDeviceType(modelName: "iPhone X", deviceYearClass: 2017)
+      case "iPhone11,2":
+        return ExpoDeviceType(modelName: "iPhone XS", deviceYearClass: 2018)
+      case "iPhone11,4", "iPhone11,6":
+        return ExpoDeviceType(modelName: "iPhone XS Max", deviceYearClass: 2018)
+      case "iPhone11,8":
+        return ExpoDeviceType(modelName: "iPhone XR", deviceYearClass: 2018)
+      case "iPhone12,1":
+        return ExpoDeviceType(modelName: "iPhone 11", deviceYearClass: 2019)
+      case "iPhone12,3":
+        return ExpoDeviceType(modelName: "iPhone 11 Pro", deviceYearClass: 2019)
+      case "iPhone12,5":
+        return ExpoDeviceType(modelName: "iPhone 11 Pro Max", deviceYearClass: 2019)
+      case "iPhone13,1":
+        return ExpoDeviceType(modelName: "iPhone 12 mini", deviceYearClass: 2020)
+      case "iPhone13,2":
+        return ExpoDeviceType(modelName: "iPhone 12", deviceYearClass: 2020)
+      case "iPhone13,3":
+        return ExpoDeviceType(modelName: "iPhone 12 Pro", deviceYearClass: 2020)
+      case "iPhone13,4":
+        return ExpoDeviceType(modelName: "iPhone 12 Pro Max", deviceYearClass: 2020)
+      case "iPhone14,4":
+        return ExpoDeviceType(modelName: "iPhone 13 mini", deviceYearClass: 2021)
+      case "iPhone14,5":
+        return ExpoDeviceType(modelName: "iPhone 13", deviceYearClass: 2021)
+      case "iPhone14,2":
+        return ExpoDeviceType(modelName: "iPhone 13 Pro", deviceYearClass: 2021)
+      case "iPhone14,3":
+        return ExpoDeviceType(modelName: "iPhone 13 Pro Max", deviceYearClass: 2021)
+      case "iPhone14,7":
+        return ExpoDeviceType(modelName: "iPhone 14", deviceYearClass: 2022)
+      case "iPhone14,8":
+        return ExpoDeviceType(modelName: "iPhone 14 Plus", deviceYearClass: 2022)
+      case "iPhone15,2":
+        return ExpoDeviceType(modelName: "iPhone 14 Pro", deviceYearClass: 2022)
+      case "iPhone15,3":
+        return ExpoDeviceType(modelName: "iPhone 14 Pro Max", deviceYearClass: 2022)
+      case "iPhone8,4":
+        return ExpoDeviceType(modelName: "iPhone SE", deviceYearClass: 2016)
+      case "iPhone12,8":
+        return ExpoDeviceType(modelName: "iPhone SE (2nd generation)", deviceYearClass: 2020)
+      case "iPhone14,6":
+        return ExpoDeviceType(modelName: "iPhone SE (3rd generation)", deviceYearClass: 2022)
+      case "iPad6,11", "iPad6,12":
+        return ExpoDeviceType(modelName: "iPad (5th generation)", deviceYearClass: 2017)
+      case "iPad7,5", "iPad7,6":
+        return ExpoDeviceType(modelName: "iPad (6th generation)", deviceYearClass: 2018)
+      case "iPad7,11", "iPad7,12":
+        return ExpoDeviceType(modelName: "iPad (7th generation)", deviceYearClass: 2019)
+      case "iPad11,6", "iPad11,7":
+        return ExpoDeviceType(modelName: "iPad (8th generation)", deviceYearClass: 2020)
+      case "iPad12,1", "iPad12,2":
+        return ExpoDeviceType(modelName: "iPad (9th generation)", deviceYearClass: 2021)
+      case "iPad4,1", "iPad4,2", "iPad4,3":
+        return ExpoDeviceType(modelName: "iPad Air", deviceYearClass: 2013)
+      case "iPad5,3", "iPad5,4":
+        return ExpoDeviceType(modelName: "iPad Air 2", deviceYearClass: 2014)
+      case "iPad11,3", "iPad11,4":
+        return ExpoDeviceType(modelName: "iPad Air (3rd generation)", deviceYearClass: 2019)
+      case "iPad13,1", "iPad13,2":
+        return ExpoDeviceType(modelName: "iPad Air (4th generation)", deviceYearClass: 2020)
+      case "iPad13,16", "iPad13,17":
+        return ExpoDeviceType(modelName: "iPad Air (5th generation)", deviceYearClass: 2022)
+      case "iPad4,4", "iPad4,5", "iPad4,6":
+        return ExpoDeviceType(modelName: "iPad mini 2", deviceYearClass: 2013)
+      case "iPad4,7", "iPad4,8", "iPad4,9":
+        return ExpoDeviceType(modelName: "iPad mini 3", deviceYearClass: 2014)
+      case "iPad5,1", "iPad5,2":
+        return ExpoDeviceType(modelName: "iPad mini 4", deviceYearClass: 2015)
+      case "iPad11,1", "iPad11,2":
+        return ExpoDeviceType(modelName: "iPad mini (5th generation)", deviceYearClass: 2019)
+      case "iPad14,1", "iPad14,2":
+        return ExpoDeviceType(modelName: "iPad mini (6th generation)", deviceYearClass: 2021)
+      case "iPad6,3", "iPad6,4":
+        return ExpoDeviceType(modelName: "iPad Pro (9.7-inch)", deviceYearClass: 2016)
+      case "iPad7,3", "iPad7,4":
+        return ExpoDeviceType(modelName: "iPad Pro (10.5-inch)", deviceYearClass: 2017)
+      case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4":
+        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (1st generation)", deviceYearClass: 2018)
+      case "iPad8,9", "iPad8,10":
+        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (2nd generation)", deviceYearClass: 2020)
+      case "iPad13,4", "iPad13,5", "iPad13,6", "iPad13,7":
+        return ExpoDeviceType(modelName: "iPad Pro (11-inch) (3rd generation)", deviceYearClass: 2021)
+      case "iPad6,7", "iPad6,8":
+        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (1st generation)", deviceYearClass: 2015)
+      case "iPad7,1", "iPad7,2":
+        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (2nd generation)", deviceYearClass: 2017)
+      case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8":
+        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (3rd generation)", deviceYearClass: 2018)
+      case "iPad8,11", "iPad8,12":
+        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (4th generation)", deviceYearClass: 2020)
+      case "iPad13,8", "iPad13,9", "iPad13,10", "iPad13,11":
+        return ExpoDeviceType(modelName: "iPad Pro (12.9-inch) (5th generation)", deviceYearClass: 2021)
+      case "AppleTV5,3":
+        return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
+      case "AppleTV6,2":
+        return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
+      case "i386", "x86_64", "arm64":
+        return ExpoDeviceType(modelName: "Simulator iOS", deviceYearClass: currentYear)
+      default:
+        return ExpoDeviceType(modelName: identifier, deviceYearClass: currentYear)
+      }
+      #elseif os(tvOS)
+      switch identifier {
+      case "AppleTV5,3":
+        return ExpoDeviceType(modelName: "Apple TV HD (4th Generation, Siri)", deviceYearClass: 2015)
+      case "AppleTV6,2":
+        return ExpoDeviceType(modelName: "Apple TV 4K", deviceYearClass: 2017)
+      case "i386", "x86_64":
+        return ExpoDeviceType(modelName: "Simulator tvOS", deviceYearClass: currentYear)
+      default:
+        return identifier
+      }
+      #endif
     }
+
+    return mapToDevice(identifier: modelIdentifier)
+  }()
+  // swiftlint:enable function_body_length closure_body_length
+
+  // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
+  var isSimulator: Bool {
+    return TARGET_OS_SIMULATOR != 0
+  }
+
+  var isJailbroken: Bool {
+    if UIDevice.current.isSimulator {
+      return false
+    }
+
+    let jailbroken = JailbreakHelper.hasCydiaInstalled() || JailbreakHelper.doesContainSuspiciousApps() ||
+    JailbreakHelper.doesSuspiciousSystemPathExist() || JailbreakHelper.canEditSystemFiles()
+
+    return jailbroken
+  }
 }
 
 // Credit: https://github.com/developerinsider/isJailBroken/blob/master/IsJailBroken/Extension/UIDevice%2BJailBroken.swift
 private struct JailbreakHelper {
-    static func hasCydiaInstalled() -> Bool {
-        if let url = URL(string: "cydia://") {
-            return UIApplication.shared.canOpenURL(url)
-        }
-        return false
+  static func hasCydiaInstalled() -> Bool {
+    if let url = URL(string: "cydia://") {
+      return UIApplication.shared.canOpenURL(url)
     }
+    return false
+  }
 
-    static func doesContainSuspiciousApps() -> Bool {
-        for path in suspiciousAppsPathToCheck where FileManager.default.fileExists(atPath: path) {
-            return true
-        }
-        return false
+  static func doesContainSuspiciousApps() -> Bool {
+    for path in suspiciousAppsPathToCheck where FileManager.default.fileExists(atPath: path) {
+      return true
     }
+    return false
+  }
 
-    static func doesSuspiciousSystemPathExist() -> Bool {
-        for path in suspiciousSystemPathsToCheck where FileManager.default.fileExists(atPath: path) {
-            return true
-        }
-        return false
+  static func doesSuspiciousSystemPathExist() -> Bool {
+    for path in suspiciousSystemPathsToCheck where FileManager.default.fileExists(atPath: path) {
+      return true
     }
+    return false
+  }
 
-    static func canEditSystemFiles() -> Bool {
-        let jailbreakText = "Developer Insider"
-        do {
-            try jailbreakText.write(toFile: jailbreakText, atomically: true, encoding: .utf8)
-            return true
-        } catch {
-            return false
-        }
+  static func canEditSystemFiles() -> Bool {
+    let jailbreakText = "Developer Insider"
+    do {
+      try jailbreakText.write(toFile: jailbreakText, atomically: true, encoding: .utf8)
+      return true
+    } catch {
+      return false
     }
+  }
 
-    /**
-     Add more paths here to check for jail break
-     */
-    static var suspiciousAppsPathToCheck: [String] {
-        return [
-            "/Applications/Cydia.app",
-            "/Applications/blackra1n.app",
-            "/Applications/FakeCarrier.app",
-            "/Applications/Icy.app",
-            "/Applications/IntelliScreen.app",
-            "/Applications/MxTube.app",
-            "/Applications/RockApp.app",
-            "/Applications/SBSettings.app",
-            "/Applications/WinterBoard.app"
-        ]
-    }
+  /**
+   Add more paths here to check for jail break
+   */
+  static var suspiciousAppsPathToCheck: [String] {
+    return [
+      "/Applications/Cydia.app",
+      "/Applications/blackra1n.app",
+      "/Applications/FakeCarrier.app",
+      "/Applications/Icy.app",
+      "/Applications/IntelliScreen.app",
+      "/Applications/MxTube.app",
+      "/Applications/RockApp.app",
+      "/Applications/SBSettings.app",
+      "/Applications/WinterBoard.app"
+    ]
+  }
 
-    static var suspiciousSystemPathsToCheck: [String] {
-        return [
-            "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
-            "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
-            "/private/var/lib/apt",
-            "/private/var/lib/apt/",
-            "/private/var/lib/cydia",
-            "/private/var/mobile/Library/SBSettings/Themes",
-            "/private/var/stash",
-            "/private/var/tmp/cydia.log",
-            "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
-            "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
-            "/usr/bin/sshd",
-            "/usr/libexec/sftp-server",
-            "/usr/sbin/sshd",
-            "/etc/apt",
-            "/bin/bash",
-            "/Library/MobileSubstrate/MobileSubstrate.dylib"
-        ]
-    }
+  static var suspiciousSystemPathsToCheck: [String] {
+    return [
+      "/Library/MobileSubstrate/DynamicLibraries/LiveClock.plist",
+      "/Library/MobileSubstrate/DynamicLibraries/Veency.plist",
+      "/private/var/lib/apt",
+      "/private/var/lib/apt/",
+      "/private/var/lib/cydia",
+      "/private/var/mobile/Library/SBSettings/Themes",
+      "/private/var/stash",
+      "/private/var/tmp/cydia.log",
+      "/System/Library/LaunchDaemons/com.ikey.bbot.plist",
+      "/System/Library/LaunchDaemons/com.saurik.Cydia.Startup.plist",
+      "/usr/bin/sshd",
+      "/usr/libexec/sftp-server",
+      "/usr/sbin/sshd",
+      "/etc/apt",
+      "/bin/bash",
+      "/Library/MobileSubstrate/MobileSubstrate.dylib"
+    ]
+  }
 }


### PR DESCRIPTION
# Why

On iOS added support for deviceType detection of Desktop on MacOS, checking for Catalyst and iPad app running on Mac.

Supersedes #15084 which got outdated before merging, broken apart as requested in previous review.

# How

By checking the `ProcessInfo.processInfo.isMacCatalystApp` and `ProcessInfo.processInfo.isiOSAppOnMac` flags.

# Test Plan

Tested in the bare-expo app. And used in production through `patch-package`.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
