### PR TITLE
[image][ios] Fixes shouldDownscale don't respect the scale factor

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed the `tintColor` not being passed to native view. ([#21576](https://github.com/expo/expo/pull/21576) by [@andrew-levy](https://github.com/andrew-levy))
 - Fixed `canvas: trying to use a recycled bitmap` on Android. ([#21658](https://github.com/expo/expo/pull/21658) by [@lukmccall](https://github.com/lukmccall))
 - Fixed crashes caused by empty placeholder or source on Android. ([#21695](https://github.com/expo/expo/pull/21695) by [@lukmccall](https://github.com/lukmccall))
+- Fixes `shouldDownscale` don't respect the scale factor on iOS. ([#21839](https://github.com/expo/expo/pull/21839) by [@ouabing](https://github.com/ouabing))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageUtils.swift
+++ b/packages/expo-image/ios/ImageUtils.swift
@@ -87,7 +87,7 @@ func shouldDownscale(image: UIImage, toSize size: CGSize, scale: Double) -> Bool
     return false
   }
   let imageSize = image.size * image.scale
-  return imageSize.width > size.width && imageSize.height > size.height
+  return imageSize.width > (size.width * scale) && imageSize.height > (size.height * scale)
 }
 
 /**


### PR DESCRIPTION
# Why

`shouldDownscale` ignores the scale factor when checking if we should resize the image.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

Correctly multiply `idealSize` by the scale factor.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
