### PR TITLE
[cli] Fix modern manifest serving for dev client without expo-updates

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.8.0 — 2023-05-08

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -23,8 +23,15 @@ import { ServerHeaders, ServerRequest } from './server.types';
 
 const debug = require('debug')('expo:start:server:middleware:ExpoGoManifestHandlerMiddleware');
 
+export enum ResponseContentType {
+  TEXT_PLAIN,
+  APPLICATION_JSON,
+  APPLICATION_EXPO_JSON,
+  MULTIPART_MIXED,
+}
+
 interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
-  explicitlyPrefersMultipartMixed: boolean;
+  responseContentType: ResponseContentType;
   expectSignature: string | null;
 }
 
@@ -46,13 +53,34 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     // URLs in a browser, we denote the response as "text/plain" if the user agent appears not to be
     // an Expo Updates client.
     const accept = accepts(req);
-    const explicitlyPrefersMultipartMixed =
-      accept.types(['unknown/unknown', 'multipart/mixed']) === 'multipart/mixed';
+    const acceptedType = accept.types([
+      'unknown/unknown',
+      'multipart/mixed',
+      'application/json',
+      'application/expo+json',
+      'text/plain',
+    ]);
+
+    let responseContentType;
+    switch (acceptedType) {
+      case 'multipart/mixed':
+        responseContentType = ResponseContentType.MULTIPART_MIXED;
+        break;
+      case 'application/json':
+        responseContentType = ResponseContentType.APPLICATION_JSON;
+        break;
+      case 'application/expo+json':
+        responseContentType = ResponseContentType.APPLICATION_EXPO_JSON;
+        break;
+      default:
+        responseContentType = ResponseContentType.TEXT_PLAIN;
+        break;
+    }
 
     const expectSignature = req.headers['expo-expect-signature'];
 
     return {
-      explicitlyPrefersMultipartMixed,
+      responseContentType,
       platform,
       expectSignature: expectSignature ? String(expectSignature) : null,
       hostname: stripPort(req.headers['host']),
@@ -142,25 +170,59 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       certificateChainBody = codeSigningInfo.certificateChainForResponse.join('\n');
     }
 
-    const form = this.getFormData({
-      stringifiedManifest,
-      manifestPartHeaders,
-      certificateChainBody,
-    });
-
     const headers = this.getDefaultResponseHeaders();
-    headers.set(
-      'content-type',
-      requestOptions.explicitlyPrefersMultipartMixed
-        ? `multipart/mixed; boundary=${form.getBoundary()}`
-        : 'text/plain'
-    );
 
-    return {
-      body: form.getBuffer().toString(),
-      version: runtimeVersion,
-      headers,
-    };
+    switch (requestOptions.responseContentType) {
+      case ResponseContentType.MULTIPART_MIXED: {
+        const form = this.getFormData({
+          stringifiedManifest,
+          manifestPartHeaders,
+          certificateChainBody,
+        });
+        headers.set('content-type', `multipart/mixed; boundary=${form.getBoundary()}`);
+        return {
+          body: form.getBuffer().toString(),
+          version: runtimeVersion,
+          headers,
+        };
+      }
+      case ResponseContentType.APPLICATION_EXPO_JSON:
+      case ResponseContentType.APPLICATION_JSON:
+      case ResponseContentType.TEXT_PLAIN: {
+        headers.set(
+          'content-type',
+          ExpoGoManifestHandlerMiddleware.getContentTypeForResponseContentType(
+            requestOptions.responseContentType
+          )
+        );
+        if (manifestPartHeaders) {
+          Object.entries(manifestPartHeaders).forEach(([key, value]) => {
+            headers.set(key, value);
+          });
+        }
+
+        return {
+          body: stringifiedManifest,
+          version: runtimeVersion,
+          headers,
+        };
+      }
+    }
+  }
+
+  private static getContentTypeForResponseContentType(
+    responseContentType: ResponseContentType
+  ): string {
+    switch (responseContentType) {
+      case ResponseContentType.MULTIPART_MIXED:
+        return 'multipart/mixed';
+      case ResponseContentType.APPLICATION_EXPO_JSON:
+        return 'application/expo+json';
+      case ResponseContentType.APPLICATION_JSON:
+        return 'application/json';
+      case ResponseContentType.TEXT_PLAIN:
+        return 'text/plain';
+    }
   }
 
   private getFormData({

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 2.3.0 — 2023-05-08

--- a/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/main/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -39,7 +39,10 @@ class DevLauncherManifestParser(
   }
 
   private fun getHeaders(): Headers {
-    val headersMap = mutableMapOf("expo-platform" to "android")
+    val headersMap = mutableMapOf(
+      "expo-platform" to "android",
+      "accept" to "application/expo+json,application/json"
+    )
     if (installationID != null) {
       headersMap["expo-dev-client-id"] = installationID
     }

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -99,6 +99,7 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:self.url];
   [request setHTTPMethod:method];
   [request setValue:@"ios" forHTTPHeaderField:@"expo-platform"];
+  [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"accept"];
   if (self.installationID) {
     [request setValue:self.installationID forHTTPHeaderField:@"Expo-Dev-Client-ID"];
   }


### PR DESCRIPTION
# Why

When a dev client doesn't have `expo-updates` installed, it uses its own manifest downloader and parser. This parser only supports a json body.

Since https://github.com/expo/expo/pull/22168, only a multipart is served by default from `npx expo start` including with the `--dev-client` flag. This causes the fallback (non-expo-updates) parser to fail on the dev client.

Closes ENG-8529.

# How

The most correct solution is to make `npx expo start` support all the content-types that the protocol supports: https://docs.expo.dev/technical-specs/expo-updates-1/

So that's what this PR does. It adds support for application/json and application/expo+json.

It also adds a small change to the fallback manifest downloader to specify content type, though the change to the CLI fixes the dev client even without this change since text/plain is the same response.

# Test Plan

CLI:
1. make change, `nexpo start --dev-client`

Android
1. `et gba -n testwat expo-dev-menu expo-dev-client expo-dev-launcher expo-manifests expo-updates-interface`
2. Comment out some stuff in gradle and interface to make build work with `et gba`
3. Run app in android studio, load, see it no longer has an error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
