### PR TITLE
[expo-updates][Android] Fix missing manifest for flavor variants

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 - iOS: Fix legacy update bundled asset parsing. ([#21691](https://github.com/expo/expo/pull/21691) by [@wschurman](https://github.com/wschurman))
 - Change arg in gradle `.execute()` call to null to inherit env variables from user's env ([#21712](https://github.com/expo/expo/pull/21712) by [@phoenixiguess](https://github.com/phoenixiguess))
 - iOS: Fix config plist overriding. ([#21702](https://github.com/expo/expo/pull/21702) by [@wschurman](https://github.com/wschurman))
+- [Android] Fix missing manifest for build flavor variants. ([#21813](https://github.com/expo/expo/pull/21813) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/scripts/create-manifest-android.gradle
+++ b/packages/expo-updates/scripts/create-manifest-android.gradle
@@ -69,6 +69,7 @@ def setupClosure = {
         name: "copy${targetName}ExpoManifest",
         type: Copy) {
       description = "expo-updates: Copy manifest into ${targetName}."
+      duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
       into ("${appProject.buildDir}/intermediates")
       into ("assets/${targetPath}") {
@@ -87,6 +88,11 @@ def setupClosure = {
 
       // Workaround for Android Gradle Plugin 7.1+ asset directory
       into ("assets/${variant.name}/merge${targetName}Assets") {
+        from(assetsDir)
+      }
+
+      // Workaround for Android Gradle Plugin 7.5+ asset directory (including flavor variants)
+      into ("assets/${variant.name}") {
         from(assetsDir)
       }
 


### PR DESCRIPTION
# Why

Fixes #21382 .

When Android flavor variants are used, builds will not contain the embedded manifest for `expo-updates`. This gradle patch fixes this issue.

# How

Modify `packages/expo-updates/scripts/create-manifest-android.gradle` to add the new location from which to copy the manifest asset. Add duplicate policy to handle cases where the manifest may be copied more than once.

# Test Plan

- Create a new bare workflow project from SDK 48
- Modify `android/app/build.gradle` similarly to this patch:

```diff
--- android/app/build.gradle.orig	2023-03-22 11:00:43.000000000 -0700
+++ android/app/build.gradle	2023-03-09 11:57:31.000000000 -0800
@@ -150,6 +150,12 @@
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    flavorDimensions "default"
+    productFlavors {
+        development {
+            applicationId "com.douglowderexpo.bareworkflow48"
+        }   
+    }
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
```

Before making this change, the `:app:installDevelopmentRelease` task would produce a build with the updates manifest missing, and therefore would not start.

After this change, the above build will run correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
