### PR TITLE
[core] fix build error on rn 0.72

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Improve the initial loading speed of the native view. ([#22153](https://github.com/expo/expo/pull/22153) by [@lukmccall](https://github.com/lukmccall))
+- Fixed build errors on React Native 0.72.x. ([#22170](https://github.com/expo/expo/pull/22170) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -5,6 +5,7 @@
 
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
+#include <react/bridging/LongLivedObject.h>
 
 namespace jsi = facebook::jsi;
 
@@ -17,6 +18,7 @@ ExpoModulesHostObject::ExpoModulesHostObject(JSIInteropModuleRegistry *installer
  * Clears jsi references held by JSRegistry and JavaScriptRuntime. 
  */
 ExpoModulesHostObject::~ExpoModulesHostObject() {
+  facebook::react::LongLivedObjectCollection::get().clear();
   installer->jsRegistry.reset();
   installer->runtimeHolder.reset();
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -257,7 +257,6 @@ void JavaScriptModuleObject::registerSyncFunction(
 
   methodsMetadata.try_emplace(
     cName,
-    longLivedObjectCollection_,
     cName,
     takesOwner,
     args,
@@ -278,7 +277,6 @@ void JavaScriptModuleObject::registerAsyncFunction(
 
   methodsMetadata.try_emplace(
     cName,
-    longLivedObjectCollection_,
     cName,
     takesOwner,
     args,
@@ -298,7 +296,6 @@ void JavaScriptModuleObject::registerClass(
 ) {
   std::string cName = name->toStdString();
   MethodMetadata constructor(
-    longLivedObjectCollection_,
     "constructor",
     takesOwner,
     args,
@@ -330,7 +327,6 @@ void JavaScriptModuleObject::registerProperty(
   auto cName = name->toStdString();
 
   auto getterMetadata = MethodMetadata(
-    longLivedObjectCollection_,
     cName,
     false,
     0,
@@ -342,7 +338,6 @@ void JavaScriptModuleObject::registerProperty(
   auto types = std::vector<std::unique_ptr<AnyType>>();
   types.push_back(std::make_unique<AnyType>(jni::make_local(expectedArgType)));
   auto setterMetadata = MethodMetadata(
-    longLivedObjectCollection_,
     cName,
     false,
     1,
@@ -361,6 +356,5 @@ void JavaScriptModuleObject::registerProperty(
 
 JavaScriptModuleObject::JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis)
   : javaPart_(jni::make_global(jThis)) {
-  longLivedObjectCollection_ = std::make_shared<react::LongLivedObjectCollection>();
 }
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -4,7 +4,6 @@
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
-#include <react/bridging/LongLivedObject.h>
 #include <react/jni/ReadableNativeArray.h>
 #include <jni/JCallback.h>
 
@@ -179,11 +178,6 @@ private:
    * The first MethodMetadata points to the getter and the second one to the setter.
    */
   std::map<std::string, std::pair<MethodMetadata, MethodMetadata>> properties;
-
-  /**
-   * The `LongLivedObjectCollection` to hold `LongLivedObject` (callbacks or promises) for this module.
-   */
-  std::shared_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
 
   std::map<
     std::string,

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -9,7 +9,6 @@
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
 #include <ReactCommon/TurboModuleUtils.h>
-#include <react/bridging/LongLivedObject.h>
 #include <react/jni/ReadableNativeArray.h>
 #include <memory>
 #include <vector>
@@ -50,7 +49,6 @@ public:
   std::vector<std::unique_ptr<AnyType>> argTypes;
 
   MethodMetadata(
-    std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
     bool takesOwner,
     int args,
@@ -60,7 +58,6 @@ public:
   );
 
   MethodMetadata(
-    std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection,
     std::string name,
     bool takesOwner,
     int args,
@@ -119,8 +116,6 @@ private:
    * To not create a jsi::Function always when we need it, we cached that value.
    */
   std::shared_ptr<jsi::Function> body = nullptr;
-
-  std::weak_ptr<react::LongLivedObjectCollection> longLivedObjectCollection_;
 
   jsi::Function toSyncFunction(jsi::Runtime &runtime, JSIInteropModuleRegistry *moduleRegistry);
 


### PR DESCRIPTION
# Why

after react-native 0.72, the `LongLivedObjectCollection` constructor is removed and only available for the singleton: https://github.com/facebook/react-native/blob/9e5c963e2dbd90dbf2d260b67c2897e924be066e/packages/react-native/ReactCommon/react/bridging/LongLivedObject.h#L41-L44
the original solution from #19699 will have a build error on react-native 0.72

# How

rather than create a dedicated `LongLivedObjectCollection`, use the singleton `LongLivedObjectCollection` and do cleanup when `~ExpoModulesHostObject()`.

note: for react-native, the only call path to `LongLivedObjectCollection::get().clear()` is from TurboModuleBinding. in old architecture mode, react-native will not cleanup the `LongLivedObjectCollection`.

# Test Plan

follow #19699 to test the reloading

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
