### PR TITLE
[ios][core] Pass AppContext to dynamic types and convertibles

### DIFF
--- a/packages/expo-clipboard/ios/Tests/ClipboardModuleSpec.swift
+++ b/packages/expo-clipboard/ios/Tests/ClipboardModuleSpec.swift
@@ -7,7 +7,7 @@ import MobileCoreServices
 
 class ClipboardModuleSpec: ExpoSpec {
   override func spec() {
-    let appContext = AppContext()
+    let appContext = AppContext.create()
     let holder = ModuleHolder(appContext: appContext, module: ClipboardModule(appContext: appContext))
 
     func testModuleFunction<T>(_ functionName: String, args: [Any], _ block: @escaping (T?) -> Void) {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method. ([#21661](https://github.com/expo/expo/pull/21661) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Removed the legacy implementation of view managers. ([#21760](https://github.com/expo/expo/pull/21760) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Passed the app context instance down to dynamic types, object builders and convertibles. ([#21819](https://github.com/expo/expo/pull/21819) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.2.6 - 2023-03-20
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -35,7 +35,7 @@ static NSString *modulesHostObjectLegacyPropertyName = @"ExpoModules";
 
 + (BOOL)installExpoModulesHostObject:(nonnull EXAppContext *)appContext
 {
-  EXJavaScriptRuntime *runtime = [appContext runtime];
+  EXJavaScriptRuntime *runtime = [appContext _runtime];
 
   // The runtime may be unavailable, e.g. remote debugger is enabled or it hasn't been set yet.
   if (!runtime) {

--- a/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
+++ b/packages/expo-modules-core/ios/JSI/ExpoModulesHostObject.mm
@@ -11,7 +11,7 @@ ExpoModulesHostObject::ExpoModulesHostObject(EXAppContext *appContext) : appCont
 
 ExpoModulesHostObject::~ExpoModulesHostObject() {
   modulesCache.clear();
-  [appContext setRuntime:nil];
+  appContext._runtime = nil;
 }
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertible.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertible.swift
@@ -2,16 +2,16 @@
 
 /**
  A protocol that allows custom classes or structs to be used as function arguments.
- It requires static `convert(from:)` function that knows how to convert incoming
+ It requires static `convert(from:appContext:)` function that knows how to convert incoming
  value of `Any` type to the type implemented by this protocol. It should throw an error
  when the value is not recognized, is invalid or doesn't meet type requirements.
  */
 public protocol Convertible: AnyArgument {
   /**
-   Converts any value to the instance of its class (or struct).
+   Converts any value to the instance of its class (or struct) in the given app context.
    Throws an error when given value cannot be converted.
    */
-  static func convert(from value: Any?) throws -> Self
+  static func convert(from value: Any?, appContext: AppContext) throws -> Self
 }
 
 @available(*, deprecated, renamed: "Convertible")

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -12,7 +12,7 @@ import CoreGraphics
 // MARK: - Foundation
 
 extension URL: Convertible {
-  public static func convert(from value: Any?) throws -> Self {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     guard let value = value as? String else {
       throw Conversions.ConvertingException<URL>(value)
     }
@@ -47,7 +47,7 @@ internal class UrlContainsInvalidCharactersException: Exception {
 // MARK: - CoreGraphics
 
 extension CGPoint: Convertible {
-  public static func convert(from value: Any?) throws -> CGPoint {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> CGPoint {
     if let value = value as? [Double], value.count == 2 {
       return CGPoint(x: value[0], y: value[1])
     }
@@ -60,7 +60,7 @@ extension CGPoint: Convertible {
 }
 
 extension CGSize: Convertible {
-  public static func convert(from value: Any?) throws -> CGSize {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> CGSize {
     if let value = value as? [Double], value.count == 2 {
       return CGSize(width: value[0], height: value[1])
     }
@@ -73,7 +73,7 @@ extension CGSize: Convertible {
 }
 
 extension CGVector: Convertible {
-  public static func convert(from value: Any?) throws -> CGVector {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> CGVector {
     if let value = value as? [Double], value.count == 2 {
       return CGVector(dx: value[0], dy: value[1])
     }
@@ -86,7 +86,7 @@ extension CGVector: Convertible {
 }
 
 extension CGRect: Convertible {
-  public static func convert(from value: Any?) throws -> CGRect {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> CGRect {
     if let value = value as? [Double], value.count == 4 {
       return CGRect(x: value[0], y: value[1], width: value[2], height: value[3])
     }

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -151,15 +151,15 @@ internal final class Conversions {
   /**
    Converts the function result to the type compatible with JavaScript.
    */
-  static func convertFunctionResult<ValueType>(_ value: ValueType?, runtime: JavaScriptRuntime? = nil) -> Any {
+  static func convertFunctionResult<ValueType>(_ value: ValueType?, appContext: AppContext? = nil) -> Any {
     if let value = value as? Record {
       return value.toDictionary()
     }
     if let value = value as? [Record] {
       return value.map { $0.toDictionary() }
     }
-    if let runtime = runtime, let value = value as? JavaScriptObjectBuilder {
-      return value.build(inRuntime: runtime)
+    if let appContext, let value = value as? JavaScriptObjectBuilder {
+      return try? value.build(appContext: appContext)
     }
     return value as Any
   }

--- a/packages/expo-modules-core/ios/Swift/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Convertibles+Color.swift
@@ -1,7 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 extension UIColor: Convertible {
-  public static func convert(from value: Any?) throws -> Self {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     // swiftlint:disable force_cast
     if let value = value as? String {
       if let namedColorComponents = namedColors[value] {
@@ -21,10 +21,10 @@ extension UIColor: Convertible {
 }
 
 extension CGColor: Convertible {
-  public static func convert(from value: Any?) throws -> Self {
+  public static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     // swiftlint:disable force_cast
     do {
-      return try UIColor.convert(from: value).cgColor as! Self
+      return try UIColor.convert(from: value, appContext: appContext).cgColor as! Self
     } catch _ as Conversions.ConvertingException<UIColor> {
       // Rethrow `ConvertingError` with proper type
       throw Conversions.ConvertingException<CGColor>(value)

--- a/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
+++ b/packages/expo-modules-core/ios/Swift/Convertibles/Either.swift
@@ -50,14 +50,16 @@ open class Either<FirstType, SecondType>: Convertible {
 
   // MARK: - Convertible
 
-  public class func convert(from value: Any?) throws -> Self {
-    for type in dynamicTypes() {
+  public class func convert(from value: Any?, appContext: AppContext) throws -> Self {
+    let dynamicTypes = dynamicTypes()
+
+    for type in dynamicTypes {
       // Initialize the "either" when the current type can cast given value.
-      if let value = try? type.cast(value) {
+      if let value = try? type.cast(value, appContext: appContext) {
         return Self(value)
       }
     }
-    throw NeitherTypeException(Self.dynamicTypes())
+    throw NeitherTypeException(dynamicTypes)
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
@@ -17,10 +17,16 @@ public protocol AnyDynamicType: CustomStringConvertible {
   func equals(_ type: AnyDynamicType) -> Bool
 
   /**
-   Casts given any value to the wrapped type and returns as `Any`.
+   Casts the given value to the wrapped type and returns it as `Any`.
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `Convertible`).
    */
-  func cast<ValueType>(_ value: ValueType) throws -> Any
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any
+}
+
+extension AnyDynamicType {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    return value
+  }
 }
 
 // MARK: - Operators

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicArrayType.swift
@@ -21,13 +21,13 @@ internal struct DynamicArrayType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     if let value = value as? [Any] {
-      return try value.map { try elementType.cast($0) }
+      return try value.map { try elementType.cast($0, appContext: appContext) }
     }
     // We should probably throw an error if we get here. On the other side, the array type
     // requirement can be more loosen so we can try to arrayize values that are not arrays.
-    return [try elementType.cast(value)]
+    return [try elementType.cast(value, appContext: appContext)]
   }
 
   var description: String {

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicConvertibleType.swift
@@ -17,8 +17,8 @@ internal struct DynamicConvertibleType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
-    return try innerType.convert(from: value)
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    return try innerType.convert(from: value, appContext: appContext)
   }
 
   var description: String {

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicEnumType.swift
@@ -17,7 +17,7 @@ internal struct DynamicEnumType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     return try innerType.create(fromRawValue: value)
   }
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicOptionalType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicOptionalType.swift
@@ -21,11 +21,11 @@ internal struct DynamicOptionalType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     if Optional.isNil(value) || value is NSNull {
       return Optional<Any>.none as Any
     }
-    return try wrappedType.cast(value)
+    return try wrappedType.cast(value, appContext: appContext)
   }
 
   var description: String {

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicRawType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicRawType.swift
@@ -15,7 +15,7 @@ internal struct DynamicRawType<InnerType>: AnyDynamicType {
     return type is Self
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     if let value = value as? InnerType {
       return value
     }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
@@ -17,7 +17,7 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     if let value = value as? SharedObject, type(of: value) == innerType {
       // Given value is a shared object already
       return value

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
@@ -14,7 +14,7 @@ internal struct DynamicTypedArrayType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType) throws -> Any {
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     // It must be a JavaScript typed array.
     guard let value = value as? JavaScriptValue, let jsTypedArray = value.getTypedArray() else {
       throw NotTypedArrayException(innerType)

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -46,7 +46,7 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
         guard let self = self, let bridge = self.appContext.reactBridge else {
           return
         }
-        self.appContext.runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
+        self.appContext._runtime = EXJavaScriptRuntimeManager.runtime(fromBridge: bridge)
       }
 
       if bridge.responds(to: Selector(("runtime"))) {

--- a/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/AnyFunction.swift
@@ -41,9 +41,10 @@ internal protocol AnyFunction: AnyDefinition, JavaScriptObjectBuilder {
       - args: An array of arguments to pass to the function. They could be Swift primitives
       when invoked through the bridge and in unit tests or `JavaScriptValue`s
       when the function is called through the JSI.
+      - appContext: An app context where the function is being executed.
       - callback: A callback that receives a result of the function execution.
    */
-  func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> ())
+  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ())
 }
 
 extension AnyFunction {
@@ -65,12 +66,12 @@ extension AnyFunction {
   }
 
   /**
-   Calls the function just like `call(by:withArguments:callback:)`, but without an owner
+   Calls the function just like `call(by:withArguments:appContext:callback:)`, but without an owner
    and with an empty callback. Might be useful when you only want to call the function,
    but don't care about the result.
    */
-  func call(withArguments args: [Any]) {
-    call(by: nil, withArguments: args, callback: { _ in })
+  func call(withArguments args: [Any], appContext: AppContext) {
+    call(by: nil, withArguments: args, appContext: appContext, callback: { _ in })
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -10,9 +10,10 @@ internal protocol AnySyncFunctionComponent: AnyFunction {
      - owner: An object that calls this function. If the `takesOwner` property is true
        and type of the first argument matches the owner type, it's being passed as the argument.
      - args: An array of arguments to pass to the function. The arguments must be of the same type as in the underlying closure.
+     - appContext: An app context where the function is executed.
    - Returns: A value returned by the called function when succeeded or an error when it failed.
    */
-  func call(by owner: AnyObject?, withArguments args: [Any]) throws -> Any
+  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any
 }
 
 /**
@@ -49,9 +50,9 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
 
   var takesOwner: Bool = false
 
-  func call(by owner: AnyObject?, withArguments args: [Any], callback: @escaping (FunctionCallResult) -> ()) {
+  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {
     do {
-      let result = try call(by: owner, withArguments: args)
+      let result = try call(by: owner, withArguments: args, appContext: appContext)
       callback(.success(Conversions.convertFunctionResult(result)))
     } catch let error as Exception {
       callback(.failure(error))
@@ -62,16 +63,17 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
 
   // MARK: - AnySyncFunctionComponent
 
-  func call(by owner: AnyObject?, withArguments args: [Any]) throws -> Any {
+  func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
     do {
       let arguments = concat(
-        arguments: try cast(arguments: args, forFunction: self),
+        arguments: try cast(arguments: args, forFunction: self, appContext: appContext),
         withOwner: owner,
-        forFunction: self
+        forFunction: self,
+        appContext: appContext
       )
       let argumentsTuple = try Conversions.toTuple(arguments) as! Args
       let result = try body(argumentsTuple)
-      return Conversions.convertFunctionResult(result)
+      return Conversions.convertFunctionResult(result, appContext: appContext)
     } catch let error as Exception {
       throw FunctionCallException(name).causedBy(error)
     } catch {
@@ -81,17 +83,17 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
 
   // MARK: - JavaScriptObjectBuilder
 
-  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
+  func build(appContext: AppContext) throws -> JavaScriptObject {
     // We intentionally capture a strong reference to `self`, otherwise the "detached" objects would
     // immediately lose the reference to the definition and thus the underlying native function.
     // It may potentially cause memory leaks, but at the time of writing this comment,
     // the native definition instance deallocates correctly when the JS VM triggers the garbage collector.
-    return runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak runtime, self] this, args in
-      guard let runtime = runtime else {
-        throw Exceptions.RuntimeLost()
+    return try appContext.runtime.createSyncFunction(name, argsCount: argumentsCount) { [weak appContext, self] this, args in
+      guard let appContext else {
+        throw Exceptions.AppContextLost()
       }
-      let result = try self.call(by: this, withArguments: args)
-      return Conversions.convertFunctionResult(result, runtime: runtime)
+      let result = try self.call(by: this, withArguments: args, appContext: appContext)
+      return Conversions.convertFunctionResult(result, appContext: appContext)
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/ModuleDefinition.swift
@@ -65,12 +65,12 @@ public final class ModuleDefinition: ObjectDefinition {
     return self
   }
 
-  public override func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
-    let object = super.build(inRuntime: runtime)
+  public override func build(appContext: AppContext) throws -> JavaScriptObject {
+    let object = try super.build(appContext: appContext)
 
     if let viewManager {
-      let reactComponentPrototype = runtime.createObject()
-      viewManager.decorateWithFunctions(runtime: runtime, object: reactComponentPrototype)
+      let reactComponentPrototype = try appContext.runtime.createObject()
+      try viewManager.decorateWithFunctions(object: reactComponentPrototype, appContext: appContext)
       object.setProperty("ViewPrototype", value: reactComponentPrototype)
     }
 

--- a/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/JavaScriptObjectBuilder.swift
@@ -7,7 +7,7 @@ internal protocol JavaScriptObjectDecorator {
   /**
    Decorates an existing `JavaScriptObject`.
    */
-  func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime)
+  func decorate(object: JavaScriptObject, appContext: AppContext) throws
 }
 
 /**
@@ -15,23 +15,23 @@ internal protocol JavaScriptObjectDecorator {
  */
 internal protocol JavaScriptObjectBuilder: JavaScriptObjectDecorator {
   /**
-   Creates a decorated `JavaScriptObject` in the given runtime.
+   Creates a decorated `JavaScriptObject` in the given app context.
    */
-  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject
+  func build(appContext: AppContext) throws -> JavaScriptObject
 }
 
 /**
  Provides the default behavior of `JavaScriptObjectBuilder`.
- The `build(inRuntime:)` creates a plain object and uses `decorate(object:)` for decoration.
+ The `build(appContext:)` creates a plain object and uses `decorate(object:appContext:)` for decoration.
  */
 extension JavaScriptObjectBuilder {
-  func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
-    let object = runtime.createObject()
-    decorate(object: object, inRuntime: runtime)
+  func build(appContext: AppContext) throws -> JavaScriptObject {
+    let object = try appContext.runtime.createObject()
+    try decorate(object: object, appContext: appContext)
     return object
   }
 
-  func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime) {
+  func decorate(object: JavaScriptObject, appContext: AppContext) throws {
     // no-op by default
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/ObjectDefinition.swift
@@ -61,43 +61,45 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
 
   // MARK: - JavaScriptObjectBuilder
 
-  public func build(inRuntime runtime: JavaScriptRuntime) -> JavaScriptObject {
-    let object = runtime.createObject()
-    decorate(object: object, inRuntime: runtime)
+  public func build(appContext: AppContext) throws -> JavaScriptObject {
+    let object = try appContext.runtime.createObject()
+    try decorate(object: object, appContext: appContext)
     return object
   }
 
-  public func decorate(object: JavaScriptObject, inRuntime runtime: JavaScriptRuntime) {
-    decorateWithConstants(runtime: runtime, object: object)
-    decorateWithFunctions(runtime: runtime, object: object)
-    decorateWithProperties(runtime: runtime, object: object)
-    decorateWithClasses(runtime: runtime, object: object)
+  public func decorate(object: JavaScriptObject, appContext: AppContext) throws {
+    let runtime = try appContext.runtime
+
+    decorateWithConstants(object: object)
+    try decorateWithFunctions(object: object, appContext: appContext)
+    try decorateWithProperties(object: object, appContext: appContext)
+    try decorateWithClasses(object: object, appContext: appContext)
   }
 
   // MARK: - Internals
 
-  internal func decorateWithConstants(runtime: JavaScriptRuntime, object: JavaScriptObject) {
+  internal func decorateWithConstants(object: JavaScriptObject) {
     for (key, value) in getConstants() {
       object.setProperty(key, value: value)
     }
   }
 
-  internal func decorateWithFunctions(runtime: JavaScriptRuntime, object: JavaScriptObject) {
+  internal func decorateWithFunctions(object: JavaScriptObject, appContext: AppContext) throws {
     for fn in functions.values {
-      object.setProperty(fn.name, value: fn.build(inRuntime: runtime))
+      object.setProperty(fn.name, value: try fn.build(appContext: appContext))
     }
   }
 
-  internal func decorateWithProperties(runtime: JavaScriptRuntime, object: JavaScriptObject) {
+  internal func decorateWithProperties(object: JavaScriptObject, appContext: AppContext) throws {
     for property in properties.values {
-      let descriptor = property.buildDescriptor(inRuntime: runtime)
+      let descriptor = try property.buildDescriptor(appContext: appContext)
       object.defineProperty(property.name, descriptor: descriptor)
     }
   }
 
-  internal func decorateWithClasses(runtime: JavaScriptRuntime, object: JavaScriptObject) {
+  internal func decorateWithClasses(object: JavaScriptObject, appContext: AppContext) throws {
     for klass in classes.values {
-      object.setProperty(klass.name, value: klass.build(inRuntime: runtime))
+      object.setProperty(klass.name, value: try klass.build(appContext: appContext))
     }
   }
 }

--- a/packages/expo-modules-core/ios/Swift/Records/AnyField.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/AnyField.swift
@@ -19,5 +19,5 @@ internal protocol AnyFieldInternal: AnyField {
    */
   var isRequired: Bool { get }
 
-  func set(_ newValue: Any?) throws
+  func set(_ newValue: Any?, appContext: AppContext) throws
 }

--- a/packages/expo-modules-core/ios/Swift/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Field.swift
@@ -74,12 +74,12 @@ public final class Field<Type>: AnyFieldInternal {
   /**
    Sets the wrapped value with a value of `Any` type.
    */
-  internal func set(_ newValue: Any?) throws {
+  internal func set(_ newValue: Any?, appContext: AppContext) throws {
     if newValue == nil && (!isOptional || isRequired) {
       throw FieldRequiredException(key!)
     }
     do {
-      if let value = try fieldType.cast(newValue) as? Type {
+      if let value = try fieldType.cast(newValue, appContext: appContext) as? Type {
         wrappedValue = value
       }
     } catch {

--- a/packages/expo-modules-core/ios/Swift/Records/Record.swift
+++ b/packages/expo-modules-core/ios/Swift/Records/Record.swift
@@ -15,7 +15,7 @@ public protocol Record: Convertible {
   /**
    Initializes a record from given dictionary. Only members wrapped by `@Field` will be set in the object.
    */
-  init(from: Dict) throws
+  init(from: Dict, appContext: AppContext) throws
 
   /**
    Converts the record back to the dictionary. Only members wrapped by `@Field` will be set in the dictionary.
@@ -27,14 +27,14 @@ public protocol Record: Convertible {
  Provides the default implementation of `Record` protocol.
  */
 public extension Record {
-  static func convert(from value: Any?) throws -> Self {
+  static func convert(from value: Any?, appContext: AppContext) throws -> Self {
     if let value = value as? Dict {
-      return try Self(from: value)
+      return try Self(from: value, appContext: appContext)
     }
     throw Conversions.ConvertingException<Self>(value)
   }
 
-  init(from dict: Dict) throws {
+  init(from dict: Dict, appContext: AppContext) throws {
     self.init()
 
     let dictKeys = dict.keys
@@ -45,7 +45,7 @@ public extension Record {
         return
       }
       if dictKeys.contains(key) || field.isRequired {
-        try field.set(dict[key])
+        try field.set(dict[key], appContext: appContext)
       }
     }
   }

--- a/packages/expo-modules-core/ios/Swift/Views/AnyViewProp.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/AnyViewProp.swift
@@ -12,5 +12,5 @@ public protocol AnyViewProp: ViewManagerDefinitionComponent {
   /**
    Function that sets the underlying prop value for given view.
    */
-  func set(value: Any, onView: UIView) throws
+  func set(value: Any, onView: UIView, appContext: AppContext) throws
 }

--- a/packages/expo-modules-core/ios/Swift/Views/ConcreteViewProp.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ConcreteViewProp.swift
@@ -32,13 +32,13 @@ public final class ConcreteViewProp<ViewType: UIView, PropType: AnyArgument>: An
   /**
    Function that sets the underlying prop value for given view.
    */
-  public func set(value: Any, onView view: UIView) throws {
+  public func set(value: Any, onView view: UIView, appContext: AppContext) throws {
     // Method's signature must be type-erased to conform to `AnyViewProp` protocol.
     // Given view must be castable to the generic `ViewType` type.
     guard let view = view as? ViewType else {
       throw IncompatibleViewException((propName: name, viewType: ViewType.self))
     }
-    guard let value = try propType.cast(value) as? PropType else {
+    guard let value = try propType.cast(value, appContext: appContext) as? PropType else {
       throw Conversions.CastingException<PropType>(value)
     }
     setter(view, value)

--- a/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ViewModuleWrapper.swift
@@ -104,7 +104,9 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
    */
   @objc
   public func set_proxiedProperties(_ json: Any, forView view: UIView, withDefaultView defaultView: UIView) {
-    guard let json = json as? [String: Any], let viewManager = wrappedModuleHolder.definition.viewManager else {
+    guard let json = json as? [String: Any],
+          let viewManager = wrappedModuleHolder.definition.viewManager,
+          let appContext = wrappedModuleHolder.appContext else {
       return
     }
     let props = viewManager.propsDict()
@@ -115,7 +117,7 @@ public final class ViewModuleWrapper: RCTViewManager, DynamicModuleWrapperProtoc
       // TODO: @tsapeta: Figure out better way to rethrow errors from here.
       // Adding `throws` keyword to the function results in different
       // method signature in Objective-C. Maybe just call `RCTLogError`?
-      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view)
+      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view, appContext: appContext)
     }
     viewManager.callLifecycleMethods(withType: .didUpdateProps, forView: view)
   }

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -32,9 +32,9 @@ class ClassComponentSpec: ExpoSpec {
       }
 
       it("builds a class") {
-        let runtime = JavaScriptRuntime()
+        let appContext = AppContext.create()
         let klass = Class("") {}
-        let object = klass.build(inRuntime: runtime)
+        let object = try klass.build(appContext: appContext)
 
         expect(object.hasProperty("prototype")) == true
         expect(object.getProperty("prototype").kind) == .object
@@ -43,7 +43,7 @@ class ClassComponentSpec: ExpoSpec {
 
     describe("module") {
       let appContext = AppContext.create()
-      let runtime = appContext.runtime
+      let runtime = try! appContext.runtime
 
       beforeSuite {
         class ClassTestModule: Module {
@@ -67,72 +67,72 @@ class ClassComponentSpec: ExpoSpec {
       }
 
       it("is a function") {
-        let klass = try runtime?.eval("expo.modules.ClassTest.MyClass")
-        expect(klass?.isFunction()) == true
+        let klass = try runtime.eval("expo.modules.ClassTest.MyClass")
+        expect(klass.isFunction()) == true
       }
 
       it("has a name") {
-        let klass = try runtime?.eval("expo.modules.ClassTest.MyClass.name")
-        expect(klass?.getString()) == "MyClass"
+        let klass = try runtime.eval("expo.modules.ClassTest.MyClass.name")
+        expect(klass.getString()) == "MyClass"
       }
 
       it("has a prototype") {
-        let prototype = try runtime?.eval("expo.modules.ClassTest.MyClass.prototype")
-        expect(prototype?.isObject()) == true
+        let prototype = try runtime.eval("expo.modules.ClassTest.MyClass.prototype")
+        expect(prototype.isObject()) == true
       }
 
       it("has keys in prototype") {
-        let prototypeKeys = try runtime?.eval("Object.keys(expo.modules.ClassTest.MyClass.prototype)")
+        let prototypeKeys = try runtime.eval("Object.keys(expo.modules.ClassTest.MyClass.prototype)")
           .getArray()
-          .map { $0.getString() } ?? []
+          .map { $0.getString() }
 
         expect(prototypeKeys).to(contain("myFunction"))
         expect(prototypeKeys).notTo(contain("__native_constructor__"))
       }
 
       it("is an instance of") {
-        let isInstanceOf = try runtime?.eval([
+        let isInstanceOf = try runtime.eval([
           "myObject = new expo.modules.ClassTest.MyClass()",
           "myObject instanceof expo.modules.ClassTest.MyClass",
         ])
 
-        expect(isInstanceOf?.getBool()) == true
+        expect(isInstanceOf.getBool()) == true
       }
 
       it("defines properties on initialization") {
         // The properties are not specified in the prototype, but defined during initialization.
-        let object = try runtime?.eval("new expo.modules.ClassTest.MyClass()").asObject()
-        expect(object?.getPropertyNames()).to(contain("foo"))
-        expect(object?.getProperty("foo").getString()) == "bar"
+        let object = try runtime.eval("new expo.modules.ClassTest.MyClass()").asObject()
+        expect(object.getPropertyNames()).to(contain("foo"))
+        expect(object.getProperty("foo").getString()) == "bar"
       }
     }
 
     describe("class with associated type") {
       let appContext = AppContext.create()
-      let runtime = appContext.runtime
+      let runtime = try! appContext.runtime
 
       beforeSuite {
         appContext.moduleRegistry.register(moduleType: ModuleWithCounterClass.self)
       }
       it("is defined") {
-        let isDefined = try! runtime!.eval("'Counter' in expo.modules.TestModule")
+        let isDefined = try runtime.eval("'Counter' in expo.modules.TestModule")
 
         expect(isDefined.getBool()) == true
       }
       it("creates shared object") {
-        let jsObject = try! runtime!.eval("new expo.modules.TestModule.Counter(0)").getObject()
+        let jsObject = try runtime.eval("new expo.modules.TestModule.Counter(0)").getObject()
         let nativeObject = SharedObjectRegistry.toNativeObject(jsObject)
 
         expect(nativeObject).notTo(beNil())
       }
       it("registers shared object") {
         let oldSize = SharedObjectRegistry.size
-        try! runtime?.eval("object = new expo.modules.TestModule.Counter(0)")
+        try runtime.eval("object = new expo.modules.TestModule.Counter(0)")
 
         expect(SharedObjectRegistry.size) == oldSize + 1
       }
       it("calls function with owner") {
-        try runtime?.eval([
+        try runtime.eval([
           "object = new expo.modules.TestModule.Counter(0)",
           "object.increment(1)",
         ])
@@ -140,7 +140,7 @@ class ClassComponentSpec: ExpoSpec {
       }
       it("creates with initial value") {
         let initialValue = Int.random(in: 1..<100)
-        let value = try runtime!.eval([
+        let value = try runtime.eval([
           "object = new expo.modules.TestModule.Counter(\(initialValue))",
           "object.getValue()",
         ])
@@ -149,7 +149,7 @@ class ClassComponentSpec: ExpoSpec {
         expect(value.getInt()) == initialValue
       }
       it("gets shared object value") {
-        let value = try runtime!.eval([
+        let value = try runtime.eval([
           "object = new expo.modules.TestModule.Counter(0)",
           "object.getValue()",
         ])
@@ -158,10 +158,10 @@ class ClassComponentSpec: ExpoSpec {
         expect(value.isNumber()) == true
       }
       it("changes shared object") {
-        try! runtime?.eval("object = new expo.modules.TestModule.Counter(0)")
+        try runtime.eval("object = new expo.modules.TestModule.Counter(0)")
         let incrementBy = Int.random(in: 1..<100)
-        let value = try runtime!.eval("object.getValue()").asInt()
-        let newValue = try runtime!.eval([
+        let value = try runtime.eval("object.getValue()").asInt()
+        let newValue = try runtime.eval([
           "object.increment(\(incrementBy))",
           "object.getValue()",
         ])
@@ -172,7 +172,7 @@ class ClassComponentSpec: ExpoSpec {
 
       it("gets value from the dynamic property") {
         let initialValue = Int.random(in: 1..<100)
-        let value = try runtime!.eval([
+        let value = try runtime.eval([
           "object = new expo.modules.TestModule.Counter(\(initialValue))",
           "object.currentValue"
         ])

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -7,10 +7,12 @@ import ExpoModulesTestCore
 
 class ConvertiblesSpec: ExpoSpec {
   override func spec() {
+    let appContext = AppContext.create()
+
     describe("URL") {
       it("converts from remote url") {
         let remoteUrlString = "https://expo.dev"
-        let url = try URL.convert(from: remoteUrlString)
+        let url = try URL.convert(from: remoteUrlString, appContext: appContext)
 
         expect(url.path) == ""
         expect(url.absoluteString) == remoteUrlString
@@ -19,7 +21,7 @@ class ConvertiblesSpec: ExpoSpec {
       it("converts from url with unencoded query") {
         let query = "param=🥓"
         let urlString = "https://expo.dev/?\(query)"
-        let url = try URL.convert(from: urlString)
+        let url = try URL.convert(from: urlString, appContext: appContext)
 
         if #available(iOS 16.0, *) {
           expect(url.query(percentEncoded: true)) == "param=%F0%9F%A5%93"
@@ -33,7 +35,7 @@ class ConvertiblesSpec: ExpoSpec {
       it("converts from url with encoded query") {
         let query = "param=%F0%9F%A5%93"
         let urlString = "https://expo.dev/?\(query)"
-        let url = try URL.convert(from: urlString)
+        let url = try URL.convert(from: urlString, appContext: appContext)
 
         if #available(iOS 16.0, *) {
           expect(url.query(percentEncoded: true)) == query
@@ -47,7 +49,7 @@ class ConvertiblesSpec: ExpoSpec {
       it("converts from url with encoded query containg the anchor") {
         let query = "color=%230000ff"
         let urlString = "https://expo.dev/?\(query)#anchor"
-        let url = try URL.convert(from: urlString)
+        let url = try URL.convert(from: urlString, appContext: appContext)
 
         expect(url.query) == query
         expect(url.absoluteString) == urlString
@@ -58,7 +60,7 @@ class ConvertiblesSpec: ExpoSpec {
       it("converts from url with encoded path") {
         let path = "/expo/%2F%25%3F%5E%26/test" // -> /expo//%?^&/test
         let urlString = "https://expo.dev\(path)"
-        let url = try URL.convert(from: urlString)
+        let url = try URL.convert(from: urlString, appContext: appContext)
 
         expect(url.absoluteString) == urlString
         expect(url.path) == path.removingPercentEncoding
@@ -73,7 +75,7 @@ class ConvertiblesSpec: ExpoSpec {
         // The percent character alone must be percent-encoded to `%25` beforehand, otherwise it should throw an exception.
         let urlString = "https://expo.dev/?param=%"
 
-        expect({ try URL.convert(from: urlString) }).to(throwError(errorType: UrlContainsInvalidCharactersException.self))
+        expect({ try URL.convert(from: urlString, appContext: appContext) }).to(throwError(errorType: UrlContainsInvalidCharactersException.self))
       }
 
       it("converts from url containing the anchor") {
@@ -82,7 +84,7 @@ class ConvertiblesSpec: ExpoSpec {
         // thus it cannot be percent-encoded.
         let query = "param=#expo"
         let urlString = "https://expo.dev/?\(query)"
-        let url = try URL.convert(from: urlString)
+        let url = try URL.convert(from: urlString, appContext: appContext)
 
         expect(url.query) == "param="
         expect(url.fragment) == "expo"
@@ -91,7 +93,7 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("converts from file url") {
         let fileUrlString = "file:///expo/tmp"
-        let url = try URL.convert(from: fileUrlString)
+        let url = try URL.convert(from: fileUrlString, appContext: appContext)
 
         expect(url.path) == "/expo/tmp"
         expect(url.absoluteString) == fileUrlString
@@ -100,7 +102,7 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("converts from file path") {
         let filePath = "/expo/image.png"
-        let url = try URL.convert(from: filePath)
+        let url = try URL.convert(from: filePath, appContext: appContext)
 
         expect(url.scheme) == "file"
         expect(url.path) == filePath
@@ -110,7 +112,7 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("converts from file path with UTF8 characters") {
         let filePath = "/中文ÅÄÖąÓśĆñ.gif"
-        let url = try URL.convert(from: filePath)
+        let url = try URL.convert(from: filePath, appContext: appContext)
 
         expect(url.scheme) == "file"
         expect(url.path) == filePath
@@ -119,7 +121,7 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("converts from file path containing percent character") {
         let filePath = "/%.png"
-        let url = try URL.convert(from: filePath)
+        let url = try URL.convert(from: filePath, appContext: appContext)
 
         expect(url.scheme) == "file"
         expect(url.path) == filePath
@@ -127,7 +129,7 @@ class ConvertiblesSpec: ExpoSpec {
       }
 
       it("throws when no string") {
-        expect { try URL.convert(from: 29.5) }.to(
+        expect { try URL.convert(from: 29.5, appContext: appContext) }.to(
           throwError(errorType: Conversions.ConvertingException<URL>.self)
         )
       }
@@ -138,34 +140,40 @@ class ConvertiblesSpec: ExpoSpec {
       let y = 4.6
 
       it("converts from array of doubles") {
-        let point = try CGPoint.convert(from: [x, y])
+        let point = try CGPoint.convert(from: [x, y], appContext: appContext)
 
         expect(point.x) == x
         expect(point.y) == y
       }
 
       it("converts from dict") {
-        let point = try CGPoint.convert(from: ["x": x, "y": y])
+        let point = try CGPoint.convert(from: ["x": x, "y": y], appContext: appContext)
 
         expect(point.x) == x
         expect(point.y) == y
       }
 
       it("throws when array size is unexpected") { // different than two
-        expect { try CGPoint.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingException<CGPoint>.self))
-        expect { try CGPoint.convert(from: [x]) }.to(throwError(errorType: Conversions.ConvertingException<CGPoint>.self))
-        expect { try CGPoint.convert(from: [x, y, x]) }.to(throwError(errorType: Conversions.ConvertingException<CGPoint>.self))
+        expect { try CGPoint.convert(from: [], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGPoint>.self)
+        )
+        expect { try CGPoint.convert(from: [x], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGPoint>.self)
+        )
+        expect { try CGPoint.convert(from: [x, y, x], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGPoint>.self)
+        )
       }
 
       it("throws when dict is missing some keys") {
-        expect { try CGPoint.convert(from: ["test": x]) }.to(throwError {
+        expect { try CGPoint.convert(from: ["test": x], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.MissingKeysException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.MissingKeysException<Double>(["x", "y"]).description
         })
       }
 
       it("throws when dict has uncastable keys") {
-        expect { try CGPoint.convert(from: ["x": x, "y": "string"]) }.to(throwError {
+        expect { try CGPoint.convert(from: ["x": x, "y": "string"], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.CastingValuesException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.CastingValuesException<Double>(["y"]).description
         })
@@ -177,34 +185,40 @@ class ConvertiblesSpec: ExpoSpec {
       let height = 81.7
 
       it("converts from array of doubles") {
-        let size = try CGSize.convert(from: [width, height])
+        let size = try CGSize.convert(from: [width, height], appContext: appContext)
 
         expect(size.width) == width
         expect(size.height) == height
       }
 
       it("converts from dict") {
-        let size = try CGSize.convert(from: ["width": width, "height": height])
+        let size = try CGSize.convert(from: ["width": width, "height": height], appContext: appContext)
 
         expect(size.width) == width
         expect(size.height) == height
       }
 
       it("throws when array size is unexpected") { // different than two
-        expect { try CGSize.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingException<CGSize>.self))
-        expect { try CGSize.convert(from: [width]) }.to(throwError(errorType: Conversions.ConvertingException<CGSize>.self))
-        expect { try CGSize.convert(from: [width, height, width]) }.to(throwError(errorType: Conversions.ConvertingException<CGSize>.self))
+        expect { try CGSize.convert(from: [], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGSize>.self)
+        )
+        expect { try CGSize.convert(from: [width], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGSize>.self)
+        )
+        expect { try CGSize.convert(from: [width, height, width], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGSize>.self)
+        )
       }
 
       it("throws when dict is missing some keys") {
-        expect { try CGSize.convert(from: ["width": width]) }.to(throwError {
+        expect { try CGSize.convert(from: ["width": width], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.MissingKeysException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.MissingKeysException<Double>(["height"]).description
         })
       }
 
       it("throws when dict has uncastable keys") {
-        expect { try CGSize.convert(from: ["width": "test", "height": height]) }.to(throwError {
+        expect { try CGSize.convert(from: ["width": "test", "height": height], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.CastingValuesException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.CastingValuesException<Double>(["width"]).description
         })
@@ -216,34 +230,40 @@ class ConvertiblesSpec: ExpoSpec {
       let dy = -4.0
 
       it("converts from array of doubles") {
-        let vector = try CGVector.convert(from: [dx, dy])
+        let vector = try CGVector.convert(from: [dx, dy], appContext: appContext)
 
         expect(vector.dx) == dx
         expect(vector.dy) == dy
       }
 
       it("converts from dict") {
-        let vector = try CGVector.convert(from: ["dx": dx, "dy": dy])
+        let vector = try CGVector.convert(from: ["dx": dx, "dy": dy], appContext: appContext)
 
         expect(vector.dx) == dx
         expect(vector.dy) == dy
       }
 
       it("throws when array size is unexpected") { // different than two
-        expect { try CGVector.convert(from: []) }.to(throwError(errorType: Conversions.ConvertingException<CGVector>.self))
-        expect { try CGVector.convert(from: [dx]) }.to(throwError(errorType: Conversions.ConvertingException<CGVector>.self))
-        expect { try CGVector.convert(from: [dx, dy, dx]) }.to(throwError(errorType: Conversions.ConvertingException<CGVector>.self))
+        expect { try CGVector.convert(from: [], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGVector>.self)
+        )
+        expect { try CGVector.convert(from: [dx], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGVector>.self)
+        )
+        expect { try CGVector.convert(from: [dx, dy, dx], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGVector>.self)
+        )
       }
 
       it("throws when dict is missing some keys") {
-        expect { try CGVector.convert(from: ["dx": dx]) }.to(throwError {
+        expect { try CGVector.convert(from: ["dx": dx], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.MissingKeysException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.MissingKeysException<Double>(["dy"]).description
         })
       }
 
       it("throws when dict has uncastable keys") {
-        expect { try CGVector.convert(from: ["dx": "dx", "dy": dy]) }.to(throwError {
+        expect { try CGVector.convert(from: ["dx": "dx", "dy": dy], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.CastingValuesException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.CastingValuesException<Double>(["dx"]).description
         })
@@ -257,7 +277,7 @@ class ConvertiblesSpec: ExpoSpec {
       let height = 81.7
 
       it("converts from array of doubles") {
-        let rect = try CGRect.convert(from: [x, y, width, height])
+        let rect = try CGRect.convert(from: [x, y, width, height], appContext: appContext)
 
         expect(rect.origin.x) == x
         expect(rect.origin.y) == y
@@ -266,7 +286,7 @@ class ConvertiblesSpec: ExpoSpec {
       }
 
       it("converts from dict") {
-        let rect = try CGRect.convert(from: ["x": x, "y": y, "width": width, "height": height])
+        let rect = try CGRect.convert(from: ["x": x, "y": y, "width": width, "height": height], appContext: appContext)
 
         expect(rect.origin.x) == x
         expect(rect.origin.y) == y
@@ -275,20 +295,26 @@ class ConvertiblesSpec: ExpoSpec {
       }
 
       it("throws when array size is unexpected") { // different than four
-        expect { try CGRect.convert(from: [x]) }.to(throwError(errorType: Conversions.ConvertingException<CGRect>.self))
-        expect { try CGRect.convert(from: [x, y]) }.to(throwError(errorType: Conversions.ConvertingException<CGRect>.self))
-        expect { try CGRect.convert(from: [x, y, width, height, y]) }.to(throwError(errorType: Conversions.ConvertingException<CGRect>.self))
+        expect { try CGRect.convert(from: [x], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGRect>.self)
+        )
+        expect { try CGRect.convert(from: [x, y], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGRect>.self)
+        )
+        expect { try CGRect.convert(from: [x, y, width, height, y], appContext: appContext) }.to(
+          throwError(errorType: Conversions.ConvertingException<CGRect>.self)
+        )
       }
 
       it("throws when dict is missing some keys") {
-        expect { try CGRect.convert(from: ["x": x]) }.to(throwError {
+        expect { try CGRect.convert(from: ["x": x], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.MissingKeysException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.MissingKeysException<Double>(["y", "width", "height"]).description
         })
       }
 
       it("throws when dict has uncastable keys") {
-        expect { try CGRect.convert(from: ["x": x, "y": nil, "width": width, "height": "\(height)"]) }.to(throwError {
+        expect { try CGRect.convert(from: ["x": x, "y": nil, "width": width, "height": "\(height)"], appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.CastingValuesException<Double>.self))
           expect(($0 as! CodedError).description) == Conversions.CastingValuesException<Double>(["y", "height"]).description
         })
@@ -303,7 +329,7 @@ class ConvertiblesSpec: ExpoSpec {
         expect(color.components?[3]) == alpha / 255.0
       }
       func testInvalidHexColor(_ hex: String) {
-        expect { try CGColor.convert(from: hex) }.to(throwError {
+        expect { try CGColor.convert(from: hex, appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.InvalidHexColorException.self))
           expect(($0 as! CodedError).description) == Conversions.InvalidHexColorException(hex).description
         })
@@ -311,37 +337,37 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("converts from ARGB int") {
         // NOTE: int representation has alpha channel at the beginning
-        let color = try CGColor.convert(from: 0x5147AC7F)
+        let color = try CGColor.convert(from: 0x5147AC7F, appContext: appContext)
         testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
       }
 
       it("converts from RGBA hex string") {
-        let color = try CGColor.convert(from: "47AC7F51")
+        let color = try CGColor.convert(from: "47AC7F51", appContext: appContext)
         testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
       }
 
       it("converts from #RGBA hex string") {
-        let color = try CGColor.convert(from: " #47AC7F51")
+        let color = try CGColor.convert(from: " #47AC7F51", appContext: appContext)
         testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)
       }
 
       it("converts from 3-character shorthand hex string") {
-        let color = try CGColor.convert(from: "C2B ")
+        let color = try CGColor.convert(from: "C2B ", appContext: appContext)
         testColorComponents(color, 0xCC, 0x22, 0xBB, 0xFF)
       }
 
       it("converts from 4-character shorthand hex string") {
-        let color = try CGColor.convert(from: " #9EA5 ")
+        let color = try CGColor.convert(from: " #9EA5 ", appContext: appContext)
         testColorComponents(color, 0x99, 0xEE, 0xAA, 0x55)
       }
 
       it("converts from CSS named color") {
-        let papayawhip = try CGColor.convert(from: "papayawhip")
+        let papayawhip = try CGColor.convert(from: "papayawhip", appContext: appContext)
         testColorComponents(papayawhip, 0xFF, 0xEF, 0xD5, 0xFF)
       }
 
       it("converts from transparent") {
-        let transparent = try CGColor.convert(from: "transparent")
+        let transparent = try CGColor.convert(from: "transparent", appContext: appContext)
         expect(transparent.alpha) == .zero
       }
 
@@ -356,7 +382,7 @@ class ConvertiblesSpec: ExpoSpec {
 
       it("throws when int overflows") {
         let hex = 0xBBAA88FF2
-        expect { try CGColor.convert(from: hex) }.to(throwError {
+        expect { try CGColor.convert(from: hex, appContext: appContext) }.to(throwError {
           expect($0).to(beAKindOf(Conversions.HexColorOverflowException.self))
           expect(($0 as! CodedError).description) == Conversions.HexColorOverflowException(UInt64(hex)).description
         })

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -7,6 +7,8 @@ import ExpoModulesTestCore
 
 final class DynamicTypeSpec: ExpoSpec {
   override func spec() {
+    let appContext = AppContext.create()
+
     // MARK: - DynamicRawType
 
     describe("DynamicRawType") {
@@ -17,20 +19,20 @@ final class DynamicTypeSpec: ExpoSpec {
       }
       describe("casts") {
         it("succeeds") {
-          expect(try (~String.self).cast("expo") as? String) == "expo"
-          expect(try (~Double.self).cast(2.1) as? Double) == 2.1
-          expect(try (~Bool.self).cast(false) as? Bool) == false
+          expect(try (~String.self).cast("expo", appContext: appContext) as? String) == "expo"
+          expect(try (~Double.self).cast(2.1, appContext: appContext) as? Double) == 2.1
+          expect(try (~Bool.self).cast(false, appContext: appContext) as? Bool) == false
         }
         it("throws NullCastException") {
           let value: Double? = nil
           let anyValue = value as Any
 
-          expect { try (~Double.self).cast(anyValue) }.to(
+          expect { try (~Double.self).cast(anyValue, appContext: appContext) }.to(
             throwError(errorType: Conversions.NullCastException<Double>.self)
           )
         }
         it("throws CastingException") {
-          expect { try (~String.self).cast(true) }.to(
+          expect { try (~String.self).cast(true, appContext: appContext) }.to(
             throwError(errorType: Conversions.CastingException<String>.self)
           )
         }
@@ -72,13 +74,13 @@ final class DynamicTypeSpec: ExpoSpec {
       }
       describe("casts") {
         it("succeeds") {
-          expect(try (~[Double].self).cast([1.2, 3.4]) as? [Double]) == [1.2, 3.4]
-          expect(try (~[[String]].self).cast([["hello", "expo"]]) as? [[String]]) == [["hello", "expo"]]
+          expect(try (~[Double].self).cast([1.2, 3.4], appContext: appContext) as? [Double]) == [1.2, 3.4]
+          expect(try (~[[String]].self).cast([["hello", "expo"]], appContext: appContext) as? [[String]]) == [["hello", "expo"]]
         }
         it("casts arrays") {
           let value = 9.9
           let anyValue = [value] as [Any]
-          let result = try (~[Double].self).cast(anyValue) as! [Any]
+          let result = try (~[Double].self).cast(anyValue, appContext: appContext) as! [Any]
 
           expect(result).to(beAKindOf([Double].self))
           expect(result as? [Double]) == [value]
@@ -86,11 +88,11 @@ final class DynamicTypeSpec: ExpoSpec {
         it("arrayizes single element") {
           // The dynamic array type can arrayize the single element
           // if only the array element's dynamic type can cast it.
-          expect(try (~[Int].self).cast(50) as? [Int]) == [50]
-          expect(try (~[String].self).cast("not an array") as? [String]) == ["not an array"]
+          expect(try (~[Int].self).cast(50, appContext: appContext) as? [Int]) == [50]
+          expect(try (~[String].self).cast("not an array", appContext: appContext) as? [String]) == ["not an array"]
         }
         it("throws CastingException") {
-          expect { try (~[String].self).cast(84) }.to(
+          expect { try (~[String].self).cast(84, appContext: appContext) }.to(
             throwError(errorType: Conversions.CastingException<String>.self)
           )
         }
@@ -131,12 +133,12 @@ final class DynamicTypeSpec: ExpoSpec {
       }
       describe("casts") {
         it("succeeds") {
-          expect(try (~CGPoint.self).cast([2.1, 3.7]) as? CGPoint) == CGPoint(x: 2.1, y: 3.7)
-          expect(try (~CGVector.self).cast(["dx": 0.8, "dy": 4.1]) as? CGVector) == CGVector(dx: 0.8, dy: 4.1)
-          expect(try (~URL.self).cast("/test/path") as? URL) == URL(fileURLWithPath: "/test/path")
+          expect(try (~CGPoint.self).cast([2.1, 3.7], appContext: appContext) as? CGPoint) == CGPoint(x: 2.1, y: 3.7)
+          expect(try (~CGVector.self).cast(["dx": 0.8, "dy": 4.1], appContext: appContext) as? CGVector) == CGVector(dx: 0.8, dy: 4.1)
+          expect(try (~URL.self).cast("/test/path", appContext: appContext) as? URL) == URL(fileURLWithPath: "/test/path")
         }
         it("throws ConvertingException") {
-          expect { try (~CGRect.self).cast("not a rect") as? CGRect }.to(
+          expect { try (~CGRect.self).cast("not a rect", appContext: appContext) as? CGRect }.to(
             throwError(errorType: Conversions.ConvertingException<CGRect>.self)
           )
         }
@@ -185,16 +187,16 @@ final class DynamicTypeSpec: ExpoSpec {
       }
       describe("casts") {
         it("succeeds") {
-          expect(try (~StringTestEnum.self).cast("expo") as? StringTestEnum) == .expo
-          expect(try (~IntTestEnum.self).cast(1) as? IntTestEnum) == .positive
+          expect(try (~StringTestEnum.self).cast("expo", appContext: appContext) as? StringTestEnum) == .expo
+          expect(try (~IntTestEnum.self).cast(1, appContext: appContext) as? IntTestEnum) == .positive
         }
         it("throws EnumNoSuchValueException") {
-          expect { try (~StringTestEnum.self).cast("react native") as? StringTestEnum }.to(
+          expect { try (~StringTestEnum.self).cast("react native", appContext: appContext) as? StringTestEnum }.to(
             throwError(errorType: EnumNoSuchValueException.self)
           )
         }
         it("throws EnumCastingException") {
-          expect { try (~IntTestEnum.self).cast(true) as? StringTestEnum }.to(
+          expect { try (~IntTestEnum.self).cast(true, appContext: appContext) as? StringTestEnum }.to(
             throwError(errorType: EnumCastingException.self)
           )
         }
@@ -234,12 +236,12 @@ final class DynamicTypeSpec: ExpoSpec {
       }
       describe("casts") {
         it("succeeds") {
-          expect(try (~String?.self).cast("expo") as? String) == "expo"
-          expect(try (~Bool?.self).cast(false) as? Bool) == false
+          expect(try (~String?.self).cast("expo", appContext: appContext) as? String) == "expo"
+          expect(try (~Bool?.self).cast(false, appContext: appContext) as? Bool) == false
         }
         it("succeeds with nil") {
           let value: Double? = nil
-          let result = try (~Double?.self).cast(value as Any)
+          let result = try (~Double?.self).cast(value as Any, appContext: appContext)
 
           expect(result).to(beAKindOf(Double?.self))
 
@@ -249,12 +251,12 @@ final class DynamicTypeSpec: ExpoSpec {
         }
         it("succeeds with NSNull") {
           let value = NSNull()
-          let result = try (~Double?.self).cast(value as Any)
+          let result = try (~Double?.self).cast(value as Any, appContext: appContext)
           expect(result).to(beAKindOf(Double?.self))
           expect(Optional.isNil(result)) == true
         }
         it("throws CastingException") {
-          expect { try (~Double?.self).cast("a string") as? Double }.to(
+          expect { try (~Double?.self).cast("a string", appContext: appContext) as? Double }.to(
             throwError(errorType: Conversions.CastingException<Double>.self)
           )
         }
@@ -296,16 +298,16 @@ final class DynamicTypeSpec: ExpoSpec {
         it("succeeds") {
           let appContext = AppContext.create()
           let nativeObject = TestSharedObject()
-          let jsObjectValue = try appContext.runtime!.eval("({})")
+          let jsObjectValue = try appContext.runtime.eval("({})")
 
           SharedObjectRegistry.add(native: nativeObject, javaScript: try jsObjectValue.asObject())
 
           // `DynamicSharedObjectType` only supports casting
           // from `JavaScriptValue`, but not from `JavaScriptObject`.
-          expect(try (~TestSharedObject.self).cast(jsObjectValue) as? TestSharedObject) === nativeObject
+          expect(try (~TestSharedObject.self).cast(jsObjectValue, appContext: appContext) as? TestSharedObject) === nativeObject
         }
         it("throws NativeSharedObjectNotFoundException") {
-          expect { try (~TestSharedObject.self).cast("a string") as? TestSharedObject }.to(
+          expect { try (~TestSharedObject.self).cast("a string", appContext: appContext) as? TestSharedObject }.to(
             throwError(errorType: NativeSharedObjectNotFoundException.self)
           )
         }

--- a/packages/expo-modules-core/ios/Tests/EitherSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/EitherSpec.swift
@@ -6,6 +6,8 @@ import ExpoModulesTestCore
 
 final class EitherSpec: ExpoSpec {
   override func spec() {
+    let appContext = AppContext.create()
+
     describe("Either") {
       it("is the first type") {
         let either = Either<String, Int>("string")
@@ -33,16 +35,16 @@ final class EitherSpec: ExpoSpec {
         expect(value).notTo(beNil())
       }
       it("converts as convertible") {
-        let either = try Either<String, Int>.convert(from: 123)
+        let either = try Either<String, Int>.convert(from: 123, appContext: appContext)
         expect(either.is(String.self)) == false
         expect(either.is(Int.self)) == true
       }
       it("throws when converting from neither type") {
-        expect({ try Either<String, Int>.convert(from: true) }).to(throwError(errorType: NeitherTypeException.self))
+        expect({ try Either<String, Int>.convert(from: true, appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
       }
 
       it("supports arrays") {
-        let either = try Either<String, [String]>.convert(from: ["foo"])
+        let either = try Either<String, [String]>.convert(from: ["foo"], appContext: appContext)
         let value: [String]? = either.get()
 
         expect(either.is([String].self)) == true
@@ -50,7 +52,7 @@ final class EitherSpec: ExpoSpec {
       }
 
       it("supports convertibles (UIColor)") {
-        let either = try Either<Int, UIColor>.convert(from: "blue")
+        let either = try Either<Int, UIColor>.convert(from: "blue", appContext: appContext)
         let color: UIColor? = either.get()
 
         expect(either.is(UIColor.self)) == true
@@ -62,7 +64,7 @@ final class EitherSpec: ExpoSpec {
           @Field
           var foo: String
         }
-        let either = try Either<String, TestRecord>.convert(from: ["foo": "bar"])
+        let either = try Either<String, TestRecord>.convert(from: ["foo": "bar"], appContext: appContext)
         let record: TestRecord? = either.get()
 
         expect(either.is(TestRecord.self)) == true
@@ -88,7 +90,7 @@ final class EitherSpec: ExpoSpec {
         expect(value).notTo(beNil())
       }
       it("throws when converting from neither type") {
-        expect({ try EitherOfThree<String, Int, Double>.convert(from: false) }).to(throwError(errorType: NeitherTypeException.self))
+        expect({ try EitherOfThree<String, Int, Double>.convert(from: false, appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
       }
     }
     describe("EitherOfFour") {
@@ -112,7 +114,7 @@ final class EitherSpec: ExpoSpec {
         expect(value).notTo(beNil())
       }
       it("throws when converting from neither type") {
-        expect({ try EitherOfFour<String, Int, Double, Bool>.convert(from: [1, 2]) }).to(throwError(errorType: NeitherTypeException.self))
+        expect({ try EitherOfFour<String, Int, Double, Bool>.convert(from: [1, 2], appContext: appContext) }).to(throwError(errorType: NeitherTypeException.self))
       }
     }
   }

--- a/packages/expo-modules-core/ios/Tests/ExpoModulesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoModulesSpec.swift
@@ -7,7 +7,7 @@ import ExpoModulesTestCore
 class ExpoModulesSpec: ExpoSpec {
   override func spec() {
     let appContext = AppContext.create()
-    let runtime = appContext.runtime
+    let runtime = try! appContext.runtime
     let testModuleName = "TestModule"
     let testFunctionName = "testFunction"
     let throwingFunctionName = "throwingFunction"
@@ -33,23 +33,23 @@ class ExpoModulesSpec: ExpoSpec {
 
     describe("host object") {
       it("is defined") {
-        expect(try! runtime?.eval("'ExpoModules' in this").asBool()) === true
+        expect(try! runtime.eval("'ExpoModules' in this").asBool()) === true
       }
 
       it("has native module defined") {
-        expect(try! runtime?.eval("'\(testModuleName)' in ExpoModules").asBool()) === true
+        expect(try! runtime.eval("'\(testModuleName)' in ExpoModules").asBool()) === true
       }
 
       it("can access native module") {
-        let nativeModule = try! runtime?.eval("expo.modules.\(testModuleName)")
-        expect(nativeModule?.isUndefined()) == false
-        expect(nativeModule?.isObject()) == true
-        expect(nativeModule?.getRaw()).notTo(beNil())
+        let nativeModule = try runtime.eval("expo.modules.\(testModuleName)")
+        expect(nativeModule.isUndefined()) == false
+        expect(nativeModule.isObject()) == true
+        expect(nativeModule.getRaw()).notTo(beNil())
       }
 
       it("has keys for registered modules") {
         let registeredModuleNames = appContext.moduleRegistry.getModuleNames()
-        let keys = try! runtime?.eval("Object.keys(ExpoModules)").asArray().compactMap {
+        let keys = try runtime.eval("Object.keys(ExpoModules)").asArray().compactMap {
           return try! $0?.asString()
         }
         expect(keys).to(contain(registeredModuleNames))
@@ -58,7 +58,7 @@ class ExpoModulesSpec: ExpoSpec {
 
     describe("module") {
       it("exposes constants") {
-        let dict = try! runtime!.eval("expo.modules.TestModule").asDict()
+        let dict = try runtime.eval("expo.modules.TestModule").asDict()
 
         dict.forEach { (key: String, value: Any) in
           expect(value) === dict[key]!
@@ -66,17 +66,17 @@ class ExpoModulesSpec: ExpoSpec {
       }
 
       it("has function") {
-        expect(try! runtime?.eval("typeof expo.modules.TestModule.\(testFunctionName)").asString()) == "function"
-        expect(try! runtime?.eval("expo.modules.TestModule.\(testFunctionName)").isFunction()) == true
+        expect(try runtime.eval("typeof expo.modules.TestModule.\(testFunctionName)").asString()) == "function"
+        expect(try runtime.eval("expo.modules.TestModule.\(testFunctionName)").isFunction()) == true
       }
 
       it("calls function") {
-        expect(try! runtime?.eval("expo.modules.TestModule.\(testFunctionName)()").asDouble()) == Double.pi
+        expect(try runtime.eval("expo.modules.TestModule.\(testFunctionName)()").asDouble()) == Double.pi
       }
 
       it("throws from sync function") {
         // Invoke the throwing function and return the error (eval shouldn't rethrow here)
-        let error = try! runtime!.eval("try { expo.modules.TestModule.\(throwingFunctionName)() } catch (error) { error }").asObject()
+        let error = try runtime.eval("try { expo.modules.TestModule.\(throwingFunctionName)() } catch (error) { error }").asObject()
 
         // We just check if it contains the description — they won't be equal for the following reasons:
         // - the `exceptionToThrow` is just the root cause, in fact it returns `FunctionCallException`

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -128,7 +128,7 @@ class FunctionSpec: ExpoSpec {
 
         it("returns the record back (sync)") {
           let result = try Function(functionName) { (record: TestRecord) in record }
-            .call(by: nil, withArguments: [dict]) as? TestRecord.Dict
+            .call(by: nil, withArguments: [dict], appContext: appContext) as? TestRecord.Dict
 
           expect(result).notTo(beNil())
           expect(result?["property"] as? String).to(equal(dict["property"]))
@@ -186,11 +186,11 @@ class FunctionSpec: ExpoSpec {
           return returnedValue
         }
 
-        expect({ try fn.call(by: nil, withArguments: ["test"]) })
+        expect({ try fn.call(by: nil, withArguments: ["test"], appContext: appContext) })
           .notTo(throwError())
           .to(be(returnedValue))
 
-        expect({ try fn.call(by: nil, withArguments: ["test", 3]) })
+        expect({ try fn.call(by: nil, withArguments: ["test", 3], appContext: appContext) })
           .notTo(throwError())
           .to(be(returnedValue))
       }
@@ -200,7 +200,7 @@ class FunctionSpec: ExpoSpec {
           return "something"
         }
 
-        expect({ try fn.call(by: nil, withArguments: []) })
+        expect({ try fn.call(by: nil, withArguments: [], appContext: appContext) })
           .to(throwError(errorType: FunctionCallException.self) { error in
             expect(error.rootCause).to(beAKindOf(InvalidArgsNumberException.self))
             let exception = error.rootCause as! InvalidArgsNumberException
@@ -234,8 +234,8 @@ class FunctionSpec: ExpoSpec {
     }
     
     context("JavaScript") {
-      let runtime = appContext.runtime
-      
+      let runtime = try! appContext.runtime
+
       beforeSuite {
         appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
           Name("TestModule")
@@ -264,26 +264,26 @@ class FunctionSpec: ExpoSpec {
       }
 
       it("returns values") {
-        expect(try runtime?.eval("expo.modules.TestModule.returnPi()").asDouble()) == Double.pi
-        expect(try runtime?.eval("expo.modules.TestModule.returnNull()").isNull()) == true
+        expect(try runtime.eval("expo.modules.TestModule.returnPi()").asDouble()) == Double.pi
+        expect(try runtime.eval("expo.modules.TestModule.returnNull()").isNull()) == true
       }
 
       it("accepts optional arguments") {
-        expect(try runtime?.eval("expo.modules.TestModule.isArgNull(3.14)").asBool()) == false
-        expect(try runtime?.eval("expo.modules.TestModule.isArgNull(null)").asBool()) == true
+        expect(try runtime.eval("expo.modules.TestModule.isArgNull(3.14)").asBool()) == false
+        expect(try runtime.eval("expo.modules.TestModule.isArgNull(null)").asBool()) == true
       }
 
       it("returns object made from definition") {
         let initialValue = Int.random(in: 1..<100)
-        let object = try runtime?.eval("object = expo.modules.TestModule.returnObjectDefinition(\(initialValue))")
+        let object = try runtime.eval("object = expo.modules.TestModule.returnObjectDefinition(\(initialValue))")
 
-        expect(object?.kind) == .object
-        expect(object?.getObject().hasProperty("increment")) == true
+        expect(object.kind) == .object
+        expect(object.getObject().hasProperty("increment")) == true
 
-        let result = try runtime?.eval("object.increment()")
+        let result = try runtime.eval("object.increment()")
 
-        expect(result?.kind) == .number
-        expect(result?.getInt()) == initialValue + 1
+        expect(result.kind) == .number
+        expect(result.getInt()) == initialValue + 1
       }
     }
   }

--- a/packages/expo-modules-core/ios/Tests/RecordSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/RecordSpec.swift
@@ -4,9 +4,11 @@ import ExpoModulesTestCore
 
 class RecordSpec: ExpoSpec {
   override func spec() {
+    let appContext = AppContext.create()
+
     it("initializes with empty dictionary") {
       struct TestRecord: Record { }
-      _ = try TestRecord(from: [:])
+      _ = try TestRecord(from: [:], appContext: appContext)
     }
 
     it("works back and forth with a field") {
@@ -14,7 +16,7 @@ class RecordSpec: ExpoSpec {
         @Field var a: String?
       }
       let dict = ["a": "b"]
-      let record = try TestRecord(from: dict)
+      let record = try TestRecord(from: dict, appContext: appContext)
 
       expect(record.a).to(be(dict["a"]))
       expect(record.toDictionary()["a"]).to(be(dict["a"]))
@@ -25,7 +27,7 @@ class RecordSpec: ExpoSpec {
         @Field("key") var a: String?
       }
       let dict = ["key": "b"]
-      let record = try TestRecord(from: dict)
+      let record = try TestRecord(from: dict, appContext: appContext)
 
       expect(record.a).to(be(dict["key"]))
       expect(record.toDictionary()["key"]).to(be(dict["key"]))
@@ -36,7 +38,7 @@ class RecordSpec: ExpoSpec {
         @Field(.required) var a: Int
       }
 
-      expect { try TestRecord(from: [:]) }.to(throwError { error in
+      expect { try TestRecord(from: [:], appContext: appContext) }.to(throwError { error in
         expect(error).to(beAKindOf(FieldRequiredException.self))
       })
     }
@@ -47,7 +49,7 @@ class RecordSpec: ExpoSpec {
       }
       let dict = ["a": "try with String instead of Int"]
 
-      expect { try TestRecord(from: dict) }.to(throwError { error in
+      expect { try TestRecord(from: dict, appContext: appContext) }.to(throwError { error in
         expect(error).to(beAKindOf(FieldInvalidTypeException.self))
       })
     }

--- a/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectRegistrySpec.swift
@@ -7,7 +7,7 @@ import ExpoModulesTestCore
 final class SharedObjectRegistrySpec: ExpoSpec {
   override func spec() {
     let appContext = AppContext.create()
-    let runtime = appContext.runtime
+    let runtime = try! appContext.runtime
 
     describe("pullNextId") {
       it("returns nextId") {
@@ -29,28 +29,28 @@ final class SharedObjectRegistrySpec: ExpoSpec {
     describe("add") {
       it("adds using nextId") {
         let nextId = SharedObjectRegistry.nextId
-        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
         expect(nextId) == id
       }
       it("is increasing size") {
         let size = SharedObjectRegistry.size
-        SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
         expect(SharedObjectRegistry.size) == size + 1
       }
       it("assigns id on native object") {
         let nativeObject = TestSharedObject()
-        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime!.createObject())
+        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
         expect(nativeObject.sharedObjectId) == id
       }
       it("assigns id on JS object") {
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
         expect(jsObject.hasProperty(sharedObjectIdPropertyName)) == true
         expect(try! jsObject.getProperty(sharedObjectIdPropertyName).asInt()) == id
       }
       it("saves objects pair") {
         let nativeObject = TestSharedObject()
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         let id = SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
         let pair = SharedObjectRegistry.get(id)
         expect(pair?.native) === nativeObject
@@ -60,18 +60,18 @@ final class SharedObjectRegistrySpec: ExpoSpec {
 
     describe("delete") {
       it("deletes objects pair") {
-        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime!.createObject())
+        let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: runtime.createObject())
         SharedObjectRegistry.delete(id)
         expect(SharedObjectRegistry.get(id)).to(beNil())
       }
       it("resets id on native object") {
         let nativeObject = TestSharedObject()
-        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime!.createObject())
+        let id = SharedObjectRegistry.add(native: nativeObject, javaScript: runtime.createObject())
         SharedObjectRegistry.delete(id)
         expect(nativeObject.sharedObjectId) == 0
       }
       it("resets id on JS object") {
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         let id = SharedObjectRegistry.add(native: TestSharedObject(), javaScript: jsObject)
         SharedObjectRegistry.delete(id)
         expect(try! jsObject.getProperty(sharedObjectIdPropertyName).asInt()) == 0
@@ -81,12 +81,12 @@ final class SharedObjectRegistrySpec: ExpoSpec {
     describe("toNativeObject") {
       it("returns native object") {
         let nativeObject = TestSharedObject()
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
         expect(SharedObjectRegistry.toNativeObject(jsObject)) === nativeObject
       }
       it("returns nil") {
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         expect(SharedObjectRegistry.toNativeObject(jsObject)).to(beNil())
       }
     }
@@ -94,7 +94,7 @@ final class SharedObjectRegistrySpec: ExpoSpec {
     describe("toJavaScriptObject") {
       it("returns JS object") {
         let nativeObject = TestSharedObject()
-        let jsObject = runtime!.createObject()
+        let jsObject = runtime.createObject()
         SharedObjectRegistry.add(native: nativeObject, javaScript: jsObject)
         expect(SharedObjectRegistry.toJavaScriptObject(nativeObject)) == jsObject
       }

--- a/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/TypedArraysSpec.swift
@@ -8,7 +8,7 @@ final class TypedArraysSpec: ExpoSpec {
   override func spec() {
     describe("module") {
       let appContext = AppContext.create()
-      let runtime = appContext.runtime!
+      let runtime = try! appContext.runtime
 
       beforeSuite {
         appContext.moduleRegistry.register(moduleType: TypedArraysModule.self)

--- a/packages/expo-modules-core/ios/Tests/ViewDefinitionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ViewDefinitionSpec.swift
@@ -15,6 +15,8 @@ final class ViewDefinitionSpec: ExpoSpec {
     }
 
     describe("Prop") {
+      let appContext = AppContext.create()
+
       it("sets the prop") {
         let textView = UITextView()
         let content = "hello"
@@ -23,7 +25,7 @@ final class ViewDefinitionSpec: ExpoSpec {
             view.text = value
           }
         }
-        try definition.propsDict()["content"]?.set(value: content, onView: textView)
+        try definition.propsDict()["content"]?.set(value: content, onView: textView, appContext: appContext)
         expect(textView.text) == content
       }
 
@@ -36,7 +38,7 @@ final class ViewDefinitionSpec: ExpoSpec {
             expect(view).to(beAKindOf(UITextView.self))
           }
         }
-        try definition.propsDict()["content"]?.set(value: content, onView: textView)
+        try definition.propsDict()["content"]?.set(value: content, onView: textView, appContext: appContext)
       }
     }
 


### PR DESCRIPTION
# Why

Unfortunately we need to pass the AppContext instance all the way down in order to implement more features such as passing view instances to function definitions and making the shared object registry non-global.

# How

- Changed the dynamic type helpers and Convertible to get the AppContext argument.
- Definitions implementing `JavaScriptObjectBuilder` now get the app context instead of the runtime.
- Accessing `appContext.runtime` now can throw when the runtime is lost. This simplifies many things since we pass the app context instead of the runtime.

# Test Plan

- Native unit tests are passing
- bare-expo compiles and seems to work fine so far

<!-- disable:swiftlint -->
