### PR TITLE
[docs] Fix incorrect EAS Update icon references

### DIFF
--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -5,7 +5,7 @@ description: Learn how to automate and maintain your app store presence from the
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { EasMetadataIcon, UpdateIcon } from '@expo/styleguide-icons';
+import { EasMetadataIcon, LayersTwo02Icon } from '@expo/styleguide-icons';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.
 
@@ -67,7 +67,7 @@ You can also re-use this command when you modify the **store.config.json** file 
 <BoxLink
   title="Instant updates with EAS Update"
   description="Learn how to automate and maintain your app store presence from the command line with EAS Metadata."
-  Icon={UpdateIcon}
+  Icon={LayersTwo02Icon}
   href="/deploy/instant-updates/"
 />
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasSubmitIcon, EasMetadataIcon, UpdateIcon } from '@expo/styleguide-icons';
+import { BuildIcon, EasSubmitIcon, EasMetadataIcon } from '@expo/styleguide-icons';
 
 EAS Build allows you to build a native app binary that is signed for app store submission. These types of builds are called **production builds**.
 

--- a/docs/pages/deploy/instant-updates.mdx
+++ b/docs/pages/deploy/instant-updates.mdx
@@ -5,7 +5,7 @@ description: Learn how to set up EAS Update to push critical bug fixes and impro
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { UpdateIcon } from '@expo/styleguide-icons';
+import { LayersTwo02Icon } from '@expo/styleguide-icons';
 
 **EAS Update** allows making small bug fixes and pushing quick improvements in a snap. It is a hosted service that uses the [`expo-updates`](/versions/latest/sdk/updates/) library to serve updates. It allows an end user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates. In this guide, you will learn how to set up EAS Update for your app.
 
@@ -81,6 +81,6 @@ Once the update is built and uploaded to EAS and the command completes, force cl
 <BoxLink
   title="How EAS Update works"
   description="A conceptual overview of how EAS Update works."
-  Icon={UpdateIcon}
+  Icon={LayersTwo02Icon}
   href="/eas-update/how-eas-update-works/"
 />

--- a/docs/pages/distribution/introduction.mdx
+++ b/docs/pages/distribution/introduction.mdx
@@ -6,7 +6,7 @@ description: An overview of submitting an app to the app stores or with the inte
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { AndroidIcon, AppleIcon, Earth02Icon, UpdateIcon } from '@expo/styleguide-icons';
+import { AndroidIcon, AppleIcon, Earth02Icon, LayersTwo02Icon } from '@expo/styleguide-icons';
 
 Get your app into the hands of users by submitting it to the app stores or with [Internal Distribution](/build/internal-distribution).
 
@@ -61,5 +61,5 @@ This automatically manages **all native code signing** for Android and iOS for a
   title="OTA updates"
   description="Send over-the-air updates to your users instantly."
   href="/eas-update/introduction"
-  Icon={UpdateIcon}
+  Icon={LayersTwo02Icon}
 />

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -4,7 +4,7 @@ description: A list of common questions and limitations about Expo and related s
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasMetadataIcon, UpdateIcon, BellRinging04Icon } from '@expo/styleguide-icons';
+import { BuildIcon, EasMetadataIcon, LayersTwo02Icon, BellRinging04Icon } from '@expo/styleguide-icons';
 
 This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [ Forums](https://forums.expo.io) for more common questions.
 
@@ -123,7 +123,7 @@ For more information on what current limitations exist with EAS, see the followi
   title="EAS Update"
   description="EAS Update is a hosted service that serves updates for projects using the expo-updates library. You can use it to fix small bugs and push quick fixes a snap in between app store submissions. In some situations, not be the right fit for a project. Learn more."
   href="/eas-update/known-issues"
-  Icon={UpdateIcon}
+  Icon={LayersTwo02Icon}
 />
 
 <BoxLink

--- a/docs/ui/components/CommandMenu/expoEntries.ts
+++ b/docs/ui/components/CommandMenu/expoEntries.ts
@@ -6,7 +6,7 @@ import {
   EasSubmitIcon,
   CredentialIcon,
   Key01Icon,
-  LayersThree01Icon,
+  LayersTwo02Icon,
   BranchIcon,
   Cube02Icon,
   Dataflow03Icon,
@@ -61,7 +61,7 @@ export const entries = [
   {
     label: 'Project Updates',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/updates',
-    Icon: LayersThree01Icon,
+    Icon: LayersTwo02Icon,
   },
   {
     label: 'Project Credentials',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8573

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing old icon reference `UpdateIcon` to `LayersTwo02`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes tested locally:

Also, updated Project Updates icon in the Cmdk:

<img width="675" alt="CleanShot 2023-05-16 at 15 27 46@2x" src="https://github.com/expo/expo/assets/10234615/d722a7af-4700-4ee6-8fbf-68dd16f74bf0">

<img width="898" alt="CleanShot 2023-05-16 at 15 28 53@2x" src="https://github.com/expo/expo/assets/10234615/23557a8c-0574-487e-bda9-b5c924d52437">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
