### PR TITLE
[docs] broken link in stripe page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -12,7 +12,7 @@ Expo includes support for [`@stripe/stripe-react-native`](https://github.com/str
 
 If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
 
-> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/master/payments-migration-guide.mdx#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
 <PlatformsSection android emulator ios simulator />
 


### PR DESCRIPTION
# Why

Fix a broken link.

# How

By updating the URL.

# Test Plan

n/a

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
