### PR TITLE
[dev-menu] Fix JS entry file in development builds

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
+- Fix JS entry file in development builds. ([#21984](https://github.com/expo/expo/pull/21984) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -46,7 +46,7 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
 
   override fun getBundleAssetName() = "EXDevMenuApp.android.js"
 
-  override fun getJSMainModuleName() = ".expo/.virtual-metro-entry"
+  override fun getJSMainModuleName() = "index"
 
   fun getContext(): Context = super.getApplication()
 

--- a/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
+++ b/packages/expo-dev-menu/ios/DevMenuAppInstance.swift
@@ -44,7 +44,7 @@ class DevMenuAppInstance: NSObject, RCTBridgeDelegate {
     #if DEBUG
     if let packagerHost = jsPackagerHost() {
       return RCTBundleURLProvider.jsBundleURL(
-        forBundleRoot: ".expo/.virtual-metro-entry",
+        forBundleRoot: "index",
         packagerHost: packagerHost,
         enableDev: true,
         enableMinification: false)


### PR DESCRIPTION
# Why

When using `.expo/.virtual-metro-entry` as an entry file the `rewriteExpoRequestUrl` detects the expected entry file by checking the `package.json`, which does not work in the case of `dev-menu` due to it primarily being a library and having it's `"main"` field inside `package.json` point to `build/DevMenu.js` instead of the necessary "index"

# How

Revert the entry file in dev-menu to `index`

# Test Plan

Run bare-expo with `override fun getUseDeveloperSupport() = true` and `export EX_DEV_LAUNCHER_URL=http://localhost:8090`

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
