### PR TITLE
Dependabot/npm and yarn/xml2js 0.5.0

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Update tests. ([#21396](https://github.com/expo/expo/pull/21396) by [@EvanBacon](https://github.com/EvanBacon))
 - Update tests to use latest Expo template. ([#21339](https://github.com/expo/expo/pull/21339) by [@EvanBacon](https://github.com/EvanBacon))
 - Update snapshots. ([#22032](https://github.com/expo/expo/pull/22032) by [@EvanBacon](https://github.com/EvanBacon))
+- Bump `xml2js` from `0.4.23` to `0.5.0` in `@expo/config-plugins` to patch security vulnerability. ([#22071](https://github.com/expo/expo/pull/22071) by [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) and [cheng-alvin](https://github.com/cheng-alvin))
 
 ## 6.0.0 — 2023-02-03
 
@@ -35,4 +36,3 @@
 ### 💡 Others
 
 - Bump `@expo/json-file`, `@expo/plist`. ([#20720](https://github.com/expo/expo/pull/20720) by [@EvanBacon](https://github.com/EvanBacon))
-- Bump `xml2js` from `0.4.23` to `0.5.0` in `@expo/config-plugins` to patch security vulnerability. ([#22071](https://github.com/expo/expo/pull/22071) by [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) and [cheng-alvin](https://github.com/cheng-alvin))

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -35,3 +35,4 @@
 ### 💡 Others
 
 - Bump `@expo/json-file`, `@expo/plist`. ([#20720](https://github.com/expo/expo/pull/20720) by [@EvanBacon](https://github.com/EvanBacon))
+- Bump `xml2js` from `0.4.23` to `0.5.0` in `@expo/config-plugins` to patch security vulnerability. ([#22071](https://github.com/expo/expo/pull/22071) by [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) and [cheng-alvin](https://github.com/cheng-alvin))

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Update tests to use latest Expo template. ([#21339](https://github.com/expo/expo/pull/21339) by [@EvanBacon](https://github.com/EvanBacon))
 - Update build files. ([#21941](https://github.com/expo/expo/pull/21941) by [@EvanBacon](https://github.com/EvanBacon))
+- Bump `xml2js` from `0.4.23` to `0.5.0` in `@expo/prebuild-config` to patch security vulnerability. ([#22071](https://github.com/expo/expo/pull/22071) by [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) and [cheng-alvin](https://github.com/cheng-alvin))
 
 ## 6.0.0 — 2023-02-03
 


### PR DESCRIPTION
Hello there! I have noticed that the bot suggested an entry to the changelogs in [this](https://github.com/expo/expo/pull/22071) PR opened by Dependabot bumping ```xml2js```. I have added the suggested changelog entry for ```expo:dependabot/npm_and_yarn```.


Thanks!