### PR TITLE
[cli][dev-client] Fix legacy accept signature parsing in CLI and don't require in dev client

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 - Respond to `Debugger.getScriptSource` CDP messages when using lan or tunnel. ([#21825](https://github.com/expo/expo/pull/21825) by [@byCedric](https://github.com/byCedric))
 - Fix main field resolution for metro web. ([#21939](https://github.com/expo/expo/pull/21939) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix legacy accept signature parsing. ([#21970](https://github.com/expo/expo/pull/21970) by [@wschurman](https://github.com/wschurman))
+
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ClassicManifestMiddleware.ts
@@ -38,7 +38,7 @@ export class ClassicManifestMiddleware extends ManifestMiddleware<ClassicManifes
     assertRuntimePlatform(platform);
     return {
       platform,
-      acceptSignature: Boolean(req.headers['exponent-accept-signature']),
+      acceptSignature: this.getLegacyAcceptSignatureHeader(req),
       hostname: stripPort(req.headers['host']),
     };
   }

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -57,7 +57,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     return {
       explicitlyPrefersMultipartMixed,
       platform,
-      acceptSignature: !!req.headers['expo-accept-signature'],
+      acceptSignature: this.getLegacyAcceptSignatureHeader(req),
       expectSignature: expectSignature ? String(expectSignature) : null,
       hostname: stripPort(req.headers['host']),
     };

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -164,6 +164,18 @@ export abstract class ManifestMiddleware<
   /** Parse request headers into options. */
   public abstract getParsedHeaders(req: ServerRequest): TManifestRequestInfo;
 
+  /**
+   * This header is specified as a string "true" or "false", in one of two headers:
+   * - exponent-accept-signature
+   * - expo-accept-signature
+   */
+  protected getLegacyAcceptSignatureHeader(req: ServerRequest): boolean {
+    return (
+      req.headers['exponent-accept-signature'] === 'true' ||
+      req.headers['expo-accept-signature'] === 'true'
+    );
+  }
+
   /** Store device IDs that were sent in the request headers. */
   private async saveDevicesAsync(req: ServerRequest) {
     const deviceIds = req.headers?.['expo-dev-client-id'];

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add missing `mimeType` when emitting network responses. ([#21676](https://github.com/expo/expo/pull/21676) by [@byCedric](https://github.com/byCedric))
 - Add missing `Network.requestWillBeSentExtraInfo` when emitting network requests. ([#21965](https://github.com/expo/expo/pull/21965) by [@byCedric](https://github.com/byCedric))
+- Don't require legacy manifest signature in dev clients. ([#21970](https://github.com/expo/expo/pull/21970) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/helpers/DevLauncherUpdatesHelper.kt
@@ -59,6 +59,7 @@ fun createUpdatesConfigurationWithUrl(url: Uri, projectUrl: Uri, installationID:
     "launchWaitMs" to 60000,
     "checkOnLaunch" to "ALWAYS",
     "enabled" to true,
-    "requestHeaders" to requestHeaders
+    "requestHeaders" to requestHeaders,
+    "expectsSignedManifest" to false,
   )
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherUpdatesHelper.m
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
     @"EXUpdatesCheckOnLaunch": @"ALWAYS",
     @"EXUpdatesHasEmbeddedUpdate": @(NO),
     @"EXUpdatesEnabled": @(YES),
-    @"EXUpdatesRequestHeaders": requestHeaders
+    @"EXUpdatesRequestHeaders": requestHeaders,
+    @"EXUpdatesExpectsSignedManifest": @(NO),
   };
 }
 


### PR DESCRIPTION
# Why

This fixes three interconnected bugs:
1. The header that controls this can be named `exponent-accept-signature` or `expo-accept-signature`. Not sure of the history here. This PR makes these consistent. And it might have been fine to leave this as-is but it's easier to reason about this way IMO.
2. The value of this header is either the string "true" or "false". `Boolean("false") === true`, so this code was always returning true. This historically seemed to not matter since all clients (including dev clients) set this to "true".
3. Dev clients were sending `expo-accept-signature: true` header, which isn't necessary (dev clients don't need signed manifests since they don't use scoped modules).

Fixes a portion of https://linear.app/expo/issue/ENG-6980/fall-back-to-serving-unsigned-manifests-if-a-user-isnt-authorized-to

# Test Plan

1. `et gba -n testwat expo-dev-menu expo-dev-client expo-dev-launcher expo-updates expo-manifests expo-updates-interface`
2. Logged-in to user that owns an account, `eas update:configure`
3. Log out
4. Log in to a different user that is a viewer on that account.
5. Build on android/ios
6. In `packages/@expo/cli` run `nexpo start --dev-client`
7. Before changes, see that it throws
    ```
    ApiV2Error: Not authorized. You must have DEVELOPER or above access on the wschurman account to develop this project, or you may remove the owner listed in app.json to develop this project under your own account.
    ```
8. After changes, see that it works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
