### PR TITLE
[dev-menu][ios] Fix compilation

### DIFF
--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -111,7 +111,7 @@ open class DevMenuManager: NSObject {
     }
   }
   @objc
-  public var currentManifest: EXManifestsManifest?
+  public var currentManifest: Manifest?
 
   @objc
   public var currentManifestURL: URL?


### PR DESCRIPTION
# Why

Tests are currently broken in main: https://github.com/expo/expo/actions/runs/4388360849/jobs/7684762451
This was due to a rename and so many different separate builds depending on it.

# How

Fix name.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
