### PR TITLE
[dev-menu] Disable Remote JS debugger on SDK 49+

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))
 
+### ⚠️ Notices
+
+- Disable the `Remote JS debugger` option on menu when using SDK 49 or above. ([#22010](https://github.com/expo/expo/pull/22010) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 2.1.4 - 2023-03-20
 
 ### 🐛 Bug fixes

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -21,6 +21,7 @@ import {
 } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Platform, ScrollView, Switch } from 'react-native';
+import semver from 'semver';
 
 import { useAppInfo } from '../hooks/useAppInfo';
 import { useClipboard } from '../hooks/useClipboard';
@@ -241,12 +242,23 @@ export function Main({ registeredCallbacks = [] }: MainProps) {
           ) : (
             <View bg="default">
               <SettingsRowSwitch
-                disabled={!devSettings.isRemoteDebuggingAvailable}
+                disabled={
+                  appInfo?.sdkVersion && semver.lt(appInfo.sdkVersion, '49.0.0')
+                    ? !devSettings.isRemoteDebuggingAvailable
+                    : true
+                }
                 testID="remote-js-debugger"
                 label="Remote JS debugger"
                 icon={<DebugIcon />}
                 isEnabled={devSettings.isDebuggingRemotely}
                 setIsEnabled={actions.toggleDebugRemoteJS}
+                description={
+                  !appInfo?.sdkVersion || semver.lt(appInfo.sdkVersion, '49.0.0')
+                    ? `This is not compatible with ${
+                        appInfo?.engine ?? 'JSC'
+                      } in this SDK version, please use Hermes to debug.`
+                    : undefined
+                }
               />
             </View>
           )}

--- a/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
+++ b/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
@@ -49,7 +49,7 @@ describe('<Main />', () => {
       appVersion: '123',
       appIcon: 'hello',
       hostUrl: '321',
-      sdkVersion: '500',
+      sdkVersion: '500.0.0',
       runtimeVersion: '10',
     };
 

--- a/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
+++ b/packages/expo-dev-menu/app/components/__tests__/Main.test.tsx
@@ -77,13 +77,33 @@ describe('<Main />', () => {
     await act(async () => fireEvent.press(getByText(/toggle element inspector/i)));
     expect(toggleElementInspectorAsync).toHaveBeenCalledTimes(1);
 
-    expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(0);
-    await act(async () => fireEvent.press(getByTestId('remote-js-debugger')));
-    expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(1);
-
     expect(toggleFastRefreshAsync).toHaveBeenCalledTimes(0);
     await act(async () => fireEvent.press(getByTestId('fast-refresh')));
     expect(toggleFastRefreshAsync).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Remote JS Debugger', () => {
+    it('should be available for SDK < 49', async () => {
+      const { getByText, getByTestId } = render(<Main />, {
+        initialAppProviderProps: {
+          appInfo: {
+            sdkVersion: '48.0.0',
+          },
+        },
+      });
+      await waitFor(() => getByText(/go home/i));
+
+      expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(0);
+      await act(async () => fireEvent.press(getByTestId('remote-js-debugger')));
+      expect(toggleDebugRemoteJSAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should be disabled for SDK 49+', async () => {
+      const { getByText, getByTestId } = render(<Main />);
+      await waitFor(() => getByText(/go home/i));
+
+      expect(getByTestId('remote-js-debugger')).toBeDisabled();
+    });
   });
 
   test('copy text functions', async () => {
@@ -92,7 +112,7 @@ describe('<Main />', () => {
       appVersion: '123',
       appIcon: 'hello',
       hostUrl: '321',
-      sdkVersion: '500',
+      sdkVersion: '500.0.0',
       runtimeVersion: '10',
     };
 


### PR DESCRIPTION
# Why

As part of https://github.com/facebook/react-native/pull/36754, we should remove the ability to use remote JS debugging from the DevMenu. This change is motivated by the fact that generally speaking, this feature does not work with the new architecture and most of the popular modules these days. 

Related to ENG-8088

# How

This PR disables the `Remote JS debugger` option inside the dev-menu when using SDK 49 or above 

# Test Plan

Run `dev-menu` locally through bare-expo
 
<table>
    <tr><th>iOS</th><th>Android</th></tr>
    <tr>
    <td>
        <img src="https://user-images.githubusercontent.com/11707729/230195305-5fcf6bbf-f669-40d6-841b-1decc967bebe.png" height="700px" />
   </td>
   <td>
   <img src="https://user-images.githubusercontent.com/11707729/230218993-b2fd081c-bc03-4330-8a61-29485c512682.png"  height="700px"  />  
    </td>
</tr> 
</table> 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
