### PR TITLE
[dev-launcher] fix crash when packager connection is not yet connected

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add missing `mimeType` when emitting network responses. ([#21676](https://github.com/expo/expo/pull/21676) by [@byCedric](https://github.com/byCedric))
 - Add missing `Network.requestWillBeSentExtraInfo` when emitting network requests. ([#21965](https://github.com/expo/expo/pull/21965) by [@byCedric](https://github.com/byCedric))
 - Don't require legacy manifest signature in dev clients. ([#21970](https://github.com/expo/expo/pull/21970) by [@wschurman](https://github.com/wschurman))
+- Fixed `Invalid State: Cannot call send: until connection is open` crash when using network inspector on iOS. ([#22130](https://github.com/expo/expo/pull/22130) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -198,9 +198,25 @@ extension RCTInspectorDevServerHelper {
 
 extension RCTInspectorPackagerConnection {
   /**
+   Indicates whether the packager connection is established and ready to send messages
+   */
+  func isReadyToSend() -> Bool {
+    guard isConnected() else {
+      return false
+    }
+    guard let webSocket = value(forKey: "_webSocket") as? RCTSRWebSocket else {
+      return false
+    }
+    return webSocket.readyState == .OPEN
+  }
+
+  /**
    Sends message from native to inspector proxy
    */
   func sendWrappedEventToAllPages(_ event: String) {
+    guard isReadyToSend() else {
+      return
+    }
     for page in RCTInspector.pages() {
       perform(NSSelectorFromString("sendWrappedEvent:message:"), with: String(page.id), with: event)
     }


### PR DESCRIPTION
# Why

in some cases, we've seen crashes happen before packager websocket connection is ready. the crash is from:
```
  RCTAssert(self.readyState != RCTSR_CONNECTING, @"Invalid State: Cannot call send: until connection is open");
```
while the readyState is connecting.

# How

add `RCTInspectorPackagerConnection.isReadyToSend` to further check the underlying websocket ready state.

# Test Plan

- ci passed
- `npx expo run:ios`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
