### PR TITLE
[ios] Fix weak objects implementation on Hermes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method. ([#21661](https://github.com/expo/expo/pull/21661) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Removed the legacy implementation of view managers. ([#21760](https://github.com/expo/expo/pull/21760) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Passed the app context instance down to dynamic types, object builders and convertibles. ([#21819](https://github.com/expo/expo/pull/21819) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Use `jsi::WeakObject` for weak objects on Hermes. ([#21986](https://github.com/expo/expo/pull/21986) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.2.6 - 2023-03-20
 


### PR DESCRIPTION
# Why

`JavaScriptWeakObject` on iOS used [`WeakRef`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) if it was supported by the engine (only JSC as of iOS 14.5), otherwise it worked like strong-referenced object and caused memory leaks. As of React Native 0.71, we can leverage `jsi::WeakObject` which is implemented on Hermes.

# How

Added separate implementation for weak objects on Hermes runtimes

# Test Plan

Added simple native class and created a milion of instances (on the JS side) and confirmed they are getting deallocated over time