### PR TITLE
Change local modules path in tsconfig so it works with default ts tem…

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix tsconfig paths for local module lookup. ([#22249](https://github.com/expo/expo/pull/22249) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ### 📚 3rd party library updates

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -13,7 +13,7 @@
     "skipLibCheck": true,
     "target": "ESNext",
     "paths": {
-      "*": ["./modules/*"]
+      "*": ["../../modules/*"]
     }
   },
 


### PR DESCRIPTION
…plate

# Why

The paths was tested on a project that had baseUrl set, where it works correctly. The default Expo template does not use the `baseUrl` option, so we should align for the path to be read relative to `/node_modules/expo` instead, hence going up twice.

Unfortunately the TS autolookup will always be a bit brittle with the options tsconfig allows us, no way to lookup paths relative to package.json :/ 

# Test Plan

Tested manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
