### PR TITLE
[docs] Fix snack example in Localization guide

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -76,7 +76,7 @@ On iOS, when a user changes the device's language, the app will reset. This mean
 
 ```tsx
 import { View, StyleSheet, Text } from 'react-native';
-import { getLocales } from 'expo-localization';
+import * as Localization from 'expo-localization';
 import { I18n } from 'i18n-js';
 
 // Set the key-value pairs for the different languages you want to support.
@@ -101,7 +101,7 @@ export default function App() {
         {i18n.t('welcome')} {i18n.t('name')}
       </Text>
       <Text>Current locale: {i18n.locale}</Text>
-      <Text>Device locale: {getLocales()[0].languageCode}</Text>
+      <Text>Device locale: {Localization.getLocales()[0].languageCode}</Text>
     </View>
   );
 }


### PR DESCRIPTION
Localization variable not declared.

# Why

The snack failed, because variable Localization is not declared

# How

Imported whole _expo-localization_ package as Localization 

# Test Plan

Run the snack

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- x[ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
