### PR TITLE
[docs] tweak sidebar activity indicator and spacing

### DIFF
--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -46,5 +46,5 @@ const shouldSkipTitle = (info: NavigationRoute, parentGroup?: NavigationRoute) =
 };
 
 const STYLES_SECTION_CATEGORY = css({
-  marginBottom: spacing[4],
+  marginBottom: spacing[5],
 });

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -119,4 +119,5 @@ const STYLES_ACTIVE_BULLET = css`
   background-color: ${theme.text.link};
   border-radius: 100%;
   margin: ${spacing[2]}px ${spacing[1.5]}px;
+  align-self: self-start;
 `;

--- a/docs/ui/components/Sidebar/SidebarSection.tsx
+++ b/docs/ui/components/Sidebar/SidebarSection.tsx
@@ -9,7 +9,7 @@ export const SidebarSection = ({ route, ...rest }: SidebarNodeProps) => {
 
   return (
     <SidebarCollapsible key={`section-${route.name}`} info={route}>
-      <div className="mt-1 mb-4">
+      <div className="mb-2">
         {route.children.map(child =>
           child.type === 'page' ? (
             <SidebarLink key={`${route.name}-${child.name}`} info={child}>

--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -17,6 +17,6 @@ const STYLES_TITLE = css({
   position: 'relative',
   marginLeft: spacing[3],
   marginRight: -spacing[4],
-  paddingBottom: spacing[2],
+  paddingBottom: spacing[1],
   userSelect: 'none',
 });


### PR DESCRIPTION
# Why

Fixes ENG-8443

Fixes 
<img width="295" src="https://user-images.githubusercontent.com/719641/234804778-a5f17aa6-27cb-40d3-bdf5-9739060f9413.png" />

# How

Move sidebar activity indicator to the center of top line for multiline entries, tweak sidebar components spacing a bit.

# Test Plan

The changes have been tested by running docs app locally. All lint checks and tests are passing.

# Preview

<img width="295" src="https://user-images.githubusercontent.com/719641/234805041-597931f1-c541-4684-98e7-52764311119f.png">
<img width="295" src="https://user-images.githubusercontent.com/719641/234805047-61a0c715-f7b9-44e9-ba0a-a6bdde7a5d3a.png">

