### PR TITLE
fix(cli): output verbose install logs when prebuilding on CI

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Import `fetch` from `node-fetch` to support older Node.js versions. ([#22480](https://github.com/expo/expo/pull/22480) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
 - Fix static export for consecutive groups. ([#22504](https://github.com/expo/expo/pull/22504) by [@EvanBacon](https://github.com/EvanBacon))
+- Enable verbose package manager logs on CI. ([#22361](https://github.com/expo/expo/pull/22361) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -104,7 +104,7 @@ export async function prebuildAsync(
       npm: !!options.packageManager?.npm,
       yarn: !!options.packageManager?.yarn,
       pnpm: !!options.packageManager?.pnpm,
-      silent: !env.EXPO_DEBUG,
+      silent: !(env.EXPO_DEBUG || env.CI),
     });
   }
 

--- a/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
+++ b/packages/@expo/cli/src/start/doctor/ngrok/ExternalModule.ts
@@ -108,10 +108,10 @@ export class ExternalModule<TModule> {
         ? new PackageManager.NpmPackageManager({
             cwd: this.projectRoot,
             log: Log.log,
-            silent: !env.EXPO_DEBUG,
+            silent: !(env.EXPO_DEBUG || env.CI),
           })
         : PackageManager.createForProject(this.projectRoot, {
-            silent: !env.EXPO_DEBUG,
+            silent: !(env.EXPO_DEBUG || env.CI),
           });
 
       try {

--- a/packages/@expo/cli/src/utils/cocoapods.ts
+++ b/packages/@expo/cli/src/utils/cocoapods.ts
@@ -77,7 +77,7 @@ export async function installCocoaPodsAsync(projectRoot: string): Promise<boolea
 
   const packageManager = new PackageManager.CocoaPodsPackageManager({
     cwd: path.join(projectRoot, 'ios'),
-    silent: !env.EXPO_DEBUG,
+    silent: !(env.EXPO_DEBUG || env.CI),
   });
 
   if (!(await packageManager.isCLIInstalledAsync())) {


### PR DESCRIPTION
# Why

This should help figuring out why a certain build failed in CI.

# How

- Added `env.CI` check besides the existing `env.EXPO_DEBUG` check

# Test Plan

- `CI=true npx expo prebuild` should output verbose install logs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
