### PR TITLE
[exupdates][ios] Make test fixtures consistent across platforms

### DIFF
--- a/packages/expo-updates/ios/Tests/CertificateChainTests.swift
+++ b/packages/expo-updates/ios/Tests/CertificateChainTests.swift
@@ -6,16 +6,16 @@ import XCTest
 
 class CertificateChainTests : XCTestCase {
   func test_ValidSingleCertificate() throws {
-    let cert = try TestHelper.getTestCertificate(TestCertificate.test)
+    let cert = getTestCertificate(TestCertificate.test)
     let codeSigningCertificate = try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()
     XCTAssertNotNil(codeSigningCertificate)
     XCTAssertNil(try codeSigningCertificate.1.expoProjectInformation())
   }
   
   func test_ValidCertificateChain() throws {
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainLeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainIntermediate)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainRoot)
+    let leafCert = getTestCertificate(TestCertificate.chainLeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainIntermediate)
+    let rootCert = getTestCertificate(TestCertificate.chainRoot)
     let codeSigningCertificate = try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()
     XCTAssertNotNil(codeSigningCertificate)
     let expoProjectInformation = try codeSigningCertificate.1.expoProjectInformation()
@@ -30,21 +30,21 @@ class CertificateChainTests : XCTestCase {
   }
   
   func test_ThrowsWhenAnyCertificateIsInvalidDate() throws {
-    let cert = try TestHelper.getTestCertificate(TestCertificate.validityExpired)
+    let cert = getTestCertificate(TestCertificate.validityExpired)
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateValidityError)
     }
   }
   
   func test_ThrowsWhenLeafIsNotCodeSigningNoKeyUsage() throws {
-    let cert = try TestHelper.getTestCertificate(TestCertificate.noKeyUsage)
+    let cert = getTestCertificate(TestCertificate.noKeyUsage)
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateMissingCodeSigningError)
     }
   }
   
   func test_ThrowsWhenLeafIsNotCodeSigningNoCodeSigningExtendedKeyUsage() throws {
-    let cert = try TestHelper.getTestCertificate(TestCertificate.noCodeSigningExtendedUsage)
+    let cert = getTestCertificate(TestCertificate.noCodeSigningExtendedUsage)
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateMissingCodeSigningError)
     }
@@ -52,8 +52,8 @@ class CertificateChainTests : XCTestCase {
   
   func test_ThrowsChainIsNotValid() throws {
     // missing intermediate
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainLeaf)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainRoot)
+    let leafCert = getTestCertificate(TestCertificate.chainLeaf)
+    let rootCert = getTestCertificate(TestCertificate.chainRoot)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, rootCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateChainError)
@@ -61,9 +61,9 @@ class CertificateChainTests : XCTestCase {
   }
   
   func test_ThrowsWhenAnySignatureInvalid() throws {
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.invalidSignatureChainLeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainIntermediate)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainRoot)
+    let leafCert = getTestCertificate(TestCertificate.invalidSignatureChainLeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainIntermediate)
+    let rootCert = getTestCertificate(TestCertificate.chainRoot)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateChainError)
@@ -72,8 +72,8 @@ class CertificateChainTests : XCTestCase {
   
   func test_ThrowsWhenRootIsNotSelfSigned() throws {
     // missing root, meaning intermediate is considered root and is not self-signed
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainLeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainIntermediate)
+    let leafCert = getTestCertificate(TestCertificate.chainLeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainIntermediate)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, intermediateCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateRootNotSelfSigned)
@@ -82,16 +82,16 @@ class CertificateChainTests : XCTestCase {
   
   // iOS doesn't provide a way to verify signature of any root cert (including self-signed), only certs up to root cert
   func skip_test_ThrowsWhenRootSignatureInvalid() throws {
-    let cert = try TestHelper.getTestCertificate(TestCertificate.signatureInvalid)
+    let cert = getTestCertificate(TestCertificate.signatureInvalid)
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [cert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateChainError)
     }
   }
   
   func test_ThrowsWhenIntermediateCANotCA() throws {
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainNotCALeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainNotCAIntermediate)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainNotCARoot)
+    let leafCert = getTestCertificate(TestCertificate.chainNotCALeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainNotCAIntermediate)
+    let rootCert = getTestCertificate(TestCertificate.chainNotCARoot)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateChainError)
@@ -99,9 +99,9 @@ class CertificateChainTests : XCTestCase {
   }
   
   func test_ThrowsWhenCAPathLenViolated() throws {
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainPathLenViolationLeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainPathLenViolationIntermediate)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainPathLenViolationRoot)
+    let leafCert = getTestCertificate(TestCertificate.chainPathLenViolationLeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainPathLenViolationIntermediate)
+    let rootCert = getTestCertificate(TestCertificate.chainPathLenViolationRoot)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateChainError)
@@ -109,9 +109,9 @@ class CertificateChainTests : XCTestCase {
   }
   
   func test_ThrowsWhenExpoProjectInformationViolation() throws {
-    let leafCert = try TestHelper.getTestCertificate(TestCertificate.chainExpoProjectInformationViolationLeaf)
-    let intermediateCert = try TestHelper.getTestCertificate(TestCertificate.chainExpoProjectInformationViolationIntermediate)
-    let rootCert = try TestHelper.getTestCertificate(TestCertificate.chainExpoProjectInformationViolationRoot)
+    let leafCert = getTestCertificate(TestCertificate.chainExpoProjectInformationViolationLeaf)
+    let intermediateCert = getTestCertificate(TestCertificate.chainExpoProjectInformationViolationIntermediate)
+    let rootCert = getTestCertificate(TestCertificate.chainExpoProjectInformationViolationRoot)
     
     XCTAssertThrowsError(try CertificateChain(certificateStrings: [leafCert, intermediateCert, rootCert]).codeSigningCertificate()) { error in
       XCTAssertEqual(error as? CodeSigningError, CodeSigningError.CertificateProjectInformationChainError)

--- a/packages/expo-updates/ios/Tests/CertificateFixtures.swift
+++ b/packages/expo-updates/ios/Tests/CertificateFixtures.swift
@@ -2,10 +2,6 @@
 
 import Foundation
 
-enum TestHelperError : Int, Error {
-  case invalidTestCertificate
-}
-
 /**
  These are generated using https://github.com/expo/code-signing-certificates/blob/main/scripts/generateCertificatesForTests.ts
  */
@@ -32,24 +28,22 @@ enum TestCertificate : String {
 
 class ForBundle {}
 
-internal final class TestHelper {
-  static func getTestCertificate(_ name: TestCertificate) throws -> String {
-    let bundle = Bundle(for: ForBundle.self)
-    guard let certPath = bundle.path(forResource: name.rawValue, ofType: "pem") else {
-      throw TestHelperError.invalidTestCertificate
-    }
-    return try String(contentsOfFile: certPath)
-  }
+internal func getTestCertificate(_ name: TestCertificate) -> String {
+  let bundle = Bundle(for: ForBundle.self)
+  let certPath = bundle.path(forResource: name.rawValue, ofType: "pem")!
+  return try! String(contentsOfFile: certPath)
+}
 
-  public static let testClassicBody = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
+internal class CertificateFixtures {
+  public static let testClassicManifestBody = "{\"sdkVersion\":\"39.0.0\",\"releaseId\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"commitTime\":\"2020-11-11T00:17:54.797Z\",\"bundleUrl\":\"https://url.to/bundle.js\"}"
 
-  public static let testBody =
+  public static let testNewManifestBody =
     "{\"id\":\"0754dad0-d200-d634-113c-ef1f26106028\",\"createdAt\":\"2021-11-23T00:57:14.437Z\",\"runtimeVersion\":\"1\",\"assets\":[{\"hash\":\"cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d\",\"key\":\"489ea2f19fa850b65653ab445637a181.jpg\",\"contentType\":\"image/jpeg\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=1&platform=android\",\"fileExtension\":\".jpg\"}],\"launchAsset\":{\"hash\":\"323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8\",\"key\":\"696a70cf7035664c20ea86f67dae822b.bundle\",\"contentType\":\"application/javascript\",\"url\":\"http://192.168.64.1:3000/api/assets?asset=updates/1/bundles/android-696a70cf7035664c20ea86f67dae822b.js&runtimeVersion=1&platform=android\",\"fileExtension\":\".bundle\"},\"extra\":{\"scopeKey\":\"@test/app\",\"eas\":{\"projectId\":\"285dc9ca-a25d-4f60-93be-36dc312266d7\"}}}"
 
-  public static let testSignature =
+  public static let testNewManifestBodySignature =
     "sig=\"iMU4xouvBS6f8Ttr2pUX+r5dJ51489SQfhHb4rG6uBhy5RxaY10o+DE3zVRyRH2yVnmp5Fe7bCQD+REZa0hvt/sKAp1aIhjH8Uv50hADwAPfbyDoOc3Kld2zOGTf70W5J6AyO5QczBrC+wB727CZU+mUkxT6rZ/uBwJVPHAF0qmNGnbJBhMRhGqSB1u/CO49Y7zQ1T53SQvcU2VDq2XtGnPDPCe4qYVV/0oLv1hDSzKqVs6IQu8OYfQwj3naGo3FBFj8fZFbcf8M3B2AU4Q5VigFpLi07rvPyCtDyD6BauU9yk5+sI9RPmm2XtCm1YFzYeicC9BN/QPCBQvj5b7ZIA==\""
 
-  public static let testValidChainLeafSignature =
+  public static let testNewManifestBodyValidChainLeafSignature =
     "sig=\"g94qm1faIg7u0CFJHb/dsk/+2GOsL9xidAbdVzwJXMkzZKaR/aoXkrUTVty1k8jJYIASLhqEQb3O4eBM0zCtzQPaquloxcLSGIA7dy2Yevnl2/HYu14Lmq6yCDMp9F47jtZdbJY+pDAg0D7SfoVkKpBwfoeP1ZXUxtbEBxxzpAkKNhAKmZ/A6VjStrxbTE6qaTEDCbQtOFiREAL2vD3fq9K02a3/PGYU7w7AS5TiPzQ+xCvXl6KOn15ZOZngZs/gvOHjDZbBJsMSzeXHUWDQ993aNzgtawFIgNJkVoiz9Z89LRdcCvCMFahpfUWQWIVsGp47scHMGX6s2PN0m/4S+A==\""
 
   public static let testNewManifestBodyIncorrectProjectId =
@@ -57,12 +51,11 @@ internal final class TestHelper {
 
   public static let testNewManifestBodyValidChainLeafSignatureIncorrectProjectId =
     "sig=\"Pqwt5yNggdCrXB1w+EeEl9ZLITZVdNeR99YRYw6la3P97xU6298eMs5Us3RNthy/DmsC1tEpqr9MZE4xv2b3l8DZTQ45OyH76TRzRKOtB+9t5VC3Zb/osYjkh/pexr7D9AopSbxNCrVLO3Ek/+2iPXhJAkO90oWpD1Axf7ZhfmzgD0t93lpCzNecyIz2/GRRA5us7VYCFJXkAF6MDzExGQmsWr4OvGpqxqYEHhLfrrFrr0aILCHRjiBlT6zhJi8RzpTPzmH3twq5LSVNES9aa5/VOCgrg2ci6rYXFbmLA4weUpzoEL1Hx88ONcchz7LuEg1zz8pJEJ0olzTGKpJFLQ==\""
-  
+
   public static let testDirectiveNoUpdateAvailable = "{\"type\":\"noUpdateAvailable\",\"extra\":{\"signingInfo\":{\"projectId\":\"285dc9ca-a25d-4f60-93be-36dc312266d7\",\"scopeKey\":\"@test/app\"}}}"
   public static let testDirectiveNoUpdateAvailableSignature = "sig=\"pOGsNA2+mO+A+dBO1g3xfWCSRvgkHUwAHPJyGl7Eds/IIuo/pVIvJNsO5Op5hAGTpRnOW8BFSeIplCQ7axdg/xg0Z6my+Uy529t+H4ReSoXIiyOI6kG6Q/mgKjnXE7HQsF0q7ycZ7qytxp6C7Wxzy3maKvHTQbuIT+gIouCd4SGb8lg2Y6B/L/yjN1LiehaKizQPNOC4AIDO5SKl3Wk5aTdnr6JYld4nSno2kfalwHnQc1NxojXoMIwAM1LBq/1YIGV8shXNgXP03pvIDwiwa548VIdSe+v4BvSKVEZvNC8Uw06j0Y1lOWkGdl+UOWR1oOZvH6PdgYj6h3rzr2gBIg==\""
   public static let testDirectiveNoUpdateAvailableValidChainLeafSignature = "sig=\"fuzNbhZ4msyGc3K8512kXQ5HNGo7+DJh++S6t+sn8PzWTnCdcdheJGMs3Irkv6rcgWE28FBiysdeH2whD25yn2AsL3EzlOkxPyT6TSkYUvcyobtBVAkpsN755XyNWnvGGMEg5UvadKqJvVJA4YpXe9CBYOq1pZoCnfKfHMHk6+pETVtup5WEpwVpeoEDHQduVAgIs3IfO7atJ+fHQH0YOlzqxKvabNyzp6vm3lEjo4y86/fZ9UzfXzMwEAJpslLadOAkiLvbPcRUMU+YRZCOj/aZ2mUZ7lq1PHLmdxCedEfOKpEUwV4sIM0rzccqRs7JanK41Du/9Jaz6grfrZ100Q==\""
 
   public static let testDirectiveNoUpdateAvailableIncorrectProjectId = "{\"type\":\"noUpdateAvailable\",\"extra\":{\"signingInfo\":{\"projectId\":\"485dc9ca-a25d-4f60-93be-36dc312266d8\",\"scopeKey\":\"@test/app\"}}}"
   public static let testDirectiveNoUpdateAvailableValidChainLeafSignatureIncorrectProjectId = "sig=\"a0k2BPevnRlBWK7w1vODW2s5iK7kt11THgawNWn4gTnwkRr/M3g4tIRsReyiRPF7+Ka5hkt9eq7LRfNuyVwaxXoJT8PrZtrrYCFfZ6ShozDH43rnE39bjkz0ORAfkUrpAoe0feZi28Vod4XCJ5LVElENULXrAxm03vYjDljMWEnW81ODm4Wp5K/9XyUYGwzKfsIMpA1pJ7J5t56I8zNFskyzH8UASlkLYHJtnu9Irpt2DppePCYdKke/dDWyokg4vl5G+k4mysbQ4osoIJNXzD8brwMXSc3dxTc5ZkTX2mGUmsjOa0lcNwCb0zbBbp4tUIJEf29zMxt2MOhfdE0DJQ==\""
-
 }

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -6,8 +6,8 @@ import ExpoModulesTestCore
 
 import EXManifests
 
-extension Data {
-  public mutating func appendStringData(_ str: String) {
+private extension Data {
+  mutating func appendStringData(_ str: String) {
     self.append(str.data(using: .utf8)!)
   }
 }
@@ -15,16 +15,6 @@ extension Data {
 class FileDownloaderManifestParsingSpec : ExpoSpec {
   override func spec() {
     let database = UpdatesDatabase()
-    let classicJSON = TestHelper.testClassicBody
-    let modernJSON = TestHelper.testBody
-    let modernJSONCertificate = try! TestHelper.getTestCertificate(.test)
-    let modernJSONSignature = TestHelper.testSignature
-    let leafCertificate = try! TestHelper.getTestCertificate(.chainLeaf)
-    let intermediateCertificate = try! TestHelper.getTestCertificate(.chainIntermediate)
-    let rootCertificate = try! TestHelper.getTestCertificate(.chainRoot)
-    let chainLeafSignature = TestHelper.testValidChainLeafSignature
-    let manifestBodyIncorrectProjectId = TestHelper.testNewManifestBodyIncorrectProjectId
-    let validChainLeafSignatureIncorrectProjectId = TestHelper.testNewManifestBodyValidChainLeafSignatureIncorrectProjectId
     
     describe("manifest parsing") {
       it("JSON body") {
@@ -40,7 +30,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           headerFields: ["content-type": contentType]
         )!
         
-        let bodyData = classicJSON.data(using: .utf8)!
+        let bodyData = CertificateFixtures.testClassicManifestBody.data(using: .utf8)!
         
         var resultUpdateResponse: UpdateResponse? = nil
         var errorOccurred: (any Error)? = nil
@@ -72,10 +62,10 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         let bodyData = FileDownloaderManifestParsingSpec.mutlipartData(
           boundary: boundary,
-          manifest: classicJSON,
+          manifest: CertificateFixtures.testClassicManifestBody,
           manifestSignature: nil,
           certificateChain: nil,
-          directive: TestHelper.testDirectiveNoUpdateAvailable,
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailable,
           directiveSignature: nil
         )
         
@@ -116,7 +106,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           manifest: nil,
           manifestSignature: nil,
           certificateChain: nil,
-          directive: TestHelper.testDirectiveNoUpdateAvailable,
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailable,
           directiveSignature: nil
         )
         
@@ -158,7 +148,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           manifest: nil,
           manifestSignature: nil,
           certificateChain: nil,
-          directive: TestHelper.testDirectiveNoUpdateAvailable,
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailable,
           directiveSignature: nil
         )
         
@@ -217,7 +207,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("json body signed") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: modernJSONCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
         let downloader = FileDownloader(config: config)
@@ -230,11 +220,11 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
             "expo-protocol-version": "0",
             "expo-sfv-version": "0",
             "content-type": contentType,
-            "expo-signature": modernJSONSignature,
+            "expo-signature": CertificateFixtures.testNewManifestBodySignature,
           ]
         )!
         
-        let bodyData = modernJSON.data(using: .utf8)!
+        let bodyData = CertificateFixtures.testNewManifestBody.data(using: .utf8)!
         
         var resultUpdateResponse: UpdateResponse? = nil
         var errorOccurred: (any Error)? = nil
@@ -252,7 +242,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("multipart body signed") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: modernJSONCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
         let downloader = FileDownloader(config: config)
@@ -272,11 +262,11 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         let bodyData = FileDownloaderManifestParsingSpec.mutlipartData(
           boundary: boundary,
-          manifest: modernJSON,
-          manifestSignature: modernJSONSignature,
+          manifest: CertificateFixtures.testNewManifestBody,
+          manifestSignature: CertificateFixtures.testNewManifestBodySignature,
           certificateChain: nil,
-          directive: TestHelper.testDirectiveNoUpdateAvailable,
-          directiveSignature: TestHelper.testDirectiveNoUpdateAvailableSignature
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailable,
+          directiveSignature: CertificateFixtures.testDirectiveNoUpdateAvailableSignature
         )
         
         var resultUpdateResponse: UpdateResponse? = nil
@@ -300,7 +290,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("json body expects signed receives unsigned") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: modernJSONCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
         ])
         let downloader = FileDownloader(config: config)
@@ -316,7 +306,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           ]
         )!
         
-        let bodyData = modernJSON.data(using: .utf8)!
+        let bodyData = CertificateFixtures.testNewManifestBody.data(using: .utf8)!
         
         var resultUpdateResponse: UpdateResponse? = nil
         var errorOccurred: (any Error)? = nil
@@ -333,7 +323,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("multipart body signed certificate particular experience") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: rootCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.chainRoot),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [
             "keyid": "ca-root",
           ],
@@ -356,11 +346,11 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         let bodyData = FileDownloaderManifestParsingSpec.mutlipartData(
           boundary: boundary,
-          manifest: modernJSON,
-          manifestSignature: chainLeafSignature,
-          certificateChain: "\(leafCertificate)\(intermediateCertificate)",
-          directive: TestHelper.testDirectiveNoUpdateAvailable,
-          directiveSignature: TestHelper.testDirectiveNoUpdateAvailableValidChainLeafSignature
+          manifest: CertificateFixtures.testNewManifestBody,
+          manifestSignature: CertificateFixtures.testNewManifestBodyValidChainLeafSignature,
+          certificateChain: "\(getTestCertificate(.chainLeaf))\(getTestCertificate(.chainIntermediate))",
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailable,
+          directiveSignature: CertificateFixtures.testDirectiveNoUpdateAvailableValidChainLeafSignature
         )
         
         var resultUpdateResponse: UpdateResponse? = nil
@@ -382,7 +372,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("multipart body signed certificate particular experience incorrect experience in manifest") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: rootCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.chainRoot),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [
             "keyid": "ca-root",
           ],
@@ -405,9 +395,9 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         let bodyData = FileDownloaderManifestParsingSpec.mutlipartData(
           boundary: boundary,
-          manifest: manifestBodyIncorrectProjectId,
-          manifestSignature: validChainLeafSignatureIncorrectProjectId,
-          certificateChain: "\(leafCertificate)\(intermediateCertificate)",
+          manifest: CertificateFixtures.testNewManifestBodyIncorrectProjectId,
+          manifestSignature: CertificateFixtures.testNewManifestBodyValidChainLeafSignatureIncorrectProjectId,
+          certificateChain: "\(getTestCertificate(.chainLeaf))\(getTestCertificate(.chainIntermediate))",
           directive: nil,
           directiveSignature: nil
         )
@@ -427,7 +417,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("multipart body signed certificate particular experience incorrect experience in directive") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: rootCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.chainRoot),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [
             "keyid": "ca-root",
           ],
@@ -452,9 +442,9 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           boundary: boundary,
           manifest: nil,
           manifestSignature: nil,
-          certificateChain: "\(leafCertificate)\(intermediateCertificate)",
-          directive: TestHelper.testDirectiveNoUpdateAvailableIncorrectProjectId,
-          directiveSignature: TestHelper.testDirectiveNoUpdateAvailableValidChainLeafSignatureIncorrectProjectId
+          certificateChain: "\(getTestCertificate(.chainLeaf))\(getTestCertificate(.chainIntermediate))",
+          directive: CertificateFixtures.testDirectiveNoUpdateAvailableIncorrectProjectId,
+          directiveSignature: CertificateFixtures.testDirectiveNoUpdateAvailableValidChainLeafSignatureIncorrectProjectId
         )
         
         var resultUpdateResponse: UpdateResponse? = nil
@@ -472,7 +462,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
       it("json body signed unsigned request manifest signature optional") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
-          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: modernJSONCertificate,
+          UpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey: getTestCertificate(.test),
           UpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey: [:],
           UpdatesConfig.EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey: true
         ])
@@ -489,7 +479,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
           ]
         )!
         
-        let bodyData = modernJSON.data(using: .utf8)!
+        let bodyData = CertificateFixtures.testNewManifestBody.data(using: .utf8)!
         
         var resultUpdateResponse: UpdateResponse? = nil
         var errorOccurred: (any Error)? = nil


### PR DESCRIPTION
# Why

Trying to make these tests more consistent with their android counterparts.

# How

Change constants to have same names and verify that the test has the same structure.

# Test Plan

Run all tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
