### PR TITLE
@expo/metro-config: add types

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix Typescript type export. ([#22410](https://github.com/expo/expo/pull/22410) by [@dcposch](https://github.com/dcposch])
 - Account for the entire dependency tree when creating module name hashes. ([#30512](https://github.com/expo/expo/pull/30512) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve missing module errors. ([#30354](https://github.com/expo/expo/pull/30354) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix support for defining variables named `module`, `require`, `global`, and `exports` with `experimentalImportSupport`. ([#30348](https://github.com/expo/expo/pull/30348) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -3,6 +3,7 @@
   "version": "0.18.4",
   "description": "A Metro config for running React Native projects with the Metro bundler",
   "main": "build/ExpoMetroConfig.js",
+  "types": "build/ExpoMetroConfig.d.ts",
   "scripts": {
     "build": "expo-module tsc",
     "clean": "expo-module clean",


### PR DESCRIPTION
# Why

Support `tsc` and the VSCode Typescript extension out of the box.

Fix the following warning, which appears after creating a hello-world Expo project with the typescript instructions, then going to `metro.config.js`.

<img width="874" alt="image" src="https://user-images.githubusercontent.com/169280/236812002-42560510-e95b-4381-8434-fd3904ab934c.png">


# How

Adding `types` to the package.json lets Typescript find the generated type definitions.


# Test Plan

- Fresh expo project
- Install modified expo with this change 
- Go to `metro.config.js` in VSCode, mouse over to confirm type information is loaded.

# Checklist

(All items below N/A -- no interface, documentation, or module changes.)

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
