### PR TITLE
feature(cli): improve prebuild for arbitrary template platforms

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Expose environment variables to Node.js processes. ([#22076](https://github.com/expo/expo/pull/22076) by [@EvanBacon](https://github.com/EvanBacon))
 - Use LogBox for static Metro errors. ([#22118](https://github.com/expo/expo/pull/22118) by [@EvanBacon](https://github.com/EvanBacon))
 - Generate experimental expo-env.d.ts when EXPO_ROUTER_TYPED_ROUTES=true ([#22096](https://github.com/expo/expo/pull/22096) by [@marklawlor](https://github.com/marklawlor))
+- Improve prebuild for arbitrary template platforms. ([#22201](https://github.com/expo/expo/pull/22201) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
@@ -1,5 +1,6 @@
 import { vol } from 'memfs';
 
+import { Log } from '../../log';
 import {
   ensureValidPlatforms,
   resolvePlatformOption,
@@ -7,6 +8,8 @@ import {
   resolvePackageManagerOptions,
   resolveTemplateOption,
 } from '../resolveOptions';
+
+jest.mock('../../log');
 
 describe(resolvePackageManagerOptions, () => {
   it(`resolves`, () => {
@@ -57,10 +60,9 @@ describe(resolvePlatformOption, () => {
 
     expect(resolvePlatformOption('all')).toEqual(['android']);
   });
-  it('throws on unknown platform', () => {
-    expect(() => resolvePlatformOption('foo')).toThrowError(
-      'Unsupported platform "foo". Options are: ios, android, all'
-    );
+  it('warns on unknown platform', () => {
+    expect(resolvePlatformOption('foo')).toEqual(['foo']);
+    expect(Log.warn).toBeCalledWith(expect.stringContaining('prebuild will continue'));
   });
 });
 

--- a/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { Log } from '../../log';
+import * as Log from '../../log';
 import {
   ensureValidPlatforms,
   resolvePlatformOption,

--- a/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/resolveOptions-test.ts
@@ -1,6 +1,5 @@
 import { vol } from 'memfs';
 
-import * as Log from '../../log';
 import {
   ensureValidPlatforms,
   resolvePlatformOption,
@@ -8,8 +7,6 @@ import {
   resolvePackageManagerOptions,
   resolveTemplateOption,
 } from '../resolveOptions';
-
-jest.mock('../../log');
 
 describe(resolvePackageManagerOptions, () => {
   it(`resolves`, () => {
@@ -60,9 +57,8 @@ describe(resolvePlatformOption, () => {
 
     expect(resolvePlatformOption('all')).toEqual(['android']);
   });
-  it('warns on unknown platform', () => {
+  it('accepts unknown platforms', () => {
     expect(resolvePlatformOption('foo')).toEqual(['foo']);
-    expect(Log.warn).toBeCalledWith(expect.stringContaining('prebuild will continue'));
   });
 });
 

--- a/packages/@expo/cli/src/prebuild/resolveOptions.ts
+++ b/packages/@expo/cli/src/prebuild/resolveOptions.ts
@@ -63,9 +63,6 @@ export function resolvePlatformOption(
     case 'all':
       return loose || process.platform !== 'win32' ? ['android', 'ios'] : ['android'];
     default:
-      Log.warn(
-        `Unkown platform "${platform}", prebuild will continue but may have unexpected side effects.`
-      );
       return [platform as ModPlatform];
   }
 }

--- a/packages/@expo/cli/src/prebuild/resolveOptions.ts
+++ b/packages/@expo/cli/src/prebuild/resolveOptions.ts
@@ -61,12 +61,12 @@ export function resolvePlatformOption(
     case 'android':
       return ['android'];
     case 'all':
-      if (loose || process.platform !== 'win32') {
-        return ['android', 'ios'];
-      }
-      return ['android'];
+      return loose || process.platform !== 'win32' ? ['android', 'ios'] : ['android'];
     default:
-      throw new CommandError(`Unsupported platform "${platform}". Options are: ios, android, all`);
+      Log.warn(
+        `Unkown platform "${platform}", prebuild will continue but may have unexpected side effects.`
+      );
+      return [platform as ModPlatform];
   }
 }
 

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -1,10 +1,8 @@
 import { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import { ModPlatform } from '@expo/config-plugins';
 import chalk from 'chalk';
-import path from 'path';
 
 import * as Log from '../log';
-import { directoryExistsAsync } from '../utils/dir';
 import { AbortCommandError, SilentError } from '../utils/errors';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';

--- a/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
+++ b/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
@@ -1,4 +1,5 @@
 import { ModPlatform } from '@expo/config-plugins';
+import chalk from 'chalk';
 import path from 'path';
 
 import * as Log from '../log';
@@ -18,7 +19,7 @@ export async function validateTemplatePlatforms({
       existingPlatforms.push(platform);
     } else {
       Log.warn(
-        `The template does not contain native files for ${platform} (./${platform}), skipping platform`
+        chalk`⚠️  Skipping platform ${platform}. Use a template that contains native files for ${platform} (./${platform}).`
       );
     }
   }

--- a/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
+++ b/packages/@expo/cli/src/prebuild/validateTemplatePlatforms.ts
@@ -1,0 +1,27 @@
+import { ModPlatform } from '@expo/config-plugins';
+import path from 'path';
+
+import * as Log from '../log';
+import { directoryExistsAsync } from '../utils/dir';
+
+export async function validateTemplatePlatforms({
+  templateDirectory,
+  platforms,
+}: {
+  templateDirectory: string;
+  platforms: ModPlatform[];
+}) {
+  const existingPlatforms: ModPlatform[] = [];
+
+  for (const platform of platforms) {
+    if (await directoryExistsAsync(path.join(templateDirectory, platform))) {
+      existingPlatforms.push(platform);
+    } else {
+      Log.warn(
+        `The template does not contain native files for ${platform} (./${platform}), skipping platform`
+      );
+    }
+  }
+
+  return existingPlatforms;
+}


### PR DESCRIPTION
# Why

This should improve users who have custom platforms for prebuild, like `tvos`.

# How

- Lifted the limitation on the `expo prebuild --platform` flag
- Check if the template has `./${platform}` folder before copying files over

# Examples

<details><summary>Platforms existing in the template</summary>

<img width="924" alt="image" src="https://user-images.githubusercontent.com/1203991/233436089-c19a1e76-5f6d-4121-8570-a8152f8039fb.png">

</details>

<details><summary>Platforms not existing in the template</summary>

<img width="564" alt="image" src="https://user-images.githubusercontent.com/1203991/233439559-bbe7cc4f-6272-4991-9d2a-fad302486b0a.png">

</details>

# Test Plan

- `$ yarn create expo-app ./test-platforms`
- `$ cd ./test-platforms`
- `$ yarn expo prebuild --platform windows --template https://github.com/microsoft/react-native-windows-samples/tree/main/samples/AppServiceDemo`

The last step should use the `./windows` folder from the [AppServiceDemo](https://github.com/microsoft/react-native-windows-samples/tree/main/samples/AppServiceDemo) as template files inside this project.

If there are any plugins defined for that platform, they should be picked up automatically.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
