### PR TITLE
[docs] fix Step component layout shift due to SSR

### DIFF
--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -23,9 +23,9 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
       ref={ref}
       className={mergeClasses(
         'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4',
-        '!prose-code:px-0',
+        'prose-code:!px-0 prose-code:!leading-snug',
         alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
-        hideOverflow && 'overflow-hidden prose-code:whitespace-nowrap',
+        hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
         skipPadding && '!p-0',
         className
       )}>

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -78,7 +78,7 @@ function cmdMapper(line: string, index: number) {
   if (line.startsWith('$')) {
     return (
       <div key={key}>
-        <CODE className="whitespace-pre !bg-[transparent] !border-none select-none !text-secondary !px-0">
+        <CODE className="whitespace-pre !bg-[transparent] !border-none select-none !text-secondary">
           -&nbsp;
         </CODE>
         <CODE className="whitespace-pre !bg-[transparent] !border-none text-default">

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -12,7 +12,9 @@ export const Step = ({ children, label }: Props) => {
       <HEADLINE className="flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1">
         {label}
       </HEADLINE>
-      <div className="pt-1 w-full prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">{children}</div>
+      <div className="pt-1 w-full prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
+        {children}
+      </div>
     </div>
   );
 };

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -1,6 +1,3 @@
-import { css } from '@emotion/react';
-import { theme } from '@expo/styleguide';
-import { spacing } from '@expo/styleguide-base';
 import { PropsWithChildren } from 'react';
 
 import { HEADLINE } from '~/ui/components/Text';
@@ -11,44 +8,11 @@ type Props = PropsWithChildren<{
 
 export const Step = ({ children, label }: Props) => {
   return (
-    <div css={stepWrapperStyle}>
-      <HEADLINE css={stepLabelStyle}>{label}</HEADLINE>
-      <div css={stepContentStyle}>{children}</div>
+    <div className="flex gap-4 mt-6 mb-4">
+      <HEADLINE className="flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1">
+        {label}
+      </HEADLINE>
+      <div className="pt-1 prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">{children}</div>
     </div>
   );
 };
-
-const stepWrapperStyle = css({
-  display: 'inline-grid',
-  gridTemplateColumns: `${spacing[7]}px minmax(0, 1fr)`,
-  gap: spacing[4],
-  margin: `${spacing[2]}px 0`,
-  width: '100%',
-});
-
-const stepLabelStyle = css({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  margin: `${spacing[1]}px auto`,
-  width: spacing[7],
-  height: spacing[7],
-  background: theme.background.element,
-  borderRadius: '100%',
-});
-
-const stepContentStyle = css({
-  paddingTop: spacing[1],
-
-  'h2:first-child': {
-    marginTop: `${-spacing[1]}px !important`,
-  },
-
-  'h3:first-child, h4:first-child': {
-    marginTop: `0 !important`,
-  },
-
-  'ul, ol': {
-    marginBottom: 0,
-  },
-});

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -12,7 +12,7 @@ export const Step = ({ children, label }: Props) => {
       <HEADLINE className="flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1">
         {label}
       </HEADLINE>
-      <div className="pt-1 prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">{children}</div>
+      <div className="pt-1 w-full prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
# Why

Fixes ENG-8572
Refs ENG-8566

# How

This PR fixes the `Step` component layout shift. Most of those those problems have their origin in SSR issues of certain pseudo-selectors with Emotion. Full switch to TW in long run should reduce those cases to minimum.

# Test Plan

The changes have been tested by running docs app locally in serve mode (`yarn export && yarn export-server`), since those shifts are not visible in dev mode.
