### PR TITLE
fix(cli): remove symbol objectIds to avoid vscode crashing hermes

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeCompat.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/VscodeCompat.ts
@@ -52,11 +52,18 @@ export class VscodeCompatHandler implements InspectorHandler {
     if ('id' in message && this.interceptDeviceMessage.has(message.id)) {
       this.interceptDeviceMessage.delete(message.id);
 
-      // Force-fully format the properties description to be an empty string
-      // See: https://github.com/facebook/hermes/issues/114
       for (const item of message.result.result ?? []) {
+        // Force-fully format the properties description to be an empty string
+        // See: https://github.com/facebook/hermes/issues/114
         if (item.value) {
           item.value.description = item.value.description ?? '';
+        }
+
+        // Avoid passing the `objectId` for symbol types.
+        // When collapsing in vscode, it will fetch information about the symbol using the `objectId`.
+        // The `Runtime.getProperties` request of the symbol hard-crashes Hermes.
+        if (item.value?.type === 'symbol' && item.value.objectId) {
+          delete item.value.objectId;
         }
       }
     }

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/VscodeCompat.test.ts
@@ -67,6 +67,40 @@ it('mutates `Runtime.getProperties` device response with `description` propertie
   expect(descriptors.result[1].value).toHaveProperty('description', 'Dont overwrite');
 });
 
+it('mutates `Runtime.getProperties` device responses and removes `objectId` from symbol types', () => {
+  const handler = new VscodeCompatHandler();
+  const debuggerSocket = { send: jest.fn() };
+
+  // This message should still be propagated, it should return `false`
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Runtime.getProperties',
+        params: { objectId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(false);
+
+  // The handler mutates the properties, we need to keep a reference
+  const descriptors: RuntimeGetProperties['result'] = {
+    result: [
+      {
+        name: 'bar',
+        configurable: true,
+        enumerable: true,
+        value: { type: 'symbol', description: 'Symbol(bar)', objectId: '1337' },
+      },
+    ],
+  };
+
+  // This message should still be propagated, it should return `false`
+  expect(handler.onDeviceMessage({ id: 420, result: descriptors })).toBe(false);
+  // Expect the descriptor value to be mutated
+  expect(descriptors.result[0].value).not.toHaveProperty('objectId');
+});
+
 it('mutates `Debugger.paused` callFrames without Hermes native function frames', () => {
   const handler = new VscodeCompatHandler();
 


### PR DESCRIPTION
# Why

Remove `objectId` from symbol types to disable vscode to improperly fetch object properties on symbols, causing Hermes to hard-crash.

vscode before | vsocde after
--- | ---
![vscode-symbol-hard-crash](https://user-images.githubusercontent.com/1203991/224037441-aba1da1f-e48b-43e7-b1ec-2e4d09ac8e2e.gif) | ![vscode-symbol-no-crash](https://user-images.githubusercontent.com/1203991/224037191-fbbd88ed-e936-4008-8ce5-cb501e56eac5.gif)

chrome before | chrome after
--- | ---
![chrome-symbol-before](https://user-images.githubusercontent.com/1203991/224038387-0b360c7a-7a1e-4abf-b809-919f4b05f730.gif) | ![chrome-symbol-after](https://user-images.githubusercontent.com/1203991/224038408-a843bb32-2541-441b-b7ad-e51ea6544fa1.gif)


# How

By removing the `objectId`, the vscode debugger doesn't have any reference to request the `Runtime.getProperties` on the symbol itself. This avoids being able to crash Hermes by running `Runtime.getProperties` on `symbol` types.

# Test Plan

- Clone https://github.com/byCedric/vscode-js-debug-issue-1583
- Add `const testSymbol = Symbol('test');` near a breakpoint
- Try to expand the `testSymbol` in the variables explorer

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
