### PR TITLE
@simek/docs search include description (part2)

### DIFF
--- a/docs/ui/components/CommandMenu/Items/RNDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/RNDocsItem.tsx
@@ -66,7 +66,7 @@ export const RNDocsItem = ({ item, onSelect }: Props) => {
           {!lvl3 && !lvl2 && !lvl1 && lvl0 && (
             <CALLOUT weight="medium" {...getHighlightHTML(item, 'lvl0')} />
           )}
-          <FOOTNOTE theme="secondary" {...getContentHighlightHTML(item)} css={contentStyle} />
+          <FOOTNOTE theme="secondary" {...getContentHighlightHTML(item, true)} css={contentStyle} />
         </div>
         <ExternalLinkIcon />
       </div>

--- a/docs/ui/components/CommandMenu/utils.ts
+++ b/docs/ui/components/CommandMenu/utils.ts
@@ -83,7 +83,7 @@ const trimContent = (content: string) => {
 
 export const getContentHighlightHTML = (item: AlgoliaItemType) => ({
   dangerouslySetInnerHTML: {
-    __html: trimContent(item._highlightResult.content?.value || ''),
+    __html: trimContent(item._highlightResult.content?.value || item.hierarchy.lvl1 || ''),
   },
 });
 

--- a/docs/ui/components/CommandMenu/utils.ts
+++ b/docs/ui/components/CommandMenu/utils.ts
@@ -70,22 +70,27 @@ export const getHighlightHTML = (
   },
 });
 
-const trimContent = (content: string) => {
+const trimContent = (content: string, length = 36) => {
   if (!content || !content.length) return '';
 
-  const trimStart = Math.max(content.indexOf('<mark>') - 36, 0);
-  const trimEnd = Math.min(content.indexOf('</mark>') + 36 + 6, content.length);
+  const trimStart = Math.max(content.indexOf('<mark>') - length, 0);
+  const trimEnd = Math.min(content.indexOf('</mark>') + length + 6, content.length);
 
   return `${trimStart !== 0 ? '…' : ''}${content.substring(trimStart, trimEnd).trim()}${
     trimEnd !== content.length ? '…' : ''
   }`;
 };
 
-export const getContentHighlightHTML = (item: AlgoliaItemType) => ({
-  dangerouslySetInnerHTML: {
-    __html: trimContent(item._highlightResult.content?.value || item.hierarchy.lvl1 || ''),
-  },
-});
+export const getContentHighlightHTML = (item: AlgoliaItemType, skipDescription = false) =>
+  skipDescription
+    ? {}
+    : {
+        dangerouslySetInnerHTML: {
+          __html: item._highlightResult.content?.value
+            ? trimContent(item._highlightResult.content?.value)
+            : trimContent(item._highlightResult.hierarchy.lvl1?.value || '', 82),
+        },
+      };
 
 // note(simek): this code make sure that browser popup blocker
 // do not prevent opening links via key press (when it fires windows.open)


### PR DESCRIPTION
# Why

Follow up to #22419

# How

Display page description for generic query matches.

> **warning** 
> We need to recrawl the docs before shipping this change.

# Test Plan

N/A