### PR TITLE
[docs] Update references from expo install to npx expo install

### DIFF
--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-apple-authentication
 ```
 

--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-apple-authentication
+```sh
+npx expo install expo-apple-authentication
 ```
 
 ### Configure for iOS

--- a/packages/expo-application/README.md
+++ b/packages/expo-application/README.md
@@ -16,7 +16,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-application
 ```
 

--- a/packages/expo-application/README.md
+++ b/packages/expo-application/README.md
@@ -16,8 +16,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-application
+```sh
+npx expo install expo-application
 ```
 
 # Contributing

--- a/packages/expo-asset/README.md
+++ b/packages/expo-asset/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-asset
 ```
 

--- a/packages/expo-asset/README.md
+++ b/packages/expo-asset/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-asset
+```sh
+npx expo install expo-asset
 ```
 
 # Contributing

--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-auth-session expo-random
+```sh
+npx expo install expo-auth-session expo-crypto
 ```
 
 ### Configuration

--- a/packages/expo-auth-session/README.md
+++ b/packages/expo-auth-session/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-auth-session expo-crypto
 ```
 

--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-av
+```sh
+npx expo install expo-av
 ```
 
 ### Configure for iOS

--- a/packages/expo-av/README.md
+++ b/packages/expo-av/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-av
 ```
 

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-background-fetch
 ```
 

--- a/packages/expo-background-fetch/README.md
+++ b/packages/expo-background-fetch/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-background-fetch
+```sh
+npx expo install expo-background-fetch
 ```
 
 ### Configure for iOS

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-barcode-scanner
+```sh
+npx expo install expo-barcode-scanner
 ```
 
 ### Configure for iOS

--- a/packages/expo-barcode-scanner/README.md
+++ b/packages/expo-barcode-scanner/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-barcode-scanner
 ```
 

--- a/packages/expo-battery/README.md
+++ b/packages/expo-battery/README.md
@@ -23,7 +23,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-battery
 ```
 

--- a/packages/expo-battery/README.md
+++ b/packages/expo-battery/README.md
@@ -23,8 +23,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-battery
+```sh
+npx expo install expo-battery
 ```
 
 # Contributing

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-blur
+```sh
+npx expo install expo-blur
 ```
 
 ### Configure for iOS

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-blur
 ```
 

--- a/packages/expo-brightness/README.md
+++ b/packages/expo-brightness/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-brightness
+```sh
+npx expo install expo-brightness
 ```
 
 ### Configure for iOS

--- a/packages/expo-brightness/README.md
+++ b/packages/expo-brightness/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-brightness
 ```
 

--- a/packages/expo-build-properties/README.md
+++ b/packages/expo-build-properties/README.md
@@ -9,7 +9,7 @@
 
 ### Installation
 
-```sh
+```
 npx expo install expo-build-properties
 ```
 

--- a/packages/expo-build-properties/README.md
+++ b/packages/expo-build-properties/README.md
@@ -9,7 +9,7 @@
 
 ### Installation
 
-```
+```sh
 npx expo install expo-build-properties
 ```
 

--- a/packages/expo-calendar/README.md
+++ b/packages/expo-calendar/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-calendar
+```sh
+npx expo install expo-calendar
 ```
 
 ### Configure for iOS

--- a/packages/expo-calendar/README.md
+++ b/packages/expo-calendar/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-calendar
 ```
 

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-camera
 ```
 

--- a/packages/expo-camera/README.md
+++ b/packages/expo-camera/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-camera
+```sh
+npx expo install expo-camera
 ```
 
 ### Configure for iOS

--- a/packages/expo-cellular/README.md
+++ b/packages/expo-cellular/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-cellular
 ```
 

--- a/packages/expo-cellular/README.md
+++ b/packages/expo-cellular/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-cellular
+```sh
+npx expo install expo-cellular
 ```
 
 ### Configure for Android

--- a/packages/expo-checkbox/README.md
+++ b/packages/expo-checkbox/README.md
@@ -8,7 +8,7 @@ Please refer to the [API documentation for the latest stable release](https://do
 
 ## Installation
 
-```sh
+```
 npx expo install expo-checkbox
 ```
 

--- a/packages/expo-checkbox/README.md
+++ b/packages/expo-checkbox/README.md
@@ -8,7 +8,9 @@ Please refer to the [API documentation for the latest stable release](https://do
 
 ## Installation
 
-`npx expo install expo-checkbox`
+```sh
+npx expo install expo-checkbox
+```
 
 ## Contributing
 

--- a/packages/expo-clipboard/README.md
+++ b/packages/expo-clipboard/README.md
@@ -8,7 +8,9 @@ Please refer to the [API documentation for the latest stable release](https://do
 
 ## Installation
 
-`npx expo install expo-clipboard`
+```sh
+npx expo install expo-clipboard
+```
 
 ## Contributing
 

--- a/packages/expo-clipboard/README.md
+++ b/packages/expo-clipboard/README.md
@@ -8,7 +8,7 @@ Please refer to the [API documentation for the latest stable release](https://do
 
 ## Installation
 
-```sh
+```
 npx expo install expo-clipboard
 ```
 

--- a/packages/expo-constants/README.md
+++ b/packages/expo-constants/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-constants
 ```
 

--- a/packages/expo-constants/README.md
+++ b/packages/expo-constants/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-constants
+```sh
+npx expo install expo-constants
 ```
 
 #### Monorepo Support

--- a/packages/expo-contacts/README.md
+++ b/packages/expo-contacts/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-contacts
 ```
 

--- a/packages/expo-contacts/README.md
+++ b/packages/expo-contacts/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-contacts
+```sh
+npx expo install expo-contacts
 ```
 
 ### Configure for iOS

--- a/packages/expo-crypto/README.md
+++ b/packages/expo-crypto/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-crypto
+```sh
+npx expo install expo-crypto
 ```
 
 ### Configure for iOS

--- a/packages/expo-crypto/README.md
+++ b/packages/expo-crypto/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-crypto
 ```
 

--- a/packages/expo-device/README.md
+++ b/packages/expo-device/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-device
 ```
 

--- a/packages/expo-device/README.md
+++ b/packages/expo-device/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-device
+```sh
+npx expo install expo-device
 ```
 
 # Contributing

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-document-picker
+```sh
+npx expo install expo-document-picker
 ```
 
 ### Configure for iOS

--- a/packages/expo-document-picker/README.md
+++ b/packages/expo-document-picker/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-document-picker
 ```
 

--- a/packages/expo-face-detector/README.md
+++ b/packages/expo-face-detector/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-face-detector
+```sh
+npx expo install expo-face-detector
 ```
 
 ### Configure for iOS

--- a/packages/expo-face-detector/README.md
+++ b/packages/expo-face-detector/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-face-detector
 ```
 

--- a/packages/expo-font/README.md
+++ b/packages/expo-font/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-font
+```sh
+npx expo install expo-font
 ```
 
 ### Configure for iOS

--- a/packages/expo-font/README.md
+++ b/packages/expo-font/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-font
 ```
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -24,26 +24,26 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-gl
+```sh
+npx expo install expo-gl
 ```
 
 ### Compatibility
 
 To use version `11.2.0` or newer of `expo-gl` you will need to use at least version `0.68.0` of React Native.
 
-| expo-gl            | react-native         |
-| ------------------ | -------------------- |
-| <=8.x.x            | \*                   |
-| >=9.0.0 && <11.2.0 | >=0.63.1 &&  <0.65.0 |
-| >=11.2.0           | >=0.68.0             |
+| expo-gl            | react-native        |
+| ------------------ | ------------------- |
+| <=8.x.x            | \*                  |
+| >=9.0.0 && <11.2.0 | >=0.63.1 && <0.65.0 |
+| >=11.2.0           | >=0.68.0            |
 
 To use reanimated worklets you will need compatible version of `react-native-reanimated`.
 
-| expo-gl            | react-native-reanimated |
-| ------------------ | ----------------------- |
-| <11.3.0            | <=2.8.0                 |
-| >=11.3.0           | >2.8.0                  |
+| expo-gl  | react-native-reanimated |
+| -------- | ----------------------- |
+| <11.3.0  | <=2.8.0                 |
+| >=11.3.0 | >2.8.0                  |
 
 ### Configure for iOS
 

--- a/packages/expo-gl/README.md
+++ b/packages/expo-gl/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-gl
 ```
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-haptics
 ```
 

--- a/packages/expo-haptics/README.md
+++ b/packages/expo-haptics/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-haptics
+```sh
+npx expo install expo-haptics
 ```
 
 ### Configure for iOS

--- a/packages/expo-image-manipulator/README.md
+++ b/packages/expo-image-manipulator/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-image-manipulator
+```sh
+npx expo install expo-image-manipulator
 ```
 
 ### Configure for iOS

--- a/packages/expo-image-manipulator/README.md
+++ b/packages/expo-image-manipulator/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-image-manipulator
 ```
 

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-image-picker
+```sh
+npx expo install expo-image-picker
 ```
 
 ### Configure for iOS

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-image-picker
 ```
 

--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -44,7 +44,7 @@ A cross-platform, performant image component for React Native and Expo.
 
 Add the package to your dependencies with the following commands:
 
-```sh
+```
 npx expo install expo-image
 npx pod-install
 ```

--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -21,17 +21,17 @@ A cross-platform, performant image component for React Native and Expo.
 
 ## Supported image formats
 
-| Format | Android | iOS | Web |
-|:---:|:---:|:---:|:---:|
-| WebP | ✅ | ✅ | ✅ [~96% adoption](https://caniuse.com/webp) |
-| PNG / APNG | ✅ | ✅ | ✅ / ✅ [~96% adoption](https://caniuse.com/apng) |
-| AVIF | ✅ | ✅ | ⏳ [~79% adoption](https://caniuse.com/avif) |
-| HEIC | ✅ | ✅ | ❌ [not adopted yet](https://caniuse.com/heif) |
-| JPEG | ✅ | ✅ | ✅ |
-| GIF | ✅ | ✅ | ✅ |
-| SVG | ✅ | ✅ | ✅ |
-| ICO | ✅ | ✅ | ✅ |
-| ICNS | ❌ | ✅ | ❌ |
+|   Format   | Android | iOS |                        Web                        |
+| :--------: | :-----: | :-: | :-----------------------------------------------: |
+|    WebP    |   ✅    | ✅  |   ✅ [~96% adoption](https://caniuse.com/webp)    |
+| PNG / APNG |   ✅    | ✅  | ✅ / ✅ [~96% adoption](https://caniuse.com/apng) |
+|    AVIF    |   ✅    | ✅  |   ⏳ [~79% adoption](https://caniuse.com/avif)    |
+|    HEIC    |   ✅    | ✅  |  ❌ [not adopted yet](https://caniuse.com/heif)   |
+|    JPEG    |   ✅    | ✅  |                        ✅                         |
+|    GIF     |   ✅    | ✅  |                        ✅                         |
+|    SVG     |   ✅    | ✅  |                        ✅                         |
+|    ICO     |   ✅    | ✅  |                        ✅                         |
+|    ICNS    |   ❌    | ✅  |                        ❌                         |
 
 # API documentation
 
@@ -44,7 +44,7 @@ A cross-platform, performant image component for React Native and Expo.
 
 Add the package to your dependencies with the following commands:
 
-```
+```sh
 npx expo install expo-image
 npx pod-install
 ```

--- a/packages/expo-in-app-purchases/README.md
+++ b/packages/expo-in-app-purchases/README.md
@@ -13,7 +13,7 @@ You must ensure that you have [installed and configured the `react-native-unimod
 
 ### Add the package to your dependencies
 
-```sh
+```
 npx expo install expo-in-app-purchases
 ```
 

--- a/packages/expo-in-app-purchases/README.md
+++ b/packages/expo-in-app-purchases/README.md
@@ -13,8 +13,8 @@ You must ensure that you have [installed and configured the `react-native-unimod
 
 ### Add the package to your dependencies
 
-```
-expo install expo-in-app-purchases
+```sh
+npx expo install expo-in-app-purchases
 ```
 
 ### Configure for iOS
@@ -27,4 +27,4 @@ No additional set up necessary.
 
 # Contributing
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).

--- a/packages/expo-intent-launcher/README.md
+++ b/packages/expo-intent-launcher/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-intent-launcher
+```sh
+npx expo install expo-intent-launcher
 ```
 
 ### Configure for iOS

--- a/packages/expo-intent-launcher/README.md
+++ b/packages/expo-intent-launcher/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-intent-launcher
 ```
 

--- a/packages/expo-keep-awake/README.md
+++ b/packages/expo-keep-awake/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-keep-awake
 ```
 

--- a/packages/expo-keep-awake/README.md
+++ b/packages/expo-keep-awake/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-keep-awake
+```sh
+npx expo install expo-keep-awake
 ```
 
 ### Configure for iOS

--- a/packages/expo-linear-gradient/README.md
+++ b/packages/expo-linear-gradient/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-linear-gradient
+```sh
+npx expo install expo-linear-gradient
 ```
 
 ### Configure for iOS

--- a/packages/expo-linear-gradient/README.md
+++ b/packages/expo-linear-gradient/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-linear-gradient
 ```
 

--- a/packages/expo-linking/README.md
+++ b/packages/expo-linking/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-linking
 ```
 

--- a/packages/expo-linking/README.md
+++ b/packages/expo-linking/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-linking
+```sh
+npx expo install expo-linking
 ```
 
 # Contributing

--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-local-authentication
+```sh
+npx expo install expo-local-authentication
 ```
 
 ### Configure for iOS

--- a/packages/expo-local-authentication/README.md
+++ b/packages/expo-local-authentication/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-local-authentication
 ```
 

--- a/packages/expo-localization/README.md
+++ b/packages/expo-localization/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-localization
+```sh
+npx expo install expo-localization
 ```
 
 ### Configure for iOS

--- a/packages/expo-localization/README.md
+++ b/packages/expo-localization/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-localization
 ```
 

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-location
 ```
 

--- a/packages/expo-location/README.md
+++ b/packages/expo-location/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-location
+```sh
+npx expo install expo-location
 ```
 
 ### Configure for iOS

--- a/packages/expo-mail-composer/README.md
+++ b/packages/expo-mail-composer/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-mail-composer
+```sh
+npx expo install expo-mail-composer
 ```
 
 ### Configure for iOS

--- a/packages/expo-mail-composer/README.md
+++ b/packages/expo-mail-composer/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-mail-composer
 ```
 

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-media-library
 ```
 

--- a/packages/expo-media-library/README.md
+++ b/packages/expo-media-library/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-media-library
+```sh
+npx expo install expo-media-library
 ```
 
 ### Configure for iOS

--- a/packages/expo-navigation-bar/README.md
+++ b/packages/expo-navigation-bar/README.md
@@ -19,7 +19,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-navigation-bar
 ```
 

--- a/packages/expo-navigation-bar/README.md
+++ b/packages/expo-navigation-bar/README.md
@@ -13,21 +13,19 @@ Properties are named after style properties; visibility, position, backgroundCol
 
 For [managed][docs-workflows] Expo projects, please follow the installation instructions in the [API documentation for the latest stable release][docs-stable].
 
-
 ## Installation in bare React Native projects
 
 For bare React Native projects, you must ensure that you have [installed and configured the `react-native-unimodules` package][unimodules] before continuing.
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-navigation-bar
+```sh
+npx expo install expo-navigation-bar
 ```
 
 ## Contributing
 
 Contributions are very welcome! Please refer to guidelines described in the [contributing guide][contributing].
-
 
 [docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/navigation-bar/

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -25,8 +25,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-network
+```sh
+npx expo install expo-network
 ```
 
 ### Configure for Android

--- a/packages/expo-network/README.md
+++ b/packages/expo-network/README.md
@@ -25,7 +25,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-network
 ```
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -33,7 +33,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-notifications
 ```
 

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -33,8 +33,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-notifications
+```sh
+npx expo install expo-notifications
 ```
 
 ### Configure for iOS
@@ -680,7 +680,7 @@ export default function App() {
           Linking.addEventListener('url', onReceiveURL);
 
           // Listen to expo push notifications
-          const subscription = Notifications.addNotificationResponseReceivedListener(response => {
+          const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
             const url = response.notification.request.content.data.url;
 
             // Any custom logic to see whether the URL needs to be handled

--- a/packages/expo-print/README.md
+++ b/packages/expo-print/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-print
 ```
 

--- a/packages/expo-print/README.md
+++ b/packages/expo-print/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-print
+```sh
+npx expo install expo-print
 ```
 
 ### Configure for iOS

--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -28,8 +28,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-random
+```sh
+npx expo install expo-random
 ```
 
 ### Configure for iOS

--- a/packages/expo-random/README.md
+++ b/packages/expo-random/README.md
@@ -28,7 +28,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-random
 ```
 

--- a/packages/expo-screen-capture/README.md
+++ b/packages/expo-screen-capture/README.md
@@ -21,13 +21,13 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-screen-capture
 ```
 
 ### Configure for iOS
 
-```sh
+```
 npx pod-install
 ```
 

--- a/packages/expo-screen-capture/README.md
+++ b/packages/expo-screen-capture/README.md
@@ -22,7 +22,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 ### Add the package to your npm dependencies
 
 ```sh
-expo install expo-screen-capture
+npx expo install expo-screen-capture
 ```
 
 ### Configure for iOS

--- a/packages/expo-secure-store/README.md
+++ b/packages/expo-secure-store/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-secure-store
+```sh
+npx expo install expo-secure-store
 ```
 
 ### Configure for iOS

--- a/packages/expo-secure-store/README.md
+++ b/packages/expo-secure-store/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-secure-store
 ```
 

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-sensors
 ```
 

--- a/packages/expo-sensors/README.md
+++ b/packages/expo-sensors/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-sensors
+```sh
+npx expo install expo-sensors
 ```
 
 ### Configure for iOS

--- a/packages/expo-sharing/README.md
+++ b/packages/expo-sharing/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-sharing
+```sh
+npx expo install expo-sharing
 ```
 
 ### Configure for iOS

--- a/packages/expo-sharing/README.md
+++ b/packages/expo-sharing/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-sharing
 ```
 

--- a/packages/expo-sms/README.md
+++ b/packages/expo-sms/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-sms
+```sh
+npx expo install expo-sms
 ```
 
 ### Configure for iOS

--- a/packages/expo-sms/README.md
+++ b/packages/expo-sms/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-sms
 ```
 

--- a/packages/expo-speech/README.md
+++ b/packages/expo-speech/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-speech
 ```
 

--- a/packages/expo-speech/README.md
+++ b/packages/expo-speech/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-speech
+```sh
+npx expo install expo-speech
 ```
 
 ### Configure for iOS

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -242,7 +242,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ## Add the package to your dependencies
 
-```sh
+```
 npx expo install expo-splash-screen
 ```
 

--- a/packages/expo-splash-screen/README.md
+++ b/packages/expo-splash-screen/README.md
@@ -31,10 +31,12 @@ Scale the image uniformly (maintaining the image's aspect ratio) so that both di
 <td>
 
 https://user-images.githubusercontent.com/379606/120575867-aeeb3580-c3d6-11eb-825d-19a847fe30f5.mp4
+
 </td>
 <td>
 
 https://user-images.githubusercontent.com/379606/120575885-b6124380-c3d6-11eb-8485-75a11832962c.mp4
+
 </td>
     </tr>
   </tbody>
@@ -50,10 +52,12 @@ Scale the image uniformly (maintaining the image's aspect ratio) so that both th
 <td>
 
 https://user-images.githubusercontent.com/379606/120575871-b1e62600-c3d6-11eb-9435-5dee19791294.mp4
+
 </td>
 <td>
 
 https://user-images.githubusercontent.com/379606/120575890-b7437080-c3d6-11eb-9c0a-3c563d1ee02a.mp4
+
 </td>
     </tr>
   </tbody>
@@ -72,6 +76,7 @@ Android (unlike iOS) does not support stretching of the provided image during la
 <td>
 
 https://user-images.githubusercontent.com/379606/120575878-b3afe980-c3d6-11eb-80c1-72441c22e8be.mp4
+
 </td>
     </tr>
   </tbody>
@@ -130,7 +135,7 @@ import * as SplashScreen from 'expo-splash-screen';
 
 // Prevent native splash screen from autohiding before App component declaration
 SplashScreen.preventAutoHideAsync()
-  .then(result => console.log(`SplashScreen.preventAutoHideAsync() succeeded: ${result}`))
+  .then((result) => console.log(`SplashScreen.preventAutoHideAsync() succeeded: ${result}`))
   .catch(console.warn); // it's good to explicitly catch and inspect any error
 
 export default class App extends React.Component {
@@ -237,8 +242,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ## Add the package to your dependencies
 
-```
-expo install expo-splash-screen
+```sh
+npx expo install expo-splash-screen
 ```
 
 ## 📱 Configure iOS

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-sqlite
+```sh
+npx expo install expo-sqlite
 ```
 
 ### Configure for iOS

--- a/packages/expo-sqlite/README.md
+++ b/packages/expo-sqlite/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-sqlite
 ```
 

--- a/packages/expo-store-review/README.md
+++ b/packages/expo-store-review/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your dependencies
 
-```
-expo install expo-store-review
+```sh
+npx expo install expo-store-review
 ```
 
 ### Configure for iOS

--- a/packages/expo-store-review/README.md
+++ b/packages/expo-store-review/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your dependencies
 
-```sh
+```
 npx expo install expo-store-review
 ```
 

--- a/packages/expo-system-ui/README.md
+++ b/packages/expo-system-ui/README.md
@@ -9,7 +9,7 @@
 
 ### Installation
 
-```sh
+```
 npx expo install expo-system-ui
 ```
 

--- a/packages/expo-system-ui/README.md
+++ b/packages/expo-system-ui/README.md
@@ -9,8 +9,8 @@
 
 ### Installation
 
-```
-expo install expo-system-ui
+```sh
+npx expo install expo-system-ui
 ```
 
 ### Extra Setup

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-task-manager
 ```
 

--- a/packages/expo-task-manager/README.md
+++ b/packages/expo-task-manager/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
+```sh
 npx expo install expo-task-manager
 ```
 

--- a/packages/expo-tracking-transparency/README.md
+++ b/packages/expo-tracking-transparency/README.md
@@ -19,7 +19,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-tracking-transparency
 ```
 

--- a/packages/expo-tracking-transparency/README.md
+++ b/packages/expo-tracking-transparency/README.md
@@ -19,8 +19,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-tracking-transparency
+```sh
+npx expo install expo-tracking-transparency
 ```
 
 ### Configure for iOS

--- a/packages/expo-video-thumbnails/README.md
+++ b/packages/expo-video-thumbnails/README.md
@@ -17,7 +17,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-video-thumbnails
 ```
 

--- a/packages/expo-video-thumbnails/README.md
+++ b/packages/expo-video-thumbnails/README.md
@@ -17,8 +17,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-video-thumbnails
+```sh
+npx expo install expo-video-thumbnails
 ```
 
 ### Configure for iOS

--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -24,7 +24,7 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```sh
+```
 npx expo install expo-web-browser
 ```
 

--- a/packages/expo-web-browser/README.md
+++ b/packages/expo-web-browser/README.md
@@ -24,8 +24,8 @@ For bare React Native projects, you must ensure that you have [installed and con
 
 ### Add the package to your npm dependencies
 
-```
-expo install expo-web-browser
+```sh
+npx expo install expo-web-browser
 ```
 
 ### Configure for iOS

--- a/packages/html-elements/README.md
+++ b/packages/html-elements/README.md
@@ -32,7 +32,7 @@ We at Expo recommend using platform agnostic primitives like `View`, `Image`, an
 
 Install:
 
-```sh
+```
 yarn add @expo/html-elements
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for PR #22197

# How

<!--
How did you build this feature or fix this bug and why?
-->

By replacing `expo install` command references to `npx expo install`.


<!-- disable:changelog-checks -->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
