### PR TITLE
[Android][core] Fixed argument trailing not working correctly when all parameters are optional

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Android] Improve the initial loading speed of the native view. ([#22153](https://github.com/expo/expo/pull/22153) by [@lukmccall](https://github.com/lukmccall))
 - Fixed build errors on React Native 0.72.x. ([#22170](https://github.com/expo/expo/pull/22170), [#22189](https://github.com/expo/expo/pull/22189) by [@kudo](https://github.com/kudo))
+- [Android] Fixed argument trailing not working correctly when all parameters are optional.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - [Android] Improve the initial loading speed of the native view. ([#22153](https://github.com/expo/expo/pull/22153) by [@lukmccall](https://github.com/lukmccall))
 - Fixed build errors on React Native 0.72.x. ([#22170](https://github.com/expo/expo/pull/22170), [#22189](https://github.com/expo/expo/pull/22189) by [@kudo](https://github.com/kudo))
-- [Android] Fixed argument trailing not working correctly when all parameters are optional.
+- [Android] Fixed argument trailing not working correctly when all parameters are optional. ([#22293](https://github.com/expo/expo/pull/22293) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -486,7 +486,7 @@ class JSIFunctionsTest {
   }
 
   @Test
-  fun allows_to_skip_trailing_optional_arguemnts() = withJSIInterop(
+  fun allows_to_skip_trailing_optional_arguments() = withJSIInterop(
     inlineModule {
       Name("TestModule")
       Function("test") { a: String, b: Int?, c: Boolean? ->
@@ -499,15 +499,22 @@ class JSIFunctionsTest {
         }
         return@Function "expo"
       }
+      Function("allOptionalArguments") { a: String?, b: Int? ->
+        Truth.assertThat(a).isNull()
+        Truth.assertThat(b).isNull()
+        return@Function "is awesome"
+      }
     }
   ) {
     val result1 = evaluateScript("expo.modules.TestModule.test('abc')").getString()
     val result2 = evaluateScript("expo.modules.TestModule.test('abc', 123)").getString()
     val result3 = evaluateScript("expo.modules.TestModule.test('abc', 123, true)").getString()
+    val result4 = evaluateScript("expo.modules.TestModule.allOptionalArguments()").getString()
 
     Truth.assertThat(result1).isEqualTo("expo")
     Truth.assertThat(result2).isEqualTo("expo")
     Truth.assertThat(result3).isEqualTo("expo")
+    Truth.assertThat(result4).isEqualTo("is awesome")
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -43,7 +43,7 @@ abstract class AnyFunction(
       .reversed()
       .indexOfFirst { !it.kType.isMarkedNullable }
     if (nonNullableArgIndex < 0) {
-      return@run desiredArgsTypes.size
+      return@run 0
     }
 
     return@run desiredArgsTypes.size - nonNullableArgIndex


### PR DESCRIPTION
# Why

Makes sure that trailing optional arguments works well when parameters are optional. 

# Test Plan

- unit tests ✅