### PR TITLE
[docs] Update Icon and FootNotePrefix for Command menu

### DIFF
--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -1,9 +1,22 @@
 import { DocsLogo } from '@expo/styleguide';
-import { PlanEnterpriseIcon, BookOpen02Icon } from '@expo/styleguide-icons';
+import {
+  PlanEnterpriseIcon,
+  BookOpen02Icon,
+  GraduationHat02Icon,
+  Home02Icon,
+} from '@expo/styleguide-icons';
 import { Command } from 'cmdk';
 
 import type { AlgoliaItemType } from '../types';
-import { getContentHighlightHTML, getHighlightHTML, isEASPath, openLink } from '../utils';
+import {
+  getContentHighlightHTML,
+  getHighlightHTML,
+  isReferencePath,
+  isEASPath,
+  openLink,
+  isHomePath,
+  isLearnPath,
+} from '../utils';
 import { FootnoteSection } from './FootnoteSection';
 import { FootnoteArrowIcon } from './icons';
 import { contentStyle, footnoteStyle, itemIconWrapperStyle, itemStyle } from './styles';
@@ -21,19 +34,27 @@ type Props = {
 const isDev = process.env.NODE_ENV === 'development';
 
 const ItemIcon = ({ url }: { url: string }) => {
-  if (url.includes('/versions/')) {
+  if (isReferencePath(url)) {
     return <DocsLogo className="text-icon-secondary" />;
   } else if (isEASPath(url)) {
     return <PlanEnterpriseIcon className="text-icon-secondary" />;
+  } else if (isHomePath(url)) {
+    return <Home02Icon className="text-icon-secondary" />;
+  } else if (isLearnPath(url)) {
+    return <GraduationHat02Icon className="text-icon-secondary" />;
   }
   return <BookOpen02Icon className="text-icon-secondary" />;
 };
 
 const getFootnotePrefix = (url: string) => {
-  if (url.includes('/versions/')) {
-    return 'API Reference';
+  if (isReferencePath(url)) {
+    return 'Reference';
   } else if (isEASPath(url)) {
     return 'Expo Application Services';
+  } else if (isHomePath(url)) {
+    return 'Home';
+  } else if (isLearnPath(url)) {
+    return 'Learn';
   } else {
     return 'Guides';
   }

--- a/docs/ui/components/CommandMenu/utils.ts
+++ b/docs/ui/components/CommandMenu/utils.ts
@@ -99,6 +99,17 @@ export const openLink = (url: string, isExternal: boolean = false) => {
   link.click();
 };
 
+const ReferencePathChunks = ['/versions/', '/modules/', '/more/'] as const;
+
+export const isReferencePath = (url: string) => {
+  for (const pathChunk of ReferencePathChunks) {
+    if (url.includes(pathChunk)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const EASPathChunks = [
   '/app-signing/',
   '/build/',
@@ -112,6 +123,36 @@ const EASPathChunks = [
 
 export const isEASPath = (url: string) => {
   for (const pathChunk of EASPathChunks) {
+    if (url.includes(pathChunk)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const HomePathChunks = [
+  '/get-started/',
+  '/develop/',
+  '/deploy/',
+  '/faq/',
+  '/core-concepts/',
+  '/debugging/',
+  '/config-plugins/',
+] as const;
+
+export const isHomePath = (url: string) => {
+  for (const pathChunk of HomePathChunks) {
+    if (url.includes(pathChunk)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const LearnPathChunks = ['/tutorial', '/ui-programming/', '/additional-resources/'] as const;
+
+export const isLearnPath = (url: string) => {
+  for (const pathChunk of LearnPathChunks) {
     if (url.includes(pathChunk)) {
       return true;
     }

--- a/docs/ui/components/CommandMenu/utils.ts
+++ b/docs/ui/components/CommandMenu/utils.ts
@@ -102,12 +102,7 @@ export const openLink = (url: string, isExternal: boolean = false) => {
 const ReferencePathChunks = ['/versions/', '/modules/', '/more/'] as const;
 
 export const isReferencePath = (url: string) => {
-  for (const pathChunk of ReferencePathChunks) {
-    if (url.includes(pathChunk)) {
-      return true;
-    }
-  }
-  return false;
+  return ReferencePathChunks.some(pathChunk => url.includes(pathChunk));
 };
 
 const EASPathChunks = [
@@ -122,12 +117,7 @@ const EASPathChunks = [
 ] as const;
 
 export const isEASPath = (url: string) => {
-  for (const pathChunk of EASPathChunks) {
-    if (url.includes(pathChunk)) {
-      return true;
-    }
-  }
-  return false;
+  return EASPathChunks.some(pathChunk => url.includes(pathChunk));
 };
 
 const HomePathChunks = [
@@ -141,23 +131,13 @@ const HomePathChunks = [
 ] as const;
 
 export const isHomePath = (url: string) => {
-  for (const pathChunk of HomePathChunks) {
-    if (url.includes(pathChunk)) {
-      return true;
-    }
-  }
-  return false;
+  return HomePathChunks.some(pathChunk => url.includes(pathChunk));
 };
 
 const LearnPathChunks = ['/tutorial', '/ui-programming/', '/additional-resources/'] as const;
 
 export const isLearnPath = (url: string) => {
-  for (const pathChunk of LearnPathChunks) {
-    if (url.includes(pathChunk)) {
-      return true;
-    }
-  }
-  return false;
+  return LearnPathChunks.some(pathChunk => url.includes(pathChunk));
 };
 
 export const isAppleDevice = () => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the Command Menu distinguishes docs based on "Guides", "API reference" and "EAS".

![CleanShot 2023-04-11 at 16 24 38@2x](https://user-images.githubusercontent.com/10234615/231147130-440046ed-bbfa-4f9a-acf1-6f1c1464cceb.png)


# How

<!--
How did you build this feature or fix this bug and why?
-->
This PR updates the Command menu to display appropriate icons and foot note prefixes for each top-level section from docs.

# Test Plan

For example, if I'm searching the "Build a screen" which is part of the Tutorial, it displays "Learn" as the foot note prefix and also displays the icon used to represent that top-level section.

<img width="685" alt="CleanShot 2023-04-11 at 16 39 00@2x" src="https://user-images.githubusercontent.com/10234615/231147746-d22f1860-dcc9-4e5e-805b-ecc1f2379e5c.png">


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
