### PR TITLE
fix(cli): load `Debugger.getScriptSource` requests when using lan or tunnel

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### 🐛 Bug fixes
 
+- Respond to `Debugger.getScriptSource` CDP messages when using lan or tunnel. ([#21825](https://github.com/expo/expo/pull/21825) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 - Update fixtures. ([#21397](https://github.com/expo/expo/pull/21397) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
@@ -1,10 +1,20 @@
 import { createInspectorDeviceClass } from '../device';
+import { DebuggerScriptSourceHandler } from '../handlers/DebuggerScriptSource';
+import { NetworkResponseHandler } from '../handlers/NetworkResponse';
+import { VscodeCompatHandler } from '../handlers/VscodeCompat';
 import { InspectorHandler } from '../handlers/types';
 
 describe('ExpoInspectorDevice', () => {
   it('initializes with default handlers', () => {
     const { device } = createTestDevice();
-    expect(device.handlers).toHaveLength(2);
+
+    function findHandler<T extends Function>(type: T) {
+      return device.handlers.find((handler) => handler instanceof type);
+    }
+
+    expect(findHandler(DebuggerScriptSourceHandler)).toBeInstanceOf(DebuggerScriptSourceHandler);
+    expect(findHandler(NetworkResponseHandler)).toBeInstanceOf(NetworkResponseHandler);
+    expect(findHandler(VscodeCompatHandler)).toBeInstanceOf(VscodeCompatHandler);
   });
 
   describe('device', () => {

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
@@ -1,6 +1,8 @@
 import type { DebuggerInfo, Device as MetroDevice } from 'metro-inspector-proxy';
+import fetch from 'node-fetch';
 import type WS from 'ws';
 
+import { DebuggerScriptSourceHandler } from './handlers/DebuggerScriptSource';
 import { NetworkResponseHandler } from './handlers/NetworkResponse';
 import { VscodeCompatHandler } from './handlers/VscodeCompat';
 import { DeviceRequest, InspectorHandler, DebuggerRequest } from './handlers/types';
@@ -8,7 +10,11 @@ import { DeviceRequest, InspectorHandler, DebuggerRequest } from './handlers/typ
 export function createInspectorDeviceClass(MetroDeviceClass: typeof MetroDevice) {
   return class ExpoInspectorDevice extends MetroDeviceClass implements InspectorHandler {
     /** All handlers that should be used to intercept or reply to CDP events */
-    public handlers: InspectorHandler[] = [new NetworkResponseHandler(), new VscodeCompatHandler()];
+    public handlers: InspectorHandler[] = [
+      new NetworkResponseHandler(),
+      new DebuggerScriptSourceHandler(this),
+      new VscodeCompatHandler(),
+    ];
 
     onDeviceMessage(message: any, info: DebuggerInfo): boolean {
       return this.handlers.some((handler) => handler.onDeviceMessage?.(message, info) ?? false);
@@ -37,6 +43,33 @@ export function createInspectorDeviceClass(MetroDeviceClass: typeof MetroDevice)
       }
 
       return super._interceptMessageFromDebugger(request, info, socket);
+    }
+
+    /**
+     * Overwrite the default text fetcher, to load sourcemaps from sources other than `localhost`.
+     * @todo Cedric: remove the custom `DebuggerScriptSource` handler when switching over to `metro@>=0.75.1`
+     * @see https://github.com/facebook/metro/blob/77f445f1bcd2264ad06174dbf8d542bc75834d29/packages/metro-inspector-proxy/src/Device.js#L573-L588
+     * @since metro-inspector-proxy@0.75.1
+     */
+    async _fetchText(url: URL): Promise<string> {
+      const LENGTH_LIMIT_BYTES = 350_000_000; // 350mb
+
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Received status ${response.status} while fetching: ${url}`);
+      }
+
+      const contentLength = response.headers.get('Content-Length');
+      if (contentLength && Number(contentLength) > LENGTH_LIMIT_BYTES) {
+        throw new Error('Expected file size is too large (more than 350mb)');
+      }
+
+      const text = await response.text();
+      if (Buffer.byteLength(text, 'utf8') > LENGTH_LIMIT_BYTES) {
+        throw new Error('File size is too large (more than 350mb)');
+      }
+
+      return text;
     }
   };
 }

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/DebuggerScriptSource.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/DebuggerScriptSource.ts
@@ -7,6 +7,7 @@ import type WS from 'ws';
 
 import { CdpMessage, DebuggerRequest, DebuggerResponse, InspectorHandler } from './types';
 
+// TODO(cedric): remove this custom handler when fully switching over to `metro@>=0.75.1`
 export class DebuggerScriptSourceHandler implements InspectorHandler {
   constructor(private readonly device: MetroDevice) {}
 

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/DebuggerScriptSource.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/DebuggerScriptSource.ts
@@ -1,0 +1,92 @@
+import type { Protocol } from 'devtools-protocol';
+import fs from 'fs';
+import type { DebuggerInfo, Device as MetroDevice } from 'metro-inspector-proxy';
+import fetch from 'node-fetch';
+import path from 'path';
+import type WS from 'ws';
+
+import { CdpMessage, DebuggerRequest, DebuggerResponse, InspectorHandler } from './types';
+
+export class DebuggerScriptSourceHandler implements InspectorHandler {
+  constructor(private readonly device: MetroDevice) {}
+
+  onDebuggerMessage(
+    message: DebuggerRequest<DebuggerGetScriptSource>,
+    { socket }: Pick<DebuggerInfo, 'socket'>
+  ) {
+    // See: https://github.com/facebook/metro/blob/65d801cb60c06c1b17f428ca79491db73c53ef87/packages/metro-inspector-proxy/src/Device.js#L488-L544
+    if (message.method === 'Debugger.getScriptSource') {
+      const { scriptId } = message.params;
+      const pathOrUrl = this.device._scriptIdToSourcePathMapping.get(scriptId);
+
+      // Unkown scriptId provided, can't reply
+      if (!pathOrUrl) {
+        return false;
+      }
+
+      // Fetch the source from URL, if the path is a bundle URL
+      if (isUrl(pathOrUrl)) {
+        fetch(pathOrUrl)
+          .then((response) =>
+            response.ok
+              ? response.text()
+              : respond(socket, message, {
+                  error: `Received status ${response.status} while fetching: ${pathOrUrl}`,
+                })
+          )
+          .then((scriptSource) => {
+            if (scriptSource !== null) {
+              respond(socket, message, { scriptSource });
+            }
+          });
+
+        return true;
+      }
+
+      // Fetch the source from file directly, using the project root as starting directory
+      try {
+        const relativePath = path.resolve(this.device._projectRoot, pathOrUrl);
+        respond(socket, message, { scriptSource: fs.readFileSync(relativePath, 'utf8') });
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        respond(socket, message, {
+          error: `Failed to load "${pathOrUrl}": ${errorMessage}`,
+        });
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/** @see https://chromedevtools.github.io/devtools-protocol/v8/Debugger/#method-getScriptSource */
+export type DebuggerGetScriptSource = CdpMessage<
+  'Debugger.getScriptSource',
+  Protocol.Debugger.GetScriptSourceRequest,
+  Protocol.Debugger.GetScriptSourceResponse
+>;
+
+function respond<T extends CdpMessage>(
+  socket: WS,
+  request: DebuggerRequest<T>,
+  response: DebuggerResponse<T>['result'] | { error: string }
+) {
+  if ('error' in response) {
+    socket.send(JSON.stringify({ id: request.id, error: { message: response.error } }));
+  } else {
+    socket.send(JSON.stringify({ id: request.id, result: response }));
+  }
+
+  return null;
+}
+
+function isUrl(pathOrUrl: string) {
+  try {
+    const url = new URL(pathOrUrl);
+    return ['http', 'https'].some((protocol) => url.protocol.toLowerCase().startsWith(protocol));
+  } catch {
+    return false;
+  }
+}

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/DebuggerScriptSource.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/DebuggerScriptSource.test.ts
@@ -1,0 +1,187 @@
+import fs from 'fs';
+import { vol } from 'memfs';
+import fetch from 'node-fetch';
+import path from 'path';
+
+import { DebuggerScriptSourceHandler } from '../DebuggerScriptSource';
+
+jest.mock('fs');
+jest.mock('node-fetch');
+
+afterEach(() => vol.reset());
+
+it('responds to script source request from url', () => {
+  const device = makeTestDevice();
+  const handler = new DebuggerScriptSourceHandler(device);
+
+  device._scriptIdToSourcePathMapping.set(
+    '1337',
+    'http://192.168.1.1:1900/index.bundle?platform=android'
+  );
+
+  // Mock successful response to fetch the bundle
+  jest.mocked(fetch).mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      text: async () => 'fake bundle content',
+    } as any)
+  );
+
+  // Fetch is async, but the handler is not. Assert response data in callback
+  const debuggerSocket = {
+    send: jest.fn((stringified) => {
+      expect(stringified).toBe(
+        JSON.stringify({ id: 420, result: { scriptSource: 'fake bundle content' } })
+      );
+    }),
+  };
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Debugger.getScriptSource',
+        params: { scriptId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(true);
+
+  expect(fetch).toBeCalledWith('http://192.168.1.1:1900/index.bundle?platform=android');
+});
+
+it('responds with fetch errors from url', () => {
+  const device = makeTestDevice();
+  const handler = new DebuggerScriptSourceHandler(device);
+
+  device._scriptIdToSourcePathMapping.set(
+    '1337',
+    'http://192.168.1.1:1900/nonexisting.bundle?platform=android'
+  );
+
+  // Mock failed response to fetch the bundle
+  jest.mocked(fetch).mockImplementation(() =>
+    Promise.resolve({
+      ok: false,
+      status: 404,
+      text() {
+        throw new Error('Cant load this');
+      },
+    } as any)
+  );
+
+  // Fetch is async, but the handler is not. Assert response data in callback
+  const debuggerSocket = {
+    send: jest.fn((stringified) => {
+      expect(stringified).toBe(
+        JSON.stringify({
+          id: 420,
+          error: {
+            message:
+              'Received status 404 while fetching: http://192.168.1.1:1900/nonexisting.bundle?platform=android',
+          },
+        })
+      );
+    }),
+  };
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Debugger.getScriptSource',
+        params: { scriptId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(true);
+
+  expect(fetch).toBeCalledWith('http://192.168.1.1:1900/nonexisting.bundle?platform=android');
+});
+
+it('responds to script source request from path', () => {
+  const device = makeTestDevice();
+  const handler = new DebuggerScriptSourceHandler(device);
+  const debuggerSocket = { send: jest.fn() };
+
+  vol.fromJSON({ 'App.js': 'fake app content' }, device._projectRoot);
+  device._scriptIdToSourcePathMapping.set('1337', path.join(device._projectRoot, 'App.js'));
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Debugger.getScriptSource',
+        params: { scriptId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(true);
+
+  expect(debuggerSocket.send).toBeCalledWith(
+    JSON.stringify({
+      id: 420,
+      result: { scriptSource: 'fake app content' },
+    })
+  );
+});
+
+it('responds with read errors from path', () => {
+  const device = makeTestDevice();
+  const handler = new DebuggerScriptSourceHandler(device);
+  const debuggerSocket = { send: jest.fn() };
+  const filePath = path.join(device._projectRoot, 'App.js');
+
+  vol.fromJSON({ 'App.js': 'fake app content' }, device._projectRoot);
+  device._scriptIdToSourcePathMapping.set('1337', path.join(device._projectRoot, 'App.js'));
+
+  jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+    throw new Error('Fake IO error');
+  });
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Debugger.getScriptSource',
+        params: { scriptId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(true);
+
+  expect(debuggerSocket.send).toBeCalledWith(
+    JSON.stringify({
+      id: 420,
+      error: {
+        message: `Failed to load "${filePath}": Fake IO error`,
+      },
+    })
+  );
+});
+
+it('does not respond to non-existing script', () => {
+  const device = makeTestDevice();
+  const handler = new DebuggerScriptSourceHandler(device);
+  const debuggerSocket = { send: jest.fn() };
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Debugger.getScriptSource',
+        params: { scriptId: '1337' },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(false);
+
+  expect(debuggerSocket.send).not.toBeCalled();
+});
+
+function makeTestDevice() {
+  return {
+    _scriptIdToSourcePathMapping: new Map<string, string>(),
+    _projectRoot: '/fake/path/to/project',
+  };
+}


### PR DESCRIPTION
# Why

This fixes the `Debugger.getScriptSource` responses in two different ways.

1. For `metro@<0.75.1`, we use the custom `DebuggerScriptSourceHandler`
2. For `metro@>=0.75.1`, we can rely on just the `_fetchText` override

# How

Do not block the fetch request when running on lan or tunnel (no `localhost`).

# Test Plan

- See added tests.
- Open Chrome inspector (`j`)
- Go to sources
- Try to load the `index.bundle` or `expo/AppEntry.bundle` file in the inspector
- Actual raw bundle file should be visible

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
