### PR TITLE
[exupdates][ios] Fix legacy update bundled asset parsing

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Make Updates API work with native debug. ([#21253](https://github.com/expo/expo/pull/21253) by [@douglowder](https://github.com/douglowder))
 - iOS: Fix odd nullability issue in expo module. ([#21655](https://github.com/expo/expo/pull/21655) by [@wschurman](https://github.com/wschurman))
+- iOS: Fix legacy update bundled asset parsing. ([#21691](https://github.com/expo/expo/pull/21691) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
@@ -78,9 +78,9 @@ internal final class LegacyUpdate: Update {
       var type: String
 
       if let extensionStartIndex = extensionStartIndex {
-        filename = String(bundledAssetString[...extensionStartIndex])
-        let hashStartIndex = bundledAssetString.index(extensionStartIndex, offsetBy: -1 * prefixLength)
-        hash = String(bundledAssetString[hashStartIndex...extensionStartIndex])
+        filename = String(bundledAssetString[..<extensionStartIndex])
+        let hashStartIndex = bundledAssetString.index(bundledAssetString.startIndex, offsetBy: prefixLength)
+        hash = String(bundledAssetString[hashStartIndex..<extensionStartIndex])
         let typeStartIndex = bundledAssetString.index(extensionStartIndex, offsetBy: 1)
         type = String(bundledAssetString[typeStartIndex...])
       } else {


### PR DESCRIPTION
# Why

Made a note to myself to add a test for this when I was converting it to swift since it seemed super fragile.

This PR adds a test with real-world data so that we can ensure it is working and remains working. In creating this test, I noticed that my conversion was broken.

Previous implementation in objc: https://github.com/expo/expo/blob/94af3eda499b5708febc14e127e01a82fb003019/packages/expo-updates/ios/EXUpdates/Update/EXUpdatesLegacyUpdate.m#L70

# How

Add test. Fix indices.

# Test Plan

Run test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
