### PR TITLE
[image][Android] Fix crashes caused by empty placeholder or source on Android

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed the `tintColor` not being passed to native view. ([#21576](https://github.com/expo/expo/pull/21576) by [@andrew-levy](https://github.com/andrew-levy))
 - Fixed `canvas: trying to use a recycled bitmap` on Android. ([#21658](https://github.com/expo/expo/pull/21658) by [@lukmccall](https://github.com/lukmccall))
+- Fixed crashes caused by empty placeholder or source on Android.
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed the `tintColor` not being passed to native view. ([#21576](https://github.com/expo/expo/pull/21576) by [@andrew-levy](https://github.com/andrew-levy))
 - Fixed `canvas: trying to use a recycled bitmap` on Android. ([#21658](https://github.com/expo/expo/pull/21658) by [@lukmccall](https://github.com/lukmccall))
-- Fixed crashes caused by empty placeholder or source on Android.
+- Fixed crashes caused by empty placeholder or source on Android. ([#21695](https://github.com/expo/expo/pull/21695) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -40,7 +40,7 @@ data class SourceMap(
   fun isBlurhash() = parsedUri?.scheme?.startsWith("blurhash") ?: false
 
   internal fun createGlideModel(context: Context): GlideModel? {
-    if (uri == null) {
+    if (uri.isNullOrBlank()) {
       return null
     }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/21675.
Closes #21693.

# How

Checks if provided URL is black. If that's the case, we don't create a glide model from it. 

# Test Plan

[snack.expo.dev/QZr6O7yza](https://snack.expo.dev/QZr6O7yza).