### PR TITLE
[docs] Fix broken Dev client links

### DIFF
--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -9,7 +9,7 @@ import { GithubIcon } from '@expo/styleguide-icons';
 
 > **warning** This guide is likely to change as we continue to work on EAS Update.
 
-The [`expo-dev-client`](develop/development-builds/introduction/) library allows launching different versions of a project. One of the most popular use cases is to preview a published update inside a development build using the `expo-dev-client` library.
+The [`expo-dev-client`](/develop/development-builds/introduction/) library allows launching different versions of a project. One of the most popular use cases is to preview a published update inside a development build using the `expo-dev-client` library.
 
 It supports loading published EAS Updates through channels. In this guide, you'll learn how to load a specific channel to preview an update in a development build.
 
@@ -17,7 +17,7 @@ It supports loading published EAS Updates through channels. In this guide, you'l
 
 <Step label="1">
 
-Create a [development build](/development/getting-started) of the project.
+Create a [development build](/develop/development-builds/create-a-build) of the project.
 
 </Step>
 


### PR DESCRIPTION
# Why

While checking the `expo-dev-client` docs I noticed that some links were broken

# How

Update links to the correct path

# Test Plan

Run docs locally and ensure links are working correctly 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
