### PR TITLE
[core][Android] Introduce shared object

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/JavaScriptViewModule.kt
@@ -15,7 +15,7 @@ class JavaScriptViewModule {
     inlineModule {
       Name("TestModule")
       View(android.view.View::class) {
-        AsyncFunction("viewFunction") { viewTag: Int -> }
+        AsyncFunction("viewFunction") { _: Int -> }
         AsyncFunction("anotherViewFunction") { -> 20 }
       }
     }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -7,6 +7,7 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.modules.ModuleDefinitionBuilder
+import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -28,9 +29,11 @@ internal inline fun withJSIInterop(
       register(it)
     }
   }
+  val sharedObjectRegistry = SharedObjectRegistry()
   every { appContextMock.registry } answers { registry }
   every { appContextMock.modulesQueue } answers { methodQueue }
   every { appContextMock.mainQueue } answers { methodQueue }
+  every { appContextMock.sharedObjectRegistry } answers { sharedObjectRegistry }
 
   val jsiIterop = JSIInteropModuleRegistry(appContextMock).apply {
     installJSIForTests()

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -3,6 +3,9 @@
 package expo.modules.kotlin.jni
 
 import com.google.common.truth.Truth
+import expo.modules.kotlin.sharedobjects.SharedObject
+import expo.modules.kotlin.sharedobjects.SharedObjectId
+import expo.modules.kotlin.sharedobjects.sharedObjectIdPropertyName
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
@@ -69,5 +72,97 @@ class JavaScriptClassTest {
   ) {
     val foo = evaluateScript("(new expo.modules.TestModule.MyClass().f())").getString()
     Truth.assertThat(foo).isEqualTo("bar")
+  }
+
+  @Test
+  fun native_constructor_should_be_called() {
+    var wasCalled = false
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Class("MyClass") {
+          Constructor {
+            wasCalled = true
+          }
+        }
+      }
+    ) {
+      evaluateScript("new expo.modules.TestModule.MyClass()")
+      Truth.assertThat(wasCalled).isTrue()
+    }
+  }
+
+  @Test
+  fun shared_object_should_be_added_to_registry() {
+    class MySharedObject : SharedObject()
+
+    val mySharedObject = MySharedObject()
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Class(MySharedObject::class) {
+          Constructor {
+            return@Constructor mySharedObject
+          }
+        }
+      }
+    ) {
+      val jsObject = evaluateScript("new expo.modules.TestModule.MySharedObject()").getObject()
+      val id = SharedObjectId(jsObject.getProperty(sharedObjectIdPropertyName).getInt())
+
+      val appContext = appContextHolder.get()!!
+      val (native, _) = appContext.sharedObjectRegistry.pairs[id]!!
+      Truth.assertThat(native).isSameInstanceAs(mySharedObject)
+    }
+  }
+
+  @Test
+  fun shared_object_should_be_passed_as_this_in_sync_function() {
+    class MySharedObject : SharedObject()
+
+    val mySharedObject = MySharedObject()
+    var wasCalled = false
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Class(MySharedObject::class) {
+          Constructor {
+            return@Constructor mySharedObject
+          }
+          Function("receiveThis") { self: MySharedObject ->
+            Truth.assertThat(self).isSameInstanceAs(mySharedObject)
+            wasCalled = true
+          }
+        }
+      }
+    ) {
+      evaluateScript("(new expo.modules.TestModule.MySharedObject()).receiveThis()")
+      Truth.assertThat(wasCalled).isTrue()
+    }
+  }
+
+  @Test
+  fun shared_object_should_be_passed_as_this_in_async_function() {
+    class MySharedObject : SharedObject()
+
+    val mySharedObject = MySharedObject()
+    var wasCalled = false
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Class(MySharedObject::class) {
+          Constructor {
+            return@Constructor mySharedObject
+          }
+          AsyncFunction("receiveThis") { self: MySharedObject ->
+            Truth.assertThat(self).isSameInstanceAs(mySharedObject)
+            wasCalled = true
+          }
+        }
+      }
+    ) {
+      waitForAsyncFunction(it, "(new expo.modules.TestModule.MySharedObject()).receiveThis()")
+      Truth.assertThat(wasCalled).isTrue()
+    }
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -119,7 +119,7 @@ bool JSIInteropModuleRegistry::callHasModule(const std::string &moduleName) cons
     ->getMethod<jboolean(std::string)>(
       "hasModule"
     );
-  return (bool)method(javaPart_, moduleName);
+  return (bool) method(javaPart_, moduleName);
 }
 
 jni::local_ref<JavaScriptModuleObject::javaobject>
@@ -151,5 +151,16 @@ jni::local_ref<JavaScriptObject::javaobject> JSIInteropModuleRegistry::createObj
 
 void JSIInteropModuleRegistry::drainJSEventLoop() {
   runtimeHolder->drainJSEventLoop();
+}
+
+void JSIInteropModuleRegistry::registerSharedObject(
+  jni::local_ref<jobject> native,
+  jni::local_ref<JavaScriptObject::javaobject> js
+) {
+  const static auto method = expo::JSIInteropModuleRegistry::javaClassLocal()
+    ->getMethod<void(jni::local_ref<jobject>, jni::local_ref<JavaScriptObject::javaobject>)>(
+      "registerSharedObject"
+    );
+  method(javaPart_, std::move(native), std::move(js));
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -78,7 +78,15 @@ public:
    */
   jni::local_ref<JavaScriptObject::javaobject> createObject();
 
-  void registerSharedObject(jni::local_ref<jobject> native, jni::local_ref<JavaScriptObject::javaobject> js);
+  /**
+   * Adds a shared object to the internal registry
+   * @param native part of the shared object
+   * @param js part of the shared object
+   */
+  void registerSharedObject(
+    jni::local_ref<jobject> native,
+    jni::local_ref<JavaScriptObject::javaobject> js
+  );
 
   /**
    * Exposes a `JavaScriptRuntime::drainJSEventLoop` function to Kotlin

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -78,6 +78,8 @@ public:
    */
   jni::local_ref<JavaScriptObject::javaobject> createObject();
 
+  void registerSharedObject(jni::local_ref<jobject> native, jni::local_ref<JavaScriptObject::javaobject> js);
+
   /**
    * Exposes a `JavaScriptRuntime::drainJSEventLoop` function to Kotlin
    */

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -48,6 +48,8 @@ void JavaReferencesCache::loadJClasses(JNIEnv *env) {
   loadJClass(env, "com/facebook/react/bridge/ReadableNativeMap", {});
   loadJClass(env, "com/facebook/react/bridge/WritableNativeArray", {});
   loadJClass(env, "com/facebook/react/bridge/WritableNativeMap", {});
+
+  loadJClass(env, "expo/modules/kotlin/sharedobjects/SharedObject", {});
 }
 
 void JavaReferencesCache::loadJClass(

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -103,7 +103,11 @@ public:
 
   void registerClass(
     jni::alias_ref<jstring> name,
-    jni::alias_ref<JavaScriptModuleObject::javaobject> classObject
+    jni::alias_ref<JavaScriptModuleObject::javaobject> classObject,
+    jboolean takesOwner,
+    jint args,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> expectedArgTypes,
+    jni::alias_ref<JNIFunctionBody::javaobject> body
   );
 
   void registerViewPrototype(
@@ -181,7 +185,10 @@ private:
    */
   std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
 
-  std::map<std::string, jni::global_ref<JavaScriptModuleObject::javaobject>> classes;
+  std::map<
+    std::string,
+    std::pair<jni::global_ref<JavaScriptModuleObject::javaobject>, MethodMetadata>
+  > classes;
 
   jni::global_ref<JavaScriptModuleObject::javaobject> viewPrototype;
 };

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -280,7 +280,8 @@ jsi::Function MethodMetadata::toSyncFunction(
     });
 }
 
-jsi::Value MethodMetadata::callSync(
+jni::local_ref<jobject> MethodMetadata::callJNISync(
+  JNIEnv *env,
   jsi::Runtime &rt,
   JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &thisValue,
@@ -288,17 +289,8 @@ jsi::Value MethodMetadata::callSync(
   size_t count
 ) {
   if (this->jBodyReference == nullptr) {
-    return jsi::Value::undefined();
+    return nullptr;
   }
-
-  JNIEnv *env = jni::Environment::current();
-
-  /**
-   * This will push a new JNI stack frame for the LocalReferences in this
-   * function call. When the stack frame for this lambda is popped,
-   * all LocalReferences are deleted.
-   */
-  jni::JniLocalScope scope(env, (int) count);
 
   auto convertedArgs = convertJSIArgsToJNI(moduleRegistry, env, rt, thisValue, args, count);
 
@@ -309,6 +301,26 @@ jsi::Value MethodMetadata::callSync(
   );
 
   env->DeleteLocalRef(convertedArgs);
+  return result;
+}
+
+jsi::Value MethodMetadata::callSync(
+  jsi::Runtime &rt,
+  JSIInteropModuleRegistry *moduleRegistry,
+  const jsi::Value &thisValue,
+  const jsi::Value *args,
+  size_t count
+) {
+  JNIEnv *env = jni::Environment::current();
+  /**
+  * This will push a new JNI stack frame for the LocalReferences in this
+  * function call. When the stack frame for this lambda is popped,
+  * all LocalReferences are deleted.
+  */
+  jni::JniLocalScope scope(env, (int) count);
+
+  auto result = this->callJNISync(env, rt, moduleRegistry, thisValue, args, count);
+
   if (result == nullptr) {
     return jsi::Value::undefined();
   }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -107,6 +107,15 @@ public:
     size_t count
   );
 
+  jni::local_ref<jobject> callJNISync(
+    JNIEnv *env,
+    jsi::Runtime &rt,
+    JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &thisValue,
+    const jsi::Value *args,
+    size_t count
+  );
+
 private:
   /**
    * Reference to one of two java objects - `JNIFunctionBody` or `JNIAsyncFunctionBody`.

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -24,5 +24,6 @@ enum CppType {
   LIST = 1 << 12,
   MAP = 1 << 13,
   VIEW_TAG = 1 << 14,
+  SHARED_OBJECT_ID = 1 << 15
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -448,4 +448,23 @@ jobject ViewTagFrontendConverter::convert(jsi::Runtime &rt, JNIEnv *env,
 bool ViewTagFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
   return value.isObject() && value.getObject(rt).hasProperty(rt, "nativeTag");
 }
+
+jobject SharedObjectIdConverter::convert(jsi::Runtime &rt, JNIEnv *env,
+                                          JSIInteropModuleRegistry *moduleRegistry,
+                                          const jsi::Value &value) const {
+  auto objectId = value.getObject(rt).getProperty(rt, "__expo_shared_object_id__");
+  if (objectId.isNull()) {
+    return nullptr;
+  }
+
+  auto viewTag = (int) objectId.getNumber();
+  auto &integerClass = JavaReferencesCache::instance()
+    ->getJClass("java/lang/Integer");
+  jmethodID integerConstructor = integerClass.getMethod("<init>", "(I)V");
+  return env->NewObject(integerClass.clazz, integerConstructor, viewTag);
+}
+
+bool SharedObjectIdConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+  return value.isObject() && value.getObject(rt).hasProperty(rt, "__expo_shared_object_id__");
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -205,7 +205,25 @@ public:
   bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
 };
 
+/**
+ * Converter from js view object to int.
+ */
 class ViewTagFrontendConverter : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+};
+
+/**
+ * Converter from js shared object to int.
+ */
+class SharedObjectIdConverter : public FrontendConverter {
 public:
   jobject convert(
     jsi::Runtime &rt,

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -23,6 +23,7 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::READABLE_MAP, ReadableNativeMapArrayFrontendConverter);
   RegisterConverter(CppType::READABLE_ARRAY, ReadableNativeArrayFrontendConverter);
   RegisterConverter(CppType::VIEW_TAG, ViewTagFrontendConverter);
+  RegisterConverter(CppType::SHARED_OBJECT_ID, SharedObjectIdConverter);
 #undef RegisterConverter
 
   auto registerPolyConverter = [this](const std::vector<CppType> &types) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -38,6 +38,7 @@ import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.providers.CurrentActivityProvider
+import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -57,6 +58,8 @@ class AppContext(
 
   // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
   private lateinit var jsiInterop: JSIInteropModuleRegistry
+
+  internal val sharedObjectRegistry = SharedObjectRegistry()
 
   private val modulesQueueDispatcher = HandlerThread("expo.modules.AsyncFunctionQueue")
     .apply { start() }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -40,7 +40,15 @@ class ModuleHolder(val module: Module) {
         val clazzModuleObject = JavaScriptModuleObject(clazz.name)
           .initUsingObjectDefinition(module.appContext, clazz.objectDefinition)
 
-        registerClass(clazz.name, clazzModuleObject)
+        val constructor = clazz.constructor
+        registerClass(
+          clazz.name,
+          clazzModuleObject,
+          constructor.takesOwner,
+          constructor.argsCount,
+          constructor.getCppRequiredTypes().toTypedArray(),
+          constructor.getJNIFunctionBody(clazz.name, appContext)
+        )
       }
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Utils.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Utils.kt
@@ -1,0 +1,21 @@
+package expo.modules.kotlin
+
+import android.os.Looper
+import expo.modules.kotlin.exception.Exceptions
+
+object Utils {
+  @Suppress("UseExpressionBody")
+  inline fun assertMainThread() {
+    if (Thread.currentThread() !== Looper.getMainLooper().thread) {
+      throw Exceptions.IncorrectThreadException(
+        Thread.currentThread().name,
+        Looper.getMainLooper().thread.name
+      )
+    }
+  }
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun AppContext?.toStrongReference(): AppContext {
+  return this ?: throw Exceptions.AppContextLost()
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -5,87 +5,105 @@ package expo.modules.kotlin.classcomponent
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class ClassComponentBuilder(val name: String) : ObjectDefinitionBuilder() {
+class ClassComponentBuilder<SharedObjectType : Any>(
+  val name: String,
+  private val ownerClass: KClass<SharedObjectType>,
+  private val ownerType: KType
+) : ObjectDefinitionBuilder() {
   var constructor: SyncFunctionComponent? = null
 
   fun buildClass(): ClassDefinitionData {
     val objectData = buildObject()
-    objectData.functions.forEach { it.canTakeOwner = true }
+    objectData.functions.forEach {
+      it.ownerType = ownerType
+      it.canTakeOwner = true
+    }
+
+    val hasSharedObject = ownerClass !== Unit::class
+    if (hasSharedObject && constructor == null) {
+      throw IllegalArgumentException("constructor cannot be null")
+    }
+
+    val constructor = constructor ?: SyncFunctionComponent("constructor", arrayOf()) {}
+    constructor.canTakeOwner = hasSharedObject
+
     return ClassDefinitionData(
       name,
-      constructor ?: SyncFunctionComponent("constructor", arrayOf()) {},
+      constructor,
       objectData,
     )
   }
 
   inline fun Constructor(
-    crossinline body: () -> Unit
+    crossinline body: () -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf()) { body() }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0> Constructor(
-    crossinline body: (p0: P0) -> R
+  inline fun <reified P0> Constructor(
+    crossinline body: (p0: P0) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType())) { body(it[0] as P0) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1> Constructor(
-    crossinline body: (p0: P0, p1: P1) -> R
+  inline fun <reified P0, reified P1> Constructor(
+    crossinline body: (p0: P0, p1: P1) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType())) { body(it[0] as P0, it[1] as P1) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  inline fun <reified P0, reified P1, reified P2> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  inline fun <reified P0, reified P1, reified P2, reified P3> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
       constructor = it
     }
   }
 
-  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
-    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Constructor(
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> SharedObjectType
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf(typeOf<P0>().toAnyType(), typeOf<P1>().toAnyType(), typeOf<P2>().toAnyType(), typeOf<P3>().toAnyType(), typeOf<P4>().toAnyType(), typeOf<P5>().toAnyType(), typeOf<P6>().toAnyType(), typeOf<P7>().toAnyType())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
       constructor = it

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -180,6 +180,12 @@ internal class ArgumentCastException(
   }
 }
 
+internal class InvalidSharedObjectException(
+  sharedType: KType,
+) : CodedException(
+  message = "Cannot converter provided JavaScriptObject to the '$sharedType', because it doesn't contain valid id"
+)
+
 internal class FieldCastException(
   fieldName: String,
   fieldType: KType,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -183,7 +183,7 @@ internal class ArgumentCastException(
 internal class InvalidSharedObjectException(
   sharedType: KType,
 ) : CodedException(
-  message = "Cannot converter provided JavaScriptObject to the '$sharedType', because it doesn't contain valid id"
+  message = "Cannot convert provided JavaScriptObject to the '$sharedType', because it doesn't contain valid id"
 )
 
 internal class FieldCastException(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SyncFunctionComponent.kt
@@ -5,6 +5,7 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.jni.JNIFunctionBody
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.JSTypeConverter
@@ -19,8 +20,19 @@ class SyncFunctionComponent(
     return body(convertArgs(args))
   }
 
-  fun call(args: Array<Any?>): Any? {
-    return body(convertArgs(args))
+  fun call(args: Array<Any?>, appContext: AppContext? = null): Any? {
+    return body(convertArgs(args, appContext))
+  }
+
+  internal fun getJNIFunctionBody(moduleName: String, appContext: AppContext?): JNIFunctionBody {
+    return JNIFunctionBody { args ->
+      return@JNIFunctionBody exceptionDecorator({
+        FunctionCallException(name, moduleName, it)
+      }) {
+        val result = call(args, appContext)
+        return@exceptionDecorator JSTypeConverter.convertToJSValue(result)
+      }
+    }
   }
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
@@ -28,14 +40,8 @@ class SyncFunctionComponent(
       name,
       takesOwner,
       argsCount,
-      getCppRequiredTypes().toTypedArray()
-    ) { args ->
-      return@registerSyncFunction exceptionDecorator({
-        FunctionCallException(name, jsObject.name, it)
-      }) {
-        val result = call(args)
-        return@exceptionDecorator JSTypeConverter.convertToJSValue(result)
-      }
-    }
+      getCppRequiredTypes().toTypedArray(),
+      getJNIFunctionBody(jsObject.name, appContext)
+    )
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -28,5 +28,6 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   PRIMITIVE_ARRAY(Array::class),
   LIST(List::class),
   MAP(Map::class),
-  VIEW_TAG(Int::class);
+  VIEW_TAG(Int::class),
+  SHARED_OBJECT_ID(Int::class);
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -6,12 +6,13 @@ import com.facebook.soloader.SoLoader
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import expo.modules.kotlin.sharedobjects.SharedObject
 import java.lang.ref.WeakReference
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JSIInteropModuleRegistry(appContext: AppContext) {
-  private val appContextHolder = WeakReference(appContext)
+  internal val appContextHolder = WeakReference(appContext)
 
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip
@@ -81,6 +82,15 @@ class JSIInteropModuleRegistry(appContext: AppContext) {
   @DoNotStrip
   fun getJavaScriptModulesName(): Array<String> {
     return appContextHolder.get()?.registry?.registry?.keys?.toTypedArray() ?: emptyArray()
+  }
+
+  @Suppress("unused")
+  @DoNotStrip
+  fun registerSharedObject(native: Any, js: JavaScriptObject) {
+    appContextHolder
+      .get()
+      ?.sharedObjectRegistry
+      ?.add(native as SharedObject, js)
   }
 
   @Throws(Throwable::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -60,7 +60,7 @@ class JavaScriptModuleObject(val name: String) {
 
   external fun registerProperty(name: String, desiredType: ExpectedType, getter: JNIFunctionBody?, setter: JNIFunctionBody?)
 
-  external fun registerClass(name: String, classModule: JavaScriptModuleObject)
+  external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -15,6 +15,7 @@ import expo.modules.kotlin.events.EventListenerWithSenderAndPayload
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
+import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
 import kotlin.reflect.KClass
@@ -124,8 +125,17 @@ class ModuleDefinitionBuilder(@PublishedApi internal val module: Module? = null)
       EventListenerWithSenderAndPayload<Activity, OnActivityResultPayload>(EventName.ON_ACTIVITY_RESULT) { sender, payload -> body(sender, payload) }
   }
 
-  inline fun Class(name: String, body: ClassComponentBuilder.() -> Unit = {}) {
-    val clazzBuilder = ClassComponentBuilder(name)
+  inline fun Class(name: String, body: ClassComponentBuilder<Unit>.() -> Unit = {}) {
+    val clazzBuilder = ClassComponentBuilder(name, Unit::class, typeOf<Unit>())
+    body.invoke(clazzBuilder)
+    classData.add(clazzBuilder.buildClass())
+  }
+
+  inline fun <reified SharedObjectType : SharedObject> Class(
+    sharedObjectClass: KClass<SharedObjectType>,
+    body: ClassComponentBuilder<SharedObjectType>.() -> Unit = {}
+  ) {
+    val clazzBuilder = ClassComponentBuilder(sharedObjectClass.java.simpleName, sharedObjectClass, typeOf<SharedObjectType>())
     body.invoke(clazzBuilder)
     classData.add(clazzBuilder.buildClass())
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -1,0 +1,12 @@
+package expo.modules.kotlin.sharedobjects
+
+import expo.modules.core.interfaces.DoNotStrip
+
+@DoNotStrip
+open class SharedObject {
+  /**
+   * An identifier of the native shared object that maps to the JavaScript object.
+   * When the object is not linked with any JavaScript object, its value is 0.
+   */
+  internal var sharedObjectId: SharedObjectId = SharedObjectId(0)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -1,0 +1,58 @@
+package expo.modules.kotlin.sharedobjects
+
+import expo.modules.kotlin.jni.JavaScriptObject
+
+@JvmInline
+value class SharedObjectId(val value: Int)
+
+// TODO(@lukmccall): use weak ref to hold js object
+typealias SharedObjectPair = Pair<SharedObject, JavaScriptObject>
+
+const val sharedObjectIdPropertyName = "__expo_shared_object_id__"
+
+class SharedObjectRegistry {
+  private var currentId: SharedObjectId = SharedObjectId(1)
+
+  internal var pairs = mutableMapOf<SharedObjectId, SharedObjectPair>()
+
+  private fun pullNextId(): SharedObjectId {
+    val current = currentId
+    currentId = SharedObjectId(current.value + 1)
+    return current
+  }
+
+  internal fun add(native: SharedObject, js: JavaScriptObject): SharedObjectId {
+    val id = pullNextId()
+    native.sharedObjectId = id
+    js.defineProperty(sharedObjectIdPropertyName, id.value)
+
+    // TODO(@lukmccall): add deallocator to remove js object
+
+    pairs[id] = native to js
+    return id
+  }
+
+  internal fun delete(id: SharedObjectId) {
+    pairs.remove(id)?.let { (native, js) ->
+      native.sharedObjectId = SharedObjectId(0)
+      js.defineProperty(sharedObjectIdPropertyName, 0)
+    }
+  }
+
+  internal fun toNativeObject(id: SharedObjectId): SharedObject? {
+    return pairs[id]?.first
+  }
+
+  internal fun toNativeObject(js: JavaScriptObject): SharedObject? {
+    if (!js.hasProperty(sharedObjectIdPropertyName)) {
+      return null
+    }
+
+    val id = SharedObjectId(js.getProperty(sharedObjectIdPropertyName).getInt())
+    return pairs[id]?.first
+  }
+
+  internal fun toJavaScriptObjet(native: SharedObject): JavaScriptObject? {
+    return pairs[native.sharedObjectId]?.second
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -1,0 +1,27 @@
+package expo.modules.kotlin.sharedobjects
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.InvalidSharedObjectException
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.toStrongReference
+import expo.modules.kotlin.types.NullAwareTypeConverter
+import kotlin.reflect.KType
+
+class SharedObjectTypeConverter<T : SharedObject>(
+  val type: KType
+) : NullAwareTypeConverter<T>(type.isMarkedNullable) {
+  @Suppress("UNCHECKED_CAST")
+  override fun convertNonOptional(value: Any, context: AppContext?): T {
+    val id = SharedObjectId(value as Int)
+    val appContext = context.toStrongReference()
+    val result = appContext.sharedObjectRegistry.toNativeObject(id)
+      ?: throw InvalidSharedObjectException(type)
+
+    return result as T
+  }
+
+  override fun getCppRequiredTypes() = ExpectedType(CppType.SHARED_OBJECT_ID)
+
+  override fun isTrivial(): Boolean = false
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -17,6 +17,8 @@ import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.JavaScriptValue
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.RecordTypeConverter
+import expo.modules.kotlin.sharedobjects.SharedObject
+import expo.modules.kotlin.sharedobjects.SharedObjectTypeConverter
 import expo.modules.kotlin.typedarray.BigInt64Array
 import expo.modules.kotlin.typedarray.BigUint64Array
 import expo.modules.kotlin.typedarray.Float32Array
@@ -119,6 +121,10 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     if (kClass.isSubclassOf(View::class)) {
       return ViewTypeConverter<View>(type)
+    }
+
+    if (kClass.isSubclassOf(SharedObject::class)) {
+      return SharedObjectTypeConverter<SharedObject>(type)
     }
 
     return handelEither(type, kClass)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -1,12 +1,13 @@
 package expo.modules.kotlin.views
 
-import android.os.Looper
 import android.view.View
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.Utils
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
+import expo.modules.kotlin.toStrongReference
 import expo.modules.kotlin.types.TypeConverter
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -16,12 +17,7 @@ class ViewTypeConverter<T : View>(
 ) : TypeConverter<T>() {
 
   override fun convert(value: Any?, context: AppContext?): T? {
-    if (Thread.currentThread() !== Looper.getMainLooper().thread) {
-      throw Exceptions.IncorrectThreadException(
-        Thread.currentThread().name,
-        Looper.getMainLooper().thread.name
-      )
-    }
+    Utils.assertMainThread()
     if (value == null) {
       if (type.isMarkedNullable) {
         return null
@@ -29,7 +25,7 @@ class ViewTypeConverter<T : View>(
       throw NullArgumentException()
     }
 
-    val appContext = context ?: throw Exceptions.AppContextLost()
+    val appContext = context.toStrongReference()
     val viewTag = value as Int
     val view = appContext.findView<T>(viewTag)
     if (!type.isMarkedNullable && view == null) {


### PR DESCRIPTION
# Why

This's a follow-up to https://github.com/expo/expo/pull/17514.

# How

- Added a shared object registry 
- Run a native constructor if present when creating a js class
- Added a shared object with its js representation to the registry 
- Added a converter for shared object 

# TODO

- [ ] call native destructor when class is deallocated 
- [ ] use weak refs to hold js objects in the registry 

# Test Plan

- unit tests ✅