### PR TITLE
feat(cli): add `add` command as alias for `install`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `npx expo add` as an alias to `npx expo install`.
+
 ### 🐛 Bug fixes
 
 - Import `fetch` from `node-fetch` to support older Node.js versions. ([#22480](https://github.com/expo/expo/pull/22480) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `npx expo add` as an alias to `npx expo install`.
+- Add `npx expo add` as an alias to `npx expo install`. ([#22510](https://github.com/expo/expo/pull/22510) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -29,6 +29,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
 
   // Auxiliary commands
   install: () => import('../src/install').then((i) => i.expoInstall),
+  add: () => import('../src/install').then((i) => i.expoInstall),
   customize: () => import('../src/customize').then((i) => i.expoCustomize),
 
   // Auth
@@ -78,6 +79,7 @@ if (!isSubcommand && args['--help']) {
     register,
     start,
     install,
+    add,
     export: _export,
     config,
     customize,


### PR DESCRIPTION
# Why

- Coming from `yarn add` to `npx expo add` feels more natural. We also had this alias in the legacy CLI.
