### PR TITLE
[docs] update code for Handle push notifications with React Navigation removeEventListener is deprecated

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -221,7 +221,7 @@ export default function App() {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
           // Listen to incoming links from deep linking
-          Linking.addEventListener('url', onReceiveURL);
+          const eventListenerSubscription = Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
@@ -236,7 +236,7 @@ export default function App() {
 
           return () => {
             // Clean up the event listeners
-            Linking.removeEventListener('url', onReceiveURL);
+            eventListenerSubscription.remove()
             subscription.remove();
           };
         },

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -221,7 +221,7 @@ export default function App() {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
           // Listen to incoming links from deep linking
-          const subEvent = Linking.addEventListener('url', onReceiveURL);
+          const eventListenerSubscription = Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -236,7 +236,7 @@ export default function App() {
 
           return () => {
             // Clean up the event listeners
-            subEvent.remove()
+            eventListenerSubscription.remove()
             subscription.remove();
           };
         },

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -221,7 +221,7 @@ export default function App() {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
           // Listen to incoming links from deep linking
-          const listener = Linking.addEventListener('url', onReceiveURL);
+          const subEvent = Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
@@ -236,7 +236,7 @@ export default function App() {
 
           return () => {
             // Clean up the event listeners
-            listener.remove()
+            subEvent.remove()
             subscription.remove();
           };
         },

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -221,7 +221,7 @@ export default function App() {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
 
           // Listen to incoming links from deep linking
-          Linking.addEventListener('url', onReceiveURL);
+          const listener = Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
@@ -236,7 +236,7 @@ export default function App() {
 
           return () => {
             // Clean up the event listeners
-            Linking.removeEventListener('url', onReceiveURL);
+            listener.remove()
             subscription.remove();
           };
         },


### PR DESCRIPTION
# Why

The code in latest sdk was flawed as the removeEventListener is deprecated
# How

<!--
How did you build this feature or fix this bug and why?
-->

by assigning event to const and using .remove()

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
