### PR TITLE
docs: Update apk.mdx by adding npx

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -39,7 +39,7 @@ To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding on
 
 Now you can run your build with the following command:
 
-<Terminal cmd={['$ eas build -p android --profile preview']} />
+<Terminal cmd={['$ npx eas build -p android --profile preview']} />
 
 Remember that you can name the profile whatever you like. We named the profile `preview`. However, you can call it `local`, `emulator`, or whatever makes the most sense for you.
 
@@ -53,7 +53,7 @@ Once your build is completed, the CLI will prompt you to automatically download 
 
 In case you have multiple builds, you can also run the `eas build:run` command at any time to download a specific build and automatically install it on the Android Emulator:
 
-<Terminal cmd={['$ eas build:run -p android']} />
+<Terminal cmd={['$ npx eas build:run -p android']} />
 
 The command also shows a list of available builds of your project. You can select the build to install on the emulator from this list. Each build in the list has a build ID, the time elapsed since the build creation, the build number, the version number, and the git commit information. The list also displays invalid builds if a project has any.
 
@@ -70,7 +70,7 @@ When the build's installation is complete, it will appear on the home screen. If
 
 Pass the `--latest` flag to the `eas build:run` command to download and install the latest build on the Android Emulator:
 
-<Terminal cmd={['$ eas build:run -p android --latest']} />
+<Terminal cmd={['$ npx eas build:run -p android --latest']} />
 
 ### Physical device
 
@@ -84,6 +84,6 @@ Pass the `--latest` flag to the `eas build:run` command to download and install 
 
 - [Install adb](https://developer.android.com/studio/command-line/adb) if you don't have it installed already.
 - Connect your device to your computer and [enable adb debugging on your device](https://developer.android.com/studio/command-line/adb#Enabling) if you haven't already.
-- Once your build is completed, download the APK from the build details page or the link provided when `eas build` is done.
+- Once your build is completed, download the APK from the build details page or the link provided when `npx eas build` is done.
 - Run `adb install path/to/the/file.apk`.
 - Run the app on your device.


### PR DESCRIPTION
- add `npx` so it can be used 
- to be sync with other use of expo to have npx as prefix of runnning commands

# Why
when run commands it gives me error:
`bash: eas: command not found`

# How
by using npx command

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
