### PR TITLE
[docs] partially migrate Snippet component to Tailwind

### DIFF
--- a/docs/.eslintrc.cjs
+++ b/docs/.eslintrc.cjs
@@ -19,7 +19,8 @@ module.exports = {
       'whitelist': [
         'diff-.+',
         'anchor-icon',
-        'react-player'
+        'react-player',
+        'dark-theme'
       ]
     }]
   },

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -27,6 +27,10 @@ export const SnippetAction = (props: SnippetActionProps) => {
       leftSlot={styledIcon}
       rightSlot={iconRight}
       css={[!alwaysDark && snippetActionStyle, alwaysDark && alwaysDarkStyle]}
+      className={mergeClasses(
+        !alwaysDark && 'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4',
+        alwaysDark && 'border-transparent bg-[transparent]'
+      )}
       {...rest}>
       <FOOTNOTE className={mergeClasses(alwaysDark && '!text-palette-white')}>{children}</FOOTNOTE>
     </Button>
@@ -34,13 +38,6 @@ export const SnippetAction = (props: SnippetActionProps) => {
 };
 
 const snippetActionStyle = css({
-  border: 0,
-  borderRadius: 0,
-  borderLeft: `1px solid ${theme.border.default}`,
-  height: 42,
-  lineHeight: 42,
-  padding: `0 16px`,
-
   ':hover': {
     backgroundColor: theme.background.subtle,
     boxShadow: 'none',
@@ -48,9 +45,6 @@ const snippetActionStyle = css({
 });
 
 const alwaysDarkStyle = css({
-  borderColor: 'transparent',
-  background: 'transparent',
-
   ':hover': {
     borderColor: palette.dark.gray9,
     background: palette.dark.gray5,

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import { forwardRef, PropsWithChildren } from 'react';
 
 export type SnippetContentProps = PropsWithChildren<{
@@ -23,47 +22,28 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
   ) => (
     <div
       ref={ref}
-      css={[
-        contentStyle,
-        alwaysDark && contentDarkStyle,
-        hideOverflow && contentHideOverflow,
-        skipPadding && skipPaddingStyle,
-      ]}
-      className={className}>
+      css={[contentStyle, hideOverflow && contentHideOverflow]}
+      className={mergeClasses(
+        'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4',
+        alwaysDark && 'bg-palette-black border-transparent whitespace-nowrap',
+        hideOverflow && 'overflow-hidden',
+        skipPadding && 'p-0',
+        className
+      )}>
       {children}
     </div>
   )
 );
 
 const contentStyle = css`
-  color: ${theme.text.default};
-  background-color: ${theme.background.subtle};
-  border: 1px solid ${theme.border.default};
-  border-bottom-left-radius: ${borderRadius.md}px;
-  border-bottom-right-radius: ${borderRadius.md}px;
-  padding: ${spacing[4]}px;
-  overflow-x: auto;
-
   code {
     padding-left: 0;
     padding-right: 0;
   }
 `;
 
-const contentDarkStyle = css`
-  background-color: ${theme.palette.black};
-  border-color: transparent;
-  white-space: nowrap;
-`;
-
 const contentHideOverflow = css`
-  overflow: hidden;
-
   code {
     white-space: nowrap;
   }
 `;
-
-const skipPaddingStyle = css({
-  padding: 0,
-});

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { borderRadius, palette } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import { PropsWithChildren } from 'react';
 
 import { LABEL } from '~/ui/components/Text';
@@ -11,45 +9,20 @@ type SnippetHeaderProps = PropsWithChildren<{
 }>;
 
 export const SnippetHeader = ({ title, children, alwaysDark = false }: SnippetHeaderProps) => (
-  <div css={[headerStyle, alwaysDark && headerDarkStyle]}>
-    <LABEL css={[headerTitleStyle, alwaysDark && { color: palette.white }]}>{title}</LABEL>
-    {!!children && <div css={headerActionsStyle}>{children}</div>}
+  <div className={mergeClasses(alwaysDark && 'dark-theme')}>
+    <div
+      className={mergeClasses(
+        'flex pl-4 overflow-hidden justify-between bg-default border border-default rounded-t-md border-b-0',
+        alwaysDark && 'pr-2 dark:border-transparent !bg-palette-gray3'
+      )}>
+      <LABEL
+        className={mergeClasses(
+          'h-10 !leading-10 pr-4 select-none font-medium text-ellipsis whitespace-nowrap overflow-hidden',
+          alwaysDark && 'text-palette-white'
+        )}>
+        {title}
+      </LABEL>
+      {!!children && <div className="flex justify-end items-center">{children}</div>}
+    </div>
   </div>
 );
-
-const headerStyle = css`
-  background-color: ${theme.background.default};
-  border: 1px solid ${theme.border.default};
-  border-bottom: none;
-  border-top-left-radius: ${borderRadius.md}px;
-  border-top-right-radius: ${borderRadius.md}px;
-  display: flex;
-  padding: 0 0 0 16px;
-  justify-content: space-between;
-  min-height: 42px;
-  max-height: 42px;
-  overflow: hidden;
-`;
-
-const headerDarkStyle = css`
-  background-color: ${palette.dark.gray3};
-  border-color: transparent;
-  padding-right: 8px;
-`;
-
-const headerTitleStyle = css`
-  height: 42px;
-  line-height: 42px !important;
-  user-select: none;
-  font-weight: 500;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  padding-right: 16px;
-`;
-
-const headerActionsStyle = css`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-`;

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { SnackLogo } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { useEffect, useRef, useState, PropsWithChildren } from 'react';
 
@@ -74,7 +73,7 @@ export const SnackInline = ({
   };
 
   return (
-    <Snippet css={inlineSnackWrapperStyle}>
+    <Snippet css={inlineSnackWrapperStyle} className="flex flex-col mb-3">
       <SnippetHeader title={label || 'Example'}>
         <form action={SNACK_URL} method="POST" target="_blank">
           <input type="hidden" name="platform" value={defaultPlatform || DEFAULT_PLATFORM} />
@@ -115,10 +114,6 @@ export const SnackInline = ({
 };
 
 const inlineSnackWrapperStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  marginBottom: spacing[3],
-
   pre: {
     margin: 0,
     border: 0,

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { darkTheme, palette, spacing } from '@expo/styleguide-base';
+import { spacing } from '@expo/styleguide-base';
 
 import { Snippet } from '../Snippet';
 import { SnippetContent } from '../SnippetContent';
@@ -62,37 +62,40 @@ function cmdMapper(line: string, index: number) {
   const key = `line-${index}`;
 
   if (line.trim() === '') {
-    return <br key={key} css={unselectableStyle} />;
+    return <br key={key} className="select-none" />;
   }
 
   if (line.startsWith('#')) {
     return (
-      <CODE key={key} css={[codeStyle, unselectableStyle, { color: palette.dark.gray10 }]}>
-        {line}
-      </CODE>
+      <div key={key} className="dark-theme">
+        <CODE className="whitespace-pre inline-block !bg-[transparent] !border-none !leading-snug select-none !text-palette-gray10">
+          {line}
+        </CODE>
+      </div>
     );
   }
 
   if (line.startsWith('$')) {
     return (
-      <div key={key}>
-        <CODE
-          css={[
-            codeStyle,
-            unselectableStyle,
-            { display: 'inline', color: darkTheme.text.secondary },
-          ]}>
+      <div key={key} className="dark-theme">
+        <CODE className="whitespace-pre inline-block !bg-[transparent] !border-none !leading-snug select-none !text-secondary">
           -&nbsp;
         </CODE>
-        <CODE css={codeStyle}>{line.substring(1).trim()}</CODE>
+        <CODE className="whitespace-pre inline-block !bg-[transparent] !border-none text-default !leading-snug">
+          {line.substring(1).trim()}
+        </CODE>
       </div>
     );
   }
 
   return (
-    <CODE key={key} css={[codeStyle, { display: 'inherit' }]}>
-      {line}
-    </CODE>
+    <div key={key} className="dark-theme">
+      <CODE
+        css={[{ display: 'inherit' }]}
+        className="whitespace-pre inline-block !bg-[transparent] !border-none text-default !leading-snug">
+        {line}
+      </CODE>
+    </div>
   );
 }
 
@@ -101,17 +104,4 @@ const wrapperStyle = css`
     margin-top: ${spacing[4]}px;
     display: flex;
   }
-`;
-
-const unselectableStyle = css`
-  user-select: none;
-`;
-
-const codeStyle = css`
-  white-space: pre;
-  display: inline-block;
-  line-height: 140%;
-  background-color: transparent;
-  border: none;
-  color: ${darkTheme.text.default};
 `;


### PR DESCRIPTION
# Why

The plan is roughly to:
1. Migrate snippet from using Emotion entirely to Tailwind.
2. Copy snippet to styleguide repo.
3. Switch to using snippet from styleguide.
4. Remove local snippet implementation.

We are in step 1.

# How

By rewriting class after class from Emotion to Styleguide.

There are some classes left but this brings us one step closer to finishing point 1.

I change I made: instead of 42px I used 40px to just use a TW class and skip adding too much custom styles. The difference is probably unnoticeable if you don't know what to look for, but of course it's an unplanned change so we might not want it. Let me know what you think.

# Test Plan

Visit snippets in docs and make sure that I didn't break anything.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
