### PR TITLE
Clarify warning about metro.config.js not being updated

### DIFF
--- a/packages/@expo/cli/src/prebuild/writeMetroConfig.ts
+++ b/packages/@expo/cli/src/prebuild/writeMetroConfig.ts
@@ -38,13 +38,11 @@ export function writeMetroConfig(
   } catch (error: any) {
     updatingMetroConfigStep.stopAndPersist({
       symbol: chalk.yellow('›'),
-      text: chalk.yellow(chalk`{bold Metro skipped:} ${error.message}`),
+      text: chalk.yellow(chalk`{bold Skipped updating Metro config:} ${error.message}`),
     });
     // Log.log(`\u203A ${e.message}`);
     Log.log(
-      chalk`\u203A Ensure the project uses {bold expo/metro-config}.\n  {dim ${learnMore(
-        'https://docs.expo.dev/guides/customizing-metro'
-      )}}`
+      chalk`\u203A {dim ${learnMore('https://docs.expo.dev/guides/customizing-metro')}}`
     );
   }
 }


### PR DESCRIPTION
# Why

As shown by issue #20763 the original verbiage was confusing and led people to believe that the configuration was being ignored.

This is an attempt to clarify what's going on.

# How

Used the GitHub web based editor to just change the code.  It is not formatted nor linted.

# Test Plan

Dunno.  I'm just helping with the English.

# Checklist

- [?] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

Fixes #20763