### PR TITLE
[ENG-8074][docs] update EAS Build images docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -177,7 +177,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-ventura-13.3-xcode-14.3` (`latest` for `m-medium` resource class, only available for `m-medium` resource class)
+#### `macos-ventura-13.3-xcode-14.3` (`latest` for workers with Apple silicon, only available for workers with Apple silicon)
 
 <Collapsible summary="Details">
 
@@ -193,7 +193,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.2` (`latest` for `intel-medium` resource class, `default` for `m-medium` resource class)
+#### `macos-monterey-12.6-xcode-14.2` (`latest` for workers with Intel silicon, `default` for workers with Apple silicon)
 
 <Collapsible summary="Details">
 
@@ -209,7 +209,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.1` (`default` for `intel-medium` resource class)
+#### `macos-monterey-12.6-xcode-14.1` (`default` for workers with Intel silicon)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -177,7 +177,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-ventura-13.3-xcode-14.3` (`latest` for `m-medium` resource class)
+#### `macos-ventura-13.3-xcode-14.3` (`latest` for `m-medium` resource class, only available for `m-medium` resource class)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -9,9 +9,9 @@ import { Collapsible } from '~/ui/components/Collapsible';
 
 > This document describes the current build infrastructure as of **June 27, 2022**. It is likely to change over time, and this document will be updated.
 
-## Worker IP addresses
+## Builder IP addresses
 
-Here is the [up-to-date list of worker IP addresses](https://expo.dev/eas-build-worker-ips.txt).
+Here is the [up-to-date list of builder IP addresses](https://expo.dev/eas-build-worker-ips.txt).
 
 ## Configuring build environment
 
@@ -29,7 +29,7 @@ When selecting an image for the build you can use the full name provided below o
 
 ## Android build server configurations
 
-Android workers run on virtual machines in an isolated environment. Every build gets its own dedicated VM instance.
+Android builders run on virtual machines in an isolated environment. Every build gets its own dedicated VM instance.
 
 - Build resources:
   - [`medium`](eas-json/#resourceclass-1): 4 CPU, 16 GB RAM ([`n2-standard-4`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)
@@ -148,7 +148,7 @@ Android workers run on virtual machines in an isolated environment. Every build 
 
 ## iOS build server configurations
 
-iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM:
+iOS builder VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM:
 
 - Hardware:
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
@@ -177,7 +177,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-ventura-13.3-xcode-14.3` (`latest` for workers with Apple silicon, only available for workers with Apple silicon)
+#### `macos-ventura-13.3-xcode-14.3` (`latest` for Apple silicon builders, only available for Apple silicon builders)
 
 <Collapsible summary="Details">
 
@@ -193,7 +193,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.2` (`latest` for workers with Intel silicon, `default` for workers with Apple silicon)
+#### `macos-monterey-12.6-xcode-14.2` (`latest` for Intel builders, `default` for Apple silicon builders)
 
 <Collapsible summary="Details">
 
@@ -209,7 +209,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.1` (`default` for workers with Intel silicon)
+#### `macos-monterey-12.6-xcode-14.1` (`default` for Intel builders)
 
 <Collapsible summary="Details">
 
@@ -305,7 +305,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-big-sur-11.4-xcode-12.5` (deprecated, not available for M1 workers)
+#### `macos-big-sur-11.4-xcode-12.5` (deprecated, only available for Intel builders)
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -177,7 +177,23 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 ### iOS server images
 
-#### `macos-monterey-12.6-xcode-14.2` (alias `latest`)
+#### `macos-ventura-13.3-xcode-14.3` (`latest` for `m-medium` resource class)
+
+<Collapsible summary="Details">
+
+- macOS Ventrua 13.3
+- Xcode 14.3 (14E222b)
+- Node.js 16.18.1
+- Yarn 1.22.17
+- pnpm 8.2.0
+- npm 8.1.2
+- fastlane 2.212.2
+- CocoaPods 1.12.0
+- Ruby 2.7
+
+</Collapsible>
+
+#### `macos-monterey-12.6-xcode-14.2` (`latest` for `intel-medium` resource class, `default` for `m-medium` resource class)
 
 <Collapsible summary="Details">
 
@@ -193,7 +209,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.1` (alias `default`)
+#### `macos-monterey-12.6-xcode-14.1` (`default` for `intel-medium` resource class)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

We added a new Xcode 14.3 image and changed what `default` and `latest` means for M workers.

# How

Update images docs


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
