### PR TITLE
[dev-launcher] fix build error on rn 0.72

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors on React Native 0.72.x. ([#22177](https://github.com/expo/expo/pull/22177) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -60,6 +60,7 @@ Pod::Spec.new do |s|
   s.dependency "EXUpdatesInterface"
   s.dependency "expo-dev-menu"
   s.dependency "ExpoModulesCore"
+  s.dependency 'SocketRocket'
 
   s.subspec 'Unsafe' do |unsafe|
     unsafe.source_files = 'ios/Unsafe/**/*.{h,m,mm,swift,cpp}'

--- a/packages/expo-dev-launcher/expo-module.config.json
+++ b/packages/expo-dev-launcher/expo-module.config.json
@@ -4,6 +4,7 @@
   "ios": {
     "podspecPath": "expo-dev-launcher.podspec",
     "swiftModuleName": "EXDevLauncher",
+    "modules": ["ExpoDevLauncherModule"],
     "appDelegateSubscribers": ["ExpoDevLauncherAppDelegateSubscriber"],
     "reactDelegateHandlers": ["ExpoDevLauncherReactDelegateHandler"],
     "debugOnly": true

--- a/packages/expo-dev-launcher/ios/ExpoDevLauncherModule.swift
+++ b/packages/expo-dev-launcher/ios/ExpoDevLauncherModule.swift
@@ -1,0 +1,11 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+/**
+ Stub empty module for expo-dev-launcher to enable `use_modular_headers_for_dependencies`
+ */
+final public class ExpoDevLauncherModule: Module {
+  public func definition() -> ModuleDefinition {
+  }
+}

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -1,3 +1,4 @@
+import SocketRocket
 import React
 
 #if DEBUG && EX_DEV_CLIENT_NETWORK_INSPECTOR
@@ -204,7 +205,7 @@ extension RCTInspectorPackagerConnection {
     guard isConnected() else {
       return false
     }
-    guard let webSocket = value(forKey: "_webSocket") as? RCTSRWebSocket else {
+    guard let webSocket = value(forKey: "_webSocket") as? SRWebSocket else {
       return false
     }
     return webSocket.readyState == .OPEN


### PR DESCRIPTION
# Why

expo-dev-launcher has a build error when upgrading to react-native 0.72 because of `RCTSRWebSocket` is being replaced with `SRWebSocket`: https://github.com/facebook/react-native/commit/9ee0e1c78e422a83de01d045657c10454f66980a

# How

use `SRWebSocket` rather than `RCTSRWebSocket`. but now we need a dependency to `SocketRocket` and add a stub module for autolinking to enable `use_modular_headers_for_dependencies` for `SocketRocket`

# Test Plan

- ci passed
- test network inspector on sdk 48 (supposedly backward compatible because of `RCTSRWebSocket` is derived of `SocketRocket`)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
