### PR TITLE
[docs] cleanup and unify snippet components

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -221,7 +221,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
         <SnippetHeader title={value.title}>
           <CopyAction text={cleanCopyValue(value.value)} />
         </SnippetHeader>
-        <SnippetContent skipPadding>
+        <SnippetContent className="p-0">
           <pre css={STYLES_CODE_CONTAINER} {...attributes}>
             <code
               css={STYLES_CODE_BLOCK}

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 import { borderRadius, spacing } from '@expo/styleguide-base';
+import { FileCode01Icon } from '@expo/styleguide-icons';
 import { Language, Prism } from 'prism-react-renderer';
 import * as React from 'react';
 import tippy, { roundArrow } from 'tippy.js';
@@ -218,7 +219,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
 
     return value?.title ? (
       <Snippet>
-        <SnippetHeader title={value.title}>
+        <SnippetHeader title={value.title} Icon={FileCode01Icon}>
           <CopyAction text={cleanCopyValue(value.value)} />
         </SnippetHeader>
         <SnippetContent className="p-0">

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -39,9 +39,7 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
       {codeBlocks.map((codeBlock, index) => (
         <Snippet key={index} css={snippetWrapperStyle}>
           <SnippetHeader title={tabNames[index]} />
-          <SnippetContent skipPadding css={snippetContentStyle}>
-            {codeBlock}
-          </SnippetContent>
+          <SnippetContent className="p-0">{codeBlock}</SnippetContent>
         </Snippet>
       ))}
     </div>
@@ -96,8 +94,4 @@ const snippetWrapperStyle = css({
       marginBottom: spacing[4],
     },
   },
-});
-
-const snippetContentStyle = css({
-  height: '100%',
 });

--- a/docs/ui/components/Snippet/SnippetAction.tsx
+++ b/docs/ui/components/Snippet/SnippetAction.tsx
@@ -1,53 +1,28 @@
-import { css } from '@emotion/react';
-import { shadows, theme, Button, ButtonProps, mergeClasses } from '@expo/styleguide';
-import { palette } from '@expo/styleguide-base';
-import { cloneElement, ReactElement } from 'react';
+import { Button, ButtonProps, mergeClasses } from '@expo/styleguide';
 
 import { FOOTNOTE } from '~/ui/components/Text';
 
 export type SnippetActionProps = ButtonProps & {
-  icon?: ReactElement;
-  iconRight?: ReactElement;
   alwaysDark?: boolean;
 };
 
 export const SnippetAction = (props: SnippetActionProps) => {
-  const { children, icon, iconRight, alwaysDark = false, ...rest } = props;
-
-  const styledIcon =
-    icon &&
-    cloneElement(icon, {
-      className: mergeClasses('icon-sm', alwaysDark && 'text-palette-white'),
-    });
+  const { children, leftSlot, rightSlot, alwaysDark = false, ...rest } = props;
 
   return (
     <Button
       size="xs"
       theme="quaternary"
-      leftSlot={styledIcon}
-      rightSlot={iconRight}
-      css={[!alwaysDark && snippetActionStyle, alwaysDark && alwaysDarkStyle]}
+      leftSlot={leftSlot}
+      rightSlot={rightSlot}
       className={mergeClasses(
-        !alwaysDark && 'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4',
-        alwaysDark && 'border-transparent bg-[transparent]'
+        alwaysDark &&
+          'dark-theme border-transparent bg-[transparent] hocus:shadow-xs hocus:border-palette-gray9 hocus:bg-palette-gray5',
+        !alwaysDark &&
+          'border-0 rounded-none border-l border-l-default h-10 leading-10 px-4 hocus:bg-subtle hocus:shadow-none'
       )}
       {...rest}>
       <FOOTNOTE className={mergeClasses(alwaysDark && '!text-palette-white')}>{children}</FOOTNOTE>
     </Button>
   );
 };
-
-const snippetActionStyle = css({
-  ':hover': {
-    backgroundColor: theme.background.subtle,
-    boxShadow: 'none',
-  },
-});
-
-const alwaysDarkStyle = css({
-  ':hover': {
-    borderColor: palette.dark.gray9,
-    background: palette.dark.gray5,
-    boxShadow: shadows.xs,
-  },
-});

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -4,29 +4,18 @@ import { forwardRef, PropsWithChildren } from 'react';
 export type SnippetContentProps = PropsWithChildren<{
   alwaysDark?: boolean;
   hideOverflow?: boolean;
-  skipPadding?: boolean;
   className?: string;
 }>;
 
 export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
-  (
-    {
-      children,
-      className,
-      alwaysDark = false,
-      hideOverflow = false,
-      skipPadding = false,
-    }: SnippetContentProps,
-    ref
-  ) => (
+  ({ children, className, alwaysDark = false, hideOverflow = false }: SnippetContentProps, ref) => (
     <div
       ref={ref}
       className={mergeClasses(
         'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4',
-        '!prose-code:px-0',
+        'prose-code:!px-0 prose-code:!leading-snug',
         alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
-        hideOverflow && 'overflow-hidden prose-code:whitespace-nowrap',
-        skipPadding && '!p-0',
+        hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
         className
       )}>
       {children}

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -1,25 +1,33 @@
 import { mergeClasses } from '@expo/styleguide';
-import { PropsWithChildren } from 'react';
+import { ComponentType, HTMLAttributes, PropsWithChildren } from 'react';
 
 import { LABEL } from '~/ui/components/Text';
 
 type SnippetHeaderProps = PropsWithChildren<{
   title: string;
+  Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
   alwaysDark?: boolean;
 }>;
 
-export const SnippetHeader = ({ title, children, alwaysDark = false }: SnippetHeaderProps) => (
+export const SnippetHeader = ({
+  title,
+  children,
+  Icon,
+  alwaysDark = false,
+}: SnippetHeaderProps) => (
   <div className={mergeClasses(alwaysDark && 'dark-theme')}>
     <div
       className={mergeClasses(
         'flex pl-4 overflow-hidden justify-between bg-default border border-default rounded-t-md border-b-0',
+        Icon && 'pl-3',
         alwaysDark && 'pr-2 dark:border-transparent !bg-palette-gray3'
       )}>
       <LABEL
         className={mergeClasses(
-          'h-10 !leading-10 pr-4 select-none font-medium text-ellipsis whitespace-nowrap overflow-hidden',
+          'flex items-center gap-2 h-10 !leading-10 pr-4 select-none font-medium text-ellipsis whitespace-nowrap overflow-hidden',
           alwaysDark && 'text-palette-white'
         )}>
+        {Icon && <Icon className="icon-sm" />}
         {title}
       </LABEL>
       {!!children && <div className="flex justify-end items-center">{children}</div>}

--- a/docs/ui/components/Snippet/actions/CopyAction.tsx
+++ b/docs/ui/components/Snippet/actions/CopyAction.tsx
@@ -16,7 +16,11 @@ export const CopyAction = ({ text, ...rest }: CopyActionProps) => {
   };
 
   return (
-    <SnippetAction icon={<ClipboardIcon />} onClick={onCopyClick} disabled={copyDone} {...rest}>
+    <SnippetAction
+      leftSlot={<ClipboardIcon className="icon-sm text-icon-default" />}
+      onClick={onCopyClick}
+      disabled={copyDone}
+      {...rest}>
       {copyDone ? 'Copied!' : 'Copy'}
     </SnippetAction>
   );

--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -49,7 +49,7 @@ export const DiffBlock = ({ source, raw }: Props) => {
   }: RenderLine) => (
     <Snippet key={oldRevision + '-' + newRevision}>
       <SnippetHeader title={newPath} />
-      <SnippetContent skipPadding hideOverflow>
+      <SnippetContent className="p-0" hideOverflow>
         <Diff viewType="unified" diffType={type} hunks={hunks}>
           {(hunks: any[]) => hunks.map(hunk => <Hunk key={hunk.content} hunk={hunk} />)}
         </Diff>

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -75,8 +75,8 @@ export const SnackInline = ({
 
   return (
     <Snippet className="flex flex-col mb-3 prose-pre:!m-0 prose-pre:!border-0">
-      <SnippetHeader title={label || 'Example'}>
-        <form action={SNACK_URL} method="POST" target="_blank">
+      <SnippetHeader title={label || 'Example'} Icon={SnackLogo}>
+        <form action={SNACK_URL} method="POST" target="_blank" className="contents">
           <input type="hidden" name="platform" value={defaultPlatform || DEFAULT_PLATFORM} />
           <input type="hidden" name="name" value={label || 'Example'} />
           <input type="hidden" name="dependencies" value={dependencies.join(',')} />
@@ -101,7 +101,6 @@ export const SnackInline = ({
           <CopyAction text={cleanCopyValue(getCode())} />
           <SnippetAction
             disabled={!isReady}
-            leftSlot={<SnackLogo className="icon-sm" />}
             rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}
             type="submit">
             {buttonTitle || 'Open in Snack'}

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -1,5 +1,4 @@
-import { css } from '@emotion/react';
-import { SnackLogo } from '@expo/styleguide';
+import { mergeClasses, SnackLogo } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { useEffect, useRef, useState, PropsWithChildren } from 'react';
 
@@ -9,8 +8,10 @@ import { SnippetContent } from '../SnippetContent';
 import { SnippetHeader } from '../SnippetHeader';
 
 import { SNACK_URL, getSnackFiles } from '~/common/snack';
+import { cleanCopyValue } from '~/components/base/code';
 import { PageApiVersionContextType, usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
+import { CopyAction } from '~/ui/components/Snippet/actions/CopyAction';
 
 const DEFAULT_PLATFORM = 'android';
 const { LATEST_VERSION } = versions;
@@ -73,7 +74,7 @@ export const SnackInline = ({
   };
 
   return (
-    <Snippet css={inlineSnackWrapperStyle} className="flex flex-col mb-3">
+    <Snippet className="flex flex-col mb-3 prose-pre:!m-0 prose-pre:!border-0">
       <SnippetHeader title={label || 'Example'}>
         <form action={SNACK_URL} method="POST" target="_blank">
           <input type="hidden" name="platform" value={defaultPlatform || DEFAULT_PLATFORM} />
@@ -97,25 +98,19 @@ export const SnackInline = ({
               )}
             />
           )}
+          <CopyAction text={cleanCopyValue(getCode())} />
           <SnippetAction
             disabled={!isReady}
-            icon={<SnackLogo />}
-            iconRight={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}
+            leftSlot={<SnackLogo className="icon-sm" />}
+            rightSlot={<ArrowUpRightIcon className="icon-sm text-icon-secondary" />}
             type="submit">
             {buttonTitle || 'Open in Snack'}
           </SnippetAction>
         </form>
       </SnippetHeader>
-      <SnippetContent ref={contentRef} css={contentHidden && css({ display: 'none' })} skipPadding>
+      <SnippetContent ref={contentRef} className={mergeClasses('p-0', contentHidden && 'hidden')}>
         {children}
       </SnippetContent>
     </Snippet>
   );
 };
-
-const inlineSnackWrapperStyle = css({
-  pre: {
-    margin: 0,
-    border: 0,
-  },
-});

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { spacing } from '@expo/styleguide-base';
+import { TerminalSquareIcon } from '@expo/styleguide-icons';
 
 import { Snippet } from '../Snippet';
 import { SnippetContent } from '../SnippetContent';
@@ -24,7 +25,7 @@ export const Terminal = ({
   title = 'Terminal',
 }: TerminalProps) => (
   <Snippet css={wrapperStyle} includeMargin={includeMargin}>
-    <SnippetHeader alwaysDark title={title}>
+    <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
     <SnippetContent alwaysDark hideOverflow={hideOverflow}>


### PR DESCRIPTION
# Why

During latest changes I have spotted that we can simplify and unify the various Snippets code.

# How

Add "Copy" ability to Snack snippets, add snippets header icons based on the type, make sure that snippet action buttons are styled correctly, rewrite most of Emotion styles to TW.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="1098" alt="Screenshot 2023-05-16 at 13 08 46" src="https://github.com/expo/expo/assets/719641/921b496d-b7e5-42eb-a707-238c413ff589">
<img width="434" alt="Screenshot 2023-05-16 at 13 05 26" src="https://github.com/expo/expo/assets/719641/db37529f-1126-424a-a06f-2e52da5d9dca">



