### PR TITLE
[docs] improve snipped code clean copy regex

### DIFF
--- a/docs/components/base/code.test.tsx
+++ b/docs/components/base/code.test.tsx
@@ -1,0 +1,84 @@
+import { cleanCopyValue } from './code';
+
+describe('Code copy', () => {
+  it('SlashComments - preserves the fully annotated line', () => {
+    expect(
+      cleanCopyValue(
+        `/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */`
+      )
+    ).toBe(`import FontAwesome from "@expo/vector-icons/FontAwesome";`);
+  });
+
+  it('SlashComments - removes the annotation mid-line', () => {
+    expect(
+      cleanCopyValue(
+        `export default function Button({ label,/* @info The prop theme to detect the button variant. */ theme/* @end */ }) {`
+      )
+    ).toBe(`export default function Button({ label, theme }) {`);
+  });
+
+  it('SlashComments - preserves the line wrapped with annotations', () => {
+    expect(
+      cleanCopyValue(
+        `/* @info This text will be shown onHover */
+        return x + 1;
+        /* @end */`
+      )
+    ).toBe(`        return x + 1;
+        `);
+  });
+
+  it('HashComments - preserves the fully annotated line', () => {
+    expect(
+      cleanCopyValue(
+        `# @info Import FontAwesome. #import FontAwesome from "@expo/vector-icons/FontAwesome";# @end #`
+      )
+    ).toBe(`import FontAwesome from "@expo/vector-icons/FontAwesome";`);
+  });
+
+  it('HashComments - removes the annotation mid-line', () => {
+    expect(
+      cleanCopyValue(
+        `export default function Button({ label,# @info The prop theme to detect the button variant. # theme# @end # }) {`
+      )
+    ).toBe(`export default function Button({ label, theme }) {`);
+  });
+
+  it('HashComments - preserves the line wrapped with annotations', () => {
+    expect(
+      cleanCopyValue(
+        `# @info This text will be shown onHover #
+        return x + 1;
+        # @end #`
+      )
+    ).toBe(`        return x + 1;
+        `);
+  });
+
+  it('XMLComments - preserves the fully annotated line', () => {
+    expect(
+      cleanCopyValue(
+        `<!-- @info Import FontAwesome. -->import FontAwesome from "@expo/vector-icons/FontAwesome";<!-- @end -->`
+      )
+    ).toBe(`import FontAwesome from "@expo/vector-icons/FontAwesome";`);
+  });
+
+  it('XMLComments - removes the annotation mid-line', () => {
+    expect(
+      cleanCopyValue(
+        `export default function Button({ label,<!-- @info The prop theme to detect the button variant. --> theme<!-- @end --> }) {`
+      )
+    ).toBe(`export default function Button({ label, theme }) {`);
+  });
+
+  it('XMLComments - preserves the line wrapped with annotations', () => {
+    expect(
+      cleanCopyValue(
+        `<!-- @info This text will be shown onHover -->
+        return x + 1;
+        <!-- @end -->`
+      )
+    ).toBe(`        return x + 1;
+        `);
+  });
+});

--- a/docs/components/base/code.test.tsx
+++ b/docs/components/base/code.test.tsx
@@ -1,6 +1,6 @@
 import { cleanCopyValue } from './code';
 
-describe('Code copy', () => {
+describe('cleanCopyValue', () => {
   it('SlashComments - preserves the fully annotated line', () => {
     expect(
       cleanCopyValue(
@@ -20,12 +20,28 @@ describe('Code copy', () => {
   it('SlashComments - preserves the line wrapped with annotations', () => {
     expect(
       cleanCopyValue(
-        `/* @info This text will be shown onHover */
+        `        /* @info This text will be shown onHover */
         return x + 1;
         /* @end */`
       )
-    ).toBe(`        return x + 1;
-        `);
+    ).toBe(`        return x + 1;`);
+  });
+
+  it('SlashComments - removes @hide line', () => {
+    expect(
+      cleanCopyValue(`const styles = StyleSheet.create({
+  /* @hide // Styles that are unchanged from previous step are hidden for brevity. */
+  container: {`)
+    ).toBe(`const styles = StyleSheet.create({
+  container: {`);
+  });
+
+  it('SlashComments - removes annotation with # in content', () => {
+    expect(
+      cleanCopyValue(`    /* @info Replace the default value of backgroundColor property with '#25292e'. */
+    backgroundColor: '#25292e',
+    /* @end */`)
+    ).toBe(`    backgroundColor: '#25292e',`);
   });
 
   it('HashComments - preserves the fully annotated line', () => {
@@ -47,12 +63,20 @@ describe('Code copy', () => {
   it('HashComments - preserves the line wrapped with annotations', () => {
     expect(
       cleanCopyValue(
-        `# @info This text will be shown onHover #
+        `        # @info This text will be shown onHover #
         return x + 1;
         # @end #`
       )
-    ).toBe(`        return x + 1;
-        `);
+    ).toBe(`        return x + 1;`);
+  });
+
+  it('HashComments - removes @hide line', () => {
+    expect(
+      cleanCopyValue(`const styles = StyleSheet.create({
+  # @hide // Styles that are unchanged from previous step are hidden for brevity. #
+  container: {`)
+    ).toBe(`const styles = StyleSheet.create({
+  container: {`);
   });
 
   it('XMLComments - preserves the fully annotated line', () => {
@@ -74,11 +98,19 @@ describe('Code copy', () => {
   it('XMLComments - preserves the line wrapped with annotations', () => {
     expect(
       cleanCopyValue(
-        `<!-- @info This text will be shown onHover -->
+        `        <!-- @info This text will be shown onHover -->
         return x + 1;
         <!-- @end -->`
       )
-    ).toBe(`        return x + 1;
-        `);
+    ).toBe(`        return x + 1;`);
+  });
+
+  it('XMLComments - removes @hide line', () => {
+    expect(
+      cleanCopyValue(`const styles = StyleSheet.create({
+  <!-- @hide // Styles that are unchanged from previous step are hidden for brevity. -->
+  container: {`)
+    ).toBe(`const styles = StyleSheet.create({
+  container: {`);
   });
 });

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -75,6 +75,10 @@ type Props = {
   className?: string;
 };
 
+export function cleanCopyValue(value: string) {
+  return value.replace(/\n?(\/\*|#|<!--)\s?@(info[^*#<>]+|end|hide).?(\*\/|#|-->)\n?/g, '');
+}
+
 export class Code extends React.Component<React.PropsWithChildren<Props>> {
   componentDidMount() {
     this.runTippy();
@@ -171,10 +175,6 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
     };
   }
 
-  private cleanCopyValue(value: string) {
-    return value.replace(/ *(\/\*|#|<!--)+\s@.+(\*\/|-->|#)\r?\n/g, '');
-  }
-
   render() {
     // note(simek): MDX dropped `inlineCode` pseudo-tag, and we need to relay on `pre` and `code` now,
     // which results in this nesting mess, we should fix it in the future
@@ -215,7 +215,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
     return value?.title ? (
       <Snippet>
         <SnippetHeader title={value.title}>
-          <CopyAction text={this.cleanCopyValue(value.value)} />
+          <CopyAction text={cleanCopyValue(value.value)} />
         </SnippetHeader>
         <SnippetContent skipPadding>
           <pre css={STYLES_CODE_CONTAINER} {...attributes}>

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -76,7 +76,11 @@ type Props = {
 };
 
 export function cleanCopyValue(value: string) {
-  return value.replace(/\n?(\/\*|#|<!--)\s?@(info[^*#<>]+|end|hide).?(\*\/|#|-->)\n?/g, '');
+  return value
+    .replace(/\/\*\s?@(info[^*]+|end|hide[^*]+).?\*\//g, '')
+    .replace(/#\s?@(info[^#]+|end|hide[^#]+).?#/g, '')
+    .replace(/<!--\s?@(info[^<>]+|end|hide[^<>]+).?-->/g, '')
+    .replace(/^ +\r?\n|\n +\r?$/gm, '');
 }
 
 export class Code extends React.Component<React.PropsWithChildren<Props>> {


### PR DESCRIPTION
# Why

Fixes #22058

# How

Improve snipped code clean copy regex.

~~There are some edge cases which still result in invalid copy string, will add specific tests and fixes soon.~~

# Test Plan

Introduce tests for the `cleanCopyValue` method.
