### PR TITLE
[expo-updates] Put extra data mutation in transaction

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Improvement in stability of useUpdateEvents() hook. ([#21880](https://github.com/expo/expo/pull/21880) by [@douglowder](https://github.com/douglowder))
 - Copy native events before transforming them. ([#22162](https://github.com/expo/expo/pull/22162) by [@douglowder](https://github.com/douglowder))
 - Fix empty body no-op multipart response. ([#22227](https://github.com/expo/expo/pull/22227) by [@wschurman](https://github.com/wschurman))
+- Put extra data mutation in transaction. ([#22252](https://github.com/expo/expo/pull/22252) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/JSONDataDao.kt
@@ -51,4 +51,11 @@ abstract class JSONDataDao {
       _insertJSONData(JSONDataEntity(entry.key, entry.value, Date(), scopeKey))
     }
   }
+
+  @Transaction
+  open fun updateJSONStringForKey(key: String, scopeKey: String, updater: (previousValue: String?) -> String) {
+    val previousValue = loadJSONStringForKey(key, scopeKey)
+    _deleteJSONDataForKey(key, scopeKey)
+    _insertJSONData(JSONDataEntity(key, updater(previousValue), Date(), scopeKey))
+  }
 }

--- a/packages/expo-updates/e2e/fixtures/App-apitest.tsx
+++ b/packages/expo-updates/e2e/fixtures/App-apitest.tsx
@@ -33,8 +33,8 @@ export default function App() {
     if (checkResult.isAvailable) {
       setUpdateMessage(
         `checkForUpdateAsync found a new update: manifest = \n${manifestToString(
-          checkResult.manifest,
-        )}...`,
+          checkResult.manifest
+        )}...`
       );
     } else {
       setUpdateMessage('No new update available');
@@ -65,9 +65,7 @@ export default function App() {
     } else if (event.type === Updates.UpdateEventType.NO_UPDATE_AVAILABLE) {
       setUpdateMessage('No new update available');
     } else if (event.type === Updates.UpdateEventType.UPDATE_AVAILABLE) {
-      setUpdateMessage(
-        `New update available\n${manifestToString(event.manifest)}`,
-      );
+      setUpdateMessage(`New update available\n${manifestToString(event.manifest)}`);
       setUpdateAvailable(true);
     }
   };
@@ -81,9 +79,7 @@ export default function App() {
 
   const handleDownloadButtonPress = () => {
     downloadAndRunUpdate().catch((error) => {
-      setUpdateMessage(
-        `Error downloading and running update: ${error.message}`,
-      );
+      setUpdateMessage(`Error downloading and running update: ${error.message}`);
     });
   };
 
@@ -160,7 +156,7 @@ const manifestToString = (manifest?: Updates.Manifest) => {
           metadata: manifest.metadata,
         },
         null,
-        2,
+        2
       )
     : 'null';
 };

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -204,7 +204,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
       }
 
-      fit("multipart body empty") {
+      it("multipart body empty") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
         ])


### PR DESCRIPTION
# Why

Noticed that if I called `Updates.setExtraParamAsync` multiple times in parallel they could probably clobber each other's changes. Putting these in transactions allows us to guarantee some consistency and thrown exceptions otherwise.

# How

Put in transaction.

# Test Plan

Run tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
