### PR TITLE
[core][dev-launcher][tools] fix react-native nightlies testing

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed build errors on React Native 0.72.x. ([#22189](https://github.com/expo/expo/pull/22189) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 - Convert EXManifests iOS implementation to Swift. ([#21298](https://github.com/expo/expo/pull/21298) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
+++ b/packages/expo-dev-launcher/ios/Network/EXDevLauncherNetworkLogger.swift
@@ -204,10 +204,17 @@ extension RCTInspectorPackagerConnection {
     guard isConnected() else {
       return false
     }
-    guard let webSocket = value(forKey: "_webSocket") as? RCTSRWebSocket else {
+    guard let webSocket = value(forKey: "_webSocket") as? AnyObject,
+      let readyState = webSocket.value(forKey: "readyState") as? Int else {
       return false
     }
-    return webSocket.readyState == .OPEN
+    // To support both RCTSRWebSocket (RN < 0.72) and SRWebSocket (RN >= 0.72)
+    // and not to introduce extra podspec dependencies,
+    // we use the internal and hardcoded value here.
+    // Given the fact that both RCTSRWebSocket and SRWebSocket has the readyState property
+    // and the open state is 1.
+    let OPEN_STATE = 1
+    return readyState == OPEN_STATE
   }
 
   /**

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Improve the initial loading speed of the native view. ([#22153](https://github.com/expo/expo/pull/22153) by [@lukmccall](https://github.com/lukmccall))
-- Fixed build errors on React Native 0.72.x. ([#22170](https://github.com/expo/expo/pull/22170) by [@kudo](https://github.com/kudo))
+- Fixed build errors on React Native 0.72.x. ([#22170](https://github.com/expo/expo/pull/22170), [#22189](https://github.com/expo/expo/pull/22189) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -68,6 +68,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-Core'
   s.dependency 'ReactCommon/turbomodule/core'
   s.dependency 'React-RCTAppDelegate' if REACT_NATIVE_MINOR_VERSION >= 71
+  s.dependency 'React-NativeModulesApple' if REACT_NATIVE_MINOR_VERSION >= 72
 
   if fabric_enabled
     compiler_flags << ' ' << fabric_compiler_flags


### PR DESCRIPTION
# Why

before upgrading react-native 0.72, let's fix the nightlies testing first.

# How

- [core][dev-launcher] fix build errors on 0.72
- [tools] update SetupReactNativeNightly

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
