### PR TITLE
Image Picker was only checking videoExportPreset on the legacy picker

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix issue where it was taking way to long to return the videos when using PHPickerViewController while videoExportPreset is passthrough. ([#22282](https://github.com/expo/expo/pull/22282) by [@posuna-cameo](https://github.com/posuna-cameo))
 - Fix images unexpectedly being converted to `.png` when opening `.bmp` files and selecting any quality in `ImagePickerOptions`. ([#21361](https://github.com/expo/expo/pull/21361) by [@behenate](https://github.com/behenate))
 - Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
 - Fix rotated videos returning incorrect width/height. [#12573](https://github.com/expo/expo/issues/12573) ([#21758](https://github.com/expo/expo/pull/21758) by [@mmmulani](https://github.com/mmmulani))

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -142,6 +142,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     // selection limit = 1 --> single selection, reflects the old picker behavior
     configuration.selectionLimit = options.allowsMultipleSelection ? options.selectionLimit : SINGLE_SELECTION
     configuration.filter = options.mediaTypes.toPickerFilter()
+    configuration.preferredAssetRepresentationMode = options.videoExportPreset == .passthrough ? .current : .automatic
     if #available(iOS 15, *) {
       configuration.selection = options.orderedSelection ? .ordered : .default
     }


### PR DESCRIPTION
# Why
Image picker takes way to long to return the videos when using PHPickerViewController 

# How
Image Picker was only checking videoExportPreset on the legacy picker, and it needed to set preferredAssetRepresentationMode to current on the PHPickerConfiguration when videoExportPreset is passthrough, otherwise loadFileRepresentation in ExpoImagePicker/MediaHandler.swift takes way too long

# Test Plan
Calling the image picker with the following configuration, select videos with different extensions and durations, and verify that it does indeed return almost immediately, compared to the current behavior that can take more than 5 seconds
```
      const result = await ImagePicker.launchImageLibraryAsync({
        allowsEditing: false,
        mediaTypes: ImagePicker.MediaTypeOptions.Videos,
        allowsMultipleSelection: false,
      });
```

# See also
Issues:
[#19463](https://github.com/expo/expo/issues/19463)