### PR TITLE
[DO NOT MERGE] chore: prepare `bare-expo` for vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "attach",
+      "name": "Attach to bare-expo",
+
+      // Define the source and actual bundled code roots
+      // This is used to load and map source code
+      // Note, this configuration assumes Metro is launched with the following flags:
+      //   - `EXPO_USE_METRO_WORKSPACE_ROOT=true`
+      //   - `EXPO_USE_CUSTOM_INSPECTOR_PROXY=true`
+      //   - `--localhost`
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "http://127.0.0.1:8081",
+
+      // Define the websocket that `vscode-js-debug` will connect to
+      // See: http://localhost/json/list, and look for "React Native Experimental (Improved Chrome Reloads)"
+      "websocketAddress": "ws://[::]:8081/inspector/debug?device=0&page=-1",
+
+      // Enable sourcemaps
+      "sourceMaps": true,
+      // But avoid loading some specific sources if they aren't available
+      "resolveSourceMapLocations": [
+        "!**/__prelude__",
+        "!**/node_modules/**"
+      ],
+
+      // Attach to whatever processes is running in Hermes (not sure if required)
+      "attachExistingChildren": true,
+      // When Hermes/app or the inspector unexpectedly disconnects, close the debug session
+      "restart": false,
+      // Speed up the sourcemap loading, it's kind of experimental in `vscode-js-debug`, but does work fine eiher way
+      "enableTurboSourcemaps": true,
+      // Enable `vscode-js-debug` to dump all incoming and outgoing messages, helps to debug (see debug console in vscode)
+      "trace": true
+    }
+  ]
+}

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java
@@ -21,7 +21,7 @@ import expo.modules.devlauncher.DevLauncherPackageDelegate;
 import expo.modules.devmenu.DevMenuPackageDelegate;
 
 public class MainApplication extends Application implements ReactApplication {
-  static final boolean USE_DEV_CLIENT = false;
+  static final boolean USE_DEV_CLIENT = true;
 
   private final ReactNativeHost mReactNativeHost =
     new ReactNativeHostWrapper(this, new DefaultReactNativeHost(this) {

--- a/apps/bare-expo/ios/BareExpo/AppDelegate.mm
+++ b/apps/bare-expo/ios/BareExpo/AppDelegate.mm
@@ -19,7 +19,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
 #if DEBUG
-  BOOL useDevClient = NO;
+  BOOL useDevClient = YES;
 
   if (!useDevClient) {
     ExpoDevLauncherReactDelegateHandler.enableAutoSetup = NO;


### PR DESCRIPTION
# Why

This PR prepares `bare-expo` to be debugged by vscode, use it as test setup for #21560

https://user-images.githubusercontent.com/1203991/224061261-375484bd-ff7d-42d9-bf12-aa78436ec779.mp4


# How

- Enabled dev-client in `bare-expo`
- Added manual configuration in `.vscode/launch.json`

# Test Plan

- Check out this branch
- `$ cd ./apps/bare-expo && yarn expo run:ios`
- After the app is ready, close the bundler
- `$ EXPO_DEBUG=true EXPO_USE_METRO_WORKSPACE_ROOT=true EXPO_USE_CUSTOM_INSPECTOR_PROXY=true expod start --dev-client --ios --localhost`
- Wait until the simulator is ready to go
- Go to `Run and debug (⇧⌘D)`
- Select `Attach to bare-expo`
- And start debugging!

> **Warning**
> The Metro inspector has a very limited device ID setup, meaning that if you close and reconnect a device multiple times, you'll need to update the `websocketAddress` in `.vscode/launch.json`, OR close and start the bundler again.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
