### PR TITLE
[docs] Added missing text in a portion of the Using custom fonts

### DIFF
--- a/docs/pages/guides/using-custom-fonts.mdx
+++ b/docs/pages/guides/using-custom-fonts.mdx
@@ -222,7 +222,7 @@ You probably don't need to know anything beyond this point to use custom fonts e
 
 In general, it's best and safest to load fonts from your local assets. If you submit to app stores, they will be bundled with the download and available immediately. You don't have to worry about CORS or other potential issues.
 
-However, if you to load a remote font file directly from the web rather than from your project's assets, you can do it by replacing the `require('./assets/fonts/MyFont.otf')` with the URL of your font. See the below example:
+However, if you need to load a remote font file directly from the web rather than from your project's assets, you can do it by replacing the `require('./assets/fonts/MyFont.otf')` with the URL of your font. See the below example:
 
 <SnackInline label="Using a remote font" dependencies={['expo-font']}>
 


### PR DESCRIPTION
I added a missing text in a portion of docs that I came across while working with the platform.

The missing text ('need') pertained to the second paragraph of the "Loading a remote font directly from the web" section under the "custom fonts" section of the docs. I noticed that the absence of this information could potentially cause confusion for other users, so I took the initiative to add it myself.

I believe that maintaining comprehensive documentation is crucial for the success of any software platform, and I am happy to have had the opportunity to contribute to the Expo community in this way.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
