### PR TITLE
[docs] Remove duplicate testing with Jest guide and update Guides navigation

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -159,6 +159,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/workflow/expo-cli/': '/more/expo-cli/',
   '/versions/latest/workflow/expo-cli/': '/more/expo-cli/',
   '/debugging/': '/debugging/runtime-issue/',
+  '/guides/testing-with-jest/': '/develop/unit-testing/',
 
   // Old redirects
   '/introduction/project-lifecycle/': '/introduction/managed-vs-bare/',

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -253,7 +253,6 @@ const general = [
     makePage('guides/authentication.mdx'),
     makePage('guides/delaying-code.mdx'),
     makePage('guides/errors.mdx'),
-    makePage('guides/testing-with-jest.mdx'),
     makePage('guides/troubleshooting-proxies.mdx'),
     makePage('guides/sharing-preview-releases.mdx'),
     makePage('guides/using-hermes.mdx'),

--- a/docs/pages/build-reference/custom-build-config.mdx
+++ b/docs/pages/build-reference/custom-build-config.mdx
@@ -55,7 +55,7 @@ describe('<App />', () => {
 });
 ```
 
-> See [Testing with Jest](/guides/testing-with-jest) for more information about configuring the `jest-expo` package and additional configuration options such as `transformIgnorePatterns`.
+> See [Testing with Jest](/develop/unit-testing/) for more information about configuring the `jest-expo` package and additional configuration options such as `transformIgnorePatterns`.
 
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, we have two duplicated Testing with Jest guides:
- https://docs.expo.dev/guides/testing-with-jest/ (old link)
- https://docs.expo.dev/develop/unit-testing/ (new link)

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- removes https://docs.expo.dev/guides/testing-with-jest/ (old link) from Assorted Guides
- Adds a redirect for the new link
- Replaces any internal links that refers to the old guide to the new guide

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
