### PR TITLE
[docs] Add redirects based on Sentry reports and fix formatting in tutorial

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -199,6 +199,9 @@ const RENAMED_PAGES: Record<string, string> = {
   '/guides/using-fcm/': '/push-notifications/using-fcm/',
   '/push-notifications/': '/push-notifications/overview/',
   '/distribution/hosting-your-app/': '/distribution/publishing-websites/',
+  '/build-reference/how-tos/': '/build-reference/private-npm-packages/',
+  '/get-started/': '/get-started/installation/',
+  '/guides/detach/': '/archive/glossary/#detach',
 
   // Renaming a submit section
   '/submit/submit-ios': '/submit/ios/',
@@ -206,8 +209,8 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Fundamentals had too many things
   '/workflow/linking/': '/guides/linking/',
-  '/workflow/how-expo-works/': '/guides/how-expo-works/',
-  '/guides/how-expo-works/': '/workflow/expo-go/',
+  '/workflow/how-expo-works/': '/workflow/already-used-react-native/#how-does-expo-work',
+  '/guides/how-expo-works/': '/workflow/already-used-react-native/#how-does-expo-work',
 
   // Archive unused pages
   '/guides/notification-channels/': '/archived/notification-channels/',

--- a/docs/pages/archive/adhoc-builds.mdx
+++ b/docs/pages/archive/adhoc-builds.mdx
@@ -13,7 +13,7 @@ Build and install a custom version of [Expo Go](../get-started/installation.mdx#
 ## Prerequisites
 
 - You’ll need a **paid** [Apple Developer Account](https://developer.apple.com/programs) to configure credentials required for the development and distribution process of an app. Learn more [here](https://developer.apple.com/programs/whats-included/).
-- Install the `expo-cli` command line app by following the instructions [here](../workflow/expo-cli.mdx).
+- Install the `expo-cli` command line app by following the instructions [here](../workflow/expo-cli).
 
 **Windows users** must have WSL enabled. You can follow the installation guide [here](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We recommend picking Ubuntu from the Windows Store. Be sure to launch Ubuntu at least once. After that, use an Admin powershell to run:
 `Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux`

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -133,5 +133,5 @@ Prebuild is the tip of the automation iceberg, here are some features you can ad
 [dev-client]: /development/introduction
 [config-plugins]: /guides/config-plugins
 [prebuild]: /workflow/prebuild
-[cli]: /workflow/expo-cli.md
+[cli]: /workflow/expo-cli
 [version-support]: /versions/latest/index#each-expo-sdk-version-depends-on-a-react-native-version

--- a/docs/pages/technical-specs/expo-updates-1-draft.mdx
+++ b/docs/pages/technical-specs/expo-updates-1-draft.mdx
@@ -42,8 +42,8 @@ The following describes how a conformant Expo Updates client library MUST retrie
 
 1. The client library MUST make a [request](#request) for the most recent update and directive, with constraints specified in the headers.
 2. If a [response](#response) is received, the client library MUST process its contents:
-    - For a response containing an _update_, the client library SHALL proceed to make additional requests to download and store any new assets specified in the manifest. The manifest and assets together are considered a new _update_. The client library will edit its local state to reflect that a new update has been added to the local storage. It will also update the local state with the new `expo-manifest-filters` and `expo-server-defined-headers` found in the response [headers](#manifest-response-headers).
-    - For a response containing a _directive_, the client library will consume the directive depending on the directive type and edit its local state accordingly.
+   - For a response containing an _update_, the client library SHALL proceed to make additional requests to download and store any new assets specified in the manifest. The manifest and assets together are considered a new _update_. The client library will edit its local state to reflect that a new update has been added to the local storage. It will also update the local state with the new `expo-manifest-filters` and `expo-server-defined-headers` found in the response [headers](#manifest-response-headers).
+   - For a response containing a _directive_, the client library will consume the directive depending on the directive type and edit its local state accordingly.
 
 ## Request
 
@@ -126,19 +126,19 @@ Part order is not strict. A multipart response with no parts should be considere
 Each part is defined as follows:
 
 1. OPTIONAL `"manifest"` part:
-    - MUST have part header `content-disposition: inline; name="manifest"`.
-    - MUST have part header `content-type: application/json` or `application/expo+json`.
-    - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
-    - The [manifest body](#manifest-body) MUST be sent in the part body.
+   - MUST have part header `content-disposition: inline; name="manifest"`.
+   - MUST have part header `content-type: application/json` or `application/expo+json`.
+   - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
+   - The [manifest body](#manifest-body) MUST be sent in the part body.
 2. OPTIONAL `"extensions"` part:
-    - MUST have part header `content-disposition: inline; name="extensions"`.
-    - MUST have part header `content-type: application/json`.
-    - The [extensions-body](#extensions-body) MUST be sent in the part body.
+   - MUST have part header `content-disposition: inline; name="extensions"`.
+   - MUST have part header `content-type: application/json`.
+   - The [extensions-body](#extensions-body) MUST be sent in the part body.
 3. OPTIONAL `"directive"` part:
-    - MUST have part header `content-disposition: inline; name="directive"`.
-    - MUST have part header `content-type: application/json` or `application/expo+json`.
-    - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
-    - The [directive body](#directive-body) MUST be sent in the part body.
+   - MUST have part header `content-disposition: inline; name="directive"`.
+   - MUST have part header `content-type: application/json` or `application/expo+json`.
+   - SHOULD have part header `expo-signature` as defined in [other response headers](#other-response-headers) if code signing is being used.
+   - The [directive body](#directive-body) MUST be sent in the part body.
 
 ### Manifest Body
 
@@ -218,7 +218,7 @@ type Directive = {
 };
 ```
 
-- `type`: The type of directive directive.
+- `type`: The type of directive.
 - `parameters`: MAY contain any extra information specific to the `type`.
 - `extra`: For storage of optional "extra" information such as third-party information. For example, if the update is hosted on Expo Application Services (EAS), the EAS project ID may be included.
 

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -6,6 +6,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import { A } from '~/ui/components/Text';
 import Video from '~/components/plugins/Video';
+import { Step } from '~/ui/components/Step';
 
 In this chapter, we will create the first screen of the StickerSmash app.
 
@@ -20,7 +21,9 @@ The screen above displays an image and two buttons. The app user can select an i
 
 Once the user selects an image, they'll be able to select and add a sticker to the image. So, let's get started creating this screen.
 
-## Step 1: Break down the screen
+<Step label="1">
+
+## Break down the screen
 
 Before we build this screen by writing code, let's break it down into some essential elements. Most of these elements directly correspond to the built-in [Core Components](https://reactnative.dev/docs/components-and-apis) from React Native.
 
@@ -50,7 +53,11 @@ In React Native, styling (such as the yellow border) is done using JavaScript as
 
 Now that we've broken down the UI into smaller chunks, we're ready to start coding.
 
-## Step 2: Style the background
+</Step>
+
+<Step label="2">
+
+## Style the background
 
 Let's change the background color. This value is defined in the `styles` object in the **App.js** file.
 
@@ -84,7 +91,11 @@ const styles = StyleSheet.create({
 
 > React Native uses the same color format as the web. It supports hex triplets (this is what `#fff` is), `rgba`, `hsl`, and a set of named colors like `red`, `green`, `blue`, `peru`, and `papayawhip`. For more information, see [Colors in React Native](https://reactnative.dev/docs/colors).
 
-## Step 3: Change the text color
+</Step>
+
+<Step label="3">
+
+## Change the text color
 
 The background is dark, so the text is difficult to read. The `<Text>` component uses `#000` (black) as its default color. Let's add a style to the `<Text>` component to change the text color to `#fff` (white) in **App.js**.
 
@@ -120,7 +131,11 @@ const styles = StyleSheet.create({
 
 </SnackInline>
 
-## Step 4: Display the image
+</Step>
+
+<Step label="4">
+
+## Display the image
 
 We can use React Native's `<Image>` component to display the image in the app. The `<Image>` component requires a source of an image. This source can be a [static asset](https://reactnative.dev/docs/images#static-image-resources) or a URL. For example, the source can be required from the app's **./assets/images** directory, or the source can come from the [Network](https://reactnative.dev/docs/images#network-images) in the form of a `uri` property.
 
@@ -184,7 +199,11 @@ const styles = StyleSheet.create({
 
 The `PlaceholderImage` variable references the **./assets/images/background-image.png** and is used as the `source` prop on the `<Image>` component.
 
-## Step 5: Dividing components into files
+</Step>
+
+<Step label="5">
+
+## Dividing components into files
 
 As we add more components to this screen, let's divide the code into multiple files:
 
@@ -250,7 +269,11 @@ const styles = StyleSheet.create({
 /* @end */
 ```
 
-## Step 6: Create buttons using Pressable
+</Step>
+
+<Step label="6">
+
+## Create buttons using Pressable
 
 React Native provides various components to handle touch events on native platforms. For this tutorial, we'll use the [`<Pressable>`](https://reactnative.dev/docs/pressable) component. It is a core component wrapper that can detect various stages of interactions, from basic single-tap events to advanced events such as a long press.
 
@@ -362,7 +385,11 @@ Let's take a look at our app on iOS, Android and the web:
 
 The second button with the label "Use this photo" resembles the actual button from the design. However, the first button needs more styling to match the design.
 
-## Step 7: Enhance the reusable button component
+</Step>
+
+<Step label="7">
+
+## Enhance the reusable button component
 
 The "Choose a photo" button requires different styling than the "Use this photo" button, so we will add a new button theme prop that will allow us to apply a `primary` theme.
 This button also has an icon before the label. We will use an icon from the <A href="/guides/icons/#expovector-icons" openInNewTab>`@expo/vector-icons`</A> library that includes icons from popular icon sets.
@@ -459,6 +486,8 @@ export default function App() {
 Let's take a look at our app on iOS, Android and the web:
 
 <Video file="tutorial/02-complete-layout.mp4" />
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -7,10 +7,13 @@ import Video from '~/components/plugins/Video';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { A } from '~/ui/components/Text';
 import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Before considering the app fully launchable, we have to configure the status bar, add a splash screen, and add an app icon. In this chapter, we will learn how to do all of that.
 
-## Step 1: Configure the status bar
+<Step label="1">
+
+## Configure the status bar
 
 The <A href="/versions/latest/sdk/status-bar/" openInNewTab>`expo-status-bar`</A> library comes pre-installed in every project created using `create-expo-app`.
 This library provides a `<StatusBar>` component that allows configuring the app's status bar to change the text color, background color, make it translucent, and so on.
@@ -41,7 +44,11 @@ To make the status bar light, change the `style` value to `light`.
   style={{ maxWidth: 480 }}
 />
 
-## Step 2: Splash screen
+</Step>
+
+<Step label="2">
+
+## Splash screen
 
 A splash screen is a screen that is visible before the contents of the app has had a chance to load. It hides once the app is ready for use and the content is ready to be displayed.
 
@@ -83,7 +90,11 @@ Don't forget to remove this code when you are done testing your splash screen!
 
 Notice that there is a white bar on the edges of the Android device in the above demo. Depending on the resolution of the device, it might not be visible. To resolve this, we need to set the `backgroundColor` for the splash screen. The background color is applied to any screen area that isn't covered by the splash image.
 
-## Step 3: Configure the splash screen background color
+</Step>
+
+<Step label="3">
+
+## Configure the splash screen background color
 
 We can configure the splash screen's background color in **app.json** file. Open it and make the following change in `"splash"`:
 
@@ -101,11 +112,15 @@ We can configure the splash screen's background color in **app.json** file. Open
 
 The `backgroundColor` value in the above snippet matches the background of the splash screen image.
 
-Let's take a look at our app now on Android, and iOS:
+Let's take a look at our app now on Android and iOS:
 
 <Video file={'tutorial/splash-fixed.mp4'} />
 
-## Step 4: App icon
+</Step>
+
+<Step label="4">
+
+## App icon
 
 Inside the project, there's an **icon.png** file inside **assets** directory. This is our app icon. It's a 1024px by 1024px image and looks as shown below:
 
@@ -123,6 +138,8 @@ You can see the icon in various places in Expo Go. Here is an example of the app
   style={{ maxWidth: 250 }}
   containerStyle={{ marginBottom: 0 }}
 />
+
+</Step>
 
 ## We have completed the app!
 

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -6,15 +6,16 @@ import { SnackInline } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { A } from '~/ui/components/Text';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Step } from '~/ui/components/Step';
 
-React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal) that presents content above the rest of your app.
-In general, modals are used to draw a user's attention toward critical information or guide them to take action.
-For example, in the <A href="/tutorial/build-a-screen/#step-7-enhance-the-reusable-button-component" openInNewTab>second chapter</A>,
+React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal) that presents content above the rest of your app. In general, modals are used to draw a user's attention toward critical information or guide them to take action. For example, in the <A href="/tutorial/build-a-screen/#step-7-enhance-the-reusable-button-component" openInNewTab>second chapter</A>,
 we used `alert()` to display a placeholder when a button is pressed. That's how a modal component displays an overlay.
 
 In this chapter, we'll create a modal that shows an emoji picker list.
 
-## Step 1: Declare a state variable to show buttons
+<Step label="1">
+
+## Declare a state variable to show buttons
 
 Before implementing the modal, we are going to add three new buttons. These buttons will only be visible when the user picks an image from the media library
 or decides to use the placeholder image. One of these buttons will trigger the emoji picker modal.
@@ -91,7 +92,11 @@ export default function App() {
 
 For now, when the value of `showAppOptions` is `true`, let's render an empty `<View>` component. We'll address this state in the next step.
 
-## Step 2: Add buttons
+</Step>
+
+<Step label="2">
+
+## Add buttons
 
 Let's break down the layout of the option buttons we will implement in this chapter. The design looks like this:
 
@@ -258,7 +263,11 @@ Let's take a look at our app on iOS, Android and the web:
   containerStyle={{ marginBottom: 0 }}
 />
 
-## Step 3: Create an emoji picker modal
+</Step>
+
+<Step label="3">
+
+## Create an emoji picker modal
 
 The modal allows the user to choose an emoji from a list of available emoji. Create an **EmojiPicker.js** file inside the **components** directory. This component accepts three props:
 
@@ -424,7 +433,11 @@ Here is the result after this step:
   containerStyle={{ marginBottom: 0 }}
 />
 
-## Step 4: Display a list of emoji
+</Step>
+
+<Step label="4">
+
+## Display a list of emoji
 
 Let's implement a horizontal list of emoji in the modal's content. We'll use is the [`<FlatList>`](https://reactnative.dev/docs/flatlist) component from React Native for it.
 
@@ -525,7 +538,11 @@ Let's take a look at our app on iOS, Android and the web:
 
 <Video file="tutorial/emoji-picker.mp4" />
 
-## Step 5: Display the selected emoji
+</Step>
+
+<Step label="5">
+
+## Display the selected emoji
 
 Now we'll put the emoji sticker on the image.
 
@@ -600,6 +617,8 @@ export default function App() {
 Let's take a look at our app on iOS, Android and the web:
 
 <Video file="tutorial/select-emoji.mp4" />
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -5,6 +5,7 @@ title: Create your first app
 import { Terminal } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { A } from '~/ui/components/Text';
+import { Step } from '~/ui/components/Step';
 
 In this chapter, let's learn how to create a new Expo project and how to get it running.
 
@@ -17,7 +18,9 @@ We'll need the following tools to get started:
 
 This tutorial also assumes that you have a basic knowledge of JavaScript and React. If you have never written React code, go through [the official React tutorial](https://reactjs.org/tutorial/tutorial.html).
 
-## Step 1: Initialize a new Expo app
+<Step label="1">
+
+## Initialize a new Expo app
 
 We will use <A href="/workflow/glossary-of-terms/#create-expo-app" openInNewTab>`create-expo-app`</A> to initialize a new Expo app. It is a command line tool that allows to create a new React Native project with the `expo` package installed.
 
@@ -40,13 +43,21 @@ Let's also <a href="/static/images/tutorial/sticker-smash-assets.zip" download>d
 
 Now, let's open the project directory in our favorite code editor or IDE. Throughout this tutorial, we will use VS Code for our examples.
 
-## Step 2: Install dependencies
+</Step>
+
+<Step label="2">
+
+## Install dependencies
 
 To run the project on the web, we need to install the following dependencies that will help to run the project on the web:
 
 <Terminal cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']} />
 
-## Step 3: Run the app on mobile and web
+</Step>
+
+<Step label="3">
+
+## Run the app on mobile and web
 
 In the project directory, run the following command to start a <A href="/guides/how-expo-works/#expo-development-server" openInNewTab>development server</A> from the terminal:
 
@@ -65,6 +76,8 @@ Once it is running on all platforms, the project should look like this:
 />
 
 The text displayed on the app's screen above can be found in the **App.js** file which is at the root of the project's directory. It is the entry point of the project and is executed when the development server starts.
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -5,6 +5,7 @@ title: Add gestures
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { A } from '~/ui/components/Text';
+import { Step } from '~/ui/components/Step';
 
 Gestures are a great way to provide an intuitive user experience in an app.
 The [React Native Gesture Handler library](https://docs.swmansion.com/react-native-gesture-handler/docs/) provides built-in native components that can handle gestures.
@@ -15,7 +16,9 @@ In this chapter, we are going to add two different gestures using the React Nati
 - Double tap to scale the size of the emoji sticker.
 - Pan to move the emoji sticker around the screen so that the user can place the sticker anywhere on the image.
 
-## Step 1: Install and configure libraries
+<Step label="1">
+
+## Install and configure libraries
 
 The React Native Gesture Handler library provides a way to interact with the native platform's gesture response system.
 To animate between gesture states, we will use the [Reanimated library](https://docs.swmansion.com/react-native-reanimated/docs/).
@@ -69,7 +72,11 @@ export default function App() {
 }
 ```
 
-## Step 2: Create animated components
+</Step>
+
+<Step label="2">
+
+## Create animated components
 
 Open the **EmojiSticker.js** file in the **components** directory. Inside it, import `Animated` from the `react-native-reanimated` library to create animated components.
 
@@ -104,7 +111,11 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 }
 ```
 
-## Step 3: Add a tap gesture
+</Step>
+
+<Step label="3">
+
+## Add a tap gesture
 
 React Native Gesture Handler allows us to add behavior when it detects touch input, like a double tap event.
 
@@ -213,7 +224,11 @@ Let's take a look at our app on iOS, Android and the web:
 
 > For a complete reference on the tap gesture API, refer to the [React Native Gesture Handler](https://docs.swmansion.com/react-native-gesture-handler/docs/api/gestures/tap-gesture) documentation.
 
-## Step 4: Add a pan gesture
+</Step>
+
+<Step label="4">
+
+## Add a pan gesture
 
 A pan gesture allows recognizing a dragging gesture and tracking its movement. We will use this gesture handler to drag the sticker across the image.
 
@@ -352,6 +367,8 @@ export default function EmojiSticker({ imageSize, stickerSource }) {
 Let's take a look at our app on iOS, Android and the web:
 
 <Video file="tutorial/pan-gesture.mp4" />
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -5,6 +5,7 @@ title: Use an image picker
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { A } from '~/ui/components/Text';
+import { Step } from '~/ui/components/Step';
 
 React Native provides built-in components that are standard building blocks used by every application, such as `<View>`, `<Text>`, and `<Pressable>`.
 We want to build a feature that isn't possible with these core components and API: selecting an image from the device's media library. For that, we will need a library.
@@ -13,7 +14,9 @@ To achieve this, we'll use an Expo SDK library called <A href="/versions/latest/
 
 > `expo-image-picker` provides access to the system's UI to select images and videos from the phone's library or take a photo with the camera.
 
-## Step 1: Install expo-image-picker
+<Step label="1">
+
+## Install expo-image-picker
 
 To install the library, run the following command:
 
@@ -22,7 +25,11 @@ To install the library, run the following command:
 > **Tip:** Any time we install a new library in our project, we must stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal and then running the installation command.
 > After the installation, we can start the development server again by running `npx expo start` from the same terminal window.
 
-## Step 2: Pick an image from the device's media library
+</Step>
+
+<Step label="2">
+
+## Pick an image from the device's media library
 
 `expo-image-picker` provides the `launchImageLibraryAsync()` method that displays the system UI for choosing an image or a video from the device's media library.
 
@@ -67,7 +74,11 @@ Let's learn what the above code does.
   We can pass the object to specify different options when invoking the method.
 - When `allowsEditing` is set to `true`, the user can crop the image during the selection process on Android and iOS but not on the web.
 
-## Step 3: Update the button component
+</Step>
+
+<Step label="3">
+
+## Update the button component
 
 When the primary button gets pressed, we need to call the `pickImageAsync()` function.
 To call it, update the `onPress` property of the `<Button>` component in **components/Button.js**:
@@ -131,7 +142,11 @@ To demonstrate what properties the `result` object contains, here is an example 
 }
 ```
 
-## Step 4: Use the selected image
+</Step>
+
+<Step label="4">
+
+## Use the selected image
 
 The `result` object provides the `assets` array, which contains the `uri` of the selected image.
 Let's take this value from the image picker and use it to show the selected image in the app.
@@ -223,6 +238,8 @@ Let's take a look at our app now:
 <Video file="tutorial/03-image-picker-demo.mp4" />
 
 > The images used for the demo in this tutorial were picked from [Unsplash](https://unsplash.com).
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -5,12 +5,15 @@ title: Handle platform differences
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { A } from '~/ui/components/Text';
+import { Step } from '~/ui/components/Step';
 
 Android, iOS, and the web have different capabilities. In our case, Android and iOS both are able to capture a screenshot with the `react-native-view-shot` library, however web browsers cannot.
 
 In this chapter, let's learn how to make an exception for web browsers to get the same functionality on all platforms.
 
-## Step 1: Install and import dom-to-image
+<Step label="1">
+
+## Install and import dom-to-image
 
 To capture a screenshot on the web and save it as an image , we'll use a third-party library called [dom-to-image](https://github.com/tsayen/dom-to-image#readme).
 It allows taking a screenshot of any DOM node and turning it into a vector (SVG) or raster (PNG or JPEG) image.
@@ -27,7 +30,11 @@ To use it, let's import it into **App.js**:
 import domtoimage from 'dom-to-image';
 ```
 
-## Step 2: Add platform-specific code
+</Step>
+
+<Step label="2">
+
+## Add platform-specific code
 
 React Native provides a `Platform` module that gives us access to information about the platform on which the app is currently running.
 You can use it to implement platform-specific behavior.
@@ -105,6 +112,8 @@ const onSaveImageAsync = async () => {
 On running the app in a web browser, we can now save a screenshot:
 
 <Video file="tutorial/web.mp4" />
+
+</Step>
 
 ## Next steps
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -5,6 +5,7 @@ title: Take screenshot
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { A } from '~/ui/components/Text';
+import { Step } from '~/ui/components/Step';
 
 In this chapter, we will learn how to take a screenshot using a third-party library and save it on the device's media library.
 We'll use the following libraries [`react-native-view-shot`](https://github.com/gre/react-native-view-shot) that allows taking a screenshot,
@@ -13,13 +14,19 @@ and <A href="/versions/latest/sdk/media-library/" openInNewTab>`expo-media-libra
 > So far, we have been using some third-party libraries such as `react-native-gesture-handler`, `react-native-reanimated`, and now `react-native-view-shot`.
 > We can find hundreds of other third-party libraries on [React Native Directory](https://reactnative.directory/).
 
-## Step 1: Install libraries
+<Step label="1">
+
+## Install libraries
 
 To install both libraries, run the following commands:
 
 <Terminal cmd={['$ npx expo install react-native-view-shot expo-media-library']} />
 
-## Step 2: Prompt for permissions
+</Step>
+
+<Step label="2">
+
+## Prompt for permissions
 
 When creating an app that requires access to potentially sensitive information, such as access to the media library, we must first request the user's permission.
 
@@ -48,9 +55,13 @@ export default function App() {
 }
 ```
 
-Once the permission is given, the value of the `status` changes to `granted`.
+Once permission is given, the value of the `status` changes to `granted`.
 
-## Step 3: Picking a library to take screenshots
+</Step>
+
+<Step label="3">
+
+## Picking a library to take screenshots
 
 To allow the user to take a screenshot within the app, we'll use [`react-native-view-shot`](https://github.com/gre/react-native-view-shot). It allows capturing a `<View>` as an image.
 
@@ -60,7 +71,11 @@ Let's import it into **App.js** file:
 import { captureRef } from 'react-native-view-shot';
 ```
 
-## Step 4: Create a ref to save the current view
+</Step>
+
+<Step label="4">
+
+## Create a ref to save the current view
 
 The `react-native-view-shot` library provides a method called `captureRef()` that captures a screenshot of a `<View>` in the app and returns the URI of the screenshot image file.
 
@@ -94,7 +109,11 @@ export default function App() {
 The `collapsable` prop is set to `false` in the above snippet because this `<View>` component is used to take a screenshot of the background image and the emoji sticker.
 The rest of the contents of the app screen (such as buttons) are not part of the screenshot.
 
-## Step 5: Capture a screenshot and save it
+</Step>
+
+<Step label="5">
+
+## Capture a screenshot and save it
 
 Now we can capture a screenshot of the view by calling the `captureRef()` method from `react-native-view-shot` inside the `onSaveImageAsync()` function.
 `captureRef()` accepts an optional argument where we can pass the `width` and `height` of the area we'd like to capture a screenshot for.
@@ -156,6 +175,8 @@ export default function App() {
 Now, choose a photo and add a sticker. Then tap the “Save” button. We should see the following result:
 
 <Video file="tutorial/saving-screenshot.mp4" />
+
+</Step>
 
 ## Next steps
 


### PR DESCRIPTION
# Why & how

- Add redirects based on weekly Sentry reports
- fix typo
- Use `<Step>` component in Tutorial to follow pattern for formatting guides that include step by step instructions

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
