### PR TITLE
[image-picker][Android] Fix image picker returning inverted dimensions for vertical images

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix rotated videos returning incorrect width/height. [#12573](https://github.com/expo/expo/issues/12573) ([#21758](https://github.com/expo/expo/pull/21758) by [@mmmulani](https://github.com/mmmulani))
 - Fix NullPointerException for launchCameraAsync on Android 13. ([#22123](https://github.com/expo/expo/pull/22123) by [@witheroux](https://github.com/witheroux))
 - [Android] Fix image picker returning inverted dimensions when selecting vertical images without editing. ([#22383](https://github.com/expo/expo/pull/22383) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 14.1.1 — 2023-02-09

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
 - Fix rotated videos returning incorrect width/height. [#12573](https://github.com/expo/expo/issues/12573) ([#21758](https://github.com/expo/expo/pull/21758) by [@mmmulani](https://github.com/mmmulani))
 - Fix NullPointerException for launchCameraAsync on Android 13. ([#22123](https://github.com/expo/expo/pull/22123) by [@witheroux](https://github.com/witheroux))
-- [Android] Fix image picker returning inverted dimensions when selecting vertical images without editing.
+- [Android] Fix image picker returning inverted dimensions when selecting vertical images without editing. ([#22383](https://github.com/expo/expo/pull/22383) by [@behenate](https://github.com/behenate))
 ### 💡 Others
 
 ## 14.1.1 — 2023-02-09

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix issue where the array of permissions could end up empty causing an exception. ([#21589](https://github.com/expo/expo/pull/21589) by [@alanhughes](https://github.com/alanjhughes))
 - Fix rotated videos returning incorrect width/height. [#12573](https://github.com/expo/expo/issues/12573) ([#21758](https://github.com/expo/expo/pull/21758) by [@mmmulani](https://github.com/mmmulani))
 - Fix NullPointerException for launchCameraAsync on Android 13. ([#22123](https://github.com/expo/expo/pull/22123) by [@witheroux](https://github.com/witheroux))
-
+- [Android] Fix image picker returning inverted dimensions when selecting vertical images without editing.
 ### 💡 Others
 
 ## 14.1.1 — 2023-02-09

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/exporters/RawImageExporter.kt
@@ -2,6 +2,7 @@ package expo.modules.imagepicker.exporters
 
 import android.content.ContentResolver
 import android.graphics.BitmapFactory
+import android.media.ExifInterface
 import android.net.Uri
 import expo.modules.imagepicker.copyFile
 import java.io.File
@@ -13,13 +14,21 @@ class RawImageExporter : ImageExporter {
     contentResolver: ContentResolver,
   ): ImageExportResult {
     copyFile(source, output, contentResolver)
-
+    val exifInterface = ExifInterface(output.absolutePath)
+    val imageRotation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, 0)
+    val isRotatedLandscape = (imageRotation == ExifInterface.ORIENTATION_ROTATE_90 || imageRotation == ExifInterface.ORIENTATION_ROTATE_270)
     val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+
     BitmapFactory.decodeFile(output.absolutePath, options)
 
+    // Image will be rotated to orientation suggested by the exif data, because of that the width and height
+    // returned by the picker should be switched if the image is rotated 90 or 270 degrees.
+    val width: Int = if (isRotatedLandscape) options.outHeight else options.outWidth
+    val height: Int = if (isRotatedLandscape) options.outWidth else options.outHeight
+
     return ImageExportResult(
-      options.outWidth,
-      options.outHeight,
+      width,
+      height,
       output,
     )
   }


### PR DESCRIPTION

# Why

https://github.com/expo/expo/issues/22097

# How

If the EXIF data was suggesting that the image is rotated the returned image would be in correct orientation, but our dimensions would not change if there was a 90 or 270 degree rotation. Added a check that switches the width and height if such situation occurs.

# Test Plan

Tested on a physical Android device (SDK 33).
