### PR TITLE
[dev-menu] Fix start script to locate the packager ip in any network interface

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
 - Fix JS entry file in development builds. ([#21984](https://github.com/expo/expo/pull/21984) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Update the start script to dynamically locate the packager IP from any network interface. ([#21977](https://github.com/expo/expo/pull/21977) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/scripts/start.sh
+++ b/packages/expo-dev-menu/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 PACKAGER_PORT=2137
-PACKAGER_IP=`ifconfig en0 | grep inet | grep -v inet6 | awk '{print $2}'`
+PACKAGER_IP=`ifconfig | grep -v 127.0.0.1  | grep inet | grep -v inet6 | awk 'NR==1 {print $2}'`
 PACKAGER_HOST="$PACKAGER_IP:$PACKAGER_PORT"
 HOST_FILE='./assets/dev-menu-packager-host'
 


### PR DESCRIPTION
# Why

The current dev-menu start script only works for computers using the `en0` network interface, but depending on your local configurations you could be using other interfaces like `en1`, which was my case. That causes the `PACKAGER_IP` value to be set to an empty string, resulting in a crash while running the dev-menu locally.

# How

To overcome this limitation, this PR updates the start script to dynamically locate the packager IP from any network interface.

# Test Plan

Run `packages/expo-dev-menu/scripts/start.sh` and ensure the `assets/dev-menu-packager-host` file is correct

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
