### PR TITLE
[docs] Fix broken links on /home/overview

### DIFF
--- a/docs/pages/home/overview.mdx
+++ b/docs/pages/home/overview.mdx
@@ -7,11 +7,11 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 Expo is an [open-source framework](https://github.com/expo/expo/) for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
-- **Develop**: Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/home/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/home/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
+- **Develop**: Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](https://docs.expo.dev/develop/project-structure) which you can customize as per your needs. It also provides [development builds](https://docs.expo.dev/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
 
 {/* TODO: (@aman) Add a section for Navigation, Review later when they are ready. */}
 
-- **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/home/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/home/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/home/deploy/instant-updates) a snap in between app store submissions.
+- **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](https://docs.expo.dev/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](https://docs.expo.dev/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](https://docs.expo.dev/deploy/instant-updates) a snap in between app store submissions.
 
 There are plenty of other features and best practices to continue exploring along the way, such as [collaborating with your team](/accounts/account-types/#organizations), using [Expo modules](/versions/latest/), [debugging](https://docs.expo.dev/home/debugging/runtime-issue/), and working on the command line with [Expo CLI](/workflow/expo-cli).
 


### PR DESCRIPTION
# Why & how

Currently, the links on `/home/overview` in production are broken that start with prefix `/home/...` (even though the relative links that start with `/home` prefix work fine on development). 

Link to page: https://docs.expo.dev/home/overview/

This PR adds absolute URLs as a temporary fix until its figured out why those links are broken.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
