### PR TITLE
[go][android] Fix requestPermissions NullPointerException

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/utils/ScopedPermissionsRequester.kt
@@ -38,6 +38,9 @@ class ScopedPermissionsRequester(private val experienceKey: ExperienceKey) {
     permissionsResult = mutableMapOf()
 
     for (permission in permissions) {
+      if (permission == null) {
+        continue
+      }
       val globalStatus = currentActivity.checkSelfPermission(permission)
       if (globalStatus == PackageManager.PERMISSION_DENIED) {
         permissionsToRequestGlobally.add(permission)


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/21544

# How

 When launching the camera through ExpoImagePicker we check for device permissions, but on an Android 13 device  
the resolution of  `Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU }` returns `null`. While this isn't a problem for apps using the default `requestPermissions` Activity function, it causes a crash on Expo Go because we have custom logic for permissions using the ScopedPermissionsRequester class. 

To resolve this issue, we have two options:

- Ensure that all `askForPermissions` calls always use `*listOfNotNull` https://github.com/expo/expo/pull/21907) 
- Update `ScopedPermissionsRequester` `requestPermissions` to ignore `null` values

In my opinion, the section option is more robust and ensures that there is no discrepancy between apps running on Expo Go and dev-client/EAS builds

# Test Plan

Run unversioned Expo Go and test launching the camera using `launchCameraAsync`

# Checklist


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
