### PR TITLE
[docs] Update App icon to add info about monochrome Image

### DIFF
--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -36,7 +36,7 @@ The design you provide should follow the [Android Adaptive Icon Guidelines](http
 
 - Use **.png** files.
 - Use the `android.adaptiveIcon.foregroundImage` property to specify the path to your foreground image.
-- Use the `android.adaptiveIcon.monochromeImage` property to specify the path to your themed app icon image.
+- Use the `android.adaptiveIcon.monochromeImage` property to specify the path to your monochrome image.
 - The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` property. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` property. Make sure that it has the same dimensions as your foreground image.
 
 You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons. You can do so with the `android.icon` property. This single icon would be a combination of your foreground and background layers.

--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -30,16 +30,16 @@ For an in-detail walkthrough, see the video below:
 
 Further customization of the Android icon is possible using the [`android.adaptiveIcon`](/versions/latest/config/app/#adaptiveicon) property, which will override both of the previously mentioned settings.
 
-The Android Adaptive Icon is formed from two separate layers &mdash; a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects. For Android 13 and later, the OS supports a monochrome foreground image layer which will use a background color taken from the device's theme.
+The Android Adaptive Icon is formed from two separate layers &mdash; a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects. For Android 13 and later, the OS supports a themed app icon that uses a wallpaper and theme to determine the color set by the device's theme.
 
 The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive) for launcher icons. You should also:
 
 - Use **.png** files.
-- Use the `android.adaptiveIcon.foregroundImage` field in **app.json** to specify path to your foreground image.
-- Use the `android.adaptiveIcon.monochromeImage` field in **app.json** to specify path to your monochrome image.
-- The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` field. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` field. Make sure that it has the same dimensions as your foreground image.
+- Use the `android.adaptiveIcon.foregroundImage` property to specify the path to your foreground image.
+- Use the `android.adaptiveIcon.monochromeImage` property to specify the path to your themed app icon image.
+- The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` property. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` property. Make sure that it has the same dimensions as your foreground image.
 
-You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons. You can do so with the `android.icon` field. This single icon would probably be a combination of your foreground and background layers.
+You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons. You can do so with the `android.icon` property. This single icon would be a combination of your foreground and background layers.
 
 > You may still want to follow some of the [Apple best practices](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/) to ensure your icon looks professional, such as testing your icon on different wallpapers and avoiding text beside your product's wordmark. Provide something that's at least 512x512 pixels. Since you already need 1024x1024 for iOS.
 

--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -28,18 +28,15 @@ For an in-detail walkthrough, see the video below:
 
 ### Android
 
-{/* TODO: (@aman) Remove comments below when monochrome is released for the next SDK. */}
+Further customization of the Android icon is possible using the [`android.adaptiveIcon`](/versions/latest/config/app/#adaptiveicon) property, which will override both of the previously mentioned settings.
 
-Further customization of the Android icon is possible using the [`android.adaptiveIcon`](versions/latest/config/app/#adaptiveicon) property, which will override both of the previously mentioned settings.
-
-The Android Adaptive Icon is formed from two separate layers &mdash; a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects.
-{/* - For Android 13 and later, the OS supports a monochrome foreground image layer which will use a background color taken from the device's theme. */}
+The Android Adaptive Icon is formed from two separate layers &mdash; a foreground image and a background color or image. This allows the OS to mask the icon into different shapes and also supports visual effects. For Android 13 and later, the OS supports a monochrome foreground image layer which will use a background color taken from the device's theme.
 
 The design you provide should follow the [Android Adaptive Icon Guidelines](https://developer.android.com/guide/practices/ui_guidelines/icon_design_adaptive) for launcher icons. You should also:
 
 - Use **.png** files.
-- Use the `android.adaptiveIcon.foregroundImage` field in **app.json** to specify your foreground image.
-  {/* - Use the `android.adaptiveIcon.monochromeImage` field in **app.json** to specify your monochrome image. */}
+- Use the `android.adaptiveIcon.foregroundImage` field in **app.json** to specify path to your foreground image.
+- Use the `android.adaptiveIcon.monochromeImage` field in **app.json** to specify path to your monochrome image.
 - The default background color is white; to specify a different background color, use the `android.adaptiveIcon.backgroundColor` field. You can instead specify a background image using the `android.adaptiveIcon.backgroundImage` field. Make sure that it has the same dimensions as your foreground image.
 
 You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons. You can do so with the `android.icon` field. This single icon would probably be a combination of your foreground and background layers.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

With [`expo@48.0.15`](https://github.com/expo/expo/issues/20549#issuecomment-1523270123) release, we need to update App Icons docs to add info about monochrome for Android 13+ which was reverted back in #20702.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing comments and also fixing a link to app.json docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running `docs` locally:

<img width="899" alt="CleanShot 2023-04-26 at 18 32 59@2x" src="https://user-images.githubusercontent.com/10234615/234583250-23ad03ed-5aa0-44e8-be40-5fc24202833f.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
