### PR TITLE
fix(cli): check if template URL is a path on windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Fix cached code signing development certificate offline behavior. ([#21989](https://github.com/expo/expo/pull/21989) by [@wschurman](https://github.com/wschurman))
 - Remove invalid array group syntax from Expo Router type generation. ([#22185](https://github.com/expo/expo/pull/22185) by [@marklawlor](https://github.com/marklawlor))
 - Skip verifying arbitrary platforms when prebuilding. ([#22228](https://github.com/expo/expo/pull/22228) by [@byCedric](https://github.com/byCedric))
+- Fix prebuild `--template` flag on Windows for local tarballs. ([#22232](https://github.com/expo/expo/pull/22232) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -130,6 +130,12 @@ export async function resolveTemplateArgAsync(
       }
     }
 
+    // On Windows, we can actually create a URL from a local path
+    // Double-check if the created URL is not a path to avoid mixing up URLs and paths
+    if (process.platform === 'win32' && repoUrl && path.isAbsolute(repoUrl.toString())) {
+      repoUrl = undefined;
+    }
+
     if (!repoUrl) {
       const templatePath = path.resolve(template);
       if (!fs.existsSync(templatePath)) {


### PR DESCRIPTION
# Why

Turns out that you can actually create a `URL` instance from absolute path on Windows... This is interesting on it's own, but also causes issues with the `--template` flag.

![image](https://user-images.githubusercontent.com/1203991/233783267-6548e3c0-4c3f-4196-a257-926bee8cc3a9.png)

# How

- Added check to filter out this scenario, windows only

# Test Plan

TBD

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
