### PR TITLE
[et] Publish client to S3 and update versions endpoint

### DIFF
--- a/apps/eas-expo-go/app.config.ts
+++ b/apps/eas-expo-go/app.config.ts
@@ -46,6 +46,16 @@ const mapBuildProfileToConfig: Record<string, ExpoConfig> = {
       },
     },
   },
+  'publish-client': {
+    ...base,
+    slug: 'release-expo-go',
+    name: 'Expo Go',
+    extra: {
+      eas: {
+        projectId: '79a64298-2d61-42ae-9cc9-b2a358d6869e',
+      },
+    },
+  },
 };
 
 const buildType = process.env.EAS_BUILD_PROFILE;

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -104,6 +104,7 @@
         "cache": {
           "disabled": true
         },
+        "withoutCredentials": false,
         "gradleCommand": ":app:assembleVersionedRelease"
       },
       "ios": {

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -93,6 +93,27 @@
         },
         "simulator": false
       }
+    },
+    "publish-client": {
+      "extends": "versioned-client",
+      "env": {
+        "EAS_BUILD_PROFILE": "publish-client"
+      },
+      "android": {
+        "autoIncrement": "versionCode",
+        "cache": {
+          "disabled": true
+        },
+        "gradleCommand": ":app:assembleVersionedRelease"
+      },
+      "ios": {
+        "resourceClass": "m-large",
+        "autoIncrement": "buildNumber",
+        "cache": {
+          "disabled": true
+        },
+        "simulator": true
+      }
     }
   },
   "submit": {

--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -47,3 +47,23 @@ if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
 
   notify_slack "$TITLE" "$MESSAGE"
 fi
+
+if [[ "$EAS_BUILD_PROFILE" == "publish-client" ]]; then
+  SLUG="publish-client"
+  COMMIT_HASH="$(git rev-parse HEAD)"
+  COMMIT_AUTHOR="$(git log --pretty=format:"%an - %ae" | head -n 1)"
+
+  EAS_BUILD_MESSAGE_PART="EAS Build: <https://expo.dev/accounts/expo-ci/projects/$SLUG/builds/$EAS_BUILD_ID|$EAS_BUILD_ID>"
+  GITHUB_MESSAGE_PART="GitHub: <https://github.com/expo/expo/commit/$COMMIT_HASH|$COMMIT_HASH>"
+
+  MESSAGE="Release triggered by: $EAS_BUILD_USERNAME\\nCommit author: $COMMIT_AUTHOR\\n$EAS_BUILD_MESSAGE_PART\\n$GITHUB_MESSAGE_PART"
+
+  source $ROOT_DIR/secrets/expotools.env
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    et eas android-apk-publish
+    notify_slack "Successfull Expo Go Android APK build. Published to S3 and updated staging versions endpoint" "$MESSAGE"
+  elif [[ "$EAS_BUILD_PLATFORM" == "ios" ]]; then
+    et eas ios-simulator-publish
+    notify_slack "Successfull Expo Go iOS simulator build. Published to S3 and updated staging versions endpoint" "$MESSAGE"
+  fi
+fi

--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -11,7 +11,7 @@ if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
   sdkmanager "cmake;3.22.1"
 fi
 
-if [ "$EAS_BUILD_PROFILE" = "release-client" ]; then
+if [ "$EAS_BUILD_PROFILE" = "release-client" ] || [ "$EAS_BUILD_PROFILE" = "publish-client" ]; then
   if [ "$EAS_BUILD_PLATFORM" = "android" ]; then
     sudo apt-get -y update
     sudo apt-get -y install git-crypt

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -2,16 +2,25 @@ import { Command } from '@expo/commander';
 import plist from '@expo/plist';
 import spawnAsync from '@expo/spawn-async';
 import assert from 'assert';
+import aws from 'aws-sdk';
 import fs, { mkdirp } from 'fs-extra';
 import glob from 'glob-promise';
+import inquirer from 'inquirer';
+import fetch from 'node-fetch';
 import os from 'os';
 import path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 
 import { EXPO_DIR } from '../Constants';
+import Git from '../Git';
 import logger from '../Logger';
+import { androidAppVersionAsync, iosAppVersionAsync } from '../ProjectVersions';
+import { modifySdkVersionsAsync } from '../Versions';
+
+const s3Client = new aws.S3({ region: 'us-east-1' });
 
 const RELEASE_BUILD_PROFILE = 'release-client';
+const PUBLISH_CLIENT_BUILD_PROFILE = 'publish-client';
 
 type Action = {
   name: string;
@@ -26,15 +35,37 @@ const CUSTOM_ACTIONS: Record<string, Action> = {
     actionId: 'ios-client-build-and-submit',
     action: iosBuildAndSubmitAsync,
   },
+  'ios-simulator-client-build-and-publish': {
+    name: 'Build a new iOS Client simulator and publish it to S3',
+    actionId: 'ios-simulator-client-build-and-publish',
+    action: iosSimulatorBuildAndPublishAsync,
+  },
   'android-client-build-and-submit': {
     name: 'Build a new Android client and submit it to the Play Store.',
     actionId: 'android-client-build-and-submit',
     action: androidBuildAndSubmitAsync,
   },
+  'android-apk-build-and-publish': {
+    name: 'Build a new Android client APK and publish it to S3',
+    actionId: 'android-apk-build-and-publish',
+    action: androidAPKBuildAndPublishAsync,
+  },
   'remove-background-permissions-from-info-plist': {
-    name: 'Removes permissions for background features that should be disabled in the App Store.',
+    name: '[internal] Removes permissions for background features that should be disabled in the App Store.',
     actionId: 'remove-background-permissions-from-info-plist',
     action: internalRemoveBackgroundPermissionsFromInfoPlistAsync,
+    internal: true,
+  },
+  'ios-simulator-publish': {
+    name: '[internal] Upload simulator builds to S3 and update www endpoint',
+    actionId: 'ios-simulator-publish',
+    action: internalIosSimulatorPublishAsync,
+    internal: true,
+  },
+  'android-apk-publish': {
+    name: '[internal] Upload Android client to S3 and update www endpoint',
+    actionId: 'android-apk-publish',
+    action: internalAndroidAPKPublishAsync,
     internal: true,
   },
 };
@@ -63,7 +94,47 @@ async function main(actionId: string | undefined) {
   CUSTOM_ACTIONS[actionId].action();
 }
 
+function getAndroidApkUrl(appVersion: string): string {
+  return `https://d1ahtucjixef4r.cloudfront.net/Exponent-${appVersion}.apk`;
+}
+
+function getIosSimulatorUrl(appVersion: string): string {
+  return `https://dpq5q02fu5f55.cloudfront.net/Exponent-${appVersion}.tar.gz`;
+}
+
+async function confirmPromptIfOverridingRemoteFileAsync(
+  url: string,
+  appVersion: string
+): Promise<void> {
+  const response = await fetch(url, {
+    method: 'HEAD',
+  });
+  if (response.status < 400) {
+    const { selection } = await inquirer.prompt<{ selection: boolean }>([
+      {
+        type: 'confirm',
+        name: 'selection',
+        default: false,
+        message: `${appVersion} version of a client was already uploaded to S3. Do you want to override it?`,
+      },
+    ]);
+    if (!selection) {
+      throw new Error('ABORTING');
+    }
+  }
+}
+
+async function enforceRunningOnSdkReleaseBranchAsync(): Promise<string> {
+  const sdkBranchVersion = await Git.getSDKVersionFromBranchNameAsync();
+  if (!sdkBranchVersion) {
+    logger.error(`Client builds can be released only from the release branch!`);
+    throw new Error('ABORTING');
+  }
+  return sdkBranchVersion;
+}
+
 async function iosBuildAndSubmitAsync() {
+  await enforceRunningOnSdkReleaseBranchAsync();
   const isDebug = !!process.env.EXPO_DEBUG;
   const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
   const credentialsDir = path.join(projectDir, 'credentials');
@@ -71,6 +142,7 @@ async function iosBuildAndSubmitAsync() {
   const releaseSecretsPath = path.join(credentialsDir, 'secrets');
   const isDarwin = os.platform() === 'darwin';
 
+  logger.info('Preparing credentials');
   try {
     await mkdirp(fastlaneMatchBucketCopyPath);
     await mkdirp(releaseSecretsPath);
@@ -174,13 +246,28 @@ async function iosBuildAndSubmitAsync() {
   );
 }
 
-async function androidBuildAndSubmitAsync() {
-  const isDebug = !!process.env.EXPO_DEBUG;
+async function iosSimulatorBuildAndPublishAsync() {
   const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  await enforceRunningOnSdkReleaseBranchAsync();
+
+  const appVersion = await iosAppVersionAsync();
+  await confirmPromptIfOverridingRemoteFileAsync(getIosSimulatorUrl(appVersion), appVersion);
+
+  await spawnAsync(
+    'eas',
+    ['build', '--platform', 'ios', '--profile', PUBLISH_CLIENT_BUILD_PROFILE],
+    {
+      cwd: projectDir,
+      stdio: 'inherit',
+    }
+  );
+}
+
+async function prepareAndroidCredentialsAsync(projectDir: string): Promise<void> {
+  const isDebug = !!process.env.EXPO_DEBUG;
   const credentialsDir = path.join(projectDir, 'credentials');
   const releaseSecretsPath = path.join(credentialsDir, 'secrets');
   await mkdirp(releaseSecretsPath);
-
   const keystorePath = path.join(releaseSecretsPath, 'android-keystore.jks');
   const keystorePasswordPath = path.join(releaseSecretsPath, 'android-keystore.password');
   const keystoreAliasPasswordPath = path.join(
@@ -217,6 +304,12 @@ async function androidBuildAndSubmitAsync() {
     }
     throw err;
   }
+}
+
+async function androidBuildAndSubmitAsync() {
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  await enforceRunningOnSdkReleaseBranchAsync();
+  await prepareAndroidCredentialsAsync(projectDir);
 
   await spawnAsync(
     'eas',
@@ -235,6 +328,28 @@ async function androidBuildAndSubmitAsync() {
   await spawnAsync(
     'eas',
     ['build:version:sync', '--platform', 'android', '--profile', RELEASE_BUILD_PROFILE],
+    {
+      cwd: projectDir,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID: 'host.exp.exponent',
+      },
+    }
+  );
+}
+
+async function androidAPKBuildAndPublishAsync() {
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  await enforceRunningOnSdkReleaseBranchAsync();
+  await prepareAndroidCredentialsAsync(projectDir);
+
+  const appVersion = await androidAppVersionAsync();
+  await confirmPromptIfOverridingRemoteFileAsync(getAndroidApkUrl(appVersion), appVersion);
+
+  await spawnAsync(
+    'eas',
+    ['build', '--platform', 'android', '--profile', PUBLISH_CLIENT_BUILD_PROFILE],
     {
       cwd: projectDir,
       stdio: 'inherit',
@@ -265,4 +380,72 @@ async function internalRemoveBackgroundPermissionsFromInfoPlistAsync(): Promise<
     (i: string) => !['location', 'audio', 'remote-notification'].includes(i)
   );
   await fs.writeFile(INFO_PLIST_PATH, plist.build(parsedPlist));
+}
+
+async function internalIosSimulatorPublishAsync() {
+  const tmpTarGzPath = path.join(os.tmpdir(), 'simulator.tar.gz');
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  const sdkVersion = await enforceRunningOnSdkReleaseBranchAsync();
+  const artifactPaths = glob.sync('ios/build/Build/Products/*simulator/*.app', {
+    absolute: true,
+    cwd: projectDir,
+  });
+
+  if (artifactPaths.length !== 1) {
+    logger.error(`Expected exactly one .app directory. Found: ${artifactPaths}.`);
+  }
+  await spawnAsync('tar', ['-zcvf', tmpTarGzPath, '-C', artifactPaths[0], '.'], {
+    stdio: ['ignore', 'ignore', 'inherit'], // only stderr
+  });
+  const appVersion = await iosAppVersionAsync();
+  const file = fs.createReadStream(tmpTarGzPath);
+
+  logger.info(`Uploading Exponent-${appVersion}.tar.gz to S3`);
+  await s3Client
+    .putObject({
+      Bucket: 'exp-ios-simulator-apps',
+      Key: `Exponent-${appVersion}.tar.gz`,
+      Body: file,
+      ACL: 'public-read',
+    })
+    .promise();
+
+  logger.info('Updating versions endpoint');
+  await modifySdkVersionsAsync(sdkVersion, (sdkVersions) => {
+    sdkVersions.iosClientUrl = getIosSimulatorUrl(appVersion);
+    sdkVersions.iosClientVersion = appVersion;
+    return sdkVersions;
+  });
+}
+
+async function internalAndroidAPKPublishAsync() {
+  const projectDir = path.join(EXPO_DIR, 'apps/eas-expo-go');
+  const sdkVersion = await enforceRunningOnSdkReleaseBranchAsync();
+  const artifactPaths = glob.sync('android/app/build/outputs/**/*.apk', {
+    absolute: true,
+    cwd: projectDir,
+  });
+
+  if (artifactPaths.length !== 1) {
+    logger.error(`Expected exactly one .apk file. Found: ${artifactPaths}`);
+  }
+  const appVersion = await androidAppVersionAsync();
+  const file = fs.createReadStream(artifactPaths[0]);
+
+  logger.info(`Uploading Exponent-${appVersion}.apk to S3`);
+  await s3Client
+    .putObject({
+      Bucket: 'exp-android-apks',
+      Key: `Exponent-${appVersion}.apk`,
+      Body: file,
+      ACL: 'public-read',
+    })
+    .promise();
+
+  logger.info('Updating versions endpoint');
+  await modifySdkVersionsAsync(sdkVersion, (sdkVersions) => {
+    sdkVersions.androidClientUrl = getAndroidApkUrl(appVersion);
+    sdkVersions.androidClientVersion = appVersion;
+    return sdkVersions;
+  });
 }


### PR DESCRIPTION
# Why

Add commands to publish ios simulator and android apk to S3 and update versions endpoint.

# How

Add new publish-client profile to eas.json
- on android, it builds signed APK
- on iOS it builds a simulator
- in the on-success hook upload artifacts to S3, updates versions endpoint and send notification to slack.

# Test Plan

- created sdk-49 branch and run `et eas ios-simulator-client-build-and-publish`
  - verified that versions endpoint on staging was updated
  - fetched that tar.gz via URL from versions endpoint
  - notification was delivered to sdk-release channel
  
# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
