### PR TITLE
[dev-launcher] support http post data for network inspector

### DIFF
--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -10,6 +10,7 @@ import expo.modules.devlauncher.DevLauncherController
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
+import okio.Buffer
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.lang.reflect.Field
@@ -48,17 +49,24 @@ class DevLauncherNetworkLogger private constructor() {
    */
   fun emitNetworkWillBeSent(request: Request, requestId: String, redirectResponse: Response?) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
+    var requestParams = buildMap<String, Any> {
+      put("url", request.url().toString())
+      put("method", request.method())
+      put("headers", request.headers().toSingleMap())
+      val body = request.body()
+      if (body != null && body.contentLength() < MAX_BODY_SIZE) {
+        val buffer = Buffer()
+        body.writeTo(buffer)
+        put("postData", buffer.readUtf8(buffer.size.coerceAtMost(MAX_BODY_SIZE)))
+      }
+    }
     var params = buildMap<String, Any> {
       put("requestId", requestId)
       put("loaderId", "")
       put("documentURL", "mobile")
       put("initiator", mapOf("type" to "script"))
       put("redirectHasExtraInfo", false)
-      put("request", mapOf(
-        "url" to request.url().toString(),
-        "method" to request.method(),
-        "headers" to request.headers().toSingleMap(),
-      ))
+      put("request", requestParams)
       put("referrerPolicy", "no-referrer")
       put("type", "Fetch")
       put("timestamp", now)

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -36,17 +36,21 @@ public class EXDevLauncherNetworkLogger: NSObject {
    */
   func emitNetworkWillBeSent(request: URLRequest, requestId: String, redirectResponse: HTTPURLResponse?) {
     let now = Date().timeIntervalSince1970
+    var requestParams: [String: Any] = [
+      "url": request.url?.absoluteString,
+      "method": request.httpMethod,
+      "headers": request.allHTTPHeaderFields
+    ]
+    if let httpBody = request.httpBodyData() {
+      requestParams["postData"] = String(data: httpBody, encoding: .utf8)
+    }
     var params = [
       "requestId": requestId,
       "loaderId": "",
       "documentURL": "mobile",
       "initiator": ["type": "script"],
       "redirectHasExtraInfo": false,
-      "request": [
-        "url": request.url?.absoluteString,
-        "method": request.httpMethod,
-        "headers": request.allHTTPHeaderFields
-      ],
+      "request": requestParams,
       "referrerPolicy": "no-referrer",
       "type": "Fetch",
       "timestamp": now,


### PR DESCRIPTION
# Why

close ENG-7772

# How

send CDP [`postData`](https://chromedevtools.github.io/devtools-protocol/1-2/Network/#type-Request)

# Test Plan

test the following js code with DevTools
```ts
  const resp = await fetch('http://localhost:8081/test', {
    method: 'POST',
    body: JSON.stringify({ foo: 'foo' }),
  });
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no new changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
