### PR TITLE
[docs] fix the update icon

### DIFF
--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -6,7 +6,7 @@ description: Learn about Expo Application Services (EAS) for Expo and React Nati
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasSubmitIcon, EasMetadataIcon, UpdateIcon } from '@expo/styleguide-icons';
+import { BuildIcon, EasSubmitIcon, EasMetadataIcon, LayersTwo02Icon } from '@expo/styleguide-icons';
 
 Expo Application Services (EAS) are deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
 
@@ -30,7 +30,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
   title="EAS Update"
   description="Address small bugs and push quick fixes directly to end-users. Learn more."
   href="/eas-update/introduction"
-  Icon={UpdateIcon}
+  Icon={LayersTwo02Icon}
 />
 
 <BoxLink


### PR DESCRIPTION
# Why
The docs EAS page is missing the Update icon

![Screenshot 2023-05-05 at 3 09 14 PM](https://user-images.githubusercontent.com/6380927/236576924-28439937-23de-405e-a5f4-4d02e590aa32.png)

# How
In the website, the Update icon looks like this:
![Screenshot 2023-05-05 at 2 59 04 PM](https://user-images.githubusercontent.com/6380927/236577117-8fce7058-5e0f-459c-a97f-2cd7bed201fd.png)

In the figma file that `@expo/styleguide-icons` is based on, the icon that matches is the outline icon, layers-two-02 
![Screenshot 2023-05-05 at 2 59 58 PM](https://user-images.githubusercontent.com/6380927/236577210-cff468a9-7477-482a-a093-0fad99094196.png)

When I import it into the docs page, it looks like this now:
![Screenshot 2023-05-05 at 3 06 43 PM](https://user-images.githubusercontent.com/6380927/236577351-e2572bf9-16f6-4d0b-8680-af89d70b170b.png)


# Test Plan

ran `yarn run dev` and see that `http://localhost:3002/eas/` has the right icons now

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
