### PR TITLE
fix: expo-env.d.ts no such file or directory

### DIFF
--- a/packages/@expo/cli/src/start/server/type-generation/expo-env.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/expo-env.ts
@@ -10,5 +10,7 @@ export async function writeExpoEnvDTS(projectRoot: string) {
 }
 
 export async function removeExpoEnvDTS(projectRoot: string) {
-  return fs.rm(path.join(projectRoot, 'expo-env.d.ts'));
+  return fs.rm(path.join(projectRoot, 'expo-env.d.ts'), {
+    force: true,
+  });
 }

--- a/packages/@expo/cli/src/utils/mergeGitIgnorePaths.ts
+++ b/packages/@expo/cli/src/utils/mergeGitIgnorePaths.ts
@@ -170,6 +170,10 @@ export function createGitIgnoreHash(gitIgnore: string): string {
 }
 
 export function removeFromGitIgnore(targetGitIgnorePath: string, contents: string) {
+  if (!fs.existsSync(targetGitIgnorePath)) {
+    return;
+  }
+
   let targetGitIgnore = fs.readFileSync(targetGitIgnorePath, 'utf-8');
 
   if (!targetGitIgnore.includes(contents)) {


### PR DESCRIPTION
# Why

`removeExpoEnvDTS` fails when `expo-env.d.ts` does not exist.
`removeFromGitIgnore` fails when `.gitignore` does not exist.