### PR TITLE
feat: add SearchParams types to Expo Router

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Generate experimental expo-env.d.ts when EXPO_ROUTER_TYPED_ROUTES=true ([#22096](https://github.com/expo/expo/pull/22096) by [@marklawlor](https://github.com/marklawlor))
 - Improve prebuild for arbitrary template platforms. ([#22201](https://github.com/expo/expo/pull/22201) by [@byCedric](https://github.com/byCedric))
 - Further improve prebuild for arbitrary template platforms. ([#22209](https://github.com/expo/expo/pull/22209) by [@EvanBacon](https://github.com/EvanBacon))
+- Add SearchParams export type for Expo Router. ([#22380](https://github.com/expo/expo/pull/22380) by [@marklawlor](https://github.com/marklawlor))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -305,6 +305,10 @@ const routerDotTSTemplate = unsafeTemplate`declare module "expo-router" {
     ? { params: RouteParams<InferPathName<T>> }
     : unknown;
 
+  /** Returns the search parameters for a route **/
+  export type SearchParams<T extends DynamicRouteTemplate | StaticRoutes | RelativePathString> =
+    T extends DynamicRouteTemplate ? RouteParams<T> : {};
+
   type InferPathName<T> = T extends { pathname: infer P } ? P : never;
 
   export interface LinkProps<T> extends OriginalLinkProps {
@@ -331,5 +335,6 @@ const routerDotTSTemplate = unsafeTemplate`declare module "expo-router" {
   };
 
   export function useRouter<T>(): Router<T>
+  export function useLocalSearchParams<T extends DynamicRouteTemplate | StaticRoutes | RelativePathString>(): SearchParams<T>
 }
 `;


### PR DESCRIPTION
# Why

`useLocalSearchParams` in currently typed. We can not generate a helper type to convert a route to the SearchParams objects

These types are strongly connected to the generated routes and will break if a route ever changes (e.g the variable is renamed).

Relative routes are ignores and are currently considered out of scope.

```tsx
// These are expected to return an empty object as there are no search parameters
SearchParams<"/">
// ^? {}
SearchParams<"/test">
// ^? {}

SearchParams<"/user/[id]">
// ^? { id: string }
SearchParams<"/team/[...id]">
// ^? { id: string[] }
```

One annoying downside is that the autocomplete doesn't work. This due to typescript simply not supporting it https://github.com/microsoft/TypeScript/issues/34771