### PR TITLE
[build-properties] should not throw error when flipper=false and useFrameworks

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed false alarm error throwing when `ios.flipper=false` and `useFrameworks`. ([#22296](https://github.com/expo/expo/pull/22296) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.6.0 - 2023-04-14

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -130,7 +130,9 @@ function validateConfig(config) {
     maybeThrowInvalidVersions(config);
     // explicitly block using use_frameworks and Flipper in iOS
     // https://github.com/facebook/flipper/issues/2414
-    if (config?.ios?.flipper !== undefined && config?.ios?.useFrameworks !== undefined) {
+    if (config.ios?.flipper !== undefined &&
+        config.ios?.flipper !== false &&
+        config.ios?.useFrameworks !== undefined) {
         throw new Error('`ios.flipper` cannot be enabled when `ios.useFrameworks` is set.');
     }
     if (config.android?.enableShrinkResourcesInReleaseBuilds === true &&

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -130,9 +130,7 @@ function validateConfig(config) {
     maybeThrowInvalidVersions(config);
     // explicitly block using use_frameworks and Flipper in iOS
     // https://github.com/facebook/flipper/issues/2414
-    if (config.ios?.flipper !== undefined &&
-        config.ios?.flipper !== false &&
-        config.ios?.useFrameworks !== undefined) {
+    if (Boolean(config.ios?.flipper) && config.ios?.useFrameworks !== undefined) {
         throw new Error('`ios.flipper` cannot be enabled when `ios.useFrameworks` is set.');
     }
     if (config.android?.enableShrinkResourcesInReleaseBuilds === true &&

--- a/packages/expo-build-properties/src/__tests__/pluginConfig-test.ts
+++ b/packages/expo-build-properties/src/__tests__/pluginConfig-test.ts
@@ -44,12 +44,26 @@ describe(validateConfig, () => {
     );
   });
 
-  it('should not allow ios.flipper and ios.useFrameworks at the same time', () => {
+  it('should not allow ios.flipper=true and ios.useFrameworks at the same time', () => {
     expect(() =>
       validateConfig({ ios: { flipper: true, useFrameworks: 'static' } })
     ).toThrowErrorMatchingInlineSnapshot(
       `"\`ios.flipper\` cannot be enabled when \`ios.useFrameworks\` is set."`
     );
+  });
+
+  it(`should not allow ios.flipper='0.999.0' and ios.useFrameworks at the same time`, () => {
+    expect(() =>
+      validateConfig({ ios: { flipper: '0.999.0', useFrameworks: 'static' } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"\`ios.flipper\` cannot be enabled when \`ios.useFrameworks\` is set."`
+    );
+  });
+
+  it('should allow ios.flipper=false and ios.useFrameworks at the same time', () => {
+    expect(() =>
+      validateConfig({ ios: { flipper: false, useFrameworks: 'static' } })
+    ).not.toThrow();
   });
 
   it('should use `enableShrinkResourcesInReleaseBuilds` with `enableProguardInReleaseBuilds`', () => {

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -286,11 +286,7 @@ export function validateConfig(config: any): PluginConfigType {
 
   // explicitly block using use_frameworks and Flipper in iOS
   // https://github.com/facebook/flipper/issues/2414
-  if (
-    config.ios?.flipper !== undefined &&
-    config.ios?.flipper !== false &&
-    config.ios?.useFrameworks !== undefined
-  ) {
+  if (Boolean(config.ios?.flipper) && config.ios?.useFrameworks !== undefined) {
     throw new Error('`ios.flipper` cannot be enabled when `ios.useFrameworks` is set.');
   }
 

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -286,7 +286,11 @@ export function validateConfig(config: any): PluginConfigType {
 
   // explicitly block using use_frameworks and Flipper in iOS
   // https://github.com/facebook/flipper/issues/2414
-  if (config?.ios?.flipper !== undefined && config?.ios?.useFrameworks !== undefined) {
+  if (
+    config.ios?.flipper !== undefined &&
+    config.ios?.flipper !== false &&
+    config.ios?.useFrameworks !== undefined
+  ) {
     throw new Error('`ios.flipper` cannot be enabled when `ios.useFrameworks` is set.');
   }
 


### PR DESCRIPTION
# Why

fixes #22199
close ENG-8395

# How

should not throw when ios.flipper=false and useFrameworks

# Test Plan

add unit tests and ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
