### PR TITLE
[core][Android] Native functions on native component instances

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
@@ -32,7 +32,7 @@ class JavaScriptViewModule {
     inlineModule {
       Name("TestModule")
       View(android.view.View::class) {
-        AsyncFunction("viewFunction") {  ->
+        AsyncFunction("viewFunction") { ->
           123
         }
       }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
@@ -1,0 +1,44 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.jni.inlineModule
+import expo.modules.kotlin.jni.waitForAsyncFunction
+import expo.modules.kotlin.jni.withJSIInterop
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JavaScriptViewModule {
+  @Test
+  fun should_export_view_prototype() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      View(android.view.View::class) {
+        AsyncFunction("viewFunction") { viewTag: Int -> }
+        AsyncFunction("anotherViewFunction") { -> 20 }
+      }
+    }
+  ) {
+    val viewFunctions = evaluateScript("Object.getOwnPropertyNames(expo.modules.TestModule.ViewPrototype)")
+      .getArray()
+      .map { it.getString() }
+
+    Truth.assertThat(viewFunctions).containsExactly("viewFunction", "anotherViewFunction")
+  }
+
+  @Test
+  fun view_functions_should_be_callable() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      View(android.view.View::class) {
+        AsyncFunction("viewFunction") {  ->
+          123
+        }
+      }
+    }
+  ) { methodQueue ->
+    val result = waitForAsyncFunction(methodQueue, "expo.modules.TestModule.ViewPrototype.viewFunction()").getInt()
+    Truth.assertThat(result).isEqualTo(123)
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -30,6 +30,7 @@ internal inline fun withJSIInterop(
   }
   every { appContextMock.registry } answers { registry }
   every { appContextMock.modulesQueue } answers { methodQueue }
+  every { appContextMock.mainQueue } answers { methodQueue }
 
   val jsiIterop = JSIInteropModuleRegistry(appContextMock).apply {
     installJSIForTests()

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -106,6 +106,10 @@ public:
     jni::alias_ref<JavaScriptModuleObject::javaobject> classObject
   );
 
+  void registerViewPrototype(
+    jni::alias_ref<JavaScriptModuleObject::javaobject> viewPrototype
+  );
+
   /**
    * Registers a property
    * @param name of the property
@@ -178,5 +182,7 @@ private:
   std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
 
   std::map<std::string, jni::global_ref<JavaScriptModuleObject::javaobject>> classes;
+
+  jni::global_ref<JavaScriptModuleObject::javaobject> viewPrototype;
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -62,6 +62,8 @@ class JavaScriptModuleObject(val name: String) {
 
   external fun registerClass(name: String, classModule: JavaScriptModuleObject)
 
+  external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
+
   @Throws(Throwable::class)
   protected fun finalize() {
     mHybridData.resetNative()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -151,7 +151,6 @@ class ViewDefinitionBuilder<T : View>(@PublishedApi internal val viewType: KClas
     viewGroupDefinition = groupViewDefinitionBuilder.build()
   }
 
-
   @JvmName("AsyncFunctionWithoutArgs")
   inline fun AsyncFunction(
     name: String,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -8,8 +8,14 @@ import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.functions.AsyncFunction
+import expo.modules.kotlin.functions.AsyncFunctionBuilder
+import expo.modules.kotlin.functions.AsyncFunctionComponent
+import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
+import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KClass
@@ -32,16 +38,26 @@ class ViewDefinitionBuilder<T : View>(@PublishedApi internal val viewType: KClas
   internal var viewGroupDefinition: ViewGroupDefinition? = null
   private var callbacksDefinition: CallbacksDefinition? = null
 
-  fun build(): ViewManagerDefinition =
-    ViewManagerDefinition(
+  @PublishedApi
+  internal var asyncFunctions = mutableMapOf<String, AsyncFunction>()
+
+  private var functionBuilders = mutableMapOf<String, AsyncFunctionBuilder>()
+
+  fun build(): ViewManagerDefinition {
+    val asyncFunctions = asyncFunctions + functionBuilders.mapValues { (_, value) -> value.build() }
+    asyncFunctions.forEach { (_, function) -> function.runOnQueue(Queues.MAIN) }
+
+    return ViewManagerDefinition(
       viewFactory = createViewFactory(),
       viewType = viewType.java,
       props = props,
       onViewDestroys = onViewDestroys,
       callbacksDefinition = callbacksDefinition,
       viewGroupDefinition = viewGroupDefinition,
-      onViewDidUpdateProps = onViewDidUpdateProps
+      onViewDidUpdateProps = onViewDidUpdateProps,
+      asyncFunctions = asyncFunctions.values.toList(),
     )
+  }
 
   /**
    * Creates view's lifecycle listener that is called right after the view isn't longer used by React Native.
@@ -134,6 +150,134 @@ class ViewDefinitionBuilder<T : View>(@PublishedApi internal val viewType: KClas
     body.invoke(groupViewDefinitionBuilder)
     viewGroupDefinition = groupViewDefinitionBuilder.build()
   }
+
+
+  @JvmName("AsyncFunctionWithoutArgs")
+  inline fun AsyncFunction(
+    name: String,
+    crossinline body: () -> Any?
+  ): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R> AsyncFunction(
+    name: String,
+    crossinline body: () -> R
+  ): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ): AsyncFunction {
+    return if (P0::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ): AsyncFunction {
+    return if (P1::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType())) { args, promise -> body(args[0] as P0, promise as P1) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ): AsyncFunction {
+    return if (P2::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): AsyncFunction {
+    return if (P3::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): AsyncFunction {
+    return if (P4::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ): AsyncFunction {
+    return if (P5::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): AsyncFunction {
+    return if (P6::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncFunction(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): AsyncFunction {
+    return if (P7::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }.also {
+      asyncFunctions[name] = it
+    }
+  }
+
+  fun AsyncFunction(
+    name: String
+  ) = AsyncFunctionBuilder(name).also { functionBuilders[name] = it }
 
   private fun createViewFactory(): (Context, AppContext) -> View = viewFactory@{ context: Context, appContext: AppContext ->
     val primaryConstructor = requireNotNull(getPrimaryConstructor()) { "$viewType doesn't have a primary constructor" }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerDefinition.kt
@@ -11,17 +11,19 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.DynamicNull
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.toCodedException
+import expo.modules.kotlin.functions.BaseAsyncFunctionComponent
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.recycle
 
 class ViewManagerDefinition(
   private val viewFactory: (Context, AppContext) -> View,
-  private val viewType: Class<out View>,
+  internal val viewType: Class<out View>,
   private val props: Map<String, AnyViewProp>,
   val onViewDestroys: ((View) -> Unit)? = null,
   val callbacksDefinition: CallbacksDefinition? = null,
   val viewGroupDefinition: ViewGroupDefinition? = null,
-  val onViewDidUpdateProps: ((View) -> Unit)? = null
+  val onViewDidUpdateProps: ((View) -> Unit)? = null,
+  val asyncFunctions: List<BaseAsyncFunctionComponent> = emptyList()
 ) {
 
   fun createView(context: Context, appContext: AppContext): View = viewFactory(context, appContext)


### PR DESCRIPTION
# Why

This's a follow-up to the https://github.com/expo/expo/pull/21746.
Closes ENG-6234.

# How

- Added async functions definition to the `ViewDefinitionBuiler` 
- Exported information about those functions to js
- Exported `ViewPrototype` from the module object

# Test Plan

- unit tests ✅
- add a function that clears the content of the image to the `expo-image` (will be added in a separate PR)