### PR TITLE
[docs][build-properties-example] Fix expo-build-properties usage example in app.config.js

### DIFF
--- a/docs/pages/versions/unversioned/sdk/build-properties.mdx
+++ b/docs/pages/versions/unversioned/sdk/build-properties.mdx
@@ -52,21 +52,25 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 ### Example app.config.js usage
 
 ```js app.config.js
-import { withPlugins } from 'expo/config-plugins';
-import { withBuildProperties } from 'expo-build-properties';
-
-export default withPlugins(config, [
-  [withBuildProperties, {
-    "android": {
-      "compileSdkVersion": 31,
-      "targetSdkVersion": 31,
-      "buildToolsVersion": "31.0.0"
-    },
-    "ios": {
-      "deploymentTarget": "13.0"
-    }
-  }]
-]);
+export default {
+  expo: {
+    plugins: [
+      [
+        'expo-build-properties',
+        {
+          android: {
+            compileSdkVersion: 31,
+            targetSdkVersion: 31,
+            buildToolsVersion: '31.0.0',
+          },
+          ios: {
+            deploymentTarget: '13.0',
+          },
+        },
+      ],
+    ],
+  },
+};
 ```
 
 ### All configurable properties

--- a/docs/pages/versions/v48.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/build-properties.mdx
@@ -52,21 +52,25 @@ of your **android/gradle.properties** and **ios/Podfile.properties.json** direct
 ### Example app.config.js usage
 
 ```js app.config.js
-import { withPlugins } from 'expo/config-plugins';
-import { withBuildProperties } from 'expo-build-properties';
-
-export default withPlugins(config, [
-  [withBuildProperties, {
-    "android": {
-      "compileSdkVersion": 31,
-      "targetSdkVersion": 31,
-      "buildToolsVersion": "31.0.0"
-    },
-    "ios": {
-      "deploymentTarget": "13.0"
-    }
-  }]
-]);
+export default {
+  expo: {
+    plugins: [
+      [
+        'expo-build-properties',
+        {
+          android: {
+            compileSdkVersion: 31,
+            targetSdkVersion: 31,
+            buildToolsVersion: '31.0.0',
+          },
+          ios: {
+            deploymentTarget: '13.0',
+          },
+        },
+      ],
+    ],
+  },
+};
 ```
 
 ### All configurable properties


### PR DESCRIPTION
# Why
After speaking to someone on discord https://discord.com/channels/695411232856997968/943206692332658688/1097597491760861275 they had issues using the example code in `app.config.js`. 

# How
Updated the usage example.

# Test Plan
n/a
