### PR TITLE
[core][Android] Make `fallbackCallback` optional in the `registerForActivityResult` method

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method.
+
 ## 1.2.3 - 2023-02-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 💡 Others
 
-- [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method.
+- [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method. ([#21661](https://github.com/expo/expo/pull/21661) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.2.3 - 2023-02-21
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultCaller.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultCaller.kt
@@ -22,7 +22,7 @@ interface AppContextActivityResultCaller {
   @MainThread
   suspend fun <I : Serializable, O> registerForActivityResult(
     contract: AppContextActivityResultContract<I, O>,
-    fallbackCallback: AppContextActivityResultFallbackCallback<I, O>,
+    fallbackCallback: AppContextActivityResultFallbackCallback<I, O> = AppContextActivityResultFallbackCallback { _, _ -> /* NOOP */ },
   ): AppContextActivityResultLauncher<I, O>
 }
 


### PR DESCRIPTION
# Why

A small improvement to the API to make users' life easier. The `fallbackCallback` is pretty advance. In most cases, it isn't needed. It handles situations where your activity was destroyed by the system during receiving a result. 

# How

- Made `fallbackCallback` optional