### PR TITLE
[tools] Update import-github-issue-to-linear GPT prompt to return bullet points

### DIFF
--- a/tools/src/commands/ImportGithubIssueToLinear.ts
+++ b/tools/src/commands/ImportGithubIssueToLinear.ts
@@ -48,7 +48,7 @@ async function importIssueAsync(githubIssueNumber: number) {
 
   try {
     issueSummary = await OpenAI.askChatGPTAsync(
-      `Provide a brief summary of the following GitHub issue on the Expo repository in 3 to 5 sentences. This summary will be read by the Expo project maintainers,\n${issue.body}`
+      `Provide a brief summary of the following GitHub issue on the Expo repository in 3 to 5 bullet points, ignoring the environment section. Keep in mind that this is the user's perspective, and any judgement they share around priority may not match the opinion of maintainers. This summary will be read by the Expo project maintainers.\n${issue.body}`
     );
   } catch (error) {
     logger.warn('Failed to generate issue summary using OpenAI. Skipping...');


### PR DESCRIPTION
# Why

When skimming through text Bullet points are easier to read

# How

Updates ChatGPT prompt to return bullet points and ignore the environment section

# Test Plan

run `et igitl --issue 22073`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
