### PR TITLE
[core][Android] Fix the `Color` converter that doesn't work on devices with SDK version below 26.

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fix failing instrumentation tests in JavaScriptViewModule. ([#22518](https://github.com/expo/expo/pull/22518) by [@aleqsio](https://github.com/aleqsio))
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
+- [Android] Fix the `Color` converter doesn't work on devices with SDK version below 26.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - Fix failing instrumentation tests in JavaScriptViewModule. ([#22518](https://github.com/expo/expo/pull/22518) by [@aleqsio](https://github.com/aleqsio))
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
-- [Android] Fix the `Color` converter doesn't work on devices with SDK version below 26.
+- [Android] Fix the `Color` converter doesn't work on devices with SDK version below 26. ([#22191](https://github.com/expo/expo/pull/22191) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -1,6 +1,8 @@
 package expo.modules.kotlin.types
 
 import android.graphics.Color
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.exception.UnexpectedException
@@ -166,6 +168,7 @@ private val namedColors = mapOf(
   value.map { it.toFloat() / 255f }
 }
 
+@RequiresApi(Build.VERSION_CODES.O)
 class ColorTypeConverter(
   isOptional: Boolean
 ) : DynamicAwareTypeConverters<Color>(isOptional) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -272,8 +272,6 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       BigUint64Array::class.createType(nullable = isOptional) to BigUint64ArrayTypeConverter(isOptional),
       TypedArray::class.createType(nullable = isOptional) to TypedArrayTypeConverter(isOptional),
 
-      Color::class.createType(nullable = isOptional) to ColorTypeConverter(isOptional),
-
       URL::class.createType(nullable = isOptional) to URLTypConverter(isOptional),
       Uri::class.createType(nullable = isOptional) to UriTypeConverter(isOptional),
       URI::class.createType(nullable = isOptional) to JavaURITypeConverter(isOptional),
@@ -286,6 +284,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
       return converters + mapOf(
         Path::class.createType(nullable = isOptional) to PathTypeConverter(isOptional),
+        Color::class.createType(nullable = isOptional) to ColorTypeConverter(isOptional),
       )
     }
 


### PR DESCRIPTION
# Why

The [Color.valueOf] feature seems not accessible on Android devices with versions below 26.
 
# Test Plan

- bare-expo ✅