### PR TITLE
[docs][expo-updates] Update protocol definition of a multipart body with 0 parts

### DIFF
--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -121,7 +121,7 @@ Headers for this response format are the [common response headers](#common-respo
 
 - `content-type` SHOULD have a `multipart/mixed` value as defined by [RFC 2046](https://tools.ietf.org/html/rfc2046#section-5.1)
 
-Part order is not strict. A multipart response with no parts should be considered a no-op (no updates or directives available), though headers SHOULD be sent nevertheless and processed by the client.
+Part order is not strict. A multipart response with no parts (zero-length body) should be considered a no-op (no updates or directives available), though headers for the response SHOULD be sent nevertheless and processed by the client.
 
 Each part is defined as follows:
 


### PR DESCRIPTION
# Why

Protocol version 1 supports "no-op" responses. How a client wants to implement this is up to the client, but a client should treat a zero-length body of a multipart response as a no-op. 

Our implementation (the expo-updates library) supports the zero-length body as of https://github.com/expo/expo/pull/22227. EAS Update supports it as of https://github.com/expo/universe/pull/12258.

Our implementation also supports a no-op directive, but we chose not to use that in EAS since code signing it is a UX challenge.

# How

Update spec.

# Test Plan

Inspect

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
