### PR TITLE
[docs] Remove expo-random references in third-party auth provider guides

### DIFF
--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -23,7 +23,7 @@ To use AuthSession API, you'll need to install the following packages in your pr
 
 <Collapsible summary="Using SDK 47 or below?">
 
-If you are using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
+If you're using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
 
 <Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -21,6 +21,16 @@ To use AuthSession API, you'll need to install the following packages in your pr
 
 <Terminal cmd={['$ npx expo install expo-auth-session expo-crypto expo-web-browser']} />
 
+<Collapsible summary="Using SDK 47 or below?">
+
+If you are using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
+
+<Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
+
+`expo-random` is deprecated from SDK 48 and above and is replaced by `expo-crypto`.
+
+</Collapsible>
+
 </Step>
 
 <Step label="2">

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -19,7 +19,7 @@ AuthSession API allows [browser-based authentication](/versions/latest/sdk/auth-
 
 To use AuthSession API, you'll need to install the following packages in your project:
 
-<Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
+<Terminal cmd={['$ npx expo install expo-auth-session expo-crypto expo-web-browser']} />
 
 </Step>
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -18,6 +18,16 @@ To use AuthSession API, you'll need to install the following packages in your pr
 
 <Terminal cmd={['$ npx expo install expo-auth-session expo-crypto expo-web-browser']} />
 
+<Collapsible summary="Using SDK 47 or below?">
+
+If you are using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
+
+<Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
+
+`expo-random` is deprecated from SDK 48 and above and is replaced by `expo-crypto`.
+
+</Collapsible>
+
 ## Get credentials
 
 You'll need to provide a Google OAuth client ID to use Google as a login provider. To create a client ID, go to your Google Cloud project's [Credentials](https://console.developers.google.com/apis/credentials) page. If you don't have an existing project, create a [new project](https://console.cloud.google.com/projectcreate).

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -16,7 +16,7 @@ AuthSession API allows [browser-based authentication](/versions/latest/sdk/auth-
 
 To use AuthSession API, you'll need to install the following packages in your project:
 
-<Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
+<Terminal cmd={['$ npx expo install expo-auth-session expo-crypto expo-web-browser']} />
 
 ## Get credentials
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -20,7 +20,7 @@ To use AuthSession API, you'll need to install the following packages in your pr
 
 <Collapsible summary="Using SDK 47 or below?">
 
-If you are using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
+If you're using SDK 47 or below, you'll need to install `expo-random` instead of `expo-crypto` package:
 
 <Terminal cmd={['$ npx expo install expo-auth-session expo-random expo-web-browser']} />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, all third-party auth provider guides reference `expo-random` to be installed as a peer dependency for `expo-auth-session`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR removes `expo-random` references from Google and Facebook Auth guides installation steps and replaces that with `expo-crypto` since `expo-random` will be deprecated in SDK 49 (I though its since more folks are going to migrate using development builds and following this guide starting with SDK 48, I think we should start recommending `expo-crypto)`.

Also, added a note for installing `expo-random` for SDK 47 and below.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="820" alt="CleanShot 2023-03-20 at 14 59 08@2x" src="https://user-images.githubusercontent.com/10234615/226299167-abb27dae-7e74-4731-ba8e-5bf6c64a5139.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
