### PR TITLE
[core][Android] Fixed `ReadableNativeMap` cannot be cast to the `Record`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed `ReadableNativeMap` cannot be cast to the `Record`.
+- [Android] Fixed `ReadableNativeMap` cannot be cast to the `Record`. ([#21773](https://github.com/expo/expo/pull/21773) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `ReadableNativeMap` cannot be cast to the `Record`.
+
 ### 💡 Others
 
 - [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method. ([#21661](https://github.com/expo/expo/pull/21661) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -509,4 +509,30 @@ class JSIFunctionsTest {
     Truth.assertThat(result2).isEqualTo("expo")
     Truth.assertThat(result3).isEqualTo("expo")
   }
+
+  @Test
+  fun complex_types_should_be_convertible() {
+    @Suppress("EqualsOrHashCode")
+    data class InlineRecord(@Field var name: String = "") : Record
+
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Function("list") { listOfRecords: List<InlineRecord> ->
+          Truth.assertThat(listOfRecords).contains(InlineRecord("expo"))
+          Truth.assertThat(listOfRecords).contains(InlineRecord("is"))
+          Truth.assertThat(listOfRecords).contains(InlineRecord("awesome"))
+          Truth.assertThat(listOfRecords).hasSize(3)
+        }
+        Function("map") { mapOfRecords: Map<String, InlineRecord> ->
+          Truth.assertThat(mapOfRecords).containsEntry("k1", InlineRecord("k1"))
+          Truth.assertThat(mapOfRecords).containsEntry("k2", InlineRecord("k2"))
+          Truth.assertThat(mapOfRecords).hasSize(2)
+        }
+      }
+    ) {
+      evaluateScript("expo.modules.TestModule.list([{ name: 'expo' }, { name: 'is' }, { name: 'awesome' }])")
+      evaluateScript("expo.modules.TestModule.map({ k1: { name: 'k1' }, k2: { name: 'k2' }})")
+    }
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -60,6 +60,8 @@ class RecordTypeConverter<T : Record>(
 
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.READABLE_MAP)
 
+  override fun isTrivial(): Boolean = false
+
   private fun convertFromReadableMap(jsMap: ReadableMap): T {
     val kClass = type.classifier as KClass<*>
     val instance = getObjectConstructor(kClass.java).construct()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -46,6 +46,8 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   }
 
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType
+
+  override fun isTrivial(): Boolean = false
 }
 
 @EitherType


### PR DESCRIPTION
# Why

Fixes https://discordapp.com/channels/695411232856997968/1009056414028812299/1086682558881878036.

# How

The RecordTypeConverter and `EitherTypeConverter` were mistakenly marked as trivial. 

# Test Plan

- unit test ✅
- https://github.com/OsamaAburabie/expo-settings