### PR TITLE
[docs] fix AppJS button hover style

### DIFF
--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -35,7 +35,7 @@ export function AppJSBanner() {
         size="xs"
         href="https://appjs.co"
         openInNewTab
-        className="bg-palette-white text-[#0019C1] border-none"
+        className="bg-palette-white text-[#0019C1] border-none hocus:bg-palette-white hocus:opacity-80"
         rightSlot={<ArrowUpRightIcon className="icon-sm text-[#0019C1]" />}>
         Learn more
       </Button>


### PR DESCRIPTION
# Why

<img width="947" alt="Screenshot 2023-03-13 at 20 15 27" src="https://user-images.githubusercontent.com/719641/224807800-c64bcbf5-4da3-4494-9d26-39a16a3bd6ef.png">

# How

"Learn more" button is based on primary theme, which also specifies the color for the hover and focus states. This PR add missing classes based on appearance and hover effect of other buttons already on the home page.

# Test Plan

<img width="947" alt="Screenshot 2023-03-13 at 20 18 08" src="https://user-images.githubusercontent.com/719641/224808732-5e7fa10b-5285-4bad-b84a-232ceb3f55ee.png">

