### PR TITLE
[expo-updates][expo-go] Support new SDK version field in new manifests

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
@@ -1,0 +1,35 @@
+package host.exp.exponent
+
+import expo.modules.manifests.core.Manifest
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.selectionpolicy.LauncherSelectionPolicy
+import expo.modules.updates.selectionpolicy.SelectionPolicies
+import org.json.JSONObject
+
+/**
+ * LauncherSelectionPolicy similar to LauncherSelectionPolicyFilterAware but specifically for
+ * Expo Go which uses a Expo-Go-specific field to determine compatibility.
+ */
+class ExpoGoLauncherSelectionPolicyFilterAware(private val sdkVersions: List<String>) :
+  LauncherSelectionPolicy {
+  override fun selectUpdateToLaunch(
+    updates: List<UpdateEntity>,
+    filters: JSONObject?
+  ): UpdateEntity? {
+    var updateToLaunch: UpdateEntity? = null
+    for (update in updates) {
+      val manifest = Manifest.fromManifestJson(update.manifest!!)
+      if (!sdkVersions.contains(manifest.getExpoGoSDKVersion()) || !SelectionPolicies.matchesFilters(
+          update,
+          filters
+        )
+      ) {
+        continue
+      }
+      if (updateToLaunch == null || updateToLaunch.commitTime.before(update.commitTime)) {
+        updateToLaunch = update
+      }
+    }
+    return updateToLaunch
+  }
+}

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -23,7 +23,6 @@ import expo.modules.updates.codesigning.CODE_SIGNING_METADATA_ALGORITHM_KEY
 import expo.modules.updates.codesigning.CODE_SIGNING_METADATA_KEY_ID_KEY
 import expo.modules.updates.codesigning.CodeSigningAlgorithm
 import expo.modules.updates.manifest.EmbeddedManifest
-import expo.modules.updates.selectionpolicy.LauncherSelectionPolicyFilterAware
 import expo.modules.updates.selectionpolicy.LoaderSelectionPolicyFilterAware
 import expo.modules.updates.selectionpolicy.ReaperSelectionPolicyDevelopmentClient
 import expo.modules.updates.selectionpolicy.SelectionPolicy
@@ -175,7 +174,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
       }
     }
     val selectionPolicy = SelectionPolicy(
-      LauncherSelectionPolicyFilterAware(sdkVersionsList),
+      ExpoGoLauncherSelectionPolicyFilterAware(sdkVersionsList),
       LoaderSelectionPolicyFilterAware(),
       ReaperSelectionPolicyDevelopmentClient()
     )
@@ -254,7 +253,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
         override fun onRemoteUpdateManifestResponseManifestLoaded(updateManifest: UpdateManifest) {
           // expo-cli does not always respect our SDK version headers and respond with a compatible update or an error
           // so we need to check the compatibility here
-          val sdkVersion = updateManifest.manifest.getSDKVersion()
+          val sdkVersion = updateManifest.manifest.getExpoGoSDKVersion()
           if (!isValidSdkVersion(sdkVersion)) {
             callback.onError(formatExceptionForIncompatibleSdk(sdkVersion))
             didAbort = true

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -448,7 +448,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     task.activityId = activityId
     task.bundleUrl = bundleUrl
 
-    sdkVersion = manifest.getSDKVersion()
+    sdkVersion = manifest.getExpoGoSDKVersion()
     isShellApp = this.manifestUrl == Constants.INITIAL_URL
 
     // Sometime we want to release a new version without adding a new .aar. Use TEMPORARY_ABI_VERSION

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -249,7 +249,7 @@ abstract class ReactNativeActivity :
     if (reactRootViewRNClass != null) {
       return reactRootViewRNClass as Class<out ViewGroup>
     }
-    var sdkVersion = manifest.getSDKVersion()
+    var sdkVersion = manifest.getExpoGoSDKVersion()
     if (Constants.TEMPORARY_ABI_VERSION != null && Constants.TEMPORARY_ABI_VERSION == this.sdkVersion) {
       sdkVersion = RNObject.UNVERSIONED
     }

--- a/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -106,7 +106,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
   private fun setManifest(manifestUrl: String, manifest: Manifest, bundleUrl: String?) {
     this.manifestUrl = manifestUrl
     this.manifest = manifest
-    sdkVersion = manifest.getSDKVersion()
+    sdkVersion = manifest.getExpoGoSDKVersion()
 
     // Notifications logic uses this to determine which experience to route a notification to
     ExponentDB.saveExperience(ExponentDBObject(this.manifestUrl!!, manifest, bundleUrl!!))

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/internal/DevMenuModule.kt
@@ -93,7 +93,7 @@ class DevMenuModule(reactContext: ReactApplicationContext, val experiencePropert
       debuggerMap.putString("label", getString(R.string.devmenu_open_js_debugger))
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
       items.putBundle("dev-remote-debug", debuggerMap)
-    } else if (devSettings != null && devSupportManager.devSupportEnabled && manifest?.getSDKVersion() ?: "" < "49.0.0") {
+    } else if (devSettings != null && devSupportManager.devSupportEnabled && manifest?.getExpoGoSDKVersion() ?: "" < "49.0.0") {
       debuggerMap.putString("label", getString(if (devSettings.isRemoteJSDebugEnabled) R.string.devmenu_stop_remote_debugging else R.string.devmenu_start_remote_debugging))
       debuggerMap.putBoolean("isEnabled", devSupportManager.devSupportEnabled)
       items.putBundle("dev-remote-debug", debuggerMap)

--- a/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi46_0_0/src/main/java/abi46_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersion()
+    val currentSDKVersion = manifest.getExpoGoSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/host/exp/exponent/modules/universal/ScopedErrorRecoveryModule.kt
@@ -13,7 +13,7 @@ class ScopedErrorRecoveryModule(
   val experienceKey: ExperienceKey
 ) : ErrorRecoveryModule(context) {
   override val mSharedPreferences: SharedPreferences = run {
-    val currentSDKVersion = manifest.getSDKVersion()
+    val currentSDKVersion = manifest.getExpoGoSDKVersion()
     context.applicationContext.getSharedPreferences(
       "$RECOVERY_STORE.$currentSDKVersion",
       Context.MODE_PRIVATE

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -144,6 +144,8 @@
 		A1C33FE52667F6E70091644A /* EXSplashScreenHUDButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A1C33FDB2667F6E70091644A /* EXSplashScreenHUDButton.m */; };
 		B0D21CC221E6488D8EDA79EA /* RNSharedElementTransitionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E9033E268A74098A882CCEB /* RNSharedElementTransitionManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		B21115F8246C1B47005BA616 /* EXScopedNotificationBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */; };
+		B216039C2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */; };
+		B216039D2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */; };
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */; };
 		B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */; };
@@ -775,6 +777,7 @@
 		AF530F40E8F84F5FB7D7C181 /* RNSharedElementTransition.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; path = RNSharedElementTransition.h; sourceTree = "<group>"; };
 		B21115F6246C1B47005BA616 /* EXScopedNotificationBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationBuilder.h; sourceTree = "<group>"; };
 		B21115F7246C1B47005BA616 /* EXScopedNotificationBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationBuilder.m; sourceTree = "<group>"; };
+		B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXExpoGoLauncherSelectionPolicyFilterAware.swift; sourceTree = "<group>"; };
 		B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXScopedErrorRecoveryModule.m; sourceTree = "<group>"; };
 		B22BB0332366F3F400EE04EC /* EXScopedErrorRecoveryModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXScopedErrorRecoveryModule.h; sourceTree = "<group>"; };
 		B236C4F124740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationSchedulerModule.h; sourceTree = "<group>"; };
@@ -1670,6 +1673,7 @@
 				B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */,
 				2D5265E9294998B5001BB2BB /* EXHomeLoader.h */,
 				2D5265EA294998B5001BB2BB /* EXHomeLoader.m */,
+				B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */,
 			);
 			path = AppLoader;
 			sourceTree = "<group>";
@@ -2879,6 +2883,7 @@
 				31E44FBF20C975BB008AA62F /* EXScopedModuleRegistryDelegate.m in Sources */,
 				B5FB74EA1FF6DADC001C764B /* EXScopedModuleRegistry.m in Sources */,
 				2F7A50E095D6492596EA0B26 /* RNSharedElementNode.m in Sources */,
+				B216039C2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */,
 				2CFE1F25CD524A7ABFCAA366 /* RNSharedElementNodeManager.m in Sources */,
 				50659F05B6314F5192BC2215 /* RNSharedElementStyle.m in Sources */,
 				BE23D5E5DA574BA3A73C19C3 /* RNSharedElementTransition.m in Sources */,
@@ -3084,6 +3089,7 @@
 				2D5265EC294998B5001BB2BB /* EXHomeLoader.m in Sources */,
 				F14218B3262CB68600BB97E6 /* EXKernelAppRegistry.m in Sources */,
 				F14218B4262CB68600BB97E6 /* EXErrorRecoveryManager.m in Sources */,
+				B216039D2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */,
 				F14218B9262CB68600BB97E6 /* AIRMapUrlTile.m in Sources */,
 				F14218BA262CB68600BB97E6 /* AIRMapCircle.m in Sources */,
 				F14218BB262CB68600BB97E6 /* EXScopedBranch.m in Sources */,
@@ -3334,7 +3340,10 @@
 				);
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -3355,7 +3364,10 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\"";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"\"$(PODS_ROOT)/boost\"",
+					"\"$(PODS_ROOT)/RCT-Folly\"",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3395,7 +3407,10 @@
 				);
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -3415,7 +3430,10 @@
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\"";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"\"$(PODS_ROOT)/boost\"",
+					"\"$(PODS_ROOT)/RCT-Folly\"",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3439,7 +3457,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3467,7 +3489,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3487,7 +3513,11 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ExponentIntegrationTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.ExponentIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3506,7 +3536,11 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ExponentIntegrationTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = host.exp.ExponentIntegrationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3550,7 +3584,10 @@
 				);
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -3571,7 +3608,10 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\"";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"\"$(PODS_ROOT)/boost\"",
+					"\"$(PODS_ROOT)/RCT-Folly\"",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -3612,7 +3652,10 @@
 				);
 				INFOPLIST_FILE = Exponent/Supporting/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -3632,7 +3675,10 @@
 				STRIP_STYLE = "non-global";
 				SWIFT_OBJC_BRIDGING_HEADER = "Exponent-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
-				SYSTEM_HEADER_SEARCH_PATHS = "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\"";
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					"\"$(PODS_ROOT)/boost\"",
+					"\"$(PODS_ROOT)/RCT-Folly\"",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -3659,7 +3705,11 @@
 				);
 				INFOPLIST_FILE = ExpoNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
@@ -3693,7 +3743,11 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = ExpoNotificationServiceExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
@@ -3701,8 +3755,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore host.exp.Exponent.ExpoNotificationServiceExtension";
 				SKIP_INSTALL = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "ExpoNotificationServiceExtension/ExpoNotificationServiceExtension-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -58,7 +58,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     for (id providedManifestJSON in jsonManifestObjArray) {
       if ([providedManifestJSON isKindOfClass:[NSDictionary class]]) {
         EXManifestsManifest *providedManifest = [EXManifestsManifestFactory manifestForManifestJSON:providedManifestJSON];
-        NSString *sdkVersion = providedManifest.sdkVersion;
+        NSString *sdkVersion = providedManifest.expoGoSDKVersion;
         if (sdkVersion && [[EXVersions sharedInstance] supportsVersion:sdkVersion]) {
           return providedManifestJSON;
         }
@@ -335,9 +335,9 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
 {
   NSString *errorCode;
   NSDictionary *metadata;
-  if (maybeManifest && maybeManifest.sdkVersion) {
-    if (![maybeManifest.sdkVersion isEqualToString:@"UNVERSIONED"]) {
-      NSInteger manifestSdkVersion = [maybeManifest.sdkVersion integerValue];
+  if (maybeManifest && maybeManifest.expoGoSDKVersion) {
+    if (![maybeManifest.expoGoSDKVersion isEqualToString:@"UNVERSIONED"]) {
+      NSInteger manifestSdkVersion = [maybeManifest.expoGoSDKVersion integerValue];
       if (manifestSdkVersion) {
         NSInteger oldestSdkVersion = [[self _earliestSdkVersionSupported] integerValue];
         NSInteger newestSdkVersion = [[self _latestSdkVersionSupported] integerValue];
@@ -345,7 +345,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
           errorCode = @"EXPERIENCE_SDK_VERSION_OUTDATED";
           // since we are spoofing this error, we put the SDK version of the project as the
           // "available" SDK version -- it's the only one available from the server
-          metadata = @{@"availableSDKVersions": @[maybeManifest.sdkVersion]};
+          metadata = @{@"availableSDKVersions": @[maybeManifest.expoGoSDKVersion]};
         }
         if (manifestSdkVersion > newestSdkVersion) {
           errorCode = @"EXPERIENCE_SDK_VERSION_TOO_NEW";

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -419,7 +419,6 @@ NS_ASSUME_NONNULL_BEGIN
   [sdkVersionRuntimeVersions addObject:@"exposdk:UNVERSIONED"];
   [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
 
-
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
                       initWithLauncherSelectionPolicy:[[EXUpdatesLauncherSelectionPolicyFilterAware alloc] initWithRuntimeVersions:sdkVersions]
                       loaderSelectionPolicy:[EXUpdatesLoaderSelectionPolicyFilterAware new]

--- a/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
+++ b/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
@@ -1,0 +1,43 @@
+//  Copyright © 2019 650 Industries. All rights reserved.
+
+// swiftlint:disable type_name
+
+import Foundation
+import EXUpdates
+import EXManifests
+
+/**
+ LauncherSelectionPolicy similar to LauncherSelectionPolicyFilterAware but specifically for
+ Expo Go which uses a Expo-Go-specific field to determine compatibility.
+ */
+@objcMembers
+public final class EXExpoGoLauncherSelectionPolicyFilterAware: NSObject, LauncherSelectionPolicy {
+  let sdkVersions: [String]
+
+  public init(sdkVersions: [String]) {
+    self.sdkVersions = sdkVersions
+  }
+
+  public func launchableUpdate(fromUpdates updates: [Update], filters: [String: Any]?) -> Update? {
+    var runnableUpdate: Update?
+    for update in updates {
+      guard let updateSDKVersion = update.manifest.expoGoSDKVersion() else {
+        continue
+      }
+
+      if !sdkVersions.contains(updateSDKVersion) || !SelectionPolicies.doesUpdate(update, matchFilters: filters) {
+        continue
+      }
+
+      guard let runnableUpdateInner = runnableUpdate else {
+        runnableUpdate = update
+        continue
+      }
+
+      if runnableUpdateInner.commitTime.compare(update.commitTime) == .orderedAscending {
+        runnableUpdate = update
+      }
+    }
+    return runnableUpdate
+  }
+}

--- a/ios/Exponent/Kernel/Environment/EXVersions.m
+++ b/ios/Exponent/Kernel/Environment/EXVersions.m
@@ -91,8 +91,8 @@
 
 - (NSString *)_versionForManifest:(EXManifestsManifest * _Nullable)manifest
 {
-  if (manifest && manifest.sdkVersion) {
-    NSString *sdkVersion = manifest.sdkVersion;
+  if (manifest && manifest.expoGoSDKVersion) {
+    NSString *sdkVersion = manifest.expoGoSDKVersion;
     NSArray *sdkVersions = _versions[@"sdkVersions"];
     if (sdkVersion && sdkVersions) {
       for (NSString *availableVersion in sdkVersions) {

--- a/ios/Exponent/Versioned/Core/EXVersionManager.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionManager.mm
@@ -187,7 +187,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
       @"isEnabled": @YES
     };
   } else if (
-      [self.manifest.sdkVersion compare:@"49.0.0" options:NSNumericSearch] == NSOrderedAscending &&
+      [self.manifest.expoGoSDKVersion compare:@"49.0.0" options:NSNumericSearch] == NSOrderedAscending &&
       devSettings.isRemoteDebuggingAvailable &&
       isDevModeEnabled
     ) {

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Support new SDK version field in new manifests. ([#22356](https://github.com/expo/expo/pull/22356) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
+++ b/packages/expo-manifests/android/src/androidTest/java/expo/modules/manifests/core/NewManifestTest.kt
@@ -15,7 +15,7 @@ class NewManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"$runtimeVersion\"}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    Assert.assertEquals(manifest.getSDKVersion(), "39.0.0")
+    Assert.assertEquals(manifest.getExpoGoSDKVersion(), "39.0.0")
   }
 
   @Test
@@ -25,7 +25,7 @@ class NewManifestTest {
     val manifestJson =
       "{\"runtimeVersion\":\"$runtimeVersion\"}"
     val manifest = NewManifest(JSONObject(manifestJson))
-    Assert.assertEquals(manifest.getSDKVersion(), "UNVERSIONED")
+    Assert.assertEquals(manifest.getExpoGoSDKVersion(), "UNVERSIONED")
   }
 
   @Test
@@ -43,7 +43,7 @@ class NewManifestTest {
       val manifestJson =
         "{\"runtimeVersion\":\"$runtimeVersion\"}"
       val manifest = NewManifest(JSONObject(manifestJson))
-      Assert.assertNull(manifest.getSDKVersion())
+      Assert.assertNull(manifest.getExpoGoSDKVersion())
     }
   }
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
@@ -18,7 +18,7 @@ abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
   @Throws(JSONException::class)
   override fun getBundleURL(): String = json.require("bundleUrl")
 
-  override fun getSDKVersion(): String? = json.getNullable("sdkVersion")
+  override fun getExpoGoSDKVersion(): String? = json.getNullable("sdkVersion")
 
   override fun getExpoGoConfigRootObject(): JSONObject? {
     return json

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -70,7 +70,11 @@ abstract class Manifest(protected val json: JSONObject) {
 
   fun getMetadata(): JSONObject? = json.getNullable("metadata")
 
-  abstract fun getSDKVersion(): String?
+  /**
+   * Get the SDK version that should be attempted to be used in Expo Go. If no SDK version can be
+   * determined, returns null
+   */
+  abstract fun getExpoGoSDKVersion(): String?
 
   abstract fun getAssets(): JSONArray?
 
@@ -172,7 +176,7 @@ abstract class Manifest(protected val json: JSONObject) {
     var result = expoClientConfig
       ?.getNullable<JSONObject>("android")?.getNullable<String>("jsEngine") ?: expoClientConfig?.getNullable<String>("jsEngine")
     if (result == null) {
-      val sdkVersionComponents = getSDKVersion()?.split(".")
+      val sdkVersionComponents = getExpoGoSDKVersion()?.split(".")
       val sdkMajorVersion = if (sdkVersionComponents?.size == 3) sdkVersionComponents[0].toIntOrNull() else 0
       result = if (sdkMajorVersion in 1..47) "jsc" else "hermes"
     }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -33,7 +33,8 @@ class NewManifest(json: JSONObject) : Manifest(json) {
   @Throws(JSONException::class)
   override fun getBundleURL(): String = getLaunchAsset().require("url")
 
-  override fun getSDKVersion(): String? {
+  @Deprecated(message = "exposdk:... runtime version is deprecated")
+  private fun getSDKVersionFromRuntimeVersion(): String? {
     val runtimeVersion = getRuntimeVersion()
     if (runtimeVersion == "exposdk:UNVERSIONED") {
       return "UNVERSIONED"
@@ -45,6 +46,10 @@ class NewManifest(json: JSONObject) : Manifest(json) {
       return expoSDKRuntimeVersionMatch.group(1)!!
     }
     return null
+  }
+
+  override fun getExpoGoSDKVersion(): String? {
+    return getExpoClientConfigRootObject()?.getString("sdkVersion") ?: getSDKVersionFromRuntimeVersion()
   }
 
   @Throws(JSONException::class)

--- a/packages/expo-manifests/ios/EXManifests/BaseLegacyManifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/BaseLegacyManifest.swift
@@ -29,7 +29,7 @@ public class BaseLegacyManifest: Manifest {
     return rawManifestJSON().requiredValue(forKey: "bundleUrl")
   }
 
-  public override func sdkVersion() -> String? {
+  public override func expoGoSDKVersion() -> String? {
     return rawManifestJSON().optionalValue(forKey: "sdkVersion")
   }
 

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -109,7 +109,11 @@ public class Manifest: NSObject {
     preconditionFailure("Must override in concrete class")
   }
 
-  public func sdkVersion() -> String? {
+  /**
+   Get the SDK version that should be attempted to be used in Expo Go. If no SDK version can be
+   determined, returns null
+   */
+  public func expoGoSDKVersion() -> String? {
     preconditionFailure("Must override in concrete class")
   }
 
@@ -308,7 +312,7 @@ public class Manifest: NSObject {
     }
 
     guard let jsEngine = jsEngine else {
-      let sdkMajorVersion = sdkMajorVersion()
+      let sdkMajorVersion = expoGoSDKMajorVersion()
       if sdkMajorVersion > 0 && sdkMajorVersion < 48 {
         return "jsc"
       } else {
@@ -318,8 +322,8 @@ public class Manifest: NSObject {
     return jsEngine
   }
 
-  private func sdkMajorVersion() -> Int {
-    let sdkVersion = sdkVersion()
+  private func expoGoSDKMajorVersion() -> Int {
+    let sdkVersion = expoGoSDKVersion()
     let components = sdkVersion?.components(separatedBy: ".")
     guard let components = components else {
       return 0

--- a/packages/expo-manifests/ios/EXManifests/NewManifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/NewManifest.swift
@@ -37,7 +37,7 @@ public class NewManifest: Manifest {
     return rawManifestJSON().requiredValue(forKey: "runtimeVersion")
   }
 
-  public override func sdkVersion() -> String? {
+  private func getSDKVersionFromRuntimeVersion() -> String? {
     let runtimeVersion = runtimeVersion()
     if runtimeVersion == "exposdk:UNVERSIONED" {
       return "UNVERSIONED"
@@ -55,6 +55,10 @@ public class NewManifest: Manifest {
       return nil
     }
     return String(runtimeVersion[range])
+  }
+
+  public override func expoGoSDKVersion() -> String? {
+    return expoClientConfigRootObject()?.optionalValue(forKey: "sdkVersion") ?? getSDKVersionFromRuntimeVersion()
   }
 
   public func launchAsset() -> [String: Any] {

--- a/packages/expo-manifests/ios/Tests/BareManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/BareManifestSpec.swift
@@ -32,7 +32,7 @@ class BareManifestSpec : ExpoSpec {
         expect(manifest.stableLegacyId()) == "0eef8214-4833-4089-9dff-b4138a14f196"
         expect(manifest.scopeKey()) == "0eef8214-4833-4089-9dff-b4138a14f196"
         expect(manifest.easProjectId()).to(beNil())
-        expect(manifest.sdkVersion()).to(beNil())
+        expect(manifest.expoGoSDKVersion()).to(beNil())
 
         // from base base class
         expect(manifest.legacyId()) == "0eef8214-4833-4089-9dff-b4138a14f196"

--- a/packages/expo-manifests/ios/Tests/LegacyManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/LegacyManifestSpec.swift
@@ -32,7 +32,7 @@ class LegacyManifestSpec : ExpoSpec {
         expect(manifest.scopeKey()) == "@esamelson/native-component-list"
         expect(manifest.easProjectId()).to(beNil())
         expect(manifest.bundleUrl()) == "https://classic-assets.eascdn.net/%40esamelson%2Fnative-component-list%2F39.0.0%2F01c86fd863cfee878068eebd40f165df-39.0.0-ios.js"
-        expect(manifest.sdkVersion()) == "39.0.0"
+        expect(manifest.expoGoSDKVersion()) == "39.0.0"
 
         // from base base class
         expect(manifest.legacyId()) == "@esamelson/native-component-list"

--- a/packages/expo-manifests/ios/Tests/NewManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/NewManifestSpec.swift
@@ -66,14 +66,14 @@ class NewManifestSpec : ExpoSpec {
         let runtimeVersion = "exposdk:39.0.0"
         let manifestJson = ["runtimeVersion": runtimeVersion]
         let manifest = NewManifest(rawManifestJSON: manifestJson)
-        expect(manifest.sdkVersion()) == "39.0.0"
+        expect(manifest.expoGoSDKVersion()) == "39.0.0"
       }
 
       it("is UNVERSIONED with valid unversioned case") {
         let runtimeVersion = "exposdk:UNVERSIONED"
         let manifestJson = ["runtimeVersion": runtimeVersion]
         let manifest = NewManifest(rawManifestJSON: manifestJson)
-        expect(manifest.sdkVersion()) == "UNVERSIONED"
+        expect(manifest.expoGoSDKVersion()) == "UNVERSIONED"
       }
 
       it("is nil with non-sdk runtime version cases") {
@@ -89,7 +89,7 @@ class NewManifestSpec : ExpoSpec {
         for runtimeVersion in runtimeVersions {
           let manifestJson = ["runtimeVersion": runtimeVersion]
           let manifest = NewManifest(rawManifestJSON: manifestJson)
-          expect(manifest.sdkVersion()).to(beNil())
+          expect(manifest.expoGoSDKVersion()).to(beNil())
         }
       }
     }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add support for extra params. ([#21837](https://github.com/expo/expo/pull/21837) by [@wschurman](https://github.com/wschurman))
 - New checkAutomatically constant. ([#22137](https://github.com/expo/expo/pull/22137) by [@douglowder](https://github.com/douglowder))
 - Support 204 status for no-op responses. ([#22348](https://github.com/expo/expo/pull/22348) by [@wschurman](https://github.com/wschurman))
+- Support new SDK version field in new manifests. ([#22356](https://github.com/expo/expo/pull/22356) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
@@ -114,7 +114,7 @@ class LegacyUpdateManifest private constructor(
         }
       }
 
-      val runtimeVersion = manifest.getRuntimeVersion() ?: manifest.getSDKVersion() ?: throw Exception("sdkVersion should not be null")
+      val runtimeVersion = manifest.getRuntimeVersion() ?: manifest.getExpoGoSDKVersion() ?: throw Exception("sdkVersion should not be null")
       val bundleUrl = Uri.parse(manifest.getBundleURL())
       val bundledAssets = manifest.getBundledAssets()
       return LegacyUpdateManifest(

--- a/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
@@ -49,7 +49,7 @@ internal final class LegacyUpdate: Update {
     if let manifestRuntimeVersion = manifestRuntimeVersion {
       runtimeVersion = assertType(value: manifestRuntimeVersion, description: "Manifest JSON runtime version must be string")
     } else {
-      runtimeVersion = manifest.sdkVersion().require("Manifest JSON must have a valid sdkVersion property defined")
+      runtimeVersion = manifest.expoGoSDKVersion().require("Manifest JSON must have a valid sdkVersion property defined")
     }
 
     let bundleUrl = URL(string: bundleUrlString).require("Manifest JSON must have a valid URL as the bundleUrl property")


### PR DESCRIPTION
# Why

We're deprecating the `exposdk:<sdk-version>` runtime version as it is causing issues with production expo updates. The issue is that setting this special runtime version allows Expo Go to be used, which contains a lot of libraries, but a client built with that runtime version on EAS build will only contain the libraries installed. Therefore, there is a mismatch in runtime between the two, which is bad.

The fix is to make runtime version always truthful. i.e. two runtime versions are equal iff they have a strictly equal runtime version string. But this means that Expo Go no longer would work (can't have a strictly equal runtime version since Expo Go is pre-built in the app store).

So we introduce a new concept in this PR, a sort of SDK version hint that projects can supply to Expo Go to tell it which SDK version they should use to load it. This is separate from the runtime version. Both will be supported for a few versions, and then runtime version will be removed from this logic after that.

Edit: After some discussion we will be re-using `manifest.extra.expoConfig.sdkVersion`. It is already put in most manifests.

~~This new hint field is:~~
~~- `manifest.extra.expoGo.sdkVersion` in modern manifests~~
~~- `manifest.sdkVersion` in classic manifests~~

~~I considered just re-using the `manifest.extra.expoConfig.sdkVersion` in modern manifests but I'm not sure it's always present and it seems riskier to add dependencies to it. We should discuss this decision as a team though as I could really go either way.~~

Closes ENG-8413.

# How

Add field getter in manifest object, use field getter in a new expo-go-specific launcher selection policy.

# Test Plan

Run expo go, load an experience. Note that this only tests the current runtime version case. I'll need to re-test once we get a CLI to put the new field in the right place with `expo start`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
