### PR TITLE
Revert "Fix screen orientation module import (#22215)" and implement the change in correct file.

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -48,7 +48,7 @@ import expo.modules.notifications.NotificationsPackage
 import expo.modules.permissions.PermissionsPackage
 import expo.modules.random.RandomModule
 import expo.modules.screencapture.ScreenCapturePackage
-import expo.modules.screenorientation.ScreenOrientationPackage
+import expo.modules.screenorientation.ScreenOrientationModule
 import expo.modules.securestore.SecureStorePackage
 import expo.modules.sensors.SensorsPackage
 import expo.modules.sharing.SharingModule
@@ -87,7 +87,6 @@ object ExperiencePackagePicker : ModulesProvider {
     PermissionsPackage(),
     SQLitePackage(),
     ScreenCapturePackage(),
-    ScreenOrientationPackage(),
     SecureStorePackage(),
     SensorsPackage(),
     SpeechPackage(),
@@ -135,6 +134,7 @@ object ExperiencePackagePicker : ModulesProvider {
     MediaLibraryModule::class.java,
     NetworkModule::class.java,
     RandomModule::class.java,
+    ScreenOrientationModule::class.java,
     SMSModule::class.java,
     SharingModule::class.java,
     StoreReviewModule::class.java,

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/host/exp/exponent/ExperiencePackagePicker.kt
@@ -48,7 +48,7 @@ import abi48_0_0.expo.modules.permissions.PermissionsPackage
 import abi48_0_0.expo.modules.print.PrintPackage
 import abi48_0_0.expo.modules.random.RandomModule
 import abi48_0_0.expo.modules.screencapture.ScreenCapturePackage
-import abi48_0_0.expo.modules.screenorientation.ScreenOrientationModule
+import abi48_0_0.expo.modules.screenorientation.ScreenOrientationPackage
 import abi48_0_0.expo.modules.securestore.SecureStorePackage
 import abi48_0_0.expo.modules.sensors.SensorsPackage
 import abi48_0_0.expo.modules.sharing.SharingModule
@@ -90,6 +90,7 @@ object ExperiencePackagePicker : ModulesProvider {
     PrintPackage(),
     SQLitePackage(),
     ScreenCapturePackage(),
+    ScreenOrientationPackage(),
     SecureStorePackage(),
     SensorsPackage(),
     SpeechPackage(),
@@ -135,7 +136,6 @@ object ExperiencePackagePicker : ModulesProvider {
     MediaLibraryModule::class.java,
     NetworkModule::class.java,
     RandomModule::class.java,
-    ScreenOrientationModule::class.java,
     SMSModule::class.java,
     SharingModule::class.java,
     StoreReviewModule::class.java,


### PR DESCRIPTION
This reverts commit 7026772d9f54c4f2861bf33a0e48bae32070bb5b.
This moves the changes from the commit into the unversioned code

# Why

I fixed the incorrect file, but the change still needs to be applied to unversioned code.

# How

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
