### PR TITLE
[core][Android] Make module initialization lazy

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptAnonymousObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptAnonymousObjectTest.kt
@@ -27,7 +27,7 @@ class JavaScriptAnonymousObjectTest {
     val f1 = evaluateScript("object.f1()").getString()
     val f2 = waitForAsyncFunction(it, "object.f2()").getString()
 
-    Truth.assertThat(anonymousObject.getPropertyNames()).isEqualTo(arrayOf("f2", "f1", "p1"))
+    Truth.assertThat(anonymousObject.getPropertyNames()).isEqualTo(arrayOf("p1", "f2", "f1"))
     Truth.assertThat(p1).isEqualTo(123)
     Truth.assertThat(f1).isEqualTo("abc")
     Truth.assertThat(f2).isEqualTo("def")

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "ExpoModulesHostObject.h"
+#include "LazyObject.h"
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
@@ -22,14 +23,28 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {
   auto cName = name.utf8(runtime);
-  auto module = installer->getModule(cName);
-  if (module == nullptr) {
+
+  if (!installer->hasModule(cName)) {
+    modulesCache.erase(cName);
     return jsi::Value::undefined();
   }
+  if (UniqueJSIObject &cachedObject = modulesCache[cName]) {
+    return jsi::Value(runtime, *cachedObject);
+  }
 
-  module->cthis()->jsiInteropModuleRegistry = installer;
-  auto jsiObject = module->cthis()->getJSIObject(runtime);
-  return jsi::Value(runtime, *jsiObject);
+  // Create a lazy object for the specific module. It defers initialization of the final module object.
+  LazyObject::Shared moduleLazyObject = std::make_shared<LazyObject>(
+    [this, cName](jsi::Runtime &rt) {
+      auto module = installer->getModule(cName);
+      module->cthis()->jsiInteropModuleRegistry = installer;
+      return module->cthis()->getJSIObject(rt);
+    });
+
+  // Save the module's lazy host object for later use.
+  modulesCache[cName] = std::make_unique<jsi::Object>(
+    jsi::Object::createFromHostObject(runtime, moduleLazyObject));
+
+  return jsi::Value(runtime, *modulesCache[cName]);
 }
 
 void ExpoModulesHostObject::set(jsi::Runtime &runtime, const jsi::PropNameID &name,

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -7,10 +7,14 @@
 #include <jsi/jsi.h>
 
 #include <vector>
+#import <unordered_map>
 
 namespace jsi = facebook::jsi;
 
 namespace expo {
+
+using UniqueJSIObject = std::unique_ptr<jsi::Object>;
+
 /**
  * An entry point to all exported functionalities like modules.
  *
@@ -30,5 +34,6 @@ public:
 
 private:
   JSIInteropModuleRegistry *installer;
+  std::unordered_map<std::string, UniqueJSIObject> modulesCache;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -114,9 +114,21 @@ JSIInteropModuleRegistry::callGetJavaScriptModulesNames() const {
   return method(javaPart_);
 }
 
+bool JSIInteropModuleRegistry::callHasModule(const std::string &moduleName) const {
+  const static auto method = expo::JSIInteropModuleRegistry::javaClassLocal()
+    ->getMethod<jboolean(std::string)>(
+      "hasModule"
+    );
+  return (bool)method(javaPart_, moduleName);
+}
+
 jni::local_ref<JavaScriptModuleObject::javaobject>
 JSIInteropModuleRegistry::getModule(const std::string &moduleName) const {
   return callGetJavaScriptModuleObjectMethod(moduleName);
+}
+
+bool JSIInteropModuleRegistry::hasModule(const std::string &moduleName) const {
+  return callHasModule(moduleName);
 }
 
 jni::local_ref<jni::JArrayClass<jni::JString>> JSIInteropModuleRegistry::getModulesName() const {

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -56,6 +56,8 @@ public:
    */
   jni::local_ref<JavaScriptModuleObject::javaobject> getModule(const std::string &moduleName) const;
 
+  bool hasModule(const std::string &moduleName) const;
+
   /**
    * Gets names of all available modules.
    */
@@ -95,5 +97,7 @@ private:
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
 
   inline jni::local_ref<jni::JArrayClass<jni::JString>> callGetJavaScriptModulesNames() const;
+
+  inline bool callHasModule(const std::string &moduleName) const;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -90,41 +90,13 @@ public:
     jni::alias_ref<JNIFunctionBody::javaobject> setter
   );
 
-  /**
-   * An inner class of the `JavaScriptModuleObject` that is exported to the JS.
-   * It's an additional communication layer between JS and Kotlin.
-   * So the high-level view on accessing the exported function will look like this:
-   * `JS` --get function--> `JavaScriptModuleObject::HostObject` --access module metadata--> `JavaScriptModuleObject`
-   *  --create JSI function--> `MethodMetadata`
-   *
-   * This abstraction wasn't necessary. However, it makes the management of ownership much easier -
-   * `JavaScriptModuleObject` is held by the ModuleHolder and `JavaScriptModuleObject::HostObject` is stored in the JS runtime.
-   * Without this distinction the `JavaScriptModuleObject` would have to turn into `HostObject` and `HybridObject` at the same time.
-   */
-  class HostObject : public jsi::HostObject {
-  public:
-    HostObject(JavaScriptModuleObject *);
-
-    ~HostObject() override;
-
-    jsi::Value get(jsi::Runtime &, const jsi::PropNameID &name) override;
-
-    void set(jsi::Runtime &, const jsi::PropNameID &name, const jsi::Value &value) override;
-
-    std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &rt) override;
-
-    jni::global_ref<jobject> jObjectRef;
-  private:
-    JavaScriptModuleObject *jsModule;
-  };
-
 private:
   explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis);
 
 private:
   friend HybridBase;
   /**
-   * A reference to the `JavaScriptModuleObject::HostObject`.
+   * A reference to the `jsi::Object`.
    * Simple we cached that value to return the same object each time.
    * It's a weak reference because the JS runtime holds the actual object. 
    * Doing that allows the runtime to deallocate jsi::Object if it's not needed anymore.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -124,4 +124,25 @@ jsi::Object JavaScriptObject::preparePropertyDescriptor(
   descriptor.setProperty(jsRuntime, "writable", (bool) ((1 << 2) & options));
   return descriptor;
 }
+
+void JavaScriptObject::defineProperty(
+  jsi::Runtime &runtime,
+  std::shared_ptr<jsi::Object> &jsthis,
+  const std::string &name,
+  jsi::Object descriptor
+) {
+  jsi::Object global = runtime.global();
+  jsi::Object objectClass = global.getPropertyAsObject(runtime, "Object");
+  jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(
+    runtime,
+    "defineProperty"
+  );
+
+  // This call is basically the same as `Object.defineProperty(object, name, descriptor)` in JS
+  definePropertyFunction.callWithThis(runtime, objectClass, {
+    jsi::Value(runtime, *jsthis),
+    jsi::String::createFromUtf8(runtime, name),
+    std::move(descriptor),
+  });
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -61,6 +61,13 @@ public:
 
   static jsi::Object preparePropertyDescriptor(jsi::Runtime &jsRuntime, int options);
 
+  static void defineProperty(
+    jsi::Runtime &runtime,
+    std::shared_ptr<jsi::Object> &jsthis,
+    const std::string &name,
+    jsi::Object descriptor
+  );
+
 protected:
   WeakRuntimeHolder runtimeHolder;
   std::shared_ptr<jsi::Object> jsObject;
@@ -114,21 +121,9 @@ private:
     jsi::Runtime &jsRuntime = runtimeHolder.getJSRuntime();
 
     auto cName = name->toStdString();
-    jsi::Object global = jsRuntime.global();
-    jsi::Object objectClass = global.getPropertyAsObject(jsRuntime, "Object");
-    jsi::Function definePropertyFunction = objectClass.getPropertyAsFunction(
-      jsRuntime,
-      "defineProperty"
-    );
     jsi::Object descriptor = preparePropertyDescriptor(jsRuntime, options);
-
     descriptor.setProperty(jsRuntime, "value", jsi_type_converter<T>::convert(jsRuntime, value));
-
-    definePropertyFunction.callWithThis(jsRuntime, objectClass, {
-      jsi::Value(jsRuntime, *jsObject),
-      jsi::String::createFromUtf8(jsRuntime, cName),
-      std::move(descriptor)
-    });
+    JavaScriptObject::defineProperty(jsRuntime, jsObject, cName, std::move(descriptor));
   }
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -68,6 +68,12 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
     return appContextHolder.get()?.registry?.getModuleHolder(name)?.jsObject
   }
 
+  @Suppress("unused")
+  @DoNotStrip
+  fun hasModule(name: String): Boolean {
+    return appContextHolder.get()?.registry?.hasModule(name) ?: false
+  }
+
   /**
    * Returns an array that contains names of available modules.
    */


### PR DESCRIPTION
# Why

This approach guarantees that module functions and properties are only initialized upon user request. When the module is required by JavaScript, it does not automatically mean that all of its members will be added at that moment. Instead, they will be added at a later time, as needed.

# How

Added `LazyObject` abstraction as it was done on iOS.
Used an arbitrary js object instead of HostObject to define modules - it'll be handy in the future when I'll be adding shared classes. 

# Test Plan

- unit tests ✅
- bare-expo ✅