### PR TITLE
[expo-updates][ios] Fix variadic String initializer usage

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -142,7 +142,8 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
         expectedBase64URLEncodedSHA256Hash != hashBase64String {
         let errorMessage = String(
           format: "File download was successful but base64url-encoded SHA-256 did not match expected; expected: %@; actual: %@",
-          [expectedBase64URLEncodedSHA256Hash, hashBase64String]
+          expectedBase64URLEncodedSHA256Hash
+          hashBase64String
         )
         self.logger.error(message: errorMessage, code: UpdatesErrorCode.assetsFailedToLoad)
         errorBlock(NSError(
@@ -160,7 +161,8 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       } catch {
         let errorMessage = String(
           format: "Could not write to path %@: %@",
-          [destinationPath, error.localizedDescription]
+          destinationPath
+          error.localizedDescription
         )
         self.logger.error(message: errorMessage, code: UpdatesErrorCode.unknown)
         errorBlock(NSError(
@@ -861,7 +863,8 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       userInfo: [
         NSLocalizedDescriptionKey: String(
           format: "No compatible update found at %@. Only %@ are supported.",
-          [config.updateUrl?.absoluteString, config.sdkVersion]
+          config.updateUrl?.absoluteString,
+          config.sdkVersion
         )
       ]
     )


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/22348#discussion_r1181958298

These were erroneously converted to non-variadic version during swift conversion. IMO that was too easy a mistake to make, they should've changed the signature, but whatever.

Closes ENG-8500.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
