### PR TITLE
[docs] Fix the link "React Native basics guide"

### DIFF
--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -14,7 +14,7 @@ We used React components and APIs. Having a solid understanding of React is esse
 
 ## React Native
 
-While developing the tutorial app, we used React Native extensively. You can start from the [React Native basics guide](https://reactnative.dev/docs/flexbox) to learn more. Also, check out the following docs:
+While developing the tutorial app, we used React Native extensively. You can start from the [React Native basics guide](https://reactnative.dev/docs/getting-started) to learn more. Also, check out the following docs:
 
 - [View API reference](https://reactnative.dev/docs/view)
 - [Text API reference](https://reactnative.dev/docs/text)


### PR DESCRIPTION
# Why

This PR fixes the link in https://docs.expo.dev/tutorial/follow-up/.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
