### PR TITLE
[expo-dev-launcher] Add missing `Network.requestWillBeSentExtraInfo` event

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Add missing `mimeType` when emitting network responses. ([#21676](https://github.com/expo/expo/pull/21676) by [@byCedric](https://github.com/byCedric))
+- Add missing `Network.requestWillBeSentExtraInfo` when emitting network requests. ([#21965](https://github.com/expo/expo/pull/21965) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -45,7 +45,7 @@ class DevLauncherNetworkLogger private constructor() {
   }
 
   /**
-   * Emits CDP `Network.requestWillBeSent` event
+   * Emits CDP `Network.requestWillBeSent` and `Network.requestWillBeSentExtraInfo` events
    */
   fun emitNetworkWillBeSent(request: Request, requestId: String, redirectResponse: Response?) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
@@ -80,9 +80,23 @@ class DevLauncherNetworkLogger private constructor() {
         ))
       }
     }
-    val data = JSONObject(mapOf(
+    var data = JSONObject(mapOf(
       "method" to "Network.requestWillBeSent",
       "params" to params,
+    ))
+    inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
+
+    params = mapOf(
+      "requestId" to requestId,
+      "associatedCookies" to emptyList<Void>(),
+      "headers" to request.headers().toSingleMap(),
+      "connectTiming" to mapOf(
+        "requestTime" to now,
+      ),
+    )
+    data = JSONObject(mapOf(
+      "method" to "Network.requestWillBeSentExtraInfo",
+      "params" to params
     ))
     inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
   }

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -49,7 +49,7 @@ class DevLauncherNetworkLogger private constructor() {
    */
   fun emitNetworkWillBeSent(request: Request, requestId: String, redirectResponse: Response?) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
-    var requestParams = buildMap<String, Any> {
+    val requestParams = buildMap<String, Any> {
       put("url", request.url().toString())
       put("method", request.method())
       put("headers", request.headers().toSingleMap())
@@ -60,7 +60,7 @@ class DevLauncherNetworkLogger private constructor() {
         put("postData", buffer.readUtf8(buffer.size.coerceAtMost(MAX_BODY_SIZE)))
       }
     }
-    var params = buildMap<String, Any> {
+    val requestWillBeSentParams = buildMap<String, Any> {
       put("requestId", requestId)
       put("loaderId", "")
       put("documentURL", "mobile")
@@ -80,13 +80,13 @@ class DevLauncherNetworkLogger private constructor() {
         ))
       }
     }
-    var data = JSONObject(mapOf(
+    val requestWillBeSentData = JSONObject(mapOf(
       "method" to "Network.requestWillBeSent",
-      "params" to params,
+      "params" to requestWillBeSentParams,
     ))
-    inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
+    inspectorPackagerConnection.sendWrappedEventToAllPages(requestWillBeSentData.toString())
 
-    params = mapOf(
+    val extraInfoParams = mapOf(
       "requestId" to requestId,
       "associatedCookies" to emptyList<Void>(),
       "headers" to request.headers().toSingleMap(),
@@ -94,11 +94,11 @@ class DevLauncherNetworkLogger private constructor() {
         "requestTime" to now,
       ),
     )
-    data = JSONObject(mapOf(
+    val extraInfodata = JSONObject(mapOf(
       "method" to "Network.requestWillBeSentExtraInfo",
-      "params" to params
+      "params" to extraInfoParams
     ))
-    inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
+    inspectorPackagerConnection.sendWrappedEventToAllPages(extraInfodata.toString())
   }
 
   /**
@@ -106,7 +106,7 @@ class DevLauncherNetworkLogger private constructor() {
    */
   fun emitNetworkResponse(request: Request, requestId: String, response: Response) {
     val now = BigDecimal(System.currentTimeMillis() / 1000.0).setScale(3, RoundingMode.CEILING)
-    var params = mapOf(
+    val responseReceivedParams = mapOf(
       "requestId" to requestId,
       "loaderId" to "",
       "hasExtraInfo" to false,
@@ -121,22 +121,22 @@ class DevLauncherNetworkLogger private constructor() {
       "type" to "Fetch",
       "timestamp" to now,
     )
-    var data = JSONObject(mapOf(
+    val responseReceivedData = JSONObject(mapOf(
       "method" to "Network.responseReceived",
-      "params" to params,
+      "params" to responseReceivedParams,
     ))
-    inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
+    inspectorPackagerConnection.sendWrappedEventToAllPages(responseReceivedData.toString())
 
-    params = mapOf(
+    val loadingFinishedParams = mapOf(
       "requestId" to requestId,
       "timestamp" to now,
       "encodedDataLength" to (response.body()?.contentLength() ?: 0),
     )
-    data = JSONObject(mapOf(
+    val loadingFinishedData = JSONObject(mapOf(
       "method" to "Network.loadingFinished",
-      "params" to params,
+      "params" to loadingFinishedParams,
     ))
-    inspectorPackagerConnection.sendWrappedEventToAllPages(data.toString())
+    inspectorPackagerConnection.sendWrappedEventToAllPages(loadingFinishedData.toString())
   }
 
   /**
@@ -151,12 +151,12 @@ class DevLauncherNetworkLogger private constructor() {
     val contentType = body.contentType()
     val isText = contentType?.type() == "text" || (contentType?.type() == "application" && contentType?.subtype() == "json")
     val bodyString = if (isText) body.string() else body.source().readByteString().base64()
-    var params = mapOf(
+    val params = mapOf(
       "requestId" to requestId,
       "body" to bodyString,
       "base64Encoded" to !isText,
     )
-    var data = JSONObject(mapOf(
+    val data = JSONObject(mapOf(
       "method" to "Expo(Network.receivedResponseBody)",
       "params" to params,
     ))

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -94,11 +94,11 @@ class DevLauncherNetworkLogger private constructor() {
         "requestTime" to now,
       ),
     )
-    val extraInfodata = JSONObject(mapOf(
+    val extraInfoData = JSONObject(mapOf(
       "method" to "Network.requestWillBeSentExtraInfo",
       "params" to extraInfoParams
     ))
-    inspectorPackagerConnection.sendWrappedEventToAllPages(extraInfodata.toString())
+    inspectorPackagerConnection.sendWrappedEventToAllPages(extraInfoData.toString())
   }
 
   /**

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/network/DevLauncherNetworkLogger.kt
@@ -65,7 +65,7 @@ class DevLauncherNetworkLogger private constructor() {
       put("loaderId", "")
       put("documentURL", "mobile")
       put("initiator", mapOf("type" to "script"))
-      put("redirectHasExtraInfo", false)
+      put("redirectHasExtraInfo", redirectResponse != null)
       put("request", requestParams)
       put("referrerPolicy", "no-referrer")
       put("type", "Fetch")

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -32,7 +32,7 @@ public class EXDevLauncherNetworkLogger: NSObject {
   }
 
   /**
-   Emits CDP `Network.requestWillBeSent` event
+   Emits CDP `Network.requestWillBeSent` and `Network.requestWillBeSentExtraInfo` events
    */
   func emitNetworkWillBeSent(request: URLRequest, requestId: String, redirectResponse: HTTPURLResponse?) {
     let now = Date().timeIntervalSince1970
@@ -66,6 +66,21 @@ public class EXDevLauncherNetworkLogger: NSObject {
     }
     if let data = try? JSONSerialization.data(
       withJSONObject: ["method": "Network.requestWillBeSent", "params": params],
+      options: []
+    ), let message = String(data: data, encoding: .utf8) {
+      inspectorPackagerConn?.sendWrappedEventToAllPages(message)
+    }
+    
+    params = [
+      "requestId": requestId,
+      "associatedCookies": [],
+      "headers": requestParams["headers"],
+      "connectTiming": [
+        "requestTime": now
+      ]
+    ] as [String: Any]
+    if let data = try? JSONSerialization.data(
+      withJSONObject: ["method": "Network.requestWillBeSentExtraInfo", "params": params],
       options: []
     ), let message = String(data: data, encoding: .utf8) {
       inspectorPackagerConn?.sendWrappedEventToAllPages(message)

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -70,7 +70,6 @@ public class EXDevLauncherNetworkLogger: NSObject {
     ), let message = String(data: data, encoding: .utf8) {
       inspectorPackagerConn?.sendWrappedEventToAllPages(message)
     }
-    
     params = [
       "requestId": requestId,
       "associatedCookies": [],

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -49,7 +49,7 @@ public class EXDevLauncherNetworkLogger: NSObject {
       "loaderId": "",
       "documentURL": "mobile",
       "initiator": ["type": "script"],
-      "redirectHasExtraInfo": false,
+      "redirectHasExtraInfo": redirectResponse != nil,
       "request": requestParams,
       "referrerPolicy": "no-referrer",
       "type": "Fetch",


### PR DESCRIPTION
# Why

This fixes the last two remaining "weird debug information" in chrome devtools.

1. The request headers are marked as "⚠️ Provisional headers shown"
2. The `Timing` column is stuck on "Pending" instead of showing the actual request time.

Page | Screenshot
--- | ---
Overview | <img src="https://user-images.githubusercontent.com/1203991/229575879-201d2b47-ff02-4512-adc3-72716fad71f8.png">
Headers tab | <img src="https://user-images.githubusercontent.com/1203991/229575999-b57c6428-a754-4e69-910e-a1cd76c9b761.png">
Timing tab | <img width="1030" alt="image" src="https://user-images.githubusercontent.com/1203991/229576107-d08d1f65-9203-4e7e-bf4d-73b42bbbbc8f.png">

# How

The two missing pieces of information are sent in the [`Network.requestWillBeSentExtraInfo`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSentExtraInfo) event, under `headers` and `connectTiming.requestTime`.

> I don't think we can actually get the `connectionStart`/`connectionEnd` timing, [as described here](https://developer.apple.com/documentation/foundation/nsurlsessiontasktransactionmetrics#3162615). Instead of fetching that value, we just skip it and let chrome devtools only show the actual response time.

# Test Plan

- Make a request `fetch('https://httpbin.org/anything')`
- Check the network tab
- Should NOT show `⚠️ Provisional headers are shown`
- Should NOT show `Pending` under `Timing`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
