### PR TITLE
[expo-updates][ios] Fix swiftlint

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -406,7 +406,12 @@ public final class AppLoaderTask: NSObject {
       return
     }
 
-    if !self.selectionPolicy.shouldLoadRollBackToEmbeddedDirective(updateDirective, withEmbeddedUpdate: embeddedManifest, launchedUpdate: self.candidateLauncher?.launchedUpdate, filters: manifestFilters) {
+    if !self.selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      updateDirective,
+      withEmbeddedUpdate: embeddedManifest,
+      launchedUpdate: self.candidateLauncher?.launchedUpdate,
+      filters: manifestFilters
+    ) {
       launchUpdate(nil, error: error)
       return
     }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
@@ -16,7 +16,7 @@ internal final class SigningInfo {
 }
 
 @objc(EXUpdatesUpdateDirective)
-public class UpdateDirective : NSObject {
+public class UpdateDirective: NSObject {
   let signingInfo: SigningInfo?
 
   init(signingInfo: SigningInfo?) {

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicy.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicy.swift
@@ -17,5 +17,10 @@ public protocol LoaderSelectionPolicy {
    * update and saved in the database (i.e. decide whether the combination of the directive's commitTime
    * and the embedded update is "newer" than the currently running update, according to this class's ordering).
    */
-  func shouldLoadRollBackToEmbeddedDirective(_ directive: RollBackToEmbeddedUpdateDirective, withEmbeddedUpdate embeddedUpdate: Update, launchedUpdate: Update?, filters: [String: Any]?) -> Bool
+  func shouldLoadRollBackToEmbeddedDirective(
+    _ directive: RollBackToEmbeddedUpdateDirective,
+    withEmbeddedUpdate embeddedUpdate: Update,
+    launchedUpdate: Update?,
+    filters: [String: Any]?
+  ) -> Bool
 }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/LoaderSelectionPolicyFilterAware.swift
@@ -31,7 +31,12 @@ public final class LoaderSelectionPolicyFilterAware: NSObject, LoaderSelectionPo
     return launchedUpdate.commitTime.compare(newUpdate.commitTime) == .orderedAscending
   }
 
-  public func shouldLoadRollBackToEmbeddedDirective(_ directive: RollBackToEmbeddedUpdateDirective, withEmbeddedUpdate embeddedUpdate: Update, launchedUpdate: Update?, filters: [String : Any]?) -> Bool {
+  public func shouldLoadRollBackToEmbeddedDirective(
+    _ directive: RollBackToEmbeddedUpdateDirective,
+    withEmbeddedUpdate embeddedUpdate: Update,
+    launchedUpdate: Update?,
+    filters: [String: Any]?
+  ) -> Bool {
     // if the embedded update doesn't match the filters, don't roll back to it (changing the
     // timestamp of it won't change filter validity)
     guard SelectionPolicies.doesUpdate(embeddedUpdate, matchFilters: filters) else {

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicy.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicy.swift
@@ -48,8 +48,18 @@ public final class SelectionPolicy: NSObject, LauncherSelectionPolicy, LoaderSel
     return loaderSelectionPolicy.shouldLoadNewUpdate(newUpdate, withLaunchedUpdate: launchedUpdate, filters: filters)
   }
 
-  public func shouldLoadRollBackToEmbeddedDirective(_ directive: RollBackToEmbeddedUpdateDirective, withEmbeddedUpdate embeddedUpdate: Update, launchedUpdate: Update?, filters: [String: Any]?) -> Bool {
-    return loaderSelectionPolicy.shouldLoadRollBackToEmbeddedDirective(directive, withEmbeddedUpdate: embeddedUpdate, launchedUpdate: launchedUpdate, filters: filters)
+  public func shouldLoadRollBackToEmbeddedDirective(
+    _ directive: RollBackToEmbeddedUpdateDirective,
+    withEmbeddedUpdate embeddedUpdate: Update,
+    launchedUpdate: Update?,
+    filters: [String: Any]?
+  ) -> Bool {
+    return loaderSelectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      directive,
+      withEmbeddedUpdate: embeddedUpdate,
+      launchedUpdate: launchedUpdate,
+      filters: filters
+    )
   }
 
   public func updatesToDelete(withLaunchedUpdate launchedUpdate: Update, updates: [Update], filters: [String: Any]?) -> [Update] {


### PR DESCRIPTION
# Why

Swiftlint CI step doesn't run on stacked PRs so all the violations in https://github.com/expo/expo/pull/22434 didn't register until after I had rebased and landed.

# How

Fix lint

# Test Plan

run swiftlint locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
