### PR TITLE
[docs][updates] keep consistency between instructions for Android and iOS

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -53,6 +53,11 @@ Add the **Supporting** directory containing **Expo.plist** to your project in Xc
     <string>ALWAYS</string>
     <key>EXUpdatesEnabled</key>
     <true/>
+    <key>EXUpdatesRequestHeaders</key>
+    <dict>
+      <key>expo-channel-name</key>
+      <string>your-channel-name</string>
+    </dict>
     <key>EXUpdatesLaunchWaitMs</key>
     <integer>0</integer>
     <key>EXUpdatesSDKVersion</key>


### PR DESCRIPTION
# Why

The "Configuration for Android" instructs to fill in the meta-data "UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY", but the "Configuration for iOS" does not instruct to fill in this data. In order to maintain consistency, I made this change.

# How

I obtained the "dictionary key" through the official API documentation and then inserted it leaving it in the same model as the Android version.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
