### PR TITLE
[expo-updates][iOS] fix bizarre bug when downloading update twice

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Copy native events before transforming them. ([#22162](https://github.com/expo/expo/pull/22162) by [@douglowder](https://github.com/douglowder))
 - Fix empty body no-op multipart response. ([#22227](https://github.com/expo/expo/pull/22227) by [@wschurman](https://github.com/wschurman))
 - Put extra data mutation in transaction. ([#22252](https://github.com/expo/expo/pull/22252) by [@wschurman](https://github.com/wschurman))
+- [iOS] fix bizarre bug when downloading update twice. ([#22355](https://github.com/expo/expo/pull/22355) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -39,6 +39,7 @@ internal final class RemoteAppLoader: AppLoader {
 
     self.successBlock = { [weak self] (updateResponse: UpdateResponse?) in
       guard let strongSelf = self else {
+        successBlockArg(updateResponse)
         return
       }
       // even if update is nil (meaning we didn't load a new update),


### PR DESCRIPTION
# Why

If `fetchUpdateAsync` is called twice on iOS, an error occurs because even though download is successful, the RemoteAppLoader object is released before the completion handler is called, and the flow errors out without calling the passed in JS callback.

# How

Add a line to call the JS callback when the above occurs.

# Test Plan

Tested manually using test app generated with `packages/expo-updates/e2e/setup/create-updates-test.js`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
