### PR TITLE
[templates] fix monorepo support for android codegenDir

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/build.gradle
+++ b/templates/expo-template-bare-minimum/android/app/build.gradle
@@ -21,6 +21,7 @@ react {
     entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
     reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
     hermesCommand = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsolutePath() + "/sdks/hermesc/%OS-BIN%/hermesc"
+    codegenDir = new File(["node", "--print", "require.resolve('react-native-codegen/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()
     debuggableVariants = expoDebuggableVariants
 
     // Use Expo CLI to bundle the app, this ensures the Metro config


### PR DESCRIPTION
# Why

fixes #22109 
close ENG-8356

# How

specify `codegenDir` path by node `require.resolve('react-native-codegen/package.json')`

# Test Plan

adding the line to sdk 48 bare template and run app with new architecture enabled

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


Co-authored-by: `Hanno J. Gödecke <die.drei99@yahoo.de>`