### PR TITLE
fix(cli): skip verifying arbitrary platforms without verifier

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix main field resolution for metro web. ([#21939](https://github.com/expo/expo/pull/21939) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix cached code signing development certificate offline behavior. ([#21989](https://github.com/expo/expo/pull/21989) by [@wschurman](https://github.com/wschurman))
 - Remove invalid array group syntax from Expo Router type generation. ([#22185](https://github.com/expo/expo/pull/22185) by [@marklawlor](https://github.com/marklawlor))
+- Skip verifying arbitrary platforms when prebuilding. ([#22228](https://github.com/expo/expo/pull/22228) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/__tests__/clearNativeFolder-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/clearNativeFolder-test.ts
@@ -51,6 +51,30 @@ describe(getMalformedNativeProjectsAsync, () => {
     expect(malformed).toStrictEqual([]);
   });
 
+  it(`skips arbitrary platforms without verifiers`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        ...Object.entries(rnFixture).reduce((prev, [key, value]) => {
+          // Skip ios project files
+          if (key.startsWith('ios')) return prev;
+          return {
+            ...prev,
+            [key]: value,
+          };
+        }, {}),
+      },
+      projectRoot
+    );
+    const malformed = await getMalformedNativeProjectsAsync(projectRoot, [
+      'windows',
+      'macos',
+      'tvos',
+      'androidtv',
+    ] as any);
+    expect(malformed).toStrictEqual([]);
+  });
+
   it(`finds a single platform`, async () => {
     const projectRoot = '/';
     vol.fromJSON(rnFixture, projectRoot);

--- a/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
+++ b/packages/@expo/cli/src/prebuild/clearNativeFolder.ts
@@ -95,7 +95,8 @@ export async function getMalformedNativeProjectsAsync(
     ios: hasRequiredIOSFilesAsync,
   };
 
-  const checkPlatforms = await filterPlatformsThatDoNotExistAsync(projectRoot, platforms);
+  const checkablePlatforms = platforms.filter((platform) => platform in VERIFIERS);
+  const checkPlatforms = await filterPlatformsThatDoNotExistAsync(projectRoot, checkablePlatforms);
   return (
     await Promise.all(
       checkPlatforms.map(async (platform) => {


### PR DESCRIPTION
# Why

We can't validate platforms without verifiers 🤷 

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/1203991/233750020-4d7d47c3-ef3b-4c7d-82a7-872050443fca.png">

# How

- Filtered platforms on verification availability

# Test Plan

See added test

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
