### PR TITLE
Revert  two commits for absolute imports we decided not to support

### DIFF
--- a/packages/expo-yarn-workspaces/index.js
+++ b/packages/expo-yarn-workspaces/index.js
@@ -57,11 +57,6 @@ exports.createMetroConfiguration = function createMetroConfiguration(projectPath
       // Include .cjs files
       sourceExts: [...defaultConfig.resolver.sourceExts, 'cjs'],
 
-      nodeModulesPaths: [
-        ...defaultConfig.resolver.nodeModulesPaths,
-        path.join(projectPath, 'modules'),
-      ],
-
       // Make the symlinked packages visible to Metro
       extraNodeModules,
 

--- a/packages/expo/tsconfig.base.json
+++ b/packages/expo/tsconfig.base.json
@@ -11,10 +11,7 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "target": "ESNext",
-    "paths": {
-      "*": ["./modules/*"]
-    }
+    "target": "ESNext"
   },
 
   "exclude": ["node_modules", "babel.config.js", "metro.config.js", "jest.config.js"]


### PR DESCRIPTION
# Why

These commits were aimed to support absolute imports with expo-modules local.

```
import module from "my-module";
```

This proved brittle (it's a relative path from tsconfig, breaks when baseUrl is set, is bundler specific, ect.)
Instead we just import relative:

```
import module from "./modules/my-module";
```
And let the user set absolute imports with good FYI docs so it doesn't collide with the paths they may have setup.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
