### PR TITLE
[core][ios] Fix passing `JavaScriptObject` and view props

### DIFF
--- a/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
+++ b/packages/expo-modules-core/ios/Swift/Classes/ClassComponent.swift
@@ -83,7 +83,7 @@ public final class ClassComponent: ObjectDefinition {
 internal protocol ClassAssociatedObject {}
 
 // Basically we only need these two
-extension JavaScriptObject: ClassAssociatedObject, AnyArgument {
+extension JavaScriptObject: ClassAssociatedObject, AnyArgument, AnyJavaScriptValue {
   internal static func convert(from value: JavaScriptValue, appContext: AppContext) throws -> Self {
     guard value.kind == .object else {
       throw Conversions.ConvertingException<JavaScriptObject>(value)

--- a/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
+++ b/packages/expo-modules-core/ios/Swift/Views/ComponentData.swift
@@ -60,6 +60,10 @@ public final class ComponentData: RCTComponentData {
     var remainingProps = props
 
     for (key, prop) in propsDict {
+      if props.index(forKey: key) == nil {
+        continue
+      }
+
       let newValue = props[key] as Any
 
       // TODO: @tsapeta: Figure out better way to rethrow errors from here.


### PR DESCRIPTION
# Why

Makes sure that `JavaScriptObject` can be passed to the native world.
Fix props not being passed correctly.

# Test Plan

- workshop app ✅
- NCL ✅