### PR TITLE
[docs] Multiple fixes include adding redirects, and following writing styleguide

### DIFF
--- a/docs/common/error-utilities.ts
+++ b/docs/common/error-utilities.ts
@@ -136,8 +136,8 @@ const RENAMED_PAGES: Record<string, string> = {
   // Redirects after creating /home route
   '/next-steps/additional-resources/': '/additional-resources/',
   // TODO: (@aman) Uncomment the two lines below when we've removed third-party libraries from Reference
-  // '/versions/latest/sdk/safe-area-context/': '/home/develop/user-interface/safe-areas',
-  // '/versions/latest/sdk/async-storage/': '/home/develop/user-interface/store-data/#async-storage',
+  // '/versions/latest/sdk/safe-area-context/': '/develop/user-interface/safe-areas',
+  // '/versions/latest/sdk/async-storage/': '/develop/user-interface/store-data/#async-storage',
   '/get-started/create-a-new-app/': '/get-started/create-a-project',
   '/guides/config-plugins/': '/config-plugins/introduction/',
   '/workflow/debugging/': '/debugging/runtime-issue/',
@@ -341,4 +341,6 @@ const RENAMED_PAGES: Record<string, string> = {
   '/tutorial/': '/tutorial/introduction/',
   // Note (@aman): The following redirect is temporary until Guides section has an overview
   '/guides/': '/workflow/customizing/',
+  '/archive/workflow/customizing/': '/workflow/customizing/',
+  '/errors-and-warnings/': '/debugging/errors-and-warnings/',
 };

--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -63,7 +63,7 @@ Save all of your changes. In Xcode, update the iOS Deployment Target under `Targ
     'npx pod-install',
     '',
     '# Alternatively, the run command will install them for you',
-    'expo run:ios',
+    'npx expo run:ios',
   ]}
   hideBareInstructions
 />

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -3,17 +3,33 @@ title: Using expo-dev-client with EAS Update
 description: Learn how how to use the expo-dev-client library to preview a published EAS Update inside a development build.
 ---
 
+import { Step } from '~/ui/components/Step';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
+
 > **warning** This guide is likely to change as we continue to work on EAS Update.
 
-The [`expo-dev-client`](/development/introduction) library allows us to launch different versions of our project. One of the most popular use cases is to preview a published update inside a development build, using the `expo-dev-client` library.
+The [`expo-dev-client`](develop/development-builds/introduction/) library allows launching different versions of a project. One of the most popular use cases is to preview a published update inside a development build using the `expo-dev-client` library.
 
-The `expo-dev-client` library supports loading published EAS Updates through channels. Below, learn how to load a specific channel to preview an update in a development build.
+It supports loading published EAS Updates through channels. In this guide, you'll learn how to load a specific channel to preview an update in a development build.
 
 ## How to load a published EAS Update inside a development build
 
-1. Create a [development build](/development/getting-started) of the project.
-2. Next, make non-native changes locally, then publish them using `eas update --branch ...`. The branch specified should correspond to a channel. You can see how channels are linked to branches with `eas channel:list`.
-3. After publishing an update, it's time to load the update in the development build. All development builds that have the `expo-updates` package installed include an Extensions tab where you can select an update:
+<Step label="1">
+
+Create a [development build](/development/getting-started) of the project.
+
+</Step>
+
+<Step label="2">
+
+Make non-native changes locally, then publish them using `eas update --branch ...`. The branch specified should correspond to a channel. You can see how channels are linked to branches with `eas channel:list`.
+
+</Step>
+
+<Step label="3">
+
+After publishing an update, it's time to load the update in the development build. All development builds that have the `expo-updates` package installed include an Extensions tab where you can select an update:
 
 <img
   src="/static/images/dev-client/extensions-panel.png"
@@ -39,6 +55,19 @@ Let's break down the parts of this URL:
 - `?channel-name=`: Defines a channel query parameter.
 - `preview`: The name of the channel to request.
 
-4. Once we've constructed the URL, we can either copy/paste it directly into the `expo-dev-client`'s launcher screen. Alternatively, we could create a QR code of the URL, then scan it. Scanning this URL should open up the development build to the specified channel.
+</Step>
 
-If you'd like to see a working example, check out this [demo repo](https://github.com/jonsamp/test-expo-dev-client-eas-update).
+<Step label="4">
+
+Once we've constructed the URL, we can either copy/paste it directly into the `expo-dev-client`'s launcher screen. Alternatively, we could create a QR code of the URL, then scan it. Scanning this URL should open up the development build to the specified channel.
+
+</Step>
+
+## More
+
+<BoxLink
+  title="Working example"
+  description="See a working example on using expo-dev-client with EAS Update."
+  Icon={GithubIcon}
+  href="https://github.com/jonsamp/test-expo-dev-client-eas-update"
+/>

--- a/docs/pages/eas-update/how-eas-update-works.mdx
+++ b/docs/pages/eas-update/how-eas-update-works.mdx
@@ -37,7 +37,7 @@ This diagram is just an example of how you could create builds and name their ch
 
 ### Publishing an update
 
-Once we've created builds, we can change the update layer of our project by publishing an update. For example, we could change some text inside `App.js`, then we could publish that change as an update.
+Once we've created builds, we can change the update layer of our project by publishing an update. For example, we could change some text inside **App.js**, then we could publish that change as an update.
 
 To publish an update, we can run `eas update --auto`. This command will create a local update bundle inside the `./dist` folder in our project. Once it's created an update bundle, it will upload that bundle to EAS' servers, in a database object named a _branch_. A branch has a name, and contains a list of updates, where the most recent update is the active update on the branch.
 We can think of EAS branches just like Git branches. Just as Git branches contain a list of commits, EAS branches contain a list of updates.

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -84,7 +84,7 @@ If you are using an emulator/simulator, you may find the following Expo CLI keyb
 
 <Step label="3">
 
-## Make your first change in `App.js`
+## Make your first change in App.js
 
 Now, all the steps are completed to get started, you can open **App.js** file in your code editor and change the contents of the existing `<Text>` to `Hello, world!`. You are going to see it update on your device.
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -45,7 +45,7 @@ If you have an **ios** directory in your project that you created using `npx exp
 > **Note:**
 > If you're using a development client, you need to rebuild your development client any time you want to use new native code.
 
-Now, import the module in your application, for example in `App.js` or `App.tsx`:
+Now, import the module in your application, for example in **App.js** or **App.tsx**:
 
 ```js
 import { hello } from './modules/my-module';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Sentry reported some redirects were missing.
- Guide at [Using expo-dev-client with EAS Update
](https://docs.expo.dev/eas-update/expo-dev-client/) doesn't use `<Step>` component

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add redirects based on weekly Sentry reports
- Apply `<Step>` component pattern and improve overall presentation of content for Using expo-dev-client with EAS Update
](https://docs.expo.dev/eas-update/expo-dev-client/) guide
- Format file names to be bold as per writing styleguide
- Add missing `npx` prefix before `expo run` command in Installing Expo modules guide

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
