### PR TITLE
Get the actual devServer hostURI

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -317,7 +317,7 @@ Make sure your `organization`, `project` and `authToken` properties are set corr
 
 <Collapsible summary={<><CODE>expo-dev-client</CODE> transactions never finish</>}>
 
-This error is caused by the HTTP request tracking, which creates spans for log requests to the development server. To fix this, stop creating spans by adding the following code snippet:
+This error is caused by the HTTP request tracking, which creates spans for log requests (`Starting 'http.client' span on transaction...`) to the development server. To fix this, stop creating spans by adding the following code snippet:
 
 ```js
 import * as Sentry from 'sentry-expo';

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -321,20 +321,14 @@ This error is caused by the HTTP request tracking, which creates spans for log r
 
 ```js
 import * as Sentry from 'sentry-expo';
-import * as Network from 'expo-network';
-
-const devServerPort = 8081;
-let devServerIpAddress: string | null = null;
-Network.getIpAddressAsync().then(ip => {
-  devServerIpAddress = ip;
-});
+import Constants from 'expo-constants';
 
 Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [
     new Sentry.Native.ReactNativeTracing({
       shouldCreateSpanForRequest: url => {
-        return !__DEV__ || !url.startsWith(`http://${devServerIpAddress}:${devServerPort}/logs`);
+        return !__DEV__ || !url.startsWith(`http://${Constants.expoConfig.hostUri}/logs`);
       },
     }),
   ],


### PR DESCRIPTION
The current workaround uses the development device's IP which might work in a simulator but not on a real device. Use the `hostURI` constant instead.
