### PR TITLE
[core][ios] Remove legacyViewManager references from ExpoFabricView

### DIFF
--- a/apps/fabric-tester/ios/Podfile.lock
+++ b/apps/fabric-tester/ios/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
     - ExpoModulesCore
   - ExpoBlur (12.2.2):
     - ExpoModulesCore
-  - ExpoImage (1.0.0):
+  - ExpoImage (1.1.0):
     - ExpoModulesCore
     - SDWebImage (~> 5.15.0)
     - SDWebImageAVIFCoder (~> 0.9.4)
@@ -39,19 +39,19 @@ PODS:
   - EXSplashScreen (0.18.1):
     - ExpoModulesCore
     - React-Core
-  - FBLazyVector (0.71.4)
-  - FBReactNativeSpec (0.71.4):
+  - FBLazyVector (0.71.6)
+  - FBReactNativeSpec (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Core (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-Core (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.71.4):
-    - hermes-engine/Pre-built (= 0.71.4)
-  - hermes-engine/Pre-built (0.71.4)
+  - hermes-engine (0.71.6):
+    - hermes-engine/Pre-built (= 0.71.6)
+  - hermes-engine/Pre-built (0.71.6)
   - libaom (2.0.2):
     - libvmaf
   - libavif (0.10.1):
@@ -93,26 +93,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.71.4)
-  - RCTTypeSafety (0.71.4):
-    - FBLazyVector (= 0.71.4)
-    - RCTRequired (= 0.71.4)
-    - React-Core (= 0.71.4)
-  - React (0.71.4):
-    - React-Core (= 0.71.4)
-    - React-Core/DevSupport (= 0.71.4)
-    - React-Core/RCTWebSocket (= 0.71.4)
-    - React-RCTActionSheet (= 0.71.4)
-    - React-RCTAnimation (= 0.71.4)
-    - React-RCTBlob (= 0.71.4)
-    - React-RCTImage (= 0.71.4)
-    - React-RCTLinking (= 0.71.4)
-    - React-RCTNetwork (= 0.71.4)
-    - React-RCTSettings (= 0.71.4)
-    - React-RCTText (= 0.71.4)
-    - React-RCTVibration (= 0.71.4)
-  - React-callinvoker (0.71.4)
-  - React-Codegen (0.71.4):
+  - RCTRequired (0.71.6)
+  - RCTTypeSafety (0.71.6):
+    - FBLazyVector (= 0.71.6)
+    - RCTRequired (= 0.71.6)
+    - React-Core (= 0.71.6)
+  - React (0.71.6):
+    - React-Core (= 0.71.6)
+    - React-Core/DevSupport (= 0.71.6)
+    - React-Core/RCTWebSocket (= 0.71.6)
+    - React-RCTActionSheet (= 0.71.6)
+    - React-RCTAnimation (= 0.71.6)
+    - React-RCTBlob (= 0.71.6)
+    - React-RCTImage (= 0.71.6)
+    - React-RCTLinking (= 0.71.6)
+    - React-RCTNetwork (= 0.71.6)
+    - React-RCTSettings (= 0.71.6)
+    - React-RCTText (= 0.71.6)
+    - React-RCTVibration (= 0.71.6)
+  - React-callinvoker (0.71.6)
+  - React-Codegen (0.71.6):
     - FBReactNativeSpec
     - hermes-engine
     - RCT-Folly
@@ -125,541 +125,541 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.71.4):
+  - React-Core (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.4)
-    - React-cxxreact (= 0.71.4)
+    - React-Core/Default (= 0.71.6)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.71.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default
-    - React-cxxreact (= 0.71.4)
-    - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-    - Yoga
-  - React-Core/Default (0.71.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.4)
-    - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-    - Yoga
-  - React-Core/DevSupport (0.71.4):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.4)
-    - React-Core/RCTWebSocket (= 0.71.4)
-    - React-cxxreact (= 0.71.4)
-    - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-jsinspector (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.71.4):
+  - React-Core/CoreModulesHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.71.4):
+  - React-Core/Default (0.71.6):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-cxxreact (= 0.71.6)
+    - React-hermes
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+    - Yoga
+  - React-Core/DevSupport (0.71.6):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core/Default (= 0.71.6)
+    - React-Core/RCTWebSocket (= 0.71.6)
+    - React-cxxreact (= 0.71.6)
+    - React-hermes
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-jsinspector (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.71.4):
+  - React-Core/RCTAnimationHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTImageHeaders (0.71.4):
+  - React-Core/RCTBlobHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.71.4):
+  - React-Core/RCTImageHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.71.4):
+  - React-Core/RCTLinkingHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.71.4):
+  - React-Core/RCTNetworkHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTTextHeaders (0.71.4):
+  - React-Core/RCTSettingsHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.71.4):
+  - React-Core/RCTTextHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - React-Core/Default
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-Core/RCTWebSocket (0.71.4):
+  - React-Core/RCTVibrationHeaders (0.71.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.4)
-    - React-cxxreact (= 0.71.4)
+    - React-Core/Default
+    - React-cxxreact (= 0.71.6)
     - React-hermes
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-perflogger (= 0.71.4)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
     - Yoga
-  - React-CoreModules (0.71.4):
+  - React-Core/RCTWebSocket (0.71.6):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Codegen (= 0.71.4)
-    - React-Core/CoreModulesHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
+    - React-Core/Default (= 0.71.6)
+    - React-cxxreact (= 0.71.6)
+    - React-hermes
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+    - Yoga
+  - React-CoreModules (0.71.6):
+    - RCT-Folly (= 2021.07.22.00)
+    - RCTTypeSafety (= 0.71.6)
+    - React-Codegen (= 0.71.6)
+    - React-Core/CoreModulesHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
     - React-RCTBlob
-    - React-RCTImage (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-cxxreact (0.71.4):
+    - React-RCTImage (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-cxxreact (0.71.6):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsinspector (= 0.71.4)
-    - React-logger (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-    - React-runtimeexecutor (= 0.71.4)
-  - React-Fabric (0.71.4):
+    - React-callinvoker (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsinspector (= 0.71.6)
+    - React-logger (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+    - React-runtimeexecutor (= 0.71.6)
+  - React-Fabric (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Fabric/animations (= 0.71.4)
-    - React-Fabric/attributedstring (= 0.71.4)
-    - React-Fabric/butter (= 0.71.4)
-    - React-Fabric/componentregistry (= 0.71.4)
-    - React-Fabric/componentregistrynative (= 0.71.4)
-    - React-Fabric/components (= 0.71.4)
-    - React-Fabric/config (= 0.71.4)
-    - React-Fabric/core (= 0.71.4)
-    - React-Fabric/debug_core (= 0.71.4)
-    - React-Fabric/debug_renderer (= 0.71.4)
-    - React-Fabric/imagemanager (= 0.71.4)
-    - React-Fabric/leakchecker (= 0.71.4)
-    - React-Fabric/mapbuffer (= 0.71.4)
-    - React-Fabric/mounting (= 0.71.4)
-    - React-Fabric/runtimescheduler (= 0.71.4)
-    - React-Fabric/scheduler (= 0.71.4)
-    - React-Fabric/telemetry (= 0.71.4)
-    - React-Fabric/templateprocessor (= 0.71.4)
-    - React-Fabric/textlayoutmanager (= 0.71.4)
-    - React-Fabric/uimanager (= 0.71.4)
-    - React-Fabric/utils (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/animations (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-Fabric/animations (= 0.71.6)
+    - React-Fabric/attributedstring (= 0.71.6)
+    - React-Fabric/butter (= 0.71.6)
+    - React-Fabric/componentregistry (= 0.71.6)
+    - React-Fabric/componentregistrynative (= 0.71.6)
+    - React-Fabric/components (= 0.71.6)
+    - React-Fabric/config (= 0.71.6)
+    - React-Fabric/core (= 0.71.6)
+    - React-Fabric/debug_core (= 0.71.6)
+    - React-Fabric/debug_renderer (= 0.71.6)
+    - React-Fabric/imagemanager (= 0.71.6)
+    - React-Fabric/leakchecker (= 0.71.6)
+    - React-Fabric/mapbuffer (= 0.71.6)
+    - React-Fabric/mounting (= 0.71.6)
+    - React-Fabric/runtimescheduler (= 0.71.6)
+    - React-Fabric/scheduler (= 0.71.6)
+    - React-Fabric/telemetry (= 0.71.6)
+    - React-Fabric/templateprocessor (= 0.71.6)
+    - React-Fabric/textlayoutmanager (= 0.71.6)
+    - React-Fabric/uimanager (= 0.71.6)
+    - React-Fabric/utils (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/animations (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/attributedstring (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/attributedstring (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/butter (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/butter (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/componentregistry (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/componentregistry (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/componentregistrynative (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/componentregistrynative (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Fabric/components/activityindicator (= 0.71.4)
-    - React-Fabric/components/image (= 0.71.4)
-    - React-Fabric/components/inputaccessory (= 0.71.4)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.4)
-    - React-Fabric/components/modal (= 0.71.4)
-    - React-Fabric/components/root (= 0.71.4)
-    - React-Fabric/components/safeareaview (= 0.71.4)
-    - React-Fabric/components/scrollview (= 0.71.4)
-    - React-Fabric/components/slider (= 0.71.4)
-    - React-Fabric/components/text (= 0.71.4)
-    - React-Fabric/components/textinput (= 0.71.4)
-    - React-Fabric/components/unimplementedview (= 0.71.4)
-    - React-Fabric/components/view (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/activityindicator (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-Fabric/components/activityindicator (= 0.71.6)
+    - React-Fabric/components/image (= 0.71.6)
+    - React-Fabric/components/inputaccessory (= 0.71.6)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.71.6)
+    - React-Fabric/components/modal (= 0.71.6)
+    - React-Fabric/components/root (= 0.71.6)
+    - React-Fabric/components/safeareaview (= 0.71.6)
+    - React-Fabric/components/scrollview (= 0.71.6)
+    - React-Fabric/components/slider (= 0.71.6)
+    - React-Fabric/components/text (= 0.71.6)
+    - React-Fabric/components/textinput (= 0.71.6)
+    - React-Fabric/components/unimplementedview (= 0.71.6)
+    - React-Fabric/components/view (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/activityindicator (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/image (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/image (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/inputaccessory (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/inputaccessory (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/legacyviewmanagerinterop (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/legacyviewmanagerinterop (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/modal (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/modal (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/root (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/root (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/safeareaview (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/safeareaview (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/scrollview (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/scrollview (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/slider (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/slider (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/text (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/text (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/textinput (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/textinput (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/unimplementedview (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/unimplementedview (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/components/view (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/components/view (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
     - Yoga
-  - React-Fabric/config (0.71.4):
+  - React-Fabric/config (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/core (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/core (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/debug_core (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/debug_core (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/debug_renderer (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/debug_renderer (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/imagemanager (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/imagemanager (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - React-RCTImage (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/leakchecker (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - React-RCTImage (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/leakchecker (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/mapbuffer (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/mapbuffer (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/mounting (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/mounting (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/runtimescheduler (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/runtimescheduler (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/scheduler (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/scheduler (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/telemetry (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/telemetry (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/templateprocessor (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/templateprocessor (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/textlayoutmanager (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/textlayoutmanager (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
     - React-Fabric/uimanager
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/uimanager (0.71.4):
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/uimanager (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-Fabric/utils (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-Fabric/utils (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - RCTRequired (= 0.71.4)
-    - RCTTypeSafety (= 0.71.4)
-    - React-graphics (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-jsiexecutor (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-graphics (0.71.4):
+    - RCTRequired (= 0.71.6)
+    - RCTTypeSafety (= 0.71.6)
+    - React-graphics (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-jsiexecutor (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-graphics (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core/Default (= 0.71.4)
-  - React-hermes (0.71.4):
+    - React-Core/Default (= 0.71.6)
+  - React-hermes (0.71.6):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
     - RCT-Folly/Futures (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.4)
+    - React-cxxreact (= 0.71.6)
     - React-jsi
-    - React-jsiexecutor (= 0.71.4)
-    - React-jsinspector (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-  - React-jsi (0.71.4):
+    - React-jsiexecutor (= 0.71.6)
+    - React-jsinspector (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+  - React-jsi (0.71.6):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-  - React-jsiexecutor (0.71.4):
+  - React-jsiexecutor (0.71.6):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-cxxreact (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-  - React-jsinspector (0.71.4)
-  - React-logger (0.71.4):
+    - React-cxxreact (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+  - React-jsinspector (0.71.6)
+  - React-logger (0.71.6):
     - glog
-  - React-perflogger (0.71.4)
-  - React-RCTActionSheet (0.71.4):
-    - React-Core/RCTActionSheetHeaders (= 0.71.4)
-  - React-RCTAnimation (0.71.4):
+  - React-perflogger (0.71.6)
+  - React-RCTActionSheet (0.71.6):
+    - React-Core/RCTActionSheetHeaders (= 0.71.6)
+  - React-RCTAnimation (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTAnimationHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTAppDelegate (0.71.4):
+    - RCTTypeSafety (= 0.71.6)
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTAnimationHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTAppDelegate (0.71.6):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -667,84 +667,84 @@ PODS:
     - React-graphics
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - React-RCTBlob (0.71.4):
+  - React-RCTBlob (0.71.6):
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTBlobHeaders (= 0.71.4)
-    - React-Core/RCTWebSocket (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-RCTNetwork (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTFabric (0.71.4):
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTBlobHeaders (= 0.71.6)
+    - React-Core/RCTWebSocket (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-RCTNetwork (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTFabric (0.71.6):
     - RCT-Folly/Fabric (= 2021.07.22.00)
-    - React-Core (= 0.71.4)
-    - React-Fabric (= 0.71.4)
-    - React-RCTImage (= 0.71.4)
-  - React-RCTImage (0.71.4):
+    - React-Core (= 0.71.6)
+    - React-Fabric (= 0.71.6)
+    - React-RCTImage (= 0.71.6)
+  - React-RCTImage (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTImageHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-RCTNetwork (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTLinking (0.71.4):
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTLinkingHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTNetwork (0.71.4):
+    - RCTTypeSafety (= 0.71.6)
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTImageHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-RCTNetwork (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTLinking (0.71.6):
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTLinkingHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTNetwork (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTNetworkHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTSettings (0.71.4):
+    - RCTTypeSafety (= 0.71.6)
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTNetworkHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTSettings (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - RCTTypeSafety (= 0.71.4)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTSettingsHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-RCTText (0.71.4):
-    - React-Core/RCTTextHeaders (= 0.71.4)
-  - React-RCTVibration (0.71.4):
+    - RCTTypeSafety (= 0.71.6)
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTSettingsHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-RCTText (0.71.6):
+    - React-Core/RCTTextHeaders (= 0.71.6)
+  - React-RCTVibration (0.71.6):
     - RCT-Folly (= 2021.07.22.00)
-    - React-Codegen (= 0.71.4)
-    - React-Core/RCTVibrationHeaders (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - ReactCommon/turbomodule/core (= 0.71.4)
-  - React-rncore (0.71.4)
-  - React-runtimeexecutor (0.71.4):
-    - React-jsi (= 0.71.4)
-  - ReactCommon/turbomodule/bridging (0.71.4):
+    - React-Codegen (= 0.71.6)
+    - React-Core/RCTVibrationHeaders (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - ReactCommon/turbomodule/core (= 0.71.6)
+  - React-rncore (0.71.6)
+  - React-runtimeexecutor (0.71.6):
+    - React-jsi (= 0.71.6)
+  - ReactCommon/turbomodule/bridging (0.71.6):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.4)
-    - React-Core (= 0.71.4)
-    - React-cxxreact (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-logger (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-  - ReactCommon/turbomodule/core (0.71.4):
+    - React-callinvoker (= 0.71.6)
+    - React-Core (= 0.71.6)
+    - React-cxxreact (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-logger (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+  - ReactCommon/turbomodule/core (0.71.6):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.07.22.00)
-    - React-callinvoker (= 0.71.4)
-    - React-Core (= 0.71.4)
-    - React-cxxreact (= 0.71.4)
-    - React-jsi (= 0.71.4)
-    - React-logger (= 0.71.4)
-    - React-perflogger (= 0.71.4)
-  - SDWebImage (5.15.2):
-    - SDWebImage/Core (= 5.15.2)
-  - SDWebImage/Core (5.15.2)
-  - SDWebImageAVIFCoder (0.9.4):
+    - React-callinvoker (= 0.71.6)
+    - React-Core (= 0.71.6)
+    - React-cxxreact (= 0.71.6)
+    - React-jsi (= 0.71.6)
+    - React-logger (= 0.71.6)
+    - React-perflogger (= 0.71.6)
+  - SDWebImage (5.15.4):
+    - SDWebImage/Core (= 5.15.4)
+  - SDWebImage/Core (5.15.4)
+  - SDWebImageAVIFCoder (0.9.5):
     - libavif (>= 0.9.1)
     - SDWebImage (~> 5.10)
   - SDWebImageSVGCoder (1.6.1):
@@ -942,57 +942,57 @@ SPEC CHECKSUMS:
   Expo: 79deb55f33fab1b232232868a74713772943238d
   ExpoAppleAuthentication: 7bd5e4150d59e8df37aa80b425850ae88adf9e65
   ExpoBlur: fac3c6318fdf409dd5740afd3313b2bd52a35bac
-  ExpoImage: b6a65c4aa891cdf00bfba0da46df14b27ae09cc7
+  ExpoImage: 80221ee353e8e7f1afee71fdbc8099ae61f394f2
   ExpoKeepAwake: 69f5f627670d62318410392d03e0b5db0f85759a
   ExpoLinearGradient: 496147427ac1a8ee4738e016e94fc19ba2f3a00a
   ExpoModulesCore: e093fd5d0fafc8d5c1d2c8c44f40811475315bf3
   EXSplashScreen: cd7fb052dff5ba8311d5c2455ecbebffe1b7a8ca
-  FBLazyVector: 446e84642979fff0ba57f3c804c2228a473aeac2
-  FBReactNativeSpec: a7aeb32e7619beba1f8041b2eda82519cba9965c
+  FBLazyVector: a83ceaa8a8581003a623facdb3c44f6d4f342ac5
+  FBReactNativeSpec: e66130899b31cbeb133f8fe1fc7002aa710b0268
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: a1f157c49ea579c28b0296bda8530e980c45bdb3
+  hermes-engine: b434cea529ad0152c56c7cb6486b0c4c0b23b5de
   libaom: 9bb51e0f8f9192245e3ca2a1c9e4375d9cbccc52
   libavif: e242998ccec1c83bcba0bbdc256f460ad5077348
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 8d61aabc2f4ed3e6591cf7406fa00a223ec11289
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
-  RCTRequired: 5a024fdf458fa8c0d82fc262e76f982d4dcdecdd
-  RCTTypeSafety: b6c253064466411c6810b45f66bc1e43ce0c54ba
-  React: 715292db5bd46989419445a5547954b25d2090f0
-  React-callinvoker: 105392d1179058585b564d35b4592fe1c46d6fba
-  React-Codegen: 2a9095f4fb5f068ab8f681456684746293eb8a20
-  React-Core: 88838ed1724c64905fc6c0811d752828a92e395b
-  React-CoreModules: cd238b4bb8dc8529ccc8b34ceae7267b04ce1882
-  React-cxxreact: 291bfab79d8098dc5ebab98f62e6bdfe81b3955a
-  React-Fabric: 8f2ea388aea7ac634b77a8123fa84c67d8f238cf
-  React-graphics: d64349105d6a5fee1fe1ebf1f299e60c56ce050e
-  React-hermes: b1e67e9a81c71745704950516f40ee804349641c
-  React-jsi: c9d5b563a6af6bb57034a82c2b0d39d0a7483bdc
-  React-jsiexecutor: d6b7fa9260aa3cb40afee0507e3bc1d17ecaa6f2
-  React-jsinspector: 1f51e775819199d3fe9410e69ee8d4c4161c7b06
-  React-logger: 0d58569ec51d30d1792c5e86a8e3b78d24b582c6
-  React-perflogger: 0bb0522a12e058f6eb69d888bc16f40c16c4b907
-  React-RCTActionSheet: bfd675a10f06a18728ea15d82082d48f228a213a
-  React-RCTAnimation: 2fa220b2052ec75b733112aca39143d34546a941
-  React-RCTAppDelegate: 5c8fa743a35915ca97e25b255a0783ab2beb17f4
-  React-RCTBlob: d0336111f46301ae8aba2e161817e451aad72dd6
-  React-RCTFabric: 4d1cb06de10f3d2435af88a244e140fe06758e4b
-  React-RCTImage: fec592c46edb7c12a9cde08780bdb4a688416c62
-  React-RCTLinking: 14eccac5d2a3b34b89dbfa29e8ef6219a153fe2d
-  React-RCTNetwork: 1fbce92e772e39ca3687a2ebb854501ff6226dd7
-  React-RCTSettings: 1abea36c9bb16d9979df6c4b42e2ea281b4bbcc5
-  React-RCTText: 15355c41561a9f43dfd23616d0a0dd40ba05ed61
-  React-RCTVibration: ad17efcfb2fa8f6bfd8ac0cf48d96668b8b28e0b
-  React-rncore: 494f091f1b97538bbdd62edf1a793e41558671a5
-  React-runtimeexecutor: 8fa50b38df6b992c76537993a2b0553d3b088004
-  ReactCommon: b49a4b00ca6d181ff74b17c12b2d59ac4add0bde
-  SDWebImage: 8ab87d4b3e5cc4927bd47f78db6ceb0b94442577
-  SDWebImageAVIFCoder: 5bf07409ab8a02f0a8e0ac976719b321d8fce209
+  RCTRequired: 5c6fd63b03abb06947d348dadac51c93e3485bd8
+  RCTTypeSafety: 1c66daedd66f674e39ce9f40782f0d490c78b175
+  React: e11ca7cdc7aa4ddd7e6a59278b808cfe17ebbd9f
+  React-callinvoker: 77a82869505c96945c074b80bbdc8df919646d51
+  React-Codegen: 45ee6e6fc41d1faeb3f6f0c144fa630f08d17906
+  React-Core: 44903e47b428a491f48fd0eae54caddb2ea05ebf
+  React-CoreModules: 83d989defdfc82be1f7386f84a56b6509f54ac74
+  React-cxxreact: 058e7e6349649eae9cfcdec5854e702b26298932
+  React-Fabric: 3dc35513f9aaa133da413bcb24f66589b7389a87
+  React-graphics: f93e662aec9a7fa7ad3f1dc78d46c8fb62ef8d6e
+  React-hermes: ba19a405804b833c9b832c1f2061ad5038bb97f2
+  React-jsi: 3fe6f589c9cafbef85ed5a4be7c6dc8edfb4ab54
+  React-jsiexecutor: 7894956638ff3e00819dd3f9f6f4a84da38f2409
+  React-jsinspector: d5ce2ef3eb8fd30c28389d0bc577918c70821bd6
+  React-logger: 9332c3e7b4ef007a0211c0a9868253aac3e1da82
+  React-perflogger: 43392072a5b867a504e2b4857606f8fc5a403d7f
+  React-RCTActionSheet: c7b67c125bebeda9fb19fc7b200d85cb9d6899c4
+  React-RCTAnimation: c2de79906f607986633a7114bee44854e4c7e2f5
+  React-RCTAppDelegate: 5a9e9c1e0c18504992e77350bc7486f1422c5962
+  React-RCTBlob: cf72446957310e7da6627a4bdaadf970d3a8f232
+  React-RCTFabric: 016020011daa0ff3b5ab97a418e1254f1e4a075c
+  React-RCTImage: c6093f1bf3d67c0428d779b00390617d5bd90699
+  React-RCTLinking: 5de47e37937889d22599af4b99d0552bad1b1c3c
+  React-RCTNetwork: e7d7077e073b08e5dd486fba3fe87ccad90a9bc4
+  React-RCTSettings: 72a04921b2e8fb832da7201a60ffffff2a7c62f7
+  React-RCTText: 7123c70fef5367e2121fea37e65b9ad6d3747e54
+  React-RCTVibration: 73d201599a64ea14b4e0b8f91b64970979fd92e6
+  React-rncore: 70d45c4dc1484e814eddba9706807990495943d6
+  React-runtimeexecutor: 8692ac548bec648fa121980ccb4304afd136d584
+  ReactCommon: 0c43eaeaaee231d7d8dc24fc5a6e4cf2b75bf196
+  SDWebImage: 1c39de67663e5eebb2f41324d5d580eeea12dd4c
+  SDWebImageAVIFCoder: d759e21cf4efb640cc97250566aa556ad8bb877c
   SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
   SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
-  Yoga: 79dd7410de6f8ad73a77c868d3d368843f0c93e0
+  Yoga: ba09b6b11e6139e3df8229238aa794205ca6a02a
 
 PODFILE CHECKSUM: 40c2a83710f34778bce3f4f788bae1a3a15bcebc
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Removed the legacy implementation of view managers. ([#21760](https://github.com/expo/expo/pull/21760) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Passed the app context instance down to dynamic types, object builders and convertibles. ([#21819](https://github.com/expo/expo/pull/21819) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use `jsi::WeakObject` for weak objects on Hermes. ([#21986](https://github.com/expo/expo/pull/21986) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Removed legacyViewManager references from ExpoFabricView. ([#22089](https://github.com/expo/expo/pull/22089) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 1.2.6 - 2023-03-20
 

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -21,13 +21,6 @@ public class ExpoFabricView: ExpoFabricViewObjC {
     return appContext?.moduleRegistry.get(moduleHolderForName: moduleName)
   }
 
-  /**
-   The view manager of the associated legacy module.
-   Not available if the module is registered in the new module registry.
-   */
-  lazy var legacyViewManager = appContext?.legacyModuleRegistry?.getAllViewManagers()
-                                 .filter { $0.viewName() == moduleName }
-                                 .first
 
   /**
    A dictionary of prop objects that contain prop setters.
@@ -52,7 +45,9 @@ public class ExpoFabricView: ExpoFabricViewObjC {
   // MARK: - ExpoFabricViewInterface
 
   public override func updateProps(_ props: [String: Any]) {
-    guard let view = contentView, let propsDict = viewManagerPropDict else {
+    guard let view = contentView,
+          let context = appContext,
+          let propsDict = viewManagerPropDict else {
       return
     }
     for (key, prop) in propsDict {
@@ -61,7 +56,7 @@ public class ExpoFabricView: ExpoFabricViewObjC {
       // TODO: @tsapeta: Figure out better way to rethrow errors from here.
       // Adding `throws` keyword to the function results in different
       // method signature in Objective-C. Maybe just call `RCTLogError`?
-      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view)
+      try? prop.set(value: Conversions.fromNSObject(newValue), onView: view, appContext: context)
     }
   }
 
@@ -110,7 +105,7 @@ public class ExpoFabricView: ExpoFabricViewObjC {
     guard let appContext = appContext else {
       fatalError(Exceptions.AppContextLost().reason)
     }
-    guard let view = moduleHolder?.definition.viewManager?.createView(appContext: appContext) ?? legacyViewManager?.view() else {
+    guard let view = moduleHolder?.definition.viewManager?.createView(appContext: appContext) else {
       fatalError("Cannot create a view from module '\(moduleName)'")
     }
     // Setting the content view automatically adds the view as a subview.

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -45,9 +45,7 @@ public class ExpoFabricView: ExpoFabricViewObjC {
   // MARK: - ExpoFabricViewInterface
 
   public override func updateProps(_ props: [String: Any]) {
-    guard let view = contentView,
-          let context = appContext,
-          let propsDict = viewManagerPropDict else {
+    guard let view = contentView, let context = appContext, let propsDict = viewManagerPropDict else {
       return
     }
     for (key, prop) in propsDict {


### PR DESCRIPTION
# Why

The `fabric-tester` app under `apps` is currently broken due to the `ExpoFabricView` class still making references to 
legacy view managers, which were removed on https://github.com/expo/expo/pull/21760

# How

This PR removes all references of `legacyViewManager` from  `ExpoFabricView` and updates the `fabric-tester` Podfile

# Test Plan

Run `fabric-tester` locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
