### PR TITLE
[exmanifests][ios] Fix unit tests

### DIFF
--- a/packages/expo-manifests/ios/Tests/NewManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/NewManifestSpec.swift
@@ -65,14 +65,14 @@ class NewManifestSpec : ExpoSpec {
       it("is correct with valid numeric case") {
         let runtimeVersion = "exposdk:39.0.0"
         let manifestJson = ["runtimeVersion": runtimeVersion]
-        let manifest = EXManifestsNewManifest(rawManifestJSON: manifestJson)
+        let manifest = NewManifest(rawManifestJSON: manifestJson)
         expect(manifest.sdkVersion()) == "39.0.0"
       }
 
       it("is UNVERSIONED with valid unversioned case") {
         let runtimeVersion = "exposdk:UNVERSIONED"
         let manifestJson = ["runtimeVersion": runtimeVersion]
-        let manifest = EXManifestsNewManifest(rawManifestJSON: manifestJson)
+        let manifest = NewManifest(rawManifestJSON: manifestJson)
         expect(manifest.sdkVersion()) == "UNVERSIONED"
       }
 
@@ -88,7 +88,7 @@ class NewManifestSpec : ExpoSpec {
 
         for runtimeVersion in runtimeVersions {
           let manifestJson = ["runtimeVersion": runtimeVersion]
-          let manifest = EXManifestsNewManifest(rawManifestJSON: manifestJson)
+          let manifest = NewManifest(rawManifestJSON: manifestJson)
           expect(manifest.sdkVersion()).to(beNil())
         }
       }


### PR DESCRIPTION
# Why

Renaming some classes for swift broke this.

# How

Fix names.

# Test Plan

Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
