### PR TITLE
[expo-updates][ios] Fix broken build

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -142,7 +142,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
         expectedBase64URLEncodedSHA256Hash != hashBase64String {
         let errorMessage = String(
           format: "File download was successful but base64url-encoded SHA-256 did not match expected; expected: %@; actual: %@",
-          expectedBase64URLEncodedSHA256Hash
+          expectedBase64URLEncodedSHA256Hash,
           hashBase64String
         )
         self.logger.error(message: errorMessage, code: UpdatesErrorCode.assetsFailedToLoad)
@@ -161,7 +161,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       } catch {
         let errorMessage = String(
           format: "Could not write to path %@: %@",
-          destinationPath
+          destinationPath,
           error.localizedDescription
         )
         self.logger.error(message: errorMessage, code: UpdatesErrorCode.unknown)
@@ -863,8 +863,8 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       userInfo: [
         NSLocalizedDescriptionKey: String(
           format: "No compatible update found at %@. Only %@ are supported.",
-          config.updateUrl?.absoluteString,
-          config.sdkVersion
+          config.updateUrl?.absoluteString ?? "(missing config updateUrl)",
+          config.sdkVersion ?? "(missing sdkVersion field)"
         )
       ]
     )


### PR DESCRIPTION
# Why

@douglowder pushed a fix for this to https://github.com/expo/expo/pull/22357 but I accidentally overwrite via a force push which was necessary due to this being a stacked PR. Github is bad and it should feel bad. (it's terrible at stacked diffs)

# How

Fix

# Test Plan

Compile

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
