### PR TITLE
[guides] Expo Go: add extension instructions

### DIFF
--- a/guides/Developing Expo Go.md
+++ b/guides/Developing Expo Go.md
@@ -65,7 +65,7 @@ If you need to make native code changes to your Expo project, such as adding cus
   - In the **General** tab, in the **Identity** section, put in a unique Bundle Identifier.
   - Also in the **General** tab, in the **Signing** section, select your personal or team Apple Developer account as your **Team**, and create a new signing certificate by clicking **Fix Issue**.
 - In the project's settings page, select the **ExpoNotificationServiceExtension** target, and then:
-  - In the **General** tab, in the **Identity** section, its Bundle Identifier should be prefixed with your unique Bundle Identifier. For example, if your unique Bundle Identifier is `host.exp.Exponent.unique`, then the Bundle Identifier for the notification service extension should be `host.exp.Exponent.unique.ExpoNotificationServiceExtension`.
+  - In the **General** tab, in the **Identity** section, change its Bundle Identifier to be prefixed with your unique Bundle Identifier. For example, if your unique Bundle Identifier is `host.exp.Exponent.unique`, then the Bundle Identifier for the notification service extension should be `host.exp.Exponent.unique.ExpoNotificationServiceExtension`.
 - Finally, run the build.
 
 ### Android

--- a/guides/Developing Expo Go.md
+++ b/guides/Developing Expo Go.md
@@ -64,6 +64,8 @@ If you need to make native code changes to your Expo project, such as adding cus
 - In the project navigator, select the **Exponent** project to bring up the project's settings, and then:
   - In the **General** tab, in the **Identity** section, put in a unique Bundle Identifier.
   - Also in the **General** tab, in the **Signing** section, select your personal or team Apple Developer account as your **Team**, and create a new signing certificate by clicking **Fix Issue**.
+- In the project's settings page, select the **ExpoNotificationServiceExtension** target, and then:
+  - In the **General** tab, in the **Identity** section, its Bundle Identifier should be prefixed with your unique Bundle Identifier. For example, if your unique Bundle Identifier is `host.exp.Exponent.unique`, then the Bundle Identifier for the notification service extension should be `host.exp.Exponent.unique.ExpoNotificationServiceExtension`.
 - Finally, run the build.
 
 ### Android
@@ -97,6 +99,7 @@ Here are the steps to build a standalone Android app:
 ### iOS
 
 The iOS standalone app script has two actions, `build` and `configure`:
+
 - `build` creates an archive or a simulator build of the Expo iOS workspace,
 - `configure` accepts a path to an existing archive and modifies all its configuration files so that it will run as a standalone Expo project rather than in Expo Go.
 


### PR DESCRIPTION
# Why

When I try building the `Expo Go (unversioned)` target in ios, it fails with this error
![Screenshot 2023-05-10 at 6 27 30 PM](https://github.com/expo/expo/assets/6380927/7a9f8569-7f93-4771-8beb-6f35ce869bd4)

I fixed the problem by changing the bundle identifier of the extension target. 

# How

add extra instructions to expo go docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
