### PR TITLE
[docs] more emphatic direnv recommendation

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -105,7 +105,7 @@ This approach this plugin will work well with environment variables set in your 
 
 ## Loading environment variables from a file
 
-If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use an environment variable manager.
+If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use an environment variable manager such as direnv or dotenv.
 
 ### direnv
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -105,7 +105,7 @@ This approach this plugin will work well with environment variables set in your 
 
 ## Loading environment variables from a file
 
-If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use an environment variable manager such as direnv or dotenv.
+If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use an environment variable manager, such as direnv or dotenv.
 
 ### direnv
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -103,17 +103,17 @@ function Post() {
 
 This approach this plugin will work well with environment variables set in your shell process, but it won't automatically load **.env** files. We recommend using [direnv](https://direnv.net/) and **.envrc** to accomplish that.
 
-## Storing environment variables in .envrc or .env
+## Loading environment variables from a file
 
-If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use a **.envrc** or **.env** file.
+If you want to automatically load environment variables from a file in your project rather than setting them in your shell profile or manually when running `npx expo start`, you may want to use an environment variable manager.
 
 ### direnv
 
-[direnv](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory. When you `cd` into your project directory, it will load all of the variables as configured in **.envrc**. [Learn more](https://direnv.net/#getting-started).
+[direnv](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory. When you `cd` into your project directory, it will load all of the variables as configured in **.envrc**. Due to its tight shell integration, we highly recommend direnv for the highest level of compatiblity with all Expo and EAS CLI tooling. [Learn more](https://direnv.net/#getting-started).
 
 ### dotenv
 
-[dotenv](https://github.com/motdotla/dotenv) is a library that you import in your project code to load the **.env** file. [Learn more](https://github.com/motdotla/dotenv).
+[dotenv](https://github.com/motdotla/dotenv) is a library that you import in your project code to load the **.env** file. Since it works at the JavaScript code level, dotenv may be affected by your Node environment or how you invoke it from your code, so be sure to check their documentation for the correct usage if you run into issues. [Learn more](https://github.com/motdotla/dotenv).
 
 ## Security considerations
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -113,7 +113,7 @@ If you want to automatically load environment variables from a file in your proj
 
 ### dotenv
 
-[dotenv](https://github.com/motdotla/dotenv) is a library that you import in your project code to load the **.env** file. Since it works at the JavaScript code level, dotenv may be affected by your Node environment or how you invoke it from your code, so be sure to check their documentation for the correct usage if you run into issues. [Learn more](https://github.com/motdotla/dotenv).
+[dotenv](https://github.com/motdotla/dotenv) is a library that you import in your project code to load the **.env** file. Since it works at the JavaScript code level, dotenv may be affected by your Node.js environment or how you invoke it from your code. Check the [documentation](https://github.com/motdotla/dotenv) for the correct usage if you run into issues.
 
 ## Security considerations
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -109,7 +109,7 @@ If you want to automatically load environment variables from a file in your proj
 
 ### direnv
 
-[direnv](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory. When you `cd` into your project directory, it will load all of the variables as configured in **.envrc**. Due to its tight shell integration, we highly recommend direnv for the highest level of compatiblity with all Expo and EAS CLI tooling. [Learn more](https://direnv.net/#getting-started).
+[direnv](https://direnv.net/) automatically loads and unloads environment variables in your shell depending on your current directory. When you `cd` into your project directory, it will load all of the variables as configured in **.envrc**. Due to its tight shell integration, **we highly recommend direnv for the highest level of compatibility with all Expo and EAS CLI tooling**. To get started, see [direnv documentation](https://direnv.net/#getting-started).
 
 ### dotenv
 


### PR DESCRIPTION
# Why

We do recommend direnv in the docs, but only briefly, and without much of a "why". It's easy to miss and draw your eyes to the next part, which seems to recommend them equally, even though it's pretty easy to end up in a situation where dotenv doesn't work so well with EAS Update.

# How

Changed the doc

# Test Plan

Tried it out

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
