### PR TITLE
[docs] Footer: tweaks based on feedback

### DIFF
--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -15,7 +15,7 @@ export const IssuesLink = ({ title, repositoryUrl }: { title: string; repository
         repositoryUrl ? `${repositoryUrl}/issues` : `https://github.com/expo/expo/labels/${title}`
       }>
       <span className="flex items-center mr-2.5">
-        <GithubIcon className="icon-sm" />
+        <GithubIcon className="text-icon-secondary" />
       </span>
       View open bug reports for {title}
     </A>
@@ -27,7 +27,7 @@ export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: st
     <LI>
       <A css={linkStyle} openInNewTab href={`https://forums.expo.dev/tag/${title}`}>
         <span className="flex items-center mr-2.5">
-          <MessageDotsSquareIcon className="icon-sm" />
+          <MessageDotsSquareIcon className="text-icon-secondary" />
         </span>
         Ask a question on the forums about {title}
       </A>
@@ -36,7 +36,7 @@ export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: st
     <LI>
       <A css={linkStyle} openInNewTab href="https://forums.expo.dev/">
         <span className="flex items-center mr-2.5">
-          <MessageDotsSquareIcon className="icon-sm" />
+          <MessageDotsSquareIcon className="text-icon-secondary" />
         </span>
         Ask a question on the forums
       </A>
@@ -47,7 +47,7 @@ export const EditPageLink = ({ pathname }: { pathname: string }) => (
   <LI>
     <A css={linkStyle} openInNewTab href={githubUrl(pathname)}>
       <span className="flex items-center mr-2.5">
-        <Edit05Icon className="icon-sm" />
+        <Edit05Icon className="text-icon-secondary" />
       </span>
       Edit this page
     </A>

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -9,38 +9,40 @@ import { reportPageVote } from '~/providers/Analytics';
 export const PageVote = () => {
   const [userVoted, setUserVoted] = useState(false);
   return (
-    <div className="min-w-[200px]">
-      <CALLOUT theme="secondary" weight="medium">
-        Was this doc helpful?
-      </CALLOUT>
+    <div>
       {userVoted ? (
-        <CALLOUT theme="secondary" className="py-3">
+        <CALLOUT theme="secondary" className="py-1">
           Thank you for your vote! 💙
         </CALLOUT>
       ) : (
-        <div className="flex flex-row">
-          <Button
-            theme="secondary"
-            size="xs"
-            aria-label="Vote up"
-            className="mt-2.5 mx-1 min-w-[40px] text-center"
-            leftSlot={<ThumbsUpSolidIcon className="icon-sm" />}
-            onClick={() => {
-              reportPageVote({ status: true });
-              setUserVoted(true);
-            }}
-          />
-          <Button
-            theme="secondary"
-            size="xs"
-            aria-label="Vote down"
-            className="mt-2.5 mx-1 min-w-[40px] text-center"
-            leftSlot={<ThumbsDownSolidIcon className="icon-sm" />}
-            onClick={() => {
-              reportPageVote({ status: false });
-              setUserVoted(true);
-            }}
-          />
+        <div className="flex flex-row items-center gap-2 max-large:flex-col">
+          <CALLOUT theme="secondary" weight="medium" className="px-2">
+            Was this doc helpful?
+          </CALLOUT>
+          <div>
+            <Button
+              theme="secondary"
+              size="xs"
+              aria-label="Vote up"
+              className="mx-1 min-w-[40px] text-center"
+              leftSlot={<ThumbsUpSolidIcon className="icon-sm" />}
+              onClick={() => {
+                reportPageVote({ status: true });
+                setUserVoted(true);
+              }}
+            />
+            <Button
+              theme="secondary"
+              size="xs"
+              aria-label="Vote down"
+              className="mx-1 min-w-[40px] text-center"
+              leftSlot={<ThumbsDownSolidIcon className="icon-sm" />}
+              onClick={() => {
+                reportPageVote({ status: false });
+                setUserVoted(true);
+              }}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@expo/styleguide';
-import { ThumbsDownSolidIcon, ThumbsUpSolidIcon } from '@expo/styleguide-icons';
+import { ThumbsDownIcon, ThumbsUpIcon } from '@expo/styleguide-icons';
 import { useState } from 'react';
 
 import { CALLOUT } from '../Text';
@@ -25,7 +25,7 @@ export const PageVote = () => {
               size="xs"
               aria-label="Vote up"
               className="mx-1 min-w-[40px] text-center"
-              leftSlot={<ThumbsUpSolidIcon className="icon-sm" />}
+              leftSlot={<ThumbsUpIcon className="icon-sm" />}
               onClick={() => {
                 reportPageVote({ status: true });
                 setUserVoted(true);
@@ -36,7 +36,7 @@ export const PageVote = () => {
               size="xs"
               aria-label="Vote down"
               className="mx-1 min-w-[40px] text-center"
-              leftSlot={<ThumbsDownSolidIcon className="icon-sm" />}
+              leftSlot={<ThumbsDownIcon className="icon-sm" />}
               onClick={() => {
                 reportPageVote({ status: false });
                 setUserVoted(true);


### PR DESCRIPTION
# Why

Address feedback from the docs meeting related to Footer.

# How

Increase the footer icons size, display vote button inline on desktop resolution.

# Test Plan

The changes have been tested by running docs app locally.

# Preview
<img width="1156" alt="Screenshot 2023-03-16 at 20 08 16" src="https://user-images.githubusercontent.com/719641/225731183-0ad94821-34a3-472f-9aaf-bf0295fc7fe9.png">
<img width="1186" alt="Screenshot 2023-03-16 at 20 21 02" src="https://user-images.githubusercontent.com/719641/225731203-6f719098-de2b-4908-9dfc-da513df20ea3.png">
<img width="423" alt="Screenshot 2023-03-16 at 20 21 40" src="https://user-images.githubusercontent.com/719641/225731200-d328911a-ca36-489b-bf5e-20208ff93b76.png">

