### PR TITLE
[packages] fix links to Docs in packages Readmes

### DIFF
--- a/packages/@expo/cli/README.md
+++ b/packages/@expo/cli/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  <a aria-label="expo documentation" href="https://docs.expo.dev/workflow/expo-cli/">📚 Read the Documentation</a>
+  <a aria-label="expo documentation" href="https://docs.expo.dev/more/expo-cli/">📚 Read the Documentation</a>
   |
   <a aria-label="Contribute to Expo CLI" href="#contributing"><b>Contribute to Expo CLI</b></a>
 </p>

--- a/packages/@expo/config-plugins/README.md
+++ b/packages/@expo/config-plugins/README.md
@@ -15,9 +15,9 @@
 
 <!-- Body -->
 
-Most basic functionality can be controlled by using the the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
+Most basic functionality can be controlled by using the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
 
-For more info, please refer to the official docs: [Config Plugins](https://docs.expo.dev/guides/config-plugins/).
+For more info, please refer to the official Expo docs: [Config Plugins](https://docs.expo.dev/home/config-plugins/introduction/).
 
 ## Environment Variables
 

--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -9,7 +9,7 @@ This library provides Apple authentication for iOS standalone apps in the manage
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/apple-authentication/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/apple-authentication/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-application/README.md
+++ b/packages/expo-application/README.md
@@ -8,7 +8,7 @@ Gets native application information such as its ID, app name, and build version 
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#https://docs.expo.dev/versions/latest/sdk/application/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#https://docs.expo.dev/versions/latest/sdk/application/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-asset/README.md
+++ b/packages/expo-asset/README.md
@@ -9,7 +9,7 @@ An Expo universal module to download assets and pass them into other APIs
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/asset/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/asset/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -9,7 +9,7 @@
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/auth-session).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/auth-session).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -16,7 +16,7 @@ Expo universal module for Audio and Video playback
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/av/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/av/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -9,7 +9,7 @@ Expo universal module for BackgroundFetch API
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/background-fetch/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/background-fetch/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -16,7 +16,7 @@ Allows scanning variety of supported barcodes both as standalone module and as e
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-battery/README.md
+++ b/packages/expo-battery/README.md
@@ -15,7 +15,7 @@ Provide battery information for the physical device.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/battery/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/battery/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -16,7 +16,7 @@ A component that renders a native blur view on iOS and falls back to a semi-tran
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/blur-view/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/blur-view/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-brightness/README.md
+++ b/packages/expo-brightness/README.md
@@ -16,7 +16,7 @@ Provides an API to get and set screen brightness.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/brightness/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/brightness/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-build-properties/README.md
+++ b/packages/expo-build-properties/README.md
@@ -48,4 +48,4 @@ Contributions are very welcome! Please refer to guidelines described in the [con
 [docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/build-properties.mdx
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/build-properties/
 [contributing]: https://github.com/expo/expo#contributing
-[config-plugins]: https://docs.expo.dev/guides/config-plugins/
+[config-plugins]: https://docs.expo.dev/home/config-plugins/introduction

--- a/packages/expo-calendar/README.md
+++ b/packages/expo-calendar/README.md
@@ -9,7 +9,7 @@ Provides an API for interacting with the device's system calendars, events, remi
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/calendar/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/calendar/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -16,7 +16,7 @@ A React component that renders a preview for the device's either front or back c
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/camera/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/camera/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-cellular/README.md
+++ b/packages/expo-cellular/README.md
@@ -9,7 +9,7 @@ Information about the user’s cellular service provider, such as its unique ide
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/cellular/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/cellular/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-constants/README.md
+++ b/packages/expo-constants/README.md
@@ -9,7 +9,7 @@ Provides system information that remains constant throughout the lifetime of you
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/constants/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/constants/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-contacts/README.md
+++ b/packages/expo-contacts/README.md
@@ -9,7 +9,7 @@ Provides access to the phone's system contacts.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/contacts/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/contacts/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-crypto/README.md
+++ b/packages/expo-crypto/README.md
@@ -16,7 +16,7 @@ Provides cryptography primitives.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/crypto/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/crypto/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-dev-client/README.md
+++ b/packages/expo-dev-client/README.md
@@ -5,7 +5,7 @@ next time you need to upgrade, install a new module, or otherwise change the nat
 
 ## Documentation
 
-You can find the documentation under [https://docs.expo.dev/clients/introduction](https://docs.expo.dev/clients/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
 
 ## Issues
 

--- a/packages/expo-dev-launcher/README.md
+++ b/packages/expo-dev-launcher/README.md
@@ -4,4 +4,4 @@
 
 ## Documentation
 
-You can find the documentation under [https://docs.expo.dev/clients/introduction](https://docs.expo.dev/clients/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).

--- a/packages/expo-dev-menu-interface/README.md
+++ b/packages/expo-dev-menu-interface/README.md
@@ -4,7 +4,7 @@ Interface for `expo-dev-menu`.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-dev-menu/README.md
+++ b/packages/expo-dev-menu/README.md
@@ -1,7 +1,7 @@
 # 📦 expo-dev-menu
 
-Expo/React Native module to add developer menu to Debug builds of your application. This package is intended to be included in your project through [`expo-dev-client`](https://docs.expo.dev/clients/introduction/).
+Expo/React Native module to add developer menu to Debug builds of your application. This package is intended to be included in your project through [`expo-dev-client`](https://docs.expo.dev/home/develop/development-builds/introduction/#what-is-an-expo-dev-client).
 
 ## Documentation
 
-You can find the documentation under [https://docs.expo.dev/clients/introduction](https://docs.expo.dev/clients/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).

--- a/packages/expo-device/README.md
+++ b/packages/expo-device/README.md
@@ -9,7 +9,7 @@ Provides specific information about the device running the application.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/device/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/device/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -9,7 +9,7 @@ Provides access to the system's UI for selecting documents from the available pr
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/document-picker/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/document-picker/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-face-detector/README.md
+++ b/packages/expo-face-detector/README.md
@@ -9,7 +9,7 @@ Lets you use the power of MLKit (https://firebase.google.com/docs/ml-kit/detect-
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/facedetector/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/facedetector/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-file-system/README.md
+++ b/packages/expo-file-system/README.md
@@ -16,7 +16,7 @@ Provides access to the local file system on the device.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/filesystem/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/filesystem/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-font/README.md
+++ b/packages/expo-font/README.md
@@ -9,7 +9,7 @@ Load fonts at runtime and use them in React Native components.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/font/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/font/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -16,7 +16,7 @@ Provides GLView that acts as OpenGL ES render target and gives GL context object
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/gl-view/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/gl-view/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -16,7 +16,7 @@ Provides access to the system's haptics engine on iOS and vibration effects on A
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/haptics/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/haptics/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-image-loader/README.md
+++ b/packages/expo-image-loader/README.md
@@ -4,7 +4,7 @@ Provides image loader
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-image-manipulator/README.md
+++ b/packages/expo-image-manipulator/README.md
@@ -16,7 +16,7 @@ Provides functions that let you manipulation images on the local file system, eg
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagemanipulator/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagemanipulator/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -16,7 +16,7 @@ Provides access to the system's UI for selecting images and videos from the phon
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagepicker/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/imagepicker/).
 
 # Installation in bare React Native projects
 
@@ -62,7 +62,7 @@ This package automatically adds the `CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRIT
 
 > This plugin is applied automatically in EAS Build, only add the config plugin if you want to pass in extra properties.
 
-After installing this npm package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+After installing this npm package, add the [config plugin](https://docs.expo.dev/home/config-plugins/introduction) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
 
 ```json
 {
@@ -72,7 +72,7 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 }
 ```
 
-Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.dev/workflow/customizing/) guide.
 
 ### API
 

--- a/packages/expo-intent-launcher/README.md
+++ b/packages/expo-intent-launcher/README.md
@@ -9,7 +9,7 @@ Provides a way to launch Android intents, e.g. opening a specific activity.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/intent-launcher/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/intent-launcher/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-keep-awake/README.md
+++ b/packages/expo-keep-awake/README.md
@@ -9,7 +9,7 @@ Provides a React component that prevents the screen sleeping when rendered. It a
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/keep-awake/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/keep-awake/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-linear-gradient/README.md
+++ b/packages/expo-linear-gradient/README.md
@@ -16,7 +16,7 @@ Provides a React component that renders a gradient view.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linear-gradient/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linear-gradient/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-linking/README.md
+++ b/packages/expo-linking/README.md
@@ -9,7 +9,7 @@ Create and open deep links universally.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linking/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/linking/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -16,7 +16,7 @@ Provides an API for FaceID and TouchID (iOS) or the Fingerprint API (Android) to
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/local-authentication/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/local-authentication/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-localization/README.md
+++ b/packages/expo-localization/README.md
@@ -16,7 +16,7 @@ Provides an interface for native user localization information.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/localization/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/localization/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -16,7 +16,7 @@ Allows reading geolocation information from the device. Your app can poll for th
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/location/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/location/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-mail-composer/README.md
+++ b/packages/expo-mail-composer/README.md
@@ -16,7 +16,7 @@ Provides an API to compose mails using OS specific UI
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/mail-composer/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/mail-composer/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -16,7 +16,7 @@ Provides access to user's media library.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/media-library/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/media-library/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-module-scripts/templates/README.md
+++ b/packages/expo-module-scripts/templates/README.md
@@ -11,7 +11,7 @@ ${description}
 <!--- end remove for interfaces --->
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-modules-autolinking/README.md
+++ b/packages/expo-modules-autolinking/README.md
@@ -16,7 +16,7 @@ Scripts that autolink Expo modules.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-modules-core/README.md
+++ b/packages/expo-modules-core/README.md
@@ -11,7 +11,7 @@ The core of Expo Modules architecture.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-navigation-bar/README.md
+++ b/packages/expo-navigation-bar/README.md
@@ -31,7 +31,7 @@ Contributions are very welcome! Please refer to guidelines described in the [con
 
 [docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/navigation-bar/
-[docs-workflows]: https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/
+[docs-workflows]: https://docs.expo.dev/archive/managed-vs-bare/
 [contributing]: https://github.com/expo/expo#contributing
 [unimodules]: https://github.com/expo/expo/tree/main/packages/react-native-unimodules
 [status-bar]: https://github.com/expo/expo/tree/main/packages/expo-status-bar

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -17,7 +17,7 @@ See [Expo Network docs](https://docs.expo.dev/versions/latest/sdk/network/) for 
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/network/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/network/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -126,7 +126,7 @@ This module requires permission to subscribe to device boot. It's used to setup 
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the expo-notifications config plugin ([what's a config plugin?](http://docs.expo.dev/guides/config-plugins/)). To setup, just add the config plugin to the plugins array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
+If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the expo-notifications config plugin ([what's a config plugin?](https://docs.expo.dev/home/config-plugins/introduction)). To setup, just add the config plugin to the plugins array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
 
 ```json
 {

--- a/packages/expo-print/README.md
+++ b/packages/expo-print/README.md
@@ -9,7 +9,7 @@ Provides an API for iOS (AirPrint) and Android printing functionality.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/print/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/print/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -9,7 +9,7 @@ Provides a native interface for creating strong random bytes. With `Random` you 
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/random/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/random/).
 
 You can add a polyfill for the web's `crypto.getRandomValues` by installing [expo-standard-web-crypto](https://github.com/expo/expo/tree/main/packages/expo-standard-web-crypto) and importing it in SDK 39 and higher:
 

--- a/packages/expo-screen-capture/README.md
+++ b/packages/expo-screen-capture/README.md
@@ -13,7 +13,7 @@ This is especially important on Android, since the [`android.media.projection`](
 
 ## Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/screen-capture/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/screen-capture/).
 
 ## Installation in bare React Native projects
 

--- a/packages/expo-screen-orientation/README.md
+++ b/packages/expo-screen-orientation/README.md
@@ -9,7 +9,7 @@ Allows you to manage the orientation of your app's interface.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/screen-orientation/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/screen-orientation/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 # Installation in bare React Native projects
 

--- a/packages/expo-secure-store/README.md
+++ b/packages/expo-secure-store/README.md
@@ -16,7 +16,7 @@ Provides a way to encrypt and securely store key–value pairs locally on the de
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/securestore/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/securestore/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -16,7 +16,7 @@ Provides access to a hardware device's accelerometer, gyroscope, magnetometer, a
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sensors/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sensors/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-sharing/README.md
+++ b/packages/expo-sharing/README.md
@@ -9,7 +9,7 @@ Sharing standalone module
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sharing/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sharing/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-sms/README.md
+++ b/packages/expo-sms/README.md
@@ -16,7 +16,7 @@ Provides access to the system's UI/app for sending SMS messages.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sms/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sms/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-speech/README.md
+++ b/packages/expo-speech/README.md
@@ -9,7 +9,7 @@ Provides text-to-speech functionality.
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/speech/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/speech/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -9,7 +9,7 @@ Provides access to a database that can be queried through a WebSQL-like API (htt
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sqlite/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/sqlite/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-status-bar/README.md
+++ b/packages/expo-status-bar/README.md
@@ -12,7 +12,7 @@ Provides the same interface as the React Native [StatusBar API](https://reactnat
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/image/). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
 
 Please refer to the [React Native StatusBar API documentation](https://reactnative.dev/docs/statusbar).
 

--- a/packages/expo-store-review/README.md
+++ b/packages/expo-store-review/README.md
@@ -9,7 +9,7 @@
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/storereview/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/storereview/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -9,7 +9,7 @@ Expo universal module for TaskManager API
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/task-manager/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/task-manager/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-tracking-transparency/README.md
+++ b/packages/expo-tracking-transparency/README.md
@@ -11,7 +11,7 @@ For more information on Apple's new App Tracking Transparency framework, please 
 
 ## Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/tracking-transparency/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/tracking-transparency/).
 
 ## Installation in bare React Native projects
 

--- a/packages/expo-updates/README.md
+++ b/packages/expo-updates/README.md
@@ -23,7 +23,7 @@ If you're upgrading from `expo-updates@0.1.x`, you can opt into the **no-publish
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/updates/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/updates/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-video-thumbnails/README.md
+++ b/packages/expo-video-thumbnails/README.md
@@ -9,7 +9,7 @@ Provides function that let you generate an image from video. This can be used fo
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/video-thumbnails/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/video-thumbnails/).
 
 # Installation in bare React Native projects
 

--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -16,7 +16,7 @@ Provides access to the system's web browser and supports handling redirects. On 
 
 # Installation in managed Expo projects
 
-For [managed](https://docs.expo.dev/versions/latest/introduction/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/webbrowser/).
+For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/webbrowser/).
 
 # Installation in bare React Native projects
 


### PR DESCRIPTION
# Why

After the latest docs reorganization some of the link used in packages Readme files results in redirects, let's updated link to address that.

# How

Update some of the spotted link, so now they lead directly to the pages instead of redirecting user on each visit.

# Test Plan

The updated links have been tested locally.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
