### PR TITLE
[expo-updates] Support 204 status for no-op responses

### DIFF
--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -81,6 +81,7 @@ A conformant server MUST return a response structured in at least one of the two
 
 - For a response with `content-type: application/json` or `content-type: application/expo+json`, the [common response headers](#common-response-headers) and [other response headers](#other-response-headers) MUST be sent in the response headers and the [manifest body](#manifest-body) MUST be sent in the response body. This format of response does not support multiple response parts and therefore does not support _directives_, and SHOULD respond with an HTTP `406` error status when the most recent response to be served is not an _update_.
 - For a response with `content-type: multipart/mixed`, the response MUST be structured as specified in the [multipart response](#multipart-response) section.
+- A [multipart response](#multipart-response) with no parts MAY respond with an HTTP `204` status and no content, and thus no `content-type` response header.
 
 The choice of update and headers are dependent on the values of the request headers. A conformant server MUST respond with the most recent update, ordered by creation time, satisfying all parameters and constraints imposed by the [request headers](#request). The server MAY use any properties of the request like its headers and source IP address to choose amongst several updates that all satisfy the request's constraints.
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add rollback to embedded update directive. ([#21007](https://github.com/expo/expo/pull/21007), [#21652](https://github.com/expo/expo/pull/21652) by [@wschurman](https://github.com/wschurman))
 - Add support for extra params. ([#21837](https://github.com/expo/expo/pull/21837) by [@wschurman](https://github.com/wschurman))
 - New checkAutomatically constant. ([#22137](https://github.com/expo/expo/pull/22137) by [@douglowder](https://github.com/douglowder))
+- Support 204 status for no-op responses. ([#22348](https://github.com/expo/expo/pull/22348) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -341,6 +341,45 @@ class FileDownloaderManifestParsingTest {
   }
 
   @Test
+  fun testManifestParsing_NullBodyResponseProtocol1() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val response = mockk<Response>().apply {
+      every { headers } returns mapOf("expo-protocol-version" to "1").toHeaders()
+      every { code } returns 200
+      every { body } returns null
+    }
+
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateResponse: UpdateResponse? = null
+
+    FileDownloader(context).parseRemoteUpdateResponse(
+      response, configuration,
+      object : FileDownloader.RemoteUpdateDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateResponse: UpdateResponse) {
+          resultUpdateResponse = updateResponse
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+
+    Assert.assertNotNull(resultUpdateResponse)
+    Assert.assertNull(resultUpdateResponse!!.manifestUpdateResponsePart)
+    Assert.assertNull(resultUpdateResponse!!.directiveUpdateResponsePart)
+  }
+
+  @Test
   fun testManifestParsing_204ResponseProtocol1() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext
     val response = mockk<Response>().apply {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -28,6 +28,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(
         "application/json; charset=utf-8".toMediaTypeOrNull(),
         CertificateFixtures.testClassicManifestBody
@@ -96,6 +97,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -153,6 +155,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -209,6 +212,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -259,6 +263,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -301,6 +306,7 @@ class FileDownloaderManifestParsingTest {
     val response = mockk<Response>().apply {
       every { header("content-type") } returns contentType
       every { headers } returns mapOf("content-type" to contentType).toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, "")
     }
 
@@ -335,6 +341,82 @@ class FileDownloaderManifestParsingTest {
   }
 
   @Test
+  fun testManifestParsing_204ResponseProtocol1() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val response = mockk<Response>().apply {
+      every { headers } returns mapOf("expo-protocol-version" to "1").toHeaders()
+      every { code } returns 204
+      every { body } returns null
+    }
+
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred = false
+    var resultUpdateResponse: UpdateResponse? = null
+
+    FileDownloader(context).parseRemoteUpdateResponse(
+      response, configuration,
+      object : FileDownloader.RemoteUpdateDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = true
+        }
+
+        override fun onSuccess(updateResponse: UpdateResponse) {
+          resultUpdateResponse = updateResponse
+        }
+      }
+    )
+
+    Assert.assertFalse(errorOccurred)
+
+    Assert.assertNotNull(resultUpdateResponse)
+    Assert.assertNull(resultUpdateResponse!!.manifestUpdateResponsePart)
+    Assert.assertNull(resultUpdateResponse!!.directiveUpdateResponsePart)
+  }
+
+  @Test
+  fun testManifestParsing_204ResponseNoProtocol() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val response = mockk<Response>().apply {
+      every { header("content-type") } returns null
+      every { headers } returns mapOf<String, String>().toHeaders()
+      every { code } returns 204
+      every { body } returns null
+    }
+
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test"),
+      )
+    )
+
+    var errorOccurred: Exception? = null
+    var resultUpdateManifest: UpdateManifest? = null
+
+    FileDownloader(context).parseRemoteUpdateResponse(
+      response, configuration,
+      object : FileDownloader.RemoteUpdateDownloadCallback {
+        override fun onFailure(message: String, e: Exception) {
+          errorOccurred = e
+        }
+
+        override fun onSuccess(updateResponse: UpdateResponse) {
+          resultUpdateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+        }
+      }
+    )
+
+    Assert.assertEquals("Missing body in remote update", errorOccurred!!.message)
+    Assert.assertNull(resultUpdateManifest)
+  }
+
+  @Test
   fun testManifestParsing_JSONBodySigned() {
     val contentType = "application/json"
     val headersMap = mapOf(
@@ -351,6 +433,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testNewManifestBody)
     }
 
@@ -435,6 +518,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -489,6 +573,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testNewManifestBody)
     }
 
@@ -580,6 +665,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -668,6 +754,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -748,6 +835,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create(MultipartBody.MIXED, contentBuffer.readByteArray())
     }
 
@@ -799,6 +887,7 @@ class FileDownloaderManifestParsingTest {
         every { header(it.key) } returns it.value
       }
       every { headers } returns headersMap.toHeaders()
+      every { code } returns 200
       every { body } returns ResponseBody.create("application/json; charset=utf-8".toMediaTypeOrNull(), CertificateFixtures.testNewManifestBody)
     }
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/UpdateManifestFactoryTest.kt
@@ -42,7 +42,7 @@ class UpdateManifestFactoryTest {
   fun testGetManifest_New() {
     val actual = getManifest(
       JSONObject(newManifestJson),
-      ResponseHeaderData(protocolVersion = "0"),
+      ResponseHeaderData(protocolVersionRaw = "0"),
       null,
       createConfig()
     )
@@ -54,7 +54,7 @@ class UpdateManifestFactoryTest {
   fun testGetManifest_UnsupportedProtocolVersion() {
     getManifest(
       JSONObject(newManifestJson),
-      ResponseHeaderData(protocolVersion = "100"),
+      ResponseHeaderData(protocolVersionRaw = "100"),
       null,
       createConfig()
     )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -95,7 +95,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
   internal fun parseRemoteUpdateResponse(response: Response, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
     val responseHeaders = response.headers
     val responseHeaderData = ResponseHeaderData(
-      protocolVersion = responseHeaders["expo-protocol-version"],
+      protocolVersionRaw = responseHeaders["expo-protocol-version"],
       manifestFiltersRaw = responseHeaders["expo-manifest-filters"],
       serverDefinedHeadersRaw = responseHeaders["expo-server-defined-headers"],
       manifestSignature = responseHeaders["expo-manifest-signature"],
@@ -103,9 +103,9 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     val responseBody = response.body
 
     if (response.code == 204 || responseBody == null) {
-      // If the protocol version is 1, we support returning a 204 and no body to mean no-op.
+      // If the protocol version greater than 0, we support returning a 204 and no body to mean no-op.
       // A 204 has no content-type.
-      if (responseHeaderData.protocolVersion == "1") {
+      if (responseHeaderData.protocolVersion != null && responseHeaderData.protocolVersion > 0) {
         callback.onSuccess(
           UpdateResponse(
             responseHeaderData = responseHeaderData,
@@ -139,7 +139,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         return
       }
 
-      parseMultipartRemoteUpdateResponse(responseBody!!, responseHeaderData, boundaryParameter, configuration, callback)
+      parseMultipartRemoteUpdateResponse(responseBody, responseHeaderData, boundaryParameter, configuration, callback)
     } else {
       val manifestResponseInfo = ResponsePartInfo(
         responseHeaderData = responseHeaderData,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -93,6 +93,38 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
   }
 
   internal fun parseRemoteUpdateResponse(response: Response, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
+    val responseHeaders = response.headers
+    val responseHeaderData = ResponseHeaderData(
+      protocolVersion = responseHeaders["expo-protocol-version"],
+      manifestFiltersRaw = responseHeaders["expo-manifest-filters"],
+      serverDefinedHeadersRaw = responseHeaders["expo-server-defined-headers"],
+      manifestSignature = responseHeaders["expo-manifest-signature"],
+    )
+    val responseBody = response.body
+
+    if (response.code == 204 || responseBody == null) {
+      // If the protocol version is 1, we support returning a 204 and no body to mean no-op.
+      // A 204 has no content-type.
+      if (responseHeaderData.protocolVersion == "1") {
+        callback.onSuccess(
+          UpdateResponse(
+            responseHeaderData = responseHeaderData,
+            manifestUpdateResponsePart = null,
+            directiveUpdateResponsePart = null
+          )
+        )
+        return
+      }
+
+      val message = "Missing body in remote update"
+      logger.error(message, UpdatesErrorCode.UpdateFailedToLoad)
+      callback.onFailure(
+        message,
+        IOException(message)
+      )
+      return
+    }
+
     val contentType = response.header("content-type") ?: ""
     val isMultipart = contentType.startsWith("multipart/", ignoreCase = true)
     if (isMultipart) {
@@ -107,17 +139,8 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         return
       }
 
-      parseMultipartRemoteUpdateResponse(response, boundaryParameter, configuration, callback)
+      parseMultipartRemoteUpdateResponse(responseBody!!, responseHeaderData, boundaryParameter, configuration, callback)
     } else {
-      val responseHeaders = response.headers
-
-      val responseHeaderData = ResponseHeaderData(
-        protocolVersion = responseHeaders["expo-protocol-version"],
-        manifestFiltersRaw = responseHeaders["expo-manifest-filters"],
-        serverDefinedHeadersRaw = responseHeaders["expo-server-defined-headers"],
-        manifestSignature = responseHeaders["expo-manifest-signature"]
-      )
-
       val manifestResponseInfo = ResponsePartInfo(
         responseHeaderData = responseHeaderData,
         responsePartHeaderData = ResponsePartHeaderData(
@@ -165,13 +188,13 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
     return headers.toHeaders()
   }
 
-  private fun parseMultipartRemoteUpdateResponse(response: Response, boundary: String, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
+  private fun parseMultipartRemoteUpdateResponse(responseBody: ResponseBody, responseHeaderData: ResponseHeaderData, boundary: String, configuration: UpdatesConfiguration, callback: RemoteUpdateDownloadCallback) {
     var manifestPartBodyAndHeaders: Pair<String, Headers>? = null
     var extensionsBody: String? = null
     var certificateChainString: String? = null
     var directivePartBodyAndHeaders: Pair<String, Headers>? = null
 
-    val multipartStream = MultipartStream(response.body!!.byteStream(), boundary.toByteArray())
+    val multipartStream = MultipartStream(responseBody.byteStream(), boundary.toByteArray())
 
     try {
       var nextPart = multipartStream.skipPreamble()
@@ -226,14 +249,6 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
       callback.onFailure(message, IOException(message))
       return
     }
-
-    val responseHeaders = response.headers
-    val responseHeaderData = ResponseHeaderData(
-      protocolVersion = responseHeaders["expo-protocol-version"],
-      manifestFiltersRaw = responseHeaders["expo-manifest-filters"],
-      serverDefinedHeadersRaw = responseHeaders["expo-server-defined-headers"],
-      manifestSignature = responseHeaders["expo-manifest-signature"],
-    )
 
     val manifestResponseInfo = manifestPartBodyAndHeaders?.let {
       ResponsePartInfo(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestFactory.kt
@@ -15,8 +15,7 @@ object ManifestFactory {
 
   @Throws(Exception::class)
   fun getManifest(manifestJson: JSONObject, responseHeaderData: ResponseHeaderData, extensions: JSONObject?, configuration: UpdatesConfiguration?): UpdateManifest {
-    val expoProtocolVersion = responseHeaderData.protocolVersion
-    return when (expoProtocolVersion?.let { Integer.valueOf(it) }) {
+    return when (val expoProtocolVersion = responseHeaderData.protocolVersion) {
       null -> {
         LegacyUpdateManifest.fromLegacyManifest(LegacyManifest(manifestJson), configuration!!)
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ResponseHeaderData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ResponseHeaderData.kt
@@ -17,7 +17,7 @@ data class ResponseHeaderData(
   /**
    * expo-protocol-version header. Indicates which version of the expo-updates protocol the response is.
    */
-  val protocolVersion: String? = null,
+  private val protocolVersionRaw: String? = null,
   /**
    * expo-server-defined-headers header.  It defines headers that this library must store until overwritten by a newer dictionary.
    * They must be included in every subsequent update request.
@@ -35,6 +35,8 @@ data class ResponseHeaderData(
    */
   val manifestSignature: String? = null,
 ) {
+  val protocolVersion = protocolVersionRaw?.let { Integer.valueOf(it) }
+
   val serverDefinedHeaders: JSONObject? by lazy {
     serverDefinedHeadersRaw?.let { headerDictionaryToJSONObject(it) }
   }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -126,7 +126,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       guard let data = data else {
         let errorMessage = String(
           format: "File download response was empty for URL: %@",
-          [url.absoluteString]
+          url.absoluteString
         )
         self.logger.error(message: errorMessage, code: UpdatesErrorCode.assetsFailedToLoad)
         errorBlock(NSError(
@@ -357,14 +357,15 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
   ) {
     let headerDictionary = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersion: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
+      protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
       serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
       manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
       manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
     )
 
-    guard let data = data else {
-      if responseHeaderData.protocolVersion == "1" && httpResponse.statusCode == 204 {
+    if httpResponse.statusCode == 204 || data == nil {
+      if let protocolVersion = responseHeaderData.protocolVersion,
+        protocolVersion > 0 {
         successBlock(UpdateResponse(
           responseHeaderData: responseHeaderData,
           manifestUpdateResponsePart: nil,
@@ -372,7 +373,9 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
         ))
         return
       }
+    }
 
+    guard let data = data else {
       let errorMessage = "Missing body in remote update"
       logger.error(message: errorMessage, code: UpdatesErrorCode.unknown)
       errorBlock(NSError(
@@ -412,7 +415,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       return
     } else {
       let responseHeaderData = ResponseHeaderData(
-        protocolVersion: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
+        protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
         serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
         manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
         manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
@@ -537,7 +540,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
 
     let responseHeaders = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersion: responseHeaders.optionalValue(forKey: "expo-protocol-version"),
+      protocolVersionRaw: responseHeaders.optionalValue(forKey: "expo-protocol-version"),
       serverDefinedHeadersRaw: responseHeaders.optionalValue(forKey: "expo-server-defined-headers"),
       manifestFiltersRaw: responseHeaders.optionalValue(forKey: "expo-manifest-filters"),
       manifestSignature: responseHeaders.optionalValue(forKey: "expo-manifest-signature")

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/ResponseHeaderData.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/ResponseHeaderData.swift
@@ -11,13 +11,13 @@ internal final class ResponseHeaderData {
   /**
    * expo-protocol-version header. Indicates which version of the expo-updates protocol the response is.
    */
-  let protocolVersion: String?
+  private let protocolVersionRaw: String?
 
   /**
    * expo-server-defined-headers header.  It defines headers that this library must store until overwritten by a newer dictionary.
    * They must be included in every subsequent update request.
    */
-  let serverDefinedHeadersRaw: String?
+  private let serverDefinedHeadersRaw: String?
 
   /**
    * expo-manifest-filters header. It is used to filter updates stored by the client library by the
@@ -25,19 +25,25 @@ internal final class ResponseHeaderData {
    * field in the metadata must either be missing or equal for the update to be included.
    * The client library must store the manifest filters until it is overwritten by a newer response.
    */
-  let manifestFiltersRaw: String?
+  private let manifestFiltersRaw: String?
 
   /**
    * Classic updates Expo Go manifest signature
    */
   let manifestSignature: String?
 
-  required init(protocolVersion: String?, serverDefinedHeadersRaw: String?, manifestFiltersRaw: String?, manifestSignature: String?) {
-    self.protocolVersion = protocolVersion
+  required init(protocolVersionRaw: String?, serverDefinedHeadersRaw: String?, manifestFiltersRaw: String?, manifestSignature: String?) {
+    self.protocolVersionRaw = protocolVersionRaw
     self.serverDefinedHeadersRaw = serverDefinedHeadersRaw
     self.manifestFiltersRaw = manifestFiltersRaw
     self.manifestSignature = manifestSignature
   }
+
+  lazy var protocolVersion: Int? = {
+    self.protocolVersionRaw.let { it in
+      Int(it)
+    }
+  }()
 
   lazy var serverDefinedHeaders: [String: Any]? = {
     self.serverDefinedHeadersRaw.let { it in

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -143,7 +143,7 @@ public class Update: NSObject {
         config: config,
         database: database
       )
-    case "0", "1":
+    case 0, 1:
       return NewUpdate.update(
         withNewManifest: NewManifest(rawManifestJSON: withManifest),
         extensions: extensions,

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -235,6 +235,63 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(resultUpdateResponse?.manifestUpdateResponsePart).to(beNil())
         expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
       }
+
+      it("204 response protocol 1") {
+        let config = UpdatesConfig.config(fromDictionary: [
+          UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        ])
+        let downloader = FileDownloader(config: config)
+
+        let response = HTTPURLResponse(
+          url: URL(string: "https://exp.host/@test/test")!,
+          statusCode: 204,
+          httpVersion: "HTTP/1.1",
+          headerFields: ["expo-protocol-version": "1"]
+        )!
+
+        let bodyData: Data? = nil
+
+        var resultUpdateResponse: UpdateResponse? = nil
+        var errorOccurred: (any Error)? = nil
+        downloader.parseManifestResponse(response, withData: bodyData, database: database) { updateResponse in
+          resultUpdateResponse = updateResponse
+        } errorBlock: { error in
+          errorOccurred = error
+        }
+
+        expect(errorOccurred).to(beNil())
+        expect(resultUpdateResponse).notTo(beNil())
+
+        expect(resultUpdateResponse?.manifestUpdateResponsePart).to(beNil())
+        expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
+      }
+
+      it("204 response no protocol") {
+        let config = UpdatesConfig.config(fromDictionary: [
+          UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        ])
+        let downloader = FileDownloader(config: config)
+
+        let response = HTTPURLResponse(
+          url: URL(string: "https://exp.host/@test/test")!,
+          statusCode: 204,
+          httpVersion: "HTTP/1.1",
+          headerFields: [:]
+        )!
+
+        let bodyData: Data? = nil
+
+        var resultUpdateResponse: UpdateResponse? = nil
+        var errorOccurred: (any Error)? = nil
+        downloader.parseManifestResponse(response, withData: bodyData, database: database) { updateResponse in
+          resultUpdateResponse = updateResponse
+        } errorBlock: { error in
+          errorOccurred = error
+        }
+
+        expect(errorOccurred?.localizedDescription) == "Missing body in remote update"
+        expect(resultUpdateResponse).to(beNil())
+      }
       
       it("json body signed") {
         let config = UpdatesConfig.config(fromDictionary: [

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -236,6 +236,38 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
       }
 
+      it("nil body protocol 1") {
+        let config = UpdatesConfig.config(fromDictionary: [
+          UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        ])
+        let downloader = FileDownloader(config: config)
+
+        let boundary = "blah"
+        let contentType = "multipart/mixed; boundary=\(boundary)"
+        let response = HTTPURLResponse(
+          url: URL(string: "https://exp.host/@test/test")!,
+          statusCode: 200,
+          httpVersion: "HTTP/1.1",
+          headerFields: ["expo-protocol-version": "1"]
+        )!
+
+        let bodyData: Data? = nil
+
+        var resultUpdateResponse: UpdateResponse? = nil
+        var errorOccurred: (any Error)? = nil
+        downloader.parseManifestResponse(response, withData: bodyData, database: database) { updateResponse in
+          resultUpdateResponse = updateResponse
+        } errorBlock: { error in
+          errorOccurred = error
+        }
+
+        expect(errorOccurred).to(beNil())
+        expect(resultUpdateResponse).notTo(beNil())
+
+        expect(resultUpdateResponse?.manifestUpdateResponsePart).to(beNil())
+        expect(resultUpdateResponse?.directiveUpdateResponsePart).to(beNil())
+      }
+
       it("204 response protocol 1") {
         let config = UpdatesConfig.config(fromDictionary: [
           UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",

--- a/packages/expo-updates/ios/Tests/UpdateSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdateSpec.swift
@@ -23,7 +23,7 @@ class UpdateSpec : ExpoSpec {
         ]
         
         let responseHeaderData = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: nil,
           manifestSignature: nil
@@ -50,7 +50,7 @@ class UpdateSpec : ExpoSpec {
         ]
         
         let responseHeaderData = ResponseHeaderData(
-          protocolVersion: "0",
+          protocolVersionRaw: "0",
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: nil,
           manifestSignature: nil
@@ -77,7 +77,7 @@ class UpdateSpec : ExpoSpec {
         ]
         
         let responseHeaderData = ResponseHeaderData(
-          protocolVersion: "2",
+          protocolVersionRaw: "2",
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: nil,
           manifestSignature: nil

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseSpec.swift
@@ -101,7 +101,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
     describe("setMetadata") {
       it("overwrites all fields") {
         let responseHeaderData1 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: "branch-name=\"rollout-1\",test=\"value\"",
           manifestSignature: nil
@@ -112,7 +112,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         }
         
         let responseHeaderData2 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: "branch-name=\"rollout-2\"",
           manifestSignature: nil
@@ -131,7 +131,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
       
       it("overwrites with empty") {
         let responseHeaderData1 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: "branch-name=\"rollout-1\"",
           manifestSignature: nil
@@ -142,7 +142,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         }
         
         let responseHeaderData2 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: "",
           manifestSignature: nil
@@ -161,7 +161,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
       
       it("does not overwrite with nil") {
         let responseHeaderData1 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: "branch-name=\"rollout-1\"",
           manifestSignature: nil
@@ -172,7 +172,7 @@ class UpdatesDatabaseSpec : ExpoSpec {
         }
         
         let responseHeaderData2 = ResponseHeaderData(
-          protocolVersion: nil,
+          protocolVersionRaw: nil,
           serverDefinedHeadersRaw: nil,
           manifestFiltersRaw: nil,
           manifestSignature: nil


### PR DESCRIPTION
# Why

https://github.com/expo/universe/pull/12258#issuecomment-1529977129

We need to support empty bodies for no-op responses. Semantically, a 204 makes the most sense for this response (no body content, no content-type). Therefore, we need to handle this case before trying to enter the methods that parse the manifest based on content-type.

# How

Handle 204 with empty body first when protocol is 1.

# Test Plan

Run new tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
