### PR TITLE
[docs] update doctor references to `npx expo-doctor`

### DIFF
--- a/docs/pages/archive/expo-cli.mdx
+++ b/docs/pages/archive/expo-cli.mdx
@@ -733,7 +733,7 @@ In Expo SDK 46, we migrated to a new suite of tooling that is versioned in the `
 | `expo send`                   | Removed                         |
 | `expo client:install:ios`     | Unimplemented                   |
 | `expo client:install:android` | Unimplemented                   |
-| `expo doctor`                 | Undecided                       |
+| `expo doctor`                 | Moved to `npx expo-doctor`      |
 | `expo upgrade`                | Undecided                       |
 
 ### Services
@@ -782,7 +782,8 @@ In Expo SDK 46, we migrated to a new suite of tooling that is versioned in the `
   - Dropped warning about clearing `dist` folder that is shown between runs, this is akin to all other bundler commands across web tooling.
   - Dropped all merging code because experimental bundle does not support index files so we don't need to support merging index files.
   - Dropped the quiet flag as this appears to do nothing anymore.
-- Parts of `expo upgrade` and `expo doctor` have been merged into `npx expo install` via the `--fix` and `--check` flags. [PR](https://github.com/expo/expo/pull/17048).
+- Parts of `expo upgrade` have been merged into `npx expo install` via the `--fix` and `--check` flags. [PR](https://github.com/expo/expo/pull/17048).
+- `expo doctor` has been deprecated in favor of `npx expo-doctor` for projects using SDK 46 and higher.
 - Dropped unused generated `.exprc`, `.expo/packager-info.json` files.
 - Dropped all deprecated support for `*.expo.js` files.
 - Reduced usage of `.expo/settings.json` to provide a more sandboxed state between processes.

--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -33,7 +33,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. [Create **.npmrc**](/build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
-1. Run `expo doctor` to diagnose potential issues with your project configuration.
+1. Run `npx expo-doctor` to diagnose potential issues with your project configuration.
 1. Additional step for **managed** projects: Run `expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI for projects that use Expo SDK 46+. In SDK 48 and lower, you can still choose to use the (deprecated) global Expo CLI installation by setting `EXPO_USE_LOCAL_CLI=0` in the build profile.
 1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run the `eas-build-post-install` script from **package.json** if defined.

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -34,7 +34,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. [Create **.npmrc**](build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if **yarn.lock** exists).
-1. Run `expo doctor` to diagnose potential issues with your project configuration.
+1. Run `npx expo-doctor` to diagnose potential issues with your project configuration.
 1. Restore the credentials
 
    - Create a new keychain.

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -55,7 +55,7 @@ It's important to note that with iOS builds the build details page only displays
 
 {/* TODO: native and js build phases should be separate in eas build logs, this is too much work for people to figure out */}
 
-If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/guides/config-plugins) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `expo doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
+If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/guides/config-plugins) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
 Armed with your error logs, you can often start to fix your build, or you can search the [forums](https://forums.expo.dev) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 


### PR DESCRIPTION
# Why
Fulfills https://linear.app/expo/issue/CX-222/update-references-to-expo-doctor-in-docs, reduces confusion when folks find references to `expo doctor` but find it doesn't work because the global CLI isn't installed.

** Note that the EAS Build steps aren't technically switched over yet, but [it's close](https://linear.app/expo/issue/ENG-8001/switch-to-npx-expo-doctor-in-eas-build), didn't feel like it was worth an extra PR IMO.

# How

Updated docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
