### PR TITLE
[cli] Default to expo go modern manifest format

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Set `NODE_ENV` and `BABEL_ENV` environment variables to `development` or `production` in `start`, `export`, `customize`, `install`, `run:ios`, `run:android`, `config`, `prebuild` commands based on the input mode. ([#21337](https://github.com/expo/expo/pull/21337) by [@EvanBacon](https://github.com/EvanBacon))
 - Export Hermes bytecode with `.hbc` extension. ([#22098](https://github.com/expo/expo/pull/22098) by [@EvanBacon](https://github.com/EvanBacon))
+- Default to expo go modern manifest format. ([#22168](https://github.com/expo/expo/pull/22168) by [@wschurman](https://github.com/wschurman))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -1,7 +1,12 @@
 /* eslint-env jest */
+import {
+  isMultipartPartWithName,
+  parseMultipartMixedResponseAsync,
+} from '@expo/multipart-body-parser';
 import execa from 'execa';
 import fs from 'fs-extra';
 import fetch from 'node-fetch';
+import nullthrows from 'nullthrows';
 import path from 'path';
 
 import {
@@ -138,40 +143,52 @@ describe('server', () => {
       });
 
       console.log('Fetching manifest');
-      const results = await fetch('http://localhost:19000/', {
+      const response = await fetch('http://localhost:19000/', {
         headers: {
           'expo-platform': 'ios',
+          Accept: 'multipart/mixed',
         },
-      }).then((res) => res.json());
+      });
+
+      const multipartParts = await parseMultipartMixedResponseAsync(
+        response.headers.get('content-type') as string,
+        await response.buffer()
+      );
+      const manifestPart = nullthrows(
+        multipartParts.find((part) => isMultipartPartWithName(part, 'manifest'))
+      );
+
+      const manifest = JSON.parse(manifestPart.body);
 
       // Required for Expo Go
-      expect(results.packagerOpts).toStrictEqual({
+      expect(manifest.extra.expoGo.packagerOpts).toStrictEqual({
         dev: true,
       });
-      expect(results.developer).toStrictEqual({
+      expect(manifest.extra.expoGo.developer).toStrictEqual({
         projectRoot: expect.anything(),
         tool: 'expo-cli',
       });
 
       // URLs
-      expect(results.bundleUrl).toBe(
+      expect(manifest.launchAsset.url).toBe(
         'http://127.0.0.1:19000/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false'
       );
-      expect(results.debuggerHost).toBe('127.0.0.1:19000');
-      expect(results.hostUri).toBe('127.0.0.1:19000');
-      expect(results.logUrl).toBe('http://127.0.0.1:19000/logs');
-      expect(results.mainModuleName).toBe('node_modules/expo/AppEntry');
+      expect(manifest.extra.expoGo.debuggerHost).toBe('127.0.0.1:19000');
+      expect(manifest.extra.expoGo.logUrl).toBe('http://127.0.0.1:19000/logs');
+      expect(manifest.extra.expoGo.mainModuleName).toBe('node_modules/expo/AppEntry');
+      expect(manifest.extra.expoClient.hostUri).toBe('127.0.0.1:19000');
 
       // Manifest
-      expect(results.sdkVersion).toBe('47.0.0');
-      expect(results.slug).toBe('basic-start');
-      expect(results.name).toBe('basic-start');
+      expect(manifest.runtimeVersion).toBe('exposdk:47.0.0');
+      expect(manifest.extra.expoClient.sdkVersion).toBe('47.0.0');
+      expect(manifest.extra.expoClient.slug).toBe('basic-start');
+      expect(manifest.extra.expoClient.name).toBe('basic-start');
 
       // Custom
-      expect(results.__flipperHack).toBe('React Native packager is running');
+      expect(manifest.extra.expoGo.__flipperHack).toBe('React Native packager is running');
 
       console.log('Fetching bundle');
-      const bundle = await fetch(results.bundleUrl).then((res) => res.text());
+      const bundle = await fetch(manifest.launchAsset.url).then((res) => res.text());
       console.log('Fetched bundle: ', bundle.length);
       expect(bundle.length).toBeGreaterThan(1000);
       console.log('Finished');

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -207,7 +207,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
 
     Log.warn(
       APISettings.isOffline
-        ? 'Using anonymous scope key in manifest for offline mode with no cached development code signing info.'
+        ? 'Using anonymous scope key in manifest for offline mode.'
         : 'Using anonymous scope key in manifest.'
     );
     return await getAnonymousScopeKeyAsync(slug);

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -79,13 +79,15 @@ export async function startAsync(
     if (exp.updates?.useClassicUpdates) {
       options.forceManifestType = 'classic';
     } else {
-      const classicUpdatesUrlRegex = /^(staging-)?exp\.host/;
+      const classicUpdatesUrlRegex = /^(staging\.)?exp\.host/;
       let parsedUpdatesUrl: { hostname: string | null } = { hostname: null };
       if (exp.updates?.url) {
         try {
           parsedUpdatesUrl = new URL(exp.updates.url);
         } catch {
-          Log.error(`Failed to parse \`updates.url\` in this project's app config.`);
+          Log.error(
+            `Failed to parse \`updates.url\` in this project's app config. ${exp.updates.url} is not a valid URL.`
+          );
         }
       }
       const isClassicUpdatesUrl = parsedUpdatesUrl.hostname

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -24,6 +24,7 @@ import { ensureLoggedInAsync } from '../api/user/actions';
 import { Actor } from '../api/user/user';
 import { AppByIdQuery, Permission } from '../graphql/generated';
 import * as Log from '../log';
+import { learnMore } from '../utils/link';
 import { CommandError } from './errors';
 
 export type CodeSigningInfo = {
@@ -181,7 +182,11 @@ async function getExpoRootDevelopmentCodeSigningInfoAsync(
   // can't check for scope key validity since scope key is derived on the server from projectId and we may be offline.
   // we rely upon the client certificate check to validate the scope key
   if (!easProjectId) {
-    Log.warn('No project ID specified in app.json, unable to sign manifest');
+    Log.warn(
+      `Expo Application Services (EAS) is not configured for your project. Configuring EAS enables a more secure development experience amongst many other benefits. ${learnMore(
+        'https://docs.expo.dev/eas/'
+      )}`
+    );
     return null;
   }
 


### PR DESCRIPTION
# Why

This is part of an effort to default to using modern manifests and EAS update.

It depends on https://github.com/expo/expo/pull/22169 (to pull in the types).

This PR respects the new flag to default to classic if the flag is specified, but otherwise defaults to modern unless a classic URL is explicitly specified.

# How

Inspect for classic URL. If classic, use classic. Otherwise use modern.

# Test Plan

Run the command in a new project, see it uses the new manifest format.
<img width="689" alt="Screenshot 2023-04-17 at 1 55 39 PM" src="https://user-images.githubusercontent.com/189568/232615210-8900ee34-0390-42e5-bd94-7b7bdcd723b1.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
