### PR TITLE
[docs] Update code example in Monorepo guide

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -108,6 +108,8 @@ const path = require('path');
 
 const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, '../..');
+  
+const config = getDefaultConfig(workspaceRoot);
 
 // Only list the packages within your monorepo that your app uses. No need to add anything else.
 // If your monorepo tooling can give you the list of monorepo workspaces linked


### PR DESCRIPTION


# Why

minor issue: the config object is never actually initialised here, so the code doesn't work as-is.

# How

this initialises the variable in the same way as above. This does use the workspace root instead of the project root.

# Test Plan

Run a vanilla/empty project with this config, it used to give a JS error, now it doesn't.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
