### PR TITLE
[expo-updates] E2E tests for JS API

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix E2E after Swift conversion. ([#21592](https://github.com/expo/expo/pull/21592) by [@douglowder](https://github.com/douglowder))
 - Fix iOS native debug after Swift conversion. ([#21602](https://github.com/expo/expo/pull/21602) by [@douglowder](https://github.com/douglowder))
 - Fix compilation errors and enable modules after Swift conversion. ([#21621](https://github.com/expo/expo/pull/21621) by [@wschurman](https://github.com/wschurman), [@douglowder](https://github.com/douglowder))
+- E2E tests for JS API. ([#22167](https://github.com/expo/expo/pull/22167) by [@douglowder](https://github.com/douglowder))
 
 ## 0.16.4 - 2023-04-03
 

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -1,4 +1,5 @@
 import { Inter_900Black } from '@expo-google-fonts/inter';
+import { useUpdates, checkForUpdate, downloadUpdate, runUpdate } from '@expo/use-updates';
 import { NativeModulesProxy } from 'expo-modules-core';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
@@ -7,12 +8,45 @@ import React from 'react';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 require('./test.png');
+// eslint-disable-next-line no-unused-expressions
 Inter_900Black;
+
+function TestValue(props: { testID: string; value: string }) {
+  return (
+    <View>
+      <Text>{props.testID}</Text>
+      <Text testID={props.testID}>{props.value}</Text>
+      <Text>---</Text>
+    </View>
+  );
+}
+
+function TestButton(props: { testID: string; onPress: () => void }) {
+  return (
+    <Pressable testID={props.testID} style={styles.button} onPress={props.onPress}>
+      <Text style={styles.buttonText}>{props.testID}</Text>
+    </Pressable>
+  );
+}
 
 export default function App() {
   const [numAssetFiles, setNumAssetFiles] = React.useState(0);
   const [logs, setLogs] = React.useState<UpdatesLogEntry[]>([]);
   const [active, setActive] = React.useState(false);
+  const [runNow, setRunNow] = React.useState(false);
+  const [lastUpdateEventType, setLastUpdateEventType] = React.useState('');
+
+  const { currentlyRunning, availableUpdate, isUpdateAvailable, isUpdatePending } = useUpdates();
+
+  Updates.useUpdateEvents((event) => {
+    setLastUpdateEventType(event.type);
+  });
+
+  React.useEffect(() => {
+    if (isUpdatePending && runNow) {
+      setTimeout(() => runUpdate(), 2000);
+    }
+  }, [isUpdatePending, runNow]);
 
   const handleReadAssetFiles = () => {
     const handleAsync = async () => {
@@ -54,6 +88,11 @@ export default function App() {
     });
   };
 
+  const handleDownloadUpdate = () => {
+    setRunNow(true);
+    downloadUpdate();
+  };
+
   const logsToString = (logs: UpdatesLogEntry[]) =>
     JSON.stringify(
       logs.map((log) => {
@@ -65,23 +104,15 @@ export default function App() {
       })
     );
 
-  const runTypeMessage = Updates.isEmbeddedLaunch
-    ? 'This app is running from built-in code'
-    : 'This app is running an update';
-
   return (
     <View style={styles.container}>
-      <Text>Update string</Text>
-      <Text testID="updateString">/notify/test</Text>
-      <Text>---</Text>
-      <Text>Update ID</Text>
-      <Text testID="updateID">{Updates.updateId}</Text>
-      <Text>---</Text>
-      <Text testID="runTypeMessage">{runTypeMessage}</Text>
-      <Text>---</Text>
-      <Text>Number of asset files in DB</Text>
-      <Text testID="numAssetFiles">{numAssetFiles}</Text>
-      <Text>---</Text>
+      <TestValue testID="lastUpdateEventType" value={`${lastUpdateEventType}`} />
+      <TestValue testID="updateString" value="test" />
+      <TestValue testID="updateID" value={`${Updates.updateId}`} />
+      <TestValue testID="numAssetFiles" value={`${numAssetFiles}`} />
+      <TestValue testID="runtimeVersion" value={`${currentlyRunning.runtimeVersion}`} />
+      <TestValue testID="isEmbeddedLaunch" value={`${currentlyRunning.isEmbeddedLaunch}`} />
+      <TestValue testID="availableUpdateID" value={`${availableUpdate?.updateId}`} />
       <Text>Log messages</Text>
       <ScrollView style={styles.logEntriesContainer}>
         <Text testID="logEntries" style={styles.logEntriesText}>
@@ -90,16 +121,13 @@ export default function App() {
       </ScrollView>
 
       {active ? <ActivityIndicator testID="activity" size="small" color="#0000ff" /> : null}
-      <Pressable testID="readAssetFiles" style={styles.button} onPress={handleReadAssetFiles}>
-        <Text style={styles.buttonText}>Read number of asset files</Text>
-      </Pressable>
-      <Pressable testID="clearAssetFiles" style={styles.button} onPress={handleClearAssetFiles}>
-        <Text style={styles.buttonText}>Clear asset files</Text>
-      </Pressable>
-      <Pressable testID="readLogEntries" style={styles.button} onPress={handleReadLogEntries}>
-        <Text style={styles.buttonText}>Read logs</Text>
-      </Pressable>
-
+      <TestButton testID="readAssetFiles" onPress={handleReadAssetFiles} />
+      <TestButton testID="clearAssetFiles" onPress={handleClearAssetFiles} />
+      <TestButton testID="readLogEntries" onPress={handleReadLogEntries} />
+      <TestButton testID="checkForUpdate" onPress={checkForUpdate} />
+      {isUpdateAvailable ? (
+        <TestButton testID="downloadUpdate" onPress={handleDownloadUpdate} />
+      ) : null}
       <StatusBar style="auto" />
     </View>
   );
@@ -124,13 +152,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
+    fontSize: 10,
   },
   button: {
     alignItems: 'center',
     justifyContent: 'center',
-    margin: 10,
-    paddingVertical: 12,
-    paddingHorizontal: 32,
+    margin: 5,
+    paddingVertical: 5,
+    paddingHorizontal: 10,
     borderRadius: 4,
     elevation: 3,
     backgroundColor: '#4630EB',
@@ -140,9 +169,9 @@ const styles = StyleSheet.create({
   },
   logEntriesContainer: {
     margin: 10,
-    height: 200,
-    paddingVertical: 12,
-    paddingHorizontal: 32,
+    height: 50,
+    paddingVertical: 10,
+    paddingHorizontal: 10,
     width: '90%',
     minWidth: '90%',
     borderColor: '#4630EB',

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -111,6 +111,7 @@ export default function App() {
       <TestValue testID="updateID" value={`${Updates.updateId}`} />
       <TestValue testID="numAssetFiles" value={`${numAssetFiles}`} />
       <TestValue testID="runtimeVersion" value={`${currentlyRunning.runtimeVersion}`} />
+      <TestValue testID="checkAutomatically" value={`${Updates.checkAutomatically}`} />
       <TestValue testID="isEmbeddedLaunch" value={`${currentlyRunning.isEmbeddedLaunch}`} />
       <TestValue testID="availableUpdateID" value={`${availableUpdate?.updateId}`} />
       <Text>Log messages</Text>

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -29,20 +29,12 @@ const clearNumAssetsAsync = async () => {
     .withTimeout(2000);
 };
 
-const checkIsEmbeddedAsync = async () => {
-  const attributes: any = await element(by.id('runTypeMessage')).getAttributes();
-  return attributes?.text === 'This app is running from built-in code';
-};
-
-const checkUpdateIDAsync = async () => {
-  const attributes: any = await element(by.id('updateID')).getAttributes();
+const testElementValueAsync = async (testID: string) => {
+  const attributes: any = await element(by.id(testID)).getAttributes();
   return attributes?.text || '';
 };
 
-const checkUpdateStringAsync = async () => {
-  const attributes: any = await element(by.id('updateString')).getAttributes();
-  return attributes?.text.substring(8) || '';
-};
+const pressTestButtonAsync = async (testID: string) => await element(by.id(testID)).tap();
 
 const readLogEntriesAsync = async () => {
   await element(by.id('readLogEntries')).tap();
@@ -81,13 +73,13 @@ describe('Basic tests', () => {
     });
     await waitForAppToBecomeVisible();
 
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
     await device.terminateApp();
     await device.launchApp();
     await waitForAppToBecomeVisible();
 
-    const message2 = await checkUpdateStringAsync();
+    const message2 = await testElementValueAsync('updateString');
     jestExpect(message2).toBe('test');
 
     await device.terminateApp();
@@ -135,7 +127,7 @@ describe('Basic tests', () => {
     });
     const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
@@ -146,7 +138,7 @@ describe('Basic tests', () => {
     await device.launchApp();
     const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const updatedMessage = await checkUpdateStringAsync();
+    const updatedMessage = await testElementValueAsync('updateString');
     jestExpect(updatedMessage).toBe(newNotifyString);
 
     jestExpect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
@@ -179,7 +171,7 @@ describe('Basic tests', () => {
     });
     await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
@@ -189,7 +181,7 @@ describe('Basic tests', () => {
     await device.terminateApp();
     await device.launchApp();
     await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
-    const updatedMessage = await checkUpdateStringAsync();
+    const updatedMessage = await testElementValueAsync('updateString');
     jestExpect(updatedMessage).toBe('test');
   });
 
@@ -240,7 +232,7 @@ describe('Basic tests', () => {
     });
     // give the app time to load the new update in the background
     await waitForAppToBecomeVisible();
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
 
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(4);
@@ -250,13 +242,11 @@ describe('Basic tests', () => {
     await device.launchApp();
     await waitForAppToBecomeVisible();
     await setTimeout(2000 * TIMEOUT_BIAS);
-    const updatedMessage = await checkUpdateStringAsync();
+    const updatedMessage = await testElementValueAsync('updateString');
     // Because of the mismatch, the new update will not load, so updatedMessage will still be 'test'
     jestExpect(updatedMessage).toBe('test');
 
-    /**
-     * Check readLogEntriesAsync
-     */
+    // Check readLogEntriesAsync
     const logEntries: any[] = await readLogEntriesAsync();
     console.warn(
       'Total number of log entries = ' +
@@ -318,7 +308,7 @@ describe('Basic tests', () => {
       newInstance: true,
     });
     await waitForAppToBecomeVisible();
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
@@ -327,7 +317,7 @@ describe('Basic tests', () => {
     // restart the app so it will launch the new update
     await device.terminateApp();
     await device.launchApp();
-    const updatedMessage = await checkUpdateStringAsync();
+    const updatedMessage = await testElementValueAsync('updateString');
 
     jestExpect(updatedMessage).toBe(newNotifyString);
   });
@@ -358,7 +348,7 @@ describe('Basic tests', () => {
     });
     await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const firstMessage = await checkUpdateStringAsync();
+    const firstMessage = await testElementValueAsync('updateString');
     jestExpect(firstMessage).toBe('test');
 
     // give the app time to load the new update in the background (i.e. to make sure it doesn't)
@@ -367,7 +357,7 @@ describe('Basic tests', () => {
     // restart the app and make sure it's still running the initial update
     await device.terminateApp();
     await device.launchApp();
-    const secondMessage = await checkUpdateStringAsync();
+    const secondMessage = await testElementValueAsync('updateString');
     jestExpect(secondMessage).toBe('test');
   });
 
@@ -397,7 +387,7 @@ describe('Basic tests', () => {
     });
     const firstRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const message = await checkUpdateStringAsync();
+    const message = await testElementValueAsync('updateString');
     jestExpect(message).toBe('test');
 
     // give the app time to load the new update in the background
@@ -408,7 +398,7 @@ describe('Basic tests', () => {
     await device.launchApp();
     const secondRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const updatedMessage = await checkUpdateStringAsync();
+    const updatedMessage = await testElementValueAsync('updateString');
     jestExpect(updatedMessage).toBe(newNotifyString);
 
     // serve a rollback now
@@ -425,7 +415,7 @@ describe('Basic tests', () => {
     await device.launchApp();
     const fourthRequest = await Server.waitForUpdateRequest(10000 * TIMEOUT_BIAS);
     await waitForAppToBecomeVisible();
-    const rolledBackMessage = await checkUpdateStringAsync();
+    const rolledBackMessage = await testElementValueAsync('updateString');
     jestExpect(rolledBackMessage).toBe('test');
     jestExpect(secondRequest.headers['expo-embedded-update-id']).toBeDefined();
     jestExpect(secondRequest.headers['expo-embedded-update-id']).toEqual(
@@ -449,87 +439,168 @@ describe('Basic tests', () => {
   });
 });
 
-/**
- * The tests in this suite install an app with multiple assets, then clear all the assets from
- * .expo-internal storage (but not SQLite). This simulates scenarios such as: a bug in our code that
- * deletes assets unintentionally; OS deleting files from app storage if it runs out of memory; etc.
- *
- * Recovery code for this situation exists in the DatabaseLauncher, these are the main tests that
- * ensure that logic doesn't regress.
- *
- * These tests all make use of the additional UpdatesE2ETestModule, which provides methods for
- * clearing and reading the .expo-internal folder.
- */
-describe('Asset deletion recovery', () => {
+describe('JS API tests', () => {
+  afterEach(async () => {
+    await device.uninstallApp();
+    Server.stop();
+  });
+
+  it('downloads and runs update with JS API', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      []
+    );
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const message = await testElementValueAsync('updateString');
+    jestExpect(message).toEqual('test');
+    const isEmbedded = await testElementValueAsync('isEmbeddedLaunch');
+    jestExpect(isEmbedded).toEqual('true');
+    Server.start(Update.serverPort, protocolVersion);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await pressTestButtonAsync('checkForUpdate');
+    const availableUpdateID = await testElementValueAsync('availableUpdateID');
+    jestExpect(availableUpdateID).toEqual(manifest.id);
+    await pressTestButtonAsync('downloadUpdate');
+    await setTimeout(2000);
+    Server.stop();
+    await device.terminateApp();
+    await device.launchApp();
+    await waitForAppToBecomeVisible();
+    const runningUpdateID = await testElementValueAsync('updateID');
+    jestExpect(runningUpdateID).toEqual(manifest.id);
+    const isEmbeddedAfterUpdate = await testElementValueAsync('isEmbeddedLaunch');
+    jestExpect(isEmbeddedAfterUpdate).toEqual('false');
+  });
+
+  it('Receives expected events when update available on start', async () => {
+    jest.setTimeout(300000 * TIMEOUT_BIAS);
+    const bundleFilename = 'bundle1.js';
+    const newNotifyString = 'test-update-1';
+    const hash = await Update.copyBundleToStaticFolder(
+      projectRoot,
+      bundleFilename,
+      newNotifyString,
+      platform
+    );
+    const manifest = Update.getUpdateManifestForBundleFilename(
+      new Date(),
+      hash,
+      'test-update-1-key',
+      bundleFilename,
+      []
+    );
+    // Launch app
+    await device.installApp();
+    await device.launchApp({
+      newInstance: true,
+    });
+    await waitForAppToBecomeVisible();
+    const lastUpdateEventType = await testElementValueAsync('lastUpdateEventType');
+    // Server is not running, so no response received
+    jestExpect(lastUpdateEventType).toEqual('');
+
+    // Start server with no update available directive,
+    // then restart app, we should get "No update available" event
+    if (protocolVersion === 1) {
+      Server.start(Update.serverPort, protocolVersion);
+      const directive = Update.getNoUpdateAvailableDirective();
+      await Server.serveSignedDirective(directive, projectRoot);
+      await device.terminateApp();
+      await device.launchApp();
+      await waitForAppToBecomeVisible();
+      const lastUpdateEventType2 = await testElementValueAsync('lastUpdateEventType');
+      jestExpect(lastUpdateEventType2).toEqual('noUpdateAvailable');
+      Server.stop();
+    }
+
+    // Relaunch app after server has an update,
+    // we should get the 'update available' event
+    Server.start(Update.serverPort, protocolVersion);
+    await Server.serveSignedManifest(manifest, projectRoot);
+    await device.terminateApp();
+    await device.launchApp();
+    await waitForAppToBecomeVisible();
+    const lastUpdateEventType3 = await testElementValueAsync('lastUpdateEventType');
+    jestExpect(lastUpdateEventType3).toEqual('updateAvailable');
+  });
+});
+
+// The tests in this suite install an app with multiple assets, then clear all the assets from
+// .expo-internal storage (but not SQLite). This simulates scenarios such as: a bug in our code that
+// deletes assets unintentionally; OS deleting files from app storage if it runs out of memory; etc.
+//
+// Recovery code for this situation exists in the DatabaseLauncher, these are the main tests that
+// ensure that logic doesn't regress.
+//
+// These tests all make use of the additional UpdatesE2ETestModule, which provides methods for
+// clearing and reading the .expo-internal folder.
+describe('Asset deletion recovery tests', () => {
   afterEach(async () => {
     await device.uninstallApp();
     Server.stop();
   });
 
   it('embedded assets deleted from internal storage should be re-copied', async () => {
-    /**
-     * Simplest scenario; only one update (embedded) is loaded, then assets are cleared from
-     * internal storage. The app is then relaunched with the same embedded update.
-     * DatabaseLauncher should copy all the missing assets and run the update as normal.
-     */
+    // Simplest scenario; only one update (embedded) is loaded, then assets are cleared from
+    // internal storage. The app is then relaunched with the same embedded update.
+    // DatabaseLauncher should copy all the missing assets and run the update as normal.
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(Update.serverPort, protocolVersion);
 
-    /**
-     * Install the app and immediately send it a message to clear internal storage. Verify storage
-     * has been cleared properly.
-     */
+    // Install the app and immediately send it a message to clear internal storage. Verify storage
+    // has been cleared properly.
     await device.installApp();
     await device.launchApp({
       newInstance: true,
     });
     await waitForAppToBecomeVisible();
-    /**
-     * Check that we are running the embedded update
-     */
-    const isEmbedded = await checkIsEmbeddedAsync();
-    jestExpect(isEmbedded).toEqual(true);
 
-    /**
-     * Check that asset files are present
-     */
+    // Check that we are running the embedded update
+    const isEmbedded = await testElementValueAsync('isEmbeddedLaunch');
+    jestExpect(isEmbedded).toEqual('true');
+
+    // Check that asset files are present
     let numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBeGreaterThan(2);
 
-    /**
-     * Get current update ID
-     */
-    const updateID = await checkUpdateIDAsync();
+    // Get current update ID
+    const updateID = await testElementValueAsync('updateID');
 
-    /**
-     * Clear assets and check that number of assets is now 0
-     */
+    // Clear assets and check that number of assets is now 0
     await clearNumAssetsAsync();
     numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBe(0);
 
-    /**
-     * Stop and then restart app.
-     */
+    // Stop and then restart app.
     await device.terminateApp();
     await device.launchApp();
     await waitForAppToBecomeVisible();
 
-    /**
-     * Check that assets are restored from DB
-     */
+    // Check that assets are restored from DB
     numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBeGreaterThan(2);
 
-    /**
-     * Check that update ID is the same
-     */
-    const updateID2 = await checkUpdateIDAsync();
+    // Check that update ID is the same
+    const updateID2 = await testElementValueAsync('updateID');
     jestExpect(updateID2).toEqual(updateID);
 
-    /**
-     * Check for log messages
-     */
+    // Check for log messages
     const logEntries = await readLogEntriesAsync();
     console.warn(
       'Total number of log entries = ' +
@@ -541,91 +612,71 @@ describe('Asset deletion recovery', () => {
   });
 
   it('embedded assets deleted from internal storage should be re-copied from a new embedded update', async () => {
-    /**
-     * This test ensures that when trying to launch a NEW update that includes some OLD assets we
-     * already have (according to SQLite), even if those assets are actually missing from disk
-     * (but included in the embedded update) DatabaseLauncher can recover.
-     *
-     * To create this scenario, we load a single (embedded) update, then clear assets from
-     * internal storage. Then we install a NEW build with a NEW embedded update but that includes
-     * some of the same assets. When we launch this new build, DatabaseLauncher should still copy
-     * the missing assets and run the update as normal.
-     */
+    // This test ensures that when trying to launch a NEW update that includes some OLD assets we
+    // already have (according to SQLite), even if those assets are actually missing from disk
+    // (but included in the embedded update) DatabaseLauncher can recover.
+    //
+    // To create this scenario, we load a single (embedded) update, then clear assets from
+    // internal storage. Then we install a NEW build with a NEW embedded update but that includes
+    // some of the same assets. When we launch this new build, DatabaseLauncher should still copy
+    // the missing assets and run the update as normal.
     jest.setTimeout(300000 * TIMEOUT_BIAS);
     Server.start(Update.serverPort, protocolVersion);
 
-    /**
-     * Install the app and immediately send it a message to clear internal storage. Verify storage
-     * has been cleared properly.
-     */
+    // Install the app and immediately send it a message to clear internal storage. Verify storage
+    // has been cleared properly.
     await device.installApp();
     await device.launchApp({
       newInstance: true,
     });
     await waitForAppToBecomeVisible();
 
-    /**
-     * Save the number of assets in storage
-     */
+    // Save the number of assets in storage
     const numAssetsSaved = await checkNumAssetsAsync();
     jestExpect(numAssetsSaved).toBeGreaterThan(0);
 
-    /**
-     * Clear assets and check that number of assets is now 0
-     */
+    // Clear assets and check that number of assets is now 0
     await clearNumAssetsAsync();
     let numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBe(0);
 
-    /**
-     * Stop the app and install a newer build on top of it. The newer build has a different
-     * embedded update (different updateId) but still includes some of the same assets. Now SQLite
-     * thinks we already have these assets, but we actually just deleted them from internal
-     * storage.
-     */
+    // Stop the app and install a newer build on top of it. The newer build has a different
+    // embedded update (different updateId) but still includes some of the same assets. Now SQLite
+    // thinks we already have these assets, but we actually just deleted them from internal
+    // storage.
     await device.terminateApp();
     await device.installApp();
 
-    /**
-     * Start the new build, and immediately send it a message to read internal storage.
-     */
+    // Start the new build, and immediately send it a message to read internal storage.
     await device.launchApp({
       newInstance: true,
     });
     await waitForAppToBecomeVisible();
 
-    /**
-     * Verify all the assets that were deleted have been re-copied back into internal storage, and
-     * that we are running a DIFFERENT update than before -- otherwise this test is no different
-     * from the previous one.
-     */
+    // Verify all the assets that were deleted have been re-copied back into internal storage, and
+    // that we are running a DIFFERENT update than before -- otherwise this test is no different
+    // from the previous one.
     numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toEqual(numAssetsSaved);
 
-    /**
-     * TODO: develop a way to modify the embedded update used by the build in a Detox test environment,
-     * so that we can actually do this test with a real modified update. Until then, disable the line below
-     * to allow the test to pass.
-     */
+    // TODO: develop a way to modify the embedded update used by the build in a Detox test environment,
+    // so that we can actually do this test with a real modified update. Until then, disable the line below
+    // to allow the test to pass.
     //jestExpect(readAssetsMessage.updateId).not.toEqual(clearAssetsMessage.updateId);
   });
 
   it('assets in a downloaded update deleted from internal storage should be re-copied or re-downloaded', async () => {
-    /**
-     * This test ensures we can (or at least try to) recover missing assets that originated from a
-     * downloaded update, as opposed to assets originally copied from an embedded update (which
-     * the previous 2 tests concern).
-     *
-     * To create this scenario, we launch an app, download an update with multiple assets
-     * (including at least one -- the bundle -- not part of the embedded update), make sure the
-     * update runs, then clear assets from internal storage. When we relaunch the app,
-     * DatabaseLauncher should re-download the missing assets and run the update as normal.
-     */
+    // This test ensures we can (or at least try to) recover missing assets that originated from a
+    // downloaded update, as opposed to assets originally copied from an embedded update (which
+    // the previous 2 tests concern).
+    //
+    // To create this scenario, we launch an app, download an update with multiple assets
+    // (including at least one -- the bundle -- not part of the embedded update), make sure the
+    // update runs, then clear assets from internal storage. When we relaunch the app,
+    // DatabaseLauncher should re-download the missing assets and run the update as normal.
     jest.setTimeout(300000 * TIMEOUT_BIAS);
 
-    /**
-     * Prepare to host update manifest and assets from the test runner
-     */
+    // Prepare to host update manifest and assets from the test runner
     const bundleFilename = 'bundle-assets.js';
     const newNotifyString = 'test-assets-1';
     const bundleHash = await Update.copyBundleToStaticFolder(
@@ -659,9 +710,7 @@ describe('Asset deletion recovery', () => {
       assets
     );
 
-    /**
-     * Install the app and launch it so that it downloads the new update we're hosting
-     */
+    // Install the app and launch it so that it downloads the new update we're hosting
     Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await device.installApp();
@@ -671,41 +720,33 @@ describe('Asset deletion recovery', () => {
     // give the app time to load the new update in the background
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1); // only the bundle should be new
 
-    /**
-     * Stop and restart the app so it will launch the new update. Immediately send it a message to
-     * clear internal storage while also verifying the new update is running.
-     */
+    // Stop and restart the app so it will launch the new update. Immediately send it a message to
+    // clear internal storage while also verifying the new update is running.
     await device.terminateApp();
     await device.launchApp({ newInstance: true });
     await waitForAppToBecomeVisible();
-    const updateString = await checkUpdateStringAsync();
+    const updateString = await testElementValueAsync('updateString');
     jestExpect(updateString).toEqual(newNotifyString);
     await clearNumAssetsAsync();
 
-    /**
-     * Verify that the assets were cleared correctly.
-     */
+    // Verify that the assets were cleared correctly.
     let numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBe(0);
-    let updateID = await checkUpdateIDAsync();
+    let updateID = await testElementValueAsync('updateID');
     jestExpect(updateID).toEqual(manifest.id);
 
-    /**
-     * Stop and restart the app and immediately send it a message to read internal storage. Verify
-     * that the new update is running (again).
-     */
+    // Stop and restart the app and immediately send it a message to read internal storage. Verify
+    // that the new update is running (again).
     await device.terminateApp();
     await device.launchApp({ newInstance: true });
     await waitForAppToBecomeVisible();
 
-    /**
-     * Verify all the assets -- including the JS bundle from the update (which wasn't in the
-     * embedded update) -- have been restored. Additionally verify from the server side that the
-     * updated bundle was re-downloaded.
-     */
+    // Verify all the assets -- including the JS bundle from the update (which wasn't in the
+    // embedded update) -- have been restored. Additionally verify from the server side that the
+    // updated bundle was re-downloaded.
     numAssets = await checkNumAssetsAsync();
     jestExpect(numAssets).toBe(manifest.assets.length + 1);
-    updateID = await checkUpdateIDAsync();
+    updateID = await testElementValueAsync('updateID');
     jestExpect(updateID).toEqual(manifest.id);
     jestExpect(Server.consumeRequestedStaticFiles().length).toBe(1); // should have re-downloaded only the JS bundle; the rest should have been copied from the app binary
   });

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -471,6 +471,8 @@ describe('JS API tests', () => {
     jestExpect(message).toEqual('test');
     const isEmbedded = await testElementValueAsync('isEmbeddedLaunch');
     jestExpect(isEmbedded).toEqual('true');
+    const checkAutomatically = await testElementValueAsync('checkAutomatically');
+    jestExpect(checkAutomatically).toEqual('ON_LOAD');
     Server.start(Update.serverPort, protocolVersion);
     await Server.serveSignedManifest(manifest, projectRoot);
     await pressTestButtonAsync('checkForUpdate');

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -512,8 +512,8 @@ describe('JS API tests', () => {
     });
     await waitForAppToBecomeVisible();
     const lastUpdateEventType = await testElementValueAsync('lastUpdateEventType');
-    // Server is not running, so no response received
-    jestExpect(lastUpdateEventType).toEqual('');
+    // Server is not running, so error received
+    jestExpect(lastUpdateEventType).toEqual('error');
 
     // Start server with no update available directive,
     // then restart app, we should get "No update available" event

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
@@ -124,12 +124,22 @@ function getRollbackDirective(date: Date) {
   };
 }
 
+/**
+ * Common method used to create "no update available" directives
+ */
+function getNoUpdateAvailableDirective() {
+  return {
+    type: 'noUpdateAvailable',
+  };
+}
+
 export default {
   copyBundleToStaticFolder,
   copyAssetToStaticFolder,
   findAssets,
   getUpdateManifestForBundleFilename,
   getRollbackDirective,
+  getNoUpdateAvailableDirective,
   serverHost,
   serverPort,
 };

--- a/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.js
+++ b/packages/expo-updates/e2e/fixtures/project_files/scripts/generate-test-update-bundles.js
@@ -13,7 +13,6 @@ const notifyStrings = [
   'test-assets-1',
 ];
 
-
 createTestUpdateBundles(projectRoot, notifyStrings);
 
 ///////////////////////////////////////////////////////////////
@@ -41,7 +40,10 @@ async function createTestUpdateBundles(projectRoot, notifyStrings) {
   const testUpdateJson = {};
   for (const notifyString of ['test', ...notifyStrings]) {
     console.log(`Creating bundle for string '${notifyString}'...`);
-    const modifiedAppJs = originalAppJs.replace(/\/notify\/test/g, `/notify/${notifyString}`);
+    const modifiedAppJs = originalAppJs.replace(
+      /testID="updateString" value="test"/g,
+      `testID="updateString" value="${notifyString}"`
+    );
     await fs.rm(appJsPath);
     await fs.writeFile(appJsPath, modifiedAppJs, 'utf-8');
     await createUpdateBundleAsync(projectRoot);

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -11,6 +11,7 @@ const expoDependencyNames = [
   '@expo/config-plugins',
   '@expo/config-types',
   '@expo/dev-server',
+  '@expo/use-updates',
   'expo-application',
   'expo-constants',
   'expo-eas-client',


### PR DESCRIPTION
# Why

Add tests to verify that the expo-updates JS API is working. Until now, we have had JS unit tests for this, but no functional or E2E tests. Test coverage includes tests for the new `@expo/use-updates` module.

# How

- Add tests
- Refactor and simplify the test app (`App.tsx`)
- Simplify some of the code in the Detox tests
- Test the `noUpdateAvailable` directive in Updates protocol 1

# Test Plan

- Tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
