### PR TITLE
[ios][sharing] Fix permissions error

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On iOS, fixed an issue where file permissions were not checked correctly.
+- On iOS, fixed an issue where file permissions were not checked correctly. ([#22112](https://github.com/expo/expo/pull/22112) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, fixed an issue where file permissions were not checked correctly.
+
 ### 💡 Others
 
 ## 11.3.0 — 2023-04-12

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -12,7 +12,7 @@ public final class SharingModule: Module {
         throw FilePermissionModuleException()
       }
 
-      let grantedPermissions = filePermissions.getPathPermissions(url.absoluteString)
+      let grantedPermissions = filePermissions.getPathPermissions(url.relativePath)
       guard grantedPermissions.rawValue >= EXFileSystemPermissionFlags.read.rawValue else {
         throw FilePermissionException()
       }


### PR DESCRIPTION
# Why
I didn't check for file permissions correctly in #22012
Closes #22108

# How
Changed `absoluteString` to `relativePath` in the call to `getPathPermissions`

# Test Plan
Tested in bare expo app
