### PR TITLE
[github] Add workflow to check issues with pending validation labels

### DIFF
--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -1,0 +1,23 @@
+name: Check issues with pending validation labels
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # 0:00 AM UTC time every day
+
+jobs:
+  validate-pending-issues:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-tools: 'true'
+      - name: 🔎 Validate issues with pending labels
+        run: expotools validate-issue --issue "*"
+        env:
+          GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -1,6 +1,7 @@
 name: Check issues with pending validation labels
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '0 8 * * *' # 8:00 AM UTC time every day
 

--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -2,7 +2,7 @@ name: Check issues with pending validation labels
 
 on:
   schedule:
-    - cron: '0 0 * * *' # 0:00 AM UTC time every day
+    - cron: '0 8 * * *' # 8:00 AM UTC time every day
 
 jobs:
   validate-pending-issues:


### PR DESCRIPTION
# Why

Our Expo bot account can sometimes get rate-limited by Github. When a user creates an issue while the account is restricted, the label indicating that the report is waiting for validation (`needs validation`) is not removed and will stay there forever as we only validate the report once when the user opens the issue.

E.g. https://github.com/expo/expo/actions/runs/4410117739/jobs/7727237372


# How

Add a new workflow to check all issues with pending validation labels once a day

# Test Plan

run `act -j validate-pending-issues -s EXPO_BOT_GITHUB_TOKEN=XXX`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
