### PR TITLE
[docs] Remove `authToken` from Sentry configuration guide

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -6,7 +6,6 @@ description: A guide on installing and configuring Sentry for crash reporting.
 
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -164,11 +163,7 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 
 To upload the source map to Sentry, you must create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](/build-reference/variables/#using-secrets-in-environment-variables).
 
-<Callout type="warning">
-
-Never commit secrets to your repository. Keep the Sentry auth token in a safe place, outside your repository and use the environment variable instead.
-
-</Callout>
+> **warning** Never commit secrets to your repository. Keep the Sentry auth token in a safe place, outside your repository and use the environment variable instead.
 
 Besides the auth token, you can also configure the following options through environment variables:
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -164,7 +164,7 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 
 To upload the source map to Sentry, you must create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](/build-reference/variables/#using-secrets-in-environment-variables).
 
-<Callout>
+<Callout type="warning">
 
 Never commit secrets to your repository. Keep the Sentry auth token in a safe place, outside your repository and use the environment variable instead.
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -6,6 +6,7 @@ description: A guide on installing and configuring Sentry for crash reporting.
 
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { Callout } from '~/ui/components/Callout';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -162,6 +163,12 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 ```
 
 To upload the source map to Sentry, you need to create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your own Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](../build-reference/variables.mdx#using-secrets-in-environment-variables).
+
+<Callout>
+
+Never commit secrets to your repository. Keep the Sentry auth token in a safe place, outside your repository and use the environment variable instead.
+
+</Callout>
 
 Besides the auth token, you can also configure the following options through environment variables:
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -162,7 +162,7 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 }
 ```
 
-To upload the source map to Sentry, you need to create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your own Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](../build-reference/variables.mdx#using-secrets-in-environment-variables).
+To upload the source map to Sentry, you must create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](/build-reference/variables/#using-secrets-in-environment-variables).
 
 <Callout>
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -151,9 +151,8 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
         {
           "file": "sentry-expo/upload-sourcemaps",
           "config": {
-            "organization": "your sentry organization slug here",
-            "project": "your sentry project name here",
-            "authToken": "your auth token here"
+            "organization": "sentry org slug, or use the `SENTRY_ORG` environment variable",
+            "project": "sentry project name, or use the `SENTRY_PROJECT` environment variable"
           }
         }
       ]
@@ -162,17 +161,12 @@ Add `expo.hooks` property to your project's **app.json** or **app.config.js** fi
 }
 ```
 
-The `authToken` value can be generated from the [Sentry API page](https://sentry.io/settings/account/api/).
+To upload the source map to Sentry, you need to create a [Sentry auth token](https://docs.sentry.io/product/cli/configuration/). After creating your own Sentry auth token [here](https://sentry.io/settings/account/api/), you can configure this token through the `SENTRY_AUTH_TOKEN` environment variable in [EAS Build](../build-reference/variables.mdx#using-secrets-in-environment-variables).
 
-<Collapsible summary="Prefer to use environment variables instead of storing values in app.json?">
-
-You can also use environment variables for your config, if you prefer:
+Besides the auth token, you can also configure the following options through environment variables:
 
 - organization → `SENTRY_ORG`
 - project → `SENTRY_PROJECT`
-- authToken → `SENTRY_AUTH_TOKEN`
-
-</Collapsible>
 
 <Collapsible summary="Additional configuration options">
 


### PR DESCRIPTION
# Why

See #321

# How

Removed `authToken` option, and updated wording around `SENTRY_AUTH_TOKEN`.

# Test Plan

Docs change only

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
