### PR TITLE
[ios][expo-av] Make addObserver thread safe in EXAVPlayerData

### DIFF
--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -557,7 +557,6 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
         if (!set.count) {
           [_observers removeObjectForKey:object];
         }
-        NSLog(@"_tryRemoveObserver: object=%@ self=%@ path=%@", object, self, path);
         [object removeObserver:self forKeyPath:path];
       }
     }

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -532,29 +532,36 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
   [self _addObserver:object forKeyPath:path options:0];
 }
 
+
 - (void)_addObserver:(NSObject *)object forKeyPath:(NSString *)path options:(NSKeyValueObservingOptions)options
 {
-  NSMutableSet<NSString *> *set = [_observers objectForKey:object];
-  if (set == nil) {
-    set = [NSMutableSet set];
-    [_observers setObject:set forKey:object];
-  }
-  if (![set containsObject:path]) {
-    [set addObject:path];
-    [object addObserver:self forKeyPath:path options:options context:nil];
+  @synchronized(_observers) {
+    NSMutableSet<NSString *> *set = [_observers objectForKey:object];
+    if (set == nil) {
+      set = [NSMutableSet set];
+      [_observers setObject:set forKey:object];
+    }
+    if (![set containsObject:path]) {
+      [set addObject:path];
+      NSLog(@"_addObserver: object=%@ self=%@ path=%@", object, self, path);
+      [object addObserver:self forKeyPath:path options:options context:nil];
+    }
   }
 }
 
 - (void)_tryRemoveObserver:(NSObject *)object forKeyPath:(NSString *)path
 {
-  NSMutableSet<NSString *> *set = [_observers objectForKey:object];
-  if (set) {
-    if ([set containsObject:path]) {
-      [set removeObject:path];
-      if (!set.count) {
-        [_observers removeObjectForKey:object];
+  @synchronized(_observers) {
+    NSMutableSet<NSString *> *set = [_observers objectForKey:object];
+    if (set) {
+      if ([set containsObject:path]) {
+        [set removeObject:path];
+        if (!set.count) {
+          [_observers removeObjectForKey:object];
+        }
+        NSLog(@"_tryRemoveObserver: object=%@ self=%@ path=%@", object, self, path);
+        [object removeObserver:self forKeyPath:path];
       }
-      [object removeObserver:self forKeyPath:path];
     }
   }
 }

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -532,7 +532,6 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
   [self _addObserver:object forKeyPath:path options:0];
 }
 
-
 - (void)_addObserver:(NSObject *)object forKeyPath:(NSString *)path options:(NSKeyValueObservingOptions)options
 {
   @synchronized(_observers) {

--- a/packages/expo-av/ios/EXAV/EXAVPlayerData.m
+++ b/packages/expo-av/ios/EXAV/EXAVPlayerData.m
@@ -542,7 +542,6 @@ NSString *const EXAVPlayerDataObserverMetadataKeyPath = @"timedMetadata";
     }
     if (![set containsObject:path]) {
       [set addObject:path];
-      NSLog(@"_addObserver: object=%@ self=%@ path=%@", object, self, path);
       [object addObserver:self forKeyPath:path options:options context:nil];
     }
   }


### PR DESCRIPTION
This PR makes the addObserver/removeObserver code thread safe in EXAVPlayerData. Previously, when have multiple videos open, we were frequently running into a crash in our app, with something such as the following in the logs:

```
2023-03-18 00:47:14.852822+0100 Unbogify-beta[9001:54650945] _addObserver: object=<AVQueuePlayer: 0x600004c4d4a0> self=<EXAVPlayerData: 0x6000070e3dc0> path=status
2023-03-18 00:47:14.853616+0100 Unbogify-beta[9001:54650945] _addObserver: object=<AVPlayerItem: 0x6000048b2310, asset = <AVURLAsset: 0x600000a87200, URL = file:///Users/biallas/Library/Containers/4D8C9E72-5D78-48CE-AA05-A1B9D3700A43/Data/Documents/recordings/91.mp4>> self=<EXAVPlayerData: 0x6000070e3dc0> path=status
2023-03-18 00:47:14.853930+0100 Unbogify-beta[9001:54645202] _tryRemoveObserver: object=<AVQueuePlayer: 0x600004c4d4a0> self=<EXAVPlayerData: 0x6000070e3dc0> path=status
2023-03-18 00:47:14.853987+0100 Unbogify-beta[9001:54645202] _tryRemoveObserver: object=<AVPlayerItem: 0x6000048b2310, asset = <AVURLAsset: 0x600000a87200, URL = file:///Users/biallas/Library/Containers/4D8C9E72-5D78-48CE-AA05-A1B9D3700A43/Data/Documents/recordings/91.mp4>> self=<EXAVPlayerData: 0x6000070e3dc0> path=status
2023-03-18 00:47:14.855040+0100 Unbogify-beta[9001:54650945] _addObserver: object=<AVPlayerItem: 0x6000048b2310, asset = <AVURLAsset: 0x600000a87200, URL = file:///Users/biallas/Library/Containers/4D8C9E72-5D78-48CE-AA05-A1B9D3700A43/Data/Documents/recordings/91.mp4>> self=<EXAVPlayerData: 0x6000070e3dc0> path=timedMetadata
2023-03-18 00:47:14.875410+0100 Unbogify-beta[9001:54645202] *** Terminating app due to uncaught exception 'NSRangeException', reason: 'Cannot remove an observer <EXAVPlayerData 0x6000070e3dc0> for the key path "status" from <AVPlayerItem 0x6000048b2310> because it is not registered as an observer.'
2023-03-18 00:47:14.876141+0100 Unbogify-beta[9001:54645202] [General] Cannot remove an observer <EXAVPlayerData 0x6000070e3dc0> for the key path "status" from <AVPlayerItem 0x6000048b2310> because it is not registered as an observer.
```

This is due to the `NSMutableSet` not being thread safe. We tested this patch for quite some time and had no further crashes in `EXAVPlayerData`.

https://github.com/expo/expo/issues/7764 describes a similar issue.