### PR TITLE
Corrected import statement for FontAwesome icons

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -409,7 +409,7 @@ To load and display the icon on the button, let's use `FontAwesome` from the lib
 {/* prettier-ignore */}
 ```jsx Button.js
 import { StyleSheet, View, Pressable, Text } from 'react-native';
-/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/FontAwesome";/* @end */
+/* @info Import FontAwesome. */import FontAwesome from "@expo/vector-icons/";/* @end */
 
 export default function Button({ label, /* @info The prop theme to detect the button variant. */ theme/* @end */ }) {
   /* @info Conditionally render the primary themed button. */


### PR DESCRIPTION
Originally the icons would not be imported with the addition of "/FontAwesome" at the end of the statement. By removing this the icons are imported correctly

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
I faced some confusion following the docs when learning react native when I encountered this issue. My change fixes that.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Using my altered code, the import of icons works correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
