### PR TITLE
[docs] Add a complete tutorial Snack link to the Tutorial's introduction

### DIFF
--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -32,6 +32,8 @@ Before we get started, take a look at what we'll build. It's an app named **Stic
 
 <Video file="tutorial/final.mp4" />
 
+> The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@amanhimself/complete-expo-tutorial-example).
+
 ## How to use this tutorial
 
 We believe in [learning by doing](https://en.wikipedia.org/wiki/Learning-by-doing) so this tutorial emphasizes doing over explaining. You can follow along the journey of building the app by creating the app from scratch.

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -32,7 +32,7 @@ Before we get started, take a look at what we'll build. It's an app named **Stic
 
 <Video file="tutorial/final.mp4" />
 
-> The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@amanhimself/complete-expo-tutorial-example).
+> **info** The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@amanhimself/complete-expo-tutorial-example).
 
 ## How to use this tutorial
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[Context on Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1681208775851409?thread_ts=1681208093.238149&cid=C1QMWQ1P0
)
# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR adds a link to the completed version of the tutorial on Snack in a callout on the Tutorial's Introduction page so that if any user requires to see the whole code at once, they can use this Snack link. 

Snack: https://snack.expo.dev/@amanhimself/complete-expo-tutorial-example

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
