### PR TITLE
[Android][image] Fix `url` property returned by the `onLoad` event

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `url` property returned by the `onLoad` event.
+
 ### 💡 Others
 
 ## 1.2.0 — 2023-04-14

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `url` property returned by the `onLoad` event.
+- [Android] Fix `url` property returned by the `onLoad` event. ([#22161](https://github.com/expo/expo/pull/22161) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -62,6 +62,10 @@ class GlideUrlWithCustomCacheKey(
  */
 data class GlideUrlWrapper(val glideUrl: GlideUrl) {
   var progressListener: OkHttpProgressListener? = null
+
+  override fun toString(): String {
+    return glideUrl.toString()
+  }
 }
 
 @GlideModule


### PR DESCRIPTION
# Why

Fixes the `url` property returned by the `onLoad` event

# How

When `GlideUrlWrapper` was introduced, it changes how `url` was passed to the js. 

# Test Plan

- bare-expo ✅