### PR TITLE
[docs] Update Video snack example to work with projects using TS

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video.mdx
+++ b/docs/pages/versions/unversioned/sdk/video.mdx
@@ -8,7 +8,7 @@ iconUrl: '/static/images/packages/expo-av.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -29,7 +29,7 @@ Here's a simple example of a video with a play/pause button.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { Video, AVPlaybackStatus } from 'expo-av';
+import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
   const video = React.useRef(null);
@@ -43,7 +43,7 @@ export default function App() {
           uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls
-        resizeMode="contain"
+        resizeMode={ResizeMode.CONTAIN}
         isLooping
         onPlaybackStatusUpdate={status => setStatus(() => status)}
       />

--- a/docs/pages/versions/v46.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/video.mdx
@@ -8,7 +8,7 @@ iconUrl: '/static/images/packages/expo-av.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -29,7 +29,7 @@ Here's a simple example of a video with a play/pause button.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { Video, AVPlaybackStatus } from 'expo-av';
+import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
   const video = React.useRef(null);
@@ -43,7 +43,7 @@ export default function App() {
           uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls
-        resizeMode="contain"
+        resizeMode={ResizeMode.CONTAIN}
         isLooping
         onPlaybackStatusUpdate={status => setStatus(() => status)}
       />

--- a/docs/pages/versions/v47.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/video.mdx
@@ -8,7 +8,7 @@ iconUrl: '/static/images/packages/expo-av.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -29,7 +29,7 @@ Here's a simple example of a video with a play/pause button.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { Video, AVPlaybackStatus } from 'expo-av';
+import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
   const video = React.useRef(null);
@@ -43,7 +43,7 @@ export default function App() {
           uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls
-        resizeMode="contain"
+        resizeMode={ResizeMode.CONTAIN}
         isLooping
         onPlaybackStatusUpdate={status => setStatus(() => status)}
       />

--- a/docs/pages/versions/v48.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/video.mdx
@@ -8,7 +8,7 @@ iconUrl: '/static/images/packages/expo-av.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 The `Video` component from **`expo-av`** displays a video inline with the other UI elements in your app.
 
@@ -29,7 +29,7 @@ Here's a simple example of a video with a play/pause button.
 ```jsx
 import * as React from 'react';
 import { View, StyleSheet, Button } from 'react-native';
-import { Video, AVPlaybackStatus } from 'expo-av';
+import { Video, ResizeMode } from 'expo-av';
 
 export default function App() {
   const video = React.useRef(null);
@@ -43,7 +43,7 @@ export default function App() {
           uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
         }}
         useNativeControls
-        resizeMode="contain"
+        resizeMode={ResizeMode.CONTAIN}
         isLooping
         onPlaybackStatusUpdate={status => setStatus(() => status)}
       />


### PR DESCRIPTION
# Why

While triaging some issues on our repo, I noticed [this report](https://github.com/expo/expo/issues/21913) regarding an error when using the `resizeMode` prop with `expo-av`'s `Video` component. The error reported is expected  and only happens in projects using Typescript, as the `resizeMode` prop expects a value from the `ResizeMode` enum, but our docs examples are using a string value directly, which can be misleading for users. By updating the example to use the `ResizeMode` enum instead of the string value, we can prevent this issue from occurring and improve the user experience.


# How

Update the `Video` snack example to use the `ResizeMode` enum instead of using the string value directly 

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
