### PR TITLE
[android][media-library] Fix throwUnlessPermissionsGranted 

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed missing permissions error on Android when the user only requests write permissions
+
 ### 💡 Others
 
 ## 15.3.0 — 2023-05-08

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed missing permissions error on Android when the user only requests write permissions
+- Fixed missing permissions error on Android when the user only requests write permissions ([#22457](https://github.com/expo/expo/pull/22457) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -89,7 +89,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("saveToLibraryAsync") { localUri: String, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         withModuleScope(promise) {
           CreateAsset(context, localUri, promise, false)
             .execute()
@@ -98,7 +98,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("createAssetAsync") { localUri: String, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         withModuleScope(promise) {
           CreateAsset(context, localUri, promise)
             .execute()
@@ -107,7 +107,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("addAssetsToAlbumAsync") { assetsId: List<String>, albumId: String, copyToAlbum: Boolean, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             AddAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum, promise)
@@ -119,7 +119,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("removeAssetsFromAlbumAsync") { assetsId: List<String>, albumId: String, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             RemoveAssetsFromAlbum(context, assetsId.toTypedArray(), albumId, promise)
@@ -131,7 +131,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAssets(context, assetsId.toTypedArray(), promise)
@@ -143,7 +143,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAssets(context, assetsId.toTypedArray(), promise)
@@ -155,7 +155,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAssetInfoAsync") { assetId: String, _: Map<String, Any?>? /* unused on android atm */, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = false) {
         withModuleScope(promise) {
           GetAssetInfo(context, assetId, promise).execute()
         }
@@ -163,7 +163,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAlbumsAsync") { _: Map<String, Any?>? /* unused on android atm */, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = false) {
         withModuleScope(promise) {
           GetAlbums(context, promise).execute()
         }
@@ -171,7 +171,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAlbumAsync") { albumName: String, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = false) {
         withModuleScope(promise) {
           GetAlbum(context, albumName, promise)
             .execute()
@@ -180,7 +180,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("createAlbumAsync") { albumName: String, assetId: String, copyAsset: Boolean, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             CreateAlbum(context, albumName, assetId, copyAsset, promise)
@@ -192,7 +192,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAlbumsAsync") { albumIds: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted(isWrite = true) {
+      throwUnlessPermissionsGranted {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAlbums(context, albumIds, promise)
@@ -205,7 +205,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAssetsAsync") { assetOptions: AssetsOptions, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = false) {
         withModuleScope(promise) {
           GetAssets(context, assetOptions, promise)
             .execute()
@@ -251,7 +251,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("albumNeedsMigrationAsync") { albumId: String, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = false) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
           moduleCoroutineScope.launch {
             CheckIfAlbumShouldBeMigrated(context, albumId, promise)
@@ -371,7 +371,7 @@ class MediaLibraryModule : Module() {
     ).toTypedArray()
   }
 
-  private inline fun throwUnlessPermissionsGranted(isWrite: Boolean = false, block: () -> Unit) {
+  private inline fun throwUnlessPermissionsGranted(isWrite: Boolean = true, block: () -> Unit) {
     val missingPermissionsCondition = if (isWrite) isMissingWritePermission else isMissingPermissions
     val missingPermissionsMessage = if (isWrite) ERROR_NO_WRITE_PERMISSION_MESSAGE else ERROR_NO_PERMISSIONS_MESSAGE
     if (missingPermissionsCondition) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -89,7 +89,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("saveToLibraryAsync") { localUri: String, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         withModuleScope(promise) {
           CreateAsset(context, localUri, promise, false)
             .execute()
@@ -98,7 +98,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("createAssetAsync") { localUri: String, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         withModuleScope(promise) {
           CreateAsset(context, localUri, promise)
             .execute()
@@ -107,7 +107,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("addAssetsToAlbumAsync") { assetsId: List<String>, albumId: String, copyToAlbum: Boolean, promise: Promise ->
-      throwUnlessPermissionsGranted(writeOnly = false) {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             AddAssetsToAlbum(context, assetsId.toTypedArray(), albumId, copyToAlbum, promise)
@@ -119,7 +119,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("removeAssetsFromAlbumAsync") { assetsId: List<String>, albumId: String, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             RemoveAssetsFromAlbum(context, assetsId.toTypedArray(), albumId, promise)
@@ -131,7 +131,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAssets(context, assetsId.toTypedArray(), promise)
@@ -143,7 +143,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAssetsAsync") { assetsId: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAssets(context, assetsId.toTypedArray(), promise)
@@ -155,7 +155,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("getAssetInfoAsync") { assetId: String, _: Map<String, Any?>? /* unused on android atm */, promise: Promise ->
-      throwUnlessPermissionsGranted(writeOnly = false) {
+      throwUnlessPermissionsGranted {
         withModuleScope(promise) {
           GetAssetInfo(context, assetId, promise).execute()
         }
@@ -180,7 +180,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("createAlbumAsync") { albumName: String, assetId: String, copyAsset: Boolean, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             CreateAlbum(context, albumName, assetId, copyAsset, promise)
@@ -192,7 +192,7 @@ class MediaLibraryModule : Module() {
     }
 
     AsyncFunction("deleteAlbumsAsync") { albumIds: List<String>, promise: Promise ->
-      throwUnlessPermissionsGranted {
+      throwUnlessPermissionsGranted(isWrite = true) {
         val action = actionIfUserGrantedPermission {
           withModuleScope(promise) {
             DeleteAlbums(context, albumIds, promise)
@@ -371,9 +371,9 @@ class MediaLibraryModule : Module() {
     ).toTypedArray()
   }
 
-  private inline fun throwUnlessPermissionsGranted(writeOnly: Boolean = false, block: () -> Unit) {
-    val missingPermissionsCondition = if (writeOnly) isMissingWritePermission else isMissingPermissions
-    val missingPermissionsMessage = if (writeOnly) ERROR_NO_WRITE_PERMISSION_MESSAGE else ERROR_NO_PERMISSIONS_MESSAGE
+  private inline fun throwUnlessPermissionsGranted(isWrite: Boolean = false, block: () -> Unit) {
+    val missingPermissionsCondition = if (isWrite) isMissingWritePermission else isMissingPermissions
+    val missingPermissionsMessage = if (isWrite) ERROR_NO_WRITE_PERMISSION_MESSAGE else ERROR_NO_PERMISSIONS_MESSAGE
     if (missingPermissionsCondition) {
       throw PermissionsException(missingPermissionsMessage)
     }


### PR DESCRIPTION
# Why
Closes #22429

If a user only requests write permissions, because most functions are writes there should be no problem. The issue was when calling `throwUnlessPermissionsGranted` the writes were not passing `writeOnly = true` and the default was set to `false`. This led to a check for read permissions which wouldn't be there and a missing permission exception is thrown. 

# How
Renamed the `writeOnly` argument for `throwUnlessPermissionsGranted` to `isWrite` for clarity, switched the default to true as the majority of functions are writes and passed `isWrite = false` on the reads

# Test Plan
NCL ✅
Native Tests ✅ 