### PR TITLE
[docs] Update outdated EAS Build limitation about memory limits

### DIFF
--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -8,7 +8,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 ## Fixed memory and CPU limits on build worker servers
 
-The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in your **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
+The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in the **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
 
 See [Server infrastructure reference](/build-reference/infrastructure) for more information. It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -4,45 +4,33 @@ sidebar_title: Limitations
 description: Learn about the current limitations of EAS Build.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
-
 EAS Build is designed to work for any React Native project. However, it is good to be aware of certain limitations that we plan to address since they could prevent you from being able to use the service for your applications or might cause an inconvenience.
 
-## Current limitations
+## Fixed memory and CPU limits on build worker servers
 
-<Collapsible summary="Fixed memory and CPU limits on build worker servers">
+You may find that the resources available are not sufficient to build your app if your build process requires a significant amount of memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in your **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
 
-The [Server infrastructure reference](/build-reference/infrastructure) contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers. You may find that the resources available are not sufficient to build your app if your build process requires more than 12GB RAM. In the future, we will add more powerful configurations to increase memory limits and speed up build times.
+For more information, see [Server infrastructure reference](/build-reference/infrastructure). It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
 
-</Collapsible>
-
-<Collapsible summary="Limited dependency caching">
+## Limited dependency caching
 
 Build jobs for Android install npm and Maven dependencies from a local cache. Build jobs for iOS install npm dependencies from a local cache, but there is no caching for CocoaPods yet.
 
 Intermediate artifacts like `node_modules` directories are not cached and restored (eg: based on `yarn.lock` or `package-lock.json`), but if you commit them to your git repository then they will be uploaded to build servers.
 
-[Learn more about dependency caching](/build-reference/caching.mdx).
+See [dependency caching](/build-reference/caching) for more information.
 
-</Collapsible>
+## Maximum build duration of 2 hours
 
-<Collapsible summary="Maximum build duration of 2 hours">
+If your build takes longer than 2 hours to run, it will be canceled. This limit is lower on the free plan, and the limit is subject to change in the future.
 
-If your build takes longer than 2 hours to run, it will be cancelled. This limit is lower on the free plan, and the limit is subject to change in the future.
-
-</Collapsible>
-
-<Collapsible summary="Yarn Workspaces is recommended for monorepos; official guidance for others is limited.">
+## Yarn Workspaces is recommended for monorepos; official guidance for others is limited
 
 While you likely can have success using other monorepo tools like Nx if you are willing to dig in and understand the tooling and get your hands dirty, the Expo team will be unable to provide support and guidance on those tools. We recommend using [Yarn Workspaces](https://yarnpkg.com/en/docs/workspaces) because it is the only monorepo tool that we provide first-class integration with at the moment.
 
-</Collapsible>
-
-<Collapsible summary="Managed workflow projects on SDK 40 and below are not supported.">
+## Managed workflow projects on SDK 40 and below are not supported
 
 EAS Build supports building iOS/Android native projects, so it works with any React Native app. Support for [Managed Expo projects](/introduction/managed-vs-bare) is only available for SDK 41 and higher. **For best results, we recommend using the latest SDK version**, or at least SDK 43.
-
-</Collapsible>
 
 ## Get notified about changes
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -8,7 +8,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 ## Fixed memory and CPU limits on build worker servers
 
-The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in the **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
+The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a [`large` resource class](/build-reference/eas-json/#resourceclass-1) in the **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
 
 See [Server infrastructure reference](/build-reference/infrastructure) for more information. It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -8,7 +8,7 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 ## Fixed memory and CPU limits on build worker servers
 
-The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a [`large` resource class](/build-reference/eas-json/#resourceclass-1) in the **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
+The resources available might be insufficient to build your app if your build process requires a significant amount of memory. In this case, consider using a [`large` resource class](/build-reference/eas-json/#resourceclass-1) in the **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
 
 See [Server infrastructure reference](/build-reference/infrastructure) for more information. It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
 

--- a/docs/pages/build-reference/limitations.mdx
+++ b/docs/pages/build-reference/limitations.mdx
@@ -8,9 +8,9 @@ EAS Build is designed to work for any React Native project. However, it is good 
 
 ## Fixed memory and CPU limits on build worker servers
 
-You may find that the resources available are not sufficient to build your app if your build process requires a significant amount of memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in your **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
+The resources available might be insufficient to build your app if your build process requires significant memory. In this case, consider using a `large` resource class](/build-reference/eas-json/#resourceclass-1) in your **eas.json**. See [Android-specific resource class](/build-reference/infrastructure/#android-build-server-configurations) and [iOS-specific resource class](/build-reference/infrastructure/#ios-build-server-configurations).
 
-For more information, see [Server infrastructure reference](/build-reference/infrastructure). It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
+See [Server infrastructure reference](/build-reference/infrastructure) for more information. It contains the most up-to-date information about the current specifications of the Android (Ubuntu) and iOS (macOS) build servers.
 
 ## Limited dependency caching
 


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack thread](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1682508124105459?thread_ts=1682418886.008459&cid=C1QMWQ1P0)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating the info in Fixed memory and CPU limits on build worker servers
- Also, remove `Collapsible` and use headings so these items are searchable in docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs` locally:

<img width="1225" alt="CleanShot 2023-04-26 at 17 53 32@2x" src="https://user-images.githubusercontent.com/10234615/234573536-3c75377b-ce18-4910-8a79-a40edcbe19ce.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
