### PR TITLE
[ENG-7709][ci][docs] use `m-medium` resource class instead of deprecated `m1-medium` resource class

### DIFF
--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -37,7 +37,7 @@ runs:
           COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)
         fi
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
-        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
+        BUILD_ID=$(EXPO_DEBUG=1 eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
         echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.projectRoot }}
       env:

--- a/.github/actions/eas-build/action.yml
+++ b/.github/actions/eas-build/action.yml
@@ -37,7 +37,7 @@ runs:
           COMMIT_MESSAGE=$(git log -1 --pretty=oneline | head -c1000)
         fi
         MESSAGE="${MESSAGE:-$COMMIT_MESSAGE}"
-        BUILD_ID=$(EXPO_DEBUG=1 eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
+        BUILD_ID=$(eas build -p $PLATFORM --profile $EAS_BUILD_PROFILE --message "$MESSAGE" --non-interactive --json --no-wait | jq -r ".[0].id")
         echo build_id="$BUILD_ID" >> $GITHUB_OUTPUT
       working-directory: ${{ inputs.projectRoot }}
       env:

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -24,11 +24,9 @@
         "cache": {
           "key": "sdk48-0.71.3",
           "cacheDefaultPaths": false,
-          "customPaths": [
-            "../../ios/Pods"
-          ]
+          "customPaths": ["../../ios/Pods"]
         },
-        "resourceClass": "m1-medium",
+        "resourceClass": "m-medium",
         "env": {
           "EAS_BUILD_PLATFORM": "ios",
           "EXPO_ROOT_DIR": "/Users/expo/workingdir/build"

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -152,10 +152,11 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
-  - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM [2020]
+  - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM
+  - M2: 3.4GHz 12-Core M2 (8 performance and 4 efficiency cores), 24 GB RAM
 - Build resources:
   - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM, 2 builder VMs per host
-  - [`m1-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
+  - [`m-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -33,7 +33,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'medium', 'm1-medium', 'intel-medium'],
+    enum: ['default', 'medium', 'm-medium', 'intel-medium'],
     description: [
       'The iOS-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#ios-build-server-configurations)',
       '- `default` maps to `intel-medium`',

--- a/packages/expo-updates/e2e/fixtures/project_files/eas.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/eas.json
@@ -24,7 +24,7 @@
       },
       "ios": {
         "simulator": true,
-        "resourceClass": "m1-medium",
+        "resourceClass": "m-medium",
         "buildConfiguration": "Debug",
         "cache": {
           "cacheDefaultPaths": false


### PR DESCRIPTION
# Why

We deprecated the `m1-medium` resource class and added the `m-medium` resource class.

# How

Use the `m-medium` resource class instead of the `m1-medium` resource class in the build reference.

Use `m-medium` in CI jobs running on EAS.
