### PR TITLE
[tools] Add command to close Linear issues given a GitHub issue

### DIFF
--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -18,7 +18,7 @@ jobs:
         id: expo-caches
         with:
           yarn-tools: 'true'
-      - name: 🔎 Close linear issue
+      - name: 🔎 Close Linear issue
         run: expotools close-linear-issue-from-github --issue "${{ github.event.issue.number }}"
         env:
           GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -1,0 +1,25 @@
+name: Process when issue is closed
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  run-on-issue-accepted:
+    runs-on: ubuntu-20.04
+    if: contains(github.event.issue.labels.*.name, 'Issue accepted')
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-tools: 'true'
+      - name: 🔎 Close linear issue
+        run: expotools close-linear-issue-from-github --issue "${{ github.event.issue.number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}

--- a/tools/src/GitHub.ts
+++ b/tools/src/GitHub.ts
@@ -351,5 +351,3 @@ export type PullRequestReview = RestEndpointMethodTypes['pulls']['getReview']['r
 export type IssueComment = RestEndpointMethodTypes['issues']['getComment']['response']['data'];
 export type ListCommentsOptions = RestEndpointMethodTypes['issues']['listComments']['parameters'];
 export type ListCommentsResponse = RestEndpointMethodTypes['issues']['listComments']['response'];
-export type ListPullRequestOptions = RestEndpointMethodTypes['pulls']['list']['parameters'];
-export type ListPullRequestResponse = RestEndpointMethodTypes['pulls']['list']['response'];

--- a/tools/src/GitHub.ts
+++ b/tools/src/GitHub.ts
@@ -55,6 +55,40 @@ export async function getPullRequestAsync(
 }
 
 /**
+ * Returns the url of the PR that closed an issue.
+ */
+export async function getIssueCloserPrUrlAsync(issueNumber: number): Promise<string> {
+  const { repository } = await octokit.graphql<any>(
+    `query GetIssueCloser($repo: String!, $owner: String!, $issueNumber: Int!) {
+        repository(name: $repo, owner: $owner) {
+          issue(number: $issueNumber) {
+            timelineItems(itemTypes: CLOSED_EVENT, last: 1) {
+              nodes {
+                ... on ClosedEvent {
+                  createdAt
+                  closer {
+                    __typename
+                    ... on PullRequest {
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }`,
+    {
+      owner,
+      repo,
+      issueNumber,
+    }
+  );
+
+  return repository?.issue?.timelineItems?.nodes?.[0]?.closer?.url;
+}
+
+/**
  * Requests and parses the diff of the pull request with given number.
  */
 export async function getPullRequestDiffAsync(
@@ -317,3 +351,5 @@ export type PullRequestReview = RestEndpointMethodTypes['pulls']['getReview']['r
 export type IssueComment = RestEndpointMethodTypes['issues']['getComment']['response']['data'];
 export type ListCommentsOptions = RestEndpointMethodTypes['issues']['listComments']['parameters'];
 export type ListCommentsResponse = RestEndpointMethodTypes['issues']['listComments']['response'];
+export type ListPullRequestOptions = RestEndpointMethodTypes['pulls']['list']['parameters'];
+export type ListPullRequestResponse = RestEndpointMethodTypes['pulls']['list']['response'];

--- a/tools/src/Linear.ts
+++ b/tools/src/Linear.ts
@@ -1,6 +1,7 @@
-import { IssueLabel, LinearClient, User, WorkflowState } from '@linear/sdk';
+import { Issue, IssueLabel, LinearClient, User, WorkflowState } from '@linear/sdk';
 import {
   IssueCreateInput,
+  IssueFilter,
   IssueLabelFilter,
   UserFilter,
 } from '@linear/sdk/dist/_generated_documents';
@@ -84,4 +85,51 @@ export async function getTeamMembersAsync({
   const states = await team.members({ filter });
 
   return states.nodes;
+}
+
+/**
+ * Gets issues by filter and team ID.
+ */
+export async function getIssuesAsync({
+  filter,
+  teamId,
+}: {
+  filter?: IssueFilter;
+  teamId: string;
+}): Promise<Issue[]> {
+  const team = await linearClient.team(teamId);
+  const issues = await team.issues({ filter });
+
+  return issues.nodes;
+}
+
+/**
+ * Updates the status of an issue to Done.
+ */
+export async function closeIssueAsync({
+  issueId,
+  teamId,
+}: {
+  issueId: string;
+  teamId: string;
+}): Promise<boolean> {
+  const doneWorkflowState = await getTeamWorkflowStateAsync('Done', teamId);
+  const payload = await linearClient.updateIssue(issueId, { stateId: doneWorkflowState.id });
+
+  return payload.success;
+}
+
+/**
+ * Creates a comment on an issue.
+ */
+export async function commentIssueAsync({
+  issueId,
+  comment,
+}: {
+  issueId: string;
+  comment: string;
+}): Promise<boolean> {
+  const payload = await linearClient.createComment({ issueId, body: comment });
+
+  return payload.success;
 }

--- a/tools/src/commands/CloseLinearIssueFromGithub.ts
+++ b/tools/src/commands/CloseLinearIssueFromGithub.ts
@@ -41,7 +41,12 @@ async function closeIssueAsync(githubIssueNumber: number) {
     teamId: Linear.ENG_TEAM_ID,
     filter: {
       description: {
-        containsIgnoreCase: `This issue was automatically imported from GitHub: [https://github.com/expo/expo/issues/${githubIssueNumber}]`,
+        containsIgnoreCase: `https://github.com/expo/expo/issues/${githubIssueNumber}`,
+      },
+      labels: {
+        some: {
+          name: { eq: 'GitHub' },
+        },
       },
     },
   });
@@ -49,18 +54,18 @@ async function closeIssueAsync(githubIssueNumber: number) {
 
   if (!linearIssue) {
     throw new Error(
-      `Unable to find a linear issue referring to the Github issue #${githubIssueNumber}.`
+      `Unable to find a Linear issue referring to the Github issue #${githubIssueNumber}.`
     );
   }
 
   await Linear.closeIssueAsync({ issueId: linearIssue.id, teamId: Linear.ENG_TEAM_ID });
 
-  const issueCloserPR = await GitHub.getIssueCloserPrUrlAsync(22192);
+  const issueCloserPR = await GitHub.getIssueCloserPrUrlAsync(githubIssueNumber);
 
   if (issueCloserPR) {
     await Linear.commentIssueAsync({
       issueId: linearIssue.id,
-      comment: `This issue was automatically marked as Done by ${issueCloserPR}`,
+      comment: `This issue was automatically marked as done by ${issueCloserPR}`,
     });
   }
 }

--- a/tools/src/commands/CloseLinearIssueFromGithub.ts
+++ b/tools/src/commands/CloseLinearIssueFromGithub.ts
@@ -1,0 +1,66 @@
+import { Command } from '@expo/commander';
+
+import * as GitHub from '../GitHub';
+import * as Linear from '../Linear';
+import logger from '../Logger';
+
+type ActionOptions = {
+  issue: string;
+};
+
+export default (program: Command) => {
+  program
+    .command('close-linear-issue-from-github')
+    .alias('clifg')
+    .description('Close a Linear issue imported from GitHub.')
+    .option('-i, --issue <string>', 'Number of the original GitHub issue.')
+    .asyncAction(action);
+};
+
+async function action(options: ActionOptions) {
+  if (isNaN(Number(options.issue))) {
+    throw new Error('Flag `--issue` must be provided with a number value');
+  }
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error('Environment variable `GITHUB_TOKEN` is required for this command.');
+  }
+  if (!process.env.LINEAR_API_KEY) {
+    throw new Error('Environment variable `LINEAR_API_KEY` is required for this command.');
+  }
+
+  try {
+    await closeIssueAsync(+options.issue);
+  } catch (error) {
+    logger.error(error);
+    throw error;
+  }
+}
+
+async function closeIssueAsync(githubIssueNumber: number) {
+  const linearIssues = await Linear.getIssuesAsync({
+    teamId: Linear.ENG_TEAM_ID,
+    filter: {
+      description: {
+        containsIgnoreCase: `This issue was automatically imported from GitHub: [https://github.com/expo/expo/issues/${githubIssueNumber}]`,
+      },
+    },
+  });
+  const linearIssue = linearIssues?.[0];
+
+  if (!linearIssue) {
+    throw new Error(
+      `Unable to find a linear issue referring to the Github issue #${githubIssueNumber}.`
+    );
+  }
+
+  await Linear.closeIssueAsync({ issueId: linearIssue.id, teamId: Linear.ENG_TEAM_ID });
+
+  const issueCloserPR = await GitHub.getIssueCloserPrUrlAsync(22192);
+
+  if (issueCloserPR) {
+    await Linear.commentIssueAsync({
+      issueId: linearIssue.id,
+      comment: `This issue was automatically marked as Done by ${issueCloserPR}`,
+    });
+  }
+}

--- a/tools/src/commands/ImportGithubIssueToLinear.ts
+++ b/tools/src/commands/ImportGithubIssueToLinear.ts
@@ -67,7 +67,9 @@ async function importIssueAsync(githubIssueNumber: number, importer?: string) {
   if (importer && (importerLinearUser = await inferLinearUserId([importer]))) {
     issueDescription += `#### Issue accepted by @${importerLinearUser.displayName}\n`;
   }
-  issueDescription += `---\n## Summary:\n${issueSummary}`;
+  if (issueSummary) {
+    issueDescription += `---\n## Summary:\n${issueSummary}`;
+  }
 
   const githubLabel = await Linear.getOrCreateLabelAsync('GitHub');
   const expoSDKLabel = await Linear.getOrCreateLabelAsync('Expo SDK', Linear.ENG_TEAM_ID);


### PR DESCRIPTION
# Why

To further improve our issue management, it would be ideal to automatically close Linear issues whenever a Github issue we've imported is closed. 

# How

This PR introduces a new et command to mark a Linear issue as Done and comment on the Linear ticket linking the GitHub PR that closed the issue. This also adds a new GitHub workflow that automatically triggers this command when an issue with the `Issue accepted` is closed.

# Test Plan

run `et clifg -i XXXX` locally

![image](https://user-images.githubusercontent.com/11707729/233453992-e2008131-3669-4f31-9ef8-11cfe342b53f.png)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
