### PR TITLE
[core][iOS] Define properties on prototype instead of the instance

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
@@ -43,9 +43,6 @@ public final class ClassComponent: ObjectDefinition {
         // TODO: Throw an exception? (@tsapeta)
         return
       }
-      // The properties can't go into the prototype as they would be shared across all instances.
-      // Instead, we decorate the instance object on initialization.
-      try? self.decorateWithProperties(object: this, appContext: appContext)
 
       // Call the native constructor when defined.
       let result = try? self.constructor?.call(by: this, withArguments: arguments, appContext: appContext)
@@ -67,6 +64,7 @@ public final class ClassComponent: ObjectDefinition {
     decorateWithConstants(object: prototype)
     try decorateWithFunctions(object: prototype, appContext: appContext)
     try decorateWithClasses(object: prototype, appContext: appContext)
+    try decorateWithProperties(object: prototype, appContext: appContext)
   }
 }
 


### PR DESCRIPTION
# Why

Well, it turned out that at the beginning I overthought on which object the properties should be defined. I thought that this will work fine only on the class instances, not the class prototype. After some testing and working on #22195 I came to the conclusion that we can safely define them on the class prototype.

# How

Moved `decorateWithProperties` call from the class constructor to the prototype builder

# Test Plan

Native unit tests covering class properties are still passing

<!-- disable:changelog-checks -->