### PR TITLE
[docs] Fix typos and update shell script to use SDK 48

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -214,7 +214,7 @@ export default function App() {
 
           // Handle URL from expo push notifications
           const response = await Notifications.getLastNotificationResponseAsync();
-                         
+
           return response?.notification.request.content.data.url;
         },
         subscribe(listener) {
@@ -510,10 +510,9 @@ by specifying the `categoryIdentifier` in the [`NotificationContent`](#notificat
   alt="Image of notification categories on Android and iOS"
 />
 
-On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take,
-but you can also configure things like the placeholder text to display when the user disables notification previews for your app.wd1
+On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take, but you can also configure things like the placeholder text to display when the user disables notification previews for your app.
 
-> Notification categories are not supported on thew web, all related methods will result in noop.
+> Notification categories are not supported on the web and all related methods will result in noop.
 
 ## Platform specific guides
 

--- a/docs/pages/versions/unversioned/sdk/stripe.mdx
+++ b/docs/pages/versions/unversioned/sdk/stripe.mdx
@@ -8,11 +8,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
+Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native and Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
-If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
-
-> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to the new `@stripe/stripe-react-native` library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -24,7 +22,7 @@ Each Expo SDK version requires a specific `@stripe/stripe-react-native` version.
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.mdx)). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
+If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` [config plugin](/guides/config-plugins). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
 
 ```json
 {
@@ -48,7 +46,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 
 ## Example
 
-Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
+Trying out Stripe takes just a few seconds. Connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
 
 Under the hood, that example connects to [this Glitch server code](https://glitch.com/edit/#!/expo-stripe-server-example), so you'll need to open that page to spin up the server. Feel free to run your own Glitch server and copy that code!
 
@@ -84,10 +82,10 @@ urlScheme:
 
 `@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
-### Apple Pay
-
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
-
 ### Google Pay
 
 Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+
+### Apple Pay
+
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v46.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/stripe.mdx
@@ -6,13 +6,11 @@ packageName: '@stripe/stripe-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
-If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
-
-> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/master/payments-migration-guide.mdx#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to the new `@stripe/stripe-react-native` library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -24,7 +22,7 @@ Each Expo SDK version requires a specific `@stripe/stripe-react-native` version.
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.mdx)). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
+If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` [config plugin](/guides/config-plugins). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
 
 ```json
 {
@@ -48,7 +46,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 
 ## Example
 
-Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
+Trying out Stripe takes just a few seconds. Connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
 
 Under the hood, that example connects to [this Glitch server code](https://glitch.com/edit/#!/expo-stripe-server-example), so you'll need to open that page to spin up the server. Feel free to run your own Glitch server and copy that code!
 
@@ -84,10 +82,10 @@ urlScheme:
 
 `@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction.mdx), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
-### Apple Pay
-
-Apple Pay **is not** supported in Expo Go. To use Apple Pay, you must use either [EAS Build](/build/introduction.mdx), or run `expo run:ios` in your project directory.
-
 ### Google Pay
 
 Google Pay **is not** supported in Expo Go. To use Google Pay, you must use either [EAS Build](/build/introduction.mdx), or run `expo run:android` in your project directory.
+
+### Apple Pay
+
+Apple Pay **is not** supported in Expo Go. To use Apple Pay, you must use either [EAS Build](/build/introduction.mdx), or run `expo run:ios` in your project directory.

--- a/docs/pages/versions/v47.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/stripe.mdx
@@ -10,9 +10,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
-If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
-
-> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/master/payments-migration-guide.mdx#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to the new `@stripe/stripe-react-native` library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -24,7 +22,7 @@ Each Expo SDK version requires a specific `@stripe/stripe-react-native` version.
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.mdx)). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
+If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` [config plugin](/guides/config-plugins). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
 
 ```json
 {
@@ -48,7 +46,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 
 ## Example
 
-Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
+Trying out Stripe takes just a few seconds. Connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
 
 Under the hood, that example connects to [this Glitch server code](https://glitch.com/edit/#!/expo-stripe-server-example), so you'll need to open that page to spin up the server. Feel free to run your own Glitch server and copy that code!
 
@@ -84,10 +82,10 @@ urlScheme:
 
 `@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
-### Apple Pay
-
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
-
 ### Google Pay
 
 Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+
+### Apple Pay
+
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/versions/v48.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/notifications.mdx
@@ -214,7 +214,7 @@ export default function App() {
 
           // Handle URL from expo push notifications
           const response = await Notifications.getLastNotificationResponseAsync();
-                         
+
           return response?.notification.request.content.data.url;
         },
         subscribe(listener) {
@@ -510,10 +510,9 @@ by specifying the `categoryIdentifier` in the [`NotificationContent`](#notificat
   alt="Image of notification categories on Android and iOS"
 />
 
-On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take,
-but you can also configure things like the placeholder text to display when the user disables notification previews for your app.wd1
+On iOS, notification categories also allow you to customize your notifications further. With each category, not only can you set interactive actions a user can take, but you can also configure things like the placeholder text to display when the user disables notification previews for your app.
 
-> Notification categories are not supported on thew web, all related methods will result in noop.
+> Notification categories are not supported on the web and all related methods will result in noop.
 
 ## Platform specific guides
 

--- a/docs/pages/versions/v48.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/stripe.mdx
@@ -10,9 +10,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
-If you're looking for a quick example, check out [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice)!
-
-> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to this new library](https://github.com/expo/fyi/blob/master/payments-migration-guide.mdx#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
+> Migrating from Expo's `expo-payments-stripe` module? [Learn more about how to transition to the new `@stripe/stripe-react-native` library](https://github.com/expo/fyi/blob/main/payments-migration-guide.md#how-to-migrate-from-expo-payments-stripe-to-the-new-stripestripe-react-native-library).
 
 <PlatformsSection android emulator ios simulator />
 
@@ -24,7 +22,7 @@ Each Expo SDK version requires a specific `@stripe/stripe-react-native` version.
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` config plugin ([what's a config plugin?](/guides/config-plugins.mdx)). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
+If you're using EAS Build, you can do most of your Stripe setup using the `@stripe/stripe-react-native` [config plugin](/guides/config-plugins). To setup, just add the config plugin to the `plugins` array of your **app.json** or **app.config.js** as shown below, then rebuild the app.
 
 ```json
 {
@@ -48,7 +46,7 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 
 ## Example
 
-Trying out Stripe takes just a few seconds. First, connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
+Trying out Stripe takes just a few seconds. Connect to [this Snack](https://snack.expo.dev/@charliecruzan/stripe-react-native-example?platform=mydevice) on your device.
 
 Under the hood, that example connects to [this Glitch server code](https://glitch.com/edit/#!/expo-stripe-server-example), so you'll need to open that page to spin up the server. Feel free to run your own Glitch server and copy that code!
 
@@ -84,10 +82,10 @@ urlScheme:
 
 `@stripe/stripe-react-native` is supported in Expo Go on Android and iOS out of the box, **however**, for iOS, it is only available for standalone apps built with [EAS Build](/build/introduction), and not for apps built on the classic build system- `expo build:ios`. Android apps built with `expo build:android` _will_ have access to the `@stripe/stripe-react-native` library.
 
-### Apple Pay
-
-Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.
-
 ### Google Pay
 
 Google Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Google Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:android`.
+
+### Apple Pay
+
+Apple Pay **is not** supported in [Expo Go](https://expo.dev/expo-go). To use Apple Pay, you must create a [development build](/development/create-development-builds). This can be done with [EAS Build](/build/introduction), or locally by running `npx expo run:ios`.

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -81,8 +81,8 @@ Create a project with the desired SDK version and open it in a simulator to inst
 
 <Terminal
   cmd={[
-    '# Bootstrap an SDK 46 project',
-    '$ npx create-expo-app --template blank@46',
+    '# Bootstrap an SDK 48 project',
+    '$ npx create-expo-app --template blank@48',
     '',
     '# Open the app on a simulator to install the required Expo Go app',
     '$ npx expo start --ios',
@@ -95,4 +95,4 @@ For miscellaneous errors, try the following:
 
 - Manually uninstall Expo Go on your simulator and reinstall by pressing <kbd>Shift</kbd> + <kbd>I</kbd> in the Expo CLI Terminal UI and selecting the desired simulator.
 - If that doesn't help, focus the simulator window and in the Mac toolbar choose **Hardware** &rarr; **Erase All Content and Settings...**<br/>
-  This will reinitialize your simulator from a blank image. This is sometimes useful for cases where your computer is low on memory and the simulator fails to store some internal file, leaving the device in a corrupt state.
+  This will reinitialize your simulator from a blank image. This is sometimes useful for cases where your computer is low on memory and the simulator fails to store some internal files, leaving the device in a corrupt state.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some typos and formatting issues I've found while going through various docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Fixes typo in `expo-notifications` pages. (Changes backported to SDK 48).
- Updates SDK 46 to SDK 48 on `/workflow/ios-simulator` page
- Follow up #21905 to fix broken migration guide link in Stripe docs. Also, formats the doc to follow our writing styleguide. (Changes backported to all SDK versions).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have bee tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
