### PR TITLE
[docs] Minor typo and formatting fixes & update note in Archive

### DIFF
--- a/docs/pages/accounts/two-factor.mdx
+++ b/docs/pages/accounts/two-factor.mdx
@@ -32,11 +32,11 @@ Provide a mobile phone number to receive a short-lived token via SMS. Codes rece
 
 ### Recovery Codes
 
-As part of setting up two-factor authentication on your account you will receive a list of recovery codes. These codes may be used in place of a one-time password if you lose access to your authenticator app or SMS device. Each recovery code may only be used once.
+When you set up two-factor authentication for your account, you'll receive a set of recovery codes. These codes can be used instead of a one-time password if you lose access to your authenticator app or SMS device. Keep in mind that each recovery code is only valid for one use.
 
-If you chose to download your recovery codes when they were generated, they will be found in a file named `expo-recovery-codes.txt`
+If you selected the option to download your recovery codes at the time they were created, you can locate them in a file labeled as **expo-recovery-codes.txt**.
 
-> Store your recovery codes in a secure and memorable place to ensure you, and only you, can access your account!
+> Store your recovery codes in a secure and memorable place to ensure you, and only you can access your account!
 
 ## Changing Your Two-Factor Settings
 

--- a/docs/pages/archive/classic-updates/advanced-release-channels.mdx
+++ b/docs/pages/archive/classic-updates/advanced-release-channels.mdx
@@ -2,7 +2,7 @@
 title: Advanced release channels
 ---
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. To learn more about why release channels were deprecated, [see our blog post on EAS Update](https://blog.expo.dev/eas-update-preview-progress-f504a30066fc#:~:text=Traditionally%2C%20Expo%20developers,need%20more%20control). Instead, we recommend using [EAS Update](/eas-update/introduction).
 
 ## Introduction
 

--- a/docs/pages/archive/classic-updates/release-channels.mdx
+++ b/docs/pages/archive/classic-updates/release-channels.mdx
@@ -4,7 +4,7 @@ title: Release channels
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
+> This doc was archived in August 2022 and will not receive any further updates. To learn more about why release channels were deprecated, [see our blog post on EAS Update](https://blog.expo.dev/eas-update-preview-progress-f504a30066fc#:~:text=Traditionally%2C%20Expo%20developers,need%20more%20control). Instead, we recommend using [EAS Update](/eas-update/introduction).
 
 ## Introduction
 

--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -71,7 +71,7 @@ When you start your project on iOS, the metro bundler will start automatically. 
 
 ### Add better error handlers
 
-For certain type of errors, you can provide more helpful error messages. To turn this on, import import `expo-dev-client` in the project's **index** file (in the managed workflow, you need to add this import on top of the **App.&lbrace;js|tsx&rbrace;**). Make sure that the import statement is above `import App from './App'`.
+For certain type of errors, you can provide more helpful error messages. To turn this on, import `expo-dev-client` in the project's **index** file (in the managed workflow, you need to add this import on top of the **App.&lbrace;js|tsx&rbrace;**). Make sure that the import statement is above `import App from './App'`.
 
 ```js
 import 'expo-dev-client';

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -49,7 +49,7 @@ The command will lead you through the process of submitting the app. It will per
 ### Prerequisites
 
 - A paid developer account is required to submit an app &mdash; you can create an Apple Developer account on the [Apple Developer Portal](https://developer.apple.com/account/).
-- Native app binary signed for Google Play Store submission using EAS Build. If you haven't followed the previous guide, see [Build your project for app stores](/deploy/build-project/) for more information.
+- Native app binary signed for Apple App Store submission using EAS Build. If you haven't followed the previous guide, see [Build your project for app stores](/deploy/build-project/) for more information.
 
 ### Submit binary to Apple App Store
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -12,7 +12,7 @@ There are [many advantages](/workflow/prebuild#pitch) of using [Expo Prebuild][p
 
 {/* NOTE: Update the version when we bump support */}
 
-<Terminal cmd={['$ npx react-native init --version 0.69.4']} />
+<Terminal cmd={['$ npx react-native init ProjectName --version 0.71.7']} />
 
 This will create a new React Native project.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Found some minor typos, formatting issues and room for improving context when talking about recovery codes for 2FAs.

Also, update note in archived EAS Update > Release channel docs to provide historical context.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing issues as stated above.

# Test Plan

Changes have been tested by running docs locally.

Here is the updated note for archived Release Channel docs.

<img width="890" alt="CleanShot 2023-05-05 at 17 07 58@2x" src="https://user-images.githubusercontent.com/10234615/236448040-624eaa16-f9e4-4a7c-acfe-f0913ba8d60f.png">


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
