### PR TITLE
[expo-updates] E2E tests: Upgrade Detox config plugin

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas-hooks/eas-build-pre-install.sh
@@ -33,6 +33,7 @@ if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "updates_tes
       pulseaudio \
       socat
 
+    # Emulator must be API 31 -- API 32 and 33 fail due to https://github.com/wix/Detox/issues/3762
     sdkmanager --install "system-images;android-31;google_apis;x86_64"
     avdmanager --verbose create avd --force --name "pixel_4" --device "pixel_4" --package "system-images;android-31;google_apis;x86_64"
   else

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -185,7 +185,7 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E) {
 
   const extraDevDependencies = configureE2E
     ? {
-        '@config-plugins/detox': '^3.0.0',
+        '@config-plugins/detox': '^5.0.1',
         '@types/express': '^4.17.17',
         '@types/jest': '^29.4.0',
         '@types/react': '~18.0.14',


### PR DESCRIPTION
# Why

Move to latest Detox config plugin (just published by Evan today). This should be used with SDK 48.


# Test Plan

E2E should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
