### PR TITLE
[core][Android] Improve memory consumption

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
@@ -1,0 +1,32 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+
+class JNIDeallocatorTest {
+  @Test
+  fun inspect_memory_should_return_references_to_existing_objects() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+    }
+  ) {
+    val moduleObject = evaluateScript("expo.modules.TestModule")
+    Truth.assertThat(JNIDeallocator.inspectMemory()).contains(moduleObject)
+  }
+
+  @Test
+  fun deallocate_should_clear_all_saved_references() {
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+      }
+    ) {
+      evaluateScript("expo.modules.TestModule")
+    }
+    // JNIDeallocator.deallocate() is automatically call in the end of `withJSIInterop` scope
+    Truth.assertThat(JNIDeallocator.inspectMemory()).isEmpty()
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -40,6 +40,9 @@ internal inline fun withJSIInterop(
   }
 
   block(jsiIterop, methodQueue)
+
+  JNIDeallocator.deallocate()
+  jsiIterop.deallocate()
 }
 
 /**

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -5,6 +5,7 @@ package expo.modules.kotlin.jni
 import com.google.common.truth.Truth
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.sharedobjects.SharedObjectId
+import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import expo.modules.kotlin.sharedobjects.sharedObjectIdPropertyName
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
@@ -164,5 +165,31 @@ class JavaScriptClassTest {
       waitForAsyncFunction(it, "(new expo.modules.TestModule.MySharedObject()).receiveThis()")
       Truth.assertThat(wasCalled).isTrue()
     }
+  }
+
+  @Test
+  fun object_native_allocator_should_be_called_on_context_destroy() {
+    class MySharedObject : SharedObject()
+
+    var registry: SharedObjectRegistry? = null
+    var id: SharedObjectId? = null
+    withJSIInterop(
+      inlineModule {
+        Name("TestModule")
+        Class(MySharedObject::class) {
+          Constructor {
+            return@Constructor MySharedObject()
+          }
+        }
+      }
+    ) {
+      val jsObject = evaluateScript("new expo.modules.TestModule.MySharedObject()").getObject()
+      id = SharedObjectId(jsObject.getProperty(sharedObjectIdPropertyName).getInt())
+      registry = appContextHolder.get()?.sharedObjectRegistry
+
+      Truth.assertThat(jsObject.hasProperty("__expo_shared_object_deallocator__")).isTrue()
+    }
+
+    Truth.assertThat(registry!!.pairs[id!!]).isNull()
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -2,6 +2,7 @@
 
 #include "JavaScriptModuleObject.h"
 #include "JSIInteropModuleRegistry.h"
+#include "ObjectDeallocator.h"
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -4,6 +4,8 @@
 #include "JavaScriptValue.h"
 #include "JavaScriptRuntime.h"
 #include "JSITypeConverter.h"
+#include "ObjectDeallocator.h"
+#include "JavaReferencesCache.h"
 
 namespace expo {
 void JavaScriptObject::registerNatives() {
@@ -29,6 +31,8 @@ void JavaScriptObject::registerNatives() {
                                     JavaScriptObject::defineProperty<jni::alias_ref<JavaScriptValue::javaobject>>),
                    makeNativeMethod("defineJSObjectProperty",
                                     JavaScriptObject::defineProperty<jni::alias_ref<JavaScriptObject::javaobject>>),
+                   makeNativeMethod("defineNativeDeallocator",
+                                    JavaScriptObject::defineNativeDeallocator),
                  });
 }
 
@@ -146,5 +150,25 @@ void JavaScriptObject::defineProperty(
     jsi::String::createFromUtf8(runtime, name),
     std::move(descriptor),
   });
+}
+
+void JavaScriptObject::defineNativeDeallocator(
+  jni::alias_ref<JNIFunctionBody::javaobject> deallocator
+) {
+  auto &rt = runtimeHolder.getJSRuntime();
+  jni::global_ref<JNIFunctionBody::javaobject> globalRef = jni::make_global(deallocator);
+  std::shared_ptr<ObjectDeallocator> nativeDeallocator = std::make_shared<ObjectDeallocator>(
+    [globalRef = std::move(globalRef)]() mutable {
+      auto args = jni::Environment::current()->NewObjectArray(
+        0,
+        JavaReferencesCache::instance()->getJClass("java/lang/Object").clazz,
+        nullptr
+      );
+      globalRef->invoke(args);
+      globalRef.reset();
+    });
+  auto descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
+  descriptor.setProperty(rt, "value", jsi::Object::createFromHostObject(rt, nativeDeallocator));
+  jsObject->setProperty(rt, "__expo_shared_object_deallocator__", std::move(descriptor));
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -6,6 +6,7 @@
 #include "JSITypeConverter.h"
 #include "JavaScriptRuntime.h"
 #include "WeakRuntimeHolder.h"
+#include "JNIFunctionBody.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -66,6 +67,10 @@ public:
     jsi::Object *jsthis,
     const std::string &name,
     jsi::Object descriptor
+  );
+
+  void defineNativeDeallocator(
+    jni::alias_ref<JNIFunctionBody::javaobject> deallocator
   );
 
 protected:

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -75,16 +75,6 @@ public:
   MethodMetadata(MethodMetadata &&other) = default;
 
   /**
-   * MethodMetadata owns the only reference to the Kotlin function.
-   * We have to clean that, cause it's a `global_ref`.
-   */
-  ~MethodMetadata() {
-    if (jBodyReference != nullptr) {
-      jBodyReference.release();
-    }
-  }
-
-  /**
    * Transforms metadata to a jsi::Function.
    *
    * @param runtime

--- a/packages/expo-modules-core/android/src/main/cpp/ObjectDeallocator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ObjectDeallocator.h
@@ -1,0 +1,25 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+
+namespace expo {
+
+class JSI_EXPORT ObjectDeallocator : public jsi::HostObject {
+public:
+  typedef std::function<void()> ObjectDeallocatorType;
+
+  ObjectDeallocator(ObjectDeallocatorType deallocator) : deallocator(deallocator) {};
+
+  virtual ~ObjectDeallocator() {
+    deallocator();
+  }
+
+  const ObjectDeallocatorType deallocator;
+
+}; // class ObjectDeallocator
+
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -35,6 +35,7 @@ import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.KEventEmitterWrapper
 import expo.modules.kotlin.events.KModuleEventEmitterWrapper
 import expo.modules.kotlin.events.OnActivityResultPayload
+import expo.modules.kotlin.jni.JNIDeallocator
 import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.providers.CurrentActivityProvider
@@ -264,6 +265,7 @@ class AppContext(
     registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
+    JNIDeallocator.deallocate()
     logger.info("✅ AppContext was destroyed")
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -8,7 +8,10 @@ import expo.modules.kotlin.exception.UnexpectedException
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) {
+class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  init {
+    JNIDeallocator.addReference(this)
+  }
 
   operator fun invoke(result: Any?) {
     if (result == null) {
@@ -38,6 +41,10 @@ class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHyb
 
   @Throws(Throwable::class)
   protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
     mHybridData.resetNative()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -16,12 +16,16 @@ import expo.modules.kotlin.objects.ObjectDefinitionData
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaScriptModuleObject(val name: String) {
+class JavaScriptModuleObject(val name: String) : Destructible {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip
   private val mHybridData = initHybrid()
 
   private external fun initHybrid(): HybridData
+
+  init {
+    JNIDeallocator.addReference(this)
+  }
 
   fun initUsingObjectDefinition(appContext: AppContext, definition: ObjectDefinitionData) = apply {
     val constants = definition.constantsProvider()
@@ -66,6 +70,14 @@ class JavaScriptModuleObject(val name: String) {
 
   @Throws(Throwable::class)
   protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
     mHybridData.resetNative()
+  }
+
+  override fun toString(): String {
+    return "JavaScriptModuleObject_$name"
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -9,7 +9,12 @@ import expo.modules.core.interfaces.DoNotStrip
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) {
+open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  init {
+    @Suppress("LeakingThis")
+    JNIDeallocator.addReference(this)
+  }
+
   /**
    * The property descriptor options for the property being defined or modified.
    */
@@ -30,22 +35,33 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
     Writable(1 shl 2),
   }
 
+  fun isValid() = mHybridData.isValid
+
   external fun hasProperty(name: String): Boolean
   external fun getProperty(name: String): JavaScriptValue
-  external fun getPropertyNames(): Array<String>
 
+  external fun getPropertyNames(): Array<String>
   private external fun setBoolProperty(name: String, value: Boolean)
   private external fun setDoubleProperty(name: String, value: Double)
   private external fun setStringProperty(name: String, value: String?)
   private external fun setJSValueProperty(name: String, value: JavaScriptValue?)
   private external fun setJSObjectProperty(name: String, value: JavaScriptObject?)
-  private external fun unsetProperty(name: String)
 
+  private external fun unsetProperty(name: String)
   private external fun defineBoolProperty(name: String, value: Boolean, options: Int)
   private external fun defineDoubleProperty(name: String, value: Double, options: Int)
   private external fun defineStringProperty(name: String, value: String?, options: Int)
   private external fun defineJSValueProperty(name: String, value: JavaScriptValue?, options: Int)
+
   private external fun defineJSObjectProperty(name: String, value: JavaScriptObject?, options: Int)
+
+  private external fun defineNativeDeallocator(deallocator: JNIFunctionBody)
+
+  internal fun defineDeallocator(deallocator: () -> Unit) {
+    defineNativeDeallocator {
+      deallocator()
+    }
+  }
 
   fun setProperty(name: String, value: Boolean) = setBoolProperty(name, value)
   fun setProperty(name: String, value: Int) = setDoubleProperty(name, value.toDouble())
@@ -103,6 +119,10 @@ open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private
 
   @Throws(Throwable::class)
   protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
     mHybridData.resetNative()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -9,7 +9,12 @@ import expo.modules.core.interfaces.DoNotStrip
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) {
+class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
+  init {
+    JNIDeallocator.addReference(this)
+  }
+
+  fun isValid() = mHybridData.isValid
   external fun kind(): String
 
   external fun isNull(): Boolean
@@ -36,6 +41,10 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
 
   @Throws(Throwable::class)
   protected fun finalize() {
+    deallocate()
+  }
+
+  override fun deallocate() {
     mHybridData.resetNative()
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectRegistry.kt
@@ -26,7 +26,9 @@ class SharedObjectRegistry {
     native.sharedObjectId = id
     js.defineProperty(sharedObjectIdPropertyName, id.value)
 
-    // TODO(@lukmccall): add deallocator to remove js object
+    js.defineDeallocator {
+      delete(id)
+    }
 
     pairs[id] = native to js
     return id
@@ -35,7 +37,9 @@ class SharedObjectRegistry {
   internal fun delete(id: SharedObjectId) {
     pairs.remove(id)?.let { (native, js) ->
       native.sharedObjectId = SharedObjectId(0)
-      js.defineProperty(sharedObjectIdPropertyName, 0)
+      if (js.isValid()) {
+        js.defineProperty(sharedObjectIdPropertyName, 0)
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Improves memory consumption. 
Adds a native destructor to the shared object. 

# How

- Adds a native destructor to the shared object instance. 
- Patched memory leak caused by unreleased global reference inside of the MethodMetadata class.
- Adds a global registry to force deallocation of JNI objects that holds references to jsi values when the app is reloaded. 
- Adds a memory inspector to check which of JNI objects are still present in the memory. 

# Test Plan

- unit tests ✅
- bare-expo with JSC and Hermes ✅