### PR TITLE
[docs] Point dev build docs to EAS Update PR previews

### DIFF
--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -81,7 +81,7 @@ These are a few examples of workflows to help your team get the most out of your
 
 You can set up your CI process to publish an EAS Update whenever a pull request is updated and add a QR code that is used to view the change in a compatible development build.
 
-Check out our [instructions for publishing app previews on pull requests](/eas-update/github-actions/#publish-previews-on-pull-requests) to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
+See [instructions for publishing app previews on pull requests](/eas-update/github-actions/#publish-previews-on-pull-requests) to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
 
 ## Extensions
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -79,9 +79,9 @@ These are a few examples of workflows to help your team get the most out of your
 
 ### PR previews
 
-You can set up your CI process to publish your project whenever a pull request is merged or updated and add a QR code that is used to view the change in a compatible development build.
+You can set up your CI process to publish an EAS Update whenever a pull request is updated and add a QR code that is used to view the change in a compatible development build.
 
-[expo-preview-action](https://github.com/expo/expo-preview-action) can be used to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
+Check out our [instructions for publishing app previews on pull requests](https://docs.expo.dev/eas-update/github-actions/#publish-previews-on-pull-requests) to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
 
 ## Extensions
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -81,7 +81,7 @@ These are a few examples of workflows to help your team get the most out of your
 
 You can set up your CI process to publish an EAS Update whenever a pull request is updated and add a QR code that is used to view the change in a compatible development build.
 
-Check out our [instructions for publishing app previews on pull requests](https://docs.expo.dev/eas-update/github-actions/#publish-previews-on-pull-requests) to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
+Check out our [instructions for publishing app previews on pull requests](/eas-update/github-actions/#publish-previews-on-pull-requests) to implement this workflow in your project using GitHub Actions or serve as a template in your CI of choice.
 
 ## Extensions
 


### PR DESCRIPTION
# Why
Previously, this doc pointed to a Github integration that works with Classic Updates. It's the number 1 result when searching for "PR Review".

# How
Linked to the new instructions for integrating EAS Update with Github Actions to generate previews in PR's.

# Test Plan
Checked the docs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
