### PR TITLE
fix: remove group arrays from router type generation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - Fix main field resolution for metro web. ([#21939](https://github.com/expo/expo/pull/21939) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cached code signing development certificate offline behavior. ([#21989](https://github.com/expo/expo/pull/21989) by [@wschurman](https://github.com/wschurman))
+- Remove invalid array group syntax from Expo Router type generation. ([#22185](https://github.com/expo/expo/pull/22185) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -108,7 +108,6 @@ describe(getTypedRoutesUtils, () => {
         {
           static: [
             '/page',
-            '/(a,b,c)/(d,e)/page',
             '/(a)/page',
             '/(a)/(d)/page',
             '/(a)/(e)/page',

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -159,7 +159,9 @@ export function getTypedRoutesUtils(appRoot: string) {
       }
     };
 
-    addRoute(route, route);
+    if (!route.match(ARRAY_GROUP_REGEX)) {
+      addRoute(route, route);
+    }
 
     // Does this route have a group? eg /(group)
     if (route.includes('/(')) {


### PR DESCRIPTION
# Why

Removes [array groups from Expo Router type generation](https://expo.github.io/router/docs/features/routing#arrays). We do not currently support this syntax for `Href` & `HrefObject`