### PR TITLE
[tools] Update Linear getTeamMembersAsync to not throw when no results are found

### DIFF
--- a/tools/src/Linear.ts
+++ b/tools/src/Linear.ts
@@ -83,11 +83,5 @@ export async function getTeamMembersAsync({
   const team = await linearClient.team(teamId);
   const states = await team.members({ filter });
 
-  if (!states.nodes?.length) {
-    throw new Error(
-      `Failed to find Linear members with the given filter: ${JSON.stringify(filter)}`
-    );
-  }
-
   return states.nodes;
 }


### PR DESCRIPTION
# Why

The `issue-accepted` workflow is failing to run `et igitl` when a user that does not have an account on Linear is assigned to the GitHub issue

E.g. https://github.com/expo/expo/actions/runs/4672005201/jobs/8273691721

# How

Instead of throwing an error when no team members have been found we just return an empty array

# Test Plan

Run `et igitl --issue 22024` locally 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
