### PR TITLE
[docs] Update links to Apple's Icon Guidelines

### DIFF
--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -41,11 +41,11 @@ The design you provide should follow the [Android Adaptive Icon Guidelines](http
 
 You may also want to provide a separate icon for older Android devices that do not support Adaptive Icons. You can do so with the `android.icon` property. This single icon would be a combination of your foreground and background layers.
 
-> You may still want to follow some of the [Apple best practices](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/) to ensure your icon looks professional, such as testing your icon on different wallpapers and avoiding text beside your product's wordmark. Provide something that's at least 512x512 pixels. Since you already need 1024x1024 for iOS.
+> You may still want to follow some of the [Apple best practices](https://developer.apple.com/design/human-interface-guidelines/app-icons/#Best-practices) to ensure your icon looks professional, such as testing your icon on different wallpapers and avoiding text beside your product's wordmark. Provide something that's at least 512x512 pixels. Since you already need 1024x1024 for iOS.
 
 ### iOS
 
-For iOS, you app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/). You should also:
+For iOS, you app's icon should follow the [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/app-icons/). You should also:
 
 - Use a **.png** file.
 - 1024x1024 is a good size. If you have an Expo managed project, [EAS Build](/build/setup) will generate the other sizes for you. If you have a bare workflow project, you should generate the icons on your own. The largest size EAS Build generates is 1024x1024.


### PR DESCRIPTION
# Why

The current link to Apple's guidelines for icons is broken, and throws a 404 error.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
