### PR TITLE
[docs][expo-task-manager] Remove outdated bare installation steps in the package's Readme

### DIFF
--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -25,7 +25,7 @@ npx expo install expo-task-manager
 
 Run `npx pod-install` after installing the npm package.
 
-To use ` TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
+To use `TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
 
 #### Configure for Android
 

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -1,40 +1,36 @@
 # expo-task-manager
 
-Expo universal module for TaskManager API
+Expo universal module for TaskManager API.
 
-# API documentation
+## API documentation
 
 - [Documentation for the main branch](https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/task-manager.mdx)
 - [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/task-manager/)
 
-# Installation in managed Expo projects
+## Installation
 
 For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/task-manager/).
 
-# Installation in bare React Native projects
+## Installation in bare React Native projects
 
 For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-## Installation in bare iOS React Native project
-
-Apart from following [those steps](#installation-in-bare-react-native-projects), make sure your `AppDelegate` extends `UMAppDelegateWrapper` as shown [here](https://gist.github.com/mczernek/a62413ca517cfd5dac015f5527dafef0).
 
 ### Add the package to your npm dependencies
 
 ```
-expo install expo-task-manager
+npx expo install expo-task-manager
 ```
 
-### Configure for iOS
+#### Configure for iOS
 
 Run `npx pod-install` after installing the npm package.
 
-In order to use `TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
+To use ` TaskManager` API in standalone, detached and bare apps on iOS, your app has to include background mode in the `Info.plist` file. See [background tasks configuration guide](https://docs.expo.dev/versions/latest/sdk/task-manager/#configuration-for-standalone-apps) for more details.
 
-### Configure for Android
+#### Configure for Android
 
 No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).
+Contributions are welcome! Please refer to the guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<!-- disable:changelog-checks -->

There is an outdated step to configure for bare iOS React Native projects that leads to a gist. It is not required anymore since the [bare installation guide](https://docs.expo.dev/bare/installing-expo-modules/#configuration-for-ios) already covers it in the form of `EXAppDelegateWrapper`.

This was brought up in issue #20856.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the Readme for the package `expo-task-manager`. Also, use writing style guidelines to enhance the document.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
