### PR TITLE
Update Expo GMS play-services-location version

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unpublished
 
+### 📚 3rd party library updates
+
+- Updated `com.google.android.gms:play-services-location` to `21.0.1` and `io.nlopez.smartlocation:library` to `3.3.3`  ([#22468](https://github.com/expo/expo/pull/22468) by [@josephyanks](https://github.com/josephyanks))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -84,9 +84,9 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api 'com.google.android.gms:play-services-location:16.0.0'
+  api 'com.google.android.gms:play-services-location:21.0.1'
 
-  api('io.nlopez.smartlocation:library:3.2.11') {
+  api('io.nlopez.smartlocation:library:3.3.3') {
     transitive = false
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The version of play services location that `expo-location` uses (`16.0.0`) is from [October 2018](https://developers.google.com/android/guides/releases#october_2_2018) and contains references to non-androidX libraries that cause jetifier to be triggered (which slows down builds)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Upgraded the version for both google play services location to the latest `21.0.1`, as well as the play services location wrapper `io.nlopez.smartlocation:library` to latest `3.3.3`.

It should be noted that `io.nlopez.smartlocation:library` has not been maintained in several years and should be replaced, but can happen as a larger rework PR.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The android library doesn't contain any tests, so I verified that location services still functions as expected in a real application.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
