### PR TITLE
[docs] Add a guide on how to use create-expo-module in your project

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -115,6 +115,7 @@ const general = [
     makePage('modules/native-module-tutorial.mdx'),
     makePage('modules/native-view-tutorial.mdx'),
     makePage('modules/config-plugin-and-native-module-tutorial.mdx'),
+    makePage('modules/use-create-expo-module-in-your-project.mdx'),
     makePage('modules/existing-library.mdx'),
     makePage('modules/module-api.mdx'),
     makePage('modules/android-lifecycle-listeners.mdx'),

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -1,0 +1,180 @@
+---
+title: How to use a module created with create-expo-module in your project
+sidebar_title: Use a create-expo-module in your project
+description: Learn how to use a module created with create-expo-module in your project.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+There are two main ways to use a module created with `create-expo-module` inside an existing project: configuring a monorepo or publishing the module to npm. In this guide, we will walk you through both alternatives.
+
+## Using a monorepo
+
+For this guide, we assume that you have the following project structure:
+
+- **apps/** - Contains multiple projects, including React Native apps.
+- **packages/** - Contains different packages used by our apps.
+- **package.json** - Root package file, containing yarn workspaces config.
+
+If you're not familiar with how to configure your project as a monorepo, check the **[Working with monorepos](/guides/monorepos/)** guide.
+
+### 1. Initialize a new module
+
+Once you have set up the basic monorepo structure, create a new module using `create-expo-module`:
+
+<Terminal cmd={['$ npx create-expo-module packages/expo-settings']} />
+
+### 2. Set up our workspace
+
+We won't need the **example** folder included by `create-expo-module`. Let's clean up the default module with the following command:
+
+<Terminal cmd={['$ rm -rf packages/expo-settings/example']} />
+
+Now, let's configure `autolinking` so all of our apps can use the newly created module. Add the following block to the **package.json** file of each app under the **apps** folder:
+
+```json package.json
+"expo": {
+    "autolinking": {
+      "nativeModulesDir": "../../packages"
+    }
+  }
+```
+
+### 3. Running your module
+
+Now let's run an app to ensure everything is working. Start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module JavaScript.
+
+<Terminal
+  cmdCopy="cd packages/expo-settings && npm run build"
+  cmd={['$ cd packages/expo-settings', '$ npm run build']}
+/>
+
+In another terminal window, chose one of your apps under the **apps** folder and run the `prebuild` command. You will need to do this in all apps inside your monorepo in order to use the new module.
+
+<Terminal cmd={['$ npx expo prebuild --clean']} />
+
+Compile and run the app with the following command:
+
+<Terminal
+  cmdCopy="npx expo run:ios"
+  cmd={[
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+  ]}
+/>
+
+You should now be able to use the module inside your app. To test this, let's edit the **App.js**
+file in the app and render the `hello` text from our `expo-settings` module:
+
+```javascript App.js
+import * as Settings from 'expo-settings';
+import { StatusBar } from 'expo-status-bar';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>{Settings.hello()}</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+```
+
+If you've configured everything correctly you should see a text saying "Hello world! 👋” in your app.
+
+## Publishing your module
+
+If you don't want to go through the process of setting up a monorepo, you can also publish your module to npm and just add it to your projects as a normal dependency.
+
+### 1. Initialize a new module
+
+First, start by creating a new module using `create-expo-module`. Pay attention to each prompt as we're going to publish this library, so make sure to choose a unique name for your npm package.
+
+<Terminal cmd={['$ npx create-expo-module expo-settings']} />
+
+### **2. Run the example project**
+
+Now let's run the example project to make sure everything is working. Start the TypeScript compiler to watch for changes and rebuild the module JavaScript.
+
+<Terminal
+  cmd={[
+    '# Run this in the root of the project to start the TypeScript compiler',
+    '$ npm run build',
+  ]}
+/>
+
+In another terminal window, compile and run the example app:
+
+<Terminal
+  cmdCopy="cd example && npx expo run:ios"
+  cmd={[
+    '$ cd example',
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+  ]}
+/>
+
+### 3. Publish your package to npm
+
+In order to publish your package to npm, you need to have an npm account. If you don't have one, first register through [the npm website](https://www.npmjs.com/signup). Once you have an account, log in using the following command:
+
+<Terminal cmd={['$ npm login']} />
+
+Then, navigate to the root of your module and publish your module running:
+
+<Terminal cmd={['$ npm publish']} />
+
+Your module is now published to npm and can be installed in other projects using `npm install`.
+
+Apart from publishing your module to npm, there are other ways to use it in your project. One way is to create a tarball of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. This is useful if you want to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry. Another way is to run a local npm registry and install your module from there.
+
+If you want to publish a private private package or use a private registry with EAS Builds you can read how to configure it [here](https://docs.expo.dev/build-reference/private-npm-packages/).
+
+### 4. Test the published module
+
+To test the published module in a new project, create a new app and add the module as a dependency:
+
+<Terminal
+  cmdCopy="npx create-expo-app my-app && cd my-app && npx expo install expo-settings"
+  cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
+/>
+
+You should now be able to use the module inside your app! To test this, let's edit the **App.js** in the app and render the `hello` text from our **expo-settings**.
+
+```javascript App.js
+import * as Settings from 'expo-settings';
+import { StatusBar } from 'expo-status-bar';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>{Settings.hello()}</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+```
+
+To run your app locally first run the `prebuild` command and then compile the app.
+
+<Terminal
+  cmdCopy="npx expo prebuild --clean && npx expo run:ios"
+  cmd={[
+    '# Re-generate the native project directories from scratch',
+    '$ npx expo prebuild --clean',
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+  ]}
+/>
+
+If you've configured everything correctly you should see a text saying "Hello world! 👋” in your app.

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -20,15 +20,11 @@ If you need to familiarize yourself with configuring your project as a monorepo,
 
 ### 1. Initialize a new module
 
-Once you have set up the basic monorepo structure, create a new module using `create-expo-module`:
+Once you have set up the basic monorepo structure, create a new module using `create-expo-module` with the flag `no-example` to skip creating the example app:
 
-<Terminal cmd={['$ npx create-expo-module packages/expo-settings']} />
+<Terminal cmd={['$ npx create-expo-module packages/expo-settings --no-example']} />
 
 ### 2. Set up our workspace
-
-You don't need the **example** folder included by `create-expo-module`. Let's clean up the default module with the following command:
-
-<Terminal cmd={['$ rm -rf packages/expo-settings/example']} />
 
 Now, let's configure `autolinking` so all your apps can use the newly created module. Add the following block to the **package.json** file of each app under the **apps** directory:
 

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -131,9 +131,7 @@ Apart from publishing your module to npm, there are other ways to use it in your
 
 - Create a tarball of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. It's useful to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry.
 - Run a local npm registry, such as [Verdaccio](https://verdaccio.org/), and install your module from there. This is useful for cases where you want to host your private npm registry to manage internal packages within a company or organization.
-- [Publish a private package or use a private registry with EAS Builds](https://docs.expo.dev/build-reference/private-npm-packages/).
-
-If you want to publish a private private package or use a private registry with EAS Builds you can read how to configure it [here](https://docs.expo.dev/build-reference/private-npm-packages/).
+- [Publish a private package or use a private registry with EAS Builds](/build-reference/private-npm-packages/).
 
 ### 4. Test the published module
 

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -1,22 +1,22 @@
 ---
 title: How to use a module created with create-expo-module in your project
-sidebar_title: Use a create-expo-module in your project
+sidebar_title: Use a module created with create-expo-module
 description: Learn how to use a module created with create-expo-module in your project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 
-There are two main ways to use a module created with `create-expo-module` inside an existing project: configuring a monorepo or publishing the module to npm. In this guide, we will walk you through both alternatives.
+There are two main ways to use a module created with `create-expo-module` inside an existing project: configuring a monorepo or publishing the module to npm. This guide walkthroughs both methods.
 
 ## Using a monorepo
 
 For this guide, we assume that you have the following project structure:
 
 - **apps/** - Contains multiple projects, including React Native apps.
-- **packages/** - Contains different packages used by our apps.
-- **package.json** - Root package file, containing yarn workspaces config.
+- **packages/** - Contains different packages used by your apps.
+- **package.json** - Root package file containing Yarn workspaces config.
 
-If you're not familiar with how to configure your project as a monorepo, check the **[Working with monorepos](/guides/monorepos/)** guide.
+If you need to familiarize yourself with configuring your project as a monorepo, see [**Working with monorepos**](/guides/monorepos/) guide.
 
 ### 1. Initialize a new module
 
@@ -26,11 +26,11 @@ Once you have set up the basic monorepo structure, create a new module using `cr
 
 ### 2. Set up our workspace
 
-We won't need the **example** folder included by `create-expo-module`. Let's clean up the default module with the following command:
+You don't need the **example** folder included by `create-expo-module`. Let's clean up the default module with the following command:
 
 <Terminal cmd={['$ rm -rf packages/expo-settings/example']} />
 
-Now, let's configure `autolinking` so all of our apps can use the newly created module. Add the following block to the **package.json** file of each app under the **apps** folder:
+Now, let's configure `autolinking` so all your apps can use the newly created module. Add the following block to the **package.json** file of each app under the **apps** directory:
 
 ```json package.json
 "expo": {
@@ -40,7 +40,7 @@ Now, let's configure `autolinking` so all of our apps can use the newly created 
 }
 ```
 
-### 3. Running your module
+### 3. Run the module
 
 Now let's run an app to ensure everything is working. Start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module JavaScript.
 
@@ -49,7 +49,7 @@ Now let's run an app to ensure everything is working. Start the TypeScript compi
   cmd={['$ cd packages/expo-settings', '$ npm run build']}
 />
 
-In another terminal window, choose one of your apps under the **apps** folder and run the `prebuild` command. You will need to do this in all apps inside your monorepo in order to use the new module.
+Open another terminal window, choose one of your apps under the **apps** folder, and run the `prebuild` command. You'll have to repeat these steps for all apps inside your monorepo to use the new module.
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 
@@ -65,10 +65,9 @@ Compile and run the app with the following command:
   ]}
 />
 
-You should now be able to use the module inside your app. To test this, let's edit the **App.js**
-file in the app and render the `hello` text from our `expo-settings` module:
+You can now use the module inside your app. To test this, let's edit the **App.js** file in the app and render the a text message from the `expo-settings` module:
 
-```javascript App.js
+```jsx App.js
 import * as Settings from 'expo-settings';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
@@ -84,7 +83,7 @@ export default function App() {
 }
 ```
 
-If you've configured everything correctly you should see a text saying "Hello world! 👋” in your app.
+If you've configured everything correctly, you'll see a text saying "Hello world! 👋" in the app.
 
 ## Publishing your module
 
@@ -92,13 +91,13 @@ If you don't want to go through the process of setting up a monorepo, you can al
 
 ### 1. Initialize a new module
 
-First, start by creating a new module using `create-expo-module`. Pay attention to each prompt as we're going to publish this library, so make sure to choose a unique name for your npm package.
+Start by creating a new module using `create-expo-module`. Pay attention to each prompt as you'll publish this library, and choose a unique name for your npm package.
 
 <Terminal cmd={['$ npx create-expo-module expo-settings']} />
 
-### **2. Run the example project**
+### 2. Run the example project
 
-Now let's run the example project to make sure everything is working. Start the TypeScript compiler to watch for changes and rebuild the module JavaScript.
+Run the example project to make sure everything is working. Then, start the TypeScript compiler to watch for changes and rebuild the JavaScript module.
 
 <Terminal
   cmd={[
@@ -107,7 +106,7 @@ Now let's run the example project to make sure everything is working. Start the 
   ]}
 />
 
-In another terminal window, compile and run the example app:
+Open another terminal window, compile and run the example app:
 
 <Terminal
   cmdCopy="cd example && npx expo run:ios"
@@ -122,7 +121,7 @@ In another terminal window, compile and run the example app:
 
 ### 3. Publish your package to npm
 
-In order to publish your package to npm, you need to have an npm account. If you don't have one, first register through [the npm website](https://www.npmjs.com/signup). Once you have an account, log in using the following command:
+To publish your package to npm, you need to have an npm account. If you don't have one, create it on [the npm website](https://www.npmjs.com/signup). Once you have an account, log in using the following command:
 
 <Terminal cmd={['$ npm login']} />
 
@@ -130,7 +129,7 @@ Then, navigate to the root of your module and publish your module running:
 
 <Terminal cmd={['$ npm publish']} />
 
-Your module is now published to npm and can be installed in other projects using `npm install`.
+Your module will now be published to npm and can be installed in other projects using `npm install`.
 
 Apart from publishing your module to npm, there are other ways to use it in your project. One way is to create a tarball of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. This is useful if you want to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry. Another way is to run a local npm registry and install your module from there.
 
@@ -138,16 +137,16 @@ If you want to publish a private private package or use a private registry with 
 
 ### 4. Test the published module
 
-To test the published module in a new project, create a new app and add the module as a dependency:
+To test the published module in a new project, create a new app and install the module as a dependency:
 
 <Terminal
   cmdCopy="npx create-expo-app my-app && cd my-app && npx expo install expo-settings"
   cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
 />
 
-You should now be able to use the module inside your app! To test this, let's edit the **App.js** in the app and render the `hello` text from our **expo-settings**.
+You should now be able to use the module inside your app! To test it, edit the **App.js** in the app and render the text message from **expo-settings**.
 
-```javascript App.js
+```jsx App.js
 import * as Settings from 'expo-settings';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
@@ -163,7 +162,7 @@ export default function App() {
 }
 ```
 
-To run your app locally first run the `prebuild` command and then compile the app.
+To run your app locally, run the `prebuild` command and then compile the app.
 
 <Terminal
   cmdCopy="npx expo prebuild --clean && npx expo run:ios"
@@ -177,4 +176,4 @@ To run your app locally first run the `prebuild` command and then compile the ap
   ]}
 />
 
-If you've configured everything correctly you should see a text saying "Hello world! 👋” in your app.
+If you've configured everything correctly, you'll see a text saying "Hello world! 👋" in the app.

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -45,7 +45,7 @@ Run one of the apps to ensure everything is working. Then, start the TypeScript 
   cmd={['$ cd packages/expo-settings', '$ npm run build']}
 />
 
-Open another terminal window, choose one of your apps under the **apps** folder, and run the `prebuild` command. You'll have to repeat these steps for all apps inside your monorepo to use the new module.
+Open another terminal window, choose an app from the **apps** directory, and run the `prebuild` command. You'll have to repeat these steps for all apps inside your monorepo to use the new module.
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 
@@ -127,7 +127,11 @@ Then, navigate to the root of your module and publish your module running:
 
 Your module will now be published to npm and can be installed in other projects using `npm install`.
 
-Apart from publishing your module to npm, there are other ways to use it in your project. One way is to create a tarball of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. This is useful if you want to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry. Another way is to run a local npm registry and install your module from there.
+Apart from publishing your module to npm, there are other ways to use it in your project:
+
+- Creating a tarball of of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. It's useful to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry.
+- Running a local npm registry, such as [Verdaccio](https://verdaccio.org/), and installing your module from there. This is useful for cases where you want to host your own private npm registry to manage internal packages within a company or organization.
+- If you want to [publish a private package or use a private registry with EAS Builds](https://docs.expo.dev/build-reference/private-npm-packages/).
 
 If you want to publish a private private package or use a private registry with EAS Builds you can read how to configure it [here](https://docs.expo.dev/build-reference/private-npm-packages/).
 

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -8,7 +8,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 There are two main ways to use a module created with `create-expo-module` inside an existing project: configuring a monorepo or publishing the module to npm. This guide walkthroughs both methods.
 
-## Using a monorepo
+## Use a monorepo
 
 For this guide, we assume that you have the following project structure:
 
@@ -24,7 +24,7 @@ Once you have set up the basic monorepo structure, create a new module using `cr
 
 <Terminal cmd={['$ npx create-expo-module packages/expo-settings --no-example']} />
 
-### 2. Set up our workspace
+### 2. Set up workspace
 
 Now, let's configure `autolinking` so all your apps can use the newly created module. Add the following block to the **package.json** file of each app under the **apps** directory:
 
@@ -79,7 +79,7 @@ export default function App() {
 }
 ```
 
-If you've configured everything correctly, you'll see a text saying "Hello world! 👋" in the app.
+After this configuration, you'll see a text that says "Hello world! 👋" in the app.
 
 ## Publish the module to npm
 
@@ -115,7 +115,7 @@ Open another terminal window, compile and run the example app:
   ]}
 />
 
-### 3. Publish your package to npm
+### 3. Publish the package to npm
 
 To publish your package to npm, you need to have an npm account. If you don't have one, create it on [the npm website](https://www.npmjs.com/signup). Once you have an account, log in using the following command:
 
@@ -129,9 +129,9 @@ Your module will now be published to npm and can be installed in other projects 
 
 Apart from publishing your module to npm, there are other ways to use it in your project:
 
-- Creating a tarball of of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. It's useful to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry.
-- Running a local npm registry, such as [Verdaccio](https://verdaccio.org/), and installing your module from there. This is useful for cases where you want to host your own private npm registry to manage internal packages within a company or organization.
-- If you want to [publish a private package or use a private registry with EAS Builds](https://docs.expo.dev/build-reference/private-npm-packages/).
+- Create a tarball of your module using `npm pack` and install it directly in your project by running `npm install /path/to/tarball`. It's useful to test your module locally before publishing it to npm or if you want to share it with others who don't have access to the npm registry.
+- Run a local npm registry, such as [Verdaccio](https://verdaccio.org/), and install your module from there. This is useful for cases where you want to host your private npm registry to manage internal packages within a company or organization.
+- [Publish a private package or use a private registry with EAS Builds](https://docs.expo.dev/build-reference/private-npm-packages/).
 
 If you want to publish a private private package or use a private registry with EAS Builds you can read how to configure it [here](https://docs.expo.dev/build-reference/private-npm-packages/).
 
@@ -176,4 +176,4 @@ To run your app locally, run the `prebuild` command and then compile the app.
   ]}
 />
 
-If you've configured everything correctly, you'll see a text saying "Hello world! 👋" in the app.
+After this configuration, you'll see a text that says "Hello world! 👋" in the app.

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -38,7 +38,7 @@ Now, let's configure `autolinking` so all your apps can use the newly created mo
 
 ### 3. Run the module
 
-Run one of the apps to ensure everything is working. Then, start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module JavaScript:
+Run one of the apps to ensure everything is working. Then, start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module's JavaScript:
 
 <Terminal
   cmdCopy="cd packages/expo-settings && npm run build"

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -83,7 +83,7 @@ If you've configured everything correctly, you'll see a text saying "Hello world
 
 ## Publish the module to npm
 
-If you don't want to go through the process of setting up a monorepo, you can also publish your module to npm and just add it to your projects as a normal dependency.
+You can publish the module on npm and then add it to your project by installing it as a dependency.
 
 ### 1. Initialize a new module
 

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -38,7 +38,7 @@ Now, let's configure `autolinking` so all your apps can use the newly created mo
 
 ### 3. Run the module
 
-Now let's run an app to ensure everything is working. Start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module JavaScript.
+Run one of the apps to ensure everything is working. Then, start the TypeScript compiler inside **packages/expo-settings** to watch for changes and rebuild the module JavaScript:
 
 <Terminal
   cmdCopy="cd packages/expo-settings && npm run build"
@@ -81,7 +81,7 @@ export default function App() {
 
 If you've configured everything correctly, you'll see a text saying "Hello world! 👋" in the app.
 
-## Publishing your module
+## Publish the module to npm
 
 If you don't want to go through the process of setting up a monorepo, you can also publish your module to npm and just add it to your projects as a normal dependency.
 

--- a/docs/pages/modules/use-create-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-create-expo-module-in-your-project.mdx
@@ -34,10 +34,10 @@ Now, let's configure `autolinking` so all of our apps can use the newly created 
 
 ```json package.json
 "expo": {
-    "autolinking": {
-      "nativeModulesDir": "../../packages"
-    }
+  "autolinking": {
+    "nativeModulesDir": "../../packages"
   }
+}
 ```
 
 ### 3. Running your module
@@ -49,7 +49,7 @@ Now let's run an app to ensure everything is working. Start the TypeScript compi
   cmd={['$ cd packages/expo-settings', '$ npm run build']}
 />
 
-In another terminal window, chose one of your apps under the **apps** folder and run the `prebuild` command. You will need to do this in all apps inside your monorepo in order to use the new module.
+In another terminal window, choose one of your apps under the **apps** folder and run the `prebuild` command. You will need to do this in all apps inside your monorepo in order to use the new module.
 
 <Terminal cmd={['$ npx expo prebuild --clean']} />
 
@@ -58,9 +58,9 @@ Compile and run the app with the following command:
 <Terminal
   cmdCopy="npx expo run:ios"
   cmd={[
-    '# Run the example app on Android',
+    '# Run the app on Android',
     '$ npx expo run:android',
-    '# Run the example app on iOS',
+    '# Run the app on iOS',
     '$ npx expo run:ios',
   ]}
 />


### PR DESCRIPTION
# Why

Closes ENG-6930

# How

This PR adds a guide on "How to use a module created with create-expo-module in your project" to the Expo Modules API section

# Test Plan

N / A

# Checklist 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
