### PR TITLE
[docs] Add Expo installation page redirect

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -138,6 +138,7 @@ const RENAMED_PAGES: Record<string, string> = {
   // TODO: (@aman) Uncomment the two lines below when we've removed third-party libraries from Reference
   // '/versions/latest/sdk/safe-area-context/': '/home/develop/user-interface/safe-areas',
   // '/versions/latest/sdk/async-storage/': '/home/develop/user-interface/store-data/#async-storage',
+  '/get-started/installation': '/home/get-started/installation/',
   '/get-started/create-a-new-app/': '/home/get-started/create-a-project',
   '/guides/config-plugins/': '/home/config-plugins/introduction/',
   '/workflow/debugging/': '/home/debugging/runtime-issue/',


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While adding redirects, forgot to add redirect for the `/get-started/installation/`. This PR fixes that by adding the correct redirect to point towards the working URL: `/home/get-started/installation/`.

# Test Plan
Changes have been tested locally.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
