### PR TITLE
[gl] Fix race condition when creating gl context in close succession

### DIFF
--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -77,6 +77,7 @@ public class GLContext {
 
     mGLThread = new GLThread(surfaceTexture);
     mGLThread.start();
+    mEXGLCtxId = EXGLContextCreate();
 
     // On JS thread, get JavaScriptCore context, create EXGL context, call JS callback
     final GLContext glContext = this;
@@ -92,7 +93,6 @@ public class GLContext {
         long jsContextRef = jsContextProvider.getJavaScriptContextRef();
         synchronized (uiManager) {
           if (jsContextRef != 0) {
-            mEXGLCtxId = EXGLContextCreate();
             EXGLRegisterThread();
             EXGLContextPrepare(jsContextRef, mEXGLCtxId, glContext);
           }

--- a/packages/expo-gl/common/EXGLContextManager.cpp
+++ b/packages/expo-gl/common/EXGLContextManager.cpp
@@ -6,24 +6,38 @@ namespace gl_cpp {
 struct ContextState {
   EXGLContext *ctx;
   std::shared_mutex mutex;
+  bool isReady;
+  std::condition_variable cv;
 };
 
 struct ContextManager {
   std::unordered_map<EXGLContextId, ContextState> contextMap;
-  std::mutex contextLookupMutex;
+  std::shared_mutex contextLookupMutex;
   EXGLContextId nextId = 1;
 };
 
 ContextManager manager;
 
 ContextWithLock ContextGet(EXGLContextId id) {
-  std::lock_guard lock(manager.contextLookupMutex);
+  std::unique_lock lock(manager.contextLookupMutex);
   auto iter = manager.contextMap.find(id);
   // if ctx is null then destroy is in progress
   if (iter == manager.contextMap.end() || iter->second.ctx == nullptr) {
     return {nullptr, std::shared_lock<std::shared_mutex>()};
   }
   return {iter->second.ctx, std::shared_lock(iter->second.mutex)};
+}
+
+void ContextMarkReady(EXGLContextId id) {
+  std::shared_lock lock(manager.contextLookupMutex);
+  auto iter = manager.contextMap.find(id);
+  // if ctx is null then destroy is in progress
+  if (iter == manager.contextMap.end() || iter->second.ctx == nullptr) {
+    return;
+  }
+  std::shared_lock contextLock(iter->second.mutex);
+  iter->second.isReady = true;
+  iter->second.cv.notify_one();
 }
 
 EXGLContextId ContextCreate() {
@@ -33,7 +47,7 @@ EXGLContextId ContextCreate() {
     return 0;
   }
 
-  std::lock_guard<std::mutex> lock(manager.contextLookupMutex);
+  std::unique_lock lock(manager.contextLookupMutex);
   EXGLContextId ctxId = manager.nextId++;
   if (manager.contextMap.find(ctxId) != manager.contextMap.end()) {
     EXGLSysLog("Tried to reuse an EXGLContext id. This shouldn't really happen...");
@@ -44,13 +58,31 @@ EXGLContextId ContextCreate() {
 }
 
 void ContextDestroy(EXGLContextId id) {
-  std::lock_guard lock(manager.contextLookupMutex);
-
-  auto iter = manager.contextMap.find(id);
-  if (iter != manager.contextMap.end()) {
+  // Wait for isReady to be set.
+  {
+    std::shared_lock lock(manager.contextLookupMutex);
+    auto iter = manager.contextMap.find(id);
+    if (iter == manager.contextMap.end()) {
+      EXGLSysLog("Unable to destory context. Context not found.");
+      return;
+    }
+    std::mutex localMutex;
+    std::unique_lock cv_lock(localMutex);
+    iter->second.cv.wait(cv_lock, [&] { return iter->second.isReady; });
+  }
+  // When we know that context is initialized, it's safe to use unique_lock
+  // without risk of a deadlock.
+  {
+    std::unique_lock lock(manager.contextLookupMutex);
+    auto iter = manager.contextMap.find(id);
+    if (iter == manager.contextMap.end()) {
+      EXGLSysLog("Unable to destory context. Context not found.");
+      return;
+    }
     {
       std::unique_lock lock(iter->second.mutex);
       delete iter->second.ctx;
+      iter->second.ctx = nullptr;
     }
     manager.contextMap.erase(iter);
   }

--- a/packages/expo-gl/common/EXGLContextManager.h
+++ b/packages/expo-gl/common/EXGLContextManager.h
@@ -10,6 +10,7 @@ using ContextWithLock = std::pair<EXGLContext *, std::shared_lock<std::shared_mu
 
 EXGLContextId ContextCreate();
 void ContextMarkReady(EXGLContextId id);
+void ContextMarkPrepareStart(EXGLContextId id);
 ContextWithLock ContextGet(EXGLContextId id);
 void ContextDestroy(EXGLContextId id);
 

--- a/packages/expo-gl/common/EXGLContextManager.h
+++ b/packages/expo-gl/common/EXGLContextManager.h
@@ -9,6 +9,7 @@ namespace gl_cpp {
 using ContextWithLock = std::pair<EXGLContext *, std::shared_lock<std::shared_mutex>>;
 
 EXGLContextId ContextCreate();
+void ContextMarkReady(EXGLContextId id);
 ContextWithLock ContextGet(EXGLContextId id);
 void ContextDestroy(EXGLContextId id);
 

--- a/packages/expo-gl/common/EXGLNativeApi.cpp
+++ b/packages/expo-gl/common/EXGLNativeApi.cpp
@@ -12,6 +12,7 @@ void EXGLContextPrepare(
     void *jsiPtr,
     EXGLContextId exglCtxId,
     std::function<void(void)> flushMethod) {
+  ContextMarkPrepareStart(exglCtxId);
   {
     auto [exglCtx, lock] = ContextGet(exglCtxId);
     if (exglCtx) {

--- a/packages/expo-gl/common/EXGLNativeApi.cpp
+++ b/packages/expo-gl/common/EXGLNativeApi.cpp
@@ -1,6 +1,6 @@
 #include "EXGLNativeApi.h"
-#include "EXGLNativeContext.h"
 #include "EXGLContextManager.h"
+#include "EXGLNativeContext.h"
 
 using namespace expo::gl_cpp;
 
@@ -8,11 +8,17 @@ EXGLContextId EXGLContextCreate() {
   return ContextCreate();
 }
 
-void EXGLContextPrepare(void *jsiPtr, EXGLContextId exglCtxId, std::function<void(void)> flushMethod) {
-  auto [exglCtx, lock] = ContextGet(exglCtxId);
-  if (exglCtx) {
-    exglCtx->prepareContext(*reinterpret_cast<jsi::Runtime *>(jsiPtr), flushMethod);
+void EXGLContextPrepare(
+    void *jsiPtr,
+    EXGLContextId exglCtxId,
+    std::function<void(void)> flushMethod) {
+  {
+    auto [exglCtx, lock] = ContextGet(exglCtxId);
+    if (exglCtx) {
+      exglCtx->prepareContext(*reinterpret_cast<jsi::Runtime *>(jsiPtr), flushMethod);
+    }
   }
+  ContextMarkReady(exglCtxId);
 }
 
 bool EXGLContextNeedsRedraw(EXGLContextId exglCtxId) {


### PR DESCRIPTION
# Why

If we create an app with more than one GLView and toggle it on and off it crashes or deadlocks.

# How

### Android

**Issue 1**: When onSurrfaceDestroy is called before we even register context in cpp, the destroy code is not able to clean up the cpp context, so when eventually context is created, jobs are pushed to the queue that no one is consuming which results in a deadlock.
Solution: Move ContextCreate just after the thread start.

**Issue 2**: A lot rarer than issue number 1, but when we create and destroy context in quick succession we can reach a situation where:
- ContextPrepare is started (holding shared lock)
- ContextDestroy is started (attempting to acquire unique lock)
- Internally in ContextPrepare we are calling addBlockingToNextBatch, which triggers flush.
- Flush is calling ContextGet to access context (tries to acquire shared lock), but in some cases it blocks indefinitely, because unique_lock from ContextDestroy might have priority and ContextDestroy is blocked because shared lock from context prepare is still locked.

Solution:
Add a promise to the context state, when prepare is finished mark it as resolved, so destroy can be executed.

After the context is initialized we can safely acquire unique_lock. 


**Issue 3**: Only happens when using reanimated:
- ContextDestroy is called before ContextPrepare is even started
- ContextDestroy (on the main thread) is starting to wait for a promise added above
- `reanimated.NodesManager.startUpdatingOnAnimationFrame` is called on the js thread and I suspect it blocks until main thread becomes available.

It deadlocks because ContextDestroy waits for ContextPrepare, but ContextPrepare will never be called because startUpdatingOnAnimationFrame is blocking the js thread, and startUpdatingOnAnimationFrame is blocking the js thread because ContextDestroy is blocking a main thread.

Solution:
Initialize future in ContextState just at the beginning of ContextPrepare (when we are already on the js thread and nothing can block the rest of the ContextPrepare). In ContextDestroy check if the future is valid, if it is we need to wait for it, but if not we can just continue without waiting because we know that ContextPrepare was not started yet.

# Test Plan

Test app that creates and removes a few GLViews every few milliseconds.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
