### PR TITLE
[expo-go] change launcher policy

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -420,7 +420,7 @@ NS_ASSUME_NONNULL_BEGIN
   [sdkVersions addObjectsFromArray:sdkVersionRuntimeVersions];
 
   _selectionPolicy = [[EXUpdatesSelectionPolicy alloc]
-                      initWithLauncherSelectionPolicy:[[EXUpdatesLauncherSelectionPolicyFilterAware alloc] initWithRuntimeVersions:sdkVersions]
+                      initWithLauncherSelectionPolicy:[[EXExpoGoLauncherSelectionPolicyFilterAware alloc] initWithSdkVersions:sdkVersions]
                       loaderSelectionPolicy:[EXUpdatesLoaderSelectionPolicyFilterAware new]
                       reaperSelectionPolicy:[EXUpdatesReaperSelectionPolicyDevelopmentClient new]];
 


### PR DESCRIPTION
# Why

Change Expo Go iOS launcher policy to the one @wschurman wrote in https://github.com/expo/expo/pull/22356

# How

use `EXExpoGoLauncherSelectionPolicyFilterAware` which uses the `sdkVersion` field if available, then uses runtimeVersion as a fallback. This allows people using EAS Update to develop with Expo Go until they make the switch to Dev Clients

# Test Plan

- [x] Tested with a published app with `appVersion` runtime policy
- [x] Tested with `npx expo start`, where we use `appVersion` runtime policy

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
