### PR TITLE
[expo-updates] fix broken reloadAsync API on iOS

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -63,7 +63,7 @@ public final class UpdatesModule: Module {
       ]
     }
 
-    AsyncFunction("reloadAsync") { (promise: Promise) in
+    AsyncFunction("reload") { (promise: Promise) in
       guard let updatesService = updatesService, let config = updatesService.config, config.isEnabled else {
         throw UpdatesDisabledException()
       }


### PR DESCRIPTION
# Why

After Swift conversion, the `reloadAsync()` JS API does not work on iOS, because the native method was renamed incorrectly.

# How

Fix the name.

# Test Plan

Manual testing of the API on iOS.

\(E2E testing of the API will be implemented in a future PR.\)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
