### PR TITLE
[ios] [image-manipulator] Fix issue when manipulating image with unsupported color space

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Handle images with an unsupported color space ([#21757](https://github.com/expo/expo/pull/21757) by [@mmmulani](https://github.com/mmmulani))
+
 ### 💡 Others
 
 ## 11.1.1 — 2023-02-09

--- a/packages/expo-image-manipulator/ios/ImageManipulations.swift
+++ b/packages/expo-image-manipulator/ios/ImageManipulations.swift
@@ -124,9 +124,12 @@ internal func fixImageOrientation(_ image: UIImage) throws -> UIImage {
   guard let cgImage = image.cgImage else {
     throw ImageNotFoundException()
   }
-  guard let colorSpace = cgImage.colorSpace else {
+  guard var colorSpace = cgImage.colorSpace else {
     // That should never happen as `colorSpace` is empty only when the image is a mask.
     throw ImageColorSpaceNotFoundException()
+  }
+  if !colorSpace.supportsOutput {
+    colorSpace = CGColorSpaceCreateDeviceRGB()
   }
 
   var transform = CGAffineTransform.identity


### PR DESCRIPTION
# Why

When using expo-image-manipulator to resize an image (https://docs.expo.dev/versions/latest/sdk/imagemanipulator/#methods), if the provided image is in a color space that iOS cannot output to, the manipulateAsync method will fail.

# How

Accomplishes this with a simple code change of using the default device's RGB colorspace when the image's colorspace does not suffice.

# Test Plan

Using this image: https://user-images.githubusercontent.com/192928/225686623-db8d4cb1-1d96-4345-8b9e-e4fbd1083e39.png
call
```
await ImageManipulator.manipulateAsync(attachment.uri,
  [{
    resize: attachment.height > attachment.width ? { height: 1500 } : { width: 1500 },
  }],
  {
    compress: 0.9,
  },
);
```
and the method should succeed.



# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
