### PR TITLE
[docs] Update Expo Image availability message

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -27,22 +27,22 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-| Format | Android | iOS | Web |
-|:---:|:---:|:---:|:---:|
-| WebP | <YesIcon /> | <YesIcon /> | <YesIcon /> [~96% adoption](https://caniuse.com/webp) |
+|   Format   |   Android   |     iOS     |                                 Web                                 |
+| :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
+|    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
 | PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-| AVIF | <YesIcon /> | <YesIcon /> | <PendingIcon /> [~79% adoption](https://caniuse.com/avif) |
-| HEIC | <YesIcon /> | <YesIcon /> | <NoIcon /> [not adopted yet](https://caniuse.com/heif) |
-| JPEG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| GIF | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| SVG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| ICO | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| ICNS | <NoIcon /> | <YesIcon /> | <NoIcon /> |
+|    AVIF    | <YesIcon /> | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
+|    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    SVG     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    ICO     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    ICNS    | <NoIcon />  | <YesIcon /> |                             <NoIcon />                              |
 
 ## Installation
 
-> **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/) and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
-> It is not available in Expo Go and Snack yet.
+> **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/), in Expo Go and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
+> It is not available with Snack yet.
 
 <APIInstallSection />
 

--- a/docs/pages/versions/v48.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/image.mdx
@@ -27,22 +27,22 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-| Format | Android | iOS | Web |
-|:---:|:---:|:---:|:---:|
-| WebP | <YesIcon /> | <YesIcon /> | <YesIcon /> [~96% adoption](https://caniuse.com/webp) |
+|   Format   |   Android   |     iOS     |                                 Web                                 |
+| :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
+|    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
 | PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-| AVIF | <YesIcon /> | <YesIcon /> | <PendingIcon /> [~79% adoption](https://caniuse.com/avif) |
-| HEIC | <YesIcon /> | <YesIcon /> | <NoIcon /> [not adopted yet](https://caniuse.com/heif) |
-| JPEG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| GIF | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| SVG | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| ICO | <YesIcon /> | <YesIcon /> | <YesIcon /> |
-| ICNS | <NoIcon /> | <YesIcon /> | <NoIcon /> |
+|    AVIF    | <YesIcon /> | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
+|    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    SVG     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    ICO     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
+|    ICNS    | <NoIcon />  | <YesIcon /> |                             <NoIcon />                              |
 
 ## Installation
 
-> **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/) and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
-> It is available in Expo Go with Expo SDK 48 and not available with Snack yet.
+> **Info** Currently `expo-image` can be used only with [development builds](/development/create-development-builds/), in Expo Go and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
+> It is not available with Snack yet.
 
 <APIInstallSection />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up PR for #21506

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the callout to add the context that Expo Image can be used in Expo Go.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
