### PR TITLE
[docs] incorporate SDK 48 changes and drop RN patch versions

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -56,7 +56,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0	         | 0.71   	            | 0.18.12                  |
+| 48.0.0           | 0.71   	            | 0.18.12                  |
 | 47.0.0           | 0.70                 | 0.18.9                   |
 | 46.0.0           | 0.69                 | 0.18.7                   |
 | 45.0.0           | 0.68                 | 0.17.7                   |

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -56,10 +56,11 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 47.0.0           | 0.70.5               | 0.18.9                   |
-| 46.0.0           | 0.69.6               | 0.18.7                   |
-| 45.0.0           | 0.68.2               | 0.17.7                   |
-| 44.0.0           | 0.64.3               | 0.17.1                   |
+| 48.0.0	         | 0.71   	            | 0.18.12                  |
+| 47.0.0           | 0.70                 | 0.18.9                   |
+| 46.0.0           | 0.69                 | 0.18.7                   |
+| 45.0.0           | 0.68                 | 0.17.7                   |
+| 44.0.0           | 0.64                 | 0.17.1                   |
 
 ### Support for other React Native versions
 

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -56,7 +56,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0           | 0.71   	            | 0.18.12                  |
+| 48.0.0           | 0.71                 | 0.18.12                  |
 | 47.0.0           | 0.70                 | 0.18.9                   |
 | 46.0.0           | 0.69                 | 0.18.7                   |
 | 45.0.0           | 0.68                 | 0.17.7                   |

--- a/docs/pages/versions/v48.0.0/index.mdx
+++ b/docs/pages/versions/v48.0.0/index.mdx
@@ -56,10 +56,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0           | 0.71.3               | 0.18.12                  |
-| 47.0.0           | 0.70.5               | 0.18.9                   |
-| 46.0.0           | 0.69.6               | 0.18.7                   |
-| 45.0.0           | 0.68.2               | 0.17.7                   |
+| 48.0.0           | 0.71                 | 0.18.12                  |
+| 47.0.0           | 0.70                 | 0.18.9                   |
+| 46.0.0           | 0.69                 | 0.18.7                   |
+| 45.0.0           | 0.68                 | 0.17.7                   |
 
 ### Support for other React Native versions
 


### PR DESCRIPTION
# Why

The patch version for RN has been bumped during this cycle, and this docs page didn't reflect that yet. @brentvatne suggested dropping the patch version altogether, as bumping patch versions is common, and including it doesn't provide much additional information.

While making the change, I also noticed that the unversioned version wasn't up to date with the SDK 48 changes, so I updated it to match.

# How

Updated mdx manually

# Test Plan

Mk I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
