### PR TITLE
[core][iOS] Initializing and returning shared objects from the native side

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [iOS] Introduced native functions on the native component instances. ([#21746](https://github.com/expo/expo/pull/21746) by [@tsapeta](https://github.com/tsapeta))
 - View tag and React component ref can now be converted to an instance of the native view when used as a function's argument. ([#21816](https://github.com/expo/expo/pull/21816) by [@lukmccall](https://github.com/lukmccall), [#21829](https://github.com/expo/expo/pull/21829) by [@tsapeta](https://github.com/tsapeta))
 - [Android] JavaScript functions can now be passed as an argument to a module method. ([#21976](https://github.com/expo/expo/pull/21976) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Initializing and returning shared objects from the native side. ([#22195](https://github.com/expo/expo/pull/22195) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.h
@@ -26,6 +26,11 @@ using ClassConstructor = std::function<void(jsi::Runtime &runtime, const jsi::Va
 
 std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *name, ClassConstructor constructor);
 
+/**
+ Creates a new object, using the provided object as the prototype.
+ */
+std::shared_ptr<jsi::Object> createObjectWithPrototype(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> prototype);
+
 #pragma mark - Weak objects
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIUtils.mm
@@ -115,6 +115,23 @@ std::shared_ptr<jsi::Function> createClass(jsi::Runtime &runtime, const char *na
   return std::make_shared<jsi::Function>(klass.asFunction(runtime));
 }
 
+std::shared_ptr<jsi::Object> createObjectWithPrototype(jsi::Runtime &runtime, std::shared_ptr<jsi::Object> prototype) {
+  // Get the "Object" class.
+  jsi::Object objectClass = runtime
+    .global()
+    .getPropertyAsObject(runtime, "Object");
+
+  // Call "Object.create(prototype)" to create an object with the given prototype without calling the constructor.
+  jsi::Object object = objectClass
+    .getPropertyAsFunction(runtime, "create")
+    .callWithThis(runtime, objectClass, {
+      jsi::Value(runtime, *prototype)
+    })
+    .asObject(runtime);
+
+  return std::make_shared<jsi::Object>(std::move(object));
+}
+
 #pragma mark - Weak objects
 
 bool isWeakRefSupported(jsi::Runtime &runtime) {

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -103,6 +103,11 @@ typedef void (^ClassConstructorBlock)(EXJavaScriptObject * _Nonnull thisValue, N
 - (nonnull EXJavaScriptObject *)createClass:(nonnull NSString *)name
                                 constructor:(nonnull ClassConstructorBlock)constructor;
 
+/**
+ Creates a new object, using the provided object as the prototype.
+ */
+- (nullable EXJavaScriptObject *)createObjectWithPrototype:(nonnull EXJavaScriptObject *)prototype;
+
 #pragma mark - Script evaluation
 
 /**

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -160,6 +160,12 @@ static NSString *mainObjectPropertyName = @"expo";
   return [[EXJavaScriptObject alloc] initWith:klass runtime:self];
 }
 
+- (nullable EXJavaScriptObject *)createObjectWithPrototype:(nonnull EXJavaScriptObject *)prototype
+{
+  std::shared_ptr<jsi::Object> object = expo::createObjectWithPrototype(*_runtime, [prototype getShared]);
+  return object ? [[EXJavaScriptObject alloc] initWith:object runtime:self] : nil;
+}
+
 #pragma mark - Script evaluation
 
 - (nonnull EXJavaScriptValue *)evaluateScript:(nonnull NSString *)scriptSource

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -112,6 +112,29 @@ public final class AppContext: NSObject {
     reactBridge?.dispatchBlock(runBlock, queue: RCTJSThread)
   }
 
+  // MARK: - Classes
+
+  /**
+   A registry containing references to JavaScript classes.
+   - ToDo: Make one registry per module, not the entire app context.
+   Perhaps it should be kept by the `ModuleHolder`.
+   */
+  internal let classRegistry = ClassRegistry()
+
+  /**
+   Creates a new JavaScript object with the class prototype associated with the given native class.
+   - ToDo: Move this to `ModuleHolder` along the `classRegistry` property.
+   */
+  internal func newObject(nativeClassId: ObjectIdentifier) throws -> JavaScriptObject? {
+    guard let jsClass = classRegistry.getJavaScriptClass(nativeClassId: nativeClassId) else {
+      return nil
+    }
+    let prototype = try jsClass.getProperty("prototype").asObject()
+    let object = try runtime.createObject(withPrototype: prototype)
+
+    return object
+  }
+
   // MARK: - Legacy modules
 
   /**

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
@@ -52,7 +52,14 @@ public final class ClassComponent: ObjectDefinition {
         SharedObjectRegistry.add(native: result, javaScript: this)
       }
     }
+
     try decorate(object: klass, appContext: appContext)
+
+    // Register the JS class and its associated native type.
+    if let sharedObjectType = associatedType as? DynamicSharedObjectType {
+      appContext.classRegistry.register(nativeClassId: sharedObjectType.typeIdentifier, javaScriptClass: klass)
+    }
+
     return klass
   }
 

--- a/packages/expo-modules-core/ios/Swift/Classes/ClassRegistry.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassRegistry.swift
@@ -1,0 +1,27 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+internal final class ClassRegistry {
+  var nativeToJS = [ObjectIdentifier: JavaScriptWeakObject]()
+
+  // MARK: - Accessing
+
+  func getJavaScriptClass(nativeClassId: ObjectIdentifier) -> JavaScriptObject? {
+    return nativeToJS[nativeClassId]?.lock()
+  }
+
+  func getJavaScriptClass(nativeClass: SharedObject.Type) -> JavaScriptObject? {
+    let nativeClassId = ObjectIdentifier(nativeClass)
+    return getJavaScriptClass(nativeClassId: nativeClassId)
+  }
+
+  // MARK: - Registration
+
+  func register(nativeClassId: ObjectIdentifier, javaScriptClass: JavaScriptObject) {
+    nativeToJS[nativeClassId] = javaScriptClass.createWeak()
+  }
+
+  func register(nativeClass: SharedObject.Type, javaScriptClass: JavaScriptObject) {
+    let nativeClassId = ObjectIdentifier(nativeClass)
+    register(nativeClassId: nativeClassId, javaScriptClass: javaScriptClass)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Conversions.swift
+++ b/packages/expo-modules-core/ios/Swift/Conversions.swift
@@ -151,15 +151,31 @@ internal final class Conversions {
   /**
    Converts the function result to the type compatible with JavaScript.
    */
-  static func convertFunctionResult<ValueType>(_ value: ValueType?, appContext: AppContext? = nil) -> Any {
+  static func convertFunctionResult<ValueType>(
+    _ value: ValueType?,
+    appContext: AppContext? = nil,
+    dynamicType: AnyDynamicType? = nil
+  ) -> Any {
     if let value = value as? Record {
       return value.toDictionary()
     }
     if let value = value as? [Record] {
       return value.map { $0.toDictionary() }
     }
-    if let appContext, let value = value as? JavaScriptObjectBuilder {
-      return try? value.build(appContext: appContext)
+    if let appContext {
+      if let value = value as? JavaScriptObjectBuilder {
+        return try? value.build(appContext: appContext)
+      }
+
+      // If the returned value is a native shared object, create its JS representation and add the pair to the registry of shared objects.
+      if let value = value as? SharedObject, let dynamicType = dynamicType as? DynamicSharedObjectType {
+        guard let object = try? appContext.newObject(nativeClassId: dynamicType.typeIdentifier) else {
+          log.warn("Unable to create a JS object for \(dynamicType.description)")
+          return Optional<Any>.none
+        }
+        SharedObjectRegistry.add(native: value, javaScript: object)
+        return object
+      }
     }
     return value as Any
   }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicSharedObjectType.swift
@@ -6,6 +6,16 @@
 internal struct DynamicSharedObjectType: AnyDynamicType {
   let innerType: SharedObject.Type
 
+  /**
+   A unique identifier of the wrapped type.
+   */
+  let typeIdentifier: ObjectIdentifier
+
+  init<SharedObjectType: SharedObject>(innerType: SharedObjectType.Type) {
+    self.innerType = innerType
+    self.typeIdentifier = ObjectIdentifier(SharedObjectType.self)
+  }
+
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
     return innerType == InnerType.self
   }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -31,12 +31,10 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
     _ name: String,
     firstArgType: FirstArgType.Type,
     dynamicArgumentTypes: [AnyDynamicType],
-    dynamicReturnType: AnyDynamicType,
     _ body: @escaping ClosureType
   ) {
     self.name = name
     self.dynamicArgumentTypes = dynamicArgumentTypes
-    self.dynamicReturnType = dynamicReturnType
     self.body = body
   }
 
@@ -45,11 +43,6 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   let name: String
 
   let dynamicArgumentTypes: [AnyDynamicType]
-
-  /**
-   A dynamic type representing the returned type.
-   */
-  let dynamicReturnType: AnyDynamicType
 
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
@@ -109,7 +102,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
         throw Exceptions.AppContextLost()
       }
       let result = try self.call(by: this, withArguments: args, appContext: appContext)
-      return Conversions.convertFunctionResult(result, appContext: appContext, dynamicType: dynamicReturnType)
+      return Conversions.convertFunctionResult(result, appContext: appContext, dynamicType: ~ReturnType.self)
     }
   }
 }
@@ -125,7 +118,6 @@ public func Function<R>(
     name,
     firstArgType: Void.self,
     dynamicArgumentTypes: [],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -141,7 +133,6 @@ public func Function<R, A0: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -157,7 +148,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self, ~A1.self],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -177,7 +167,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
       ~A1.self,
       ~A2.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -198,7 +187,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A2.self,
       ~A3.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -220,7 +208,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A3.self,
       ~A4.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -243,7 +230,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A4.self,
       ~A5.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -267,7 +253,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A5.self,
       ~A6.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -292,7 +277,6 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A6.self,
       ~A7.self
     ],
-    dynamicReturnType: ~R.self,
     closure
   )
 }

--- a/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Functions/SyncFunctionComponent.swift
@@ -31,10 +31,12 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
     _ name: String,
     firstArgType: FirstArgType.Type,
     dynamicArgumentTypes: [AnyDynamicType],
+    dynamicReturnType: AnyDynamicType,
     _ body: @escaping ClosureType
   ) {
     self.name = name
     self.dynamicArgumentTypes = dynamicArgumentTypes
+    self.dynamicReturnType = dynamicReturnType
     self.body = body
   }
 
@@ -43,6 +45,11 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
   let name: String
 
   let dynamicArgumentTypes: [AnyDynamicType]
+
+  /**
+   A dynamic type representing the returned type.
+   */
+  let dynamicReturnType: AnyDynamicType
 
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
@@ -82,8 +89,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
       arguments = try cast(arguments: arguments, forFunction: self, appContext: appContext)
 
       let argumentsTuple = try Conversions.toTuple(arguments) as! Args
-      let result = try body(argumentsTuple)
-      return Conversions.convertFunctionResult(result, appContext: appContext)
+      return try body(argumentsTuple)
     } catch let error as Exception {
       throw FunctionCallException(name).causedBy(error)
     } catch {
@@ -103,7 +109,7 @@ public final class SyncFunctionComponent<Args, FirstArgType, ReturnType>: AnySyn
         throw Exceptions.AppContextLost()
       }
       let result = try self.call(by: this, withArguments: args, appContext: appContext)
-      return Conversions.convertFunctionResult(result, appContext: appContext)
+      return Conversions.convertFunctionResult(result, appContext: appContext, dynamicType: dynamicReturnType)
     }
   }
 }
@@ -119,6 +125,7 @@ public func Function<R>(
     name,
     firstArgType: Void.self,
     dynamicArgumentTypes: [],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -134,6 +141,7 @@ public func Function<R, A0: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -149,6 +157,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument>(
     name,
     firstArgType: A0.self,
     dynamicArgumentTypes: [~A0.self, ~A1.self],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -168,6 +177,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument>(
       ~A1.self,
       ~A2.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -188,6 +198,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A2.self,
       ~A3.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -209,6 +220,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A3.self,
       ~A4.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -231,6 +243,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A4.self,
       ~A5.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -254,6 +267,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A5.self,
       ~A6.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }
@@ -278,6 +292,7 @@ public func Function<R, A0: AnyArgument, A1: AnyArgument, A2: AnyArgument, A3: A
       ~A6.self,
       ~A7.self
     ],
+    dynamicReturnType: ~R.self,
     closure
   )
 }

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -66,6 +66,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "get",
       firstArgType: Void.self,
       dynamicArgumentTypes: [],
+      dynamicReturnType: ~ReturnType.self,
       getter
     )
     return self
@@ -81,6 +82,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "get",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self],
+      dynamicReturnType: ~ReturnType.self,
       getter
     )
     self.getter?.takesOwner = true
@@ -96,6 +98,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "set",
       firstArgType: ValueType.self,
       dynamicArgumentTypes: [~ValueType.self],
+      dynamicReturnType: ~Void.self,
       setter
     )
     return self
@@ -111,6 +114,7 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "set",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self, ~ValueType.self],
+      dynamicReturnType: ~Void.self,
       setter
     )
     self.setter?.takesOwner = true

--- a/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Objects/PropertyComponent.swift
@@ -66,7 +66,6 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "get",
       firstArgType: Void.self,
       dynamicArgumentTypes: [],
-      dynamicReturnType: ~ReturnType.self,
       getter
     )
     return self
@@ -82,7 +81,6 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "get",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self],
-      dynamicReturnType: ~ReturnType.self,
       getter
     )
     self.getter?.takesOwner = true
@@ -98,7 +96,6 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "set",
       firstArgType: ValueType.self,
       dynamicArgumentTypes: [~ValueType.self],
-      dynamicReturnType: ~Void.self,
       setter
     )
     return self
@@ -114,7 +111,6 @@ public final class PropertyComponent<OwnerType>: AnyDefinition, AnyPropertyCompo
       "set",
       firstArgType: OwnerType.self,
       dynamicArgumentTypes: [~OwnerType.self, ~ValueType.self],
-      dynamicReturnType: ~Void.self,
       setter
     )
     self.setter?.takesOwner = true

--- a/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassComponentSpec.swift
@@ -180,6 +180,14 @@ class ClassComponentSpec: ExpoSpec {
         expect(value.kind) == .number
         expect(value.getInt()) == initialValue
       }
+
+      it("initializes the shared object from native") {
+        let initialValue = Int.random(in: 1..<100)
+        let value = try runtime.eval("expo.modules.TestModule.newCounter(\(initialValue))")
+
+        expect(value.kind) == .object
+        expect(value.getObject().getProperty("currentValue").getInt()) == initialValue
+      }
     }
   }
 }
@@ -190,6 +198,10 @@ class ClassComponentSpec: ExpoSpec {
 fileprivate final class ModuleWithCounterClass: Module {
   func definition() -> ModuleDefinition {
     Name("TestModule")
+
+    Function("newCounter") { (initialValue: Int) in
+      return Counter(initialValue: initialValue)
+    }
 
     Class(Counter.self) {
       Constructor { (initialValue: Int) in

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -128,11 +128,15 @@ class FunctionSpec: ExpoSpec {
 
         it("returns the record back (sync)") {
           let result = try Function(functionName) { (record: TestRecord) in record }
-            .call(by: nil, withArguments: [dict], appContext: appContext) as? TestRecord.Dict
+            .call(by: nil, withArguments: [dict], appContext: appContext) as? TestRecord
+
+          guard let result = Conversions.convertFunctionResult(result, appContext: appContext) as? TestRecord.Dict else {
+            return fail()
+          }
 
           expect(result).notTo(beNil())
-          expect(result?["property"] as? String).to(equal(dict["property"]))
-          expect(result?["propertyWithCustomKey"] as? String).to(equal(dict["propertyWithCustomKey"]))
+          expect(result["property"] as? String).to(equal(dict["property"]))
+          expect(result["propertyWithCustomKey"] as? String).to(equal(dict["propertyWithCustomKey"]))
         }
 
         it("returns the record back (async)") {


### PR DESCRIPTION
# Why

So far we could create shared objects only from the JS side. We also want to be able to return a native instance and automatically create its JS instance.
Closes ENG-8381

# How

- Introduced `ClassRegistry` where we can store JS classes for each shared object class. There will be only one registry per app context, but in the future we'll need to make one for each module instance.
- Added an easy way to create a JS object with the given prototype (using `Object.create`).

# Test Plan

Added one simple native unit test to cover this functionality – it passes.
