### PR TITLE
Update customizing-webpack.mdx

### DIFF
--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -12,7 +12,9 @@ When you run `npx expo start --web` or `expo export:web` the CLI will check to s
 
 To edit the config, install `@expo/webpack-config` as a dev dependency and create a template **webpack.config.js** at the root of your project. This can be done by running the following command:
 
-<Terminal cmd={['$ npx expo customize webpack.config.js']} />
+<Terminal cmd={['$ npx expo customize:web']} />
+
+> Navigate the options, choose the file you want to generate with the space key, then press enter. If the file exists it would not be choosable.
 
 You can now make changes to a config object based on the default config and return it for Expo CLI to use. Deleting the config will cause Expo to fall back to the default again.
 


### PR DESCRIPTION
- [x] Fixed expo customize
- [x] Added indications and warning about generating the files

# Why
The command sintax is wrong, saying: _The expected package.json path: webpack.config.js\package.json does not exist_

# How
Here is mentioned how to use it:
[The fix is here https://github.com/expo/expo-cli/issues/4319](https://github.com/expo/expo-cli/tree/main/packages/pwa#usage-in-expo)

# Test Plan
Tested and passed.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
