### PR TITLE
[docs] No longer need to mention @types/react-native as react native ships with them internally for SDK 48

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -13,7 +13,7 @@ To get started, create a **tsconfig.json** in your project root:
 
 <Terminal cmd={['$ touch tsconfig.json']} />
 
-Running `npx expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`), and automatically configure your **tsconfig.json**.
+For SDK 48 and above, running `npx expo start` will prompt you to install the required dependencies, such as `typescript` and `@types/react`, and automatically configure your **tsconfig.json**. For SDK 47 and below, the command will also prompt to install `@types/react-native` as an additional dependency.
 
 Rename files to convert them to TypeScript. For example, you would rename **App.js** to **App.tsx**. Use the **.tsx** extension if the file includes React components (JSX). If the file did not include any JSX, you can use the **.ts** file extension.
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -13,7 +13,7 @@ To get started, create a **tsconfig.json** in your project root:
 
 <Terminal cmd={['$ touch tsconfig.json']} />
 
-Running `npx expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`, `@types/react-native`), and automatically configure your **tsconfig.json**.
+Running `npx expo start` will prompt you to install the required dependencies (`typescript`, `@types/react`), and automatically configure your **tsconfig.json**.
 
 Rename files to convert them to TypeScript. For example, you would rename **App.js** to **App.tsx**. Use the **.tsx** extension if the file includes React components (JSX). If the file did not include any JSX, you can use the **.ts** file extension.
 


### PR DESCRIPTION
can also be verified with:
```ts
npx create-expo-app -t expo-template-blank-typescript
```
Which uses the package.json shown here : https://github.com/expo/expo/blob/baba66d8af3e831143ff2e3c1e2d0a8bbbd4a43c/templates/expo-template-blank-typescript/package.json (note that no need for `@types/react-native`)