### PR TITLE
fix: android crash if thumbnail cannot be created (e.g. file corruption)

### DIFF
--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailsModule.kt
@@ -40,22 +40,27 @@ class VideoThumbnailsModule : Module() {
         val thumbnail = GetThumbnail(sourceFilename, options, context).execute()
           ?: throw GenerateThumbnailException()
 
-        try {
-          val path = FileUtilities.generateOutputPath(context.cacheDir, "VideoThumbnails", "jpg")
-          FileOutputStream(path).use { outputStream ->
-            thumbnail.compress(Bitmap.CompressFormat.JPEG, (options.quality * 100).toInt(), outputStream)
-          }
-          promise.resolve(
-            VideoThumbnailResult(
-              uri = Uri.fromFile(File(path)).toString(),
-              width = thumbnail.width,
-              height = thumbnail.height
+        if(thumbnail == null){
+          promise.reject(ERROR_TAG, "Thumbnail generation failed", GenerateThumbnailException())
+        }
+        else{
+          try {
+            val path = FileUtilities.generateOutputPath(context.cacheDir, "VideoThumbnails", "jpg")
+            FileOutputStream(path).use { outputStream ->
+              thumbnail.compress(Bitmap.CompressFormat.JPEG, (options.quality * 100).toInt(), outputStream)
+            }
+            promise.resolve(
+              VideoThumbnailResult(
+                uri = Uri.fromFile(File(path)).toString(),
+                width = thumbnail.width,
+                height = thumbnail.height
+              )
             )
-          )
-        } catch (ex: IOException) {
-          promise.reject(ERROR_TAG, ex.message, ex)
-        } catch (ex: RuntimeException) {
-          promise.reject(ERROR_TAG, ex.message, ex)
+          } catch (ex: IOException) {
+            promise.reject(ERROR_TAG, ex.message, ex)
+          } catch (ex: RuntimeException) {
+            promise.reject(ERROR_TAG, ex.message, ex)
+          }
         }
       }
     }
@@ -71,21 +76,28 @@ class VideoThumbnailsModule : Module() {
 
   private class GetThumbnail(private val sourceFilename: String, private val videoOptions: VideoThumbnailOptions, private val context: Context) {
     fun execute(): Bitmap? {
-      val retriever = MediaMetadataRetriever()
+      try{
+        val retriever = MediaMetadataRetriever()
 
-      if (URLUtil.isFileUrl(sourceFilename)) {
-        retriever.setDataSource(Uri.decode(sourceFilename).replace("file://", ""))
-      } else if (URLUtil.isContentUrl(sourceFilename)) {
-        val fileUri = Uri.parse(sourceFilename)
-        val fileDescriptor = context.contentResolver.openFileDescriptor(fileUri, "r")!!.fileDescriptor
-        FileInputStream(fileDescriptor).use { inputStream ->
-          retriever.setDataSource(inputStream.fd)
+        if (URLUtil.isFileUrl(sourceFilename)) {
+          retriever.setDataSource(Uri.decode(sourceFilename).replace("file://", ""))
+        } else if (URLUtil.isContentUrl(sourceFilename)) {
+          val fileUri = Uri.parse(sourceFilename)
+          val fileDescriptor = context.contentResolver.openFileDescriptor(fileUri, "r")!!.fileDescriptor
+          FileInputStream(fileDescriptor).use { inputStream ->
+            retriever.setDataSource(inputStream.fd)
+          }
+        } else {
+          retriever.setDataSource(sourceFilename, videoOptions.headers)
         }
-      } else {
-        retriever.setDataSource(sourceFilename, videoOptions.headers)
-      }
 
-      return retriever.getFrameAtTime(videoOptions.time.toLong() * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+        return retriever.getFrameAtTime(videoOptions.time.toLong() * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+      }
+      catch(e: RuntimeException){
+        Log.e(ERROR_TAG, "setDataSource failed")
+
+        return null
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Seems like there is a regression in SDK 48. Came across this PR when I was looking up the crash logs we were getting in prod.
https://github.com/expo/expo/pull/6877
The module crashes on Android if a thumbnail cannot be created (due to file corruption for example).

# How

Simple exception handling. Could probably be done better, but I am by no means good at Kotlin.

# Test Plan

Install version 7.2.1 of expo-video-thumbnails from NPM, corrupt a video file on purpose and watch the app crash when trying to generate a thumbnail of it.

Simply rejects the promise now instead of throwing an uncaught exception.

# Checklist

- [ x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [? ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
