### PR TITLE
[expo-updates][ios] Refactor errors

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -35,8 +35,6 @@ public protocol AppControllerDelegate: AnyObject {
 @objc(EXUpdatesAppController)
 @objcMembers
 public class AppController: NSObject, AppLoaderTaskDelegate, ErrorRecoveryDelegate {
-  private static let ErrorDomain = "EXUpdatesAppController"
-
   private static let UpdateAvailableEventName = "updateAvailable"
   private static let NoUpdateAvailableEventName = "noUpdateAvailable"
   private static let ErrorEventName = "error"
@@ -471,7 +469,7 @@ public class AppController: NSObject, AppLoaderTaskDelegate, ErrorRecoveryDelega
 
   // MARK: - ErrorRecoveryDelegate
 
-  public func relaunch(completion: @escaping (Error?, Bool) -> Void) {
+  public func relaunch(completion: @escaping (_ error: Error?, _ success: Bool) -> Void) {
     let launcher = AppLauncherWithDatabase(
       config: config,
       database: database,

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -27,8 +27,6 @@ typealias AppLoaderErrorBlock = (_ error: Error) -> Void
 @objc(EXUpdatesAppLoader)
 @objcMembers
 public class AppLoader: NSObject {
-  private static let ErrorDomain = "EXUpdatesAppLoader"
-
   internal let config: UpdatesConfig
   internal let database: UpdatesDatabase
   internal let directory: URL
@@ -371,13 +369,7 @@ public class AppLoader: NSObject {
 
       self.completionQueue.async {
         if let errorBlock = errorBlock {
-          errorBlock(NSError(
-            domain: AppLoader.ErrorDomain,
-            code: 1012,
-            userInfo: [
-              NSLocalizedDescriptionKey: "Failed to load all assets"
-            ]
-          ))
+          errorBlock(UpdatesError.appLoaderFailedToLoadAllAssets)
         } else if let successBlock = successBlock {
           successBlock(self.updateResponseContainingManifest!)
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/Crypto.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/Crypto.swift
@@ -7,7 +7,7 @@ import ASN1Decoder
 import CommonCrypto
 
 internal typealias VerifySignatureSuccessBlock = (_ success: Bool) -> Void
-internal typealias VerifySignatureErrorBlock = (_ error: Error) -> Void
+internal typealias VerifySignatureErrorBlock = (_ error: UpdatesError) -> Void
 
 internal enum PEMType {
   case publicKey
@@ -30,11 +30,6 @@ internal enum PEMType {
       return "-----END CERTIFICATE-----"
     }
   }
-}
-
-private let ErrorDomain = "EXUpdatesCrypto"
-private enum CryptoErrorCode: Int {
-  case PublicKeyDownloadError = 1049
 }
 
 /**
@@ -88,11 +83,7 @@ internal final class Crypto {
     errorBlock: @escaping VerifySignatureErrorBlock
   ) {
     guard !data.isEmpty && !signature.isEmpty else {
-      errorBlock(NSError(
-        domain: "EXUpdatesCrypto",
-        code: 1001,
-        userInfo: [NSLocalizedDescriptionKey: "Cannot verify the manifest because it is empty or has no signature."]
-      ))
+      errorBlock(UpdatesError.cryptoManifestEmptyOrMissingSignature)
       return
     }
 
@@ -139,11 +130,7 @@ internal final class Crypto {
       extraHeaders: [:]
     ) { publicKeyData, _ in
       guard let publicKeyData = publicKeyData else {
-        errorBlock(NSError(
-          domain: ErrorDomain,
-          code: CryptoErrorCode.PublicKeyDownloadError.rawValue,
-          userInfo: [NSLocalizedDescriptionKey: "Public key response body empty"]
-        ))
+        errorBlock(UpdatesError.cryptoPublicKeyDownloadError)
         return
       }
       verify(withPublicKey: publicKeyData, signature: signature, signedString: data, callback: successBlock)

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -28,8 +28,6 @@ public final class EmbeddedAppLoader: AppLoader {
   public static let EXUpdatesBareEmbeddedBundleFilename = "main"
   public static let EXUpdatesBareEmbeddedBundleFileType = "jsbundle"
 
-  private static let ErrorDomain = "EXUpdatesEmbeddedAppLoader"
-
   private static var embeddedManifestInternal: Update?
   public static func embeddedManifest(withConfig config: UpdatesConfig, database: UpdatesDatabase?) -> Update? {
     guard config.hasEmbeddedUpdate else {
@@ -107,13 +105,7 @@ public final class EmbeddedAppLoader: AppLoader {
     error errorBlock: @escaping AppLoaderErrorBlock
   ) {
     guard let embeddedManifest = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database) else {
-      errorBlock(NSError(
-        domain: EmbeddedAppLoader.ErrorDomain,
-        code: 1008,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
-        ]
-      ))
+      errorBlock(UpdatesError.appLoaderFailedToLoadEmbeddedManifest)
       return
     }
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -8,8 +8,6 @@ import Foundation
  * Subclass of AppLoader which handles downloading updates from a remote server.
  */
 internal final class RemoteAppLoader: AppLoader {
-  private static let ErrorDomain = "EXUpdatesRemoteAppLoader"
-
   private let downloader: FileDownloader
   private var remoteUpdateResponse: UpdateResponse?
   private let completionQueue: DispatchQueue
@@ -96,13 +94,7 @@ internal final class RemoteAppLoader: AppLoader {
       } else {
         guard let assetUrl = asset.url else {
           self.handleAssetDownload(
-            withError: NSError(
-              domain: RemoteAppLoader.ErrorDomain,
-              code: 1006,
-              userInfo: [
-                NSLocalizedDescriptionKey: "Failed to download asset with no URL provided"
-              ]
-            ),
+            withError: UpdatesError.appLoaderFailedToDownloadAssetNoURL,
             asset: asset
           )
           return

--- a/packages/expo-updates/ios/EXUpdates/CodeSigning/CodeSigningError.swift
+++ b/packages/expo-updates/ios/EXUpdates/CodeSigning/CodeSigningError.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-internal enum CodeSigningError: Error {
+internal enum CodeSigningError: LocalizedError {
   case CertificateEncodingError
   case CertificateDERDecodeError
   case CertificateValidityError
@@ -26,7 +26,7 @@ internal enum CodeSigningError: Error {
   case AlgorithmParseError
   case InvalidExpoProjectInformationExtensionValue
 
-  func message() -> String {
+  var errorDescription: String {
     switch self {
     case .CertificateEncodingError:
       return "Code signing certificate could not be encoded in a lossless manner using utf8 encoding"

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -18,14 +18,6 @@ import EXUpdatesInterface
 @objc(EXUpdatesDevLauncherController)
 @objcMembers
 public final class DevLauncherController: NSObject, UpdatesExternalInterface {
-  private static let ErrorDomain = "EXUpdatesDevLauncherController"
-
-  enum ErrorCode: Int {
-    case invalidUpdateURL = 1
-    case updateLaunchFailed = 4
-    case configFailed = 5
-  }
-
   private var tempConfig: UpdatesConfig?
 
   private weak var _bridge: AnyObject?
@@ -149,25 +141,12 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
     do {
       updatesConfiguration = try UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: nil)
     } catch {
-      errorBlock(NSError(
-        domain: DevLauncherController.ErrorDomain,
-        code: ErrorCode.configFailed.rawValue,
-        userInfo: [
-          // swiftlint:disable:next line_length
-          NSLocalizedDescriptionKey: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
-        ]
-      ))
+      errorBlock(UpdatesError.devLauncherConfigFailed)
       return nil
     }
 
     guard updatesConfiguration.updateUrl != nil && updatesConfiguration.scopeKey != nil else {
-      errorBlock(NSError(
-        domain: DevLauncherController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid update URL"
-        ]
-      ))
+      errorBlock(UpdatesError.devLauncherInvalidUpdateURL)
       return nil
     }
 
@@ -224,11 +203,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
       if !success {
         // reset controller's configuration to what it was before this request
         controller.setConfigurationInternal(config: self.tempConfig!)
-        errorBlock(error ?? NSError(
-          domain: DevLauncherController.ErrorDomain,
-          code: ErrorCode.updateLaunchFailed.rawValue,
-          userInfo: [NSLocalizedDescriptionKey: "Failed to launch update with an unknown error"]
-        ))
+        errorBlock(error ?? UpdatesError.devLauncherUpdateLaunchFailed)
         return
       }
 

--- a/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
+++ b/packages/expo-updates/ios/EXUpdates/Logging/UpdatesLogger.swift
@@ -116,6 +116,12 @@ internal final class UpdatesLogger {
     error(message: message, code: code, updateId: nil, assetId: nil)
   }
 
+  func error(
+    _ updatesError: UpdatesError
+  ) {
+    error(message: updatesError.errorDescription, code: updatesError.updatesErrorCode)
+  }
+
   func fatal(
     message: String,
     code: UpdatesErrorCode = .none,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
@@ -1,0 +1,109 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+import Foundation
+
+internal enum UpdatesError: LocalizedError {
+  case responseErrorMissingResponse(reason: Error)
+  case responseError(code: Int, body: String)
+  case fileWriteError(path: String, reason: Error)
+  case manifestVerificationError
+  case fileHashMismatchError(expectedHash: String, actualHash: String)
+  case noCompatibleUpdateError(updateUrl: String?, sdkVersion: String?)
+  case mismatchedManifestFiltersError
+  case manifestParseError(reason: Error)
+  case emptyResponseError(url: String)
+  case remoteUpdateMissingBody
+  case invalidResponseTypeError
+  case directiveParseError(reason: Error)
+  case manifestStringError
+  case manifestJSONError
+  case manifestSignatureError
+  case multipartParsingError
+  case multipartExtensionsParseError
+  case multipartMissingManifestError
+  case missingMultipartBoundaryError
+  case codeSigningError(reason: Error)
+  case codeSigningSignatureError(part: String)
+  case codeSigningCertificateExtensionMismatch
+  case cryptoManifestEmptyOrMissingSignature
+  case cryptoPublicKeyDownloadError
+  case appLauncherAssetDownloadNoURL
+  case appLauncherAssetBundlePathNil
+  case appLauncherAssetCopyFailed
+  case appLauncherNoLaunchableUpdates(reason: Error?)
+  case appLoaderFailedToLoadEmbeddedManifest
+  case appLoaderFailedToDownloadAssetNoURL
+  case appLoaderFailedToLoadAllAssets
+  case updatesDirectoryCreationFailed
+  case appLoaderTaskUpdatesDisabled
+  case appLoaderTaskNullURL
+  case appLoaderTaskUnexpectedError
+  case devLauncherConfigFailed
+  case devLauncherInvalidUpdateURL
+  case devLauncherUpdateLaunchFailed
+
+  var errorDescription: String {
+    switch self {
+    case .responseErrorMissingResponse(let reason): return reason.localizedDescription
+    case .responseError(let code, let body): return "HTTP Error \(code): \(body)"
+    case .fileWriteError(let path, let reason): return "Could not write to path \(path): \(reason.localizedDescription)"
+    case .manifestVerificationError: return "Manifest verification failed"
+    case .fileHashMismatchError(let expectedHash, let actualHash): return "File download was successful but base64url-encoded SHA-256 did not match expected; expected: \(expectedHash); actual: \(actualHash)"
+    case .noCompatibleUpdateError(let updateUrl, let sdkVersion): return "No compatible update found at \(updateUrl ?? "(missing config updateUrl)"). Only \(sdkVersion ?? "(missing sdkVersion field)") are supported."
+    case .mismatchedManifestFiltersError: return "Downloaded manifest is invalid; provides filters that do not match its content"
+    case .manifestParseError(let reason): return "Failed to parse manifest: \(reason.localizedDescription)"
+    case .emptyResponseError(let url): return "File download response was empty for URL: \(url)"
+    case .remoteUpdateMissingBody: return "Missing body in remote update"
+    case .invalidResponseTypeError: return "Response must be a HTTPURLResponse"
+    case .directiveParseError(let reason): return "Failed to parse directive: \(reason.localizedDescription)"
+    case .manifestStringError: return "manifestString should be a string"
+    case .manifestJSONError: return "manifest should be a valid JSON object"
+    case .manifestSignatureError: return "signature should be a string"
+    case .multipartParsingError: return "Could not read multipart remote update response"
+    case .multipartExtensionsParseError: return "Failed to parse multipart remote update extensions"
+    case .multipartMissingManifestError: return "Multipart response missing manifest part. Manifest is required in version 0 of the expo-updates protocol. This may be due to the update being a rollback or other directive."
+    case .missingMultipartBoundaryError: return "Missing boundary in multipart manifest content-type"
+    case .codeSigningError(let reason): return reason.localizedDescription
+    case .codeSigningSignatureError(let part): return "Download of \(part) was successful, but signature was incorrect"
+    case .codeSigningCertificateExtensionMismatch: return "Invalid certificate for project ID or scope key"
+    case .cryptoManifestEmptyOrMissingSignature: return "Cannot verify the manifest because it is empty or has no signature."
+    case .cryptoPublicKeyDownloadError: return "Public key response body empty"
+    case .appLauncherAssetDownloadNoURL: return "Failed to download asset with no URL provided"
+    case .appLauncherAssetBundlePathNil: return "Asset bundlePath was unexpectedly nil"
+    case .appLauncherAssetCopyFailed: return "Asset copy failed"
+    case .appLauncherNoLaunchableUpdates(let reason): return "No launchable updates found in database: \(reason?.localizedDescription ?? "")"
+    case .appLoaderFailedToLoadEmbeddedManifest: return "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
+    case .appLoaderFailedToDownloadAssetNoURL: return "Failed to download asset with no URL provided"
+    case .appLoaderFailedToLoadAllAssets: return "Failed to load all assets"
+    case .updatesDirectoryCreationFailed: return "Failed to create the Updates Directory; a file already exists with the required directory name"
+    case .appLoaderTaskUpdatesDisabled: return "AppLoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling AppLoaderTask, or enable updates in the configuration."
+    case .appLoaderTaskNullURL: return "AppLoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use AppLoaderTask to load updates."
+    case .appLoaderTaskUnexpectedError: return "AppLoaderTask encountered an unexpected error and could not launch an update."
+    case .devLauncherConfigFailed: return "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+    case .devLauncherInvalidUpdateURL: return "Failed to read stored updates: configuration object must include a valid update URL"
+    case .devLauncherUpdateLaunchFailed: return "Failed to launch update with an unknown error"
+    }
+  }
+
+  var failureReason: String? {
+    switch self {
+    case .responseErrorMissingResponse(let reason): return reason.localizedDescription
+    case .fileWriteError(_, let reason): return reason.localizedDescription
+    case .codeSigningError(let reason): return reason.localizedDescription
+    case .directiveParseError(let reason): return reason.localizedDescription
+    case .manifestParseError(let reason): return reason.localizedDescription
+    default: return nil
+    }
+  }
+
+  var updatesErrorCode: UpdatesErrorCode {
+    switch self {
+    case .fileHashMismatchError: return UpdatesErrorCode.assetsFailedToLoad
+    case .emptyResponseError: return UpdatesErrorCode.assetsFailedToLoad
+    case .appLoaderTaskUpdatesDisabled: return UpdatesErrorCode.updateFailedToLoad
+    case .appLoaderTaskNullURL: return UpdatesErrorCode.updateFailedToLoad
+    case .appLoaderTaskUnexpectedError: return UpdatesErrorCode.updateFailedToLoad
+    default: return UpdatesErrorCode.unknown
+    }
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -19,7 +19,6 @@ internal extension Array where Element: Equatable {
 @objcMembers
 public final class UpdatesUtils: NSObject {
   private static let EXUpdatesEventName = "Expo.nativeUpdatesEvent"
-  private static let EXUpdatesUtilsErrorDomain = "EXUpdatesUtils"
 
   internal static func runBlockOnMainThread(_ block: @escaping () -> Void) {
     if Thread.isMainThread {
@@ -64,13 +63,7 @@ public final class UpdatesUtils: NSObject {
 
     if exists {
       if !isDir.boolValue {
-        throw NSError(
-          domain: EXUpdatesUtilsErrorDomain,
-          code: 1005,
-          userInfo: [
-            NSLocalizedDescriptionKey: "Failed to create the Updates Directory; a file already exists with the required directory name"
-          ]
-        )
+        throw UpdatesError.updatesDirectoryCreationFailed
       }
     } else {
       try fileManager.createDirectory(atPath: updatesDirectoryPath, withIntermediateDirectories: true)


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/22348#discussion_r1183109155 started the discussion. Essentially maintaining these error codes was a concern since they were scattered across the codebase and had various domains, etc.

One thing I noticed while trying to consolidate them is that the codes actually weren't used, at least not in a very meaningful way unless a NSError didn't provide a localized description key since all of our errors are caught and the localized description is extracted (had to trace through all callsites to see this).

Closes ENG-8502.

# How

Create a new error type that replaces all manually-created NSError's. Simplify logging. There's probably a lot we can do here to clean up the logging of these errors.

https://nshipster.com/swift-foundation-error-protocols/

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
