### PR TITLE
[android] Inherit shell environment in scripts executed from build.gradle

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Change arg in gradle `.execute()` call to null to inherit env variables from user's env ([#21712](https://github.com/expo/expo/pull/21712) by [@phoenixiguess](https://github.com/phoenixiguess))
+
 ### 💡 Others
 
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -180,7 +180,7 @@ def versionToNumber(major, minor, patch) {
 }
 
 def getNodeModulesPackageVersion(packageName, overridePropName) {
-  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute([], projectDir).text.trim()
+  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute(null, projectDir).text.trim()
   def version = safeExtGet(overridePropName, nodeModulesVersion)
 
   def coreVersion = version.split("-")[0]

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
+- Change arg in gradle `.execute()` call to null to inherit env variables from user's env ([#21712](https://github.com/expo/expo/pull/21712) by [@phoenixiguess](https://github.com/phoenixiguess))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -175,7 +175,7 @@ def versionToNumber(major, minor, patch) {
 }
 
 def getNodeModulesPackageVersion(packageName, overridePropName) {
-  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute([], projectDir).text.trim()
+  def nodeModulesVersion = ["node", "-e", "console.log(require('$packageName/package.json').version);"].execute(null, projectDir).text.trim()
   def version = safeExtGet(overridePropName, nodeModulesVersion)
 
   def coreVersion = version.split("-")[0]

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - iOS: Fix odd nullability issue in expo module. ([#21655](https://github.com/expo/expo/pull/21655) by [@wschurman](https://github.com/wschurman))
 - iOS: Fix legacy update bundled asset parsing. ([#21691](https://github.com/expo/expo/pull/21691) by [@wschurman](https://github.com/wschurman))
+- Change arg in gradle `.execute()` call to null to inherit env variables from user's env ([#21712](https://github.com/expo/expo/pull/21712) by [@phoenixiguess](https://github.com/phoenixiguess))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -3,7 +3,7 @@
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.util.GradleVersion
 
-def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute([], projectDir).text.trim()
+def expoUpdatesDir = ["node", "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));"].execute(null, projectDir).text.trim()
 
 def ex_updates_native_debug = System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1"
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Change arg in gradle `.execute()` call to null to inherit env variables from user's env ([#21712](https://github.com/expo/expo/pull/21712) by [@phoenixiguess](https://github.com/phoenixiguess))
+
 ### 💡 Others
 
 ## 48.0.1 — 2023-02-15

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -15,7 +15,7 @@ def getRNVersion() {
       "-e",
       "console.log(require('react-native/package.json').version);"
   ]
-      .execute([], projectDir)
+      .execute(null, projectDir)
       .text
       .trim()
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Some version management tools (like `asdf`) and env configurations do not load into an empty shell. If the build is executed with these configs, commands that rely on them are not on PATH and the build fails.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Groovy [.execute(String[], File)](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/List.html#execute(java.lang.String[],%20java.io.File)) loads the first arg as env variables. By passing an empty array, nothing gets loaded. `null` is the correct arg to inherit from the user's shell.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Remove any globally installed/available versions of node.
Set up asdf with nodejs.
Kick off a build and observe that it fails when the an empty array is used in execute. The script cannot be found.
Replace the empty array with null, and notice that the script can now be found.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).

# See also
PR:
#17254
Issues:
#18129 
#8547
