### PR TITLE
[expo-crypto] lower case randomUUID result on iOS

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Return lower case UUID on iOS. ([#22509](https://github.com/expo/expo/pull/22509) by [@LinusU](https://github.com/LinusU))
+
 ### 💡 Others
 
 ## 12.3.0 — 2023-05-08

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -20,7 +20,7 @@ public class CryptoModule: Module {
     Function("digest", digest)
 
     Function("randomUUID") {
-      UUID().uuidString
+      UUID().uuidString.lowercased()
     }
   }
 }


### PR DESCRIPTION
# Why

On iOS the UUID returned from `randomUUID` is currently upper case, this is in contrast to Android and [the web specification](https://w3c.github.io/webcrypto/#Crypto-method-randomUUID) which requires lower case.

This changes iOS to match the other platforms.

# How

Added `.lowercased()` to turn the string into lower case.

# Test Plan

Unfortunately, I'm not 100% how to best test this, but I think that if the automated CI tests passes than that should mean that the module still builds, and that should mean that the string gets lower cased since the change is very simple...

# Checklist

- [n/a] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [n/a] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [not sure] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).


ping @aleqsio 