### PR TITLE
[core][iOS] Passing JS functions to native methods

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [iOS] Introduced native functions on the native component instances. ([#21746](https://github.com/expo/expo/pull/21746) by [@tsapeta](https://github.com/tsapeta))
 - View tag and React component ref can now be converted to an instance of the native view when used as a function's argument. ([#21816](https://github.com/expo/expo/pull/21816) by [@lukmccall](https://github.com/lukmccall), [#21829](https://github.com/expo/expo/pull/21829) by [@tsapeta](https://github.com/tsapeta))
-- [Android] JavaScript functions can now be passed as an argument to a module method. ([#21976](https://github.com/expo/expo/pull/21976) by [@lukmccall](https://github.com/lukmccall))
+- JavaScript functions can now be passed as an argument to a module method. ([#21976](https://github.com/expo/expo/pull/21976) by [@lukmccall](https://github.com/lukmccall), [#22245](https://github.com/expo/expo/pull/22245) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Initializing and returning shared objects from the native side. ([#22195](https://github.com/expo/expo/pull/22195) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.h
@@ -9,6 +9,7 @@ namespace jsi = facebook::jsi;
 #endif // __cplusplus
 
 @class EXJavaScriptRuntime;
+@class EXRawJavaScriptFunction;
 @class EXJavaScriptTypedArray;
 
 /**
@@ -49,6 +50,7 @@ NS_SWIFT_NAME(JavaScriptValue)
 - (nonnull NSArray<EXJavaScriptValue *> *)getArray;
 - (nonnull NSDictionary<NSString *, id> *)getDictionary;
 - (nonnull EXJavaScriptObject *)getObject;
+- (nonnull EXRawJavaScriptFunction *)getFunction;
 - (nullable EXJavaScriptTypedArray *)getTypedArray;
 
 #pragma mark - Helpers

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptValue.mm
@@ -3,6 +3,7 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/EXJavaScriptValue.h>
 #import <ExpoModulesCore/EXJavaScriptRuntime.h>
+#import <ExpoModulesCore/EXRawJavaScriptFunction.h>
 #import <ExpoModulesCore/EXJavaScriptTypedArray.h>
 #import <ExpoModulesCore/TypedArray.h>
 
@@ -140,6 +141,13 @@
   jsi::Runtime *runtime = [_runtime get];
   std::shared_ptr<jsi::Object> objectPtr = std::make_shared<jsi::Object>(_value->asObject(*runtime));
   return [[EXJavaScriptObject alloc] initWith:objectPtr runtime:_runtime];
+}
+
+- (nonnull EXRawJavaScriptFunction *)getFunction
+{
+  jsi::Runtime *runtime = [_runtime get];
+  std::shared_ptr<jsi::Function> functionPtr = std::make_shared<jsi::Function>(_value->asObject(*runtime).asFunction(*runtime));
+  return [[EXRawJavaScriptFunction alloc] initWith:functionPtr runtime:_runtime];
 }
 
 - (nullable EXJavaScriptTypedArray *)getTypedArray

--- a/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.h
+++ b/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.h
@@ -1,0 +1,24 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+#import <ExpoModulesCore/EXJavaScriptRuntime.h>
+
+#ifdef __cplusplus
+#import <jsi/jsi.h>
+
+namespace jsi = facebook::jsi;
+#endif // __cplusplus
+
+NS_SWIFT_NAME(RawJavaScriptFunction)
+@interface EXRawJavaScriptFunction : NSObject
+
+#ifdef __cplusplus
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Function>)function
+                         runtime:(nonnull EXJavaScriptRuntime *)runtime;
+#endif // __cplusplus
+
+- (nonnull EXJavaScriptValue *)callWithArguments:(nonnull NSArray<id> *)arguments
+                                      thisObject:(nullable EXJavaScriptObject *)thisObject
+                                   asConstructor:(BOOL)asConstructor;
+
+@end

--- a/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.mm
+++ b/packages/expo-modules-core/ios/JSI/EXRawJavaScriptFunction.mm
@@ -1,0 +1,52 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXJSIConversions.h>
+#import <ExpoModulesCore/EXRawJavaScriptFunction.h>
+
+@implementation EXRawJavaScriptFunction {
+  /**
+   Pointer to the `EXJavaScriptRuntime` wrapper.
+
+   \note It must be weak because only then the original runtime can be safely deallocated
+   when the JS engine wants to without unsetting it on each created object.
+   */
+  __weak EXJavaScriptRuntime *_runtime;
+
+  /**
+   Shared pointer to the `WeakRef` JS object. Available only on JSC engine.
+   */
+  std::shared_ptr<jsi::Function> _function;
+}
+
+- (nonnull instancetype)initWith:(std::shared_ptr<jsi::Function>)function
+                         runtime:(nonnull EXJavaScriptRuntime *)runtime
+{
+  if (self = [super init]) {
+    _runtime = runtime;
+    _function = function;
+  }
+  return self;
+}
+
+- (nonnull EXJavaScriptValue *)callWithArguments:(nonnull NSArray<id> *)arguments
+                                      thisObject:(nullable EXJavaScriptObject *)thisObject
+                                   asConstructor:(BOOL)asConstructor
+{
+  jsi::Runtime *runtime = [_runtime get];
+  std::vector<jsi::Value> vector = expo::convertNSArrayToStdVector(*runtime, arguments);
+  const jsi::Value *data = vector.data();
+  jsi::Value result;
+
+  if (asConstructor) {
+    result = _function->callAsConstructor(*runtime, data, arguments.count);
+  } else if (thisObject) {
+    result = _function->callWithThis(*runtime, *[thisObject get], data, arguments.count);
+  } else {
+    result = _function->call(*runtime, data, arguments.count);
+  }
+
+  std::shared_ptr<jsi::Value> resultPtr = std::make_shared<jsi::Value>(*runtime, result);
+  return [[EXJavaScriptValue alloc] initWithRuntime:_runtime value:resultPtr];
+}
+
+@end

--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -15,7 +15,17 @@ public enum JavaScriptValueKind: String {
   case object
 }
 
-public extension JavaScriptValue {
+/**
+ A protocol that JavaScript values, objects and functions can conform to.
+ */
+protocol AnyJavaScriptValue {
+  /**
+   Tries to convert a raw JavaScript value to the conforming type.
+   */
+  static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self
+}
+
+extension JavaScriptValue: AnyJavaScriptValue {
   var kind: JavaScriptValueKind {
     switch true {
     case isUndefined():
@@ -86,11 +96,28 @@ public extension JavaScriptValue {
     throw JavaScriptValueConversionException((kind: kind, target: "Object"))
   }
 
+  func asFunction() throws -> RawJavaScriptFunction {
+    if isFunction() {
+      return getFunction()
+    }
+    throw JavaScriptValueConversionException((kind: kind, target: "Function"))
+  }
+
   func asTypedArray() throws -> JavaScriptTypedArray {
     if let typedArray = getTypedArray() {
       return typedArray
     }
     throw JavaScriptValueConversionException((kind: kind, target: "TypedArray"))
+  }
+
+  // MARK: - AnyJavaScriptValue
+
+  internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
+    // It's already a `JavaScriptValue` so it should always pass through.
+    if let value = value as? Self {
+      return value
+    }
+    throw JavaScriptValueConversionException((kind: value.kind, target: String(describing: Self.self)))
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicJavaScriptType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicJavaScriptType.swift
@@ -1,0 +1,27 @@
+// Copyright 2022-present 650 Industries. All rights reserved.
+
+/**
+ A dynamic type representing various types of JavaScript values.
+ */
+internal struct DynamicJavaScriptType: AnyDynamicType {
+  let innerType: AnyJavaScriptValue.Type
+
+  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
+    return innerType == InnerType.self
+  }
+
+  func equals(_ type: AnyDynamicType) -> Bool {
+    if let providedType = type as? Self {
+      return providedType.innerType == innerType
+    }
+    return false
+  }
+
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    return try innerType.convert(from: jsValue, appContext: appContext)
+  }
+
+  var description: String {
+    return String(describing: innerType.self)
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicType.swift
@@ -30,6 +30,9 @@ internal func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if let TypedArrayType = T.self as? AnyTypedArray.Type {
     return DynamicTypedArrayType(innerType: TypedArrayType)
   }
+  if let JavaScriptValueType = T.self as? any AnyJavaScriptValue.Type {
+    return DynamicJavaScriptType(innerType: JavaScriptValueType)
+  }
   return DynamicRawType(innerType: T.self)
 }
 

--- a/packages/expo-modules-core/ios/Swift/JavaScriptFunction.swift
+++ b/packages/expo-modules-core/ios/Swift/JavaScriptFunction.swift
@@ -1,0 +1,68 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+/**
+ Represents a JavaScript function that can be called by the native code and that must return the given generic `ReturnType`.
+ */
+public final class JavaScriptFunction<ReturnType>: AnyArgument, AnyJavaScriptValue {
+  /**
+   Raw representation of the JavaScript function that doesn't impose any restrictions on the returned type.
+   */
+  private let rawFunction: RawJavaScriptFunction
+
+  /**
+   Weak reference to the app context that is necessary to convert some arguments associated with the context (e.g. shared objects).
+   */
+  private weak var appContext: AppContext?
+
+  init(rawFunction: RawJavaScriptFunction, appContext: AppContext) {
+    self.rawFunction = rawFunction
+    self.appContext = appContext
+  }
+
+  // MARK: - Calling
+
+  /**
+   Calls the function with the given `this` object and arguments.
+   */
+  public func call(_ arguments: Any..., usingThis this: JavaScriptObject? = nil) throws -> ReturnType {
+    return try call(withArguments: arguments, asConstructor: false, usingThis: this)
+  }
+
+  /**
+   Calls the function as a constructor with the given arguments. It's like calling a function with the `new` keyword.
+   */
+  public func callAsConstructor(_ arguments: Any...) throws -> ReturnType {
+    return try call(withArguments: arguments, asConstructor: true, usingThis: nil)
+  }
+
+  /**
+   Universal function that calls the function with given arguments, this object and whether to call it as a constructor.
+   */
+  private func call(withArguments arguments: [Any] = [], asConstructor: Bool = false, usingThis this: JavaScriptObject? = nil) throws -> ReturnType {
+    guard let appContext else {
+      throw AppContextLostException()
+    }
+    let value = rawFunction.call(withArguments: arguments, thisObject: this, asConstructor: false)
+    let dynamicType = ~ReturnType.self
+
+    guard let result = try dynamicType.cast(jsValue: value, appContext: appContext) as? ReturnType else {
+      throw UnexpectedReturnType(dynamicType.description)
+    }
+    return result
+  }
+
+  // MARK: - AnyJavaScriptValue
+
+  internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
+    guard value.kind == .function else {
+      throw Conversions.ConvertingException<JavaScriptFunction<ReturnType>>(value)
+    }
+    return Self(rawFunction: value.getFunction(), appContext: appContext)
+  }
+}
+
+private final class UnexpectedReturnType: GenericException<String> {
+  override var reason: String {
+    return "The function returned a value that cannot be converted to \(param)"
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -265,6 +265,10 @@ class FunctionSpec: ExpoSpec {
               }
             }
           }
+
+          Function("withFunction") { (fn: JavaScriptFunction<String>) -> String in
+            return try fn.call("foo", "bar")
+          }
         })
       }
 
@@ -289,6 +293,13 @@ class FunctionSpec: ExpoSpec {
 
         expect(result.kind) == .number
         expect(result.getInt()) == initialValue + 1
+      }
+
+      it("takes JavaScriptFunction argument") {
+        let value = try runtime.eval("expo.modules.TestModule.withFunction((a, b) => a + b)")
+
+        expect(value.kind) == .string
+        expect(value.getString()) == "foobar"
       }
     }
   }


### PR DESCRIPTION
# Why

Another missing piece is to conveniently pass JS functions to native and then be able to call it from native.

# How

Introduced a new type `JavaScriptFunction<ReturnType>` that can be used as a function argument.

# Test Plan

Added simple test case