### PR TITLE
[docs] Fix link to Snack in features table

### DIFF
--- a/docs/pages/introduction/expo.mdx
+++ b/docs/pages/introduction/expo.mdx
@@ -49,7 +49,7 @@ The `expo` npm package enables a suite of incredible features for React Native a
 | Develop complex apps **entirely** in JavaScript.                                | <YesIcon /> | <NoIcon />                         |
 | Write JSI native modules with Swift & Kotlin.                                   | <YesIcon /> | <NoIcon />                         |
 | Develop apps without Xcode or Android Studio.                                   | <YesIcon /> | <NoIcon />                         |
-| Create and share example apps in the browser with [Snack][build/introduction/]. | <YesIcon /> | <NoIcon />                         |
+| Create and share example apps in the browser with [Snack](/workflow/snack/).    | <YesIcon /> | <NoIcon />                         |
 | Major upgrades without native changes.                                          | <YesIcon /> | <NoIcon />                         |
 | First-class TypeScript support.                                                 | <YesIcon /> | <NoIcon />                         |
 | Install natively compatible libraries from the command line.                    | <YesIcon /> | <NoIcon />                         |


### PR DESCRIPTION
Fix link to Snack in features table on [`introduction/expo/`](https://docs.expo.dev/introduction/expo/) page.