### PR TITLE
[core][Android] Improve the initial loading speed of the native view

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Improve the initial loading speed of the native view.
+
 ### 💡 Others
 
 - [Android] Made `fallbackCallback` optional in the `registerForActivityResult` method. ([#21661](https://github.com/expo/expo/pull/21661) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Improve the initial loading speed of the native view.
+- [Android] Improve the initial loading speed of the native view. ([#22153](https://github.com/expo/expo/pull/22153) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -68,6 +68,15 @@ class AppContext(
     .asCoroutineDispatcher()
 
   /**
+   * A scope used to dispatch all background work.
+   */
+  val backgroundCoroutineScope = CoroutineScope(
+    Dispatchers.IO +
+      SupervisorJob() +
+      CoroutineName("expo.modules.BackgroundCoroutineScope")
+  )
+
+  /**
    * A queue used to dispatch all async methods that are called via JSI.
    */
   val modulesQueue = CoroutineScope(
@@ -265,6 +274,7 @@ class AppContext(
     registry.cleanUp()
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
+    backgroundCoroutineScope.cancel(ContextDestroyedException())
     JNIDeallocator.deallocate()
     logger.info("✅ AppContext was destroyed")
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import android.view.View
 import com.facebook.react.bridge.ReadableArray
 import expo.modules.kotlin.events.BasicEventListener
 import expo.modules.kotlin.events.EventListenerWithPayload
@@ -11,6 +12,7 @@ import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
 import kotlinx.coroutines.launch
+import kotlin.reflect.KClass
 
 class ModuleHolder(val module: Module) {
   val definition = module.definition()
@@ -99,5 +101,9 @@ class ModuleHolder(val module: Module) {
         it.invoke(module.appContext.appContextActivityResultCaller)
       }
     }
+  }
+
+  fun viewClass(): KClass<out View>? {
+    return definition.viewManagerDefinition?.viewType?.kotlin
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -34,8 +34,10 @@ class ModuleRegistry(
     // However, until then, we must find a way to address this problem.
     // Therefore, we have decided to dispatch a lambda
     // that invokes `declaredMemberProperties` during module creation.
-    appContext.get()?.backgroundCoroutineScope?.launch {
-      holder.viewClass()?.declaredMemberProperties
+    holder.viewClass()?.let { viewType ->
+      appContext.get()?.backgroundCoroutineScope?.launch {
+        viewType.declaredMemberProperties
+      }
     }
     registry[holder.name] = holder
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.lang.ref.WeakReference
+import kotlin.reflect.full.declaredMemberProperties
 
 class ModuleRegistry(
   private val appContext: WeakReference<AppContext>
@@ -26,6 +28,15 @@ class ModuleRegistry(
     }
     holder.post(EventName.MODULE_CREATE)
     holder.registerContracts()
+    // The initial invocation of `declaredMemberProperties` appears to be slow,
+    // as Kotlin must deserialize metadata internally.
+    // This is a known issue that may be resolved by the new K2 compiler in the future.
+    // However, until then, we must find a way to address this problem.
+    // Therefore, we have decided to dispatch a lambda
+    // that invokes `declaredMemberProperties` during module creation.
+    appContext.get()?.backgroundCoroutineScope?.launch {
+      holder.viewClass()?.declaredMemberProperties
+    }
     registry[holder.name] = holder
   }
 


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/21921.

# How

The initial invocation of `declaredMemberProperties` appears to be slow, as Kotlin must deserialize metadata internally. This is a known issue that may be resolved by the new K2 compiler in the future. However, until then, we must find a way to address this problem. Therefore, we have decided to dispatch a lambda that invokes `declaredMemberProperties` during module creation.

# Test Plan

- https://github.com/RRaideRR/expo-image-slow