### PR TITLE
[docs] Move Expo modules api section to top-level Guides

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -18,7 +18,7 @@ const learnDirectories = ['tutorial', 'ui-programming', 'additional-resources'];
 /** Manual list of directories to categorize as "Archive" */
 const archiveDirectories = ['archive'];
 /** Manual list of directories to categorize as "Reference" */
-const referenceDirectories = ['versions', 'modules', 'technical-specs', 'more'];
+const referenceDirectories = ['versions', 'technical-specs', 'more'];
 /** Private preview section which isn't linked in the documentation */
 const previewDirectories = ['feature-preview', 'preview'];
 /** All other unlisted directories */
@@ -233,6 +233,24 @@ const general = [
     makePage('eas/metadata/schema.mdx'),
     makePage('eas/metadata/faq.mdx'),
   ]),
+  makeSection(
+    'Expo Modules API',
+    [
+      makePage('modules/overview.mdx'),
+      makePage('modules/get-started.mdx'),
+      makePage('modules/native-module-tutorial.mdx'),
+      makePage('modules/native-view-tutorial.mdx'),
+      makePage('modules/config-plugin-and-native-module-tutorial.mdx'),
+      makePage('modules/use-standalone-expo-module-in-your-project.mdx'),
+      makePage('modules/existing-library.mdx'),
+      makePage('modules/module-api.mdx'),
+      makePage('modules/android-lifecycle-listeners.mdx'),
+      makePage('modules/appdelegate-subscribers.mdx'),
+      makePage('modules/autolinking.mdx'),
+      makePage('modules/module-config.mdx'),
+    ],
+    { expanded: true }
+  ),
   makeSection('Push notifications', [
     makePage('push-notifications/overview.mdx'),
     makePage('push-notifications/push-notifications-setup.mdx'),
@@ -393,24 +411,6 @@ const versionsReference = VERSIONS.reduce(
         expanded: true,
       }),
       makeSection('Expo SDK', pagesFromDir(`versions/${version}/sdk`), { expanded: true }),
-      makeSection(
-        'Expo Modules API',
-        [
-          makePage('modules/overview.mdx'),
-          makePage('modules/get-started.mdx'),
-          makePage('modules/native-module-tutorial.mdx'),
-          makePage('modules/native-view-tutorial.mdx'),
-          makePage('modules/config-plugin-and-native-module-tutorial.mdx'),
-          makePage('modules/use-standalone-expo-module-in-your-project.mdx'),
-          makePage('modules/existing-library.mdx'),
-          makePage('modules/module-api.mdx'),
-          makePage('modules/android-lifecycle-listeners.mdx'),
-          makePage('modules/appdelegate-subscribers.mdx'),
-          makePage('modules/autolinking.mdx'),
-          makePage('modules/module-config.mdx'),
-        ],
-        { expanded: true }
-      ),
       makeSection('Technical specs', [
         makePage('technical-specs/expo-updates-1.mdx'),
         makePage('technical-specs/expo-sfv-0.mdx'),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1682018323516669)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By moving Expo modules API section under top-level "Guides" from "Reference".

## Todo

- [x] Re-run algolia search crawler after this PR gets merged.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and then clicking "Guides" from the sidebar.

<img width="278" alt="CleanShot 2023-04-27 at 00 12 38@2x" src="https://user-images.githubusercontent.com/10234615/234672409-a6072d2b-cf77-4cd0-aa4e-44cdaca89b3e.png">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
