### PR TITLE
fix(cli): Fix static export for consecutive groups.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Import `fetch` from `node-fetch` to support older Node.js versions. ([#22480](https://github.com/expo/expo/pull/22480) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
-- Fix static export for consecutive groups.
+- Fix static export for consecutive groups. ([#22504](https://github.com/expo/expo/pull/22504) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Import `fetch` from `node-fetch` to support older Node.js versions. ([#22480](https://github.com/expo/expo/pull/22480) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
+- Fix static export for consecutive groups.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -13,6 +13,49 @@ describe(getPathVariations, () => {
       '(foo)/bar/(bax)/baz',
     ]);
   });
+  it(`should get path variations 1`, () => {
+    expect(getPathVariations('a').sort((a, b) => a.length - b.length)).toEqual(['a']);
+    expect(getPathVariations('(a)').sort((a, b) => a.length - b.length)).toEqual(['(a)']);
+  });
+  it(`should get path variations 2`, () => {
+    expect(getPathVariations('(a)/b').sort((a, b) => a.length - b.length)).toEqual(['b', '(a)/b']);
+    expect(getPathVariations('(a)/(b)').sort((a, b) => a.length - b.length)).toEqual([
+      '(b)',
+      '(a)',
+      '(a)/(b)',
+    ]);
+  });
+  it(`should get path variations 3`, () => {
+    expect(getPathVariations('(a)/(b)/c').sort((a, b) => a.length - b.length)).toEqual([
+      'c',
+      '(b)/c',
+      '(a)/c',
+      '(a)/(b)/c',
+    ]);
+  });
+  it(`should get path variations 4`, () => {
+    expect(getPathVariations('(a)/(b)/c/(d)/(e)/f').sort((a, b) => a.length - b.length)).toEqual([
+      'c/f',
+      '(b)/c/f',
+      'c/(e)/f',
+      'c/(d)/f',
+      '(a)/c/f',
+      '(b)/c/(e)/f',
+      '(b)/c/(d)/f',
+      'c/(d)/(e)/f',
+      '(a)/c/(e)/f',
+      '(a)/c/(d)/f',
+      '(a)/(b)/c/f',
+      '(b)/c/(d)/(e)/f',
+      '(a)/c/(d)/(e)/f',
+      '(a)/(b)/c/(e)/f',
+      '(a)/(b)/c/(d)/f',
+      '(a)/(b)/c/(d)/(e)/f',
+    ]);
+  });
+  it(`should get path variations 5`, () => {
+    expect(getPathVariations('a/(b)').sort((a, b) => a.length - b.length)).toEqual(['a', 'a/(b)']);
+  });
 });
 
 describe(getHtmlFiles, () => {
@@ -51,6 +94,45 @@ describe(getHtmlFiles, () => {
       '(app)/compose.html',
       '(auth)/sign-in.html',
       '(app)/note/[note].html',
+    ]);
+  });
+  it(`should get html files 2`, () => {
+    expect(
+      getHtmlFiles({
+        manifest: {
+          initialRouteName: undefined,
+          screens: {
+            '(root)': {
+              path: '(root)',
+              screens: {
+                '(index)': {
+                  path: '(index)',
+                  screens: {
+                    '[...missing]': '*missing',
+                    index: '',
+                    notifications: 'notifications',
+                  },
+                  initialRouteName: 'index',
+                },
+              },
+              initialRouteName: '(index)',
+            },
+          },
+        },
+      }).sort((a, b) => a.length - b.length)
+    ).toEqual([
+      'index.html',
+      '[...missing].html',
+      '(root)/index.html',
+      '(index)/index.html',
+      'notifications.html',
+      '(root)/[...missing].html',
+      '(index)/[...missing].html',
+      '(root)/(index)/index.html',
+      '(root)/notifications.html',
+      '(index)/notifications.html',
+      '(root)/(index)/[...missing].html',
+      '(root)/(index)/notifications.html',
     ]);
   });
 });

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -188,13 +188,14 @@ export function getPathVariations(routePath: string): string[] {
       return;
     }
 
-    const segment = segments[index];
-    const groupName = matchGroupName(segment);
-    if (groupName) {
-      const newSegments = [...segments];
+    const newSegments = [...segments];
+    while (
+      index < newSegments.length &&
+      matchGroupName(newSegments[index]) &&
+      newSegments.length > 1
+    ) {
       newSegments.splice(index, 1);
       variations.add(newSegments.join('/'));
-
       generateVariations(newSegments, index + 1);
     }
 


### PR DESCRIPTION
# Why

While porting bluesky to expo-router I found a bug in the group variation logic. We aren't collecting variations where consecutive groups are used, e.g. `(a)/(b)/c` -> `c`.
