### PR TITLE
[docs] Fix video link in Development Builds: Introduction

### DIFF
--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -12,9 +12,9 @@ When you make a change to your iOS entitlements, this change needs to be updated
 
 ## Entitlements
 
-In bare workflow apps, the entitlements are read from your __ios/**/*.entitlements__ file.
-
 In the managed workflow, the entitlements are read from the introspected app config. To edit them, see the [`ios.entitlements`](/versions/latest/config/app/#entitlements) field in your app config file. You can see your introspected config by running `npx expo config --type introspect` in your project and then look for the `ios.entitlements` object for the results.
+
+In bare workflow apps, the entitlements are read from your __ios/**/*.entitlements__ file.
 
 ## Enabling
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -19,7 +19,7 @@ You need to be authenticated with Expo:
 - Company policies that restrict the use of third-party CI/CD services. With local builds, the entire process runs on your infrastructure and the only communication with EAS servers is:
   - to make sure project `@account/slug` exists
   - if you are using managed credentials to download them.
-- Debugging (more info in [the next section](#using-local-builds-for-debugging))
+- [Debugging](#using-local-builds-for-debugging)
 
 ## Using local builds for debugging
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -17,7 +17,7 @@ When your project requires custom native code, a config plugin, a custom runtime
 
 ## What is a development build
 
-<Video url="https://youtube.com/embed/_SWalkrP0CA" />
+<Video url="https://www.youtube.com/embed/Iw8FAUftJFU" />
 
 A **development build** of your app is a Debug build that contains the `expo-dev-client` package. As a production build is for the general public, and a preview build lets your team test your next release, a development build lets developers iterate as quickly as possible. It comes with extensible development tools to develop and test your project.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the video embedded at https://docs.expo.dev/develop/development-builds/introduction/ is unavailable. Looks the link might have changed.

Here is the issue: 
<img width="898" alt="CleanShot 2023-04-20 at 23 14 48@2x" src="https://user-images.githubusercontent.com/10234615/233447622-cf7ce4b1-3ed0-4e94-b27a-fbc5f60a6cdc.png">


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- updates the YouTube video link for https://docs.expo.dev/develop/development-builds/introduction
- Fixes section link on Local builds page
- Moves bare workflow instructions after managed on iOS entitlements

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

After updating the link, the video shows:

<img width="874" alt="CleanShot 2023-04-20 at 23 22 23@2x" src="https://user-images.githubusercontent.com/10234615/233448036-526dbad5-688e-4e33-a722-2e0e8d04f5ce.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
