### PR TITLE
[docs] Add info about animated AVIFs not supported on Android in Image API 

### DIFF
--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -31,7 +31,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 | :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
 |    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
 | PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> (animated AVIFs not supported yet)| <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs)| <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
 |    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
 |    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
 |    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |

--- a/docs/pages/versions/unversioned/sdk/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/image.mdx
@@ -31,7 +31,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 | :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
 |    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
 | PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    AVIF    | <YesIcon /> (animated AVIFs not supported yet)| <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
 |    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
 |    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
 |    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |

--- a/docs/pages/versions/v48.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/image.mdx
@@ -31,7 +31,7 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 | :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
 |    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
 | PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
 |    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
 |    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
 |    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |


### PR DESCRIPTION
Adding to the documentation that animated AVIFs are not supported yet. https://github.com/expo/expo/issues/21890

# Why

<!--
The documentation lacks the information that animated AVIFs are not supported on Android currently. See also: https://github.com/expo/expo/issues/21890
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
