### PR TITLE
[dev-client-launcher] Add `mimeType` to network response enabling image previews

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `mimeType` when emitting network responses. ([#21676](https://github.com/expo/expo/pull/21676) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -92,6 +92,7 @@ class DevLauncherNetworkLogger private constructor() {
    */
   fun emitNetworkResponse(request: Request, requestId: String, response: Response) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
+    val contentType = response.headers().get("Content-Type")
     var params = mapOf(
       "requestId" to requestId,
       "loaderId" to "",
@@ -101,6 +102,7 @@ class DevLauncherNetworkLogger private constructor() {
         "status" to response.code(),
         "statusText" to response.message(),
         "headers" to response.headers().toSingleMap(),
+        "mimeType" to (contentType ?: ""),
       ),
       "referrerPolicy" to "no-referrer",
       "type" to "Fetch",

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -92,7 +92,6 @@ class DevLauncherNetworkLogger private constructor() {
    */
   fun emitNetworkResponse(request: Request, requestId: String, response: Response) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
-    val contentType = response.headers().get("Content-Type")
     var params = mapOf(
       "requestId" to requestId,
       "loaderId" to "",
@@ -102,7 +101,7 @@ class DevLauncherNetworkLogger private constructor() {
         "status" to response.code(),
         "statusText" to response.message(),
         "headers" to response.headers().toSingleMap(),
-        "mimeType" to (contentType ?: ""),
+        "mimeType" to response.header("Content-Type", ""),
       ),
       "referrerPolicy" to "no-referrer",
       "type" to "Fetch",

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -88,7 +88,7 @@ public class EXDevLauncherNetworkLogger: NSObject {
         "status": response.statusCode,
         "statusText": "",
         "headers": response.allHeaderFields,
-        "mimeType": contentType ?? "",
+        "mimeType": contentType ?? ""
       ],
       "referrerPolicy": "no-referrer",
       "type": "Fetch",

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -77,6 +77,7 @@ public class EXDevLauncherNetworkLogger: NSObject {
    */
   func emitNetworkResponse(request: URLRequest, requestId: String, response: HTTPURLResponse) {
     let now = Date().timeIntervalSince1970
+    let contentType = response.value(forHTTPHeaderField: "Content-Type")
 
     var params = [
       "requestId": requestId,
@@ -86,7 +87,8 @@ public class EXDevLauncherNetworkLogger: NSObject {
         "url": request.url?.absoluteString,
         "status": response.statusCode,
         "statusText": "",
-        "headers": response.allHeaderFields
+        "headers": response.allHeaderFields,
+        "mimeType": contentType ?? "",
       ],
       "referrerPolicy": "no-referrer",
       "type": "Fetch",

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -77,7 +77,6 @@ public class EXDevLauncherNetworkLogger: NSObject {
    */
   func emitNetworkResponse(request: URLRequest, requestId: String, response: HTTPURLResponse) {
     let now = Date().timeIntervalSince1970
-    let contentType = response.value(forHTTPHeaderField: "Content-Type")
 
     var params = [
       "requestId": requestId,
@@ -88,7 +87,7 @@ public class EXDevLauncherNetworkLogger: NSObject {
         "status": response.statusCode,
         "statusText": "",
         "headers": response.allHeaderFields,
-        "mimeType": contentType ?? ""
+        "mimeType": response.value(forHTTPHeaderField: "Content-Type") ?? ""
       ],
       "referrerPolicy": "no-referrer",
       "type": "Fetch",


### PR DESCRIPTION
# Why

Fixes ENG-7741

# How

This adds the missing `response.mimeType` property to `Network.responseReceived` CDP messages. It's a rough implementation where we just reuse whatever `Content-Type` header was received.

# Test Plan

- Run a project with `$ EXPO_USE_CUSTOM_INSPECTOR_PROXY=true expod start`
- Open Chrome Devtools by pressing `j`
- Go to Network tab
- Try to fetch an image in the app with `fetch('https://github.com/bycedric.png')`
- Go to network request that's marked as finished
- Go to `preview` tab, that should display this image

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
