### PR TITLE
[package][expo-network] Fix broken link for docs

### DIFF
--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -6,7 +6,6 @@
       height="64" />
   </a>
 </p>
-
 Gets device's network information such as ip address, mac address and check for airplane mode.
 
 See [Expo Network docs](https://docs.expo.dev/versions/latest/sdk/network/) for documentation of this universal module's API.

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -9,7 +9,7 @@
 
 Gets device's network information such as ip address, mac address and check for airplane mode.
 
-See [<ModuleName> docs](https://docs.expo.dev/versions/latest/sdk/<module-docs-name>) for documentation of this universal module's API.
+See [Expo Network docs](https://docs.expo.dev/versions/latest/sdk/network/) for documentation of this universal module's API.
 
 # API documentation
 


### PR DESCRIPTION
# Why
The link for Expo Network Docs was broken. So I fixed it.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
I searched for the link. And followed the format and edited like this
`https://docs.expo.dev/versions/latest/sdk/%3Cmodule-docs-name%3E/?redirected`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
Tested the link in my branch and its working
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).