### PR TITLE
[docs] update `debugging/runtime-issues` URLs to avoid redirects

### DIFF
--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -21,7 +21,7 @@ Before you go further, you need to be sure that you have located the error messa
 
 ### Runtime errors
 
-Refer to the [debugging guide](/debugging/runtime-issue/#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
+Refer to the [debugging guide](/debugging/runtime-issues/#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
 
 ### Build errors
 

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -14,7 +14,7 @@ A Redbox error is displayed when a fatal error prevents your app from running. A
 
 You can also create warnings and errors on your own with `console.warn("Warning message")` and `console.error("Error message")`. Another way to trigger the redbox is to throw an error and not catch it: `throw Error("Error message")`.
 
-> This is a brief introduction to debugging a React Native app with Expo CLI. For in-depth information, see [Debugging](/debugging/runtime-issue/).
+> This is a brief introduction to debugging a React Native app with Expo CLI. For in-depth information, see [Debugging](/debugging/runtime-issues/).
 
 ## Stack traces
 

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -52,7 +52,7 @@ If you add a library to your project that contains native code APIs, for example
 
 When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> or <kbd>Ctrl</kbd> + <kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, any debugging functionality you need, or switch to a different version of your app.
 
-See [Debugging](/debugging/runtime-issue/) guide for more information.
+See [Debugging](/debugging/runtime-issues/) guide for more information.
 
 ## Next step
 

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -255,13 +255,13 @@ We also provide a [step-by-step guide to try out EAS Update quickly](/eas-update
 sed -i '' 's/SKIP_BUNDLING/FORCE_BUNDLING/g;' ios/&lt;project name&gt;.xcodeproj/project.pbxproj
 ```
 
-- Execute a [debug build](/debugging/runtime-issue/#native-debugging) of the app with Xcode or from the command line.
+- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Xcode or from the command line.
 
 #### Android local builds
 
 - Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
 - [Ensure the desired channel is set in your **AndroidManifest.xml**](/bare/updating-your-app/#configuring-the-channel-manually)
-- Execute a [debug build](/debugging/runtime-issue/#native-debugging) of the app with Android Studio or from the command line.
+- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Android Studio or from the command line.
 
 #### EAS Build
 

--- a/docs/pages/guides/errors.mdx
+++ b/docs/pages/guides/errors.mdx
@@ -19,6 +19,6 @@ We recommend using [Sentry](/guides/using-sentry) to track JavaScript errors in 
 
 ## Native errors
 
-You can compile your project locally to use first-party native debuggers (Xcode/Android Studio). See [native debugging guide](/debugging/runtime-issue/#native-debugging) for more information.
+You can compile your project locally to use first-party native debuggers (Xcode/Android Studio). See [native debugging guide](/debugging/runtime-issues/#native-debugging) for more information.
 
 Unlike the browser, there are a few circumstances where it's possible to crash the native app by writing invalid JavaScript. Usually, these are in areas where it would be performance-prohibitive to add native validation to your code, e.g. the part of the React Native bridge that converts JS objects into typed native values. If you encounter an inexplicable native crash, double check that your parameters are of the right type. These types of issues can be mitigated by [using TypeScript](/guides/typescript).

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -149,7 +149,7 @@ You can compile your app locally with the `run` commands:
 
 `npx expo run:ios` can only be run on a Mac, and Xcode must be installed. You can build the app in the cloud from any computer using `eas build -p ios`. Similarly, `npx expo run:android` requires Android Studio and Java to be installed and configured on your computer.
 
-Building locally is useful for developing native modules and [debugging complex native issues](/debugging/runtime-issue/#native-debugging). Building remotely with `eas build` is a much more resilient option due to the pre-configured cloud environment.
+Building locally is useful for developing native modules and [debugging complex native issues](/debugging/runtime-issues/#native-debugging). Building remotely with `eas build` is a much more resilient option due to the pre-configured cloud environment.
 
 If your project does not have the corresponding native directories, the `npx expo prebuild` command will run once to generate the respective directory before building.
 

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -13,7 +13,7 @@ Expo is an [open-source framework](https://github.com/expo/expo/) for apps that 
 
 - **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
 
-There are plenty of other features and best practices to continue exploring along the way, such as [collaborating with your team](/accounts/account-types/#organizations), using [Expo modules](/versions/latest/), [debugging](/debugging/runtime-issue/), and working on the command line with [Expo CLI](/workflow/expo-cli).
+There are plenty of other features and best practices to continue exploring along the way, such as [collaborating with your team](/accounts/account-types/#organizations), using [Expo modules](/versions/latest/), [debugging](/debugging/runtime-issues/), and working on the command line with [Expo CLI](/workflow/expo-cli).
 
 ## Next step
 

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -40,7 +40,7 @@ We had one screen in the tutorial app. Most apps have multiple screens. See [Rou
 
 ### Debugging
 
-Sometimes things go wrong, and when they do, you'll need to use debugging tools to find and fix errors. See [Debugging](/debugging/runtime-issue/).
+Sometimes things go wrong, and when they do, you'll need to use debugging tools to find and fix errors. See [Debugging](/debugging/runtime-issues/).
 
 ### Gestures and Animations
 

--- a/docs/pages/workflow/development-mode.mdx
+++ b/docs/pages/workflow/development-mode.mdx
@@ -12,7 +12,7 @@ Your project will always run in either **development** or **production** mode. B
 
 ## Development mode
 
-React Native includes some very useful tools for development: remote JavaScript debugging in Chrome, live reload, hot reloading, and an element inspector similar to the beloved inspector you use in Chrome. If you want to see how to use those tools, see [Debugging](/debugging/runtime-issue/).
+React Native includes some very useful tools for development: remote JavaScript debugging in Chrome, live reload, hot reloading, and an element inspector similar to the beloved inspector you use in Chrome. If you want to see how to use those tools, see [Debugging](/debugging/runtime-issues/).
 
 Development mode also performs validations while your app is running to give you warnings if, for example, you're using a deprecated property or if you forgot to pass a required property into a component. The video below shows the Element Inspector and Performance Monitor in action on both Android and iOS simulators:
 

--- a/docs/pages/workflow/logging.mdx
+++ b/docs/pages/workflow/logging.mdx
@@ -15,7 +15,7 @@ You can view **high fidelity** logs and use advanced logging functions like `con
 
 ## Native logs
 
-You can view native runtime logs in Android Studio and Xcode by compiling the native app locally. For more information, see [native debugging](/debugging/runtime-issue/#native-debugging).
+You can view native runtime logs in Android Studio and Xcode by compiling the native app locally. For more information, see [native debugging](/debugging/runtime-issues/#native-debugging).
 
 ## System logs
 


### PR DESCRIPTION
# Why

If possible, we should updated the internally used URLs when we change the page name/location.

The redirect functionality should be mostly reserve for the external users.

# How

Correct the internal links to `/debugging/runtime-issue` page.

# Test Plan

the changes have been tested by running docs app locally.
