### PR TITLE
[cli] fix activity starting error on android 13

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Remove invalid array group syntax from Expo Router type generation. ([#22185](https://github.com/expo/expo/pull/22185) by [@marklawlor](https://github.com/marklawlor))
 - Skip verifying arbitrary platforms when prebuilding. ([#22228](https://github.com/expo/expo/pull/22228) by [@byCedric](https://github.com/byCedric))
 - Fix prebuild `--template` flag on Windows for local tarballs. ([#22232](https://github.com/expo/expo/pull/22232) by [@byCedric](https://github.com/byCedric))
+- Fixed Activity does not start on Android 13 devices. ([#22286](https://github.com/expo/expo/pull/22286) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -67,8 +67,6 @@ describe(launchActivityAsync, () => {
       'shell',
       'am',
       'start',
-      '-a',
-      'android.intent.action.RUN',
       '-f',
       '0x20000000',
       '-n',

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -104,8 +104,6 @@ export async function launchActivityAsync(
       'shell',
       'am',
       'start',
-      '-a',
-      'android.intent.action.RUN',
       // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
       '-f',
       '0x20000000',


### PR DESCRIPTION
# Why

fix `yarn run android` does not start activity on android 13 from a bare-minimum app
fix #22210
close ENG-8426

# How

from android 13, starting will fail if there are no explicitly matched intent-filters: https://developer.android.com/guide/components/intents-filters#match-intent-filter
on an app from generated from bare-minimum template: `yarn create expo -t bare-minimum` without ever prebuilding. we will start the activity with `android.intent.action.RUN` action, but the app does not register this action and cause an error.
```
Starting: Intent { act=android.intent.action.RUN cmp=com.testapp/.MainActivity }
Error type 3
Error: Activity class {com.testapp/com.testapp.MainActivity} does not exist.
```

this pr tries to remove the `android.intent.action.RUN` given that `-n package/.MainActivity` should be good enough.

# Test Plan

- ✅ ci passed
- ✅ bare-minimum app on android 13
- ✅ bare-minimum app on android 12
- ✅ bare-minimum app after prebuild (will start with deep linking because we will generate scheme after prebuild: `adb shell am start -a android.intent.action.VIEW -d com.testapp://expo-development-client/?url=...`)
- ✅ npx expo run:android with expo-dev-client (`adb shell am start -a android.intent.action.VIEW -d com.testapp://expo-development-client/?url=...`)
- ✅ npx expo start (Expo Go case, `adb shell monkey -p host.exp.exponent -c android.intent.category.LAUNCHER 1` + `adb shell am start -a android.intent.action.VIEW -d exp://192.168.1.1:19000`)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
