### PR TITLE
[cli] Add graphql generated file to eslintignore

### DIFF
--- a/packages/@expo/cli/.eslintignore
+++ b/packages/@expo/cli/.eslintignore
@@ -1,1 +1,1 @@
-src/api/graphql/generated.ts
+src/graphql/generated.ts

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix node rendering. ([#21902](https://github.com/expo/expo/pull/21902) by [@EvanBacon](https://github.com/EvanBacon))
 - Update migration map to suggest standalone npx expo doctor instead of expo-cli doctor. ([#21931](https://github.com/expo/expo/pull/21931) by [@keith-kurak](https://github.com/keith-kurak))
 - Add graphql-codegen. ([#21980](https://github.com/expo/expo/pull/21980) by [@wschurman](https://github.com/wschurman))
+- Add graphql generated file to eslintignore. ([#22001](https://github.com/expo/expo/pull/22001) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.6.1 — 2023-02-15
 


### PR DESCRIPTION
# Why

When we added the graphql-codegen to the cli on https://github.com/expo/expo/pull/21980, we forgot to also update `.eslintignore`, causing the `SDK / check-packages` action to fail

# How

Update `.eslintignore` to point to the new generated file path

# Test Plan

`SDK / check-packages` should succeed 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
