### PR TITLE
[android][image-picker] Fix Android 13 permissions

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -213,8 +213,10 @@ class ImagePickerModule : Module() {
           continuation.resumeWithException(UserRejectedPermissionsException())
         }
       },
-      Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU },
-      Manifest.permission.CAMERA
+      *listOfNotNull(
+        Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU },
+        Manifest.permission.CAMERA
+      ).toTypedArray()
     )
   }
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/21544

# How
 The `askForPermissions` function expects nonnull values but when using an Android 13 device the resolution of `Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU }` returns `null`, resulting in a `java.lang.NullPointerException` error when calling `launchCameraAsync `

# Test Plan

Run unversioned Expo Go and test launching the camera using `launchCameraAsync`

# Checklist


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
