### PR TITLE
[core][Android] Fix `trying to resolve view with a tag which doesn't exist`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -79,6 +79,12 @@ abstract class AsyncFunction(
 
       if (queue == Queues.MAIN) {
         if (!BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+          // On certain occasions, invoking a function on a view could lead to an error
+          // because of the asynchronous communication between the JavaScript and native components.
+          // In such cases, the native view may not have been mounted yet,
+          // but the JavaScript code has already received the future tag of the view.
+          // To avoid this issue, we have decided to temporarily utilize
+          // the UIManagerModule for dispatching functions on the main thread.
           val uiManager = UIManagerHelper.getUIManagerForReactTag(
             appContext.reactContext as? ReactContext ?: throw Exceptions.ReactContextLost(),
             UIManagerType.DEFAULT


### PR DESCRIPTION
# Why

Fixes rare exceptions thrown by RN when trying to dispatch a function on a view.

```tsx
const chartRef = React.useCallback(async (node) => {
  if (node !== null) {
    await node.setDataSet(dataSet);
  }
}, [dataSet]);

return <LinearChartView nativeRef={chartRef} />
```
Sometimes, this code may result in an error due to unsynchronized communication between the JavaScript and native sides, causing the native view to be unmounted while the JavaScript receives the future tag of the view. Although this is not the most ideal solution, it is currently the only one available until upstream changes are made. Additionally, it may not function properly on Fabric at the moment.

# Test Plan

- workshop project ✅