### PR TITLE
[docs] Fix Separator component background color

### DIFF
--- a/docs/ui/components/Separator.tsx
+++ b/docs/ui/components/Separator.tsx
@@ -1,1 +1,1 @@
-export const Separator = () => <hr className="mt-4 mb-6 bg-default border-0 h-[0.05rem]" />;
+export const Separator = () => <hr className="mt-4 mb-6 bg-palette-gray6 border-0 h-[0.05rem]" />;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In `<Separator>` the `bg-default` color wasn't working. Simek pointed out that the `bg-default` is not defined due to semantic reasons.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR changes `bg-default` to `bg-palette-gray6`. Thanks to @Simek for suggesting the fix!

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="952" alt="CleanShot 2023-03-20 at 15 25 57@2x" src="https://user-images.githubusercontent.com/10234615/226306067-527ea93e-3e9e-472c-8362-c4f0d7d8f9a5.png">

<img width="955" alt="CleanShot 2023-03-20 at 15 26 04@2x" src="https://user-images.githubusercontent.com/10234615/226306083-57ff794a-f049-4af6-9787-e9e7bf217141.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
