### PR TITLE
[core][ios] Make `JavaScriptValue.kind` public

### DIFF
--- a/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
+++ b/packages/expo-modules-core/ios/JSI/JavaScriptValue.swift
@@ -26,7 +26,7 @@ protocol AnyJavaScriptValue {
 }
 
 extension JavaScriptValue: AnyJavaScriptValue {
-  var kind: JavaScriptValueKind {
+  public var kind: JavaScriptValueKind {
     switch true {
     case isUndefined():
       return .undefined


### PR DESCRIPTION
# Why

Makes `JavaScriptValue.kind` public. 

# How

That part of our API should be public. 

# Test Plan

- workshops app ✅