### PR TITLE
[docs] small improvements to staring pages, support image in BoxLink

### DIFF
--- a/docs/pages/develop/project-structure.mdx
+++ b/docs/pages/develop/project-structure.mdx
@@ -9,7 +9,7 @@ When you create a new Expo project, a few files and folders are provided by defa
 
 ## App.js
 
-The **App.js** file is the default screen of your project. It is the root file that you'll load after running the development server with `npx expo start` or `yarn expo start`. You can edit this file to see the project update instantly. Generally, this file will contain root-level React Contexts and navigation.
+The **App.js** file is the default screen of your project. It is the root file that you'll load after running the development server with `npx expo start`. You can edit this file to see the project update instantly. Generally, this file will contain root-level React Contexts and navigation.
 
 > [Expo Router](https://expo.github.io/router/docs) is now available and supports file-based navigation in projects. With Expo Router, the route file will become **index.js** and all the screens in the project will be in the **app** folder.
 
@@ -31,7 +31,7 @@ The standard files listed below are part of every project created with Expo CLI.
 
 ### .gitignore
 
-A `.gitignore` allows you to list files and folders that you don't want to be tracked by Git. You can modify the files to list other files and folders in your project. Generally, the default list is sufficient for most projects.
+A **.gitignore** allows you to list files and folders that you don't want to be tracked by Git. You can modify the files to list other files and folders in your project. Generally, the default list is sufficient for most projects.
 
 ### babel.config.js
 
@@ -39,7 +39,7 @@ Applies the `babel-preset-expo` preset that extends the default React Native pre
 
 ### package.json
 
-The `package.json` file contains the project's dependencies and scripts. Anytime a new dependency is added to your project, it will be added to this file.
+The **package.json** file contains the project's dependencies, scripts and metadata. Anytime a new dependency is added to your project, it will be added to this file.
 
 You can also modify the `scripts` to add or remove them. Four default scripts are provided to trigger the development server of your project such as `expo start`, `expo start --android`, `expo start --ios`, and `expo start --web`.
 

--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -3,7 +3,7 @@ title: Next steps
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Brush01Icon, Settings02Icon } from '@expo/styleguide-icons';
+import { Brush01Icon, Settings02Icon, TableIcon } from "@expo/styleguide-icons";
 
 The following resources are useful when learning more about User Interface.
 
@@ -16,7 +16,7 @@ The following resources are useful when learning more about User Interface.
 
 <BoxLink
   title="UI component libraries"
-  Icon={Brush01Icon}
+  Icon={TableIcon}
   description="Learn about different UI libraries available in Expo and React Native ecosystem."
   href="/ui-programming/user-interface-libraries/"
 />

--- a/docs/pages/develop/user-interface/store-data.mdx
+++ b/docs/pages/develop/user-interface/store-data.mdx
@@ -3,7 +3,6 @@ title: Store data
 description: Learn about different libraries available to store data in your Expo project.
 ---
 
-import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 
 Storing data can be essential to the features implemented in your mobile app. There are different ways to save data in your Expo project depending on the type of data you want to store and the security requirements of your app. This page lists a variety of libraries to help you decide which solution is best for your project.
@@ -16,6 +15,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
   title="SecureStore API reference"
   description="For more information on how to install and use expo-secure-store, see its API documentation."
   href="/versions/latest/sdk/securestore"
+  imageUrl="/static/images/packages/expo-secure-store.png"
 />
 
 ## FileSystem
@@ -26,6 +26,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
   title="FileSystem API reference"
   description="For more information on how to install and use expo-file-system, see its API documentation."
   href="/versions/latest/sdk/filesystem"
+  imageUrl="/static/images/packages/expo-file-system.png"
 />
 
 ## Expo SQLite
@@ -46,6 +47,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
   title="Async Storage documentation"
   description="For more information on how to install and use Async Storage, see its documentation."
   href="https://react-native-async-storage.github.io/async-storage/docs/usage"
+  imageUrl="https://react-native-async-storage.github.io/async-storage/img/logo.svg"
 />
 
 ## Other libraries

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -39,7 +39,7 @@ To initialize a new project, use [`create-expo-app`](/more/glossary-of-terms/#cr
 To start the development server, run the following command:
 
 <Terminal
-  cmd={['$ npx expo start', '', '# If using yarn', '$ yarn expo start']}
+  cmd={['$ npx expo start']}
   cmdCopy="npx expo start"
 />
 
@@ -82,13 +82,13 @@ If you are using an emulator/simulator, you may find the following Expo CLI keyb
 
 </Step>
 
-<Step label="3">
+<Step label="4">
 
 ## Make your first change in App.js
 
 Now, all the steps are completed to get started, you can open **App.js** file in your code editor and change the contents of the existing `<Text>` to `Hello, world!`. You are going to see it update on your device.
 
-_Amazing, progress!_ You now have the Expo toolchain running on your machine, can edit the source code for a project, and see the changes live on your device.
+Amazing, progress! You now have the Expo toolchain running on your machine, can edit the source code for a project, and see the changes live on your device.
 
 <Collapsible summary="Changes not showing up on your device?">
 
@@ -96,8 +96,8 @@ Expo Go is configured by default to automatically reload the app whenever a file
 
 - Make sure you have the [development mode enabled in Expo CLI](/workflow/development-mode#development-mode).
 - Close the Expo app and reopen it.
-- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>Ctrl</kbd> + <kbd>m</kbd> for Android or <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> for iOS.
-- If you see `Enable Fast Refresh`, press it. If you see `Disable Fast Refresh`, dismiss the developer menu. Now try making another change.
+- Once the app is open again, shake your device to reveal the developer menu. If you are using an emulator, press <kbd>Ctrl</kbd> + <kbd>M</kbd> for Android or <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> for iOS.
+- If you see **Enable Fast Refresh**, press it. If you see **Disable Fast Refresh**, dismiss the developer menu. Now try making another change.
 
   <ImageSpotlight
     alt="Developer menu in Expo Go app."

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -6,16 +6,16 @@ description: Learn how to get started creating a new Expo project quickly and ea
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ExpoGoLogo } from '@expo/styleguide';
+import { CALLOUT } from "~/ui/components/Text";
 
 To develop applications with Expo, you will want to start with two tools:
 
 - [Expo CLI](#expo-cli) a command-line tool to serve your project
-- [Expo Go](#expo-go-app-for-android-and-ios) a mobile client app to open the project on Android and iOS platforms.
+- [Expo Go](/get-started/expo-go) a mobile client app to open the project on Android and iOS platforms.
 
-Additionally, you can use any web browser to run the project on the web.
+Linux, macOS and Windows are all supported as your development machine. You can use any web browser to run the project on the web.
 
-> **info** You don't need macOS to build an iOS app with [EAS](/eas). You only need an iOS device to run [development builds](/develop/development-builds/introduction/). Windows, Linux, and macOS are all supported as your development machine.
-
+> **info** You don't need macOS to build an iOS app with [EAS](/eas). You only need an iOS device to run [development builds](/develop/development-builds/introduction/).
 ## Expo CLI
 
 [Expo CLI](/more/expo-cli/) is a command-line tool that is the primary interface between a developer and other Expo tools. It is used for different tasks in the development life cycle of your project such as serving the project in development, viewing logs, opening the app on an emulator or a physical device, and so on.
@@ -24,15 +24,15 @@ Additionally, you can use any web browser to run the project on the web.
 
 To use Expo CLI, you need to have the following tools installed on your developer machine:
 
-- [Node.js LTS release](https://nodejs.org/en/) - Only Node.js LTS releases (even-numbered) are recommended. As Node.js [officially states](https://nodejs.org/en/about/releases/), _"Production applications should only use Active LTS or Maintenance LTS releases"_. You can install Node.js using a version management tool (such as `nvm` or `volta` or any other of your choice) to switch between different Node.js versions.
+- [Node.js LTS release](https://nodejs.org/en/) - Only Node.js LTS releases (even-numbered) are recommended.
+  <CALLOUT theme="secondary">As Node.js [officially states](https://nodejs.org/en/about/releases/), "Production applications should only use Active LTS or Maintenance LTS releases". You can install Node.js using a version management tool (such as `nvm` or `volta` or any other of your choice) to switch between different Node.js versions.</CALLOUT>
 - [Git](https://git-scm.com)
-- [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall) for macOS or Linux users.
+- [Watchman](https://facebook.github.io/watchman/docs/install#buildinstall) (for Linux or macOS users).
 
 ### Recommended tools
 
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
-- [VS Code Editor](https://code.visualstudio.com/download)
-  - [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for Expo config debugging and autocomplete.
+- [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for Expo easier debugging and config autocomplete.
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal for developers who prefer Windows.
 
 ### Use Expo CLI

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -32,7 +32,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 ### Recommended tools
 
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
-- [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for Expo easier debugging and config autocomplete.
+- [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for easier debugging and Expo config autocomplete.
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal for developers who prefer Windows.
 
 ### Use Expo CLI

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -1,5 +1,5 @@
 import { ArrowRightIcon, ArrowUpRightIcon } from '@expo/styleguide-icons';
-import type { AnchorHTMLAttributes, ComponentType, ReactNode } from 'react';
+import type { AnchorHTMLAttributes, ComponentType, HTMLAttributes, ReactNode } from 'react';
 
 import { A, DEMI, P } from '~/ui/components/Text';
 
@@ -7,10 +7,11 @@ type BoxLinkProps = AnchorHTMLAttributes<HTMLLinkElement> & {
   title: string;
   description: ReactNode;
   testID?: string;
-  Icon?: ComponentType<any>;
+  Icon?: ComponentType<HTMLAttributes<SVGSVGElement>>;
+  imageUrl?: string;
 };
 
-export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps) {
+export function BoxLink({ title, description, href, testID, Icon, imageUrl }: BoxLinkProps) {
   const isExternal = Boolean(href && href.startsWith('http'));
   const ArrowIcon = isExternal ? ArrowUpRightIcon : ArrowRightIcon;
   return (
@@ -26,6 +27,7 @@ export function BoxLink({ title, description, href, testID, Icon }: BoxLinkProps
             <Icon className="icon-lg text-icon-default" />
           </div>
         )}
+        {imageUrl && <img className="!w-9 !h-9 self-center" src={imageUrl} alt="Icon" />}
         <div>
           <DEMI>{title}</DEMI>
           <P>{description}</P>


### PR DESCRIPTION
# Why

Let's make few tweak to the starting pages on the docs, so they are up to date when it comes to content.

# How

Make a several tweaks and fixes to the starting pages docs, introduce an usage of `CALLOUT` text component for less important content (will rename our current `Callout` in the future PR, so it do not produce a confusion), add support for images (via URL) in `BoxLink` component.

# Test Plan

The changes have been tested by running docs app locally.

# Preview


<img width="1202" alt="Screenshot 2023-05-16 at 16 03 34" src="https://github.com/expo/expo/assets/719641/c4b88e78-2209-4cad-9976-43f02acba3d1">
<img width="1202" alt="Screenshot 2023-05-16 at 15 42 36" src="https://github.com/expo/expo/assets/719641/aca25b48-5393-4890-be8d-52092eef808e">
