### PR TITLE
[docs] [ENG-8120] Rename `cache.customPaths` to `cache.paths` in eas.json

### DIFF
--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -90,7 +90,7 @@ To use our CocoaPods cache server for your builds set the `EAS_BUILD_DISABLE_COC
 It is typical to not have your project **Podfile.lock** committed to source control when using [prebuild](/workflow/prebuild) to generate your **ios** directory [remotely at build time](/build-reference/ios-builds).
 It can be useful to cache your **Podfile.lock** in order to have deterministic builds, but the tradeoff in this case is that, because you don't use the lockfile during local development, your ability to determine when a change is needed and to update specific dependencies is limited.
 If you cache this file, you may occasionally end up with build errors that require clearing the cache.
-To cache **Podfile.lock**, add **./ios/Podfile.lock** to the `cache.customPaths` list in your build profile in **eas.json**.
+To cache **Podfile.lock**, add **./ios/Podfile.lock** to the `cache.paths` list in your build profile in **eas.json**.
 
 {/* prettier-ignore */}
 ```json eas.json
@@ -98,7 +98,7 @@ To cache **Podfile.lock**, add **./ios/Podfile.lock** to the `cache.customPaths`
   "build": {
     "production": {
       "cache": {
-        "customPaths": ["./ios/Podfile.lock"]
+        "paths": ["./ios/Podfile.lock"]
         /* @hide ... */ /* @end */
       }
       /* @hide ... */ /* @end */

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -124,7 +124,7 @@ export default [
         description: ['Cache key. You can invalidate the cache by changing this value.'],
       },
       {
-        name: 'customPaths',
+        name: 'paths',
         type: 'array',
         description: [
           'List of the paths that will be saved after a successful build and restored at the beginning of the next one. Both absolute and relative paths are supported, where relative paths are resolved from the directory with `eas.json`.',


### PR DESCRIPTION
Adjusted all references of `cache.customPaths` to mention the actual name of the field which is `cache.paths`

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
After disabling the default caching in EAS Build, it doesn't make much sense to keep a field called `cache.customPaths` (since there are no more default paths) and it was decided to replace it with just `cache.paths`. Here I update the docs to reflect that change
See: https://linear.app/expo/issue/ENG-8120/rename-cachecustompaths-to-cachepaths-in-easjson-and-job-schema

# How

<!--
How did you build this feature or fix this bug and why?
-->
Adjusted all references of `cache.customPaths` to mention the actual name of the field which is `cache.paths`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Tested manually by running the dev server
- `/build-reference/caching/`
<img width="1103" alt="Screenshot 2023-04-21 at 14 36 13" src="https://user-images.githubusercontent.com/2974455/233637817-556cc9dc-09e6-4ab4-bfda-db3a000dc1e4.png">
- `/build-reference/eas-json/#cache`
<img width="1103" alt="Screenshot 2023-04-21 at 14 35 50" src="https://user-images.githubusercontent.com/2974455/233637885-5452ca2c-b3e0-4587-9c30-1c42d0b4aed7.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
