### PR TITLE
[et] commands for build and submitting Expo Go using EAS

### DIFF
--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -10,8 +10,6 @@ on:
         options:
           - versioned-client
           - unversioned-client
-          - versioned-client-signed
-          - versioned-client-signed-apk
           - versioned-client-add-sdk
   schedule:
     # 5:20 AM UTC time on every Monday, Wednesday and Friday

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -10,7 +10,6 @@ on:
         options:
           - versioned-client
           - unversioned-client
-          - versioned-client-signed
           - versioned-client-add-sdk
   schedule:
     # 5:20 AM UTC time on every Monday, Wednesday and Friday

--- a/apps/eas-expo-go/.envrc
+++ b/apps/eas-expo-go/.envrc
@@ -1,0 +1,1 @@
+export EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID=host.exp.exponent

--- a/apps/eas-expo-go/.gitignore
+++ b/apps/eas-expo-go/.gitignore
@@ -1,2 +1,3 @@
 credentials.json
 release.keystore
+credentials/**

--- a/apps/eas-expo-go/app.config.ts
+++ b/apps/eas-expo-go/app.config.ts
@@ -26,26 +26,6 @@ const mapBuildProfileToConfig: Record<string, ExpoConfig> = {
       },
     },
   },
-  'versioned-client-signed': {
-    ...base,
-    slug: 'versioned-expo-go',
-    name: 'Expo Go (versioned)',
-    extra: {
-      eas: {
-        projectId: '97ab66f4-49e2-4ec7-85cc-922c56a68bae',
-      },
-    },
-  },
-  'versioned-client-signed-apk': {
-    ...base,
-    slug: 'versioned-expo-go',
-    name: 'Expo Go (versioned)',
-    extra: {
-      eas: {
-        projectId: '97ab66f4-49e2-4ec7-85cc-922c56a68bae',
-      },
-    },
-  },
   'unversioned-client': {
     ...base,
     slug: 'unversioned-expo-go',
@@ -53,6 +33,16 @@ const mapBuildProfileToConfig: Record<string, ExpoConfig> = {
     extra: {
       eas: {
         projectId: '09066dbe-ef65-460e-9201-b7aa931abbf4',
+      },
+    },
+  },
+  'release-client': {
+    ...base,
+    slug: 'release-expo-go',
+    name: 'Expo Go',
+    extra: {
+      eas: {
+        projectId: '79a64298-2d61-42ae-9cc9-b2a358d6869e',
       },
     },
   },

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -78,6 +78,7 @@
         "EAS_BUILD_PROFILE": "release-client"
       },
       "android": {
+        "autoIncrement": "versionCode",
         "cache": {
           "disabled": true
         },
@@ -85,6 +86,7 @@
         "gradleCommand": ":app:bundleVersionedRelease"
       },
       "ios": {
+        "autoIncrement": "buildNumber",
         "resourceClass": "m-large",
         "cache": {
           "disabled": true
@@ -103,7 +105,7 @@
       },
       "android": {
         "serviceAccountKeyPath": "./credentials/secrets/android-service-account-key.json",
-        "track": "internal"
+        "track": "production"
       }
     }
   }

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -1,7 +1,9 @@
 {
   "cli": {
     "version": ">= 0.52.0",
-    "requireCommit": true
+    "requireCommit": true,
+    "appVersionSource": "remote",
+    "promptToConfigurePushNotifications": false
   },
   "build": {
     "base": {
@@ -23,8 +25,9 @@
       "ios": {
         "cache": {
           "key": "sdk48-0.71.3",
-          "cacheDefaultPaths": false,
-          "customPaths": ["../../ios/Pods"]
+          "customPaths": [
+            "../../ios/Pods"
+          ]
         },
         "resourceClass": "m-medium",
         "env": {
@@ -48,29 +51,6 @@
         "buildConfiguration": "Release"
       }
     },
-    "versioned-client-signed": {
-      "extends": "versioned-client",
-      "env": {
-        "EAS_BUILD_PROFILE": "versioned-client-signed"
-      },
-      "android": {
-        "withoutCredentials": false,
-        "gradleCommand": ":app:bundleVersionedRelease"
-      },
-      "ios": {
-        "credentialsSource": "remote",
-        "simulator": false
-      }
-    },
-    "versioned-client-signed-apk": {
-      "extends": "versioned-client-signed",
-      "env": {
-        "EAS_BUILD_PROFILE": "versioned-client-signed-apk"
-      },
-      "android": {
-        "gradleCommand": ":app:assembleVersionedRelease"
-      }
-    },
     "versioned-client-add-sdk": {
       "extends": "versioned-client",
       "env": {
@@ -90,6 +70,40 @@
         "scheme": "Expo Go \\(unversioned\\)",
         "simulator": true,
         "buildConfiguration": "Release"
+      }
+    },
+    "release-client": {
+      "extends": "versioned-client",
+      "env": {
+        "EAS_BUILD_PROFILE": "release-client"
+      },
+      "android": {
+        "cache": {
+          "disabled": true
+        },
+        "withoutCredentials": false,
+        "gradleCommand": ":app:bundleVersionedRelease"
+      },
+      "ios": {
+        "resourceClass": "m-large",
+        "cache": {
+          "disabled": true
+        },
+        "simulator": false
+      }
+    }
+  },
+  "submit": {
+    "release-client": {
+      "ios": {
+        "ascApiKeyPath": "./credentials/secrets/ios-AuthKey-2A94XP6D72.p8",
+        "ascApiKeyId": "2A94XP6D72",
+        "ascApiKeyIssuerId": "69a6de7e-ee52-47e3-e053-5b8c7c11a4d1",
+        "ascAppId": "982107779"
+      },
+      "android": {
+        "serviceAccountKeyPath": "./credentials/secrets/android-service-account-key.json",
+        "track": "internal"
       }
     }
   }

--- a/apps/eas-expo-go/package.json
+++ b/apps/eas-expo-go/package.json
@@ -10,6 +10,7 @@
     "postinstall": "expo-yarn-workspaces postinstall",
     "eas-build-pre-install": "./scripts/eas-build-pre-install.sh",
     "eas-build-post-install": "./scripts/eas-build-post-install.sh",
-    "eas-build-pre-upload-artifacts": "./scripts/eas-build-pre-upload-artifacts.sh"
+    "eas-build-pre-upload-artifacts": "./scripts/eas-build-pre-upload-artifacts.sh",
+    "eas-build-on-success": "./scripts/eas-build-on-success.sh"
   }
 }

--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -13,26 +13,27 @@ notify_slack(){
     $SLACK_HOOK
 }
 
-fake_notify_slack(){
-  echo "TITLE: $1"
-  echo "MESSAGE: $2"
-}
-
 if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
   SLUG="release-client"
   COMMIT_HASH="$(git rev-parse HEAD)"
   COMMIT_AUTHOR="$(git log --pretty=format:"%an - %ae" | head -n 1)"
 
-  EAS_BUILD_MESSAGE_PART="EAS Build: [$EAS_BUILD_ID](https://expo.dev/accounts/expo-ci/projects/$SLUG/builds/$EAS_BUILD_ID)"
-  GITHUB_MESSAGE_PART="GitHub: [$COMMIT_HASH](https://github.com/expo/expo/commit/$COMMIT_HASH)"
+  EAS_BUILD_MESSAGE_PART="EAS Build: <https://expo.dev/accounts/expo-ci/projects/$SLUG/builds/$EAS_BUILD_ID|$EAS_BUILD_ID>"
+  GITHUB_MESSAGE_PART="GitHub: <https://github.com/expo/expo/commit/$COMMIT_HASH|$COMMIT_HASH>"
 
   TITLE=""
   if [[ "$EAS_BUILD_PLATFORM" = "android" ]]; then
-    TITLE="Successfull Expo Go release build. Submitting build to the Play Store"
+    TITLE="Successfull Expo Go release build. Submitting build to the Play Store."
   elif [[ "$EAS_BUILD_PLATFORM" = "ios" ]]; then
-    TITLE="Successfull Expo Go release build. Submitting build to the TestFlight"
+    TITLE="Successfull Expo Go release build. Submitting build to the TestFlight."
   fi
   MESSAGE="Release triggered by: $EAS_BUILD_USERNAME\\nCommit author: $COMMIT_AUTHOR\\n$EAS_BUILD_MESSAGE_PART\\n$GITHUB_MESSAGE_PART"
 
-  fake_notify_slack "$TITLE" "$MESSAGE"
+  if [[ ! -z "$SLACK_HOOK" ]]; then
+    notify_slack "$TITLE" "$MESSAGE"
+  else
+    echo "SLACK_HOOK is not defined, skip sending slack notification."
+    echo "TITLE: $TITLE"
+    echo "MESSAGE: $MESSAGE"
+  fi
 fi

--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. && pwd )"
+export PATH="$ROOT_DIR/bin:$PATH"
+
+notify_slack(){
+  curl \
+    -X POST \
+    -H 'Content-type: application/json' \
+    --data "{ \"text\": \"$1\", \"attachments\": [ { \"text\": \"$2\", \"color\": \"good\" } ] }" \
+    $SLACK_HOOK
+}
+
+fake_notify_slack(){
+  echo "TITLE: $1"
+  echo "MESSAGE: $2"
+}
+
+if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
+  SLUG="release-client"
+  COMMIT_HASH="$(git rev-parse HEAD)"
+  COMMIT_AUTHOR="$(git log --pretty=format:"%an - %ae" | head -n 1)"
+
+  EAS_BUILD_MESSAGE_PART="EAS Build: [$EAS_BUILD_ID](https://expo.dev/accounts/expo-ci/projects/$SLUG/builds/$EAS_BUILD_ID)"
+  GITHUB_MESSAGE_PART="GitHub: [$COMMIT_HASH](https://github.com/expo/expo/commit/$COMMIT_HASH)"
+
+  TITLE=""
+  if [[ "$EAS_BUILD_PLATFORM" = "android" ]]; then
+    TITLE="Successfull Expo Go release build. Submitting build to the Play Store"
+  elif [[ "$EAS_BUILD_PLATFORM" = "ios" ]]; then
+    TITLE="Successfull Expo Go release build. Submitting build to the TestFlight"
+  fi
+  MESSAGE="Release triggered by: $EAS_BUILD_USERNAME\\nCommit author: $COMMIT_AUTHOR\\n$EAS_BUILD_MESSAGE_PART\\n$GITHUB_MESSAGE_PART"
+
+  fake_notify_slack "$TITLE" "$MESSAGE"
+fi

--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. && pwd )"
 
 if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
   sudo apt-get -y update
-  sudo apt-get -y install ruby icu-devtools libicu66 libicu-dev maven 
+  sudo apt-get -y install ruby icu-devtools libicu66 libicu-dev maven
   sdkmanager "cmake;3.22.1"
 fi
 

--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -6,8 +6,18 @@ ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../.. && pwd )"
 
 if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
   sudo apt-get -y update
-  sudo apt-get -y install ruby icu-devtools libicu66 libicu-dev maven
+  sudo apt-get -y install ruby icu-devtools libicu66 libicu-dev maven 
   sdkmanager "cmake;3.22.1"
+fi
+
+if [ "$EAS_BUILD_PROFILE" = "release-client" ]; then
+  if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
+    sudo apt-get -y update
+    sudo apt-get -y install git-crypt
+  elif [ "$EAS_BUILD_PLATFORM" = "ios" ]; then
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install git-crypt
+  fi
+  git-crypt unlock $GIT_CRYPT_KEY
 fi
 
 cat << EOF > $ROOT_DIR/.gitmodules

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.28.8</string>
+	<string>2.28.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -55,7 +55,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.28.8</string>
+	<string>2.28.2</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false/>
 	<key>FacebookAppID</key>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.28.2</string>
+	<string>2.28.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -55,7 +55,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>2.28.2</string>
+	<string>2.28.8</string>
 	<key>FacebookAdvertiserIDCollectionEnabled</key>
 	<false/>
 	<key>FacebookAppID</key>

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -52,6 +52,7 @@ async function iosBuildAndSubmitAsync() {
   const credentialsDir = path.join(projectDir, 'credentials');
   const fastlaneMatchBucketCopyPath = path.join(credentialsDir, 'fastlane-match');
   const releaseSecretsPath = path.join(credentialsDir, 'secrets');
+  const isDarwin = os.platform() === 'darwin';
 
   try {
     await mkdirp(fastlaneMatchBucketCopyPath);
@@ -97,7 +98,7 @@ async function iosBuildAndSubmitAsync() {
       [
         'pkcs12',
         '-export',
-        '-legacy',
+        ...(isDarwin ? [] : ['-legacy']),
         '-out',
         p12KeystorePath,
         '-inkey',

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -207,4 +207,18 @@ async function androidBuildAndSubmitAsync() {
       },
     }
   );
+
+  logger.info('Updating versionCode in local app/build.gradle with value from EAS servers.');
+  await spawnAsync(
+    'eas',
+    ['build:version:sync', '--platform', 'android', '--profile', RELEASE_BUILD_PROFILE],
+    {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: 'host.exp.exponent',
+      },
+    }
+  );
 }

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -101,10 +101,6 @@ async function iosBuildAndSubmitAsync() {
     `pass:${p12KeystorePassword}`,
   ]);
 
-  // TODO
-  // - Enable auto-increment on release-client build profile
-  // - Add --auto-submit option
-
   await fs.writeFile(
     path.join(projectDir, 'credentials.json'),
     JSON.stringify({
@@ -133,10 +129,14 @@ async function iosBuildAndSubmitAsync() {
     })
   );
 
-  await spawnAsync('eas', ['build', '--platform', 'ios', '--profile', RELEASE_BUILD_PROFILE], {
-    cwd: projectDir,
-    stdio: 'inherit',
-  });
+  await spawnAsync(
+    'eas',
+    ['build', '--platform', 'ios', '--profile', RELEASE_BUILD_PROFILE, '--auto-submit'],
+    {
+      cwd: projectDir,
+      stdio: 'inherit',
+    }
+  );
 }
 
 async function androidBuildAndSubmitAsync() {
@@ -160,11 +160,6 @@ async function androidBuildAndSubmitAsync() {
     releaseSecretsPath,
   ]);
 
-  // TODO:
-  // - Change track to production (using internal track for testing)
-  // - Enable auto-increment on release-client build profile
-  // - Add --auto-submit option
-
   await fs.writeFile(
     path.join(projectDir, 'credentials.json'),
     JSON.stringify({
@@ -179,12 +174,16 @@ async function androidBuildAndSubmitAsync() {
     })
   );
 
-  await spawnAsync('eas', ['build', '--platform', 'android', '--profile', RELEASE_BUILD_PROFILE], {
-    cwd: projectDir,
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: 'host.exp.exponent',
-    },
-  });
+  await spawnAsync(
+    'eas',
+    ['build', '--platform', 'android', '--profile', RELEASE_BUILD_PROFILE, '--auto-submit'],
+    {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: 'host.exp.exponent',
+      },
+    }
+  );
 }

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -139,9 +139,11 @@ async function iosBuildAndSubmitAsync() {
       })
     );
   } catch (err) {
-    logger.error(
-      'There was an error when preparing build credentials. Run with EXPO_DEBUG=1 env to see more details.'
-    );
+    if (!isDebug) {
+      logger.error(
+        'There was an error when preparing build credentials. Run with EXPO_DEBUG=1 env to see more details.'
+      );
+    }
     throw err;
   }
 
@@ -190,9 +192,11 @@ async function androidBuildAndSubmitAsync() {
       })
     );
   } catch (err) {
-    logger.error(
-      'There was an error when preparing build credentials. Run with EXPO_DEBUG=1 env to see more details.'
-    );
+    if (!isDebug) {
+      logger.error(
+        'There was an error when preparing build credentials. Run with EXPO_DEBUG=1 env to see more details.'
+      );
+    }
     throw err;
   }
   await spawnAsync(

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -3,6 +3,7 @@ import spawnAsync from '@expo/spawn-async';
 import assert from 'assert';
 import fs, { mkdirp } from 'fs-extra';
 import glob from 'glob-promise';
+import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -1,0 +1,190 @@
+import { Command } from '@expo/commander';
+import spawnAsync from '@expo/spawn-async';
+import assert from 'assert';
+import fs, { mkdirp } from 'fs-extra';
+import glob from 'glob-promise';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+
+import { EXPO_DIR } from '../Constants';
+import logger from '../Logger';
+
+const RELEASE_BUILD_PROFILE = 'release-client';
+
+const CUSTOM_ACTIONS = {
+  'ios-client-build-and-submit': {
+    name: 'Build a new iOS client and submit it to the App Store',
+    actionId: 'ios-client-build-and-submit',
+    action: iosBuildAndSubmitAsync,
+  },
+  'android-client-build-and-submit': {
+    name: 'Build a new Android client and submit it to the Play Store',
+    actionId: 'android-client-build-and-submit',
+    action: androidBuildAndSubmitAsync,
+  },
+};
+
+export default (program: Command) => {
+  program
+    .command('eas-dispatch [action]')
+    .alias('eas')
+    .description(`Runs predefined EAS Build & Submit jobs.`)
+    .asyncAction(main);
+};
+
+async function main(actionId: string | undefined) {
+  if (!actionId || !CUSTOM_ACTIONS[actionId]) {
+    const actions = Object.values(CUSTOM_ACTIONS).map((i) => `\n- ${i.actionId} - ${i.name}`);
+    if (!actionId) {
+      logger.error(`You need to provide action name. Select one of: ${actions}`);
+    } else {
+      logger.error(`Unknown action ${actionId}. Select one of: ${actions}`);
+    }
+    return;
+  }
+
+  CUSTOM_ACTIONS[actionId].action();
+}
+
+async function iosBuildAndSubmitAsync() {
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  const credentialsDir = path.join(projectDir, 'credentials');
+  const fastlaneMatchBucketCopyPath = path.join(credentialsDir, 'fastlane-match');
+  const releaseSecretsPath = path.join(credentialsDir, 'secrets');
+  await mkdirp(fastlaneMatchBucketCopyPath);
+  await mkdirp(releaseSecretsPath);
+  await spawnAsync('gsutil', [
+    'rsync',
+    '-r',
+    '-d',
+    'gs://expo-client-certificates',
+    fastlaneMatchBucketCopyPath,
+  ]);
+  await spawnAsync('gsutil', [
+    'rsync',
+    '-r',
+    '-d',
+    'gs://expo-go-release-secrets',
+    releaseSecretsPath,
+  ]);
+
+  const privateKeyMatches = glob.sync('*/certs/distribution/*.p12', {
+    absolute: true,
+    cwd: fastlaneMatchBucketCopyPath,
+  });
+  assert(privateKeyMatches.length === 1);
+  const privateKeyPath = privateKeyMatches[0];
+
+  const certDERMatches = glob.sync('*/certs/distribution/*.cer', {
+    absolute: true,
+    cwd: fastlaneMatchBucketCopyPath,
+  });
+  assert(certDERMatches.length === 1);
+  const certDERPath = certDERMatches[0];
+
+  const certPEMPath = path.join(credentialsDir, 'cert.pem');
+  const p12KeystorePath = path.join(credentialsDir, 'dist.p12');
+  const p12KeystorePassword = uuidv4();
+
+  await spawnAsync('openssl', ['x509', '-inform', 'der', '-in', certDERPath, '-out', certPEMPath]);
+  await spawnAsync('openssl', [
+    'pkcs12',
+    '-export',
+    '-legacy',
+    '-out',
+    p12KeystorePath,
+    '-inkey',
+    privateKeyPath,
+    '-in',
+    certPEMPath,
+    '-password',
+    `pass:${p12KeystorePassword}`,
+  ]);
+
+  // TODO
+  // - Enable auto-increment on release-client build profile
+  // - Add --auto-submit option
+
+  await fs.writeFile(
+    path.join(projectDir, 'credentials.json'),
+    JSON.stringify({
+      ios: {
+        'Expo Go (versioned)': {
+          provisioningProfilePath: path.join(
+            fastlaneMatchBucketCopyPath,
+            'C8D8QTF339/profiles/appstore/AppStore_host.exp.Exponent.mobileprovision'
+          ),
+          distributionCertificate: {
+            path: p12KeystorePath,
+            password: p12KeystorePassword,
+          },
+        },
+        ExpoNotificationServiceExtension: {
+          provisioningProfilePath: path.join(
+            fastlaneMatchBucketCopyPath,
+            'C8D8QTF339/profiles/appstore/AppStore_host.exp.Exponent.ExpoNotificationServiceExtension.mobileprovision'
+          ),
+          distributionCertificate: {
+            path: p12KeystorePath,
+            password: p12KeystorePassword,
+          },
+        },
+      },
+    })
+  );
+
+  await spawnAsync('eas', ['build', '--platform', 'ios', '--profile', RELEASE_BUILD_PROFILE], {
+    cwd: projectDir,
+    stdio: 'inherit',
+  });
+}
+
+async function androidBuildAndSubmitAsync() {
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  const credentialsDir = path.join(projectDir, 'credentials');
+  const releaseSecretsPath = path.join(credentialsDir, 'secrets');
+  await mkdirp(releaseSecretsPath);
+
+  const keystorePath = path.join(releaseSecretsPath, 'android-keystore.jks');
+  const keystorePasswordPath = path.join(releaseSecretsPath, 'android-keystore.password');
+  const keystoreAliasPasswordPath = path.join(
+    releaseSecretsPath,
+    'android-keystore-alias.password'
+  );
+
+  await spawnAsync('gsutil', [
+    'rsync',
+    '-r',
+    '-d',
+    'gs://expo-go-release-secrets',
+    releaseSecretsPath,
+  ]);
+
+  // TODO:
+  // - Change track to production (using internal track for testing)
+  // - Enable auto-increment on release-client build profile
+  // - Add --auto-submit option
+
+  await fs.writeFile(
+    path.join(projectDir, 'credentials.json'),
+    JSON.stringify({
+      android: {
+        keystore: {
+          keystorePath,
+          keystorePassword: (await fs.readFile(keystorePasswordPath, 'utf-8')).trim(),
+          keyAlias: 'ExponentKey',
+          keyPassword: (await fs.readFile(keystoreAliasPasswordPath, 'utf-8')).trim(),
+        },
+      },
+    })
+  );
+
+  await spawnAsync('eas', ['build', '--platform', 'android', '--profile', RELEASE_BUILD_PROFILE], {
+    cwd: projectDir,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: 'host.exp.exponent',
+    },
+  });
+}


### PR DESCRIPTION
# Why

We want to use EAS Build & Submit to deliver Expo Go to the stores.

# How

- Remove existing workflows for building signed apps that were set up on a CI. I'm not sure if everything worked, plus we don't want to maintain both approaches.
- iOS Build & Submit:
  - download credentials from GCS bucket generated by Fastlane match
  - use openssl to convert credentials into p12 keystore
  - generate credentials.json
  - Run build and submit using EAS CLI
- Android Build&Submit
  - I don't have credentials yet so I used some random Keystore for testing. I'll download it from GCS bucket when it's ready
  - Create credentials.json.
  - Set track to internal, but it will be switched to production after everything is implemented and tested.
  - Run build and submit using EAS CLI. (Build failed for some unrelated reason, gha android builds are also failing)
- Enable remote version source. It can't be enabled per profile, so I set to 1 in `versioned-client`, `unversioned-client`, and `versioned-client-add-sdk` projects. For `release-client` I set  android version code to `189` (latest released version in playstore) and ios buildNumber to `1017524` (latest test flight version has `2.28.7.1017523`)
- Send notification to slack on successful build (before submit is started)

### Note on iOS versions

According to https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion?language=objc CFBundleVersion should be 3 numbers separated by a period, any additional values are ignored, so it looks like the values we have currently are not correct e.g. `2.28.7.1017523`.  As mentioned above I decided to change the build numbers to be a single integer and start with number that was on the last position in the latest test flight upload, from there new versions will be incremented

### TODO

- ~~Before merging this PR I'll set up all the missing credentials and verify everything e2e.~~
- In follow-up PRs, reimplement actions from Fastfile that are done during a release (disabling permissions, uploading crashlitics, maybe metadata update)
  - I don't plan to add version updates. Build number and version code will be updated automatically by EAS CLI, but user-facing version needs to be updated manually in xcode and android projects. If it's needed we can discuss adding some one place that will updated and sync rest of the project to that version

# Test Plan

Run new command on linux
TODO: test on macos

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
