### PR TITLE
[go] integrate firebase crashlytics on android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,6 @@
+import java.nio.file.Files
+import java.nio.file.Paths
+
 apply plugin: 'kotlin-kapt'
 
 buildscript {
@@ -17,6 +20,7 @@ buildscript {
 }
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.google.firebase.crashlytics'
 
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
@@ -73,6 +77,9 @@ android {
       if (!System.getenv("ANDROID_UNSIGNED")) {
         signingConfig signingConfigs.release
       }
+      firebaseCrashlytics {
+        nativeSymbolUploadEnabled true
+      }
     }
   }
 
@@ -81,11 +88,17 @@ android {
     versioned {
       dimension "versioning"
       manifestPlaceholders = [appLabel:"@string/versioned_app_name"]
+      firebaseCrashlytics {
+        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/versionedRelease/out/lib")
+      }
     }
     unversioned {
       dimension "versioning"
       getIsDefault().set(true)
       manifestPlaceholders = [appLabel: "@string/unversioned_app_name"]
+      firebaseCrashlytics {
+        unstrippedNativeLibsDir file("${buildDir}/intermediates/merged_native_libs/unversionedRelease/out/lib")
+      }
     }
   }
 
@@ -209,3 +222,11 @@ dependencies {
 
 // This has to be down here for some reason
 apply plugin: 'com.google.gms.google-services'
+
+def ensureCrashlyticsDir = tasks.register('ensureCrashlyticsDir') {
+  doLast {
+    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/versionedRelease/out/lib"))
+    Files.createDirectories(Paths.get("${buildDir}/intermediates/merged_native_libs/unversionedRelease/out/lib"))
+  }
+}
+preBuild.dependsOn(ensureCrashlyticsDir)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ buildscript {
   dependencies {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
     classpath 'com.google.gms:google-services:4.3.5'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 

--- a/android/expoview/build.gradle
+++ b/android/expoview/build.gradle
@@ -243,6 +243,8 @@ dependencies {
   // Our dependencies
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
   api 'de.greenrobot:eventbus:2.4.0'
+  api 'com.google.firebase:firebase-crashlytics:18.3.6'
+  api 'com.google.firebase:firebase-crashlytics-ndk:18.3.6'
   api "androidx.room:room-runtime:2.1.0"
 
   api("com.facebook.fresco:animated-gif:${reactProperties.getProperty('FRESCO_VERSION')}")

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -23,6 +23,7 @@ import androidx.core.content.ContextCompat
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.soloader.SoLoader
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import de.greenrobot.event.EventBus
 import expo.modules.core.interfaces.Package
 import expo.modules.manifests.core.Manifest
@@ -170,6 +171,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
       }
     }
 
+    FirebaseCrashlytics.getInstance().log("ExperienceActivity.manifestUrl: ${this.manifestUrl}")
     if (this.manifestUrl != null && shouldOpenImmediately) {
       val forceCache = intent.getBooleanExtra(KernelConstants.LOAD_FROM_CACHE_KEY, false)
       ExpoUpdatesAppLoader(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -324,6 +324,15 @@ platform :android do
     )
   end
 
+  lane :upload_crashlytics_symbols do |flavor: "versioned"|
+    gradle(
+      project_dir: "android",
+      task: "app:uploadCrashlyticsSymbolFile",
+      flavor: flavor,
+      build_type: "Release",
+    )
+  end
+
   lane :prod_release do
     build_gradle = File.read("../android/app/build.gradle")
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -92,6 +92,14 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 
 
 
+### android upload_crashlytics_symbols
+
+```sh
+[bundle exec] fastlane android upload_crashlytics_symbols
+```
+
+
+
 ### android prod_release
 
 ```sh

--- a/tools/src/client-build/AndroidClientBuilder.ts
+++ b/tools/src/client-build/AndroidClientBuilder.ts
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { ANDROID_DIR } from '../Constants';
+import logger from '../Logger';
 import { androidAppVersionAsync } from '../ProjectVersions';
 import { spawnAsync } from '../Utils';
 import { ClientBuilder, ClientBuildFlavor, Platform, S3Client } from './types';
@@ -34,6 +35,13 @@ export default class AndroidClientBuilder implements ClientBuilder {
     await spawnAsync('fastlane', ['android', 'build', 'build_type:Release', `flavor:${flavor}`], {
       stdio: 'inherit',
     });
+
+    if (flavor === ClientBuildFlavor.VERSIONED) {
+      logger.info('Uploading Crashlytics symbols');
+      await spawnAsync('fastlane', ['android', 'upload_crashlytics_symbols', `flavor:${flavor}`], {
+        stdio: 'inherit',
+      });
+    }
   }
 
   async uploadBuildAsync(s3Client: S3Client, appVersion: string) {


### PR DESCRIPTION
# Why

to have more information about the crashes than just from google play store. this pr tries to integrate firebase crashlytics with more powerful features like ndk integration and custom logging.
close ENG-1380

# How

- integrate crashlytics with ndk support
<img src="https://user-images.githubusercontent.com/46429/230618237-3385730e-3cb4-4700-ac23-04ee055accd8.png" width="75%">
- log the loading experience manifest url
<img src="https://user-images.githubusercontent.com/46429/230618367-1699445f-ef4b-4622-b6d5-328a9d7c11d0.png" width="75%">
- [tools] we need a further step `./gradlew :app:uploadCrashlyticsSymbolFileUnversionedRelease` for uploading ndk native symbols to crashlytics. we also integrate this into fastlane and expotools. this step may take longer time to process. from my environment, it takes about 30mins.

# Test Plan

manually triggering crash and see the crashlytics dashboard

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
