### PR TITLE
Fix missing await keyword when generating android monochrome image

### DIFF
--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing await keyword when generating android monochrome image. ([#21841](https://github.com/expo/expo/pull/21841) by [@rightones](https://github.com/rightones))
+
 ### 💡 Others
 
 - Update tests to use latest Expo template. ([#21339](https://github.com/expo/expo/pull/21339) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/prebuild-config/src/plugins/icons/withAndroidIcons.ts
+++ b/packages/@expo/prebuild-config/src/plugins/icons/withAndroidIcons.ts
@@ -336,11 +336,11 @@ async function generateMonochromeImageAsync(
   }: { icon: string; imageCacheFolder: string; outputImageFileName: string }
 ) {
   await iterateDpiValues(projectRoot, async ({ dpiFolder, scale }) => {
-    const monochromeIcon = generateIconAsync(projectRoot, {
-      cacheType: imageCacheFolder,
-      src: icon,
-      scale,
-      backgroundColor: 'transparent',
+    const monochromeIcon = await generateIconAsync(projectRoot, {
+        cacheType: imageCacheFolder,
+        src: icon,
+        scale,
+        backgroundColor: "transparent",
     });
     await fs.ensureDir(dpiFolder);
     await fs.writeFile(path.resolve(dpiFolder, outputImageFileName), monochromeIcon);

--- a/packages/@expo/prebuild-config/src/plugins/icons/withAndroidIcons.ts
+++ b/packages/@expo/prebuild-config/src/plugins/icons/withAndroidIcons.ts
@@ -337,10 +337,10 @@ async function generateMonochromeImageAsync(
 ) {
   await iterateDpiValues(projectRoot, async ({ dpiFolder, scale }) => {
     const monochromeIcon = await generateIconAsync(projectRoot, {
-        cacheType: imageCacheFolder,
-        src: icon,
-        scale,
-        backgroundColor: "transparent",
+      cacheType: imageCacheFolder,
+      src: icon,
+      scale,
+      backgroundColor: 'transparent',
     });
     await fs.ensureDir(dpiFolder);
     await fs.writeFile(path.resolve(dpiFolder, outputImageFileName), monochromeIcon);


### PR DESCRIPTION


This PR fixes missing await keyword when generating monochrome image.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
