### PR TITLE
[docs] mention `large` resource class for iOS in `eas.json` schema

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -154,9 +154,11 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
   - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
   - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM
   - M2: 3.4GHz 12-Core M2 (8 performance and 4 efficiency cores), 24 GB RAM
+  - M2 Pro: 3.4GHz 10-Core M2 Pro (6 performance and 4 efficiency cores), 32 GB RAM
 - Build resources:
   - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM, 2 builder VMs per host
   - [`m-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
+  - [`large`](eas-json/#resourceclass-2): 4 cores, 12 GB RAM, 2 builder VMs per host (for builds running on M2 Pro hosts) or 4 cores, 12 GB RAM, 1 builder VM per host (for builds running on M2 hosts)
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -158,7 +158,7 @@ iOS worker VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build
 - Build resources:
   - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM, 2 builder VMs per host
   - [`m-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
-  - [`large`](eas-json/#resourceclass-2): 4 cores, 12 GB RAM, 2 builder VMs per host (for builds running on M2 Pro hosts) or 4 cores, 12 GB RAM, 1 builder VM per host (for builds running on M2 hosts)
+  - [`large`](eas-json/#resourceclass-2): 4 cores, 12 GB RAM, 2 builder VMs per host (for builds running on M2 Pro hosts) or 4 cores, 22 GB RAM, 1 builder VM per host (for builds running on M2 hosts)
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -50,7 +50,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'medium'],
+    enum: ['default', 'medium', 'large'],
     description: [
       'The resource class that will be used to run this build.',
       'To see mapping for `default` and `medium` resource classes for each platform, see [Android-specific resource class field](eas-json/#resourceclass-1) and [iOS-specific resource class field](eas-json/#resourceclass-2) documentation.',

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -33,7 +33,7 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'medium', 'm-medium', 'intel-medium'],
+    enum: ['default', 'medium', 'large', 'm-medium', 'intel-medium'],
     description: [
       'The iOS-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#ios-build-server-configurations)',
       '- For SDK version >= 45 or React Native version >= 0.71.0 `default` maps to `m-medium`, otherwise it maps to `intel-medium`',


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-cli/pull/1817

# How

Add info about the `large` resource class for iOS to our infrastructure docs and `eas.json` reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
