### PR TITLE
[expo-updates][android] Fix rollback to embedded logic

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix empty body no-op multipart response. ([#22227](https://github.com/expo/expo/pull/22227) by [@wschurman](https://github.com/wschurman))
 - Put extra data mutation in transaction. ([#22252](https://github.com/expo/expo/pull/22252) by [@wschurman](https://github.com/wschurman))
 - [iOS] fix bizarre bug when downloading update twice. ([#22355](https://github.com/expo/expo/pull/22355) by [@douglowder](https://github.com/douglowder))
+- Fix rollback to embedded logic. ([#22433](https://github.com/expo/expo/pull/22433) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/SelectionPolicyFilterAwareTest.kt
@@ -4,48 +4,41 @@ import android.net.Uri
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import expo.modules.manifests.core.NewManifest
 import expo.modules.updates.UpdatesConfiguration
-import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.UpdatesUtils
+import expo.modules.updates.loader.UpdateDirective
 import expo.modules.updates.manifest.NewUpdateManifest
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.Date
 
 @RunWith(AndroidJUnit4ClassRunner::class)
 class SelectionPolicyFilterAwareTest {
-  private lateinit var manifestFilters: JSONObject
-  private lateinit var selectionPolicy: SelectionPolicy
-  private lateinit var updateDefault1: UpdateEntity
-  private lateinit var updateDefault2: UpdateEntity
-  private lateinit var updateRollout0: UpdateEntity
-  private lateinit var updateRollout1: UpdateEntity
-  private lateinit var updateRollout2: UpdateEntity
-  private lateinit var updateMultipleFilters: UpdateEntity
-  private lateinit var updateNoMetadata: UpdateEntity
-
-  @Before
-  @Throws(JSONException::class)
-  fun setup() {
-    manifestFilters = JSONObject("{\"branchname\": \"rollout\"}")
-    selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy("1.0")
-    val configMap = mapOf<String, Any>("updateUrl" to Uri.parse("https://exp.host/@test/test"))
-    val config = UpdatesConfiguration(null, configMap)
-    val manifestJsonRollout0 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e71\",\"createdAt\":\"2021-01-10T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout0 = NewUpdateManifest.fromNewManifest(manifestJsonRollout0, null, config).updateEntity
-    val manifestJsonDefault1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}"))
-    updateDefault1 = NewUpdateManifest.fromNewManifest(manifestJsonDefault1, null, config).updateEntity
-    val manifestJsonRollout1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e73\",\"createdAt\":\"2021-01-12T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout1 = NewUpdateManifest.fromNewManifest(manifestJsonRollout1, null, config).updateEntity
-    val manifestJsonDefault2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e74\",\"createdAt\":\"2021-01-13T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}"))
-    updateDefault2 = NewUpdateManifest.fromNewManifest(manifestJsonDefault2, null, config).updateEntity
-    val manifestJsonRollout2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}"))
-    updateRollout2 = NewUpdateManifest.fromNewManifest(manifestJsonRollout2, null, config).updateEntity
-    val manifestJsonMultipleFilters = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"firstKey\": \"value1\", \"secondKey\": \"value2\"}}"))
-    updateMultipleFilters = NewUpdateManifest.fromNewManifest(manifestJsonMultipleFilters, null, config).updateEntity
-    val manifestJsonNoMetadata = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}]}"))
-    updateNoMetadata = NewUpdateManifest.fromNewManifest(manifestJsonNoMetadata, null, config).updateEntity
+  private val config = UpdatesConfiguration(null, mapOf<String, Any>("updateUrl" to Uri.parse("https://exp.host/@test/test")))
+  private val manifestFilters = JSONObject("{\"branchname\": \"rollout\"}")
+  private val selectionPolicy = SelectionPolicyFactory.createFilterAwarePolicy("1.0")
+  private val updateRollout0 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e71\",\"createdAt\":\"2021-01-10T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateDefault1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateRollout1 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e73\",\"createdAt\":\"2021-01-12T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateDefault2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e74\",\"createdAt\":\"2021-01-13T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"default\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateRollout2 = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e75\",\"createdAt\":\"2021-01-14T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"branchName\":\"rollout\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateMultipleFilters = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}],\"metadata\":{\"firstKey\": \"value1\", \"secondKey\": \"value2\"}}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
+  }
+  private val updateNoMetadata = NewManifest(JSONObject("{\"id\":\"079cde35-8433-4c17-81c8-7117c1513e72\",\"createdAt\":\"2021-01-11T19:39:22.480Z\",\"runtimeVersion\":\"1.0\",\"launchAsset\":{\"hash\":\"DW5MBgKq155wnX8rCP1lnsW6BsTbfKLXxGXRQx1RcOA\",\"key\":\"0436e5821bff7b95a84c21f22a43cb96.bundle\",\"contentType\":\"application/javascript\",\"url\":\"https://url.to/bundle\"},\"assets\":[{\"hash\":\"JSeRsPNKzhVdHP1OEsDVsLH500Zfe4j1O7xWfa14oBo\",\"key\":\"3261e570d51777be1e99116562280926.png\",\"contentType\":\"image/png\",\"url\":\"https://url.to/asset\"}]}")).let {
+    NewUpdateManifest.fromNewManifest(it, null, config).updateEntity
   }
 
   @Test
@@ -114,6 +107,65 @@ class SelectionPolicyFilterAwareTest {
   fun testShouldLoadNewUpdate_DoesntMatch() {
     // should never choose to load an update that doesn't match its own filters
     val actual = selectionPolicy.shouldLoadNewUpdate(updateDefault2, null, manifestFilters)
+    Assert.assertFalse(actual)
+  }
+
+  @Test
+  fun testShouldLoadRollBackToEmbeddedDirective_EmbeddedDoesNotMatchFilters() {
+    val actual = selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      UpdateDirective.RollBackToEmbeddedUpdateDirective(Date(), null),
+      updateDefault1,
+      null,
+      manifestFilters
+    )
+    Assert.assertFalse(actual)
+  }
+
+  @Test
+  fun testShouldLoadRollBackToEmbeddedDirective_NoLaunchedUpdate() {
+    val actual = selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      UpdateDirective.RollBackToEmbeddedUpdateDirective(Date(), null),
+      updateRollout0,
+      null,
+      manifestFilters
+    )
+    Assert.assertTrue(actual)
+  }
+
+  @Test
+  fun testShouldLoadRollBackToEmbeddedDirective_LaunchedUpdateDoesNotMatchFilters() {
+    val actual = selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      UpdateDirective.RollBackToEmbeddedUpdateDirective(Date(), null),
+      updateRollout0,
+      updateDefault1,
+      manifestFilters
+    )
+    Assert.assertTrue(actual)
+  }
+
+  @Test
+  fun testShouldLoadRollBackToEmbeddedDirective_CommitTimeOfLaunchedUpdateBeforeRollBack() {
+    // updateRollout1 has commitTime = 2021-01-12T19:39:22.480Z
+    // roll back is 1 year later
+    val actual = selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      UpdateDirective.RollBackToEmbeddedUpdateDirective(UpdatesUtils.parseDateString("2022-01-12T19:39:22.480Z"), null),
+      updateRollout0,
+      updateRollout1,
+      manifestFilters
+    )
+    Assert.assertTrue(actual)
+  }
+
+  @Test
+  fun testShouldLoadRollBackToEmbeddedDirective_CommitTimeOfLaunchedUpdateAfterRollBack() {
+    // updateRollout1 has commitTime = 2021-01-12T19:39:22.480Z
+    // roll back is 1 year earlier
+    val actual = selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      UpdateDirective.RollBackToEmbeddedUpdateDirective(UpdatesUtils.parseDateString("2020-01-12T19:39:22.480Z"), null),
+      updateRollout0,
+      updateRollout1,
+      manifestFilters
+    )
     Assert.assertFalse(actual)
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LoaderSelectionPolicy.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LoaderSelectionPolicy.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.selectionpolicy
 
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.loader.UpdateDirective
 import org.json.JSONObject
 
 /**
@@ -11,6 +12,13 @@ import org.json.JSONObject
 interface LoaderSelectionPolicy {
   fun shouldLoadNewUpdate(
     newUpdate: UpdateEntity?,
+    launchedUpdate: UpdateEntity?,
+    filters: JSONObject?
+  ): Boolean
+
+  fun shouldLoadRollBackToEmbeddedDirective(
+    directive: UpdateDirective.RollBackToEmbeddedUpdateDirective,
+    embeddedUpdate: UpdateEntity,
     launchedUpdate: UpdateEntity?,
     filters: JSONObject?
   ): Boolean

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LoaderSelectionPolicyFilterAware.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/LoaderSelectionPolicyFilterAware.kt
@@ -1,10 +1,11 @@
 package expo.modules.updates.selectionpolicy
 
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.loader.UpdateDirective
 import org.json.JSONObject
 
 /**
- * LoaderSelectionPolicy which decides whether or not to load an update, taking filters into
+ * LoaderSelectionPolicy which decides whether or not to load an update or directive, taking filters into
  * account. Returns true (should load the update) if we don't have an existing newer update that
  * matches the given manifest filters.
  *
@@ -31,5 +32,28 @@ class LoaderSelectionPolicyFilterAware : LoaderSelectionPolicy {
     return if (!SelectionPolicies.matchesFilters(launchedUpdate, filters)) {
       true
     } else newUpdate.commitTime.after(launchedUpdate.commitTime)
+  }
+
+  override fun shouldLoadRollBackToEmbeddedDirective(
+    directive: UpdateDirective.RollBackToEmbeddedUpdateDirective,
+    embeddedUpdate: UpdateEntity,
+    launchedUpdate: UpdateEntity?,
+    filters: JSONObject?
+  ): Boolean {
+    // if the embedded update doesn't match the filters, don't roll back to it (changing the
+    // timestamp of it won't change filter validity)
+    if (!SelectionPolicies.matchesFilters(embeddedUpdate, filters)) {
+      return false
+    }
+
+    if (launchedUpdate == null) {
+      return true
+    }
+
+    // if the current update doesn't pass the manifest filters
+    // we should roll back to the embedded update no matter the commitTime
+    return if (!SelectionPolicies.matchesFilters(launchedUpdate, filters)) {
+      true
+    } else directive.commitTime.after(launchedUpdate.commitTime)
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicy.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicy.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates.selectionpolicy
 
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.loader.UpdateDirective
 import org.json.JSONObject
 
 /**
@@ -61,5 +62,20 @@ class SelectionPolicy(
     filters: JSONObject?
   ): Boolean {
     return loaderSelectionPolicy.shouldLoadNewUpdate(newUpdate, launchedUpdate, filters)
+  }
+
+  /**
+   * Given a roll back to embedded directive, the embedded update before the directive is applied,
+   * and the currently running update, decide whether the directive should be applied to the embedded
+   * update and saved in the database (i.e. decide whether the combination of the directive's commitTime
+   * and the embedded update is "newer" than the currently running update, according to this class's ordering).
+   */
+  fun shouldLoadRollBackToEmbeddedDirective(
+    directive: UpdateDirective.RollBackToEmbeddedUpdateDirective,
+    embeddedUpdate: UpdateEntity,
+    launchedUpdate: UpdateEntity?,
+    filters: JSONObject?
+  ): Boolean {
+    return loaderSelectionPolicy.shouldLoadRollBackToEmbeddedDirective(directive, embeddedUpdate, launchedUpdate, filters)
   }
 }


### PR DESCRIPTION
# Why

@douglowder noticed that the rollback was applied even if the current embedded update was newer. This is incorrect since roll backs should obey the same selection policy criteria as normal updates (to the extent to which this is possible, they don't have filters, but their embedded updates do). This noticed a bug where we would roll back to the embedded update even if it didn't match the manifest filters.

# How

We think the correct behavior is to only roll back to the embedded if both of the following are true, otherwise no-op:
- Roll back directive is newer than the latest update (including the embedded update). This means that it will not roll back over existing updates in the db if it is older, and also will not roll back to the embedded if the embedded is newer.
- Embedded update matches the manifest filters (selection criteria).

# Test Plan

Wait for CI.

Manual test steps:
1. `et gba -n testwat expo-updates expo-manifests expo-updates-interface`
2. eas init, eas update:configure
3. Add channel name header to app.json
4. Do a release build (to embed update)
5. Open app, see embedded, make change & `eas update`, open app twice, see new update, `eas update:roll-back-to-embedded`, open app twice, see embedded

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
