### PR TITLE
[Android][core] Class constructors should be able to receive `this`

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptClassTest.kt
@@ -192,4 +192,19 @@ class JavaScriptClassTest {
 
     Truth.assertThat(registry!!.pairs[id!!]).isNull()
   }
+
+  @Test
+  fun object_constructor_should_be_able_to_receive_js_object() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Class("MyClass") {
+        Constructor { self: JavaScriptObject ->
+          self.setProperty("foo", "bar")
+        }
+      }
+    }
+  ) {
+    val result = evaluateScript("new expo.modules.TestModule.MyClass().foo").getString()
+    Truth.assertThat(result).isEqualTo("bar")
+  }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -29,7 +29,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     }
 
     val constructor = constructor ?: SyncFunctionComponent("constructor", arrayOf()) {}
-    constructor.canTakeOwner = hasSharedObject
+    constructor.canTakeOwner = true
 
     return ClassDefinitionData(
       name,


### PR DESCRIPTION
# Why

The class constructor should be able to receive the js object as `this` even if isn't connected with any shared object. 

# Test Plan

- workshop project ✅
- unit test ✅