### PR TITLE
[cli] Fix e2e tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -17,8 +17,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/config').expoConfig`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/customize-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/customize-test.ts
@@ -23,8 +23,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/customize').expoCustomize`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-embed-test.ts
@@ -27,8 +27,8 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/export/embed').expoExportEmbed`
   );
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/export-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-test.ts
@@ -34,8 +34,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/export').expoExport`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/export-web-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-web-test.ts
@@ -27,8 +27,8 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/export/web').expoExportWeb`
   );
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -29,8 +29,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/install').expoInstall`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -19,8 +19,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/login');`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/logout-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/logout-test.ts
@@ -17,8 +17,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/logout');`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -54,8 +54,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/prebuild').expoPrebuild`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/register-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/register-test.ts
@@ -19,8 +19,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/register');`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/run-android-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-android-test.ts
@@ -22,8 +22,8 @@ it('loads expected modules by default', async () => {
     `require('../../build/src/run/android').expoRunAndroid`
   );
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-ios-test.ts
@@ -20,8 +20,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/run/ios').expoRunIos`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -30,8 +30,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/start').expoStart`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',

--- a/packages/@expo/cli/e2e/__tests__/whoami-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/whoami-test.ts
@@ -17,8 +17,8 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/whoami');`);
   expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
     '../node_modules/arg/index.js',
-    '../node_modules/chalk/node_modules/ansi-styles/index.js',
     '../node_modules/chalk/source/index.js',
     '../node_modules/chalk/source/util.js',
     '../node_modules/has-flag/index.js',


### PR DESCRIPTION
# Why

These are failing in main: https://github.com/expo/expo/actions/workflows/cli.yml?query=branch%3Amain

Blame seems to be 8fd977ade89c14fcf9229c10eb19590a3c52c80b. No idea why that changes these or what these are testing but meh.

# How

Update tests.

# Test Plan

`yarn test:e2e`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
