### PR TITLE
[docs] Fix empty space in Regulatory compliance navigation structure

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -523,10 +523,12 @@ function pageUrl(file) {
 /**
  * Sort the list of pages alphabetically by either the sidebarTitle or title.
  */
-function sortAlphabetical(pages) {
-  return pages.sort((a, b) => {
-    const aTitle = a.sidebarTitle || a.name;
-    const bTitle = b.sidebarTitle || b.name;
-    return aTitle.localeCompare(bTitle);
-  });
-}
+// Note: (@aman) to refactor or remove the function below
+// We're not using it anywhere as of now.
+// function sortAlphabetical(pages) {
+//   return pages.sort((a, b) => {
+//     const aTitle = a.sidebarTitle || a.name;
+//     const bTitle = b.sidebarTitle || b.name;
+//     return aTitle.localeCompare(bTitle);
+//   });
+// }

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -299,7 +299,12 @@ const general = [
     ],
     { expanded: true }
   ),
-  makeSection('Regulatory compliance', sortAlphabetical(pagesFromDir('regulatory-compliance')), {}),
+  makeSection('Regulatory compliance', [
+    makePage('regulatory-compliance/data-and-privacy-protection.mdx'),
+    makePage('regulatory-compliance/gdpr.mdx'),
+    makePage('regulatory-compliance/hipaa.mdx'),
+    makePage('regulatory-compliance/privacy-shield.mdx'),
+  ]),
 ];
 
 const learn = [

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -519,16 +519,3 @@ function pageUrl(file) {
     .replace(filePath.base, filePath.name === 'index' ? '' : filePath.name)
     .replace(/\/$/, '');
 }
-
-/**
- * Sort the list of pages alphabetically by either the sidebarTitle or title.
- */
-// Note: (@aman) to refactor or remove the function below
-// We're not using it anywhere as of now.
-// function sortAlphabetical(pages) {
-//   return pages.sort((a, b) => {
-//     const aTitle = a.sidebarTitle || a.name;
-//     const bTitle = b.sidebarTitle || b.name;
-//     return aTitle.localeCompare(bTitle);
-//   });
-// }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After adding redirects for sections in the PR #22222, we've noticed that there is an empty space created with the current navigation structure of the Regulatory compliance section defined in `navigation.js` file. The PR changes introduced an `index.js` file to add a redirect for `/regulatory-compliance` URL.

<img width="279" alt="CleanShot 2023-04-22 at 16 16 27@2x" src="https://user-images.githubusercontent.com/10234615/233779753-4ed8eefe-0cc8-4c6f-9592-ea41de83a199.png">

# How

By adding each page in the order they should be defined in the section's navigation structure in `navigation.js` and removing the empty object along with sorting pages alphabetically.

# Test Plan

<img width="271" alt="CleanShot 2023-04-22 at 16 17 35@2x" src="https://user-images.githubusercontent.com/10234615/233779706-cee83663-e072-45bd-85b7-a49caeeaa9f7.png">

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
