### PR TITLE
add prettier `endOfLine: "auto"` to enable Windows users to contribute

### DIFF
--- a/packages/expo-module-scripts/eslintrc.base.js
+++ b/packages/expo-module-scripts/eslintrc.base.js
@@ -16,5 +16,11 @@ module.exports = {
         patterns: ['fbjs/*', 'fbjs'],
       },
     ],
+    'prettier/prettier': [
+      'warn',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };


### PR DESCRIPTION
# Why

Without this, Windows users will see the following
```
Delete `␍`
```
on every newline in every file, unless they have manually changed their settings from CRLF to LF

# How

Using the existing prettier rule

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
