### PR TITLE
[docs] Update EAS Build workers instances

### DIFF
--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -9,7 +9,7 @@ When using the default Version Control Systems (VCS) workflow, the content of yo
 
 ## Submodules initialization
 
-To initialize a submodule on EAS Build worker:
+To initialize a submodule on EAS Build builder:
 
 <Step label="1">
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -10,7 +10,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 ## Current limitations
 
-<Collapsible summary="Fixed memory and CPU limits on build worker servers">
+<Collapsible summary="Fixed memory and CPU limits on build servers">
 
 The [Server infrastructure reference](/build-reference/infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future, we will add more powerful configurations to increase memory limits and speed up build times.
 

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -17,7 +17,7 @@ EAS Build only supports SDK 41 and above projects. You must upgrade your project
 
 Apps built with EAS Build are like other CI services &mdash; the entire project is uploaded securely to the cloud, then downloaded by a build server, the dependencies are installed, and the build is run.
 
-With classic builds, your app's JavaScript is built on your development machine (when you publish the app bundle before building), but now the app's JavaScript is built on an EAS Build worker. Everything required to build your app [must be included in the project to be uploaded](https://expo.fyi/eas-build-archive).
+With classic builds, your app's JavaScript is built on your development machine (when you publish the app bundle before building), but now the app's JavaScript is built on an EAS Build builder. Everything required to build your app [must be included in the project to be uploaded](https://expo.fyi/eas-build-archive).
 
 To learn more about how EAS Build creates a successful build of your project, see [Android](/build-reference/android-builds) and [iOS](/build-reference/ios-builds) build processes.
 

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -133,7 +133,7 @@ Classic builds had no knowledge of your repository setup. You could use a monore
 or birepo or trirepo, the service was entirely indifferent. As long as you could publish a
 bundle, that's all that was needed.
 
-EAS Build needs to be able to install all of your project dependencies to set up the development environment inside of a worker. In some cases, that will require some additional configuration. For more information, see [How to set up EAS Build with a monorepo](/build-reference/build-with-monorepos/) and [Working with Monorepos](/guides/monorepos).
+EAS Build needs to be able to install all of your project dependencies to set up the development environment inside of a builder. In some cases, that will require some additional configuration. For more information, see [How to set up EAS Build with a monorepo](/build-reference/build-with-monorepos/) and [Working with Monorepos](/guides/monorepos).
 
 ## Miscellaneous
 

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -11,7 +11,7 @@ Before starting the build, you will need to configure your project to provide EA
 
 ## Default npm configuration
 
-By default, EAS Build uses a self-hosted npm cache that speeds up installing dependencies for all builds. Every EAS Build worker is configured with a **.npmrc** file is as follows for each platform:
+By default, EAS Build uses a self-hosted npm cache that speeds up installing dependencies for all builds. Every EAS Build builder is configured with a **.npmrc** file for each platform:
 
 #### Android
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -63,7 +63,7 @@ Armed with your error logs, you can often start to fix your build, or you can se
 
 Monorepos are incredibly useful but they do introduce their own set of problems. A monorepo that you have set up to work with `expo build` will not necessarily work with `eas build`.
 
-With EAS Build, it's necessary to upload the entire monorepo to the builders, set it up, and run the build; but, on `expo build` you only had to be able to build the JavaScript bundle locally and upload that to the builder.
+It's necessary to upload the entire monorepo to the EAS Build builders, set it up, and run the build. However, on `expo build` you only had to be able to build the JavaScript bundle locally and upload that to the builder.
 
 EAS Build is more like a typical CI service in that we need the source code, rather than a compiled JavaScript bundle and manifest. EAS Build has first-class support for Yarn workspaces, and [your success may vary when using other monorepo tools](/build-reference/limitations).
 
@@ -79,7 +79,7 @@ This can often be a sign that your app bundle is extremely large, which will mak
 
 To determine how large your bundle is and to see a breakdown of where the size comes from, use [react-native-bundle-visualizer](https://github.com/IjzerenHein/react-native-bundle-visualizer).
 
-It's not yet possible to increase memory limits on your build workers, [only one worker configuration is currently available](/build-reference/limitations).
+It's not yet possible to increase memory limits on your EAS Build builders, [only one builder configuration is currently available](/build-reference/limitations).
 
 </Collapsible>
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -63,7 +63,7 @@ Armed with your error logs, you can often start to fix your build, or you can se
 
 Monorepos are incredibly useful but they do introduce their own set of problems. A monorepo that you have set up to work with `expo build` will not necessarily work with `eas build`.
 
-With EAS Build, it's necessary to upload the entire monorepo to the build worker, set it up, and run the build; but, on `expo build` you only had to be able to build the JavaScript bundle locally and upload that to the worker.
+With EAS Build, it's necessary to upload the entire monorepo to the builders, set it up, and run the build; but, on `expo build` you only had to be able to build the JavaScript bundle locally and upload that to the builder.
 
 EAS Build is more like a typical CI service in that we need the source code, rather than a compiled JavaScript bundle and manifest. EAS Build has first-class support for Yarn workspaces, and [your success may vary when using other monorepo tools](/build-reference/limitations).
 
@@ -113,7 +113,7 @@ You can verify that your project builds on your local machine with the `npx expo
 
 <Collapsible summary="Don't have Xcode and Android Studio set up on your machine?">
 
-**If you do not have native toolchains installed locally**, for example, because you do not have an Apple computer and therefore cannot build an iOS app on your machine, it can be trickier to get to the bottom of build errors. The feedback loop of making small changes locally and then seeing the result on EAS Build is slower than doing the same steps locally because the EAS Build worker must set up its environment, download your project, and install dependencies before starting the build.
+**If you do not have native toolchains installed locally**, for example, because you do not have an Apple computer and therefore cannot build an iOS app on your machine, it can be trickier to get to the bottom of build errors. The feedback loop of making small changes locally and then seeing the result on EAS Build is slower than doing the same steps locally because the EAS Build builder must set up its environment, download your project, and install dependencies before starting the build.
 
 If you are willing and able to set up the appropriate native tools, then refer to the [React Native environment setup guide](https://reactnative.dev/docs/environment-setup).
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -79,7 +79,7 @@ This can often be a sign that your app bundle is extremely large, which will mak
 
 To determine how large your bundle is and to see a breakdown of where the size comes from, use [react-native-bundle-visualizer](https://github.com/IjzerenHein/react-native-bundle-visualizer).
 
-It's not yet possible to increase memory limits on your EAS Build builders, [only one builder configuration is currently available](/build-reference/limitations).
+To increase memory limits on your EAS Build builders, you can use [`large` resource class](/build-reference/eas-json/#resourceclass-1) in your **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations) for more information.
 
 </Collapsible>
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -51,7 +51,7 @@ See the [eas.json reference](/build/eas-json) for more information.
 
 ## Environment variables and app.config.js
 
-Environment variables used in your build profile will also be used to evaluate **app.config.js** when you run `eas build`. This is important to ensure that the result of evaluating **app.config.js** is the same when it's done locally while initiating the build (to gather metadata for the build job) and when it occurs on the remote build worker, for example, to configure the project during `npx expo prebuild` or to embed the configuration data in the app.
+Environment variables used in your build profile will also be used to evaluate **app.config.js** when you run `eas build`. This is important to ensure that the result of evaluating **app.config.js** is the same when it's done locally while initiating the build (to gather metadata for the build job) and when it occurs on the remote builder, for example, to configure the project during `npx expo prebuild` or to embed the configuration data in the app.
 
 ## Built-in environment variables
 
@@ -299,7 +299,7 @@ Environment variables set in your build profile that impact **app.config.js** wi
 
 ### Can I just set my environment variables on a CI provider?
 
-Environment variables must be defined in **eas.json** to be made available to EAS Build workers. If you are [triggering builds from CI](/build/building-on-ci) this same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets in **eas.json**.
+Environment variables must be defined in **eas.json** to be made available to EAS Build builders. If you are [triggering builds from CI](/build/building-on-ci) this same rule applies, and you should be careful to not confuse setting environment variables on GitHub Actions (or the provider of your choice) with setting environment variables and secrets in **eas.json**.
 
 ### How to upload a secret file and use it in my app config?
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -83,7 +83,7 @@ export default {
 };
 ```
 
-> **Note**: if you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps, you will need to have a separate configuration for that API for the iOS Bundle Identifier and Android Package. You can also swap this configuration in using the same approach as above.
+> **Note**: if you are using any libraries that require you to register your application identifier with an external service to use the SDK, such as Google Maps, you will need to have a separate configuration for that API for the iOS Bundle Identifier and Android Package. You can also swap this configuration using the same approach as above.
 
 To automatically set the `APP_VARIANT` environment variable when running builds with the "development" profile, we can use `env` in **eas.json**:
 
@@ -101,7 +101,7 @@ To automatically set the `APP_VARIANT` environment variable when running builds 
 }
 ```
 
-Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"development"` when evaluating **app.config.js** both locally and on the EAS Build worker. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
+Now when you run `eas build --profile development`, the environment variable `APP_VARIANT` will be set to `"development"` when evaluating **app.config.js** both locally and on the EAS Build builder. When you start your development server, you will need to run `APP_VARIANT=development expo start` (or the platform equivalent if you use Windows); a shortcut for this could be to add a script to your **package.json** such as `"dev": "APP_VARIANT=development expo start"`.
 
 When you run `eas build --profile production` the `APP_VARIANT` variable environment will not be set, and the build will run as the production variant.
 

--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -23,7 +23,7 @@ description: Learn how a project using EAS services is configured with eas.json.
 
 ## Build profiles
 
-A build profile is a named grouping of configuration that describes the necessary parameters to perform a certain type of build.
+A build profile is a named grouping of configurations that describes the necessary parameters to perform a certain type of build.
 
 The JSON object under the `build` key can contain multiple build profiles, and you can name these build profiles whatever you like; in the above example, there are three build profiles: `development`, `preview`, and `production`, but these could have been named `foo`, `bar`, and `baz` if that was your preference.
 
@@ -45,11 +45,11 @@ Developers using Expo tools usually end up having three different types of build
 
 These builds include developer tools, and they are never submitted to an app store.
 
-By default, `eas build:configure` will create a `development` profile with `"developmentClient": true`. This indicates that this build depends on [expo-dev-client](/clients/introduction.mdx).
+By default, `eas build:configure` will create a `development` profile with `"developmentClient": true`. This indicates that this build depends on [expo-dev-client](/clients/introduction).
 
-The `development` profile also defaults to `"distribution": "internal"`. This will make it easy to distribute your app directly to physical iOS and Android devices &mdash; [learn more](/build/internal-distribution.mdx).
+The `development` profile also defaults to `"distribution": "internal"`. This will make it easy to distribute your app directly to physical iOS and Android devices &mdash; [learn more](/build/internal-distribution).
 
-You may alternatively prefer for your development build to [run on an iOS Simulator](/build-reference/simulators.mdx). To do this, use the following configuration for `development` profile:
+You may alternatively prefer for your development build to [run on an iOS Simulator](/build-reference/simulators). To do this, use the following configuration for `development` profile:
 
 ```json eas.json
 {
@@ -67,7 +67,7 @@ You may alternatively prefer for your development build to [run on an iOS Simula
 }
 ```
 
-If you'd like to create a build for internal distribution and another for the iOS Simulator then you can create another development profile for that build. You might call the profile something like `development-simulator` and use the above configuration on that profile instead of on `development`. [No such configuration is required to run an Android APK on your device and in an emulator](/build-reference/apk.mdx); the same APK will work in both circumstances.
+If you'd like to create a build for internal distribution and another for the iOS Simulator then you can create another development profile for that build. You might call the profile something like `development-simulator` and use the above configuration on that profile instead of on `development`. [No such configuration is required to run an Android APK on your device and in an emulator](/build-reference/apk); the same APK will work in both circumstances.
 
 ### Preview builds
 
@@ -158,11 +158,11 @@ It's common to want to share build tool configuration between profiles, and we c
 
 The base image for the build job controls the default versions for a variety of dependencies, such as Node.js, Yarn, and Cocoapods. You can override them using the specific named fields as described in the previous section. However, the image includes specific versions of tools that can't be explicitly set any other way, such as the operating system version and Xcode version.
 
-If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to read about the available images on ["Build server infrastructure"](/build-reference/infrastructure.mdx).
+If you are using the Expo managed workflow, EAS Build will pick the appropriate image to use with a reasonable set of dependencies for the SDK version that you are building for. Otherwise, it is recommended to read about the available images on [Build server infrastructure](/build-reference/infrastructure).
 
 ## Environment variables
 
-You can configure environment variables on your build profiles using the `"env"` field. These environment variable will be used to evaluate **app.config.js** locally when you run `eas build`, and they will also be set on the EAS Build worker.
+You can configure environment variables on your build profiles using the `"env"` field. These environment variables will be used to evaluate **app.config.js** locally when you run `eas build`, and they will also be set on the EAS Build builder.
 
 ```json eas.json
 {
@@ -186,4 +186,4 @@ You can configure environment variables on your build profiles using the `"env"`
 }
 ```
 
-The ["Environment variables and secrets" reference](/build-reference/variables.mdx) explains this topic in greater detail, and the [updates guide](/build/updates.mdx) provides guidance on considerations when using this feature alongside **expo-updates**.
+The [Environment variables and secrets](/build-reference/variables) reference explains this topic in greater detail, and the [updates guide](/build/updates) provides guidance on considerations when using this feature alongside `expo-updates`.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for PR #22248

# How

<!--
How did you build this feature or fix this bug and why?
-->

As discussed in this [slack thread](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1682418886008459), this PR updates any instances from workers to builders in EAS Build docs.

Also, fixed some typos and applied writing style guidelines.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
