### PR TITLE
[dev-menu] Fix hermes inspector not inspecting app target

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1261,7 +1261,7 @@ SPEC CHECKSUMS:
   Expo: 79deb55f33fab1b232232868a74713772943238d
   expo-dev-client: 71c7a10806a324e4312c1cac34d4a439670d2c3b
   expo-dev-launcher: b3ef874bd1676f248bc134c2ba38fa916e6dd314
-  expo-dev-menu: 1c514e8816e8ff0685bebbfc9a6e1c80519f0bb2
+  expo-dev-menu: 47c8d048c20a17f1713fe32bfab2726e805c1541
   expo-dev-menu-interface: 6c82ae323c4b8724dead4763ce3ff24a2108bdb1
   ExpoAppleAuthentication: 7bd5e4150d59e8df37aa80b425850ae88adf9e65
   ExpoBattery: 678d2b710a8fc398c30258c4dc22c12340ee5411

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -2,6 +2,8 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
+folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+
 Pod::Spec.new do |s|
   s.name           = 'expo-dev-menu'
   s.version        = package['version']
@@ -31,8 +33,17 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/expo-dev-menu/Swift Compatibility Header\"",
   }
 
-  # Swift/Objective-C compatibility
-  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
+  header_search_paths = [
+    '"$(PODS_ROOT)/boost"',
+    '"${PODS_ROOT}/Headers/Private/React-Core"',
+    '"$(PODS_CONFIGURATION_BUILD_DIR)/ExpoModulesCore/Swift Compatibility Header"',
+    '"$(PODS_CONFIGURATION_BUILD_DIR)/expo-dev-menu-interface/Swift Compatibility Header"',
+  ]
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
+    'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
+  }
 
   s.subspec 'SafeAreaView' do |safearea|
     if File.exist?("vendored/react-native-safe-area-context/dev-menu-react-native-safe-area-context.xcframework") && Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.10.0')
@@ -55,6 +66,7 @@ Pod::Spec.new do |s|
     s.source_files   = 'ios/**/*.{h,m,mm,swift}'
     s.preserve_paths = 'ios/**/*.{h,m,mm,swift}'
     s.exclude_files  = 'ios/*Tests/**/*', 'vendored/**/*'
+    s.compiler_flags = folly_compiler_flags
 
     main.dependency 'React-Core'
     main.dependency "EXManifests"

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -3,7 +3,7 @@
 import React
 
 @objc
-class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
+class DevMenuAppInstance: DevMenuRCTCxxBridgeDelegate, RCTBridgeDelegate {
   static private var CloseEventName = "closeDevMenu"
   static private var OpenEventName = "openDevMenu"
 

--- a/packages/expo-dev-menu/ios/DevMenuRCTBridge.h
+++ b/packages/expo-dev-menu/ios/DevMenuRCTBridge.h
@@ -16,4 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface DevMenuRCTCxxBridgeDelegate : NSObject
+
+@end
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
# Why

probably a regression from #21268. now the hermes inspector will inspect the dev menu bundle again.
close ENG-7928

# How

- add `DevMenuRCTCxxBridgeDelegate` to call `setEnableDebugger(false)`

# Test Plan

- ✅ ci passed
- ✅ check hermes inspector loads app target rather than dev-menu bundle
- ✅ build passed on use_frameworks! mode

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes since the last publishment
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
