### PR TITLE
feat(cli): Export Hermes bytecode with `.hbc` extension.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode. ([#21337](https://github.com/expo/expo/pull/21337) by [@EvanBacon](https://github.com/EvanBacon))
-- Export Hermes bytecode with `.hbc` extension.
+- Export Hermes bytecode with `.hbc` extension. ([#22098](https://github.com/expo/expo/pull/22098) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode. ([#21337](https://github.com/expo/expo/pull/21337) by [@EvanBacon](https://github.com/EvanBacon))
+- Export Hermes bytecode with `.hbc` extension.
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/src/export/__tests__/printBundleSizes-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/printBundleSizes-test.ts
@@ -53,10 +53,10 @@ describe(printBundleSizes, () => {
       })
     ).toEqual([
       ['index.ios.js', 'foo'],
-      ['index.android.js (Hermes)', expect.anything()],
+      ['index.android.hbc', expect.anything()],
       [expect.stringContaining('index.ios.js.map'), 'bars'],
       ['index.web.js', 'foo2'],
-      [expect.stringContaining('index.android.js.map (Hermes)'), '12345'],
+      [expect.stringContaining('index.android.hbc.map'), '12345'],
       [expect.stringContaining('index.web.js.map'), 'bars2'],
     ]);
   });

--- a/packages/@expo/cli/src/export/__tests__/writeContents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/writeContents-test.ts
@@ -67,7 +67,7 @@ describe(writeBundlesAsync, () => {
       },
     });
 
-    expect(results.fileNames.ios).toBe('ios-5289df737df57326fcdd22597afb1fac.js');
+    expect(results.fileNames.ios).toBe('ios-5289df737df57326fcdd22597afb1fac.hbc');
     expect(results.hashes).toStrictEqual({
       ios: expect.any(String),
     });

--- a/packages/@expo/cli/src/export/printBundleSizes.ts
+++ b/packages/@expo/cli/src/export/printBundleSizes.ts
@@ -16,12 +16,12 @@ export function printBundleSizes(bundles: Partial<Record<Platform, BundleOutput>
     Pick<BundleOutput, 'hermesBytecodeBundle' | 'code' | 'hermesSourcemap' | 'map'>
   ][]) {
     if (bundleOutput.hermesBytecodeBundle) {
-      files.push([chalk.bold(`index.${platform}.js (Hermes)`), bundleOutput.hermesBytecodeBundle]);
+      files.push([chalk.bold(`index.${platform}.hbc`), bundleOutput.hermesBytecodeBundle]);
     } else if (bundleOutput.code) {
       files.push([chalk.bold(`index.${platform}.js`), bundleOutput.code]);
     }
     if (bundleOutput.hermesSourcemap) {
-      files.push([chalk.dim(`index.${platform}.js.map (Hermes)`), bundleOutput.hermesSourcemap]);
+      files.push([chalk.dim(`index.${platform}.hbc.map`), bundleOutput.hermesSourcemap]);
     } else if (bundleOutput.map) {
       files.push([chalk.dim(`index.${platform}.js.map`), bundleOutput.map]);
     }

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -14,8 +14,16 @@ const debug = require('debug')('expo:export:write') as typeof console.log;
  * @param props.hash crypto hash for the bundle contents
  * @returns filename for the JS bundle.
  */
-function createBundleFileName({ platform, hash }: { platform: string; hash: string }): string {
-  return `${platform}-${hash}.js`;
+function createBundleFileName({
+  platform,
+  format,
+  hash,
+}: {
+  platform: string;
+  format: 'javascript' | 'bytecode';
+  hash: string;
+}): string {
+  return `${platform}-${hash}.${format === 'javascript' ? 'js' : 'hbc'}`;
 }
 
 /**
@@ -42,7 +50,11 @@ export async function writeBundlesAsync({
   ][]) {
     const bundle = bundleOutput.hermesBytecodeBundle ?? bundleOutput.code;
     const hash = createBundleHash(bundle);
-    const fileName = createBundleFileName({ platform, hash });
+    const fileName = createBundleFileName({
+      platform,
+      format: bundleOutput.hermesBytecodeBundle ? 'bytecode' : 'javascript',
+      hash,
+    });
 
     hashes[platform] = hash;
     fileNames[platform] = fileName;

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -100,7 +100,13 @@ export async function writeSourceMapsAsync({
         const mapName = `${platform}-${hash}.map`;
         await fs.writeFile(path.join(outputDir, mapName), sourceMap);
 
-        const jsBundleFileName = fileNames?.[platform] ?? createBundleFileName({ platform, hash });
+        const jsBundleFileName =
+          fileNames?.[platform] ??
+          createBundleFileName({
+            platform,
+            format: bundle.hermesBytecodeBundle ? 'bytecode' : 'javascript',
+            hash,
+          });
         const jsPath = path.join(outputDir, jsBundleFileName);
 
         // Add correct mapping to sourcemap paths

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -11,6 +11,7 @@ const debug = require('debug')('expo:export:write') as typeof console.log;
 
 /**
  * @param props.platform native platform for the bundle
+ * @param props.format extension to use for the name
  * @param props.hash crypto hash for the bundle contents
  * @returns filename for the JS bundle.
  */


### PR DESCRIPTION
# Why

- related https://github.com/expo/expo/issues/21990

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
