### PR TITLE
[expo-image] update readme to match docs

### DIFF
--- a/packages/expo-image/README.md
+++ b/packages/expo-image/README.md
@@ -39,8 +39,8 @@ A cross-platform, performant image component for React Native and Expo.
 
 # Installation
 
-> Currently `expo-image` can be used only with Expo SDK47 in [development builds](/development/create-development-builds/) and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
-> It is not available in Expo Go and Snack yet.
+> Currently `expo-image` can be used only with [development builds](/development/create-development-builds/), in Expo Go, and bare React Native apps with [configured Expo modules](/bare/installing-expo-modules/).
+> It is not available with Snack yet.
 
 Add the package to your dependencies with the following commands:
 


### PR DESCRIPTION
# Why

Readme contained outdated information about availability.

# How

Updated to match docs.

# Test Plan

Mk I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
