### PR TITLE
[docs] Fix typos

### DIFF
--- a/docs/common/headingManager.ts
+++ b/docs/common/headingManager.ts
@@ -25,7 +25,7 @@ export const BASE_HEADING_LEVEL = 2;
  * How deeply nested headings to display
  * 0 - means only root headings
  *
- * Can be overriden in `.md` pages by setting
+ * Can be overridden in `.md` pages by setting
  * `maxHeadingDepth` attribute
  */
 const DEFAULT_NESTING_LIMIT = 1;

--- a/docs/pages/build-reference/eas-json.mdx
+++ b/docs/pages/build-reference/eas-json.mdx
@@ -140,7 +140,7 @@ This document is a reference that outlines the schema for the `"build"` key in *
   "cli": {
     "version": /* @info Required EAS CLI version range. */"SEMVER_RANGE"/* @end */,
     "requireCommit": /* @info If true, ensures that all changes are committed before a build. Defaults to false. */boolean/* @end */,
-    "appVersionSource": /* @info If set to remote, values stored on EAS servers will take precedense over local values. Defaults to local. */string/* @end */,
+    "appVersionSource": /* @info If set to remote, values stored on EAS servers will take precedence over local values. Defaults to local. */string/* @end */,
     "promptToConfigurePushNotifications": /* @info If set to false, skips Push Notifications credentials setup for EAS Build. Defaults to true. */boolean/* @end */,
   },
   "build": {

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -462,7 +462,7 @@ Defines action the retrieves the number of child views in the view group.
 
 #### Arguments
 
-- **action**: `(parent: ParentType) -> Int` — A function that returns numer of child views.
+- **action**: `(parent: ParentType) -> Int` — A function that returns number of child views.
 
 This property can only be used within a [`GroupView`](#groupview) closure.
 

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -107,12 +107,12 @@ Next, import all required functions from installed packages and initialize `mult
 ```js
 // Multer is a middleware for handling `multipart/form-data`.
 const multer = require('multer');
-// Sharp allows you to recieve a data buffer from the uploaded image.
+// Sharp allows you to receive a data buffer from the uploaded image.
 const sharp = require('sharp');
 // Import the encode function from the blurhash package.
 const { encode } = require('blurhash');
 
-// Initilize `multer`.
+// Initialize `multer`.
 const upload = multer();
 ```
 

--- a/docs/pages/versions/v46.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/camera.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
+**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Moreover, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
 
 <PlatformsSection android ios web />
 

--- a/docs/pages/versions/v47.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/camera.mdx
@@ -10,7 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline} from '~/ui/components/Snippet';
 
-**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Morever, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
+**`expo-camera`** provides a React component that renders a preview for the device's front or back camera. The camera's parameters like zoom, auto focus, white balance and flash mode are adjustable. With the use of `Camera`, one can also take photos and record videos that are then saved to the app's cache. Moreover, the component is also capable of detecting faces and bar codes appearing in the preview. Run the [example](#usage) on your device to see all these features working together!
 
 <PlatformsSection android ios web />
 

--- a/docs/pages/versions/v48.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/image.mdx
@@ -107,12 +107,12 @@ Next, import all required functions from installed packages and initialize `mult
 ```js
 // Multer is a middleware for handling `multipart/form-data`.
 const multer = require('multer');
-// Sharp allows you to recieve a data buffer from the uploaded image.
+// Sharp allows you to receive a data buffer from the uploaded image.
 const sharp = require('sharp');
 // Import the encode function from the blurhash package.
 const { encode } = require('blurhash');
 
-// Initilize `multer`.
+// Initialize `multer`.
 const upload = multer();
 ```
 

--- a/docs/ui/components/TableOfContents/useHeadingObserver.ts
+++ b/docs/ui/components/TableOfContents/useHeadingObserver.ts
@@ -8,7 +8,7 @@ export type HeadingEntry = {
 /**
  * Retrieve all headings matching the selector within the document.
  * This will search for all elements matching the heading tags, and generate a selector string.
- * The string can be used to properly intialize the intersection observer.
+ * The string can be used to properly initialize the intersection observer.
  * Currently, only headings with either an `[id="<id>"]` or `[data-id="<id>"]` are supported.
  */
 export function useHeadingsObserver(tags = 'h2,h3') {


### PR DESCRIPTION
# Why

To fix typos across docs.





# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
