### PR TITLE
[core] fix androidTest error

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -23,7 +23,12 @@ internal inline fun withJSIInterop(
   block: JSIInteropModuleRegistry.(methodQueue: TestScope) -> Unit
 ) {
   val appContextMock = mockk<AppContext>()
+
   val methodQueue = TestScope()
+  every { appContextMock.modulesQueue } answers { methodQueue }
+  every { appContextMock.mainQueue } answers { methodQueue }
+  every { appContextMock.backgroundCoroutineScope } answers { methodQueue }
+
   val registry = ModuleRegistry(WeakReference(appContextMock)).apply {
     modules.forEach {
       register(it)
@@ -31,8 +36,6 @@ internal inline fun withJSIInterop(
   }
   val sharedObjectRegistry = SharedObjectRegistry()
   every { appContextMock.registry } answers { registry }
-  every { appContextMock.modulesQueue } answers { methodQueue }
-  every { appContextMock.mainQueue } answers { methodQueue }
   every { appContextMock.sharedObjectRegistry } answers { sharedObjectRegistry }
 
   val jsiIterop = JSIInteropModuleRegistry(appContextMock).apply {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.logging
 
 import android.os.Bundle
+import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
 import expo.modules.core.Promise
 import expo.modules.core.logging.LogType
@@ -8,13 +9,14 @@ import expo.modules.core.logging.PersistentFileLog
 import expo.modules.updates.UpdatesModule
 import expo.modules.updates.logging.UpdatesLogger.Companion.EXPO_UPDATES_LOGGING_TAG
 import expo.modules.updates.logging.UpdatesLogger.Companion.MAX_FRAMES_IN_STACKTRACE
-import junit.framework.TestCase
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import java.util.*
 
-class UpdatesLoggingTest : TestCase() {
+@RunWith(AndroidJUnit4ClassRunner::class)
+class UpdatesLoggingTest {
 
   @Before
   fun setup() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.util.Log
+import expo.modules.core.errors.InvalidArgumentException
 import expo.modules.updates.codesigning.CodeSigningConfiguration
 
 /**
@@ -48,7 +49,9 @@ data class UpdatesConfiguration(
     ALWAYS {
       override fun toJSString() = "ALWAYS"
     };
-    abstract fun toJSString(): String
+    open fun toJSString(): String {
+      throw InvalidArgumentException("Unsupported CheckAutomaticallyConfiguration value")
+    }
   }
 
   constructor(context: Context?, overrideMap: Map<String, Any>?) : this(


### PR DESCRIPTION
# Why

fix android instrumentation test error:
expo-modules-core: https://github.com/expo/expo/actions/runs/4770550299/jobs/8481882792
expo-updates: https://github.com/expo/expo/actions/runs/4785632925/jobs/8509073622


### expo-modules-core

```
expo.modules.JavaScriptViewModule > should_export_view_prototype[avd-31(AVD) - 12] FAILED 
	io.mockk.MockKException: no answer found for: AppContext(#1).getBackgroundCoroutineScope()
	at io.mockk.impl.stub.MockKStub.defaultAnswer(MockKStub.kt:93)

expo.modules.JavaScriptViewModule > view_functions_should_be_callable[avd-31(AVD) - 12] FAILED 
	io.mockk.MockKException: no answer found for: AppContext(#2).getBackgroundCoroutineScope()
	at io.mockk.impl.stub.MockKStub.defaultAnswer(MockKStub.kt:93)
```

### expo-updates

1. crashes from `mockDelegate.getCheckAutomaticallyConfiguration()`
2. https://github.com/expo/expo/blob/79c05375b8ae9149aa4dff456a3c25641a68f360/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt#L106 the line here is two rather than one: 

# How

- [core] answers mocked `getBackgroundCoroutineScope`
- [updates] my hypothesis is that mockk cannot [instantiate abstract classes](https://github.com/mockk/mockk/issues/1080). after #22137, the `UpdatesConfiguration.CheckAutomaticallyConfiguration` is now an anonymous class. the workaround here is having a default implementation for `UpdatesConfiguration.CheckAutomaticallyConfiguration.toJSString()`.
- [updates] fix `@Before` does not be called in `UpdatesLoggingTest`.  in the `@Before` block, the test purges log and will make the test more reliable.

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - no user faced changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
