### PR TITLE
[docs] Fix sentry organization slug issue in Using Sentry guide

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -38,21 +38,27 @@ It notifies you of exceptions or errors that your users run into while using you
 Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you've created a Sentry project. Here's how to do that:
 
 <Step label="1.1">
-  [Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your
-  Dashboard. Take note of your **organization name**, **project name**, and **`DSN`**; you'll need
-  them later. - **organization name** is available in your `Organization settings` tab - **project
-  name** is available in your project's `Settings` > `Projects` tab (find it in the list) -
-  **`DSN`** is available in your project's `Settings` > `Projects` > **Project name** > `Client Keys
-  (DSN)` tab
+
+[Sign up for Sentry](https://sentry.io/signup/) (it's free), and create a project in your
+Dashboard. Take note of your **organization slug**, **project name**, and **`DSN`** as you'll need
+them later:
+
+- **organization slug** is available in your **Organization settings** tab
+- **project name** is available in your project's **Settings** > **Projects** tab (find it in the list)
+- **`DSN`** is available in your project's **Settings** > **Projects** > **Project name** > **Client Keys
+  (DSN)** tab.
+
 </Step>
 
 <Step label="1.2">
-  Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an
-  **auth token**. The token requires the scopes: `org:read`, `project:releases`, and
-  `project:write`. Save this, too.
+
+Go to the [Sentry API section](https://sentry.io/settings/account/api/auth-tokens/), and create an
+**auth token**. The token requires the scopes: `org:read`, `project:releases`, and
+`project:write`. Save them.
+
 </Step>
 
-Once you have each of these: organization name, project name, DSN, and auth token, you're all set!
+Once you have each of these: organization slug, project name, DSN, and auth token, you're all set!
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: https://discord.com/channels/695411232856997968/1012054197409165387/1090408414645075968

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR updates the mention of Sentry's **organization name** when creating a Sentry account to **organization slug** as mentioned in `postPublish` hook.

Also, updated a list formatting issue in the `<Step>` component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

<img width="874" alt="CleanShot 2023-03-31 at 11 48 39@2x" src="https://user-images.githubusercontent.com/10234615/229039566-a779c7f0-bc6b-4214-9409-957d0c0bae70.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
