### PR TITLE
fix the label for the code snippet

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -354,7 +354,7 @@ Now, let's modify the **App.js** to:
 - Place the `<EmojiPicker>` component at the bottom of the `<App>` component, above the `<StatusBar>` component.
 
 <SnackInline
-label="Create a modal"
+label="App.js"
 templateId="tutorial/04-modal/App"
 dependencies={['expo-image-picker', '@expo/vector-icons/FontAwesome', '@expo/vector-icons', 'expo-status-bar', '@expo/vector-icons/MaterialIcons']}
 files={{


### PR DESCRIPTION
# Why

The label for the code snippet is wrong. It shows `Create a modal` instead of `App.js`.

# How

It's part of the tutorial documentation that I came across.

# Test Plan
![Screenshot 2023-04-30 at 10 06 47 PM](https://user-images.githubusercontent.com/7308807/235409513-84785945-1a2f-452c-af92-79fe36a622f8.png)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
