### PR TITLE
[exupdates][ios] Fix odd nullability issue in expo module

### DIFF
--- a/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -58,17 +58,17 @@ ofDownloadWithManifest:(EXManifestsManifest * _Nullable)manifest
 
 # pragma mark - EXUpdatesBindingDelegate
 
-- (EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey
+- (nullable EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey
 {
   return [self _appLoaderWithScopeKey:scopeKey].config;
 }
 
-- (EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey
+- (nullable EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey
 {
   return [self _appLoaderWithScopeKey:scopeKey].selectionPolicy;
 }
 
-- (nullable EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey
+- (nullable nullable EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey
 {
   return [self _appLoaderWithScopeKey:scopeKey].appLauncher.launchedUpdate;
 }

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.h
@@ -14,8 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol EXUpdatesBindingDelegate
 
-- (EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
-- (EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
+- (nullable EXUpdatesConfig *)configForScopeKey:(NSString *)scopeKey;
+- (nullable EXUpdatesSelectionPolicy *)selectionPolicyForScopeKey:(NSString *)scopeKey;
 - (nullable EXUpdatesUpdate *)launchedUpdateForScopeKey:(NSString *)scopeKey;
 - (nullable NSDictionary *)assetFilesMapForScopeKey:(NSString *)scopeKey;
 - (BOOL)isUsingEmbeddedAssetsForScopeKey:(NSString *)scopeKey;

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXUpdatesBinding.m
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (EXUpdatesConfig *)config
+- (nullable EXUpdatesConfig *)config
 {
   return [_updatesKernelService configForScopeKey:_scopeKey];
 }
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
   return _databaseKernelService.database;
 }
 
-- (EXUpdatesSelectionPolicy *)selectionPolicy
+- (nullable EXUpdatesSelectionPolicy *)selectionPolicy
 {
   return [_updatesKernelService selectionPolicyForScopeKey:_scopeKey];
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - Make Updates API work with native debug. ([#21253](https://github.com/expo/expo/pull/21253) by [@douglowder](https://github.com/douglowder))
+- iOS: Fix odd nullability issue in expo module. ([#21655](https://github.com/expo/expo/pull/21655) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.h
@@ -13,9 +13,9 @@ typedef void (^EXUpdatesAppRelaunchCompletionBlock)(BOOL success);
 
 @protocol EXUpdatesModuleInterface
 
-@property (nonatomic, readonly) EXUpdatesConfig *config;
+@property (nonatomic, readonly, nullable) EXUpdatesConfig *config;
 @property (nonatomic, readonly) EXUpdatesDatabase *database;
-@property (nonatomic, readonly) EXUpdatesSelectionPolicy *selectionPolicy;
+@property (nonatomic, readonly, nullable) EXUpdatesSelectionPolicy *selectionPolicy;
 @property (nonatomic, readonly) NSURL *directory;
 
 @property (nullable, nonatomic, readonly, strong) EXUpdatesUpdate *embeddedUpdate;

--- a/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
+++ b/packages/expo-updates/ios/EXUpdates/EXUpdatesService.m
@@ -31,7 +31,7 @@ EX_REGISTER_MODULE();
   return @[@protocol(EXUpdatesModuleInterface)];
 }
 
-- (EXUpdatesConfig *)config
+- (nullable EXUpdatesConfig *)config
 {
 #if SUPPRESS_EXPO_UPDATES_SERVICE // used in Expo Go
   return nil;
@@ -44,7 +44,7 @@ EX_REGISTER_MODULE();
   return EXUpdatesAppController.sharedInstance.database;
 }
 
-- (EXUpdatesSelectionPolicy *)selectionPolicy
+- (nullable EXUpdatesSelectionPolicy *)selectionPolicy
 {
   return EXUpdatesAppController.sharedInstance.selectionPolicy;
 }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -27,10 +27,22 @@ public final class UpdatesModule: Module {
     Name("ExpoUpdates")
 
     Constants {
-      let releaseChannel = updatesService?.config.releaseChannel
-      let channel = updatesService?.config.requestHeaders["expo-channel-name"] ?? ""
-      let runtimeVersion = updatesService?.config.runtimeVersion ?? ""
-      let isMissingRuntimeVersion = updatesService?.config.isMissingRuntimeVersion()
+      // this is nil in expo go for some reason
+      guard let config = (updatesService?.config as UpdatesConfig?) else {
+        return [
+          "isEnabled": false,
+          "isEmbeddedLaunch": false,
+          "isMissingRuntimeVersion": false,
+          "releaseChannel": "",
+          "runtimeVersion": "",
+          "channel": ""
+        ]
+      }
+      
+      let releaseChannel = config.releaseChannel
+      let channel = config.requestHeaders["expo-channel-name"] ?? ""
+      let runtimeVersion = config.runtimeVersion ?? ""
+      let isMissingRuntimeVersion = config.isMissingRuntimeVersion()
 
       guard let updatesService = updatesService,
         updatesService.isStarted,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -27,22 +27,10 @@ public final class UpdatesModule: Module {
     Name("ExpoUpdates")
 
     Constants {
-      // this is nil in expo go for some reason
-      guard let config = (updatesService?.config as UpdatesConfig?) else {
-        return [
-          "isEnabled": false,
-          "isEmbeddedLaunch": false,
-          "isMissingRuntimeVersion": false,
-          "releaseChannel": "",
-          "runtimeVersion": "",
-          "channel": ""
-        ]
-      }
-      
-      let releaseChannel = config.releaseChannel
-      let channel = config.requestHeaders["expo-channel-name"] ?? ""
-      let runtimeVersion = config.runtimeVersion ?? ""
-      let isMissingRuntimeVersion = config.isMissingRuntimeVersion()
+      let releaseChannel = updatesService?.config?.releaseChannel
+      let channel = updatesService?.config?.requestHeaders["expo-channel-name"] ?? ""
+      let runtimeVersion = updatesService?.config?.runtimeVersion ?? ""
+      let isMissingRuntimeVersion = updatesService?.config?.isMissingRuntimeVersion()
 
       guard let updatesService = updatesService,
         updatesService.isStarted,
@@ -76,7 +64,7 @@ public final class UpdatesModule: Module {
     }
 
     AsyncFunction("reloadAsync") { (promise: Promise) in
-      guard let updatesService = updatesService, updatesService.config.isEnabled else {
+      guard let updatesService = updatesService, let config = updatesService.config, config.isEnabled else {
         throw UpdatesDisabledException()
       }
       guard updatesService.canRelaunch else {
@@ -92,7 +80,10 @@ public final class UpdatesModule: Module {
     }
 
     AsyncFunction("checkForUpdateAsync") { (promise: Promise) in
-      guard let updatesService = updatesService, updatesService.config.isEnabled else {
+      guard let updatesService = updatesService,
+        let config = updatesService.config,
+        let selectionPolicy = updatesService.selectionPolicy,
+        config.isEnabled else {
         throw UpdatesDisabledException()
       }
       guard updatesService.isStarted else {
@@ -103,21 +94,20 @@ public final class UpdatesModule: Module {
       updatesService.database.databaseQueue.sync {
         extraHeaders = FileDownloader.extraHeaders(
           withDatabase: updatesService.database,
-          config: updatesService.config,
+          config: config,
           launchedUpdate: updatesService.launchedUpdate,
           embeddedUpdate: updatesService.embeddedUpdate
         )
       }
 
-      let fileDownloader = FileDownloader(config: updatesService.config)
+      let fileDownloader = FileDownloader(config: config)
       fileDownloader.downloadManifest(
         // swiftlint:disable:next force_unwrapping
-        fromURL: updatesService.config.updateUrl!,
+        fromURL: config.updateUrl!,
         withDatabase: updatesService.database,
         extraHeaders: extraHeaders
       ) { update in
         let launchedUpdate = updatesService.launchedUpdate
-        let selectionPolicy = updatesService.selectionPolicy
         if selectionPolicy.shouldLoadNewUpdate(update, withLaunchedUpdate: launchedUpdate, filters: update.manifestFilters) {
           promise.resolve([
             "isAvailable": true,
@@ -149,7 +139,10 @@ public final class UpdatesModule: Module {
     }
 
     AsyncFunction("fetchUpdateAsync") { (promise: Promise) in
-      guard let updatesService = updatesService, updatesService.config.isEnabled else {
+      guard let updatesService = updatesService,
+        let config = updatesService.config,
+        let selectionPolicy = updatesService.selectionPolicy,
+        config.isEnabled else {
         throw UpdatesDisabledException()
       }
       guard updatesService.isStarted else {
@@ -157,7 +150,7 @@ public final class UpdatesModule: Module {
       }
 
       let remoteAppLoader = RemoteAppLoader(
-        config: updatesService.config,
+        config: config,
         database: updatesService.database,
         directory: updatesService.directory,
         launchedUpdate: updatesService.launchedUpdate,
@@ -165,9 +158,9 @@ public final class UpdatesModule: Module {
       )
       remoteAppLoader.loadUpdate(
         // swiftlint:disable:next force_unwrapping
-        fromURL: updatesService.config.updateUrl!
+        fromURL: config.updateUrl!
       ) { update in
-        return updatesService.selectionPolicy.shouldLoadNewUpdate(
+        return selectionPolicy.shouldLoadNewUpdate(
           update,
           withLaunchedUpdate: updatesService.launchedUpdate,
           filters: update.manifestFilters


### PR DESCRIPTION
# Why

1. `EXUpdatesBinding.config` returns nil when called here
2. This is because `EXUpdatesManager.configForScopeKey` returns nil for what I assume is the home scope key.

I checked and it was also the case prior to the swift conversion, but didn't crash because objective-c is more nil-selector-call-lenient.

# How

Check if it's nil even though it shouldn't be according to the types. Changing all the types in the interface to be nullable introduces quite a number of issues.

# Test Plan

Run expo go, see no more crash.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
