### PR TITLE
[docs] Improve preview introduction page

### DIFF
--- a/docs/pages/preview/custom-build-config-schema.mdx
+++ b/docs/pages/preview/custom-build-config-schema.mdx
@@ -2,6 +2,7 @@
 title: EAS Build custom builds config schema
 description: A reference of configuration options for custom workflows with EAS Build.
 hideFromSearch: true
+maxHeadingDepth: 5
 ---
 
 Creating custom workflows for EAS Build helps customize the build process for your project.

--- a/docs/pages/preview/introduction.mdx
+++ b/docs/pages/preview/introduction.mdx
@@ -1,12 +1,17 @@
 ---
 title: Introduction
+hideTOC: true
 ---
 
-This section of the documentation provides a preview of experimental new features that we're working on at Expo. It is not linked from the main documentation but it is also not particularly well hidden &mdash; if you want to find it, [you can](https://github.com/expo/expo/tree/main/docs/pages/preview/introduction.mdx). We just ask that you please keep the following in mind when exploring preview features:
+This section of the documentation provides a preview of experimental new features that we're working on at Expo. It is not linked from the main documentation but it is also not particularly well hidden &mdash; if you want to find it, [you can](https://github.com/expo/expo/tree/main/docs/pages/preview/introduction.mdx).
 
-1. 🚫 **Please don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
-2. 👀 **You probably should not depend on preview features in production** unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
-3. 💰 **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
-4. 💌 **Please provide us with detailed feedback from your experiences using experimental features** &mdash; from documentation to API interfaces to CLI commands, we want to hear your feedback now, because it will never be quite as easy to change it as during the preview phase. More information on this in [Support & Feedback](/preview/support/).
+> **info** Pages behind `/preview` are not indexed on search engines.
+
+We just ask that you please keep the following in mind when exploring preview features:
+
+1. **Please don't produce blogs posts, YouTube videos, or other content covering the preview features.** Everything documented here is likely to change and the content will quickly go stale.
+2. **You probably should not depend on preview features in production** unless you are prepared to deal with the instability that may come with a rapidly evolving product offering.
+3. **Features that are free to preview may end up being paid services when they are released**. Don't plan your business around these features being free.
+4. **Please provide us with detailed feedback from your experiences using experimental features** &mdash; from documentation to API interfaces to CLI commands, we want to hear your feedback now, because it will never be quite as easy to change it as during the preview phase. More information on this in [Support & Feedback](/preview/support/).
 
 Thank you! Now take a look at the sidebar (or the `...` menu on mobile) to explore.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the `/preview` introduction page does not follow our writing style guidelines.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove emojis as per our writing styleguide
- Also, increase heading levels to appear in sidebar on config schema page

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Preview introduction page:

<img width="1223" alt="CleanShot 2023-04-24 at 20 36 20@2x" src="https://user-images.githubusercontent.com/10234615/234037897-eda77c30-6743-4a3f-ad9c-df6d8528c64a.png">

Sidebar improvements:

<img width="275" alt="CleanShot 2023-04-24 at 20 37 04@2x" src="https://user-images.githubusercontent.com/10234615/234038056-16844889-bb19-4bf2-90d0-c9a8af3478fc.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
