### PR TITLE
[gl] Fix race condition when creating gl context in quick succession

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fix deadlock when creating and destroying GLViews in a quick succession. ([#22484](https://github.com/expo/expo/pull/22484) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 💡 Others
 

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -77,6 +77,7 @@ public class GLContext {
 
     mGLThread = new GLThread(surfaceTexture);
     mGLThread.start();
+    mEXGLCtxId = EXGLContextCreate();
 
     // On JS thread, get JavaScriptCore context, create EXGL context, call JS callback
     final GLContext glContext = this;
@@ -92,7 +93,6 @@ public class GLContext {
         long jsContextRef = jsContextProvider.getJavaScriptContextRef();
         synchronized (uiManager) {
           if (jsContextRef != 0) {
-            mEXGLCtxId = EXGLContextCreate();
             EXGLRegisterThread();
             EXGLContextPrepare(jsContextRef, mEXGLCtxId, glContext);
           }

--- a/packages/expo-gl/common/EXGLContextManager.cpp
+++ b/packages/expo-gl/common/EXGLContextManager.cpp
@@ -1,4 +1,5 @@
 #include "EXGLContextManager.h"
+#include <mutex>
 
 namespace expo {
 namespace gl_cpp {
@@ -10,14 +11,32 @@ struct ContextState {
 
 struct ContextManager {
   std::unordered_map<EXGLContextId, ContextState> contextMap;
-  std::mutex contextLookupMutex;
+  std::shared_mutex contextLookupMutex;
   EXGLContextId nextId = 1;
 };
 
 ContextManager manager;
 
+// When multiple threads are attempting to establish shared and unique locks on a mutex
+// we can reach a situation where an unique lock gets priority to run first, but waits
+// for existing shared locks to be released, while no new shared locks can be acquired.
+//
+// When we run ContextPrepare we hold a shared lock, but we also trigger flush on
+// a different thread which also needs to hold a shared lock. This situation can lead
+// to deadlock if unique lock have a priority and flush can never start.
+//
+// This solution resolves an issue, but introduces a risk that uniqe lock will never
+// be establish, but given the use-case that should never happen.
+std::unique_lock<std::shared_mutex> getUniqueLockSafelly(std::shared_mutex &mutex) {
+  std::unique_lock lock(mutex, std::defer_lock);
+  while (!lock.try_lock()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  return lock;
+}
+
 ContextWithLock ContextGet(EXGLContextId id) {
-  std::lock_guard lock(manager.contextLookupMutex);
+  std::shared_lock lock(manager.contextLookupMutex);
   auto iter = manager.contextMap.find(id);
   // if ctx is null then destroy is in progress
   if (iter == manager.contextMap.end() || iter->second.ctx == nullptr) {
@@ -33,7 +52,7 @@ EXGLContextId ContextCreate() {
     return 0;
   }
 
-  std::lock_guard<std::mutex> lock(manager.contextLookupMutex);
+  std::unique_lock lock = getUniqueLockSafelly(manager.contextLookupMutex);
   EXGLContextId ctxId = manager.nextId++;
   if (manager.contextMap.find(ctxId) != manager.contextMap.end()) {
     EXGLSysLog("Tried to reuse an EXGLContext id. This shouldn't really happen...");
@@ -44,14 +63,20 @@ EXGLContextId ContextCreate() {
 }
 
 void ContextDestroy(EXGLContextId id) {
-  std::lock_guard lock(manager.contextLookupMutex);
+  {
+    std::shared_lock lock(manager.contextLookupMutex);
 
+    auto iter = manager.contextMap.find(id);
+    if (iter != manager.contextMap.end()) {
+      std::unique_lock lock = getUniqueLockSafelly(iter->second.mutex);
+      delete iter->second.ctx;
+      iter->second.ctx = nullptr;
+    }
+  }
+
+  std::unique_lock lock = getUniqueLockSafelly(manager.contextLookupMutex);
   auto iter = manager.contextMap.find(id);
   if (iter != manager.contextMap.end()) {
-    {
-      std::unique_lock lock(iter->second.mutex);
-      delete iter->second.ctx;
-    }
     manager.contextMap.erase(iter);
   }
 }

--- a/packages/expo-gl/ios/EXGLContext.mm
+++ b/packages/expo-gl/ios/EXGLContext.mm
@@ -167,11 +167,14 @@
     // Flush all the stuff
     EXGLContextFlush(self->_contextId);
 
-    // Destroy JS binding
-    EXGLContextDestroy(self->_contextId);
+    id<EXUIManager> uiManager = [_moduleRegistry getModuleImplementingProtocol:@protocol(EXUIManager)];
+    [uiManager dispatchOnClientThread:^{
+      // Destroy JS binding
+      EXGLContextDestroy(self->_contextId);
 
-    // Remove from dictionary of contexts
-    [self->_objectManager deleteContextWithId:@(self->_contextId)];
+      // Remove from dictionary of contexts
+      [self->_objectManager deleteContextWithId:@(self->_contextId)];
+    }];
   }];
 }
 


### PR DESCRIPTION
# Why

If we create an app with more than one GLView and toggle it on and off it crashes or deadlocks.
https://linear.app/expo/issue/ENG-8087

# How

One of the previous attemts https://github.com/expo/expo/pull/22431. It resolved issues on Android, but running that on iOS uncovered additional race conditions that could not be addressed with that approach.

### Android

**Issue 1**: When onSurrfaceDestroy is called before we even register context in cpp, the destroy code is not able to clean up the cpp context, so when eventually context is created, jobs are pushed to the queue that no one is consuming which results in a deadlock.
Solution: Move ContextCreate just after the thread start.

**Issue 2**: A lot rarer than issue number 1, but when we create and destroy context in quick succession we can reach a situation where:
- ContextPrepare is started (holding shared lock)
- ContextDestroy is started (attempting to acquire unique lock)
- Internally in ContextPrepare we are calling addBlockingToNextBatch, which triggers flush.
- Flush is calling ContextGet to access context (tries to acquire shared lock), but in some cases it blocks indefinitely, because unique_lock from ContextDestroy might have priority and ContextDestroy is blocked because shared lock from context prepare is still locked.

Solution: Never try to acquire a unique lock in a blocking way, instead use try_lock periodically.


### iOS

**Issue 3**: On iOS ContextDestroy is run on GL thread which might lead to an issue where blocking tasks waits for sth to finish, and ContextDestroy can't establish the lock, but blocks the thread.

Solution: Run ContextDestroy on a different thread. I'm not sure if this is the best way to run sth on a different thread(not necessarily UI thread), so I'm open to suggestions).

# Test Plan

Run example with 1, 2 and 100 GLViews that creates GLViews on and off every 10ms/50ms on:
- ios Expo Go (unversioned, simulator)
- android Expo Go (unversioned)
- android bare app (without reanimated)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
