### PR TITLE
[ios][sharing] Fix crash when share menu is presented on iPad

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On iOS, fix crash when share menu is presented on iPad.
+- On iOS, fix crash when share menu is presented on iPad. ([#22193](https://github.com/expo/expo/pull/22193) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, fix crash when share menu is presented on iPad.
+
 ### 💡 Others
 
 ## 11.3.1 — 2023-04-14

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -36,6 +36,18 @@ public final class SharingModule: Module {
         throw MissingCurrentViewControllerException()
       }
 
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        let viewFrame = currentViewcontroller.view.frame
+        activityController.popoverPresentationController?.sourceRect = CGRect(
+          x: viewFrame.midX,
+          y: viewFrame.maxY,
+          width: 0,
+          height: 0
+        )
+        activityController.popoverPresentationController?.sourceView = currentViewcontroller.view
+        activityController.modalPresentationStyle = .pageSheet
+      }
+
       currentViewcontroller.present(activityController, animated: true)
     }
     .runOnQueue(.main)

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -36,6 +36,8 @@ public final class SharingModule: Module {
         throw MissingCurrentViewControllerException()
       }
 
+      /// Apple docs state that `UIActivityViewController` must be presented in a
+      /// popover on iPad https://developer.apple.com/documentation/uikit/uiactivityviewcontroller
       if UIDevice.current.userInterfaceIdiom == .pad {
         let viewFrame = currentViewcontroller.view.frame
         activityController.popoverPresentationController?.sourceRect = CGRect(

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -36,8 +36,8 @@ public final class SharingModule: Module {
         throw MissingCurrentViewControllerException()
       }
 
-      /// Apple docs state that `UIActivityViewController` must be presented in a
-      /// popover on iPad https://developer.apple.com/documentation/uikit/uiactivityviewcontroller
+      // Apple docs state that `UIActivityViewController` must be presented in a
+      // popover on iPad https://developer.apple.com/documentation/uikit/uiactivityviewcontroller
       if UIDevice.current.userInterfaceIdiom == .pad {
         let viewFrame = currentViewcontroller.view.frame
         activityController.popoverPresentationController?.sourceRect = CGRect(


### PR DESCRIPTION
# Why 
`popoverPresentationController` should be configured when on an iPad
Closes #22192

# How
Check if we are on an iPad and configure the `popoverPresentationController`

# Test Plan
Tested on a physical iPad and simulator with bare expo
