### PR TITLE
[tools] Add importer flag to the igitl command

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           yarn-tools: 'true'
       - name: 🔎 Import issue to Linear
-        run: expotools import-github-issue-to-linear --issue "${{ github.event.issue.number }}"
+        run: expotools import-github-issue-to-linear --issue "${{ github.event.issue.number }}" --importer "${{ github.triggering_actor }}"
         env:
           GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}


### PR DESCRIPTION
# Why

We should add some context about who is importing Github issues into linear

# How

This PR introduces a new `importer` flag to the et `import-github-issue-to-linear` command, automatically subscribing the importer to the issue

# Test Plan

Run `et igitl --issue 22073 --importer gabrieldonadel` locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
