### PR TITLE
[expo-updates] Fix empty body no-op multipart response

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Align properties for different UpdateEvent types. ([#21818](https://github.com/expo/expo/pull/21818) by [@douglowder](https://github.com/douglowder))
 - Improvement in stability of useUpdateEvents() hook. ([#21880](https://github.com/expo/expo/pull/21880) by [@douglowder](https://github.com/douglowder))
 - Copy native events before transforming them. ([#22162](https://github.com/expo/expo/pull/22162) by [@douglowder](https://github.com/douglowder))
+- Fix empty body no-op multipart response. ([#22227](https://github.com/expo/expo/pull/22227) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -417,7 +417,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
     var certificateChainStringData: Data?
     var directivePartHeadersAndData: ([String: Any], Data)?
 
-    let completed = reader.readAllParts { headers, content, _ in
+    let completed = data.isEmpty || reader.readAllParts { headers, content, _ in
       if let contentDisposition = (headers as! [String: Any]).stringValueForCaseInsensitiveKey("content-disposition") {
         if let contentDispositionParameters = EXUpdatesParameterParser().parseParameterString(
           contentDisposition,

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -203,6 +203,38 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(resultUpdateResponse?.manifestUpdateResponsePart).to(beNil())
         expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
       }
+
+      fit("multipart body empty") {
+        let config = UpdatesConfig.config(fromDictionary: [
+          UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        ])
+        let downloader = FileDownloader(config: config)
+
+        let boundary = "blah"
+        let contentType = "multipart/mixed; boundary=\(boundary)"
+        let response = HTTPURLResponse(
+          url: URL(string: "https://exp.host/@test/test")!,
+          statusCode: 200,
+          httpVersion: "HTTP/1.1",
+          headerFields: ["content-type": contentType]
+        )!
+
+        let bodyData = Data()
+
+        var resultUpdateResponse: UpdateResponse? = nil
+        var errorOccurred: (any Error)? = nil
+        downloader.parseManifestResponse(response, withData: bodyData, database: database) { updateResponse in
+          resultUpdateResponse = updateResponse
+        } errorBlock: { error in
+          errorOccurred = error
+        }
+
+        expect(errorOccurred).to(beNil())
+        expect(resultUpdateResponse).notTo(beNil())
+
+        expect(resultUpdateResponse?.manifestUpdateResponsePart).to(beNil())
+        expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
+      }
       
       it("json body signed") {
         let config = UpdatesConfig.config(fromDictionary: [


### PR DESCRIPTION
# Why

@douglowder noticed that the new no-op (empty body) responses added in https://github.com/expo/universe/pull/12050 were not working on iOS. This is probably because it's always a lot easier for me to test and debug on android so I must've missed this case when implementing the iOS equivalent.

# How

Add test to both platforms, run tests, fix it on iOS.

# Test Plan

Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
