### PR TITLE
[docs] Update using-nextjs.mdx

### DIFF
--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -5,10 +5,11 @@ description: A guide for integrating Next.js with Expo for the web.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **Warning:** Using Next.js is not an official part of Expo's universal app development workflow.
 
-[Next.js][nextjs] is a React framework that provides simple page-based routing as well as server-side rendering. To use Next.js with the Expo SDK, we recommend that you use a library called [`@expo/next-adapter`][next-adapter] to handle the configuration.
+[Next.js][nextjs] is a React framework that provides simple page-based routing as well as server-side rendering. To use Next.js with the Expo SDK, we recommend using [`@expo/next-adapter`][next-adapter] library to handle the configuration.
 
 Using Expo with Next.js means you can share some of your existing components and APIs across your mobile and web app. Next.js has its own CLI that you'll need to use when developing for the web platform, so **you'll need to start your web projects with the Next.js CLI and not with `npx expo start`.**
 
@@ -18,18 +19,18 @@ Using Expo with Next.js means you can share some of your existing components and
 
 To get started, create a new project with [the template](https://github.com/expo/examples/tree/master/with-nextjs):
 
-```sh
-npx create-expo-app -e with-nextjs
-```
+<Terminal cmd={["$ npx create-expo-app -e with-nextjs"]} />
 
 - **Native**: `npx expo start` -- start the Expo project
 - **Web**: `npx next dev` -- start the Next.js project
 
 ## Manual setup
 
-### Dependencies
+### Install dependencies
 
-Ensure you have `expo`, `next`, `@expo/next-adapter` installed in your project. `yarn add expo next @expo/next-adapter`
+Ensure you have `expo`, `next`, `@expo/next-adapter` installed in your project:
+
+<Terminal cmd={["$ yarn add expo next @expo/next-adapter"]} />
 
 ### Transpilation
 
@@ -37,7 +38,7 @@ Configure Next.js to transform language features:
 
 <Collapsible summary={<>Next.js with swc. (Recommended)</>}>
   
-  When using Next.js with SWC, you can configure the `babel.config.js` to only account for native.
+  When using Next.js with SWC, you can configure the **babel.config.js** to only account for native.
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -48,7 +49,7 @@ module.exports = function (api) {
 };
 ```
 
-You will also have to [force Next.js to use SWC](https://nextjs.org/docs/messages/swc-disabled) by adding the following to your `next.config.js`:
+You will also have to [force Next.js to use SWC](https://nextjs.org/docs/messages/swc-disabled) by adding the following to your **next.config.js**:
 
 ```js next.config.js
 module.exports = {
@@ -62,7 +63,7 @@ module.exports = {
 
 <Collapsible summary={<>Next.js with Babel. (Not recommended)</>}>
   
-  Adjust your `babel.config.js` to conditionally add `next/babel` when bundling with Webpack for web.
+  Adjust your **babel.config.js** to conditionally add `next/babel` when bundling with webpack for web.
 
 ```js babel.config.js
 module.exports = function (api) {
@@ -85,7 +86,7 @@ module.exports = function (api) {
 
 ### Next.js configuration
 
-Add the following to your `next.config.js`:
+Add the following to your **next.config.js**:
 
 ```js next.config.js
 const { withExpo } = require('@expo/next-adapter');
@@ -125,7 +126,7 @@ module.exports = nextConfig;
 
 ### React Native Web styling
 
-The package `react-native-web` builds on the assumption of reset CSS styles, here's how you reset styles in Next.js using the `pages/` directory.
+The package `react-native-web` builds on the assumption of reset CSS styles. Here's how you reset styles in Next.js using the **pages** directory.
 
 ```js pages/_document.js
 import { Children } from 'react';
@@ -204,7 +205,7 @@ export default function App({ Component, pageProps }) {
 
 ## Transpiling modules
 
-By default, modules in the React Native ecosystem are not transpiled to run in web browsers. React Native relies on advanced caching in Metro to reload quickly. Next.js uses Webpack, which does not have the same level of caching, so by default, no node modules are transpiled. You will have to manually mark every module you want to transpile with the `transpilePackages` option in `next.config.js`:
+By default, modules in the React Native ecosystem are not transpiled to run in web browsers. React Native relies on advanced caching in Metro to reload quickly. Next.js uses webpack, which does not have the same level of caching, so no node modules are transpiled by default. You will have to manually mark every module you want to transpile with the `transpilePackages` option in **next.config.js**:
 
 ```js next.config.js
 const { withExpo } = require('@expo/next-adapter');
@@ -244,14 +245,14 @@ This is Vercel's preferred method for deploying Next.js projects to production.
 
 ## Limitations or differences comparing to the default Expo for Web
 
-Using Next.js for the web means you will be bundling with the Next.js Webpack config. This will lead to some core differences in how you develop your app vs your website.
+Using Next.js for the web means you will be bundling with the Next.js webpack config. This will lead to some core differences in how you develop your app vs your website.
 
 - Expo Next.js adapter does not support the experimental app directory.
 - For File-based routing on native, we recommend using [Expo Router](https://github.com/expo/router).
 
 ## Contributing
 
-If you would like to help make Next.js support in Expo better, please feel free to open a PR or submit an issue:
+If you would like to help make Next.js support in Expo better, feel free to open a PR or submit an issue:
 
 - [@expo/next-adapter][next-adapter]
 
@@ -259,7 +260,7 @@ If you would like to help make Next.js support in Expo better, please feel free 
 
 ### Cannot use import statement outside a module
 
-Figure out which module has the import statement and add it to the `transpilePackages` option in `next.config.js`:
+Figure out which module has the import statement and add it to the `transpilePackages` option in **next.config.js**:
 
 ```js next.config.js
 const { withExpo } = require('@expo/next-adapter');

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -6,123 +6,222 @@ description: A guide for integrating Next.js with Expo for the web.
 
 import { Collapsible } from '~/ui/components/Collapsible';
 
-> Please open any issues related to Next.js with Expo at [expo-cli/issues](https://github.com/expo/expo-cli/issues).
+> **Warning:** Using Next.js is not an official part of Expo's universal app development workflow.
 
-[Next.js][nextjs] is a React framework that provides simple page-based routing as well as server-side rendering. To use Next.js with Expo for web we recommend that you use a library called [`@expo/next-adapter`][next-adapter] to handle the configuration and integration of the tools.
+[Next.js][nextjs] is a React framework that provides simple page-based routing as well as server-side rendering. To use Next.js with the Expo SDK, we recommend that you use a library called [`@expo/next-adapter`][next-adapter] to handle the configuration.
 
-Using Expo with Next.js means you can share all of your existing components and APIs across your mobile and web. Next.js has its own webpack config so **you'll need to start your web projects with the Next.js CLI and not with `npx expo start`.**
+Using Expo with Next.js means you can share some of your existing components and APIs across your mobile and web app. Next.js has its own CLI that you'll need to use when developing for the web platform, so **you'll need to start your web projects with the Next.js CLI and not with `npx expo start`.**
 
 > Next.js can only be used with Expo for web, this doesn't provide Server-Side Rendering (SSR) for native apps.
-
-## TL;DR:
-
-- Init: `npx create-react-native-app -t with-nextjs` (or `npx create-next-app -e with-expo`)
-- Start: `yarn next dev`
-- Open: `http://localhost:3000/`
 
 ## Setup
 
 To get started, create a new project with [the template](https://github.com/expo/examples/tree/master/with-nextjs):
 
 ```sh
-npx create-react-native-app -t with-nextjs
+npx create-expo-app -e with-nextjs
 ```
 
-- **Web**: `yarn next dev` -- start the Next.js project
 - **Native**: `npx expo start` -- start the Expo project
+- **Web**: `npx next dev` -- start the Next.js project
 
-### Add Next.js to Expo projects
+## Manual setup
 
-> This is for already existing Expo projects.
+### Dependencies
 
-In this approach you would be using SSR for web in your universal project. This is the recommended path because it gives you full access to the features of Expo and Next.js.
+Ensure you have `expo`, `next`, `@expo/next-adapter` installed in your project. `yarn add expo next @expo/next-adapter`
 
-<Collapsible summary="Instructions">
+### Transpilation
 
-- Install the adapter:
-  - **yarn:** `yarn add -D @expo/next-adapter`
-  - npm: `npm i --save-dev @expo/next-adapter`
-- Add Next.js support: `yarn next-expo`
-  - Always commit your changes first!
-  - You can optionally choose which customizations you want to do with `--customize or -c`
-  - Force reload changes with `--force or -f`
-- Start the project with `yarn next dev`
-  - Go to `http://localhost:3000/` to see your project!
+Configure Next.js to transform language features:
 
-</Collapsible>
+<Collapsible summary={<>Next.js with swc. (Recommended)</>}>
+  
+  When using Next.js with SWC, you can configure the `babel.config.js` to only account for native.
 
-### Add Expo to Next.js projects
-
-> This is for already existing Next.js projects.
-
-This approach is useful if you only want to use Expo components in your web-only project.
-
-<Collapsible summary="Instructions">
-
-- Install the adapter:
-  - **yarn:** `yarn add -D @expo/next-adapter`
-  - npm: `npm i --save-dev @expo/next-adapter`
-- Add Next.js support: `yarn next-expo`
-  - Always commit your changes first!
-  - You can optionally choose which customizations you want to do with `--customize or -c`
-  - Force reload changes with `--force or -f`
-- Start the project with `yarn next dev`
-  - Go to `http://localhost:3000/` to see your project!
-
-</Collapsible>
-
-### Manual setup
-
-Optionally you can set the project up manually (not recommended).
-
-<Collapsible summary="Instructions">
-
-- Re-export the custom `Document` component in the **pages/\_document.js** file of your Next.js project.
-
-  - This will ensure `react-native-web` styling works.
-  - You can run `yarn next-expo -c` then select **pages/\_document.js**
-  - Or you can create the file - `mkdir pages; touch pages/_document.js`
-
-  **pages/\_document.js**
-
-  ```js
-  export { default } from '@expo/next-adapter/document';
-  ```
-
-- Create a **babel.config.js** and use [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo).
-
-  - You can run `yarn next-expo -c` then select **babel.config.js**
-  - Or you can You may have installed this earlier with `yarn add -D babel-preset-expo`
-
-  **babel.config.js**
-
-  ```js
-  module.exports = {
-    presets: ['@expo/next-adapter/babel'],
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
   };
-  ```
+};
+```
 
-- Update the Next.js **next.config.js** file to support loading React Native and Expo packages:
+You will also have to [force Next.js to use SWC](https://nextjs.org/docs/messages/swc-disabled) by adding the following to your `next.config.js`:
 
-  - yarn add -D next-compose-plugins next-transpile-modules
-
-  - `touch next.config.js`
-
-  **next.config.js**
-
-  ```js
-  const { withExpo } = require('@expo/next-adapter');
-  const withPlugins = require('next-compose-plugins');
-  const withTM = require('next-transpile-modules')(['react-native-web']);
-
-  const nextConfig = {};
-
-  module.exports = withPlugins([withTM, [withExpo, { projectRoot: __dirname }]], nextConfig);
-  ```
-
-- You can now start your Expo web + Next.js project with `yarn next dev` 🎉
+```js next.config.js
+module.exports = {
+  experimental: {
+    forceSwcTransforms: true,
+  },
+};
+```
 
 </Collapsible>
+
+<Collapsible summary={<>Next.js with Babel. (Not recommended)</>}>
+  
+  Adjust your `babel.config.js` to conditionally add `next/babel` when bundling with Webpack for web.
+
+```js babel.config.js
+module.exports = function (api) {
+  // Detect web usage (this may change in the future if Next.js changes the loader)
+  const isWeb = api.caller(
+    caller =>
+      caller && (caller.name === 'babel-loader' || caller.name === 'next-babel-turbo-loader')
+  );
+  return {
+    presets: [
+      // Only use next in the browser, it'll break your native project
+      isWeb && require('next/babel'),
+      'babel-preset-expo',
+    ].filter(Boolean),
+  };
+};
+```
+
+</Collapsible>
+
+### Next.js configuration
+
+Add the following to your `next.config.js`:
+
+```js next.config.js
+const { withExpo } = require('@expo/next-adapter');
+
+module.exports = withExpo({
+  // transpilePackages is a Next.js +13.1 feature.
+  // older versions can use next-transpile-modules
+  transpilePackages: [
+    'react-native',
+    'expo',
+    // Add more React Native / Expo packages here...
+  ],
+});
+```
+
+The fully qualified Next.js config may look like:
+
+```js next.config.js
+const { withExpo } = require('@expo/next-adapter');
+
+/** @type {import('next').NextConfig} */
+const nextConfig = withExpo({
+  reactStrictMode: true,
+  swcMinify: true,
+  transpilePackages: [
+    'react-native',
+    'expo',
+    // Add more React Native / Expo packages here...
+  ],
+  experimental: {
+    forceSwcTransforms: true,
+  },
+});
+
+module.exports = nextConfig;
+```
+
+### React Native Web styling
+
+The package `react-native-web` builds on the assumption of reset CSS styles, here's how you reset styles in Next.js using the `pages/` directory.
+
+```js pages/_document.js
+import { Children } from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { AppRegistry } from 'react-native';
+
+// Follows the setup for react-native-web:
+// https://necolas.github.io/react-native-web/docs/setup/#root-element
+// Plus additional React Native scroll and text parity styles for various
+// browsers.
+// Force Next-generated DOM elements to fill their parent's height
+const style = `
+html, body, #__next {
+  -webkit-overflow-scrolling: touch;
+}
+#__next {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  /* Allows you to scroll below the viewport; default value is visible */
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -ms-overflow-style: scrollbar;
+}
+`;
+
+export default class MyDocument extends Document {
+  static async getInitialProps({ renderPage }) {
+    AppRegistry.registerComponent('main', () => Main);
+    const { getStyleElement } = AppRegistry.getApplication('main');
+    const page = await renderPage();
+    const styles = [
+      <style key="react-native-style" dangerouslySetInnerHTML={{ __html: style }} />,
+      getStyleElement(),
+    ];
+    return { ...page, styles: Children.toArray(styles) };
+  }
+
+  render() {
+    return (
+      <Html style={{ height: '100%' }}>
+        <Head />
+        <body style={{ height: '100%', overflow: 'hidden' }}>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+```
+
+```js pages/_app.js
+import Head from 'next/head';
+
+export default function App({ Component, pageProps }) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
+}
+```
+
+## Transpiling modules
+
+By default, modules in the React Native ecosystem are not transpiled to run in web browsers. React Native relies on advanced caching in Metro to reload quickly. Next.js uses Webpack, which does not have the same level of caching, so by default, no node modules are transpiled. You will have to manually mark every module you want to transpile with the `transpilePackages` option in `next.config.js`:
+
+```js next.config.js
+const { withExpo } = require('@expo/next-adapter');
+
+module.exports = withExpo({
+  experimental: {
+    transpilePackages: [
+      // NOTE: Even though `react-native` is never used in Next.js,
+      // you need to list `react-native` because `react-native-web`
+      // is aliased to `react-native`. Adding `react-native-web` will not work.
+      'react-native',
+      'expo',
+      // Add more React Native / Expo packages here...
+    ],
+  },
+});
+```
 
 ## Guides
 
@@ -133,7 +232,7 @@ Optionally you can set the project up manually (not recommended).
 This is Vercel's preferred method for deploying Next.js projects to production.
 
 - Add a **build** script to your **package.json**
-  ```json
+  ```json package.json
   {
     "scripts": {
       "build": "next build"
@@ -143,224 +242,12 @@ This is Vercel's preferred method for deploying Next.js projects to production.
 - Install the Vercel CLI: `npm i -g vercel`
 - Deploy to Vercel: `vercel`
 
-### Polyfill setImmediate
-
-> Fixes `setImmediate is not defined` error.
-
-A lot of libraries in the React ecosystem use the `setImmediate()` API (like `react-native-reanimated`), which Next.js doesn't polyfill by default. To fix this you can polyfill it yourself.
-
-- Install: `yarn add setimmediate`
-- Import in **pages/\_app.js**, at the top of the file:
-  ```js
-  import 'setimmediate';
-  ```
-
-If you restart the server this error should go away.
-
-- [Related issue and solution](https://github.com/expo/expo/issues/7996).
-
-### Image support
-
-By default Next.js won't load your statically imported images (images that you include in your project with `require('./path/to/image.png')`) like an Expo project will. If you want to load static images into your `<Image />` components or use `react-native-svg` then you can do the following:
-
-- Install the plugin - `yarn add next-images`
-  - [`next-images`][next-images] injects a webpack loader to handle images.
-  - [`next-optimized-images`][next-optimized-images] is another good solution that you could check out.
-- Wrap your Next.js configuration object with the image method and the Expo method in your **next.config.js**:
-
-  ```js
-  const { withExpo } = require('@expo/next-adapter');
-  const withImages = require('next-images');
-
-  module.exports = withExpo(
-    withImages({
-      projectRoot: __dirname,
-    })
-  );
-  ```
-
-- Now restart your project and you should be able to load images!
-
-You can test your config with the following example:
-
-<Collapsible summary="Show Example">
-
-```js
-import React from 'react';
-import { Image } from 'react-native';
-
-export default function ImageDemo() {
-  return <Image source={require('./assets/image.png')} style={{ flex: 1 }} />;
-}
-```
-
-</Collapsible>
-
-[next-images]: https://github.com/twopluszero/next-images
-[next-optimized-images]: https://github.com/cyrilwanner/next-optimized-images
-
-### Font support
-
-By default Next.js doesn't support static assets like an Expo project. Because this is the intended functionality of Next.js, `@expo/next-adapter` doesn't add font support by default. If you want to use libraries like `expo-font`, `@expo/vector-icons`, or `react-native-vector-icons` you'll need to change a few things.
-
-- Install the plugin - `yarn add next-fonts`
-  - [`next-fonts`][next-fonts] injects a webpack loader to handle fonts.
-- Wrap the font method with the Expo method in your **next.config.js**:
-
-  - The order is important because Expo can mix in the location of vector icons to the existing font loader.
-
-  ```js
-  const { withExpo } = require('@expo/next-adapter');
-  const withFonts = require('next-fonts');
-
-  module.exports = withExpo(
-    withFonts({
-      projectRoot: __dirname,
-    })
-  );
-  ```
-
-- Now restart your project and you should be able to load fonts!
-
-You can test your config with the following example:
-
-<Collapsible summary="Show Example">
-
-```js
-import React, { useEffect, useState } from 'react';
-import * as Font from 'expo-font';
-import { Text } from 'react-native';
-
-export default function FontDemo() {
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    (async () => {
-      try {
-        await Font.loadAsync({
-          // You can get this font on GitHub: https://shorturl.at/chEHS
-          'space-mono': require('./assets/SpaceMono-Regular.ttf'),
-        });
-      } catch ({ message }) {
-        // This will be called if something is broken
-        console.log(`Error loading font: ${message}`);
-      } finally {
-        setLoaded(true);
-      }
-    })();
-  }, []);
-
-  if (!loaded) return <Text>Loading fonts...</Text>;
-
-  return <Text style={{ fontFamily: 'space-mono' }}>Hello from Space Mono</Text>;
-}
-```
-
-</Collapsible>
-
-[next-fonts]: https://github.com/rohanray/next-fonts
-
-## API
-
-### CLI
-
-Generate static Next.js files into your project.
-
-#### CLI Options
-
-For more information run `yarn next-expo --help` (or `-h`)
-
-| Shortcut | Flag          | Description                                           |
-| -------- | ------------- | ----------------------------------------------------- |
-| `-f`     | `--force`     | Allows replacing existing files                       |
-| `-c`     | `--customize` | Select template files you want to add to your project |
-| `-V`     | `--version`   | output the version number                             |
-
-### Babel
-
-The adapter provides a Babel config [`@expo/next-adapter/babel`](https://github.com/expo/expo-cli/blob/master/packages/next-adapter/src/babel.ts) to simplify setup.
-
-- Always use the universal [`babel-preset-expo`](https://github.com/expo/expo/tree/main/packages/babel-preset-expo)
-  - Provides React Native support for all platforms that Expo supports (web, iOS, Android)
-- When running in the browser, also use `next/babel` preset.
-
-### Config
-
-#### `withExpo`
-
-Wraps your [**next.config.js**](https://nextjs.org/docs#custom-configuration) and adds universal platform support.
-
-- Defines a custom `pageExtensions` which makes webpack resolve **.web.js** before **.js**, we call this feature "platform extensions".
-- Wraps the webpack config in `withUnimodules` from `@expo/webpack-config`
-  - Makes Babel target all Expo, and React Native packages that you've installed
-  - Aliases `react-native` to `react-native-web` in the browser
-  - Defines the platform constants you get in React Native like `__DEV__`
-
-```js
-const { withExpo } = require('@expo/next-adapter');
-
-module.exports = withExpo({
-  /* next.config.js code */
-});
-```
-
-### Document
-
-Next.js uses the **pages/\_document.js** file to augment your app's `<html>` and `<body>` tags. Learn more [here](https://nextjs.org/docs#custom-document).
-
-This adapter provides a default `Document` (extended from Next.js's Document) that you can use to skip all of the React Native setup.
-
-- Registers your app with `AppRegistry` from `react-native-web` to start your project.
-- Implements the `react-native-web` CSS reset.
-
-```js
-import Document, { style, getInitialProps } from '@expo/next-adapter/document';
-```
-
-#### Customizing the Document
-
-If you need more control you can import then recompose the `Document` how you like. This is good for augmenting the `<head />` element or mixing your own styles.
-
-```tsx
-import { getInitialProps } from '@expo/next-adapter/document';
-import Document, { Head, Main, NextScript } from 'next/document';
-import React from 'react';
-
-class CustomDocument extends Document {
-  render() {
-    return (
-      <html>
-        <Head>
-          <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
-        </Head>
-        <body>
-          <Main />
-          <NextScript />
-        </body>
-      </html>
-    );
-  }
-}
-
-// Import the getInitialProps method and assign it to your component to ensure the react-native-web styles are used.
-CustomDocument.getInitialProps = getInitialProps;
-
-// OR...
-
-CustomDocument.getInitialProps = async props => {
-  const result = await getInitialProps(props);
-  // Mutate result...
-  return result;
-};
-
-export default CustomDocument;
-```
-
 ## Limitations or differences comparing to the default Expo for Web
 
-- To get PWA support, use Next.js plugins such as [next-offline][next-offline] instead. Learn more [here][next-pwa].
-- You might need to use the [next-transpile-modules](https://github.com/martpie/next-transpile-modules) plugin to transpile certain third-party modules in order for them to work (such as Emotion).
-- Only the Next.js default page-based routing is supported. You'll need to use a completely different routing solution to do native navigation. We strongly recommend [react-navigation](https://reactnavigation.org/) for this.
+Using Next.js for the web means you will be bundling with the Next.js Webpack config. This will lead to some core differences in how you develop your app vs your website.
+
+- Expo Next.js adapter does not support the experimental app directory.
+- For File-based routing on native, we recommend using [Expo Router](https://github.com/expo/router).
 
 ## Contributing
 
@@ -368,9 +255,25 @@ If you would like to help make Next.js support in Expo better, please feel free 
 
 - [@expo/next-adapter][next-adapter]
 
-If you have any problems rendering a certain component with SSR then you can submit fixes to the expo/expo repo:
+## Troubleshooting
 
-- [Expo SDK packages][expo-packages]
+### Cannot use import statement outside a module
+
+Figure out which module has the import statement and add it to the `transpilePackages` option in `next.config.js`:
+
+```js next.config.js
+const { withExpo } = require('@expo/next-adapter');
+
+module.exports = withExpo({
+  experimental: {
+    transpilePackages: [
+      'react-native',
+      'expo',
+      // Add failing package here, and restart the server...
+    ],
+  },
+});
+```
 
 {/* Footer */}
 
@@ -378,7 +281,4 @@ If you have any problems rendering a certain component with SSR then you can sub
 [nextjs]: https://nextjs.org/
 [next-adapter]: https://github.com/expo/expo-cli/tree/main/packages/next-adapter
 [next-docs]: https://nextjs.org/docs
-[custom-document]: https://nextjs.org/docs#custom-document
-[next-offline]: https://github.com/hanford/next-offline
-[next-pwa]: https://nextjs.org/features/progressive-web-apps
-[next-transpile-modules]: https://github.com/martpie/next-transpile-modules
+[next-optimized-images]: https://github.com/cyrilwanner/next-optimized-images


### PR DESCRIPTION
# Why

- Update the docs to reflect the README https://www.npmjs.com/package/@expo/next-adapter
- Drop outdated guides. 
- fix https://github.com/expo/expo/issues/22403 https://github.com/expo/expo/issues/22453

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
