### PR TITLE
feature(cli): add basic `Page.reload` support to reload the app from inspector

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add experimental inspector proxy to handle more CDP requests. ([#21449](https://github.com/expo/expo/pull/21449) by [@byCedric](https://github.com/byCedric))
 - Set node env for metro config in `expo export:embed`. ([#21644](https://github.com/expo/expo/pull/21644) by [@EvanBacon](https://github.com/EvanBacon))
 - Add inspector proxy workarounds for known issues with vscode debugger and Hermes CDP messages. ([#21560](https://github.com/expo/expo/pull/21560) by [@byCedric](https://github.com/byCedric))
+- Add inspector support for `Page.reload` CDP message.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Add experimental inspector proxy to handle more CDP requests. ([#21449](https://github.com/expo/expo/pull/21449) by [@byCedric](https://github.com/byCedric))
 - Set node env for metro config in `expo export:embed`. ([#21644](https://github.com/expo/expo/pull/21644) by [@EvanBacon](https://github.com/EvanBacon))
 - Add inspector proxy workarounds for known issues with vscode debugger and Hermes CDP messages. ([#21560](https://github.com/expo/expo/pull/21560) by [@byCedric](https://github.com/byCedric))
-- Add inspector support for `Page.reload` CDP message.
+- Add inspector support for `Page.reload` CDP message. ([#21827](https://github.com/expo/expo/pull/21827) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -101,7 +101,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     };
 
     const { metro, server, middleware, messageSocket } = await instantiateMetroAsync(
-      this.projectRoot,
+      this,
       parsedOptions
     );
 

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
@@ -1,6 +1,7 @@
 import { createInspectorDeviceClass } from '../device';
 import { DebuggerScriptSourceHandler } from '../handlers/DebuggerScriptSource';
 import { NetworkResponseHandler } from '../handlers/NetworkResponse';
+import { PageReloadHandler } from '../handlers/PageReload';
 import { VscodeCompatHandler } from '../handlers/VscodeCompat';
 import { InspectorHandler } from '../handlers/types';
 
@@ -14,6 +15,7 @@ describe('ExpoInspectorDevice', () => {
 
     expect(findHandler(DebuggerScriptSourceHandler)).toBeInstanceOf(DebuggerScriptSourceHandler);
     expect(findHandler(NetworkResponseHandler)).toBeInstanceOf(NetworkResponseHandler);
+    expect(findHandler(PageReloadHandler)).toBeInstanceOf(PageReloadHandler);
     expect(findHandler(VscodeCompatHandler)).toBeInstanceOf(VscodeCompatHandler);
   });
 
@@ -116,6 +118,7 @@ describe('ExpoInspectorDevice', () => {
 
 /** Create a test device instance without extending the Metro device */
 function createTestDevice() {
+  const metroBundler = { broadcastMessage: jest.fn() };
   class MetroDevice {
     _processMessageFromDevice() {}
     _interceptMessageFromDebugger() {}
@@ -125,7 +128,7 @@ function createTestDevice() {
   MetroDevice.prototype._processMessageFromDevice = jest.fn();
   MetroDevice.prototype._interceptMessageFromDebugger = jest.fn();
 
-  const ExpoDevice = createInspectorDeviceClass(MetroDevice);
+  const ExpoDevice = createInspectorDeviceClass(metroBundler, MetroDevice);
   const device = new ExpoDevice();
 
   return { ExpoDevice, MetroDevice, device };

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/device.test.ts
@@ -118,7 +118,7 @@ describe('ExpoInspectorDevice', () => {
 
 /** Create a test device instance without extending the Metro device */
 function createTestDevice() {
-  const metroBundler = { broadcastMessage: jest.fn() };
+  const metroBundler: any = { broadcastMessage: jest.fn() };
   class MetroDevice {
     _processMessageFromDevice() {}
     _interceptMessageFromDebugger() {}
@@ -131,5 +131,5 @@ function createTestDevice() {
   const ExpoDevice = createInspectorDeviceClass(metroBundler, MetroDevice);
   const device = new ExpoDevice();
 
-  return { ExpoDevice, MetroDevice, device };
+  return { ExpoDevice, MetroDevice, device, metroBundler };
 }

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/device.ts
@@ -2,17 +2,23 @@ import type { DebuggerInfo, Device as MetroDevice } from 'metro-inspector-proxy'
 import fetch from 'node-fetch';
 import type WS from 'ws';
 
+import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { DebuggerScriptSourceHandler } from './handlers/DebuggerScriptSource';
 import { NetworkResponseHandler } from './handlers/NetworkResponse';
+import { PageReloadHandler } from './handlers/PageReload';
 import { VscodeCompatHandler } from './handlers/VscodeCompat';
 import { DeviceRequest, InspectorHandler, DebuggerRequest } from './handlers/types';
 
-export function createInspectorDeviceClass(MetroDeviceClass: typeof MetroDevice) {
+export function createInspectorDeviceClass(
+  metroBundler: MetroBundlerDevServer,
+  MetroDeviceClass: typeof MetroDevice
+) {
   return class ExpoInspectorDevice extends MetroDeviceClass implements InspectorHandler {
     /** All handlers that should be used to intercept or reply to CDP events */
     public handlers: InspectorHandler[] = [
       new NetworkResponseHandler(),
       new DebuggerScriptSourceHandler(this),
+      new PageReloadHandler(metroBundler),
       new VscodeCompatHandler(),
     ];
 

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/PageReload.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/PageReload.ts
@@ -1,0 +1,25 @@
+import type { Protocol } from 'devtools-protocol';
+import { DebuggerInfo } from 'metro-inspector-proxy';
+
+import { MetroBundlerDevServer } from '../../MetroBundlerDevServer';
+import { CdpMessage, DebuggerRequest, InspectorHandler } from './types';
+
+export class PageReloadHandler implements InspectorHandler {
+  constructor(private readonly metroBundler: MetroBundlerDevServer) {}
+
+  onDebuggerMessage(
+    message: DebuggerRequest<PageReload>,
+    { socket }: Pick<DebuggerInfo, 'socket'>
+  ) {
+    if (message.method === 'Page.reload') {
+      this.metroBundler.broadcastMessage('reload');
+      socket.send(JSON.stringify({ id: message.id }));
+      return true;
+    }
+
+    return false;
+  }
+}
+
+/** @see https://chromedevtools.github.io/devtools-protocol/1-2/Page/#method-reload */
+export type PageReload = CdpMessage<'Page.reload', Protocol.Page.ReloadRequest, never>;

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/PageReload.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/__tests__/PageReload.test.ts
@@ -1,0 +1,21 @@
+import { PageReloadHandler } from '../PageReload';
+
+it('broadcasts reload message', () => {
+  const bundler = { broadcastMessage: jest.fn() };
+  const handler = new PageReloadHandler(bundler as any);
+  const debuggerSocket = { send: jest.fn() };
+
+  expect(
+    handler.onDebuggerMessage(
+      {
+        id: 420,
+        method: 'Page.reload',
+        params: { ignoreCache: false },
+      },
+      { socket: debuggerSocket }
+    )
+  ).toBe(true);
+
+  expect(bundler.broadcastMessage).toBeCalledWith('reload');
+  expect(debuggerSocket.send).toBeCalledWith(JSON.stringify({ id: 420 }));
+});

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/types.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/handlers/types.ts
@@ -23,19 +23,17 @@ export type CdpMessage<
   Request extends object = object,
   Response extends object = object
 > = {
+  id: number;
   method: Method;
   params: Request;
   result: Response;
 };
 
 export type DeviceRequest<M extends CdpMessage = CdpMessage> = Pick<M, 'method' | 'params'>;
-export type DeviceResponse<M extends CdpMessage = CdpMessage> = Pick<M, 'result'> & {
-  /** The request identifier, used to link requests and responses */
-  id: number;
-};
+export type DeviceResponse<M extends CdpMessage = CdpMessage> = Pick<M, 'id' | 'result'>;
 
-export type DebuggerRequest<M extends CdpMessage = CdpMessage> = Pick<M, 'method' | 'params'> & {
-  /** The request identifier, used to link requests and responses */
-  id: number;
-};
+export type DebuggerRequest<M extends CdpMessage = CdpMessage> = Pick<
+  M,
+  'id' | 'method' | 'params'
+>;
 export type DebuggerResponse<M extends CdpMessage = CdpMessage> = Pick<M, 'result'>;

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/index.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/index.ts
@@ -1,3 +1,4 @@
+import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import {
   importMetroInspectorDeviceFromProject,
   importMetroInspectorProxyFromProject,
@@ -9,7 +10,7 @@ export { ExpoInspectorProxy } from './proxy';
 
 const debug = require('debug')('expo:metro:inspector-proxy') as typeof console.log;
 
-export function createInspectorProxy(projectRoot: string) {
+export function createInspectorProxy(metroBundler: MetroBundlerDevServer, projectRoot: string) {
   debug('Experimental inspector proxy enabled');
 
   // Import the installed `metro-inspector-proxy` from the project
@@ -17,6 +18,7 @@ export function createInspectorProxy(projectRoot: string) {
   const { InspectorProxy: MetroInspectorProxy } = importMetroInspectorProxyFromProject(projectRoot);
   // The device is slightly more complicated, we need to extend that class
   const ExpoInspectorDevice = createInspectorDeviceClass(
+    metroBundler,
     importMetroInspectorDeviceFromProject(projectRoot)
   );
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -14,6 +14,7 @@ import { env } from '../../../utils/env';
 import { getMetroServerRoot } from '../middleware/ManifestMiddleware';
 import { createDevServerMiddleware } from '../middleware/createDevServerMiddleware';
 import { getPlatformBundlers } from '../platformBundlers';
+import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { importExpoMetroConfigFromProject } from './resolveFromProject';
 import { runServer } from './runServer-fork';
@@ -65,7 +66,7 @@ export async function loadMetroConfigAsync(
 
 /** The most generic possible setup for Metro bundler. */
 export async function instantiateMetroAsync(
-  projectRoot: string,
+  metroBundler: MetroBundlerDevServer,
   options: Omit<MetroDevServerOptions, 'logger'>
 ): Promise<{
   metro: Metro.Server;
@@ -73,6 +74,8 @@ export async function instantiateMetroAsync(
   middleware: any;
   messageSocket: MessageSocket;
 }> {
+  const projectRoot = metroBundler.projectRoot;
+
   // TODO: When we bring expo/metro-config into the expo/expo repo, then we can upstream this.
   const { exp } = getConfig(projectRoot, {
     skipSDKVersionRequirement: true,
@@ -102,7 +105,7 @@ export async function instantiateMetroAsync(
 
   middleware.use(createDebuggerTelemetryMiddleware(projectRoot, exp));
 
-  const { server, metro } = await runServer(projectRoot, metroConfig, {
+  const { server, metro } = await runServer(metroBundler, metroConfig, {
     hmrEnabled: true,
     websocketEndpoints,
     watch: isWatchEnabled(),

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -11,6 +11,7 @@ import { InspectorProxy } from 'metro-inspector-proxy';
 import { parse } from 'url';
 
 import { env } from '../../../utils/env';
+import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { createInspectorProxy, ExpoInspectorProxy } from './inspector-proxy';
 import {
   importMetroCreateWebsocketServerFromProject,
@@ -20,7 +21,7 @@ import {
 } from './resolveFromProject';
 
 export const runServer = async (
-  projectRoot: string,
+  metroBundler: MetroBundlerDevServer,
   config: ConfigT,
   {
     hasReducedPerformance = false,
@@ -33,6 +34,8 @@ export const runServer = async (
     watch,
   }: RunServerOptions
 ): Promise<{ server: http.Server | https.Server; metro: Server }> => {
+  const projectRoot = metroBundler.projectRoot;
+
   const Metro = importMetroFromProject(projectRoot);
 
   const createWebsocketServer = importMetroCreateWebsocketServerFromProject(projectRoot);
@@ -68,7 +71,7 @@ export const runServer = async (
 
   let inspectorProxy: InspectorProxy | ExpoInspectorProxy | null = null;
   if (config.server.runInspectorProxy && env.EXPO_USE_CUSTOM_INSPECTOR_PROXY) {
-    inspectorProxy = createInspectorProxy(config.projectRoot);
+    inspectorProxy = createInspectorProxy(metroBundler, config.projectRoot);
   } else if (config.server.runInspectorProxy) {
     inspectorProxy = new InspectorProxy(config.projectRoot);
   }


### PR DESCRIPTION
# Why

This implements the `Page.reload` CDP event, to reload the app itself.

> Would be nice if there is a way to send this to _JUST_ the device you are inspecting. But not sure what socket connection that would be, don't think it's the actual device socket in the inspector (that's inspector messages only).

# How

- Provided the reference of `MetroBundlerDevServer` to the inspector
- Called `MetroBundlerDevServer.broadcastMessage('reload')`

# Test Plan

- Open chrome inspector (`j`)
- Anywhere in the inspector, press `cmd+r`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
