### PR TITLE
[ENG-7968][docs] add info about how user can cache `Podfile.lock` across builds

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -68,7 +68,7 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 EAS Build serves most CocoaPods artifacts from a cache server. This improves consistency of `pod install` times while also generally improving speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.
 
-To using our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
+To use our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -87,8 +87,8 @@ To using our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_C
 }
 ```
 
-EAS Build also allows you to cache **Podfile.lock** file to provide consistent results across managed app builds.
-To enable it add `./ios/Podfile.lock` path to `"cache"."customPaths"` array in your build profile in **eas.json**.
+EAS Build allows you to cache the **Podfile.lock** file to provide consistent results across builds when using the managed workflow.
+To enable it, add `./ios/Podfile.lock` to the `"cache"."customPaths"` list in your build profile in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -66,7 +66,7 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 ## iOS dependencies
 
-EAS Build serves most CocoaPods artifacts from a cache server. This improves consistency of `pod install` times while also generally improving speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files. 
+EAS Build serves most CocoaPods artifacts from a cache server. This improves consistency of `pod install` times while also generally improving speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.
 
 To using our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
@@ -77,6 +77,26 @@ To using our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_C
     "production": {
       "env": {
         "EAS_BUILD_DISABLE_COCOAPODS_CACHE": "1"
+        /* @hide ... */ /* @end */
+      }
+      /* @hide ... */ /* @end */
+    }
+    /* @hide ... */ /* @end */
+  }
+  /* @hide ... */ /* @end */
+}
+```
+
+EAS Build also allows you to cache **Podfile.lock** file to provide consistent results across managed app builds.
+To enable it add `./ios/Podfile.lock` path to `"cache"."customPaths"` array in your build profile in **eas.json**.
+
+{/* prettier-ignore */}
+```json eas.json
+{
+  "build": {
+    "production": {
+      "cache": {
+        "customPaths": ["./ios/Podfile.lock"]
         /* @hide ... */ /* @end */
       }
       /* @hide ... */ /* @end */

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -66,7 +66,7 @@ To disable using our Maven cache server for your builds set the `EAS_BUILD_DISAB
 
 ## iOS dependencies
 
-EAS Build serves most CocoaPods artifacts from a cache server. This improves consistency of `pod install` times while also generally improving speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.
+EAS Build serves most CocoaPods artifacts from a cache server. This improves the consistency of `pod install` times and generally improves speed. The cache will be bypassed automatically if you provide your own **.netrc** or **.curlrc** files.
 
 To use our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COCOAPODS_CACHE` env variable value to `"1"` in **eas.json**.
 
@@ -87,8 +87,10 @@ To use our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COC
 }
 ```
 
-EAS Build allows you to cache the **Podfile.lock** file to provide consistent results across builds when using the managed workflow.
-To enable it, add `./ios/Podfile.lock` to the `"cache"."customPaths"` list in your build profile in **eas.json**.
+It is typical to not have your project **Podfile.lock** committed to source control when using [prebuild](/workflow/prebuild) to generate your **ios** directory [remotely at build time](/build-reference/ios-builds).
+It can be useful to cache your **Podfile.lock** in order to have deterministic builds, but the tradeoff in this case is that, because you don't use the lockfile during local development, your ability to determine when a change is needed and to update specific dependencies is limited.
+If you cache this file, you may occasionally end up with build errors that require clearing the cache.
+To cache **Podfile.lock**, add **./ios/Podfile.lock** to the `cache.customPaths` list in your build profile in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -130,13 +130,6 @@ export default [
           'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',
         ],
       },
-      {
-        name: 'cacheDefaultPaths',
-        type: 'boolean',
-        description: [
-          'Specifies whether to cache the recommended set of files, currently only Podfile.lock is cached by default for iOS build and nothing is cached for Android. Defaults to true.',
-        ],
-      },
     ],
   },
 ];


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-7968/do-not-cache-podfilelock-by-default

Companion to https://github.com/expo/turtle-v2/pull/1256

We are planning to stop caching `Podfile.lock` by default, so it would be helpful to explain to users how they can enable it for themselves.

# How

Explain how users can enable caching `Podfile.lock`

# Test Plan

Run docs locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
