### PR TITLE
fix(cli): ensure fixture package jsons are private

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Mark fixture `package.json` files as private.
+- Mark fixture `package.json` files as private. ([#22417](https://github.com/expo/expo/pull/22417) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.8.0 — 2023-05-08
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Mark fixture `package.json` files as private.
+
 ## 0.8.0 — 2023-05-08
 
 ### 🛠 Breaking changes

--- a/packages/@expo/cli/e2e/fixtures/with-assets/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-assets/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
      "expo": "~47.0.13",

--- a/packages/@expo/cli/e2e/fixtures/with-blank/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-blank/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
     "expo": "~47.0.13",

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "expo": "^48.0.4",
     "expo-constants": "~14.2.1",
@@ -17,6 +18,5 @@
   "devDependencies": {
     "@babel/core": "^7.19.3"
   },
-  "name": "with-router",
   "version": "1.0.0"
 }

--- a/packages/@expo/cli/e2e/fixtures/with-web/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-web/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
     "expo": "~47.0.13",


### PR DESCRIPTION
# Why

prevent expo tools from thinking fixture projects are public