### PR TITLE
[core][ios] Split arguments conversion into two steps

### DIFF
--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/AnyDynamicType.swift
@@ -17,6 +17,12 @@ public protocol AnyDynamicType: CustomStringConvertible {
   func equals(_ type: AnyDynamicType) -> Bool
 
   /**
+   Preliminarily casts the given JavaScriptValue to a non-JS value that the other `cast` function can handle.
+   It **must** be run on the thread used by the JavaScript runtime.
+   */
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any
+
+  /**
    Casts the given value to the wrapped type and returns it as `Any`.
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `Convertible`).
    */
@@ -24,6 +30,10 @@ public protocol AnyDynamicType: CustomStringConvertible {
 }
 
 extension AnyDynamicType {
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    return jsValue.getRaw()
+  }
+
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     return value
   }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
@@ -22,7 +22,11 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
       // Given value is a shared object already
       return value
     }
-    if let jsObject = try (value as? JavaScriptValue)?.asObject(),
+    throw NativeSharedObjectNotFoundException()
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    if let jsObject = try? jsValue.asObject(),
        let nativeSharedObject = SharedObjectRegistry.toNativeObject(jsObject) {
       return nativeSharedObject
     }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicTypedArrayType.swift
@@ -14,13 +14,24 @@ internal struct DynamicTypedArrayType: AnyDynamicType {
     return false
   }
 
-  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
-    // It must be a JavaScript typed array.
-    guard let value = value as? JavaScriptValue, let jsTypedArray = value.getTypedArray() else {
+  /**
+   Converts JS typed array to its native representation.
+   */
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    guard let jsTypedArray = jsValue.getTypedArray() else {
       throw NotTypedArrayException(innerType)
     }
-    let typedArray = TypedArray.create(from: jsTypedArray)
+    return TypedArray.create(from: jsTypedArray)
+  }
 
+  /**
+   Converts the given native `TypedArray` to a concrete typed array class wrapped by the dynamic type.
+   Throws `ArrayTypeMismatchException` otherwise.
+   */
+  func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
+    guard let typedArray = value as? TypedArray else {
+      throw NotTypedArrayException(innerType)
+    }
     // Concrete typed arrays must be the same as the inner type.
     guard innerType == TypedArray.self || type(of: typedArray) == innerType else {
       throw ArrayTypeMismatchException((received: type(of: typedArray), expected: innerType))

--- a/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/ConcurrentFunctionDefinition.swift
@@ -29,15 +29,21 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
   var takesOwner: Bool = false
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
-    let arguments: [Any]
+    var arguments: [Any]
 
     do {
+      try validateArgumentsNumber(function: self, received: args.count)
+
       arguments = concat(
-        arguments: try cast(arguments: args, forFunction: self, appContext: appContext),
+        arguments: args,
         withOwner: owner,
+        withPromise: nil,
         forFunction: self,
         appContext: appContext
       )
+
+      // All `JavaScriptValue` args must be preliminarly converted on the JS thread, before we jump to the function's queue.
+      arguments = try cast(jsValues: args, forFunction: self, appContext: appContext)
     } catch let error as Exception {
       callback(.failure(error))
       return
@@ -51,9 +57,12 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
       let result: Result<Any, Exception>
 
       do {
+        // Convert arguments to the types desired by the function.
+        let finalArguments = try cast(arguments: arguments, forFunction: self, appContext: appContext)
+
         // TODO: Right now we force cast the tuple in all types of functions, but we should throw another exception here.
         // swiftlint:disable force_cast
-        let argumentsTuple = try Conversions.toTuple(arguments) as! Args
+        let argumentsTuple = try Conversions.toTuple(finalArguments) as! Args
         let returnValue = try await body(argumentsTuple)
 
         result = .success(returnValue)
@@ -70,17 +79,23 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
   // MARK: - JavaScriptObjectBuilder
 
   func build(appContext: AppContext) throws -> JavaScriptObject {
-    return try appContext.runtime.createAsyncFunction(name, argsCount: argumentsCount) { [weak self, name] this, args, resolve, reject in
-      guard let self = self else {
+    return try appContext.runtime.createAsyncFunction(name, argsCount: argumentsCount) {
+      [weak appContext, weak self, name] this, args, resolve, reject in
+
+      guard let appContext else {
+        let exception = Exceptions.AppContextLost()
+        return reject(exception.code, exception.description, nil)
+      }
+      guard let self else {
         let exception = NativeFunctionUnavailableException(name)
         return reject(exception.code, exception.description, nil)
       }
       self.call(by: this, withArguments: args, appContext: appContext) { result in
         switch result {
-        case .failure(let error):
-          reject(error.code, error.description, nil)
-        case .success(let value):
-          resolve(value)
+          case .failure(let error):
+            reject(error.code, error.description, nil)
+          case .success(let value):
+            resolve(value)
         }
       }
     }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -65,12 +65,22 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext) throws -> Any {
     do {
-      let arguments = concat(
-        arguments: try cast(arguments: args, forFunction: self, appContext: appContext),
+      try validateArgumentsNumber(function: self, received: args.count)
+
+      var arguments = concat(
+        arguments: args,
         withOwner: owner,
+        withPromise: nil,
         forFunction: self,
         appContext: appContext
       )
+
+      // Convert JS values to non-JS native types.
+      arguments = try cast(jsValues: arguments, forFunction: self, appContext: appContext)
+
+      // Convert arguments to the types desired by the function.
+      arguments = try cast(arguments: arguments, forFunction: self, appContext: appContext)
+
       let argumentsTuple = try Conversions.toTuple(arguments) as! Args
       let result = try body(argumentsTuple)
       return Conversions.convertFunctionResult(result, appContext: appContext)

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeSpec.swift
@@ -304,7 +304,7 @@ final class DynamicTypeSpec: ExpoSpec {
 
           // `DynamicSharedObjectType` only supports casting
           // from `JavaScriptValue`, but not from `JavaScriptObject`.
-          expect(try (~TestSharedObject.self).cast(jsObjectValue, appContext: appContext) as? TestSharedObject) === nativeObject
+          expect(try (~TestSharedObject.self).cast(jsValue: jsObjectValue, appContext: appContext) as? TestSharedObject) === nativeObject
         }
         it("throws NativeSharedObjectNotFoundException") {
           expect { try (~TestSharedObject.self).cast("a string", appContext: appContext) as? TestSharedObject }.to(

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -222,7 +222,8 @@ class FunctionSpec: ExpoSpec {
             switch result {
             case .failure(let error):
               expect(error).notTo(beNil())
-              expect(error).to(beAKindOf(ArgumentCastException.self))
+              expect(error).to(beAKindOf(FunctionCallException.self))
+              expect(error.isCausedBy(ArgumentCastException.self)) == true
               expect(error.isCausedBy(Conversions.CastingException<String>.self)) == true
             case .success(_):
               fail()
@@ -232,7 +233,7 @@ class FunctionSpec: ExpoSpec {
         }
       }
     }
-    
+
     context("JavaScript") {
       let runtime = try! appContext.runtime
 
@@ -241,11 +242,11 @@ class FunctionSpec: ExpoSpec {
           Name("TestModule")
 
           Function("returnPi") { Double.pi }
-          
+
           Function("returnNull") { () -> Double? in
             return nil
           }
-          
+
           Function("isArgNull") { (arg: Double?) -> Bool in
             return arg == nil
           }


### PR DESCRIPTION
# Why

Currently arguments conversion happens on the JS thread (for async functions it's before we jump into the function's queue). Since we want to accept views as arguments, the conversion needs to be split into two steps:
- convert JS values to non-JS types on the JS thread
- convert these non-JS types to the final types expected by the function on the thread the function is run (functions using a view as an argument will be required to run on the main thread)

# How

Added new `cast(jsValue:appContext:)` function to dynamic types that preliminarly casts `JavaScriptValue` to a native type that can later be handled by `cast(_:appContext:)`.

# Test Plan

Native unit tests are passing, I tested a few modules in bare-expo and haven't encountered any crashes or unexpected behaviors

<!-- disable:swiftlint -->