### PR TITLE
Switch from deprecated kotlin method

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 11.1.1 — 2023-02-09
 

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 11.1.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/CalendarModule.kt
@@ -681,7 +681,7 @@ class CalendarModule(
     val rruleBundle = if (rrule != null) {
       val recurrenceRule = Bundle()
       val recurrenceRules = rrule.split(";").toTypedArray()
-      recurrenceRule.putString("frequency", recurrenceRules[0].split("=").toTypedArray()[1].toLowerCase(Locale.getDefault()))
+      recurrenceRule.putString("frequency", recurrenceRules[0].split("=").toTypedArray()[1].lowercase(Locale.getDefault()))
       if (recurrenceRules.size >= 2 && recurrenceRules[1].split("=").toTypedArray()[0] == "INTERVAL") {
         recurrenceRule.putInt("interval", recurrenceRules[1].split("=").toTypedArray()[1].toInt())
       }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 15.2.2 — 2023-02-09
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 15.2.2 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -1245,7 +1245,7 @@ open class FileSystemModule(
 
   private fun getEncodingFromOptions(options: Map<String?, Any?>): String {
     return if (options.containsKey("encoding") && options["encoding"] is String) {
-      (options["encoding"] as String).toLowerCase(Locale.ROOT)
+      (options["encoding"] as String).lowercase(Locale.ROOT)
     } else {
       "utf8"
     }

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 2.1.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 2.1.1 — 2023-02-09
 

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -50,13 +50,13 @@ class NavigationBarReactActivityLifecycleListener(activityContext: Context) : Re
     return parsed
   }
 
-  private fun getVisibility(context: Context): String = context.getString(R.string.expo_navigation_bar_visibility).toLowerCase()
+  private fun getVisibility(context: Context): String = context.getString(R.string.expo_navigation_bar_visibility).lowercase()
 
-  private fun getPosition(context: Context): String = context.getString(R.string.expo_navigation_bar_position).toLowerCase()
+  private fun getPosition(context: Context): String = context.getString(R.string.expo_navigation_bar_position).lowercase()
 
-  private fun getBehavior(context: Context): String = context.getString(R.string.expo_navigation_bar_behavior).toLowerCase()
+  private fun getBehavior(context: Context): String = context.getString(R.string.expo_navigation_bar_behavior).lowercase()
 
-  private fun getLegacyVisible(context: Context): String = context.getString(R.string.expo_navigation_bar_legacy_visible).toLowerCase()
+  private fun getLegacyVisible(context: Context): String = context.getString(R.string.expo_navigation_bar_legacy_visible).lowercase()
 
   companion object {
     private const val ERROR_TAG = "ERR_NAVIGATION_BAR"

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 5.1.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 5.1.1 — 2023-02-09
 

--- a/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
+++ b/packages/expo-screen-capture/android/src/main/java/expo/modules/screencapture/ScreenShotEventEmitter.kt
@@ -83,7 +83,7 @@ class ScreenshotEventEmitter(val context: Context, moduleRegistry: ModuleRegistr
   }
 
   private fun isPathOfNewScreenshot(path: String): Boolean {
-    if (!path.toLowerCase().contains("screenshot")) {
+    if (!path.lowercase().contains("screenshot")) {
       return false
     }
     // Cannot check that the onChange event is for an insert operation until API level 30

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 0.18.1 — 2023-02-09
 

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 0.18.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -32,7 +32,7 @@ class SplashScreenReactActivityLifecycleListener(activityContext: Context) : Rea
 
   private fun getResizeMode(context: Context): SplashScreenImageResizeMode =
     SplashScreenImageResizeMode.fromString(
-      context.getString(R.string.expo_splash_screen_resize_mode).toLowerCase()
+      context.getString(R.string.expo_splash_screen_resize_mode).lowercase()
     )
       ?: SplashScreenImageResizeMode.CONTAIN
 

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+
 ## 2.2.1 — 2023-02-09
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 2.2.1 — 2023-02-09
 

--- a/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
+++ b/packages/expo-system-ui/android/src/main/java/expo/modules/systemui/SystemUIReactActivityLifecycleListener.kt
@@ -14,5 +14,5 @@ class SystemUIReactActivityLifecycleListener(activityContext: Context) : ReactAc
   }
 
   private fun getUserInterfaceStyle(context: Context): String =
-    context.getString(R.string.expo_system_ui_user_interface_style).toLowerCase()
+    context.getString(R.string.expo_system_ui_user_interface_style).lowercase()
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix iOS native debug after Swift conversion. ([#21602](https://github.com/expo/expo/pull/21602) by [@douglowder](https://github.com/douglowder))
 - Fix compilation errors and enable modules after Swift conversion. ([#21621](https://github.com/expo/expo/pull/21621) by [@wschurman](https://github.com/wschurman), [@douglowder](https://github.com/douglowder))
 - E2E tests for JS API. ([#22167](https://github.com/expo/expo/pull/22167) by [@douglowder](https://github.com/douglowder))
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function
 
 ## 0.16.4 - 2023-04-03
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Fix iOS native debug after Swift conversion. ([#21602](https://github.com/expo/expo/pull/21602) by [@douglowder](https://github.com/douglowder))
 - Fix compilation errors and enable modules after Swift conversion. ([#21621](https://github.com/expo/expo/pull/21621) by [@wschurman](https://github.com/wschurman), [@douglowder](https://github.com/douglowder))
 - E2E tests for JS API. ([#22167](https://github.com/expo/expo/pull/22167) by [@douglowder](https://github.com/douglowder))
-- Android: Switch from deprecated `toLowerCase` to `lowercase` function
+- Android: Switch from deprecated `toLowerCase` to `lowercase` function ([#22225](https://github.com/expo/expo/pull/22225) by [@hbiede](https://github.com/hbiede))
 
 ## 0.16.4 - 2023-04-03
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
@@ -28,7 +28,7 @@ object SelectionPolicies {
       val metadataKeySet = metadata.keys()
       while (metadataKeySet.hasNext()) {
         val key = metadataKeySet.next()
-        metadataLCKeys.put(key.toLowerCase(), metadata[key])
+        metadataLCKeys.put(key.lowercase(), metadata[key])
       }
       val filterKeySet = manifestFilters.keys()
       while (filterKeySet.hasNext()) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`toLowerCase` is deprecated, switch to `lowercase` function

# How

<!--
How did you build this feature or fix this bug and why?
-->

`sed -i '' -E -e 's|toLowerCase|lowercase|g' packages/**/*.kt`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
No testing should be necessary

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
