### PR TITLE
[docs] Add redirects for sections that can be referred as short urls

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -158,6 +158,7 @@ const RENAMED_PAGES: Record<string, string> = {
   '/development/development-workflows/': '/develop/development-builds/development-workflows/',
   '/workflow/expo-cli/': '/more/expo-cli/',
   '/versions/latest/workflow/expo-cli/': '/more/expo-cli/',
+  '/debugging/': '/debugging/runtime-issue/',
   '/guides/testing-with-jest/': '/develop/unit-testing/',
   '/workflow/glossary-of-terms/': '/more/glossary-of-terms/',
   '/development/installation/': '/develop/development-builds/installation/',

--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -158,7 +158,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/development/development-workflows/': '/develop/development-builds/development-workflows/',
   '/workflow/expo-cli/': '/more/expo-cli/',
   '/versions/latest/workflow/expo-cli/': '/more/expo-cli/',
-  '/debugging/': '/debugging/runtime-issue/',
   '/guides/testing-with-jest/': '/develop/unit-testing/',
   '/workflow/glossary-of-terms/': '/more/glossary-of-terms/',
   '/development/installation/': '/develop/development-builds/installation/',

--- a/docs/pages/config-plugins/index.js
+++ b/docs/pages/config-plugins/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/config-plugins/introduction/');

--- a/docs/pages/debugging/index.js
+++ b/docs/pages/debugging/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/debugging/runtime-issue/');

--- a/docs/pages/deploy/index.js
+++ b/docs/pages/deploy/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/deploy/build-project/');

--- a/docs/pages/develop/index.js
+++ b/docs/pages/develop/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/develop/development-builds/introduction');

--- a/docs/pages/get-started/index.js
+++ b/docs/pages/get-started/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/get-started/installation/');

--- a/docs/pages/push-notifications/index.js
+++ b/docs/pages/push-notifications/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/push-notifications/overview/');

--- a/docs/pages/regulatory-compliance/index.js
+++ b/docs/pages/regulatory-compliance/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/regulatory-compliance/data-and-privacy-protection/');

--- a/docs/pages/tutorial/index.js
+++ b/docs/pages/tutorial/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/tutorial/introduction/');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1679938683342149)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding redirects that can be used as short URLs for the following sections that utilize the existing `redirect` component based on the file structure we've in **docs** repo:
- `/develop/` will direct to `/develop/development-builds/introduction`
- `/get-started/ will direct to `/get-started/installation`
- `/regulatory-compliance/` will lead to `/regulatory-compliance/data-and-privacy-protection/`
- `/deploy/` will lead to `/deploy/build-project/`
- `/debugging/` will lead to`/debugging/runtime-issue/`
- `/config-plugins` will lead to `/config-plugins/introduction/`
- `/tutorial` will lead to `/tutorial/introduction/`
- `/push-notifications/` will lead to `/push-notifications/overview`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested locally by using the URLs (mentioned on the left-hand side above).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
