### PR TITLE
[docs] hide unversioned docs in PROD

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "yarn generate-static-resoures && next dev -p 3002",
     "build": "next build",
-    "export": "yarn generate-static-resoures && yarn run build && next export && yarn run export-issue-404",
+    "export": "yarn generate-static-resoures production && yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
     "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",


### PR DESCRIPTION
# Why

Fixes ENG-8442

# How

Add missing parameter for the constant generation script (removed by mistake in Home reorganization).

# Test Plan

Running `yarn export` and `yarn export-server` locally.
