### PR TITLE
Update build.gradle

### DIFF
--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -108,6 +108,7 @@ android {
     buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
     buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", "false")
+    buildConfigField("boolean", "IS_HERMES_ENABLED", "false")
     // WHEN_VERSIONING_REMOVE_TO_HERE
   }
 


### PR DESCRIPTION
Should fixes BuildConfig.IS_HERMES_ENABLED unknown symbol

# Why

MainApplication.java has following lines:
```
      @Override
      protected Boolean isHermesEnabled() {
        return BuildConfig.IS_HERMES_ENABLED;
      }
```

Seems to be expo-modules-core not generated properly

# How

Add default value for BuildConfig.IS_HERMES_ENABLED

# Test Plan

node_modules/expo-modules-core/android/build/generated/source/buildConfig/debug/expo/modules/BuildConfig.java

```diff
+++:  public static final boolean IS_HERMES_ENABLED = false;
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
