### PR TITLE
[core][Android] Add converter for `View`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -46,6 +46,14 @@ jni::local_ref<UnexpectedException> UnexpectedException::create(const std::strin
   );
 }
 
+jni::local_ref<InvalidArgsNumberException> InvalidArgsNumberException::create(int received, int expected) {
+  return InvalidArgsNumberException::newInstance(
+    received,
+    expected,
+    expected // number of required arguments
+  );
+}
+
 jsi::Value makeCodedError(
   jsi::Runtime &rt,
   jsi::String code,

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -60,6 +60,17 @@ public:
   );
 };
 
+class InvalidArgsNumberException
+: public jni::JavaClass<InvalidArgsNumberException, CodedException> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/exception/InvalidArgsNumberException;";
+
+  static jni::local_ref<InvalidArgsNumberException> create(
+    int received,
+    int expected
+  );
+};
+
 /**
  * Tries to rethrow an jni::JniException as a js version of the CodedException
  */

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -141,6 +141,16 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
     count++;
   }
 
+  // The `count < this->args` case is handled by the Kotlin part
+  if (count > this->args) {
+    throwNewJavaException(
+      InvalidArgsNumberException::create(
+        count,
+        this->args
+      ).get()
+    );
+  }
+
   auto argumentArray = env->NewObjectArray(
     count,
     JavaReferencesCache::instance()->getJClass("java/lang/Object").clazz,

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -22,6 +22,7 @@ enum CppType {
   TYPED_ARRAY = 1 << 10,
   PRIMITIVE_ARRAY = 1 << 11,
   LIST = 1 << 12,
-  MAP = 1 << 13
+  MAP = 1 << 13,
+  VIEW_TAG = 1 << 14,
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -429,4 +429,23 @@ bool MapFrontendConverter::canConvert(
 ) const {
   return value.isObject();
 }
+
+jobject ViewTagFrontendConverter::convert(jsi::Runtime &rt, JNIEnv *env,
+                                          JSIInteropModuleRegistry *moduleRegistry,
+                                          const jsi::Value &value) const {
+  auto nativeTag = value.getObject(rt).getProperty(rt, "nativeTag");
+  if (nativeTag.isNull()) {
+    return nullptr;
+  }
+
+  auto viewTag = (int) nativeTag.getNumber();
+  auto &integerClass = JavaReferencesCache::instance()
+    ->getJClass("java/lang/Integer");
+  jmethodID integerConstructor = integerClass.getMethod("<init>", "(I)V");
+  return env->NewObject(integerClass.clazz, integerConstructor, viewTag);
+}
+
+bool ViewTagFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+  return value.isObject() && value.getObject(rt).hasProperty(rt, "nativeTag");
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -205,6 +205,18 @@ public:
   bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
 };
 
+class ViewTagFrontendConverter : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+};
+
 /**
  * Converter that always fails.
  * Used to not fail when the function is created.

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -22,6 +22,7 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::STRING, StringFrontendConverter);
   RegisterConverter(CppType::READABLE_MAP, ReadableNativeMapArrayFrontendConverter);
   RegisterConverter(CppType::READABLE_ARRAY, ReadableNativeArrayFrontendConverter);
+  RegisterConverter(CppType::VIEW_TAG, ViewTagFrontendConverter);
 #undef RegisterConverter
 
   auto registerPolyConverter = [this](const std::vector<CppType> &types) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -91,6 +91,7 @@ internal class MissingTypeConverter(
   message = "Cannot find type converter for '$forType'.",
 )
 
+@DoNotStrip
 internal class InvalidArgsNumberException(received: Int, expected: Int, required: Int = expected) :
   CodedException(
     message = if (required < expected) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
@@ -15,6 +15,11 @@ class Exceptions {
   ) : CodedException(message = "Unable to find the $viewType view with tag $viewTag")
 
   /**
+   * The app context is no longer available.
+   */
+  class AppContextLost : CodedException(message = "The app context has been lost")
+
+  /**
    * The react app context is no longer available.
    */
   class ReactContextLost : CodedException(message = "The react context has been lost")
@@ -43,4 +48,14 @@ class Exceptions {
    * An exception to throw when the current Android activity is not longer available.
    */
   class MissingActivity : CodedException(message = "The current activity is no longer available")
+
+  /**
+   * An exception to throw when function was called on the incorrect thread.
+   */
+  class IncorrectThreadException(
+    currentThreadName: String,
+    expectedThreadName: String
+  ) : CodedException(
+    message = "Expected to run on $expectedThreadName thread, but was run on $currentThreadName"
+  )
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -48,7 +48,7 @@ abstract class AsyncFunction(
   @Throws(CodedException::class)
   internal abstract fun callUserImplementation(args: ReadableArray, promise: Promise)
 
-  internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise)
+  internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext)
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     jsObject.registerAsyncFunction(
@@ -67,7 +67,7 @@ abstract class AsyncFunction(
           exceptionDecorator({
             FunctionCallException(name, jsObject.name, it)
           }) {
-            callUserImplementation(args, bridgePromise)
+            callUserImplementation(args, bridgePromise, appContext)
           }
         } catch (e: CodedException) {
           bridgePromise.reject(e)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionComponent.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.types.AnyType
@@ -15,7 +16,7 @@ class AsyncFunctionComponent(
     promise.resolve(body(convertArgs(args)))
   }
 
-  override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
-    promise.resolve(body(convertArgs(args)))
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    promise.resolve(body(convertArgs(args, appContext)))
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromiseComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionWithPromiseComponent.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.types.AnyType
@@ -15,7 +16,7 @@ class AsyncFunctionWithPromiseComponent(
     body(convertArgs(args), promise)
   }
 
-  override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
-    body(convertArgs(args), promise)
+  override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
+    body(convertArgs(args, appContext), promise)
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -27,5 +27,6 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   TYPED_ARRAY(TypedArray::class),
   PRIMITIVE_ARRAY(Array::class),
   LIST(List::class),
-  MAP(Map::class);
+  MAP(Map::class),
+  VIEW_TAG(Int::class);
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -18,6 +18,7 @@ import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
 import kotlin.reflect.KClass
+import kotlin.reflect.typeOf
 
 @DefinitionMarker
 class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null) : ObjectDefinitionBuilder() {
@@ -58,10 +59,10 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
   /**
    * Creates the view manager definition that scopes other view-related definitions.
    */
-  inline fun <T : View> View(viewType: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
+  inline fun <reified T : View> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
     require(viewManagerDefinition == null) { "The module definition may have exported only one view manager." }
 
-    val viewDefinitionBuilder = ViewDefinitionBuilder(viewType)
+    val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, typeOf<T>())
     body.invoke(viewDefinitionBuilder)
     viewManagerDefinition = viewDefinitionBuilder.build()
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
 import kotlin.reflect.KType
 
@@ -10,7 +11,7 @@ class AnyType(val kType: KType) {
     TypeConverterProviderImpl.obtainTypeConverter(kType)
   }
 
-  fun convert(value: Any?): Any? = converter.convert(value)
+  fun convert(value: Any?, appContext: AppContext? = null): Any? = converter.convert(value, appContext)
 
   fun getCppRequiredTypes(): ExpectedType = converter.getCppRequiredTypes()
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
@@ -21,7 +22,7 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   private val firstType = firstTypeConverter.getCppRequiredTypes()
   private val secondType = secondTypeConverter.getCppRequiredTypes()
 
-  override fun convertNonOptional(value: Any): Either<FirstType, SecondType> {
+  override fun convertNonOptional(value: Any, context: AppContext?): Either<FirstType, SecondType> {
     val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
       for (singleType in types) {
         if (singleType.expectedCppType.clazz.isInstance(value)) {
@@ -71,7 +72,7 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
   private val secondType = secondTypeConverter.getCppRequiredTypes()
   private val thirdType = thirdTypeConverter.getCppRequiredTypes()
 
-  override fun convertNonOptional(value: Any): EitherOfThree<FirstType, SecondType, ThirdType> {
+  override fun convertNonOptional(value: Any, context: AppContext?): EitherOfThree<FirstType, SecondType, ThirdType> {
     val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
       for (singleType in types) {
         if (singleType.expectedCppType.clazz.isInstance(value)) {
@@ -127,7 +128,7 @@ class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : A
   private val thirdType = thirdTypeConverter.getCppRequiredTypes()
   private val fourthType = fourthTypeConverter.getCppRequiredTypes()
 
-  override fun convertNonOptional(value: Any): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
+  override fun convertNonOptional(value: Any, context: AppContext?): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
     val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
       for (singleType in types) {
         if (singleType.expectedCppType.clazz.isInstance(value)) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.exception.UnsupportedClass
 import expo.modules.kotlin.jni.ExpectedType
@@ -13,7 +14,7 @@ abstract class TypeConverter<Type : Any> {
   /**
    * Tries to convert from [Any]? (can be also [Dynamic]) to the desired type.
    */
-  abstract fun convert(value: Any?): Type?
+  abstract fun convert(value: Any?, context: AppContext? = null): Type?
 
   /**
    * Returns a list of [ExpectedType] types that can be converted to the desired type.
@@ -37,21 +38,21 @@ abstract class NullAwareTypeConverter<Type : Any>(
    */
   private val isOptional: Boolean
 ) : TypeConverter<Type>() {
-  override fun convert(value: Any?): Type? {
+  override fun convert(value: Any?, context: AppContext?): Type? {
     if (value == null || value is Dynamic && value.isNull) {
       if (isOptional) {
         return null
       }
       throw NullArgumentException()
     }
-    return convertNonOptional(value)
+    return convertNonOptional(value, context)
   }
 
   /**
    * Tries to convert from [Any] to the desired type.
    * We know in that place that we're not dealing with `null`.
    */
-  abstract fun convertNonOptional(value: Any): Type
+  abstract fun convertNonOptional(value: Any, context: AppContext?): Type
 }
 
 /**
@@ -60,7 +61,7 @@ abstract class NullAwareTypeConverter<Type : Any>(
  * stop using the bridge to pass data between JS and Kotlin.
  */
 abstract class DynamicAwareTypeConverters<T : Any>(isOptional: Boolean) : NullAwareTypeConverter<T>(isOptional) {
-  override fun convertNonOptional(value: Any): T =
+  override fun convertNonOptional(value: Any, context: AppContext?): T =
     if (value is Dynamic) {
       convertFromDynamic(value)
     } else {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -4,6 +4,7 @@ package expo.modules.kotlin.types
 
 import android.graphics.Color
 import android.net.Uri
+import android.view.View
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -33,6 +34,7 @@ import expo.modules.kotlin.types.io.PathTypeConverter
 import expo.modules.kotlin.types.net.JavaURITypeConverter
 import expo.modules.kotlin.types.net.URLTypConverter
 import expo.modules.kotlin.types.net.UriTypeConverter
+import expo.modules.kotlin.views.ViewTypeConverter
 import java.io.File
 import java.net.URI
 import java.net.URL
@@ -113,6 +115,10 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       val converter = RecordTypeConverter<Record>(this, type)
       cachedRecordConverters[kClass] = converter
       return converter
+    }
+
+    if (kClass.isSubclassOf(View::class)) {
+      return ViewTypeConverter<View>(type)
     }
 
     return handelEither(type, kClass)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypedArrayTypeConverter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptTypedArray
@@ -17,7 +18,7 @@ import expo.modules.kotlin.typedarray.Uint8Array
 import expo.modules.kotlin.typedarray.Uint8ClampedArray
 
 abstract class BaseTypeArrayConverter<T : TypedArray>(isOptional: Boolean) : NullAwareTypeConverter<T>(isOptional) {
-  override fun convertNonOptional(value: Any): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
+  override fun convertNonOptional(value: Any, context: AppContext?): T = wrapJavaScriptTypedArray(value as JavaScriptTypedArray)
   override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.TYPED_ARRAY)
   override fun isTrivial() = false
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -1,0 +1,48 @@
+package expo.modules.kotlin.views
+
+import android.os.Looper
+import android.view.View
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.exception.NullArgumentException
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.types.TypeConverter
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+class ViewTypeConverter<T : View>(
+  val type: KType
+) : TypeConverter<T>() {
+
+  override fun convert(value: Any?, context: AppContext?): T? {
+    if (Thread.currentThread() !== Looper.getMainLooper().thread) {
+      throw Exceptions.IncorrectThreadException(
+        Thread.currentThread().name,
+        Looper.getMainLooper().thread.name
+      )
+    }
+    if (value == null) {
+      if (type.isMarkedNullable) {
+        return null
+      }
+      throw NullArgumentException()
+    }
+
+    val appContext = context ?: throw Exceptions.AppContextLost()
+    val viewTag = value as Int
+    val view = appContext.findView<T>(viewTag)
+    if (!type.isMarkedNullable && view == null) {
+      throw Exceptions.ViewNotFound(type.classifier as KClass<*>, viewTag)
+    }
+
+    return view
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(
+    CppType.INT,
+    CppType.VIEW_TAG
+  )
+
+  override fun isTrivial(): Boolean = false
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth
 import expo.modules.PromiseMock
 import expo.modules.PromiseState
 import expo.modules.assertThrows
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.ArgumentCastException
 import expo.modules.kotlin.exception.InvalidArgsNumberException
@@ -26,7 +27,7 @@ class AnyFunctionTest {
       throw NullPointerException()
     }
 
-    override fun callUserImplementation(args: Array<Any?>, promise: Promise) {
+    override fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext) {
       error("Not implemented.")
     }
   }


### PR DESCRIPTION
# Why

Adds a converter for the `View` type.
If you're using our view, it will be converted from the view instance. If not, you can always pass the view tag. 

# How

- Added a front-end and back-end for view type. 
- Allowed conversion from int or expo view object to the view's class.

# Usage

```tsx
class ExpoView {
  nativeRef = React.createRef<NativeViewRef>();

  function() {
    return this.nativeRef.current?.function?.();
  }

  render() {
    return <NativeView nativeRef={this.nativeRef} />
  }
}
```

```kotlin
 AsyncFunction("function") { view: ExpoView ->
	// your code
 }
```
# Test Plan

- unit tests ✅
- clear function on expo-image