### PR TITLE
[image][iOS] Fix for the "limited" media library permission

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageMediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageMediaLibraryScreen.tsx
@@ -1,0 +1,89 @@
+import { Image, ImageSource } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
+import * as MediaLibrary from 'expo-media-library';
+import { useCallback, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import Button from '../../components/Button';
+import MonoText from '../../components/MonoText';
+import { Colors } from '../../constants';
+
+export default function ImagePlaceholderScreen() {
+  const [source, setSource] = useState<ImageSource | null>(null);
+
+  const pickImage = useCallback(async () => {
+    const { assets } = await ImagePicker.launchImageLibraryAsync();
+    const uri = assets?.[0].uri;
+
+    if (uri) {
+      setSource({ uri });
+    } else {
+      setSource(null);
+    }
+  }, []);
+
+  const showRandomAsset = useCallback(async () => {
+    const { assets } = await MediaLibrary.getAssetsAsync();
+    const randomIndex = Math.floor(Math.random() * assets.length);
+    const randomAsset = assets[randomIndex];
+
+    if (randomAsset) {
+      setSource({ uri: randomAsset.uri });
+    } else {
+      setSource(null);
+    }
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Image
+        style={styles.image}
+        source={source}
+        placeholder={require('../../../assets/images/expo-icon.png')}
+        cachePolicy="none"
+        onError={(event) => {
+          alert(`Failed to load the image: ${event.error}`);
+        }}
+      />
+
+      <View style={styles.actionsContainer}>
+        <Text style={styles.text}>Integration with expo-image-picker</Text>
+        <Button style={styles.actionButton} title="Launch image picker" onPress={pickImage} />
+
+        <Text style={styles.text}>Integration with expo-media-library</Text>
+        <Button
+          style={styles.actionButton}
+          title="Show random recent asset"
+          onPress={showRandomAsset}
+        />
+
+        <Text style={styles.text}>Current source 👇</Text>
+        <MonoText>{JSON.stringify(source, null, 2)}</MonoText>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  image: {
+    height: 220,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  actionsContainer: {
+    alignItems: 'center',
+    padding: 10,
+  },
+  actionButton: {
+    marginVertical: 15,
+  },
+  text: {
+    marginTop: 15,
+    color: Colors.secondaryText,
+    textAlign: 'center',
+  },
+});

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -90,6 +90,13 @@ export const ImageScreens = [
       return optionalRequire(() => require('./ImageGifsScreen'));
     },
   },
+  {
+    name: 'MediaLibrary and ImagePicker integration',
+    route: 'image/media-library',
+    getComponent() {
+      return optionalRequire(() => require('./ImageMediaLibraryScreen'));
+    },
+  },
 ];
 
 if (Platform.OS === 'ios') {

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix for the "limited" media library permission.
+- Fix for the "limited" media library permission. ([#22261](https://github.com/expo/expo/pull/22261) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix for the "limited" media library permission.
+
 ### 💡 Others
 
 ## 1.2.1 — 2023-04-17

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -78,7 +78,8 @@ private func assetLocalIdentifier(fromUrl url: URL) -> String? {
  */
 private func isPhotoLibraryStatusAuthorized() -> Bool {
   if #available(iOS 14, *) {
-    return PHPhotoLibrary.authorizationStatus(for: .readWrite) == .authorized
+    let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    return status == .authorized || status == .limited
   } else {
     return PHPhotoLibrary.authorizationStatus() == .authorized
   }


### PR DESCRIPTION
# Why

Fixes #22251 

# How

Don't throw an error when the "limited" media library permission is granted

# Test Plan

Added new example to native-component-list that shows the integration with `expo-media-library` and `expo-image-picker`. I confirmed that it's now possible to show assets from the media library when the permission is limited.