### PR TITLE
[go] Disable Remote JS debugger on SDK 49+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+### ⚠️ Notices
+
+- Removed the `Remote JS debugger` option from Expo Go menu when using SDK 49 or above. ([#22027](https://github.com/expo/expo/pull/22027) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 48.0.0 — 2023-02-09
 
 ### 📚 3rd party library updates

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -92,14 +92,12 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
     if (devSettings != null && devSupportManager.devSupportEnabled && isJsExecutorInspectable) {
       debuggerMap.putString("label", getString(R.string.devmenu_open_js_debugger))
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
-    } else if (devSettings != null && devSupportManager.devSupportEnabled) {
+      items.putBundle("dev-remote-debug", debuggerMap)
+    } else if (devSettings != null && devSupportManager.devSupportEnabled && manifest?.getSDKVersion() ?: "" < "49.0.0") {
       debuggerMap.putString("label", getString(if (devSettings.isRemoteJSDebugEnabled) R.string.devmenu_stop_remote_debugging else R.string.devmenu_start_remote_debugging))
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
-    } else {
-      debuggerMap.putString("label", getString(R.string.devmenu_remote_debugger_unavailable))
-      debuggerMap.putBoolean("isEnabled", false)
+      items.putBundle("dev-remote-debug", debuggerMap)
     }
-    items.putBundle("dev-remote-debug", debuggerMap)
 
     if (devSettings != null && devSupportManager.devSupportEnabled && devSettings is DevInternalSettings) {
       hmrMap.putString("label", getString(if (devSettings.isHotModuleReplacementEnabled) R.string.devmenu_disable_fast_refresh else R.string.devmenu_enable_fast_refresh))

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -186,16 +186,14 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
       @"label": @"Open JS Debugger",
       @"isEnabled": @YES
     };
-  } else if (devSettings.isRemoteDebuggingAvailable && isDevModeEnabled) {
+  } else if (
+      [self.manifest.sdkVersion compare:@"49.0.0" options:NSNumericSearch] == NSOrderedAscending &&
+      devSettings.isRemoteDebuggingAvailable &&
+      isDevModeEnabled
+    ) {
     items[@"dev-remote-debug"] = @{
       @"label": (devSettings.isDebuggingRemotely) ? @"Stop Remote Debugging" : @"Debug Remote JS",
       @"isEnabled": @YES
-    };
-  } else {
-    items[@"dev-remote-debug"] =  @{
-      @"label": @"Remote Debugger Unavailable",
-      @"isEnabled": @NO,
-      @"detail": RCTTurboModuleEnabled() ? @"Remote debugging is unavailable while Turbo Modules are enabled. To debug remotely, please set `turboModules` to false in app.json." : [NSNull null]
     };
   }
 


### PR DESCRIPTION
# Why

As part of https://github.com/facebook/react-native/pull/36754, we should remove the ability to use remote JS debugging from the DevMenu. This change is motivated by the fact that generally speaking, this feature does not work with the new architecture and most of the popular modules these days. 

Follow up of https://github.com/expo/expo/pull/22010
Closes ENG-8088

# How

This PR removes the `Remote JS debugger` option from Expo Go menu when using SDK 49 or above 

# Test Plan


Run Expo Go locally 
 
<table>
    <tr><th>iOS</th><th>Android</th></tr>
    <tr>
    <td>
        <img src="https://user-images.githubusercontent.com/11707729/230474710-28b0a90a-9f49-48c1-baaf-8883fdad8178.png" height="700px" />
   </td>
   <td>
   <img src="https://user-images.githubusercontent.com/11707729/230473058-e06831e6-96d9-4a17-8da1-d884d9c9678f.png"  height="700px"  />  
    </td>
</tr> 
</table> 
  

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
