### PR TITLE
[docs] Update E2E test doc for SDK 48 and Detox 20

### DIFF
--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -170,11 +170,9 @@ module.exports = {
     },
     'android.release': {
       type: 'android.apk',
-      /* @info This is project-specific, replace eastestsexample with correct value */
       build:
         'cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      /* @end */
     },
   },
   devices: {
@@ -402,7 +400,7 @@ When an E2E test case fails, it can be helpful to see the screenshot of the appl
 
 #### Take screenshots for failed tests
 
-Detox supports taking in-test screenshots of the device. The **detox.config.js** sample above includes a line to configure Detox to take screenshots of failed tests.
+Detox supports taking in-test screenshots of the device. The [**detox.config.js** sample](/build-reference/e2e-tests/#configure-detox) above includes a line to configure Detox to take screenshots of failed tests.
 
 #### Configure EAS Build for screenshots upload
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -135,54 +135,73 @@ Let's add two development dependencies to the project - `jest` and `detox`. `jes
 
 Detox requires you to specify both the build command and path to the binary produced by it. Technically, the build command is not necessary when running tests on EAS Build, but allows you to run tests locally (for example, using `npx detox build --configuration ios.release`).
 
-Edit **.detoxrc.json** and replace the configuration with:
+Edit **detox.config.js** and replace the configuration with:
 
-```json .detoxrc.json
-{
-  "testRunner": "jest",
-  "runnerConfig": "e2e/config.json",
-  "skipLegacyWorkersInjection": true,
-  "apps": {
-    "ios.release": {
-      "type": "ios.app",
-      /* @info This is project-specific, replace eastestsexample with correct value */
-      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
+```js detox.config.js
+/** @type {Detox.DetoxConfig} */
+module.exports = {
+  logger: {
+    level: process.env.CI ? 'debug' : undefined,
+  },
+  testRunner: {
+    $0: 'jest',
+    args: {
+      config: 'e2e/jest.config.js',
+      _: ['e2e'],
+    },
+  },
+  artifacts: {
+    plugins: {
+      log: process.env.CI ? 'failing' : undefined,
+      /* @info In Detox 20, this plugin setting will take screenshots if tests fail */
+      screenshot: 'failing',
       /* @end */
     },
-    "android.release": {
-      "type": "android.apk",
+  },
+  apps: {
+    'ios.release': {
+      type: 'ios.app',
       /* @info This is project-specific, replace eastestsexample with correct value */
-      "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
-      "binaryPath": "android/app/build/outputs/apk/release/app-release.apk"
+      build:
+        'xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build',
+      binaryPath:
+        'ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app',
       /* @end */
-    }
-  },
-  "devices": {
-    "simulator": {
-      "type": "ios.simulator",
-      "device": {
-        "type": "iPhone 14"
-      }
     },
-    "emulator": {
-      "type": "android.emulator",
-      "device": {
-        "avdName": "pixel_4"
-      }
-    }
-  },
-  "configurations": {
-    "ios.release": {
-      "device": "simulator",
-      "app": "ios.release"
+    'android.release': {
+      type: 'android.apk',
+      /* @info This is project-specific, replace eastestsexample with correct value */
+      build:
+        'cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+      /* @end */
     },
-    "android.release": {
-      "device": "emulator",
-      "app": "android.release"
-    }
-  }
-}
+  },
+  devices: {
+    simulator: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 14',
+      },
+    },
+    emulator: {
+      type: 'android.emulator',
+      device: {
+        avdName: 'pixel_4',
+      },
+    },
+  },
+  configurations: {
+    'ios.release': {
+      device: 'simulator',
+      app: 'ios.release',
+    },
+    'android.release': {
+      device: 'emulator',
+      app: 'android.release',
+    },
+  },
+};
 ```
 
 ### 4. Write E2E tests
@@ -291,8 +310,9 @@ if [[ "$EAS_BUILD_RUNNER" == "eas-build" && "$EAS_BUILD_PROFILE" == "test"* ]]; 
       pulseaudio \
       socat
 
-    sdkmanager --install "system-images;android-32;google_apis;x86_64"
-    avdmanager --verbose create avd --force --name "pixel_4" --device "pixel_4" --package "system-images;android-32;google_apis;x86_64"
+    # Emulator must be API 31 -- API 32 and 33 fail due to https://github.com/wix/Detox/issues/3762
+    sdkmanager --install "system-images;android-31;google_apis;x86_64"
+    avdmanager --verbose create avd --force --name "pixel_4" --device "pixel_4" --package "system-images;android-31;google_apis;x86_64"
   else
     brew tap wix/brew
     brew install applesimutils
@@ -306,7 +326,23 @@ Next, create **eas-hooks/eas-build-on-success.sh** with the following contents. 
 ```sh eas-hooks/eas-build-on-success.sh
 #!/usr/bin/env bash
 
+function cleanup()
+{
+  echo 'Cleaning up...'
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    # Kill emulator
+    adb emu kill &
+  fi
+}
+
+if [[ "$EAS_BUILD_PROFILE" != "test" ]]; then
+  exit
+fi
+
+# Fail if anything errors
 set -eox pipefail
+# If this script exits, trap it first and clean up the emulator
+trap cleanup EXIT
 
 ANDROID_EMULATOR=pixel_4
 
@@ -323,21 +359,14 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     counter=$((counter + 1))
   done
 
+  # Execute Android tests
   if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
-    detox test --configuration android.release --headless
+    detox test --configuration android.release
   fi
-  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
-    detox test --configuration android.debug --headless
-  fi
-
-  # Kill emulator
-  adb emu kill
 else
+  # Execute iOS tests
   if [[  "$EAS_BUILD_PROFILE" == "test" ]]; then
-    detox test --configuration ios.release --headless
-  fi
-  if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
-    detox test --configuration ios.debug --headless
+    detox test --configuration ios.release
   fi
 fi
 ```
@@ -354,16 +383,6 @@ Edit **package.json** to use [EAS Build hooks](/build-reference/npm-hooks.mdx) t
 ```
 
 > Don't forget to add executable permissions to **eas-build-pre-install.sh** and **eas-build-on-success.sh**. Run `chmod +x eas-hooks/*.sh`.
-
-### 5.1. Patch **build.gradle**
-
-> This step will be redundant in the future.
-
-The Android build command that you use to produce the test build is `./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release`. Notice that it consists of two Gradle tasks. Unfortunately, when building the `*AndroidTest` task, some versions of the `expo-modules-core` module change what native libraries are included in the app binary. Those settings don't work with settings for `assembleRelease`.
-
-To fix the problem, add the `pickFirsts` list under `android.packagingOptions` in your **android/app/build.gradle**. The `pickFirsts` property overrides the setting for your project.
-
-<DiffBlock source="/static/diffs/e2e-tests-pickfirsts.diff" />
 
 ### 6. Run tests on EAS Build
 
@@ -383,52 +402,7 @@ When an E2E test case fails, it can be helpful to see the screenshot of the appl
 
 #### Take screenshots for failed tests
 
-[Detox supports taking in-test screenshots of the device](https://wix.github.io/Detox/docs/api/screenshots). It exposes the `device.takeScreenshot()` function that can be called from any test case.
-
-Neither `jest` nor `detox` offers a simple way to detect when a particular test case has failed and take a screenshot for only failed test cases. You will have to implement your own mechanism for that.
-
-Edit **e2e/environment.js** and add the `handleTestEvent` method to the `CustomDetoxEnvironment` class. The function handles test events and sets a global `testFailed` variable for test case failure. See the snippet below:
-
-```ts e2e/environment.js
-class CustomDetoxEnvironment extends DetoxCircusEnvironment {
-  // ...
-
-  async handleTestEvent(event, state) {
-    const { name } = event;
-
-    if (['test_start', 'test_fn_start'].includes(name)) {
-      this.global.testFailed = false;
-    }
-
-    if (name === 'test_fn_failure') {
-      this.global.testFailed = true;
-    }
-
-    await super.handleTestEvent(event, state);
-  }
-}
-```
-
-After modifying the environment class, define an `afterEach` hook that calls `device.takeScreenshot()` for failed tests. Create the **e2e/setup.js** file with the following snippet:
-
-```ts e2e/setup.js
-afterEach(async () => {
-  if (testFailed) {
-    await device.takeScreenshot('screenshot');
-  }
-});
-```
-
-The last step is to configure `jest` to load `e2e/setup.js` before running tests. This way, you don't need to include the `afterEach` hook in every test suite:
-
-```json e2e/config.json
-{
-  /// ...
-  "setupFilesAfterEnv": ["./setup.js"]
-}
-```
-
-After making those changes, screenshots for failed tests will be saved in the `artifacts` directory.
+Detox supports taking in-test screenshots of the device. The **detox.config.js** sample above includes a line to configure Detox to take screenshots of failed tests.
 
 #### Configure EAS Build for screenshots upload
 
@@ -522,10 +496,13 @@ describe('Home screen', () => {
 
 ```js
 const appConfig = require('../../../app.json');
+const { resolveConfig } = require('detox/internals');
+
+const platform = device.getPlatform();
 
 module.exports.openApp = async function openApp() {
-  const [platform, target] = process.env.DETOX_CONFIGURATION.split('.');
-  if (target === 'debug') {
+  const config = await resolveConfig();
+  if (config.configurationName.split('.')[1] === 'debug') {
     return await openAppForDebugBuild(platform);
   } else {
     return await device.launchApp({
@@ -542,7 +519,6 @@ async function openAppForDebugBuild(platform) {
       getDeepLinkUrl(getDevLauncherPackagerUrl(platform));
 
   if (platform === 'ios') {
-    // For iOS, the app must be launched, then the deep link URL invoked
     await device.launchApp({
       newInstance: true,
     });
@@ -551,7 +527,6 @@ async function openAppForDebugBuild(platform) {
       url: deepLinkUrl,
     });
   } else {
-    // For Android, the app must be launched directly with the deep link URL
     await device.launchApp({
       newInstance: true,
       url: deepLinkUrl,
@@ -561,12 +536,10 @@ async function openAppForDebugBuild(platform) {
   await sleep(3000);
 }
 
-const getDeepLinkUrl = url =>
-  /* @info This is project-specific, replace eastestsexample with correct value */
+const getDeepLinkUrl = (url) =>
   `eastestsexample://expo-development-client/?url=${encodeURIComponent(url)}`;
-/* @end */
 
-const getDevLauncherPackagerUrl = platform =>
+const getDevLauncherPackagerUrl = (platform) =>
   `http://localhost:8081/index.bundle?platform=${platform}&dev=true&minify=false&disableOnboarding=1`;
 
 const getLatestUpdateUrl = () =>
@@ -574,73 +547,94 @@ const getLatestUpdateUrl = () =>
 
 const getAppId = () => appConfig?.expo?.extra?.eas?.projectId ?? '';
 
-const sleep = t => new Promise(res => setTimeout(res, t));
+const sleep = (t) => new Promise((res) => setTimeout(res, t));
 ```
 
 </Collapsible>
 
-<Collapsible summary=".detoxrc.json">
+<Collapsible summary="detox.config.js">
 
-```json
-{
-  "testRunner": "jest",
-  "runnerConfig": "e2e/config.json",
-  "skipLegacyWorkersInjection": true,
-  "apps": {
-    /* @info New section */ "ios.debug": {
-      "type": "ios.app",
-      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
-      "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app"
-    } /* @end */,
-    "ios.release": {
-      "type": "ios.app",
-      "build": "xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build",
-      "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app"
-    },
-    /* @info New section */ "android.debug": {
-      "type": "android.apk",
-      "build": "cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..",
-      "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk"
-    } /* @end */,
-    "android.release": {
-      "type": "android.apk",
-      "build": "cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..",
-      "binaryPath": "android/app/build/outputs/apk/release/app-release.apk"
-    }
+```js
+/** @type {Detox.DetoxConfig} */
+module.exports = {
+  logger: {
+    level: process.env.CI ? 'debug' : undefined,
   },
-  "devices": {
-    "simulator": {
-      "type": "ios.simulator",
-      "device": {
-        "type": "iPhone 14"
-      }
+  testRunner: {
+    $0: 'jest',
+    args: {
+      config: 'e2e/jest.config.js',
+      _: ['e2e'],
     },
-    "emulator": {
-      "type": "android.emulator",
-      "device": {
-        "avdName": "pixel_4"
-      }
-    }
   },
-  "configurations": {
-    /* @info New section */ "ios.debug": {
-      "device": "simulator",
-      "app": "ios.debug"
-    } /* @end */,
-    "ios.release": {
-      "device": "simulator",
-      "app": "ios.release"
+  artifacts: {
+    plugins: {
+      log: process.env.CI ? 'failing' : undefined,
+      screenshot: 'failing',
     },
-    /* @info New section */ "android.debug": {
-      "device": "emulator",
-      "app": "android.debug"
-    } /* @end */,
-    "android.release": {
-      "device": "emulator",
-      "app": "android.release"
-    }
-  }
-}
+  },
+  apps: {
+    'ios.debug': {
+      type: 'ios.app',
+      build:
+        'xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Debug -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build',
+      binaryPath:
+        'ios/build/Build/Products/Debug-iphonesimulator/eastestsexample.app',
+    },
+    'ios.release': {
+      type: 'ios.app',
+      build:
+        'xcodebuild -workspace ios/eastestsexample.xcworkspace -scheme eastestsexample -configuration Release -sdk iphonesimulator -arch x86_64 -derivedDataPath ios/build',
+      binaryPath:
+        'ios/build/Build/Products/Release-iphonesimulator/eastestsexample.app',
+    },
+    'android.debug': {
+      type: 'android.apk',
+      build:
+        'cd android && ./gradlew :app:assembleDebug :app:assembleAndroidTest -DtestBuildType=debug && cd ..',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+    },
+    'android.release': {
+      type: 'android.apk',
+      build:
+        'cd android && ./gradlew :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release && cd ..',
+      binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
+    },
+  },
+  devices: {
+    simulator: {
+      type: 'ios.simulator',
+      device: {
+        type: 'iPhone 14',
+      },
+    },
+    emulator: {
+      type: 'android.emulator',
+      device: {
+        avdName: 'pixel_4',
+      },
+    },
+  },
+  configurations: {
+    'ios.debug': {
+      device: 'simulator',
+      app: 'ios.debug',
+    },
+    'ios.release': {
+      device: 'simulator',
+      app: 'ios.release',
+    },
+    'android.debug': {
+      device: 'emulator',
+      app: 'android.debug',
+    },
+    'android.release': {
+      device: 'emulator',
+      app: 'android.release',
+    },
+  },
+};
+
 ```
 
 </Collapsible>
@@ -650,7 +644,23 @@ const sleep = t => new Promise(res => setTimeout(res, t));
 ```sh
 #!/usr/bin/env bash
 
+function cleanup()
+{
+  echo 'Cleaning up...'
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    # Kill emulator
+    adb emu kill &
+  fi
+}
+
+if [[ "$EAS_BUILD_PROFILE" != "test"* ]]; then
+  exit
+fi
+
+# Fail if anything errors
 set -eox pipefail
+# If this script exits, trap it first and clean up the emulator
+trap cleanup EXIT
 
 ANDROID_EMULATOR=pixel_4
 
@@ -667,25 +677,22 @@ if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
     counter=$((counter + 1))
   done
 
+
+  # Execute Android tests
   if [[ "$EAS_BUILD_PROFILE" == "test" ]]; then
-    detox test --configuration android.release --headless
+    detox test --configuration android.release
   fi
-  # @info New section #
   if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
-    detox test --configuration android.debug --headless
+    detox test --configuration android.debug
   fi
-  # @end #
-  # Kill emulator
-  adb emu kill
 else
+  # Execute iOS tests
   if [[  "$EAS_BUILD_PROFILE" == "test" ]]; then
-    detox test --configuration ios.release --headless
+    detox test --configuration ios.release
   fi
-  # @info New section #
   if [[ "$EAS_BUILD_PROFILE" == "test_debug" ]]; then
-    detox test --configuration ios.debug --headless
+    detox test --configuration ios.debug
   fi
-  # @end #
 fi
 ```
 


### PR DESCRIPTION
# Why

Update E2E testing doc to correspond with changes to the E2E example: https://github.com/expo/eas-tests-example/pull/8

# How

Update the doc with new versions of the scripts and instructions.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
