### PR TITLE
[core][Android] Add class component

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -1,0 +1,55 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JavaScriptClassTest {
+  @Test
+  fun has_a_prototype() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Class("MyClass")
+    }
+  ) {
+    val prototype = evaluateScript("expo.modules.TestModule.MyClass.prototype")
+    Truth.assertThat(prototype.isObject()).isTrue()
+  }
+
+  @Test
+  fun has_keys_in_prototype() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Class("MyClass") {
+        Function("myFunction") { }
+        AsyncFunction("myAsyncFunction") { }
+      }
+    }
+  ) {
+    val prototypeKeys = evaluateScript("Object.keys(expo.modules.TestModule.MyClass.prototype)")
+      .getArray()
+      .map { it.getString() }
+    Truth.assertThat(prototypeKeys).containsExactly(
+      "myFunction",
+      "myAsyncFunction"
+    )
+  }
+
+  @Test
+  fun defines_properties_on_initialization() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Class("MyClass") {
+        Property("foo") {
+          "bar"
+        }
+      }
+    }
+  ) {
+    val jsObject = evaluateScript("new expo.modules.TestModule.MyClass()").getObject()
+    Truth.assertThat(jsObject.getPropertyNames()).asList().containsExactly("foo")
+    Truth.assertThat(jsObject.getProperty("foo").getString()).isEqualTo("bar")
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -52,4 +52,22 @@ class JavaScriptClassTest {
     Truth.assertThat(jsObject.getPropertyNames()).asList().containsExactly("foo")
     Truth.assertThat(jsObject.getProperty("foo").getString()).isEqualTo("bar")
   }
+
+  @Test
+  fun should_be_able_to_receive_owner() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Class("MyClass") {
+        Function("f") { owner: JavaScriptObject ->
+          return@Function owner.getProperty("foo").getString()
+        }
+        Property("foo") {
+          "bar"
+        }
+      }
+    }
+  ) {
+    val foo = evaluateScript("(new expo.modules.TestModule.MyClass().f())").getString()
+    Truth.assertThat(foo).isEqualTo("bar")
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -16,12 +16,67 @@
 #include <utility>
 #include <tuple>
 #include <algorithm>
+#include <sstream>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;
 
 namespace expo {
+
+void decorateObjectWithFunctions(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData) {
+  for (auto &[name, method]: objectData->methodsMetadata) {
+    jsObject->setProperty(
+      runtime,
+      jsi::String::createFromUtf8(runtime, name),
+      jsi::Value(runtime, *method.toJSFunction(runtime, jsiInteropModuleRegistry))
+    );
+  }
+}
+
+void decorateObjectWithProperties(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData) {
+  for (auto &[name, property]: objectData->properties) {
+    auto &[getter, setter] = property;
+
+    auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime,
+                                                                  1 << 1 /* enumerable */);
+    descriptor.setProperty(
+      runtime,
+      "get",
+      jsi::Value(runtime, *getter.toJSFunction(runtime,
+                                               jsiInteropModuleRegistry))
+    );
+    descriptor.setProperty(
+      runtime,
+      "set",
+      jsi::Value(runtime, *setter.toJSFunction(runtime,
+                                               jsiInteropModuleRegistry))
+    );
+    JavaScriptObject::defineProperty(runtime, jsObject, name, std::move(descriptor));
+  }
+}
+
+void decorateObjectWithConstants(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData) {
+  for (const auto &[name, value]: objectData->constants) {
+    jsObject->setProperty(
+      runtime,
+      jsi::String::createFromUtf8(runtime, name),
+      jsi::valueFromDynamic(runtime, value)
+    );
+  }
+}
 
 jni::local_ref<jni::HybridClass<JavaScriptModuleObject>::jhybriddata>
 JavaScriptModuleObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {
@@ -38,6 +93,8 @@ void JavaScriptModuleObject::registerNatives() {
                                     JavaScriptModuleObject::registerAsyncFunction),
                    makeNativeMethod("registerProperty",
                                     JavaScriptModuleObject::registerProperty),
+                   makeNativeMethod("registerClass",
+                                    JavaScriptModuleObject::registerClass)
                  });
 }
 
@@ -48,30 +105,79 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
 
   auto moduleObject = std::make_shared<jsi::Object>(runtime);
 
-  for (const auto &[name, value]: constants) {
+  decorateObjectWithConstants(
+    runtime,
+    jsiInteropModuleRegistry,
+    moduleObject.get(),
+    this
+  );
+  decorateObjectWithProperties(
+    runtime,
+    jsiInteropModuleRegistry,
+    moduleObject.get(),
+    this
+  );
+  decorateObjectWithFunctions(
+    runtime,
+    jsiInteropModuleRegistry,
+    moduleObject.get(),
+    this
+  );
+
+  for (auto &[name, classRef]: classes) {
+    auto classObject = jni::static_ref_cast<JavaScriptModuleObject::javaobject>(
+      jni::make_local(classRef))->cthis();
+
+    std::string nativeConstructorKey("__native_constructor__");
+
+    // Create a string buffer of the source code to evaluate.
+    std::stringstream source;
+    source << "(function " << name << "(...args) { this." << nativeConstructorKey
+           << "(...args); return this; })";
+    std::shared_ptr<jsi::StringBuffer> sourceBuffer = std::make_shared<jsi::StringBuffer>(
+      source.str());
+
+    // Evaluate the code and obtain returned value (the constructor function).
+    jsi::Object klass = runtime.evaluateJavaScript(sourceBuffer, "").asObject(runtime);
+
+    // Set the native constructor in the prototype.
+    jsi::Object prototype = klass.getPropertyAsObject(runtime, "prototype");
+    jsi::PropNameID nativeConstructorPropId = jsi::PropNameID::forAscii(runtime,
+                                                                        nativeConstructorKey);
+    jsi::Function nativeConstructor = jsi::Function::createFromHostFunction(
+      runtime,
+      nativeConstructorPropId,
+      // The paramCount is not obligatory to match, it only affects the `length` property of the function.
+      0,
+      [classObject, jsiInteropModuleRegistry = jsiInteropModuleRegistry](
+        jsi::Runtime &runtime,
+        const jsi::Value &thisValue,
+        const jsi::Value *args,
+        size_t count
+      ) -> jsi::Value {
+        auto thisObject = thisValue.asObject(runtime);
+        decorateObjectWithProperties(runtime, jsiInteropModuleRegistry, &thisObject, classObject);
+        // TODO(@lukmccall): call the constructor from the class definition
+        return jsi::Value::undefined();
+      });
+
+    auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime, 0);
+    descriptor.setProperty(runtime, "value", jsi::Value(runtime, nativeConstructor));
+
+    JavaScriptObject::defineProperty(runtime, &prototype, nativeConstructorKey,
+                                     std::move(descriptor));
+
     moduleObject->setProperty(
       runtime,
       jsi::String::createFromUtf8(runtime, name),
-      jsi::valueFromDynamic(runtime, value)
+      jsi::Value(runtime, klass.asFunction(runtime))
     );
-  }
 
-  for (auto &[name, property]: properties) {
-    auto &[getter, setter] = property;
-
-    auto descriptor = JavaScriptObject::preparePropertyDescriptor(runtime, 1 << 1 /* enumerable */);
-    descriptor.setProperty(runtime, "get", jsi::Value(runtime, *getter.toJSFunction(runtime,
-                                                                                    jsiInteropModuleRegistry)));
-    descriptor.setProperty(runtime, "set", jsi::Value(runtime, *setter.toJSFunction(runtime,
-                                                                                    jsiInteropModuleRegistry)));
-    JavaScriptObject::defineProperty(runtime, moduleObject, name, std::move(descriptor));
-  }
-
-  for (auto &[name, method]: methodsMetadata) {
-    moduleObject->setProperty(
+    decorateObjectWithFunctions(
       runtime,
-      jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *method.toJSFunction(runtime, jsiInteropModuleRegistry))
+      jsiInteropModuleRegistry,
+      &prototype,
+      classObject
     );
   }
 
@@ -126,6 +232,14 @@ void JavaScriptModuleObject::registerAsyncFunction(
     jni::make_local(expectedArgTypes),
     jni::make_global(body)
   );
+}
+
+void JavaScriptModuleObject::registerClass(
+  jni::alias_ref<jstring> name,
+  jni::alias_ref<JavaScriptModuleObject::javaobject> classObject
+) {
+  std::string cName = name->toStdString();
+  classes[cName] = jni::make_global(classObject);
 }
 
 void JavaScriptModuleObject::registerProperty(

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -198,6 +198,7 @@ void JavaScriptModuleObject::exportConstants(
 
 void JavaScriptModuleObject::registerSyncFunction(
   jni::alias_ref<jstring> name,
+  jboolean takesOwner,
   jint args,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIFunctionBody::javaobject> body
@@ -208,6 +209,7 @@ void JavaScriptModuleObject::registerSyncFunction(
     cName,
     longLivedObjectCollection_,
     cName,
+    takesOwner,
     args,
     false,
     jni::make_local(expectedArgTypes),
@@ -217,6 +219,7 @@ void JavaScriptModuleObject::registerSyncFunction(
 
 void JavaScriptModuleObject::registerAsyncFunction(
   jni::alias_ref<jstring> name,
+  jboolean takesOwner,
   jint args,
   jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
@@ -227,6 +230,7 @@ void JavaScriptModuleObject::registerAsyncFunction(
     cName,
     longLivedObjectCollection_,
     cName,
+    takesOwner,
     args,
     true,
     jni::make_local(expectedArgTypes),
@@ -253,6 +257,7 @@ void JavaScriptModuleObject::registerProperty(
   auto getterMetadata = MethodMetadata(
     longLivedObjectCollection_,
     cName,
+    false,
     0,
     false,
     std::vector<std::unique_ptr<AnyType>>(),
@@ -264,6 +269,7 @@ void JavaScriptModuleObject::registerProperty(
   auto setterMetadata = MethodMetadata(
     longLivedObjectCollection_,
     cName,
+    false,
     1,
     false,
     std::move(types),

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -21,6 +21,29 @@ namespace react = facebook::react;
 namespace expo {
 class JSIInteropModuleRegistry;
 
+class JavaScriptModuleObject;
+
+void decorateObjectWithFunctions(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData
+);
+
+void decorateObjectWithProperties(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData
+);
+
+void decorateObjectWithConstants(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData
+);
+
 /**
  * A CPP part of the module.
  *
@@ -76,6 +99,11 @@ public:
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> body
   );
 
+  void registerClass(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<JavaScriptModuleObject::javaobject> classObject
+  );
+
   /**
    * Registers a property
    * @param name of the property
@@ -95,6 +123,28 @@ private:
 
 private:
   friend HybridBase;
+
+  friend void decorateObjectWithFunctions(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    jsi::Object *jsObject,
+    JavaScriptModuleObject *objectData
+  );
+
+  friend void decorateObjectWithProperties(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    jsi::Object *jsObject,
+    JavaScriptModuleObject *objectData
+  );
+
+  friend void decorateObjectWithConstants(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    jsi::Object *jsObject,
+    JavaScriptModuleObject *objectData
+  );
+
   /**
    * A reference to the `jsi::Object`.
    * Simple we cached that value to return the same object each time.
@@ -124,5 +174,7 @@ private:
    * The `LongLivedObjectCollection` to hold `LongLivedObject` (callbacks or promises) for this module.
    */
   std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
+
+  std::map<std::string, jni::global_ref<JavaScriptModuleObject::javaobject>> classes;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -83,6 +83,7 @@ public:
    */
   void registerSyncFunction(
     jni::alias_ref<jstring> name,
+    jboolean takesOwner,
     jint args,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> body
@@ -94,6 +95,7 @@ public:
    */
   void registerAsyncFunction(
     jni::alias_ref<jstring> name,
+    jboolean takesOwner,
     jint args,
     jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
     jni::alias_ref<JNIAsyncFunctionBody::javaobject> body

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -121,13 +121,15 @@ jsi::Object JavaScriptObject::preparePropertyDescriptor(
   jsi::Object descriptor(jsRuntime);
   descriptor.setProperty(jsRuntime, "configurable", (bool) ((1 << 0) & options));
   descriptor.setProperty(jsRuntime, "enumerable", (bool) ((1 << 1) & options));
-  descriptor.setProperty(jsRuntime, "writable", (bool) ((1 << 2) & options));
+  if ((bool) (1 << 2 & options)) {
+    descriptor.setProperty(jsRuntime, "writable", true);
+  }
   return descriptor;
 }
 
 void JavaScriptObject::defineProperty(
   jsi::Runtime &runtime,
-  std::shared_ptr<jsi::Object> &jsthis,
+  jsi::Object *jsthis,
   const std::string &name,
   jsi::Object descriptor
 ) {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -63,7 +63,7 @@ public:
 
   static void defineProperty(
     jsi::Runtime &runtime,
-    std::shared_ptr<jsi::Object> &jsthis,
+    jsi::Object *jsthis,
     const std::string &name,
     jsi::Object descriptor
   );
@@ -123,7 +123,7 @@ private:
     auto cName = name->toStdString();
     jsi::Object descriptor = preparePropertyDescriptor(jsRuntime, options);
     descriptor.setProperty(jsRuntime, "value", jsi_type_converter<T>::convert(jsRuntime, value));
-    JavaScriptObject::defineProperty(jsRuntime, jsObject, cName, std::move(descriptor));
+    JavaScriptObject::defineProperty(jsRuntime, jsObject.get(), cName, std::move(descriptor));
   }
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -332,7 +332,7 @@ jsi::Value MethodMetadata::callSync(
 
     auto descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
     descriptor.setProperty(rt, "value", jsi::Object::createFromHostObject(rt, deallocator));
-    JavaScriptObject::defineProperty(rt, jsiObject, "__expo_object_deallocator__", std::move(descriptor));
+    JavaScriptObject::defineProperty(rt, jsiObject.get(), "__expo_object_deallocator__", std::move(descriptor));
 
     return jsi::Value(rt, *jsiObject);
   }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -132,9 +132,15 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
   JSIInteropModuleRegistry *moduleRegistry,
   JNIEnv *env,
   jsi::Runtime &rt,
+  const jsi::Value &thisValue,
   const jsi::Value *args,
   size_t count
 ) {
+  // This function takes the owner, so the args number is higher because we have access to the thisValue.
+  if (takesOwner) {
+    count++;
+  }
+
   auto argumentArray = env->NewObjectArray(
     count,
     JavaReferencesCache::instance()->getJClass("java/lang/Object").clazz,
@@ -143,8 +149,21 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
 
   std::vector<jobject> result(count);
 
-  for (unsigned int argIndex = 0; argIndex < count; argIndex++) {
-    const jsi::Value &arg = args[argIndex];
+  const auto getCurrentArg = [&thisValue, args, takesOwner = takesOwner](
+    size_t index
+  ) -> const jsi::Value & {
+    if (!takesOwner) {
+      return args[index];
+    } else {
+      if (index != 0) {
+        return args[index - 1];
+      }
+      return thisValue;
+    }
+  };
+
+  for (size_t argIndex = 0; argIndex < count; argIndex++) {
+    const jsi::Value &arg = getCurrentArg(argIndex);
     auto &type = argTypes[argIndex];
     if (arg.isNull() || arg.isUndefined()) {
       // If value is null or undefined, we just passes a null
@@ -171,11 +190,13 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
 MethodMetadata::MethodMetadata(
   std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
   std::string name,
+  bool takesOwner,
   int args,
   bool isAsync,
   jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
 ) : name(std::move(name)),
+    takesOwner(takesOwner),
     args(args),
     isAsync(isAsync),
     jBodyReference(std::move(jBodyReference)),
@@ -192,11 +213,13 @@ MethodMetadata::MethodMetadata(
 MethodMetadata::MethodMetadata(
   std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
   std::string name,
+  bool takesOwner,
   int args,
   bool isAsync,
   std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
   jni::global_ref<jobject> &&jBodyReference
 ) : name(std::move(name)),
+    takesOwner(takesOwner),
     args(args),
     isAsync(isAsync),
     argTypes(std::move(expectedArgTypes)),
@@ -237,6 +260,7 @@ jsi::Function MethodMetadata::toSyncFunction(
         return this->callSync(
           rt,
           moduleRegistry,
+          thisValue,
           args,
           count
         );
@@ -249,6 +273,7 @@ jsi::Function MethodMetadata::toSyncFunction(
 jsi::Value MethodMetadata::callSync(
   jsi::Runtime &rt,
   JSIInteropModuleRegistry *moduleRegistry,
+  const jsi::Value &thisValue,
   const jsi::Value *args,
   size_t count
 ) {
@@ -265,7 +290,7 @@ jsi::Value MethodMetadata::callSync(
    */
   jni::JniLocalScope scope(env, (int) count);
 
-  auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, args, count);
+  auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, thisValue, args, count);
 
   // Cast in this place is safe, cause we know that this function is promise-less.
   auto syncFunction = jni::static_ref_cast<JNIFunctionBody>(this->jBodyReference);
@@ -332,7 +357,8 @@ jsi::Value MethodMetadata::callSync(
 
     auto descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
     descriptor.setProperty(rt, "value", jsi::Object::createFromHostObject(rt, deallocator));
-    JavaScriptObject::defineProperty(rt, jsiObject.get(), "__expo_object_deallocator__", std::move(descriptor));
+    JavaScriptObject::defineProperty(rt, jsiObject.get(), "__expo_object_deallocator__",
+                                     std::move(descriptor));
 
     return jsi::Value(rt, *jsiObject);
   }
@@ -368,7 +394,7 @@ jsi::Function MethodMetadata::toAsyncFunction(
       );
 
       try {
-        auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, args, count);
+        auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, thisValue, args, count);
         auto globalConvertedArgs = (jobjectArray) env->NewGlobalRef(convertedArgs);
         env->DeleteLocalRef(convertedArgs);
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -33,10 +33,14 @@ public:
    */
   std::string name;
   /**
+   * Whether this function takes owner
+   */
+  bool takesOwner;
+  /**
    * Number of arguments
    */
   int args;
-  /*
+  /**
    * Whether this function is async
    */
   bool isAsync;
@@ -48,6 +52,7 @@ public:
   MethodMetadata(
     std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
+    bool takesOwner,
     int args,
     bool isAsync,
     jni::local_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
@@ -57,6 +62,7 @@ public:
   MethodMetadata(
     std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
+    bool takesOwner,
     int args,
     bool isAsync,
     std::vector<std::unique_ptr<AnyType>> &&expectedArgTypes,
@@ -96,6 +102,7 @@ public:
   jsi::Value callSync(
     jsi::Runtime &rt,
     JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &thisValue,
     const jsi::Value *args,
     size_t count
   );
@@ -130,6 +137,7 @@ private:
     JSIInteropModuleRegistry *moduleRegistry,
     JNIEnv *env,
     jsi::Runtime &rt,
+    const jsi::Value &thisValue,
     const jsi::Value *args,
     size_t count
   );

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin
 
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -22,24 +21,16 @@ class ModuleHolder(val module: Module) {
    * Cached instance of HybridObject used by CPP to interact with underlying [expo.modules.kotlin.modules.Module] object.
    */
   val jsObject by lazy {
-    JavaScriptModuleObject(name)
-      .apply {
-        val constants = definition.constantsProvider()
-        val convertedConstants = Arguments.makeNativeMap(constants)
-        exportConstants(convertedConstants)
+    JavaScriptModuleObject(name).apply {
+      initUsingObjectDefinition(module.appContext, definition.objectDefinition)
 
-        definition
-          .functions
-          .forEach { function ->
-            function.attachToJSObject(module.appContext, this)
-          }
+      definition.classData.forEach { clazz ->
+        val clazzModuleObject = JavaScriptModuleObject(clazz.name)
+          .initUsingObjectDefinition(module.appContext, clazz.objectDefinition)
 
-        definition
-          .properties
-          .forEach { (_, prop) ->
-            prop.attachToJSObject(this)
-          }
+        registerClass(clazz.name, clazzModuleObject)
       }
+    }
   }
 
   /**

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -1,0 +1,93 @@
+@file:Suppress("FunctionName")
+
+package expo.modules.kotlin.classcomponent
+
+import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.objects.ObjectDefinitionBuilder
+import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.typeOf
+
+class ClassComponentBuilder(val name: String) : ObjectDefinitionBuilder() {
+  var constructor: SyncFunctionComponent? = null
+
+  fun buildClass(): ClassDefinitionData {
+    val objectData = buildObject()
+    return ClassDefinitionData(
+      name,
+      constructor ?: SyncFunctionComponent("constructor", arrayOf()) {},
+      objectData,
+    )
+  }
+
+  inline fun Constructor(
+    crossinline body: () -> Unit
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf()) { body() }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0> Constructor(
+    crossinline body: (p0: P0) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> Constructor(
+    crossinline body: (p0: P0, p1: P1) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+      constructor = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+      constructor = it
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -12,6 +12,7 @@ class ClassComponentBuilder(val name: String) : ObjectDefinitionBuilder() {
 
   fun buildClass(): ClassDefinitionData {
     val objectData = buildObject()
+    objectData.functions.forEach { it.canTakeOwner = true }
     return ClassDefinitionData(
       name,
       constructor ?: SyncFunctionComponent("constructor", arrayOf()) {},

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassDefinitionData.kt
@@ -1,0 +1,10 @@
+package expo.modules.kotlin.classcomponent
+
+import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.objects.ObjectDefinitionData
+
+class ClassDefinitionData(
+  val name: String,
+  val constructor: SyncFunctionComponent,
+  val objectDefinition: ObjectDefinitionData
+)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -9,8 +9,11 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.iterator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptModuleObject
+import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.AnyType
+import kotlin.reflect.full.isSubtypeOf
+import kotlin.reflect.typeOf
 
 /**
  * Base class of all exported functions
@@ -20,6 +23,11 @@ abstract class AnyFunction(
   protected val desiredArgsTypes: Array<AnyType>
 ) {
   internal val argsCount get() = desiredArgsTypes.size
+
+  internal var canTakeOwner: Boolean = false
+
+  internal val takesOwner: Boolean
+    get() = canTakeOwner && desiredArgsTypes.firstOrNull()?.kType?.isSubtypeOf(typeOf<JavaScriptObject>()) == true
 
   /**
    * A minimum number of arguments the functions needs which equals to `argumentsCount` reduced by the number of trailing optional arguments.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -53,6 +53,7 @@ abstract class AsyncFunction(
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     jsObject.registerAsyncFunction(
       name,
+      takesOwner,
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, bridgePromise ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -48,6 +48,7 @@ class SuspendFunctionComponent(
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     jsObject.registerAsyncFunction(
       name,
+      takesOwner,
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
     ) { args, bridgePromise ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -26,6 +26,7 @@ class SyncFunctionComponent(
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     jsObject.registerSyncFunction(
       name,
+      takesOwner,
       argsCount,
       getCppRequiredTypes().toTypedArray()
     ) { args ->

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -50,13 +50,13 @@ class JavaScriptModuleObject(val name: String) {
    * Register a promise-less function on the CPP module representation.
    * After calling this function, user can access the exported function in the JS code.
    */
-  external fun registerSyncFunction(name: String, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
+  external fun registerSyncFunction(name: String, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   /**
    * Register a promise function on the CPP module representation.
    * After calling this function, user can access the exported function in the JS code.
    */
-  external fun registerAsyncFunction(name: String, args: Int, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
+  external fun registerAsyncFunction(name: String, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
 
   external fun registerProperty(name: String, desiredType: ExpectedType, getter: JNIFunctionBody?, setter: JNIFunctionBody?)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionData.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.modules
 
 import expo.modules.kotlin.activityresult.AppContextActivityResultCaller
+import expo.modules.kotlin.classcomponent.ClassDefinitionData
 import expo.modules.kotlin.events.EventListener
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.objects.ObjectDefinitionData
@@ -11,7 +12,8 @@ class ModuleDefinitionData(
   val objectDefinition: ObjectDefinitionData,
   val viewManagerDefinition: ViewManagerDefinition? = null,
   val eventListeners: Map<EventName, EventListener> = emptyMap(),
-  val registerContracts: (suspend AppContextActivityResultCaller.() -> Unit)? = null
+  val registerContracts: (suspend AppContextActivityResultCaller.() -> Unit)? = null,
+  val classData: List<ClassDefinitionData> = emptyList()
 ) {
 
   val constantsProvider = objectDefinition.constantsProvider


### PR DESCRIPTION
# Why

Adds class component. This's a follow-up to https://github.com/expo/expo/pull/17412.

# How

Added a class component similar to the one on iOS. It's not finished yet - this's just the first part. 

# To do 

- Rename `JavaScriptModuleObject` to something more descriptive. That class is no longer used just to declare modules
- Call constructor defined in the class component 
- Pass `this` to sync/async functions. 
- Add shared objects

# Test Plan

- unit tests ✅