### PR TITLE
[docs] Minor fixes in development build docs to follow styleguide

### DIFF
--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -124,7 +124,7 @@ This will create a new section in the dev menu that includes the buttons you hav
 
 The EAS Update extension provides the ability to view and load published updates in your development client.
 
-It's now available for all development clients `v0.9.0` and above. In order to install it, you'll need the most recent publish of `expo-updates`:
+It's available for all development clients `v0.9.0` and above. To install it, you'll need the most recent publish of `expo-updates`:
 
 <Terminal cmd={['$ npx expo install expo-dev-client expo-updates']} />
 
@@ -136,13 +136,13 @@ You can now view and load EAS Updates in your development build via the `Extensi
 
 ## Set runtimeVersion in Expo config
 
-When you create a development build of your project, you'll get a stable environment to load any changes to your app that are defined in JavaScript or other asset-related changes. Other changes to your app, whether defined directly in **ios/** and **android/** directories or by packages or SDKs you choose to install, will require you to create a new build of your development build.
+When you create a development build of your project, you'll get a stable environment to load any changes to your app that are defined in JavaScript or other asset-related changes. Other changes to your app, whether defined directly in **android** and **ios** directories or by packages or SDKs you choose to install, will require you to create a new build of your development build.
 
 To enforce an API contract between the JavaScript and native layers of your app, you should set the [`runtimeVersion`](/distribution/runtime-versions) value in the Expo config. Each build you make will have this value embedded and will only load bundles with the same `runtimeVersion`, in both development and production.
 
 ## Build locally with Android Studio and Xcode
 
-> **warning** We do not recommend this method or modifying these **android/** and **ios/** directories directly, especially when creating a development build with EAS Build. For more information, see [Prebuild](/workflow/prebuild/).
+> **warning** We do not recommend this method or modifying these **android** and **ios** directories directly, especially when creating a development build with EAS Build. For more information, see [Prebuild](/workflow/prebuild/).
 
 If you need to debug native code or you prefer to manage your native projects, you can build and distribute your project using the `npx expo run` commands. You'll need to set up or have access to Android Studio, Xcode, and related dependencies on your local computer.
 

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 Building your project with Expo allows you to make most changes in JavaScript. This helps iterate quickly and safely and allows your team to [achieve web-like iteration speeds](https://blog.expo.dev/javascript-driven-development-with-custom-runtimes-eda87d574c9d) by dividing your application into:
 
-- **A native runtime**: A native binary that is built with Xcode or Android Studio. Expo Go is an example of a native runtime for iterating on React Native projects.
+- **A native runtime**: A native binary that is built with Android Studio or Xcode. Expo Go is an example of a native runtime for iterating on React Native projects.
 - **An update**: A bundle of your application's JavaScript code and assets (images, video, fonts, and so on). An update can be served from your local computer with Expo CLI, embedded in the binary by EAS Build, or hosted on a publicly available server.
 
 When your project requires custom native code, a config plugin, a custom runtime version, or a reduced bundle size of the app, you can transition from using [Expo Go](https://expo.dev/client) to develop to a development build.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found some instances in development build docs where writing styleguide wasn't being followed.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Applied guidelines such as [platform order](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-android-ios-and-web).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
