### PR TITLE
[ios] [image-picker] Return correct width/height for rotated videos

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix images unexpectedly being converted to `.png` when opening `.bmp` files and selecting any quality in `ImagePickerOptions`. ([#21361](https://github.com/expo/expo/pull/21361) by [@behenate](https://github.com/behenate))
 - Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
+- Fix rotated videos returning incorrect width/height. [#12573](https://github.com/expo/expo/issues/12573) ([#21758](https://github.com/expo/expo/pull/21758) by [@mmmulani](https://github.com/mmmulani))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -616,8 +616,12 @@ private struct VideoUtils {
 
   static func readSizeFrom(url: URL) -> CGSize? {
     let asset = AVURLAsset(url: url)
-    let size: CGSize? = asset.tracks(withMediaType: .video).first?.naturalSize
-    return size
+    guard let assetTrack = asset.tracks(withMediaType: .video).first else {
+      return nil
+    }
+    // The video could be rotated and the resulting transform can result in a negative width/height.
+    let size = assetTrack.naturalSize.applying(assetTrack.preferredTransform)
+    return CGSize(width: abs(size.width), height: abs(size.height))
   }
 
   static func readVideoUrlFrom(mediaInfo: MediaInfo) -> URL? {


### PR DESCRIPTION
# Why

Rotated videos (e.g. taken from camera in portrait mode or rotated in an editing tool) usually have their original width/height set as `naturalSize` but also have a rotation transformation set to result in the correct width/height.

# How

Using the same technique as in expo-av/EXVideoView: https://github.com/expo/expo/blob/4707085c830d4f687e4aa0ae19352206abe4714e/packages/expo-av/ios/EXAV/Video/EXVideoView.m#L238-L246

# Test Plan

Upload some rotated videos to the camera roll, such as: https://user-images.githubusercontent.com/192928/226122003-a9f138eb-9655-4672-9e3f-74ae0cd0d8fa.mov
Select them using expo-image-picker and ensure that the width/height is correct. Also select some regular videos and ensure that the width/height is correct.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
