### PR TITLE
[docs] Move In-app debugging example to `expo-updates` API reference

### DIFF
--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -158,6 +158,10 @@ The EAS website has a page that shows the current state of our apps. We can view
 
 After verifying `expo-updates` and EAS Update configurations, we can move on to debugging how our project is interacting with updates.
 
+### In-app debugging
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause. We can make a simulator build of the project and manually check to see if updates are available or if there are errors when fetching updates. See the code example to [check for updates manually](/versions/latest/sdk/updates/#use-expo-updates-with-a-custom-server).
+
 ### Viewing network requests
 
 Another way to identify the root cause of an issue is to look at the network requests that the app is making to EAS servers, then viewing the responses. We recommend using a program like [Proxyman](https://proxyman.io/) or [Charles Proxy](https://www.charlesproxy.com/) to watch network requests from our app.

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -158,38 +158,6 @@ The EAS website has a page that shows the current state of our apps. We can view
 
 After verifying `expo-updates` and EAS Update configurations, we can move on to debugging how our project is interacting with updates.
 
-### In-app debugging
-
-The expo-updates library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause.
-
-We can write the following code and then make a simulator build of our project to see if there are errors fetching updates:
-
-```jsx
-import { View, Button } from 'react-native';
-import * as Updates from 'expo-updates';
-
-function App() {
-  async function onFetchUpdateAsync() {
-    try {
-      const update = await Updates.checkForUpdateAsync();
-
-      if (update.isAvailable) {
-        await Updates.fetchUpdateAsync();
-        await Updates.reloadAsync();
-      }
-    } catch (error) {
-      alert(`Error fetching latest Expo update: ${error}`);
-    }
-  }
-
-  return (
-    <View>
-      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
-    </View>
-  );
-}
-```
-
 ### Viewing network requests
 
 Another way to identify the root cause of an issue is to look at the network requests that the app is making to EAS servers, then viewing the responses. We recommend using a program like [Proxyman](https://proxyman.io/) or [Charles Proxy](https://www.charlesproxy.com/) to watch network requests from our app.

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
 
@@ -86,11 +88,16 @@ function App() {
 }
 ```
 
-### Using expo-updates with a custom server
+### Use `expo-updates` with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).
 
-You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
+<BoxLink
+  title="Custom Expo Updates Server"
+  description="You can find an example implementation of a custom server and an app using that server in this GitHub repository."
+  href="https://github.com/expo/custom-expo-updates-server"
+  Icon={GithubIcon}
+/>
 
 ### Configuration options
 

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -55,6 +55,37 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
+### Check for updates manually
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
+
+```jsx App.js
+import { View, Button } from 'react-native';
+import * as Updates from 'expo-updates';
+
+function App() {
+  async function onFetchUpdateAsync() {
+    try {
+      const update = await Updates.checkForUpdateAsync();
+
+      if (update.isAvailable) {
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync();
+      }
+    } catch (error) {
+      // You can also add an alert() to see the error message in case of an error when fetching updates.
+      alert(`Error fetching latest Expo update: ${error}`);
+    }
+  }
+
+  return (
+    <View>
+      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+    </View>
+  );
+}
+```
+
 ### Using expo-updates with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -53,7 +53,7 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
-**To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
+**To test manual updates with standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
 
 ### Check for updates manually
 

--- a/docs/pages/versions/v46.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/updates.mdx
@@ -26,6 +26,37 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in bare workflow apps**, make a release build with `expo run:ios --configuration Release` or `expo run:android --variant release` (you don't need to submit this build to the store to test).
 
+### Check for updates manually
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
+
+```jsx App.js
+import { View, Button } from 'react-native';
+import * as Updates from 'expo-updates';
+
+function App() {
+  async function onFetchUpdateAsync() {
+    try {
+      const update = await Updates.checkForUpdateAsync();
+
+      if (update.isAvailable) {
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync();
+      }
+    } catch (error) {
+      // You can also add an alert() to see the error message in case of an error when fetching updates.
+      alert(`Error fetching latest Expo update: ${error}`);
+    }
+  }
+
+  return (
+    <View>
+      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+    </View>
+  );
+}
+```
+
 ## API
 
 ```js

--- a/docs/pages/versions/v46.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/updates.mdx
@@ -22,9 +22,9 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
-**To test manual updates with managed workflow standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `expo run:ios --configuration Release` and `expo run:android --variant release`.
+**To test manual updates with managed workflow standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators) or , or make a release build locally with `expo run:android --variant release` and `expo run:ios --configuration Release`.
 
-**To test manual updates in bare workflow apps**, make a release build with `expo run:ios --configuration Release` or `expo run:android --variant release` (you don't need to submit this build to the store to test).
+**To test manual updates in bare workflow apps**, make a release build with `expo run:android --variant release` or `expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
 
 ### Check for updates manually
 

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -23,7 +23,7 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
-**To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
+**To test manual updates with standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
 
 ### Check for updates manually
 

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -8,6 +8,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
 

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -25,6 +25,37 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
+### Check for updates manually
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
+
+```jsx App.js
+import { View, Button } from 'react-native';
+import * as Updates from 'expo-updates';
+
+function App() {
+  async function onFetchUpdateAsync() {
+    try {
+      const update = await Updates.checkForUpdateAsync();
+
+      if (update.isAvailable) {
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync();
+      }
+    } catch (error) {
+      // You can also add an alert() to see the error message in case of an error when fetching updates.
+      alert(`Error fetching latest Expo update: ${error}`);
+    }
+  }
+
+  return (
+    <View>
+      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+    </View>
+  );
+}
+```
+
 ### Using expo-updates with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -56,11 +56,16 @@ function App() {
 }
 ```
 
-### Using expo-updates with a custom server
+### Use `expo-updates` with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).
 
-You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
+<BoxLink
+  title="Custom Expo Updates Server"
+  description="You can find an example implementation of a custom server and an app using that server in this GitHub repository."
+  href="https://github.com/expo/custom-expo-updates-server"
+  Icon={GithubIcon}
+/>
 
 ### Configuration options
 

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -55,6 +55,37 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
 
+### Check for updates manually
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In some scenarios, you may want to check if updates are available or not. This can be done manually by using [`checkForUpdateAsync()`](#updatescheckforupdateasync) as shown in the example below:
+
+```jsx App.js
+import { View, Button } from 'react-native';
+import * as Updates from 'expo-updates';
+
+function App() {
+  async function onFetchUpdateAsync() {
+    try {
+      const update = await Updates.checkForUpdateAsync();
+
+      if (update.isAvailable) {
+        await Updates.fetchUpdateAsync();
+        await Updates.reloadAsync();
+      }
+    } catch (error) {
+      // You can also add an alert() to see the error message in case of an error when fetching updates.
+      alert(`Error fetching latest Expo update: ${error}`);
+    }
+  }
+
+  return (
+    <View>
+      <Button title="Fetch update" onPress={onFetchUpdateAsync} />
+    </View>
+  );
+}
+```
+
 ### Using expo-updates with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -86,11 +86,16 @@ function App() {
 }
 ```
 
-### Using expo-updates with a custom server
+### Use `expo-updates` with a custom server
 
 Every custom updates server must implement the [Expo Updates protocol](/technical-specs/expo-updates-1/).
 
-You can find an example implementation of a custom server and an app using that server in the [custom-expo-updates-server](https://github.com/expo/custom-expo-updates-server) repository.
+<BoxLink
+  title="Custom Expo Updates Server"
+  description="You can find an example implementation of a custom server and an app using that server in this GitHub repository."
+  href="https://github.com/expo/custom-expo-updates-server"
+  Icon={GithubIcon}
+/>
 
 ### Configuration options
 

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -9,6 +9,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `expo-updates` library allows you to programmatically control and respond to new updates made available to your app.
 

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -53,7 +53,7 @@ Most of the methods and constants in this module can only be used or tested in r
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 
-**To test manual updates with standalone apps**, you can create a [simulator build](/build-reference/simulators.mdx) or [APK](/build-reference/apk.mdx), or make a release build locally with `npx expo run:ios --configuration Release` and `npx expo run:android --variant release` (you don't need to submit this build to the store to test).
+**To test manual updates with standalone apps**, you can create a [**.apk**](/build-reference/apk) or a [simulator build](/build-reference/simulators), or make a release build locally with `npx expo run:android --variant release` and `npx expo run:ios --configuration Release` (you don't need to submit this build to the store to test).
 
 ### Check for updates manually
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8377

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By removing in-app debugging section from Debugging EAS Update guide (as mentioned in the original issue).
- By adding the example from the above section to the `expo-updates` API reference. 
- By fixing typos and applying writing style guidelines (eg: ordering of platforms).

Changes backported to SDK 48, 47, 46.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Main update:

<img width="888" alt="CleanShot 2023-04-21 at 18 11 03@2x" src="https://user-images.githubusercontent.com/10234615/233638617-f6931583-1c1c-4982-b092-3426449725ee.png">

Enhancement:

<img width="892" alt="CleanShot 2023-04-21 at 18 12 35@2x" src="https://user-images.githubusercontent.com/10234615/233638935-f74e8949-ac3b-4c13-b40a-b7ad122c5f43.png">

In-app debugging section refers to the code example from Updates API.

<img width="896" alt="CleanShot 2023-04-21 at 19 12 23@2x" src="https://user-images.githubusercontent.com/10234615/233651301-4f43714e-7c5a-41bd-ab5c-6d147a8b49ea.png">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
