### PR TITLE
[expo-go] change project/branch screens to query updates by sdkVersion

### DIFF
--- a/home/graphql.schema.json
+++ b/home/graphql.schema.json
@@ -736,6 +736,83 @@
             "deprecationReason": null
           },
           {
+            "name": "appsPaginated",
+            "description": "Paginated list of apps associated with this account. By default sorted by name. Use filter to adjust the sorting order.",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AccountAppsFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AccountAppsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "availableBuilds",
             "description": null,
             "args": [],
@@ -1185,6 +1262,18 @@
             "deprecationReason": null
           },
           {
+            "name": "ownerUserActor",
+            "description": "Owning UserActor of this account if personal account",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "pushSecurityEnabled",
             "description": null,
             "args": [],
@@ -1310,6 +1399,83 @@
             "deprecationReason": "No longer needed"
           },
           {
+            "name": "timelineActivity",
+            "description": "Coalesced project activity for an app using pagination",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TimelineActivityFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimelineActivityConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "unlimitedBuilds",
             "description": null,
             "args": [],
@@ -1356,6 +1522,18 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "userActorOwner",
+            "description": "Owning UserActor of this account if personal account",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Deprecated in favor of ownerUserActor"
           },
           {
             "name": "userInvitations",
@@ -1421,6 +1599,150 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAppsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccountAppsEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AccountAppsEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AccountAppsFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "sortByField",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AccountAppsSortByField",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "AccountAppsSortByField",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LATEST_ACTIVITY_TIME",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NAME",
+            "description": "Name prefers the display name but falls back to full_name with @account/\npart stripped.",
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -1523,6 +1845,39 @@
             },
             "isDeprecated": true,
             "deprecationReason": "Build packs are no longer supported"
+          },
+          {
+            "name": "cancelAllSubscriptionsImmediately",
+            "description": "Cancels all subscriptions immediately",
+            "args": [
+              {
+                "name": "accountID",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "cancelScheduledSubscriptionChange",
@@ -2045,6 +2400,81 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "AccountNotificationSubscriptionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "AccountQuery",
         "description": null,
@@ -2219,6 +2649,18 @@
             "deprecationReason": null
           },
           {
+            "name": "endSessionEndpoint",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -2239,9 +2681,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2399,12 +2845,28 @@
             "deprecationReason": null
           },
           {
-            "name": "issuer",
+            "name": "endSessionEndpoint",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "issuer",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -2671,6 +3133,18 @@
             "deprecationReason": null
           },
           {
+            "name": "endSessionEndpoint",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "id",
             "description": null,
             "args": [],
@@ -2691,9 +3165,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2798,6 +3276,65 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AccountUsageEASBuildMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "billingResourceClass",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASBuildBillingResourceClass",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "UNION",
+        "name": "AccountUsageMetadata",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "AccountUsageEASBuildMetadata",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
         "name": "AccountUsageMetric",
         "description": null,
         "fields": [
@@ -2889,113 +3426,6 @@
       },
       {
         "kind": "OBJECT",
-        "name": "AccountUsageMetricAndCost",
-        "description": null,
-        "fields": [
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "limit",
-            "description": "The limit, in units, allowed by this plan",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "metricType",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "UsageMetricType",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "serviceMetric",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "ENUM",
-                "name": "EASServiceMetric",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "totalCost",
-            "description": "Total cost of this particular metric, in cents",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "value",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
         "name": "AccountUsageMetrics",
         "description": null,
         "fields": [
@@ -3014,6 +3444,18 @@
                     "name": "DateTime",
                     "ofType": null
                   }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "service",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "EASService",
+                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -3237,7 +3679,7 @@
       {
         "kind": "INTERFACE",
         "name": "Actor",
-        "description": "A user or robot that can authenticate with Expo services and be a member of accounts.",
+        "description": "A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts.",
         "fields": [
           {
             "name": "accessTokens",
@@ -3408,6 +3850,11 @@
           {
             "kind": "OBJECT",
             "name": "Robot",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "SSOUser",
             "ofType": null
           },
           {
@@ -5010,6 +5457,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildType",
             "description": null,
             "type": {
@@ -5046,6 +5505,18 @@
             "deprecationReason": null
           },
           {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "developmentClient",
             "description": null,
             "type": {
@@ -5075,6 +5546,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
               "ofType": null
             },
             "defaultValue": null,
@@ -5131,6 +5614,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "AndroidJobSecretsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "triggeredBy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildTrigger",
               "ofType": null
             },
             "defaultValue": null,
@@ -5316,6 +5811,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildType",
             "description": null,
             "type": {
@@ -5381,6 +5888,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
               "ofType": null
             },
             "defaultValue": null,
@@ -5464,6 +5983,18 @@
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "AndroidJobBuildCredentialsInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -6280,6 +6811,71 @@
             "deprecationReason": null
           },
           {
+            "name": "branchesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppBranchesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": null,
             "args": [
@@ -6495,6 +7091,83 @@
             "deprecationReason": null
           },
           {
+            "name": "buildsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "BuildFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppBuildsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildsReleaseChannels",
             "description": "Classic update release channel names that have at least one build",
             "args": [],
@@ -6519,6 +7192,71 @@
             "deprecationReason": null
           },
           {
+            "name": "channelsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppChannelsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "deployment",
             "description": null,
             "args": [
@@ -6533,18 +7271,6 @@
                     "name": "String",
                     "ofType": null
                   }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "options",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "DeploymentOptions",
-                  "ofType": null
                 },
                 "defaultValue": null,
                 "isDeprecated": false,
@@ -6576,76 +7302,15 @@
             "deprecationReason": null
           },
           {
-            "name": "deploymentNew",
-            "description": null,
-            "args": [
-              {
-                "name": "channel",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "runtimeVersion",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "DeploymentNew",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "deployments",
             "description": "Deployments associated with this app",
             "args": [
               {
-                "name": "limit",
+                "name": "after",
                 "description": null,
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "mostRecentlyUpdatedAt",
-                "description": "Offset the query",
-                "type": {
                   "kind": "SCALAR",
-                  "name": "DateTime",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6653,11 +7318,35 @@
                 "deprecationReason": null
               },
               {
-                "name": "options",
+                "name": "before",
                 "description": null,
                 "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "DeploymentOptions",
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
                   "ofType": null
                 },
                 "defaultValue": null,
@@ -6669,17 +7358,9 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Deployment",
-                    "ofType": null
-                  }
-                }
+                "kind": "OBJECT",
+                "name": "DeploymentsConnection",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -6922,6 +7603,22 @@
             },
             "isDeprecated": true,
             "deprecationReason": "No longer supported"
+          },
+          {
+            "name": "latestActivity",
+            "description": "Time of the last user activity (update, branch, submission).",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           },
           {
             "name": "latestAppVersionByPlatformAndApplicationIdentifier",
@@ -7271,6 +7968,22 @@
             "deprecationReason": "Legacy access tokens are deprecated"
           },
           {
+            "name": "scopeKey",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sdkVersion",
             "description": "SDK version of the latest classic update publish, 0.0.0 otherwise",
             "args": [],
@@ -7370,6 +8083,148 @@
                     "ofType": null
                   }
                 }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "submissionsPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppSubmissionsConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timelineActivity",
+            "description": "Coalesced project activity for an app using pagination",
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "TimelineActivityFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "TimelineActivityConnection",
+                "ofType": null
               }
             },
             "isDeprecated": false,
@@ -7714,6 +8569,71 @@
             "deprecationReason": null
           },
           {
+            "name": "updatesPaginated",
+            "description": null,
+            "args": [
+              {
+                "name": "after",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "before",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "first",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "last",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppUpdatesConnection",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "username",
             "description": null,
             "args": [],
@@ -7791,6 +8711,288 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBranchEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateBranch",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBranchesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppBranchEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBuildEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "BuildOrBuildJob",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppBuildsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppBuildEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppChannelEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UpdateChannel",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppChannelsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppChannelEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -8174,6 +9376,81 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppNotificationSubscriptionInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -9033,6 +10310,194 @@
       },
       {
         "kind": "OBJECT",
+        "name": "AppSubmissionEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Submission",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppSubmissionsConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppSubmissionEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppUpdateEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Update",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppUpdatesConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AppUpdateEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "AppVersion",
         "description": "Represents Play Store/App Store version of an application",
         "fields": [
@@ -9822,6 +11287,55 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updateAppleDevice",
+            "description": "Update an Apple Device",
+            "args": [
+              {
+                "name": "appleDeviceUpdateInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppleDeviceUpdateInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppleDevice",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -9989,6 +11503,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "AppleDeviceUpdateInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -11882,6 +13419,22 @@
             "deprecationReason": null
           },
           {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "start",
             "description": null,
             "args": [],
@@ -11947,18 +13500,6 @@
             "deprecationReason": null
           },
           {
-            "name": "actualResourceClass",
-            "description": "The actual resource class of the builder assigned to the build job",
-            "args": [],
-            "type": {
-              "kind": "ENUM",
-              "name": "BuildResourceClass",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "appBuildVersion",
             "description": null,
             "args": [],
@@ -11995,6 +13536,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildMode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildProfile",
             "description": null,
             "args": [],
@@ -12009,7 +13562,20 @@
           {
             "name": "canRetry",
             "description": null,
-            "args": [],
+            "args": [
+              {
+                "name": "newMode",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "BuildMode",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -12082,6 +13648,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customWorkflowName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12160,6 +13738,30 @@
           },
           {
             "name": "gitCommitMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitRef",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepositoryOwnerAndName",
             "description": null,
             "args": [],
             "type": {
@@ -12291,13 +13893,9 @@
             "description": "Retry time starts after completedAt",
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12387,6 +13985,18 @@
             "deprecationReason": null
           },
           {
+            "name": "projectRootDirectory",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "provisioningStartedAt",
             "description": null,
             "args": [],
@@ -12446,6 +14056,47 @@
                 "name": "BuildResourceClass",
                 "ofType": null
               }
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Use resourceClassDisplayName instead"
+          },
+          {
+            "name": "resourceClassDisplayName",
+            "description": "String describing the resource class used to run the build",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "retryDisabledReason",
+            "description": null,
+            "args": [
+              {
+                "name": "newMode",
+                "description": null,
+                "type": {
+                  "kind": "ENUM",
+                  "name": "BuildMode",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildRetryDisabledReason",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -12676,40 +14327,12 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "cacheDefaultPaths",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "clear",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "customPaths",
-            "description": null,
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -12734,6 +14357,26 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "paths",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -12966,6 +14609,61 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseChannel",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "BuildIosEnterpriseProvisioning",
         "description": null,
@@ -12993,6 +14691,18 @@
         "name": "BuildJob",
         "description": "Represents an Standalone App build job",
         "fields": [
+          {
+            "name": "accountUserActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "activityTimestamp",
             "description": null,
@@ -13255,22 +14965,6 @@
         "description": null,
         "fields": [
           {
-            "name": "cancel",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "BuildJob",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "del",
             "description": null,
             "args": [],
@@ -13278,22 +14972,6 @@
               "kind": "OBJECT",
               "name": "BuildJob",
               "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "restart",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "BuildJob",
-                "ofType": null
-              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -13578,6 +15256,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildMode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildProfile",
             "description": null,
             "type": {
@@ -13619,6 +15309,18 @@
             "type": {
               "kind": "ENUM",
               "name": "BuildCredentialsSource",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "customWorkflowName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -13855,6 +15557,35 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildMode",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CUSTOM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "RESIGN",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -14212,6 +15943,55 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updateBuildMetadata",
+            "description": "Update metadata for EAS Build build",
+            "args": [
+              {
+                "name": "buildId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "BuildMetadataInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -14308,6 +16088,18 @@
         "fields": null,
         "inputFields": [
           {
+            "name": "reactNativeVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "resourceClass",
             "description": null,
             "type": {
@@ -14318,6 +16110,18 @@
                 "name": "BuildResourceClass",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sdkVersion",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -14711,6 +16515,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "BuildResignInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "applicationArchiveSource",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "ProjectArchiveSourceInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "BuildResourceClass",
         "description": null,
@@ -14731,7 +16558,25 @@
             "deprecationReason": null
           },
           {
+            "name": "ANDROID_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "IOS_DEFAULT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_INTEL_LARGE",
+            "description": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use IOS_INTEL_MEDIUM instead"
+          },
+          {
+            "name": "IOS_INTEL_MEDIUM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -14744,12 +16589,77 @@
           },
           {
             "name": "IOS_M1_LARGE",
-            "description": "@experimental This resource class is not yet ready to be used in production. For testing purposes only.",
+            "description": null,
+            "isDeprecated": true,
+            "deprecationReason": "Use IOS_M_MEDIUM instead"
+          },
+          {
+            "name": "IOS_M1_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_MEDIUM",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M_LARGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IOS_M_MEDIUM",
+            "description": null,
             "isDeprecated": false,
             "deprecationReason": null
           },
           {
             "name": "LEGACY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BuildRetryDisabledReason",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "ALREADY_RETRIED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "INVALID_STATUS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IS_GITHUB_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NOT_COMPLETED_YET",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "TOO_MUCH_TIME_ELAPSED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -14805,6 +16715,29 @@
         "possibleTypes": null
       },
       {
+        "kind": "ENUM",
+        "name": "BuildTrigger",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EAS_CLI",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GIT_BASED_INTEGRATION",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
         "kind": "INPUT_OBJECT",
         "name": "BuildUpdatesInput",
         "description": null,
@@ -14846,26 +16779,9 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
-          }
-        ],
-        "possibleTypes": null
-      },
-      {
-        "kind": "ENUM",
-        "name": "CacheControlScope",
-        "description": null,
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": [
-          {
-            "name": "PRIVATE",
-            "description": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           },
           {
-            "name": "PUBLIC",
+            "name": "UNKNOWN",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -14954,9 +16870,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -14966,9 +16886,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -15006,9 +16930,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -15030,138 +16958,11 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ClientBuild",
-        "description": "Represents a client build request",
-        "fields": [
-          {
-            "name": "buildJobId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
                 "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "manifestPlistUrl",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "status",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userFacingErrorMessage",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "userId",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "ClientBuildQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": null,
-            "args": [
-              {
-                "name": "requestId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ClientBuild",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -15748,7 +17549,7 @@
           },
           {
             "name": "baseDirectory",
-            "description": "The base directory is the directory to change to before starting a build. This string should be a properly formatted Unix path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository.",
+            "description": "The base directory is the directory to change to before starting a build. This string should be a properly formatted POSIX path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository.",
             "type": {
               "kind": "NON_NULL",
               "name": null,
@@ -15913,6 +17714,33 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "CustomBuildConfigInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "path",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -16117,7 +17945,61 @@
       },
       {
         "kind": "OBJECT",
+        "name": "DeleteDiscordUserResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "DeleteEnvironmentSecretResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteGitHubUserResult",
         "description": null,
         "fields": [
           {
@@ -16391,211 +18273,6 @@
         "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
         "fields": [
           {
-            "name": "channel",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "UpdateChannel",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "channelName",
-            "description": "The name of this deployment's associated channel. It is specified separately from the `channel`\nfield to allow specifying a deployment before an EAS Update channel has been created.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "ID",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "mostRecentlyUpdatedAt",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "DateTime",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "recentBuilds",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Build",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "runtimeVersion",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DeploymentBuildEdge",
-        "description": null,
-        "fields": [
-          {
-            "name": "cursor",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "node",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Build",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DeploymentBuildsConnection",
-        "description": null,
-        "fields": [
-          {
-            "name": "edges",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "DeploymentBuildEdge",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "pageInfo",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "DeploymentNew",
-        "description": "Represents a Deployment - a set of Builds with the same Runtime Version and Channel",
-        "fields": [
-          {
             "name": "builds",
             "description": null,
             "args": [
@@ -16693,6 +18370,18 @@
             "deprecationReason": null
           },
           {
+            "name": "latestUpdate",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Update",
+              "ofType": null
+            },
+            "isDeprecated": true,
+            "deprecationReason": "Not required for the new Deployment UI"
+          },
+          {
             "name": "runtime",
             "description": null,
             "args": [],
@@ -16715,25 +18404,364 @@
         "possibleTypes": null
       },
       {
-        "kind": "INPUT_OBJECT",
-        "name": "DeploymentOptions",
+        "kind": "OBJECT",
+        "name": "DeploymentBuildEdge",
         "description": null,
-        "fields": null,
-        "inputFields": [
+        "fields": [
           {
-            "name": "buildListMaxSize",
-            "description": "Max number of associated builds to return",
+            "name": "cursor",
+            "description": null,
+            "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Int",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
-            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Build",
+                "ofType": null
+              }
+            },
             "isDeprecated": false,
             "deprecationReason": null
           }
         ],
-        "interfaces": null,
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentBuildsConnection",
+        "description": "Represents the connection over the builds edge of a Deployment",
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DeploymentBuildEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Deployment",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeploymentsConnection",
+        "description": "Represents the connection over the deployments edge of an App",
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "DeploymentEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "discordIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUserMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "UserActor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUserMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "discordAvatarUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordDiscriminator",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DiscordUserMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deleteDiscordUser",
+            "description": "Delete a Discord User by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteDiscordUserResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -16759,6 +18787,29 @@
           },
           {
             "name": "STORE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EASBuildBillingResourceClass",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "LARGE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "MEDIUM",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -16855,6 +18906,29 @@
       },
       {
         "kind": "ENUM",
+        "name": "EASService",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILDS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATES",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
         "name": "EASServiceMetric",
         "description": null,
         "fields": null,
@@ -16893,6 +18967,92 @@
           },
           {
             "name": "UNIQUE_USERS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EASTotalPlanEnablement",
+        "description": null,
+        "fields": [
+          {
+            "name": "total",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "ENUM",
+              "name": "EASTotalPlanEnablementUnit",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "EASTotalPlanEnablementUnit",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BYTE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "CONCURRENCY",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "REQUEST",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "UPDATER",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "USER",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -17261,6 +19421,248 @@
             "deprecationReason": null
           }
         ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EstimatedOverageAndCost",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": "The limit, in units, allowed by this plan",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "UNION",
+              "name": "AccountUsageMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UsageMetricType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "service",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASService",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "serviceMetric",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASServiceMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "totalCost",
+            "description": "Total cost of this particular metric, in cents",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "EstimatedUsage",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "limit",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metricType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "UsageMetricType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "service",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASService",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "serviceMetric",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EASServiceMetric",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "value",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
         "possibleTypes": null
       },
       {
@@ -18075,6 +20477,50 @@
       },
       {
         "kind": "OBJECT",
+        "name": "GitHubAppMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "createGitHubBuild",
+            "description": "Create a GitHub build for an app",
+            "args": [
+              {
+                "name": "buildInput",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "GitHubBuildInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "GitHubAppQuery",
         "description": null,
         "fields": [
@@ -18231,6 +20677,93 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "GitHubBuildInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "baseDirectory",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gitRef",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platform",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AppPlatform",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "GitHubRepository",
         "description": null,
@@ -18279,6 +20812,18 @@
                 "name": "Int",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubRepositoryUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -18852,6 +21397,192 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "GitHubRepositorySettings",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubUser",
+        "description": null,
+        "fields": [
+          {
+            "name": "githubUserIdentifier",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "metadata",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubUserMetadata",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "UserActor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubUserMetadata",
+        "description": null,
+        "fields": [
+          {
+            "name": "avatarUrl",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "login",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "url",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "GitHubUserMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "deleteGitHubUser",
+            "description": "Delete a GitHub User by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteGitHubUserResult",
                 "ofType": null
               }
             },
@@ -20890,6 +23621,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildType",
             "description": "@deprecated",
             "type": {
@@ -20926,6 +23669,18 @@
             "deprecationReason": null
           },
           {
+            "name": "customBuildConfig",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "CustomBuildConfigInput",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "developmentClient",
             "description": null,
             "type": {
@@ -20955,6 +23710,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "JSONObject",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "mode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
               "ofType": null
             },
             "defaultValue": null,
@@ -21035,6 +23802,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "triggeredBy",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildTrigger",
               "ofType": null
             },
             "defaultValue": null,
@@ -21161,6 +23940,18 @@
             "deprecationReason": null
           },
           {
+            "name": "buildProfile",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildType",
             "description": "@deprecated",
             "type": {
@@ -21233,11 +24024,35 @@
             "deprecationReason": null
           },
           {
+            "name": "mode",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildMode",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "releaseChannel",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resign",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "BuildResignInput",
               "ofType": null
             },
             "defaultValue": null,
@@ -21274,6 +24089,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "BuildWorkflow",
               "ofType": null
             },
             "defaultValue": null,
@@ -21338,6 +24165,18 @@
                 "name": "IosJobTargetCredentialsInput",
                 "ofType": null
               }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "robotAccessToken",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -22396,7 +25235,7 @@
           },
           {
             "name": "updateProfile",
-            "description": "Update the current user's data",
+            "description": "Update the current regular user's data",
             "args": [
               {
                 "name": "userData",
@@ -22426,6 +25265,39 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "updateSSOProfile",
+            "description": "Update the current SSO user's data",
+            "args": [
+              {
+                "name": "userData",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "SSOUserDataInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SSOUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -22438,6 +25310,22 @@
         "name": "MeteredBillingStatus",
         "description": null,
         "fields": [
+          {
+            "name": "EAS_BUILD",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "EAS_UPDATE",
             "description": null,
@@ -22458,6 +25346,326 @@
         "inputFields": null,
         "interfaces": [],
         "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "NotificationEvent",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "BUILD_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUBMISSION_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationSubscription",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Account",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "actor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "App",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationEvent",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "NotificationType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "NotificationSubscriptionFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "accountId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appId",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "event",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "NotificationEvent",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "NotificationType",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "NotificationSubscriptionMutation",
+        "description": null,
+        "fields": [
+          {
+            "name": "subscribeToEventForAccount",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AccountNotificationSubscriptionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubscribeToNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "subscribeToEventForApp",
+            "description": null,
+            "args": [
+              {
+                "name": "input",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "AppNotificationSubscriptionInput",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SubscribeToNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "unsubscribe",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UnsubscribeFromNotificationResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "NotificationType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "EMAIL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
         "possibleTypes": null
       },
       {
@@ -22990,6 +26198,27 @@
         "possibleTypes": null
       },
       {
+        "kind": "UNION",
+        "name": "PlanEnablement",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "Concurrencies",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "EASTotalPlanEnablement",
+            "ofType": null
+          }
+        ]
+      },
+      {
         "kind": "INTERFACE",
         "name": "Project",
         "description": null,
@@ -23170,6 +26399,30 @@
             "deprecationReason": null
           },
           {
+            "name": "gitRef",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "repositoryUrl",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "type",
             "description": null,
             "type": {
@@ -23212,6 +26465,18 @@
         "enumValues": [
           {
             "name": "GCS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "GIT",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "NONE",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -23602,6 +26867,18 @@
             "deprecationReason": null
           },
           {
+            "name": "rollBackToEmbeddedInfoGroup",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "UpdateRollBackToEmbeddedGroup",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "runtimeVersion",
             "description": null,
             "type": {
@@ -23621,13 +26898,9 @@
             "name": "updateInfoGroup",
             "description": null,
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "INPUT_OBJECT",
-                "name": "UpdateInfoGroup",
-                "ofType": null
-              }
+              "kind": "INPUT_OBJECT",
+              "name": "UpdateInfoGroup",
+              "ofType": null
             },
             "defaultValue": null,
             "isDeprecated": false,
@@ -24471,6 +27744,22 @@
             "deprecationReason": null
           },
           {
+            "name": "discordUser",
+            "description": "Mutations for Discord users",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DiscordUserMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "emailSubscription",
             "description": "Mutations that modify an EmailSubscription",
             "args": [],
@@ -24496,6 +27785,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "EnvironmentSecretMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubApp",
+            "description": "Mutations that utilize services facilitated by the GitHub App",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubAppMutation",
                 "ofType": null
               }
             },
@@ -24544,6 +27849,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "GitHubRepositorySettingsMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUser",
+            "description": "Mutations for GitHub users",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "GitHubUserMutation",
                 "ofType": null
               }
             },
@@ -24624,6 +27945,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "MeMutation",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscription",
+            "description": "Mutations that modify a NotificationSubscription",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscriptionMutation",
                 "ofType": null
               }
             },
@@ -25076,22 +28413,6 @@
             "deprecationReason": null
           },
           {
-            "name": "clientBuilds",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ClientBuildQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "experimentation",
             "description": "Top-level query object for querying Experimentation configuration.",
             "args": [],
@@ -25169,11 +28490,23 @@
           },
           {
             "name": "meActor",
-            "description": "If authenticated as a any type of Actor, this is the appropriate top-level\nquery object",
+            "description": "If authenticated as any type of Actor, this is the appropriate top-level\nquery object",
             "args": [],
             "type": {
               "kind": "INTERFACE",
               "name": "Actor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "meUserActor",
+            "description": "If authenticated as any type of human end user (Actor types User or SSOUser),\nthis is the appropriate top-level query object",
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
               "ofType": null
             },
             "isDeprecated": false,
@@ -25205,6 +28538,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "SnackQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ssoUser",
+            "description": "Top-level query object for querying SSO Users.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SSOUserQuery",
                 "ofType": null
               }
             },
@@ -25294,6 +28643,22 @@
               "ofType": {
                 "kind": "OBJECT",
                 "name": "UserQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userActor",
+            "description": "Top-level query object for querying UserActors.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UserActorQuery",
                 "ofType": null
               }
             },
@@ -25471,6 +28836,769 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SSOUser",
+        "description": "Represents a human SSO (not robot) actor.",
+        "fields": [
+          {
+            "name": "accessTokens",
+            "description": "Access Tokens belonging to this actor, none at present",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccessToken",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accounts",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Account",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer.",
+            "args": [
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appetizeCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "apps",
+            "description": "Apps this user has published. If this user is the viewer, this field returns the apps the user has access to.",
+            "args": [
+              {
+                "name": "includeUnpublished",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bestContactEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUser",
+            "description": "Discord account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureGates",
+            "description": "Server feature gate values for this actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fullName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUser",
+            "description": "GitHub account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isExpoAdmin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscriptions",
+            "description": null,
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NotificationSubscriptionFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NotificationSubscription",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "primaryAccount",
+            "description": "Associated accounts",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "profilePhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snacks",
+            "description": "Snacks associated with this account",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Snack",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Actor",
+            "ofType": null
+          },
+          {
+            "kind": "INTERFACE",
+            "name": "UserActor",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "SSOUserDataInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "firstName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "SSOUserQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Query an SSOUser by ID",
+            "args": [
+              {
+                "name": "userId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SSOUser",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byUsername",
+            "description": "Query an SSOUser by username",
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "SSOUser",
                 "ofType": null
               }
             },
@@ -27666,6 +31794,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "SubscribeToNotificationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "notificationSubscription",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscription",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "SubscriptionDetails",
         "description": null,
         "fields": [
@@ -27822,6 +31977,35 @@
             "deprecationReason": null
           },
           {
+            "name": "planEnablement",
+            "description": null,
+            "args": [
+              {
+                "name": "serviceMetric",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "EASServiceMetric",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "UNION",
+              "name": "PlanEnablement",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "planId",
             "description": null,
             "args": [],
@@ -27881,6 +32065,218 @@
               "kind": "SCALAR",
               "name": "Boolean",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TimelineActivityConnection",
+        "description": null,
+        "fields": [
+          {
+            "name": "edges",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TimelineActivityEdge",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "pageInfo",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "TimelineActivityEdge",
+        "description": null,
+        "fields": [
+          {
+            "name": "cursor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "node",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "ActivityTimelineProjectActivity",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "TimelineActivityFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "channels",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "platforms",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "AppPlatform",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "releaseChannels",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "types",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ActivityTimelineProjectActivityType",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UnsubscribeFromNotificationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "notificationSubscription",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "NotificationSubscription",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -28061,6 +32457,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isRollBackToEmbedded",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "manifestFragment",
             "description": null,
             "args": [],
@@ -28121,6 +32533,22 @@
             "deprecationReason": null
           },
           {
+            "name": "runtime",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Runtime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "runtimeVersion",
             "description": null,
             "args": [],
@@ -28133,8 +32561,8 @@
                 "ofType": null
               }
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "Use 'runtime' field ."
           },
           {
             "name": "updatedAt",
@@ -29063,6 +33491,53 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "UpdateRollBackToEmbeddedGroup",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "android",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "ios",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "web",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "UpdatesFilter",
         "description": null,
         "fields": null,
@@ -29098,18 +33573,28 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "sdkVersions",
+            "description": null,
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "Upload",
-        "description": "The `Upload` scalar type represents a file upload.",
-        "fields": null,
-        "inputFields": null,
         "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
@@ -29245,7 +33730,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "AccountUsageMetricAndCost",
+                    "name": "EstimatedOverageAndCost",
                     "ofType": null
                   }
                 }
@@ -29269,7 +33754,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "OBJECT",
-                    "name": "AccountUsageMetricAndCost",
+                    "name": "EstimatedUsage",
                     "ofType": null
                   }
                 }
@@ -29643,6 +34128,18 @@
             "deprecationReason": null
           },
           {
+            "name": "bestContactEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "created",
             "description": null,
             "args": [],
@@ -29654,6 +34151,18 @@
                 "name": "DateTime",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUser",
+            "description": "Discord account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUser",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -29764,6 +34273,18 @@
             "deprecationReason": null
           },
           {
+            "name": "githubUser",
+            "description": "GitHub account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "githubUsername",
             "description": null,
             "args": [],
@@ -29820,22 +34341,6 @@
             "deprecationReason": null
           },
           {
-            "name": "isEmailUnsubscribed",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
             "name": "isExpoAdmin",
             "description": null,
             "args": [],
@@ -29856,24 +34361,16 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
             },
             "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "isOnboarded",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
+            "deprecationReason": "This field no longer exists"
           },
           {
             "name": "isSecondFactorAuthenticationEnabled",
@@ -29892,18 +34389,6 @@
             "deprecationReason": null
           },
           {
-            "name": "lastLogin",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
             "name": "lastName",
             "description": null,
             "args": [],
@@ -29916,67 +34401,6 @@
             "deprecationReason": null
           },
           {
-            "name": "lastPasswordReset",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
-          },
-          {
-            "name": "likes",
-            "description": null,
-            "args": [
-              {
-                "name": "limit",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "App",
-                "ofType": null
-              }
-            },
-            "isDeprecated": true,
-            "deprecationReason": "'likes' have been deprecated."
-          },
-          {
             "name": "location",
             "description": null,
             "args": [],
@@ -29984,6 +34408,43 @@
               "kind": "SCALAR",
               "name": "String",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscriptions",
+            "description": null,
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NotificationSubscriptionFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NotificationSubscription",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -30152,18 +34613,609 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [
+          {
+            "kind": "INTERFACE",
+            "name": "Actor",
+            "ofType": null
           },
           {
-            "name": "wasLegacy",
+            "kind": "INTERFACE",
+            "name": "UserActor",
+            "ofType": null
+          }
+        ],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INTERFACE",
+        "name": "UserActor",
+        "description": "A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts.",
+        "fields": [
+          {
+            "name": "accessTokens",
+            "description": "Access Tokens belonging to this user actor",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "AccessToken",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accounts",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Account",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "activityTimelineProjectActivities",
+            "description": "Coalesced project activity for all apps belonging to all accounts this user actor belongs to.\nOnly resolves for the viewer.",
+            "args": [
+              {
+                "name": "createdBefore",
+                "description": " Offset the query ",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "filterTypes",
+                "description": " Types of objects to filter ",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "ActivityTimelineProjectActivityType",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "ActivityTimelineProjectActivity",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appCount",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "appetizeCode",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
-              "name": "Boolean",
+              "name": "String",
               "ofType": null
             },
-            "isDeprecated": true,
-            "deprecationReason": "No longer supported"
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "apps",
+            "description": "Apps this user has published",
+            "args": [
+              {
+                "name": "includeUnpublished",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "App",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "bestContactEmail",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "created",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "discordUser",
+            "description": "Discord account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DiscordUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "displayName",
+            "description": "Best-effort human readable name for this human actor for use in user interfaces during action attribution.\nFor example, when displaying a sentence indicating that actor X created a build or published an update.",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "featureGates",
+            "description": "Server feature gate values for this user actor, optionally filtering by desired gates.\nOnly resolves for the viewer.",
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "JSONObject",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "firstName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "fullName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUser",
+            "description": "GitHub account linked to a user",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "GitHubUser",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "githubUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "industry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isExpoAdmin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "lastName",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "location",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "notificationSubscriptions",
+            "description": null,
+            "args": [
+              {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "NotificationSubscriptionFilter",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "NotificationSubscription",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "primaryAccount",
+            "description": "Associated accounts",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "profilePhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "snacks",
+            "description": "Snacks associated with this user's personal account",
+            "args": [
+              {
+                "name": "limit",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Snack",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "twitterUsername",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "username",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -30174,6 +35226,94 @@
             "ofType": null
           }
         ],
+        "enumValues": null,
+        "possibleTypes": [
+          {
+            "kind": "OBJECT",
+            "name": "SSOUser",
+            "ofType": null
+          },
+          {
+            "kind": "OBJECT",
+            "name": "User",
+            "ofType": null
+          }
+        ]
+      },
+      {
+        "kind": "OBJECT",
+        "name": "UserActorQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Query a UserActor by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "UserActor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "byUsername",
+            "description": "Query a UserActor by username",
+            "args": [
+              {
+                "name": "username",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INTERFACE",
+                "name": "UserActor",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -30268,42 +35408,6 @@
             "deprecationReason": null
           },
           {
-            "name": "isEmailUnsubscribed",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isLegacy",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "isOnboarded",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "lastName",
             "description": null,
             "type": {
@@ -30362,18 +35466,6 @@
             "defaultValue": null,
             "isDeprecated": false,
             "deprecationReason": null
-          },
-          {
-            "name": "wasLegacy",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
           }
         ],
         "interfaces": null,
@@ -30397,6 +35489,18 @@
                 "name": "String",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "accountProfilePhoto",
+            "description": "If the invite is for a personal team, the profile photo of account owner",
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -30459,6 +35563,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isForOrganization",
+            "description": "If the invite is for an organization or a personal team",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -30778,6 +35898,18 @@
             "deprecationReason": null
           },
           {
+            "name": "accountProfilePhoto",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "created",
             "description": null,
             "args": [],
@@ -30835,6 +35967,22 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "isForOrganization",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -30941,9 +36089,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "ENUM",
-              "name": "Role",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "Role",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -30959,6 +36111,18 @@
             },
             "isDeprecated": true,
             "deprecationReason": "User type is deprecated"
+          },
+          {
+            "name": "userActor",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "INTERFACE",
+              "name": "UserActor",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -30983,7 +36147,7 @@
                   "name": null,
                   "ofType": {
                     "kind": "SCALAR",
-                    "name": "String",
+                    "name": "ID",
                     "ofType": null
                   }
                 },
@@ -32692,7 +37856,7 @@
       },
       {
         "name": "specifiedBy",
-        "description": "Exposes a URL that specifies the behaviour of this scalar.",
+        "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
         "locations": [
           "SCALAR"
@@ -32700,7 +37864,7 @@
         "args": [
           {
             "name": "url",
-            "description": "The URL that specifies the behaviour of this scalar.",
+            "description": "The URL that specifies the behavior of this scalar.",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/home/graphql/queries/BranchDetails.query.graphql
+++ b/home/graphql/queries/BranchDetails.query.graphql
@@ -2,7 +2,7 @@ query BranchDetails(
   $name: String!
   $appId: String!
   $platform: AppPlatform!
-  $runtimeVersions: [String!]!
+  $sdkVersions: [String!]!
 ) {
   app {
     byId(appId: $appId) {
@@ -13,11 +13,7 @@ query BranchDetails(
       updateBranchByName(name: $name) {
         id
         name
-        updates(
-          limit: 100
-          offset: 0
-          filter: { platform: $platform, runtimeVersions: $runtimeVersions }
-        ) {
+        updates(limit: 100, offset: 0, filter: { platform: $platform, sdkVersions: $sdkVersions }) {
           id
           group
           message

--- a/home/graphql/queries/BranchesForProjectQuery.query.graphql
+++ b/home/graphql/queries/BranchesForProjectQuery.query.graphql
@@ -1,7 +1,7 @@
 query BranchesForProject(
   $appId: String!
   $platform: AppPlatform!
-  $runtimeVersions: [String!]!
+  $sdkVersions: [String!]!
   $limit: Int!
   $offset: Int!
 ) {
@@ -26,11 +26,7 @@ query BranchesForProject(
       updateBranches(limit: $limit, offset: $offset) {
         id
         name
-        updates(
-          limit: 1
-          offset: 0
-          filter: { platform: $platform, runtimeVersions: $runtimeVersions }
-        ) {
+        updates(limit: 1, offset: 0, filter: { platform: $platform, sdkVersions: $sdkVersions }) {
           id
           group
           message

--- a/home/graphql/queries/ProjectQuery.query.graphql
+++ b/home/graphql/queries/ProjectQuery.query.graphql
@@ -1,7 +1,7 @@
 query WebContainerProjectPage_Query(
   $appId: String!
   $platform: AppPlatform!
-  $runtimeVersions: [String!]!
+  $sdkVersions: [String!]!
 ) {
   app {
     byId(appId: $appId) {
@@ -28,11 +28,7 @@ query WebContainerProjectPage_Query(
       updateBranches(limit: 100, offset: 0) {
         id
         name
-        updates(
-          limit: 1
-          offset: 0
-          filter: { platform: $platform, runtimeVersions: $runtimeVersions }
-        ) {
+        updates(limit: 1, offset: 0, filter: { platform: $platform, sdkVersions: $sdkVersions }) {
           id
           group
           message

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -13,14 +13,9 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  /** Date custom scalar type */
   DateTime: any;
-  /** The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSON: any;
-  /** The `JSONObject` scalar type represents JSON objects as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf). */
   JSONObject: any;
-  /** The `Upload` scalar type represents a file upload. */
-  Upload: any;
 };
 
 export type AcceptUserInvitationResult = {
@@ -88,6 +83,8 @@ export type Account = {
   appleTeams: Array<AppleTeam>;
   /** Apps associated with this account */
   apps: Array<App>;
+  /** Paginated list of apps associated with this account. By default sorted by name. Use filter to adjust the sorting order. */
+  appsPaginated: AccountAppsConnection;
   /** @deprecated Build packs are no longer supported */
   availableBuilds?: Maybe<Scalars['Int']>;
   /** Billing information. Only visible to members with the ADMIN or OWNER role. */
@@ -116,6 +113,8 @@ export type Account = {
   offers?: Maybe<Array<Offer>>;
   /** Owning User of this account if personal account */
   owner?: Maybe<User>;
+  /** Owning UserActor of this account if personal account */
+  ownerUserActor?: Maybe<UserActor>;
   pushSecurityEnabled: Scalars['Boolean'];
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
@@ -127,11 +126,18 @@ export type Account = {
   subscription?: Maybe<SubscriptionDetails>;
   /** @deprecated No longer needed */
   subscriptionChangesPending?: Maybe<Scalars['Boolean']>;
+  /** Coalesced project activity for an app using pagination */
+  timelineActivity: TimelineActivityConnection;
   /** @deprecated See isCurrent */
   unlimitedBuilds: Scalars['Boolean'];
   updatedAt: Scalars['DateTime'];
   /** Account query object for querying EAS usage metrics */
   usageMetrics: AccountUsageMetrics;
+  /**
+   * Owning UserActor of this account if personal account
+   * @deprecated Deprecated in favor of ownerUserActor
+   */
+  userActorOwner?: Maybe<UserActor>;
   /** Pending user invitations for this account */
   userInvitations: Array<UserInvitation>;
   /** Actors associated with this account and permissions they hold */
@@ -207,6 +213,19 @@ export type AccountAppsArgs = {
  * An account is a container owning projects, credentials, billing and other organization
  * data and settings. Actors may own and be members of accounts.
  */
+export type AccountAppsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<AccountAppsFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
 export type AccountBillingPeriodArgs = {
   date: Scalars['DateTime'];
 };
@@ -263,6 +282,44 @@ export type AccountSnacksArgs = {
   offset: Scalars['Int'];
 };
 
+
+/**
+ * An account is a container owning projects, credentials, billing and other organization
+ * data and settings. Actors may own and be members of accounts.
+ */
+export type AccountTimelineActivityArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<TimelineActivityFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type AccountAppsConnection = {
+  __typename?: 'AccountAppsConnection';
+  edges: Array<AccountAppsEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AccountAppsEdge = {
+  __typename?: 'AccountAppsEdge';
+  cursor: Scalars['String'];
+  node: App;
+};
+
+export type AccountAppsFilterInput = {
+  sortByField: AccountAppsSortByField;
+};
+
+export enum AccountAppsSortByField {
+  LatestActivityTime = 'LATEST_ACTIVITY_TIME',
+  /**
+   * Name prefers the display name but falls back to full_name with @account/
+   * part stripped.
+   */
+  Name = 'NAME'
+}
+
 export type AccountDataInput = {
   name: Scalars['String'];
 };
@@ -274,6 +331,8 @@ export type AccountMutation = {
    * @deprecated Build packs are no longer supported
    */
   buyProduct?: Maybe<Account>;
+  /** Cancels all subscriptions immediately */
+  cancelAllSubscriptionsImmediately: Account;
   /** Cancel scheduled subscription change */
   cancelScheduledSubscriptionChange: Account;
   /** Cancels the active subscription */
@@ -305,6 +364,11 @@ export type AccountMutationBuyProductArgs = {
   autoRenew?: InputMaybe<Scalars['Boolean']>;
   paymentSource?: InputMaybe<Scalars['ID']>;
   productId: Scalars['ID'];
+};
+
+
+export type AccountMutationCancelAllSubscriptionsImmediatelyArgs = {
+  accountID: Scalars['ID'];
 };
 
 
@@ -370,6 +434,13 @@ export type AccountMutationSetPushSecurityEnabledArgs = {
   pushSecurityEnabled: Scalars['Boolean'];
 };
 
+export type AccountNotificationSubscriptionInput = {
+  accountId: Scalars['ID'];
+  event: NotificationEvent;
+  type: NotificationType;
+  userId: Scalars['ID'];
+};
+
 export type AccountQuery = {
   __typename?: 'AccountQuery';
   /** Query an Account by ID */
@@ -397,8 +468,9 @@ export type AccountSsoConfiguration = {
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
   createdAt: Scalars['DateTime'];
+  endSessionEndpoint?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  issuer?: Maybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: Maybe<Scalars['String']>;
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
@@ -412,7 +484,8 @@ export type AccountSsoConfigurationData = {
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
-  issuer?: InputMaybe<Scalars['String']>;
+  endSessionEndpoint?: InputMaybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: InputMaybe<Scalars['String']>;
   revokeEndpoint?: InputMaybe<Scalars['String']>;
   tokenEndpoint?: InputMaybe<Scalars['String']>;
@@ -453,8 +526,9 @@ export type AccountSsoConfigurationPublicData = {
   authProtocol: AuthProtocolType;
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
+  endSessionEndpoint?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  issuer?: Maybe<Scalars['String']>;
+  issuer: Scalars['String'];
   jwksEndpoint?: Maybe<Scalars['String']>;
   revokeEndpoint?: Maybe<Scalars['String']>;
   tokenEndpoint?: Maybe<Scalars['String']>;
@@ -472,24 +546,20 @@ export type AccountSsoConfigurationPublicDataQueryPublicDataByAccountNameArgs = 
   accountName: Scalars['String'];
 };
 
+export type AccountUsageEasBuildMetadata = {
+  __typename?: 'AccountUsageEASBuildMetadata';
+  billingResourceClass: EasBuildBillingResourceClass;
+  platform: AppPlatform;
+};
+
+export type AccountUsageMetadata = AccountUsageEasBuildMetadata;
+
 export type AccountUsageMetric = {
   __typename?: 'AccountUsageMetric';
   id: Scalars['ID'];
   metricType: UsageMetricType;
   serviceMetric: EasServiceMetric;
   timestamp: Scalars['DateTime'];
-  value: Scalars['Float'];
-};
-
-export type AccountUsageMetricAndCost = {
-  __typename?: 'AccountUsageMetricAndCost';
-  id: Scalars['ID'];
-  /** The limit, in units, allowed by this plan */
-  limit: Scalars['Float'];
-  metricType: UsageMetricType;
-  serviceMetric: EasServiceMetric;
-  /** Total cost of this particular metric, in cents */
-  totalCost: Scalars['Float'];
   value: Scalars['Float'];
 };
 
@@ -502,6 +572,7 @@ export type AccountUsageMetrics = {
 
 export type AccountUsageMetricsByBillingPeriodArgs = {
   date: Scalars['DateTime'];
+  service?: InputMaybe<EasService>;
 };
 
 
@@ -525,7 +596,7 @@ export enum ActivityTimelineProjectActivityType {
   Update = 'UPDATE'
 }
 
-/** A user or robot that can authenticate with Expo services and be a member of accounts. */
+/** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
 export type Actor = {
   /** Access Tokens belonging to this actor */
   accessTokens: Array<AccessToken>;
@@ -548,7 +619,7 @@ export type Actor = {
 };
 
 
-/** A user or robot that can authenticate with Expo services and be a member of accounts. */
+/** A regular user, SSO user, or robot that can authenticate with Expo services and be a member of accounts. */
 export type ActorFeatureGatesArgs = {
   filter?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -778,16 +849,20 @@ export type AndroidJobInput = {
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
   buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildProfile?: InputMaybe<Scalars['String']>;
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
   releaseChannel?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<AndroidJobSecretsInput>;
+  triggeredBy?: InputMaybe<BuildTrigger>;
   type: BuildWorkflow;
   updates?: InputMaybe<BuildUpdatesInput>;
   username?: InputMaybe<Scalars['String']>;
@@ -806,12 +881,14 @@ export type AndroidJobOverridesInput = {
   /** @deprecated */
   artifactPath?: InputMaybe<Scalars['String']>;
   buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
+  buildProfile?: InputMaybe<Scalars['String']>;
   buildType?: InputMaybe<AndroidBuildType>;
   builderEnvironment?: InputMaybe<AndroidBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
   gradleCommand?: InputMaybe<Scalars['String']>;
+  mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<AndroidJobSecretsInput>;
   updates?: InputMaybe<BuildUpdatesInput>;
@@ -821,6 +898,7 @@ export type AndroidJobOverridesInput = {
 
 export type AndroidJobSecretsInput = {
   buildCredentials?: InputMaybe<AndroidJobBuildCredentialsInput>;
+  robotAccessToken?: InputMaybe<Scalars['String']>;
 };
 
 export type AndroidJobVersionInput = {
@@ -908,6 +986,7 @@ export type App = Project & {
   /** ios.appStoreUrl field from most recent classic update manifest */
   appStoreUrl?: Maybe<Scalars['String']>;
   assetLimitPerUpdateGroup: Scalars['Int'];
+  branchesPaginated: AppBranchesConnection;
   buildJobs: Array<BuildJob>;
   /**
    * Coalesced Build (EAS) or BuildJob (Classic) items for this app.
@@ -916,12 +995,13 @@ export type App = Project & {
   buildOrBuildJobs: Array<BuildOrBuildJob>;
   /** (EAS Build) Builds associated with this app */
   builds: Array<Build>;
+  buildsPaginated: AppBuildsConnection;
   /** Classic update release channel names that have at least one build */
   buildsReleaseChannels: Array<Scalars['String']>;
+  channelsPaginated: AppChannelsConnection;
   deployment?: Maybe<Deployment>;
-  deploymentNew?: Maybe<DeploymentNew>;
   /** Deployments associated with this app */
-  deployments: Array<Deployment>;
+  deployments: DeploymentsConnection;
   description: Scalars['String'];
   /** Environment secrets for an app */
   environmentSecrets: Array<EnvironmentSecret>;
@@ -943,6 +1023,8 @@ export type App = Project & {
   isLikedByMe: Scalars['Boolean'];
   /** @deprecated No longer supported */
   lastPublishedTime: Scalars['DateTime'];
+  /** Time of the last user activity (update, branch, submission). */
+  latestActivity: Scalars['DateTime'];
   latestAppVersionByPlatformAndApplicationIdentifier?: Maybe<AppVersion>;
   latestReleaseForReleaseChannel?: Maybe<AppRelease>;
   /** ID of latest classic update release */
@@ -969,11 +1051,15 @@ export type App = Project & {
   releaseChannels: Array<Scalars['String']>;
   /** @deprecated Legacy access tokens are deprecated */
   requiresAccessTokenForPushSecurity: Scalars['Boolean'];
+  scopeKey: Scalars['String'];
   /** SDK version of the latest classic update publish, 0.0.0 otherwise */
   sdkVersion: Scalars['String'];
   slug: Scalars['String'];
   /** EAS Submissions associated with this app */
   submissions: Array<Submission>;
+  submissionsPaginated: AppSubmissionsConnection;
+  /** Coalesced project activity for an app using pagination */
+  timelineActivity: TimelineActivityConnection;
   /** @deprecated 'likes' have been deprecated. */
   trendScore: Scalars['Float'];
   /** get an EAS branch owned by the app by name */
@@ -990,6 +1076,7 @@ export type App = Project & {
   updated: Scalars['DateTime'];
   /** EAS updates owned by an app */
   updates: Array<Update>;
+  updatesPaginated: AppUpdatesConnection;
   /** @deprecated Use ownerAccount.name instead */
   username: Scalars['String'];
   /** @deprecated No longer supported */
@@ -1013,6 +1100,15 @@ export type AppActivityTimelineProjectActivitiesArgs = {
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppAndroidAppCredentialsArgs = {
   filter?: InputMaybe<AndroidAppCredentialsFilter>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppBranchesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1042,15 +1138,26 @@ export type AppBuildsArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppDeploymentArgs = {
-  channel: Scalars['String'];
-  options?: InputMaybe<DeploymentOptions>;
-  runtimeVersion: Scalars['String'];
+export type AppBuildsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<BuildFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
-export type AppDeploymentNewArgs = {
+export type AppChannelsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppDeploymentArgs = {
   channel: Scalars['String'];
   runtimeVersion: Scalars['String'];
 };
@@ -1058,9 +1165,10 @@ export type AppDeploymentNewArgs = {
 
 /** Represents an Exponent App (or Experience in legacy terms) */
 export type AppDeploymentsArgs = {
-  limit: Scalars['Int'];
-  mostRecentlyUpdatedAt?: InputMaybe<Scalars['DateTime']>;
-  options?: InputMaybe<DeploymentOptions>;
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 
@@ -1106,6 +1214,25 @@ export type AppSubmissionsArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
+export type AppSubmissionsPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
+export type AppTimelineActivityArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<TimelineActivityFilterInput>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppUpdateBranchByNameArgs = {
   name: Scalars['String'];
 };
@@ -1147,8 +1274,53 @@ export type AppUpdatesArgs = {
 
 
 /** Represents an Exponent App (or Experience in legacy terms) */
+export type AppUpdatesPaginatedArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+
+/** Represents an Exponent App (or Experience in legacy terms) */
 export type AppWebhooksArgs = {
   filter?: InputMaybe<WebhookFilter>;
+};
+
+export type AppBranchEdge = {
+  __typename?: 'AppBranchEdge';
+  cursor: Scalars['String'];
+  node: UpdateBranch;
+};
+
+export type AppBranchesConnection = {
+  __typename?: 'AppBranchesConnection';
+  edges: Array<AppBranchEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppBuildEdge = {
+  __typename?: 'AppBuildEdge';
+  cursor: Scalars['String'];
+  node: BuildOrBuildJob;
+};
+
+export type AppBuildsConnection = {
+  __typename?: 'AppBuildsConnection';
+  edges: Array<AppBuildEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppChannelEdge = {
+  __typename?: 'AppChannelEdge';
+  cursor: Scalars['String'];
+  node: UpdateChannel;
+};
+
+export type AppChannelsConnection = {
+  __typename?: 'AppChannelsConnection';
+  edges: Array<AppChannelEdge>;
+  pageInfo: PageInfo;
 };
 
 export type AppDataInput = {
@@ -1209,6 +1381,13 @@ export type AppMutationSetAppInfoArgs = {
 export type AppMutationSetPushSecurityEnabledArgs = {
   appId: Scalars['ID'];
   pushSecurityEnabled: Scalars['Boolean'];
+};
+
+export type AppNotificationSubscriptionInput = {
+  appId: Scalars['ID'];
+  event: NotificationEvent;
+  type: NotificationType;
+  userId: Scalars['ID'];
 };
 
 export enum AppPlatform {
@@ -1333,6 +1512,30 @@ export enum AppStoreConnectUserRole {
   Unknown = 'UNKNOWN'
 }
 
+export type AppSubmissionEdge = {
+  __typename?: 'AppSubmissionEdge';
+  cursor: Scalars['String'];
+  node: Submission;
+};
+
+export type AppSubmissionsConnection = {
+  __typename?: 'AppSubmissionsConnection';
+  edges: Array<AppSubmissionEdge>;
+  pageInfo: PageInfo;
+};
+
+export type AppUpdateEdge = {
+  __typename?: 'AppUpdateEdge';
+  cursor: Scalars['String'];
+  node: Update;
+};
+
+export type AppUpdatesConnection = {
+  __typename?: 'AppUpdatesConnection';
+  edges: Array<AppUpdateEdge>;
+  pageInfo: PageInfo;
+};
+
 /** Represents Play Store/App Store version of an application */
 export type AppVersion = {
   __typename?: 'AppVersion';
@@ -1440,6 +1643,8 @@ export type AppleDeviceMutation = {
   createAppleDevice: AppleDevice;
   /** Delete an Apple Device */
   deleteAppleDevice: DeleteAppleDeviceResult;
+  /** Update an Apple Device */
+  updateAppleDevice: AppleDevice;
 };
 
 
@@ -1450,6 +1655,12 @@ export type AppleDeviceMutationCreateAppleDeviceArgs = {
 
 
 export type AppleDeviceMutationDeleteAppleDeviceArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type AppleDeviceMutationUpdateAppleDeviceArgs = {
+  appleDeviceUpdateInput: AppleDeviceUpdateInput;
   id: Scalars['ID'];
 };
 
@@ -1480,6 +1691,10 @@ export type AppleDeviceRegistrationRequestQuery = {
 
 export type AppleDeviceRegistrationRequestQueryByIdArgs = {
   id: Scalars['ID'];
+};
+
+export type AppleDeviceUpdateInput = {
+  name?: InputMaybe<Scalars['String']>;
 };
 
 export type AppleDistributionCertificate = {
@@ -1744,6 +1959,7 @@ export type BillingPeriod = {
   __typename?: 'BillingPeriod';
   anchor: Scalars['DateTime'];
   end: Scalars['DateTime'];
+  id: Scalars['ID'];
   start: Scalars['DateTime'];
 };
 
@@ -1752,11 +1968,10 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
-  /** The actual resource class of the builder assigned to the build job */
-  actualResourceClass?: Maybe<BuildResourceClass>;
   appBuildVersion?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
+  buildMode?: Maybe<BuildMode>;
   buildProfile?: Maybe<Scalars['String']>;
   canRetry: Scalars['Boolean'];
   cancelingActor?: Maybe<Actor>;
@@ -1764,6 +1979,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   childBuild?: Maybe<Build>;
   completedAt?: Maybe<Scalars['DateTime']>;
   createdAt: Scalars['DateTime'];
+  customWorkflowName?: Maybe<Scalars['String']>;
   distribution?: Maybe<DistributionType>;
   enqueuedAt?: Maybe<Scalars['DateTime']>;
   error?: Maybe<BuildError>;
@@ -1771,6 +1987,8 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   expirationDate?: Maybe<Scalars['DateTime']>;
   gitCommitHash?: Maybe<Scalars['String']>;
   gitCommitMessage?: Maybe<Scalars['String']>;
+  gitRef?: Maybe<Scalars['String']>;
+  githubRepositoryOwnerAndName?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   /** Queue position is 1-indexed */
   initialQueuePosition?: Maybe<Scalars['Int']>;
@@ -1782,20 +2000,27 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   logFiles: Array<Scalars['String']>;
   maxBuildTimeSeconds: Scalars['Int'];
   /** Retry time starts after completedAt */
-  maxRetryTimeMinutes: Scalars['Int'];
+  maxRetryTimeMinutes?: Maybe<Scalars['Int']>;
   message?: Maybe<Scalars['String']>;
   metrics?: Maybe<BuildMetrics>;
   parentBuild?: Maybe<Build>;
   platform: AppPlatform;
   priority: BuildPriority;
   project: Project;
+  projectRootDirectory?: Maybe<Scalars['String']>;
   provisioningStartedAt?: Maybe<Scalars['DateTime']>;
   /** Queue position is 1-indexed */
   queuePosition?: Maybe<Scalars['Int']>;
   reactNativeVersion?: Maybe<Scalars['String']>;
   releaseChannel?: Maybe<Scalars['String']>;
-  /** The builder resource class requested by the developer */
+  /**
+   * The builder resource class requested by the developer
+   * @deprecated Use resourceClassDisplayName instead
+   */
   resourceClass: BuildResourceClass;
+  /** String describing the resource class used to run the build */
+  resourceClassDisplayName: Scalars['String'];
+  retryDisabledReason?: Maybe<BuildRetryDisabledReason>;
   runFromCI?: Maybe<Scalars['Boolean']>;
   runtimeVersion?: Maybe<Scalars['String']>;
   sdkVersion?: Maybe<Scalars['String']>;
@@ -1803,6 +2028,18 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   submissions: Array<Submission>;
   updatedAt: Scalars['DateTime'];
   workerStartedAt?: Maybe<Scalars['DateTime']>;
+};
+
+
+/** Represents an EAS Build */
+export type BuildCanRetryArgs = {
+  newMode?: InputMaybe<BuildMode>;
+};
+
+
+/** Represents an EAS Build */
+export type BuildRetryDisabledReasonArgs = {
+  newMode?: InputMaybe<BuildMode>;
 };
 
 export type BuildArtifact = {
@@ -1820,11 +2057,10 @@ export type BuildArtifacts = {
 };
 
 export type BuildCacheInput = {
-  cacheDefaultPaths?: InputMaybe<Scalars['Boolean']>;
   clear?: InputMaybe<Scalars['Boolean']>;
-  customPaths?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   disabled?: InputMaybe<Scalars['Boolean']>;
   key?: InputMaybe<Scalars['String']>;
+  paths?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export enum BuildCredentialsSource {
@@ -1853,6 +2089,12 @@ export type BuildFilter = {
   status?: InputMaybe<BuildStatus>;
 };
 
+export type BuildFilterInput = {
+  channel?: InputMaybe<Scalars['String']>;
+  platforms?: InputMaybe<Array<AppPlatform>>;
+  releaseChannel?: InputMaybe<Scalars['String']>;
+};
+
 export enum BuildIosEnterpriseProvisioning {
   Adhoc = 'ADHOC',
   Universal = 'UNIVERSAL'
@@ -1861,6 +2103,7 @@ export enum BuildIosEnterpriseProvisioning {
 /** Represents an Standalone App build job */
 export type BuildJob = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'BuildJob';
+  accountUserActor?: Maybe<UserActor>;
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
   app?: Maybe<App>;
@@ -1887,9 +2130,7 @@ export enum BuildJobLogsFormat {
 
 export type BuildJobMutation = {
   __typename?: 'BuildJobMutation';
-  cancel: BuildJob;
   del?: Maybe<BuildJob>;
-  restart: BuildJob;
 };
 
 export type BuildJobQuery = {
@@ -1937,10 +2178,12 @@ export type BuildMetadataInput = {
   appIdentifier?: InputMaybe<Scalars['String']>;
   appName?: InputMaybe<Scalars['String']>;
   appVersion?: InputMaybe<Scalars['String']>;
+  buildMode?: InputMaybe<BuildMode>;
   buildProfile?: InputMaybe<Scalars['String']>;
   channel?: InputMaybe<Scalars['String']>;
   cliVersion?: InputMaybe<Scalars['String']>;
   credentialsSource?: InputMaybe<BuildCredentialsSource>;
+  customWorkflowName?: InputMaybe<Scalars['String']>;
   distribution?: InputMaybe<DistributionType>;
   gitCommitHash?: InputMaybe<Scalars['String']>;
   gitCommitMessage?: InputMaybe<Scalars['String']>;
@@ -1964,6 +2207,12 @@ export type BuildMetrics = {
   buildQueueTime?: Maybe<Scalars['Int']>;
   buildWaitTime?: Maybe<Scalars['Int']>;
 };
+
+export enum BuildMode {
+  Build = 'BUILD',
+  Custom = 'CUSTOM',
+  Resign = 'RESIGN'
+}
 
 export type BuildMutation = {
   __typename?: 'BuildMutation';
@@ -1989,6 +2238,8 @@ export type BuildMutation = {
   retryBuild: Build;
   /** Retry an iOS EAS Build */
   retryIosBuild: Build;
+  /** Update metadata for EAS Build build */
+  updateBuildMetadata: Build;
 };
 
 
@@ -2034,6 +2285,12 @@ export type BuildMutationRetryIosBuildArgs = {
   jobOverrides?: InputMaybe<IosJobOverridesInput>;
 };
 
+
+export type BuildMutationUpdateBuildMetadataArgs = {
+  buildId: Scalars['ID'];
+  metadata: BuildMetadataInput;
+};
+
 export type BuildOrBuildJob = {
   id: Scalars['ID'];
 };
@@ -2050,7 +2307,9 @@ export type BuildOrBuildJobQueryByIdArgs = {
 };
 
 export type BuildParamsInput = {
+  reactNativeVersion?: InputMaybe<Scalars['String']>;
   resourceClass: BuildResourceClass;
+  sdkVersion?: InputMaybe<Scalars['String']>;
 };
 
 export enum BuildPriority {
@@ -2121,14 +2380,34 @@ export type BuildQueryByIdArgs = {
   buildId: Scalars['ID'];
 };
 
+export type BuildResignInput = {
+  applicationArchiveSource?: InputMaybe<ProjectArchiveSourceInput>;
+};
+
 export enum BuildResourceClass {
   AndroidDefault = 'ANDROID_DEFAULT',
   AndroidLarge = 'ANDROID_LARGE',
+  AndroidMedium = 'ANDROID_MEDIUM',
   IosDefault = 'IOS_DEFAULT',
+  /** @deprecated Use IOS_INTEL_MEDIUM instead */
+  IosIntelLarge = 'IOS_INTEL_LARGE',
+  IosIntelMedium = 'IOS_INTEL_MEDIUM',
   IosLarge = 'IOS_LARGE',
-  /** @experimental This resource class is not yet ready to be used in production. For testing purposes only. */
+  /** @deprecated Use IOS_M_MEDIUM instead */
   IosM1Large = 'IOS_M1_LARGE',
+  IosM1Medium = 'IOS_M1_MEDIUM',
+  IosMedium = 'IOS_MEDIUM',
+  IosMLarge = 'IOS_M_LARGE',
+  IosMMedium = 'IOS_M_MEDIUM',
   Legacy = 'LEGACY'
+}
+
+export enum BuildRetryDisabledReason {
+  AlreadyRetried = 'ALREADY_RETRIED',
+  InvalidStatus = 'INVALID_STATUS',
+  IsGithubBuild = 'IS_GITHUB_BUILD',
+  NotCompletedYet = 'NOT_COMPLETED_YET',
+  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED'
 }
 
 export enum BuildStatus {
@@ -2140,18 +2419,19 @@ export enum BuildStatus {
   New = 'NEW'
 }
 
+export enum BuildTrigger {
+  EasCli = 'EAS_CLI',
+  GitBasedIntegration = 'GIT_BASED_INTEGRATION'
+}
+
 export type BuildUpdatesInput = {
   channel?: InputMaybe<Scalars['String']>;
 };
 
 export enum BuildWorkflow {
   Generic = 'GENERIC',
-  Managed = 'MANAGED'
-}
-
-export enum CacheControlScope {
-  Private = 'PRIVATE',
-  Public = 'PUBLIC'
+  Managed = 'MANAGED',
+  Unknown = 'UNKNOWN'
 }
 
 export type Card = {
@@ -2165,34 +2445,13 @@ export type Card = {
 
 export type Charge = {
   __typename?: 'Charge';
-  amount?: Maybe<Scalars['Int']>;
-  createdAt?: Maybe<Scalars['DateTime']>;
+  amount: Scalars['Int'];
+  createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
   invoiceId?: Maybe<Scalars['String']>;
-  paid?: Maybe<Scalars['Boolean']>;
+  paid: Scalars['Boolean'];
   receiptUrl?: Maybe<Scalars['String']>;
-  wasRefunded?: Maybe<Scalars['Boolean']>;
-};
-
-/** Represents a client build request */
-export type ClientBuild = {
-  __typename?: 'ClientBuild';
-  buildJobId?: Maybe<Scalars['String']>;
-  id: Scalars['ID'];
-  manifestPlistUrl?: Maybe<Scalars['String']>;
-  status?: Maybe<Scalars['String']>;
-  userFacingErrorMessage?: Maybe<Scalars['String']>;
-  userId?: Maybe<Scalars['String']>;
-};
-
-export type ClientBuildQuery = {
-  __typename?: 'ClientBuildQuery';
-  byId: ClientBuild;
-};
-
-
-export type ClientBuildQueryByIdArgs = {
-  requestId: Scalars['ID'];
+  wasRefunded: Scalars['Boolean'];
 };
 
 export type CodeSigningInfo = {
@@ -2262,7 +2521,7 @@ export type CreateGitHubRepositoryInput = {
 
 export type CreateGitHubRepositorySettingsInput = {
   appId: Scalars['ID'];
-  /** The base directory is the directory to change to before starting a build. This string should be a properly formatted Unix path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository. */
+  /** The base directory is the directory to change to before starting a build. This string should be a properly formatted POSIX path starting with '/', './', or the name of the directory relative to the root of the repository. Valid examples include: '/apps/expo-app', './apps/expo-app', and 'apps/expo-app'. This is intended for monorepos or apps that live in a subdirectory of a repository. */
   baseDirectory: Scalars['String'];
 };
 
@@ -2284,6 +2543,10 @@ export type CreateSubmissionResult = {
   __typename?: 'CreateSubmissionResult';
   /** Created submission */
   submission: Submission;
+};
+
+export type CustomBuildConfigInput = {
+  path: Scalars['String'];
 };
 
 export type DeleteAccessTokenResult = {
@@ -2321,8 +2584,18 @@ export type DeleteAppleProvisioningProfileResult = {
   id: Scalars['ID'];
 };
 
+export type DeleteDiscordUserResult = {
+  __typename?: 'DeleteDiscordUserResult';
+  id: Scalars['ID'];
+};
+
 export type DeleteEnvironmentSecretResult = {
   __typename?: 'DeleteEnvironmentSecretResult';
+  id: Scalars['ID'];
+};
+
+export type DeleteGitHubUserResult = {
+  __typename?: 'DeleteGitHubUserResult';
   id: Scalars['ID'];
 };
 
@@ -2374,16 +2647,21 @@ export type DeployServerlessFunctionResult = {
 /** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
 export type Deployment = {
   __typename?: 'Deployment';
-  channel?: Maybe<UpdateChannel>;
-  /**
-   * The name of this deployment's associated channel. It is specified separately from the `channel`
-   * field to allow specifying a deployment before an EAS Update channel has been created.
-   */
-  channelName: Scalars['String'];
+  builds: DeploymentBuildsConnection;
+  channel: UpdateChannel;
   id: Scalars['ID'];
-  mostRecentlyUpdatedAt: Scalars['DateTime'];
-  recentBuilds: Array<Build>;
-  runtimeVersion: Scalars['String'];
+  /** @deprecated Not required for the new Deployment UI */
+  latestUpdate?: Maybe<Update>;
+  runtime: Runtime;
+};
+
+
+/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
+export type DeploymentBuildsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 export type DeploymentBuildEdge = {
@@ -2392,39 +2670,61 @@ export type DeploymentBuildEdge = {
   node: Build;
 };
 
+/** Represents the connection over the builds edge of a Deployment */
 export type DeploymentBuildsConnection = {
   __typename?: 'DeploymentBuildsConnection';
   edges: Array<DeploymentBuildEdge>;
   pageInfo: PageInfo;
 };
 
-/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
-export type DeploymentNew = {
-  __typename?: 'DeploymentNew';
-  builds: DeploymentBuildsConnection;
-  channel: UpdateChannel;
+export type DeploymentEdge = {
+  __typename?: 'DeploymentEdge';
+  cursor: Scalars['String'];
+  node: Deployment;
+};
+
+/** Represents the connection over the deployments edge of an App */
+export type DeploymentsConnection = {
+  __typename?: 'DeploymentsConnection';
+  edges: Array<DeploymentEdge>;
+  pageInfo: PageInfo;
+};
+
+export type DiscordUser = {
+  __typename?: 'DiscordUser';
+  discordIdentifier: Scalars['String'];
   id: Scalars['ID'];
-  runtime: Runtime;
+  metadata?: Maybe<DiscordUserMetadata>;
+  userActor: UserActor;
+};
+
+export type DiscordUserMetadata = {
+  __typename?: 'DiscordUserMetadata';
+  discordAvatarUrl: Scalars['String'];
+  discordDiscriminator: Scalars['String'];
+  discordUsername: Scalars['String'];
+};
+
+export type DiscordUserMutation = {
+  __typename?: 'DiscordUserMutation';
+  /** Delete a Discord User by ID */
+  deleteDiscordUser: DeleteDiscordUserResult;
 };
 
 
-/** Represents a Deployment - a set of Builds with the same Runtime Version and Channel */
-export type DeploymentNewBuildsArgs = {
-  after?: InputMaybe<Scalars['String']>;
-  before?: InputMaybe<Scalars['String']>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-};
-
-export type DeploymentOptions = {
-  /** Max number of associated builds to return */
-  buildListMaxSize?: InputMaybe<Scalars['Int']>;
+export type DiscordUserMutationDeleteDiscordUserArgs = {
+  id: Scalars['ID'];
 };
 
 export enum DistributionType {
   Internal = 'INTERNAL',
   Simulator = 'SIMULATOR',
   Store = 'STORE'
+}
+
+export enum EasBuildBillingResourceClass {
+  Large = 'LARGE',
+  Medium = 'MEDIUM'
 }
 
 export type EasBuildDeprecationInfo = {
@@ -2440,6 +2740,11 @@ export enum EasBuildDeprecationInfoType {
 
 export type EasBuildOrClassicBuildJob = Build | BuildJob;
 
+export enum EasService {
+  Builds = 'BUILDS',
+  Updates = 'UPDATES'
+}
+
 export enum EasServiceMetric {
   AssetsRequests = 'ASSETS_REQUESTS',
   BandwidthUsage = 'BANDWIDTH_USAGE',
@@ -2447,6 +2752,21 @@ export enum EasServiceMetric {
   ManifestRequests = 'MANIFEST_REQUESTS',
   UniqueUpdaters = 'UNIQUE_UPDATERS',
   UniqueUsers = 'UNIQUE_USERS'
+}
+
+export type EasTotalPlanEnablement = {
+  __typename?: 'EASTotalPlanEnablement';
+  total: Scalars['Int'];
+  unit?: Maybe<EasTotalPlanEnablementUnit>;
+};
+
+export enum EasTotalPlanEnablementUnit {
+  Build = 'BUILD',
+  Byte = 'BYTE',
+  Concurrency = 'CONCURRENCY',
+  Request = 'REQUEST',
+  Updater = 'UPDATER',
+  User = 'USER'
 }
 
 export type EditUpdateBranchInput = {
@@ -2506,6 +2826,30 @@ export enum EnvironmentSecretType {
   FileBase64 = 'FILE_BASE64',
   String = 'STRING'
 }
+
+export type EstimatedOverageAndCost = {
+  __typename?: 'EstimatedOverageAndCost';
+  id: Scalars['ID'];
+  /** The limit, in units, allowed by this plan */
+  limit: Scalars['Float'];
+  metadata?: Maybe<AccountUsageMetadata>;
+  metricType: UsageMetricType;
+  service: EasService;
+  serviceMetric: EasServiceMetric;
+  /** Total cost of this particular metric, in cents */
+  totalCost: Scalars['Int'];
+  value: Scalars['Float'];
+};
+
+export type EstimatedUsage = {
+  __typename?: 'EstimatedUsage';
+  id: Scalars['ID'];
+  limit: Scalars['Float'];
+  metricType: UsageMetricType;
+  service: EasService;
+  serviceMetric: EasServiceMetric;
+  value: Scalars['Float'];
+};
 
 export type ExperimentationQuery = {
   __typename?: 'ExperimentationQuery';
@@ -2623,6 +2967,17 @@ export enum GitHubAppInstallationStatus {
   Suspended = 'SUSPENDED'
 }
 
+export type GitHubAppMutation = {
+  __typename?: 'GitHubAppMutation';
+  /** Create a GitHub build for an app */
+  createGitHubBuild: Scalars['Boolean'];
+};
+
+
+export type GitHubAppMutationCreateGitHubBuildArgs = {
+  buildInput: GitHubBuildInput;
+};
+
 export type GitHubAppQuery = {
   __typename?: 'GitHubAppQuery';
   appIdentifier: Scalars['String'];
@@ -2644,11 +2999,20 @@ export type GitHubAppQuerySearchRepositoriesArgs = {
   query: Scalars['String'];
 };
 
+export type GitHubBuildInput = {
+  appId: Scalars['ID'];
+  baseDirectory?: InputMaybe<Scalars['String']>;
+  buildProfile: Scalars['String'];
+  gitRef: Scalars['String'];
+  platform: AppPlatform;
+};
+
 export type GitHubRepository = {
   __typename?: 'GitHubRepository';
   app: App;
   githubAppInstallation: GitHubAppInstallation;
   githubRepositoryIdentifier: Scalars['Int'];
+  githubRepositoryUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   metadata?: Maybe<GitHubRepositoryMetadata>;
   nodeIdentifier: Scalars['String'];
@@ -2730,6 +3094,33 @@ export type GitHubRepositorySettingsMutationDeleteGitHubRepositorySettingsArgs =
 export type GitHubRepositorySettingsMutationUpdateGitHubRepositorySettingsArgs = {
   githubRepositorySettingsData: UpdateGitHubRepositorySettingsInput;
   githubRepositorySettingsId: Scalars['ID'];
+};
+
+export type GitHubUser = {
+  __typename?: 'GitHubUser';
+  githubUserIdentifier: Scalars['String'];
+  id: Scalars['ID'];
+  metadata?: Maybe<GitHubUserMetadata>;
+  userActor: UserActor;
+};
+
+export type GitHubUserMetadata = {
+  __typename?: 'GitHubUserMetadata';
+  avatarUrl: Scalars['String'];
+  login: Scalars['String'];
+  name?: Maybe<Scalars['String']>;
+  url: Scalars['String'];
+};
+
+export type GitHubUserMutation = {
+  __typename?: 'GitHubUserMutation';
+  /** Delete a GitHub User by ID */
+  deleteGitHubUser: DeleteGitHubUserResult;
+};
+
+
+export type GitHubUserMutationDeleteGitHubUserArgs = {
+  id: Scalars['ID'];
 };
 
 export type GoogleServiceAccountKey = {
@@ -3009,20 +3400,24 @@ export type IosJobInput = {
   artifactPath?: InputMaybe<Scalars['String']>;
   buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
   buildConfiguration?: InputMaybe<Scalars['String']>;
+  buildProfile?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   buildType?: InputMaybe<IosBuildType>;
   builderEnvironment?: InputMaybe<IosBuilderEnvironmentInput>;
   cache?: InputMaybe<BuildCacheInput>;
+  customBuildConfig?: InputMaybe<CustomBuildConfigInput>;
   developmentClient?: InputMaybe<Scalars['Boolean']>;
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  mode?: InputMaybe<BuildMode>;
   projectArchive: ProjectArchiveSourceInput;
   projectRootDirectory: Scalars['String'];
   releaseChannel?: InputMaybe<Scalars['String']>;
   scheme?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<IosJobSecretsInput>;
   simulator?: InputMaybe<Scalars['Boolean']>;
+  triggeredBy?: InputMaybe<BuildTrigger>;
   type: BuildWorkflow;
   updates?: InputMaybe<BuildUpdatesInput>;
   username?: InputMaybe<Scalars['String']>;
@@ -3035,6 +3430,7 @@ export type IosJobOverridesInput = {
   artifactPath?: InputMaybe<Scalars['String']>;
   buildArtifactPaths?: InputMaybe<Array<Scalars['String']>>;
   buildConfiguration?: InputMaybe<Scalars['String']>;
+  buildProfile?: InputMaybe<Scalars['String']>;
   /** @deprecated */
   buildType?: InputMaybe<IosBuildType>;
   builderEnvironment?: InputMaybe<IosBuilderEnvironmentInput>;
@@ -3043,10 +3439,13 @@ export type IosJobOverridesInput = {
   /** @deprecated */
   distribution?: InputMaybe<DistributionType>;
   experimental?: InputMaybe<Scalars['JSONObject']>;
+  mode?: InputMaybe<BuildMode>;
   releaseChannel?: InputMaybe<Scalars['String']>;
+  resign?: InputMaybe<BuildResignInput>;
   scheme?: InputMaybe<Scalars['String']>;
   secrets?: InputMaybe<IosJobSecretsInput>;
   simulator?: InputMaybe<Scalars['Boolean']>;
+  type?: InputMaybe<BuildWorkflow>;
   updates?: InputMaybe<BuildUpdatesInput>;
   username?: InputMaybe<Scalars['String']>;
   version?: InputMaybe<IosJobVersionInput>;
@@ -3054,6 +3453,7 @@ export type IosJobOverridesInput = {
 
 export type IosJobSecretsInput = {
   buildCredentials?: InputMaybe<Array<InputMaybe<IosJobTargetCredentialsInput>>>;
+  robotAccessToken?: InputMaybe<Scalars['String']>;
 };
 
 export type IosJobTargetCredentialsInput = {
@@ -3159,8 +3559,10 @@ export type MeMutation = {
   unpublishApp: App;
   /** Update an App that the current user owns */
   updateApp: App;
-  /** Update the current user's data */
+  /** Update the current regular user's data */
   updateProfile: User;
+  /** Update the current SSO user's data */
+  updateSSOProfile: SsoUser;
 };
 
 
@@ -3247,10 +3649,65 @@ export type MeMutationUpdateProfileArgs = {
   userData: UserDataInput;
 };
 
+
+export type MeMutationUpdateSsoProfileArgs = {
+  userData: SsoUserDataInput;
+};
+
 export type MeteredBillingStatus = {
   __typename?: 'MeteredBillingStatus';
+  EAS_BUILD: Scalars['Boolean'];
   EAS_UPDATE: Scalars['Boolean'];
 };
+
+export enum NotificationEvent {
+  BuildComplete = 'BUILD_COMPLETE',
+  SubmissionComplete = 'SUBMISSION_COMPLETE'
+}
+
+export type NotificationSubscription = {
+  __typename?: 'NotificationSubscription';
+  account?: Maybe<Account>;
+  actor?: Maybe<Actor>;
+  app?: Maybe<App>;
+  createdAt: Scalars['DateTime'];
+  event: NotificationEvent;
+  id: Scalars['ID'];
+  type: NotificationType;
+};
+
+export type NotificationSubscriptionFilter = {
+  accountId?: InputMaybe<Scalars['ID']>;
+  appId?: InputMaybe<Scalars['ID']>;
+  event?: InputMaybe<NotificationEvent>;
+  type?: InputMaybe<NotificationType>;
+};
+
+export type NotificationSubscriptionMutation = {
+  __typename?: 'NotificationSubscriptionMutation';
+  subscribeToEventForAccount: SubscribeToNotificationResult;
+  subscribeToEventForApp: SubscribeToNotificationResult;
+  unsubscribe: UnsubscribeFromNotificationResult;
+};
+
+
+export type NotificationSubscriptionMutationSubscribeToEventForAccountArgs = {
+  input: AccountNotificationSubscriptionInput;
+};
+
+
+export type NotificationSubscriptionMutationSubscribeToEventForAppArgs = {
+  input: AppNotificationSubscriptionInput;
+};
+
+
+export type NotificationSubscriptionMutationUnsubscribeArgs = {
+  id: Scalars['ID'];
+};
+
+export enum NotificationType {
+  Email = 'EMAIL'
+}
 
 export type Offer = {
   __typename?: 'Offer';
@@ -3320,6 +3777,8 @@ export enum Permission {
   View = 'VIEW'
 }
 
+export type PlanEnablement = Concurrencies | EasTotalPlanEnablement;
+
 export type Project = {
   description: Scalars['String'];
   fullName: Scalars['String'];
@@ -3335,12 +3794,16 @@ export type Project = {
 
 export type ProjectArchiveSourceInput = {
   bucketKey?: InputMaybe<Scalars['String']>;
+  gitRef?: InputMaybe<Scalars['String']>;
+  repositoryUrl?: InputMaybe<Scalars['String']>;
   type: ProjectArchiveSourceType;
   url?: InputMaybe<Scalars['String']>;
 };
 
 export enum ProjectArchiveSourceType {
   Gcs = 'GCS',
+  Git = 'GIT',
+  None = 'NONE',
   S3 = 'S3',
   Url = 'URL'
 }
@@ -3394,8 +3857,9 @@ export type PublishUpdateGroupInput = {
   gitCommitHash?: InputMaybe<Scalars['String']>;
   isGitWorkingTreeDirty?: InputMaybe<Scalars['Boolean']>;
   message?: InputMaybe<Scalars['String']>;
+  rollBackToEmbeddedInfoGroup?: InputMaybe<UpdateRollBackToEmbeddedGroup>;
   runtimeVersion: Scalars['String'];
-  updateInfoGroup: UpdateInfoGroup;
+  updateInfoGroup?: InputMaybe<UpdateInfoGroup>;
 };
 
 export type RescindUserInvitationResult = {
@@ -3516,16 +3980,22 @@ export type RootMutation = {
   build: BuildMutation;
   /** Mutations that modify an BuildJob */
   buildJob: BuildJobMutation;
+  /** Mutations for Discord users */
+  discordUser: DiscordUserMutation;
   /** Mutations that modify an EmailSubscription */
   emailSubscription: EmailSubscriptionMutation;
   /** Mutations that create and delete EnvironmentSecrets */
   environmentSecret: EnvironmentSecretMutation;
+  /** Mutations that utilize services facilitated by the GitHub App */
+  githubApp: GitHubAppMutation;
   /** Mutations for GitHub App installations */
   githubAppInstallation: GitHubAppInstallationMutation;
   /** Mutations for GitHub repositories */
   githubRepository: GitHubRepositoryMutation;
   /** Mutations for GitHub repository settings */
   githubRepositorySettings: GitHubRepositorySettingsMutation;
+  /** Mutations for GitHub users */
+  githubUser: GitHubUserMutation;
   /** Mutations that modify a Google Service Account Key */
   googleServiceAccountKey: GoogleServiceAccountKeyMutation;
   /** Mutations that modify the build credentials for an iOS app */
@@ -3535,6 +4005,8 @@ export type RootMutation = {
   keystoreGenerationUrl: KeystoreGenerationUrlMutation;
   /** Mutations that modify the currently authenticated User */
   me: MeMutation;
+  /** Mutations that modify a NotificationSubscription */
+  notificationSubscription: NotificationSubscriptionMutation;
   /** Mutations that create, update, and delete Robots */
   robot: RobotMutation;
   serverlessFunction: ServerlessFunctionMutation;
@@ -3604,7 +4076,6 @@ export type RootQuery = {
   /** Top-level query object for querying BuildPublicData publicly. */
   buildPublicData: BuildPublicDataQuery;
   builds: BuildQuery;
-  clientBuilds: ClientBuildQuery;
   /** Top-level query object for querying Experimentation configuration. */
   experimentation: ExperimentationQuery;
   /** Top-level query object for querying GitHub App information and resources it has access to. */
@@ -3619,12 +4090,19 @@ export type RootQuery = {
    */
   me?: Maybe<User>;
   /**
-   * If authenticated as a any type of Actor, this is the appropriate top-level
+   * If authenticated as any type of Actor, this is the appropriate top-level
    * query object
    */
   meActor?: Maybe<Actor>;
+  /**
+   * If authenticated as any type of human end user (Actor types User or SSOUser),
+   * this is the appropriate top-level query object
+   */
+  meUserActor?: Maybe<UserActor>;
   project: ProjectQuery;
   snack: SnackQuery;
+  /** Top-level query object for querying SSO Users. */
+  ssoUser: SsoUserQuery;
   /** Top-level query object for querying Expo status page services. */
   statuspageService: StatuspageServiceQuery;
   submissions: SubmissionQuery;
@@ -3632,6 +4110,8 @@ export type RootQuery = {
   updatesByGroup: Array<Update>;
   /** Top-level query object for querying Users. */
   user: UserQuery;
+  /** Top-level query object for querying UserActors. */
+  userActor: UserActorQuery;
   /** @deprecated Use 'byId' field under 'user'. */
   userByUserId?: Maybe<User>;
   /** @deprecated Use 'byUsername' field under 'user'. */
@@ -3681,6 +4161,110 @@ export type Runtime = {
   firstBuildCreatedAt: Scalars['DateTime'];
   id: Scalars['ID'];
   version: Scalars['String'];
+};
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUser = Actor & UserActor & {
+  __typename?: 'SSOUser';
+  /** Access Tokens belonging to this actor, none at present */
+  accessTokens: Array<AccessToken>;
+  accounts: Array<Account>;
+  /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  appCount: Scalars['Int'];
+  appetizeCode?: Maybe<Scalars['String']>;
+  /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
+  apps: Array<App>;
+  bestContactEmail?: Maybe<Scalars['String']>;
+  created: Scalars['DateTime'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
+  displayName: Scalars['String'];
+  /**
+   * Server feature gate values for this actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject'];
+  firstName?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  /** GitHub account linked to a user */
+  githubUser?: Maybe<GitHubUser>;
+  githubUsername?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  industry?: Maybe<Scalars['String']>;
+  isExpoAdmin: Scalars['Boolean'];
+  lastName?: Maybe<Scalars['String']>;
+  location?: Maybe<Scalars['String']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
+  /** Associated accounts */
+  primaryAccount: Account;
+  profilePhoto: Scalars['String'];
+  /** Snacks associated with this account */
+  snacks: Array<Snack>;
+  twitterUsername?: Maybe<Scalars['String']>;
+  username: Scalars['String'];
+};
+
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserActivityTimelineProjectActivitiesArgs = {
+  createdBefore?: InputMaybe<Scalars['DateTime']>;
+  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  limit: Scalars['Int'];
+};
+
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserAppsArgs = {
+  includeUnpublished?: InputMaybe<Scalars['Boolean']>;
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserFeatureGatesArgs = {
+  filter?: InputMaybe<Array<Scalars['String']>>;
+};
+
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserNotificationSubscriptionsArgs = {
+  filter?: InputMaybe<NotificationSubscriptionFilter>;
+};
+
+
+/** Represents a human SSO (not robot) actor. */
+export type SsoUserSnacksArgs = {
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+export type SsoUserDataInput = {
+  firstName?: InputMaybe<Scalars['String']>;
+  githubUsername?: InputMaybe<Scalars['String']>;
+  industry?: InputMaybe<Scalars['String']>;
+  lastName?: InputMaybe<Scalars['String']>;
+  location?: InputMaybe<Scalars['String']>;
+  twitterUsername?: InputMaybe<Scalars['String']>;
+};
+
+export type SsoUserQuery = {
+  __typename?: 'SSOUserQuery';
+  /** Query an SSOUser by ID */
+  byId: SsoUser;
+  /** Query an SSOUser by username */
+  byUsername: SsoUser;
+};
+
+
+export type SsoUserQueryByIdArgs = {
+  userId: Scalars['ID'];
+};
+
+
+export type SsoUserQueryByUsernameArgs = {
+  username: Scalars['String'];
 };
 
 export type SecondFactorBooleanResult = {
@@ -4028,6 +4612,11 @@ export enum SubmissionStatus {
   InQueue = 'IN_QUEUE'
 }
 
+export type SubscribeToNotificationResult = {
+  __typename?: 'SubscribeToNotificationResult';
+  notificationSubscription: NotificationSubscription;
+};
+
 export type SubscriptionDetails = {
   __typename?: 'SubscriptionDetails';
   addons: Array<AddonDetails>;
@@ -4041,11 +4630,41 @@ export type SubscriptionDetails = {
   meteredBillingStatus: MeteredBillingStatus;
   name?: Maybe<Scalars['String']>;
   nextInvoice?: Maybe<Scalars['DateTime']>;
+  planEnablement?: Maybe<PlanEnablement>;
   planId?: Maybe<Scalars['String']>;
   price: Scalars['Int'];
   status?: Maybe<Scalars['String']>;
   trialEnd?: Maybe<Scalars['DateTime']>;
   willCancel?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type SubscriptionDetailsPlanEnablementArgs = {
+  serviceMetric: EasServiceMetric;
+};
+
+export type TimelineActivityConnection = {
+  __typename?: 'TimelineActivityConnection';
+  edges: Array<TimelineActivityEdge>;
+  pageInfo: PageInfo;
+};
+
+export type TimelineActivityEdge = {
+  __typename?: 'TimelineActivityEdge';
+  cursor: Scalars['String'];
+  node: ActivityTimelineProjectActivity;
+};
+
+export type TimelineActivityFilterInput = {
+  channels?: InputMaybe<Array<Scalars['String']>>;
+  platforms?: InputMaybe<Array<AppPlatform>>;
+  releaseChannels?: InputMaybe<Array<Scalars['String']>>;
+  types?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+};
+
+export type UnsubscribeFromNotificationResult = {
+  __typename?: 'UnsubscribeFromNotificationResult';
+  notificationSubscription: NotificationSubscription;
 };
 
 export type Update = ActivityTimelineProjectActivity & {
@@ -4061,10 +4680,13 @@ export type Update = ActivityTimelineProjectActivity & {
   group: Scalars['String'];
   id: Scalars['ID'];
   isGitWorkingTreeDirty: Scalars['Boolean'];
+  isRollBackToEmbedded: Scalars['Boolean'];
   manifestFragment: Scalars['String'];
   manifestPermalink: Scalars['String'];
   message?: Maybe<Scalars['String']>;
   platform: Scalars['String'];
+  runtime: Runtime;
+  /** @deprecated Use 'runtime' field . */
   runtimeVersion: Scalars['String'];
   updatedAt: Scalars['DateTime'];
 };
@@ -4214,9 +4836,16 @@ export type UpdateMutationSetCodeSigningInfoArgs = {
   updateId: Scalars['ID'];
 };
 
+export type UpdateRollBackToEmbeddedGroup = {
+  android?: InputMaybe<Scalars['Boolean']>;
+  ios?: InputMaybe<Scalars['Boolean']>;
+  web?: InputMaybe<Scalars['Boolean']>;
+};
+
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersions?: InputMaybe<Array<Scalars['String']>>;
+  sdkVersions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export type UploadSession = {
@@ -4241,8 +4870,8 @@ export type UsageMetricTotal = {
   __typename?: 'UsageMetricTotal';
   billingPeriod: BillingPeriod;
   id: Scalars['ID'];
-  overageMetrics: Array<AccountUsageMetricAndCost>;
-  planMetrics: Array<AccountUsageMetricAndCost>;
+  overageMetrics: Array<EstimatedOverageAndCost>;
+  planMetrics: Array<EstimatedUsage>;
   /** Total cost of overages, in cents */
   totalCost: Scalars['Float'];
 };
@@ -4268,7 +4897,7 @@ export type UsageMetricsTimespan = {
 };
 
 /** Represents a human (not robot) actor. */
-export type User = Actor & {
+export type User = Actor & UserActor & {
   __typename?: 'User';
   /** Access Tokens belonging to this actor */
   accessTokens: Array<AccessToken>;
@@ -4279,7 +4908,10 @@ export type User = Actor & {
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
   apps: Array<App>;
+  bestContactEmail?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
   displayName: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   emailVerified: Scalars['Boolean'];
@@ -4290,27 +4922,20 @@ export type User = Actor & {
   featureGates: Scalars['JSONObject'];
   firstName?: Maybe<Scalars['String']>;
   fullName?: Maybe<Scalars['String']>;
+  /** GitHub account linked to a user */
+  githubUser?: Maybe<GitHubUser>;
   githubUsername?: Maybe<Scalars['String']>;
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean'];
   id: Scalars['ID'];
   industry?: Maybe<Scalars['String']>;
-  /** @deprecated No longer supported */
-  isEmailUnsubscribed: Scalars['Boolean'];
   isExpoAdmin: Scalars['Boolean'];
-  /** @deprecated No longer supported */
-  isLegacy?: Maybe<Scalars['Boolean']>;
-  /** @deprecated No longer supported */
-  isOnboarded?: Maybe<Scalars['Boolean']>;
+  /** @deprecated This field no longer exists */
+  isLegacy: Scalars['Boolean'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
-  /** @deprecated No longer supported */
-  lastLogin?: Maybe<Scalars['DateTime']>;
   lastName?: Maybe<Scalars['String']>;
-  /** @deprecated No longer supported */
-  lastPasswordReset?: Maybe<Scalars['DateTime']>;
-  /** @deprecated 'likes' have been deprecated. */
-  likes?: Maybe<Array<Maybe<App>>>;
   location?: Maybe<Scalars['String']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
   pendingUserInvitations: Array<UserInvitation>;
   /** Associated accounts */
@@ -4322,8 +4947,6 @@ export type User = Actor & {
   snacks: Array<Snack>;
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
-  /** @deprecated No longer supported */
-  wasLegacy?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -4350,9 +4973,8 @@ export type UserFeatureGatesArgs = {
 
 
 /** Represents a human (not robot) actor. */
-export type UserLikesArgs = {
-  limit: Scalars['Int'];
-  offset: Scalars['Int'];
+export type UserNotificationSubscriptionsArgs = {
+  filter?: InputMaybe<NotificationSubscriptionFilter>;
 };
 
 
@@ -4360,6 +4982,107 @@ export type UserLikesArgs = {
 export type UserSnacksArgs = {
   limit: Scalars['Int'];
   offset: Scalars['Int'];
+};
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActor = {
+  /** Access Tokens belonging to this user actor */
+  accessTokens: Array<AccessToken>;
+  accounts: Array<Account>;
+  /**
+   * Coalesced project activity for all apps belonging to all accounts this user actor belongs to.
+   * Only resolves for the viewer.
+   */
+  activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
+  appCount: Scalars['Int'];
+  appetizeCode?: Maybe<Scalars['String']>;
+  /** Apps this user has published */
+  apps: Array<App>;
+  bestContactEmail?: Maybe<Scalars['String']>;
+  created: Scalars['DateTime'];
+  /** Discord account linked to a user */
+  discordUser?: Maybe<DiscordUser>;
+  /**
+   * Best-effort human readable name for this human actor for use in user interfaces during action attribution.
+   * For example, when displaying a sentence indicating that actor X created a build or published an update.
+   */
+  displayName: Scalars['String'];
+  /**
+   * Server feature gate values for this user actor, optionally filtering by desired gates.
+   * Only resolves for the viewer.
+   */
+  featureGates: Scalars['JSONObject'];
+  firstName?: Maybe<Scalars['String']>;
+  fullName?: Maybe<Scalars['String']>;
+  /** GitHub account linked to a user */
+  githubUser?: Maybe<GitHubUser>;
+  githubUsername?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  industry?: Maybe<Scalars['String']>;
+  isExpoAdmin: Scalars['Boolean'];
+  lastName?: Maybe<Scalars['String']>;
+  location?: Maybe<Scalars['String']>;
+  notificationSubscriptions: Array<NotificationSubscription>;
+  /** Associated accounts */
+  primaryAccount: Account;
+  profilePhoto: Scalars['String'];
+  /** Snacks associated with this user's personal account */
+  snacks: Array<Snack>;
+  twitterUsername?: Maybe<Scalars['String']>;
+  username: Scalars['String'];
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorActivityTimelineProjectActivitiesArgs = {
+  createdBefore?: InputMaybe<Scalars['DateTime']>;
+  filterTypes?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
+  limit: Scalars['Int'];
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorAppsArgs = {
+  includeUnpublished?: InputMaybe<Scalars['Boolean']>;
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorFeatureGatesArgs = {
+  filter?: InputMaybe<Array<Scalars['String']>>;
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorNotificationSubscriptionsArgs = {
+  filter?: InputMaybe<NotificationSubscriptionFilter>;
+};
+
+
+/** A human user (type User or SSOUser) that can login to the Expo website, use Expo services, and be a member of accounts. */
+export type UserActorSnacksArgs = {
+  limit: Scalars['Int'];
+  offset: Scalars['Int'];
+};
+
+export type UserActorQuery = {
+  __typename?: 'UserActorQuery';
+  /** Query a UserActor by ID */
+  byId: UserActor;
+  /** Query a UserActor by username */
+  byUsername: UserActor;
+};
+
+
+export type UserActorQueryByIdArgs = {
+  id: Scalars['ID'];
+};
+
+
+export type UserActorQueryByUsernameArgs = {
+  username: Scalars['String'];
 };
 
 export type UserDataInput = {
@@ -4370,26 +5093,26 @@ export type UserDataInput = {
   githubUsername?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
   industry?: InputMaybe<Scalars['String']>;
-  isEmailUnsubscribed?: InputMaybe<Scalars['Boolean']>;
-  isLegacy?: InputMaybe<Scalars['Boolean']>;
-  isOnboarded?: InputMaybe<Scalars['Boolean']>;
   lastName?: InputMaybe<Scalars['String']>;
   location?: InputMaybe<Scalars['String']>;
   profilePhoto?: InputMaybe<Scalars['String']>;
   twitterUsername?: InputMaybe<Scalars['String']>;
   username?: InputMaybe<Scalars['String']>;
-  wasLegacy?: InputMaybe<Scalars['Boolean']>;
 };
 
 /** An pending invitation sent to an email granting membership on an Account. */
 export type UserInvitation = {
   __typename?: 'UserInvitation';
   accountName: Scalars['String'];
+  /** If the invite is for a personal team, the profile photo of account owner */
+  accountProfilePhoto?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   /** Email to which this invitation was sent */
   email: Scalars['String'];
   expires: Scalars['DateTime'];
   id: Scalars['ID'];
+  /** If the invite is for an organization or a personal team */
+  isForOrganization: Scalars['Boolean'];
   /** Account permissions to be granted upon acceptance of this invitation */
   permissions: Array<Permission>;
   /** Role to be granted upon acceptance of this invitation */
@@ -4458,11 +5181,13 @@ export type UserInvitationMutationResendUserInvitationArgs = {
 export type UserInvitationPublicData = {
   __typename?: 'UserInvitationPublicData';
   accountName: Scalars['String'];
+  accountProfilePhoto?: Maybe<Scalars['String']>;
   created: Scalars['DateTime'];
   email: Scalars['String'];
   expires: Scalars['DateTime'];
   /** Email to which this invitation was sent */
   id: Scalars['ID'];
+  isForOrganization: Scalars['Boolean'];
 };
 
 export type UserInvitationPublicDataQuery = {
@@ -4480,9 +5205,10 @@ export type UserPermission = {
   __typename?: 'UserPermission';
   actor: Actor;
   permissions: Array<Permission>;
-  role?: Maybe<Role>;
+  role: Role;
   /** @deprecated User type is deprecated */
   user?: Maybe<User>;
+  userActor?: Maybe<UserActor>;
 };
 
 export type UserQuery = {
@@ -4495,7 +5221,7 @@ export type UserQuery = {
 
 
 export type UserQueryByIdArgs = {
-  userId: Scalars['String'];
+  userId: Scalars['ID'];
 };
 
 
@@ -4618,7 +5344,7 @@ export type BranchDetailsQueryVariables = Exact<{
   name: Scalars['String'];
   appId: Scalars['String'];
   platform: AppPlatform;
-  runtimeVersions: Array<Scalars['String']> | Scalars['String'];
+  sdkVersions: Array<Scalars['String']> | Scalars['String'];
 }>;
 
 
@@ -4627,7 +5353,7 @@ export type BranchDetailsQuery = { __typename?: 'RootQuery', app: { __typename?:
 export type BranchesForProjectQueryVariables = Exact<{
   appId: Scalars['String'];
   platform: AppPlatform;
-  runtimeVersions: Array<Scalars['String']> | Scalars['String'];
+  sdkVersions: Array<Scalars['String']> | Scalars['String'];
   limit: Scalars['Int'];
   offset: Scalars['Int'];
 }>;
@@ -4667,7 +5393,7 @@ export type Home_ProfileSnacksQuery = { __typename?: 'RootQuery', me?: { __typen
 export type WebContainerProjectPage_QueryVariables = Exact<{
   appId: Scalars['String'];
   platform: AppPlatform;
-  runtimeVersions: Array<Scalars['String']> | Scalars['String'];
+  sdkVersions: Array<Scalars['String']> | Scalars['String'];
 }>;
 
 
@@ -4715,7 +5441,7 @@ export type SendSmsotpToSecondFactorDeviceMutationVariables = Exact<{
 
 export type SendSmsotpToSecondFactorDeviceMutation = { __typename?: 'RootMutation', me: { __typename?: 'MeMutation', sendSMSOTPToSecondFactorDevice: { __typename?: 'SecondFactorBooleanResult', success: boolean } } };
 
-export type UserPermissionDataFragment = { __typename?: 'UserPermission', permissions: Array<Permission>, role?: Role | null, user?: { __typename?: 'User', id: string, fullName?: string | null, profilePhoto: string, username: string, email?: string | null } | null };
+export type UserPermissionDataFragment = { __typename?: 'UserPermission', permissions: Array<Permission>, role: Role, user?: { __typename?: 'User', id: string, fullName?: string | null, profilePhoto: string, username: string, email?: string | null } | null };
 
 export type HomeScreenDataQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -4851,7 +5577,7 @@ export function refetchHome_AccountDataQuery(variables: Home_AccountDataQueryVar
       return { query: Home_AccountDataDocument, variables: variables }
     }
 export const BranchDetailsDocument = gql`
-    query BranchDetails($name: String!, $appId: String!, $platform: AppPlatform!, $runtimeVersions: [String!]!) {
+    query BranchDetails($name: String!, $appId: String!, $platform: AppPlatform!, $sdkVersions: [String!]!) {
   app {
     byId(appId: $appId) {
       id
@@ -4864,7 +5590,7 @@ export const BranchDetailsDocument = gql`
         updates(
           limit: 100
           offset: 0
-          filter: {platform: $platform, runtimeVersions: $runtimeVersions}
+          filter: {platform: $platform, sdkVersions: $sdkVersions}
         ) {
           id
           group
@@ -4895,7 +5621,7 @@ export const BranchDetailsDocument = gql`
  *      name: // value for 'name'
  *      appId: // value for 'appId'
  *      platform: // value for 'platform'
- *      runtimeVersions: // value for 'runtimeVersions'
+ *      sdkVersions: // value for 'sdkVersions'
  *   },
  * });
  */
@@ -4914,7 +5640,7 @@ export function refetchBranchDetailsQuery(variables: BranchDetailsQueryVariables
       return { query: BranchDetailsDocument, variables: variables }
     }
 export const BranchesForProjectDocument = gql`
-    query BranchesForProject($appId: String!, $platform: AppPlatform!, $runtimeVersions: [String!]!, $limit: Int!, $offset: Int!) {
+    query BranchesForProject($appId: String!, $platform: AppPlatform!, $sdkVersions: [String!]!, $limit: Int!, $offset: Int!) {
   app {
     byId(appId: $appId) {
       id
@@ -4939,7 +5665,7 @@ export const BranchesForProjectDocument = gql`
         updates(
           limit: 1
           offset: 0
-          filter: {platform: $platform, runtimeVersions: $runtimeVersions}
+          filter: {platform: $platform, sdkVersions: $sdkVersions}
         ) {
           id
           group
@@ -4969,7 +5695,7 @@ export const BranchesForProjectDocument = gql`
  *   variables: {
  *      appId: // value for 'appId'
  *      platform: // value for 'platform'
- *      runtimeVersions: // value for 'runtimeVersions'
+ *      sdkVersions: // value for 'sdkVersions'
  *      limit: // value for 'limit'
  *      offset: // value for 'offset'
  *   },
@@ -5167,7 +5893,7 @@ export function refetchHome_ProfileSnacksQuery(variables: Home_ProfileSnacksQuer
       return { query: Home_ProfileSnacksDocument, variables: variables }
     }
 export const WebContainerProjectPage_QueryDocument = gql`
-    query WebContainerProjectPage_Query($appId: String!, $platform: AppPlatform!, $runtimeVersions: [String!]!) {
+    query WebContainerProjectPage_Query($appId: String!, $platform: AppPlatform!, $sdkVersions: [String!]!) {
   app {
     byId(appId: $appId) {
       id
@@ -5196,7 +5922,7 @@ export const WebContainerProjectPage_QueryDocument = gql`
         updates(
           limit: 1
           offset: 0
-          filter: {platform: $platform, runtimeVersions: $runtimeVersions}
+          filter: {platform: $platform, sdkVersions: $sdkVersions}
         ) {
           id
           group
@@ -5226,7 +5952,7 @@ export const WebContainerProjectPage_QueryDocument = gql`
  *   variables: {
  *      appId: // value for 'appId'
  *      platform: // value for 'platform'
- *      runtimeVersions: // value for 'runtimeVersions'
+ *      sdkVersions: // value for 'sdkVersions'
  *   },
  * });
  */

--- a/home/package.json
+++ b/home/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@apollo/client": "^3.4.10",
-    "@expo/sdk-runtime-versions": "^1.0.0",
     "@expo/styleguide-native": "^1.0.1",
     "@expo/vector-icons": "^13.0.0",
     "@graphql-codegen/introspection": "^2.1.1",

--- a/home/screens/BranchDetailsScreen/BranchDetailsContainer.tsx
+++ b/home/screens/BranchDetailsScreen/BranchDetailsContainer.tsx
@@ -1,4 +1,3 @@
-import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform } from 'react-native';
@@ -18,9 +17,7 @@ export function BranchDetailsContainer(
       appId: props.appId,
       name: props.branchName,
       platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
-      runtimeVersions: Kernel.sdkVersions
-        .split(',')
-        .map((kernelSDKVersion) => getRuntimeVersionForSDKVersion(kernelSDKVersion)),
+      sdkVersions: Kernel.sdkVersions.split(','),
     },
   });
 

--- a/home/screens/BranchListScreen/BranchList.tsx
+++ b/home/screens/BranchListScreen/BranchList.tsx
@@ -1,4 +1,3 @@
-import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import * as React from 'react';
@@ -7,23 +6,22 @@ import { Platform } from 'react-native';
 import { AppPlatform, useBranchesForProjectQuery } from '../../graphql/types';
 import * as Kernel from '../../kernel/Kernel';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
-import { getSDKMajorVersionForEASUpdateBranch } from '../ProjectScreen/EASUpdateLaunchSection';
 import { BranchListView } from './BranchListView';
 
 function useBranchesQuery({
   appId,
   platform,
-  runtimeVersions,
+  sdkVersions,
 }: {
   appId: string;
   platform: AppPlatform;
-  runtimeVersions: string[];
+  sdkVersions: string[];
 }) {
   const { data, fetchMore } = useBranchesForProjectQuery({
     variables: {
       appId,
       platform,
-      runtimeVersions,
+      sdkVersions,
       limit: 15,
       offset: 0,
     },
@@ -41,7 +39,6 @@ function useBranchesQuery({
     name: branch.name,
     id: branch.id,
     latestUpdate: branch.updates[0],
-    sdkVersion: getSDKMajorVersionForEASUpdateBranch(branch),
   }));
 
   const loadMoreAsync = React.useCallback(() => {
@@ -72,9 +69,7 @@ export function BranchList({ appId }: { appId: string }) {
   const { branchManifests, loadMoreAsync } = useBranchesQuery({
     appId,
     platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
-    runtimeVersions: Kernel.sdkVersions
-      .split(',')
-      .map((kernelSDKVersion) => getRuntimeVersionForSDKVersion(kernelSDKVersion)),
+    sdkVersions: Kernel.sdkVersions.split(','),
   });
 
   return <BranchListView data={branchManifests} appId={appId} loadMoreAsync={loadMoreAsync} />;

--- a/home/screens/BranchListScreen/BranchListView.tsx
+++ b/home/screens/BranchListScreen/BranchListView.tsx
@@ -10,7 +10,6 @@ type BranchManifest = {
   name: string;
   id: string;
   latestUpdate: BranchesForProjectQuery['app']['byId']['updateBranches'][0]['updates'][0];
-  sdkVersion: number | null;
 };
 
 type Props = {

--- a/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
+++ b/home/screens/ProjectScreen/EASUpdateLaunchSection.tsx
@@ -1,11 +1,9 @@
-import { getSDKVersionFromRuntimeVersion } from '@expo/sdk-runtime-versions';
 import { ChevronDownIcon } from '@expo/styleguide-native';
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { Divider, Row, View, Text, useExpoTheme } from 'expo-dev-client-components';
 import React, { Fragment } from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
-import semver from 'semver';
 
 import { BranchListItem } from '../../components/BranchListItem';
 import { SectionHeader } from '../../components/SectionHeader';
@@ -13,28 +11,6 @@ import { WebContainerProjectPage_Query } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
 
 type ProjectPageApp = WebContainerProjectPage_Query['app']['byId'];
-type ProjectUpdateBranch = WebContainerProjectPage_Query['app']['byId']['updateBranches'][0];
-
-function truthy<TValue>(value: TValue | null | undefined): value is TValue {
-  return !!value;
-}
-
-export function getSDKMajorVersionForEASUpdateBranch(branch: ProjectUpdateBranch): number | null {
-  const updates = branch.updates;
-  if (updates.length === 0) {
-    return null;
-  }
-
-  return (
-    updates
-      .map((update) => {
-        const potentialSDKVersion = getSDKVersionFromRuntimeVersion(update.runtimeVersion);
-        return potentialSDKVersion ? semver.major(potentialSDKVersion) : null;
-      })
-      .filter(truthy)
-      .sort((a, b) => b - a)[0] ?? null
-  );
-}
 
 export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
   const branchesToRender = app.updateBranches.filter(
@@ -45,7 +21,6 @@ export function EASUpdateLaunchSection({ app }: { app: ProjectPageApp }) {
     name: branch.name,
     id: branch.id,
     latestUpdate: branch.updates[0],
-    sdkVersion: getSDKMajorVersionForEASUpdateBranch(branch),
   }));
 
   const theme = useExpoTheme();

--- a/home/screens/ProjectScreen/ProjectContainer.tsx
+++ b/home/screens/ProjectScreen/ProjectContainer.tsx
@@ -1,4 +1,3 @@
-import { getRuntimeVersionForSDKVersion } from '@expo/sdk-runtime-versions';
 import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 import { Platform } from 'react-native';
@@ -16,9 +15,7 @@ export function ProjectContainer(
     variables: {
       appId: props.appId,
       platform: Platform.OS === 'ios' ? AppPlatform.Ios : AppPlatform.Android,
-      runtimeVersions: Kernel.sdkVersions
-        .split(',')
-        .map((kernelSDKVersion) => getRuntimeVersionForSDKVersion(kernelSDKVersion)),
+      sdkVersions: Kernel.sdkVersions.split(','),
     },
   });
   return <ProjectView {...props} {...query} />;


### PR DESCRIPTION
# Why

We want to deprecate `sdkVersion` runtime, but still want to let users develop in Expo Go if they are using a supported SDK version.

In the Expo Go project view, we filter all the updates by supported `runtimeVersion` (ie) `expoSdk:48.0.0`. This means anyone on a runtime policy like `appVersion` wont have any of their updates show up even though they are on a supported sdk.

<img src="https://github.com/expo/universe/assets/6380927/e96f1db2-201e-4e14-98d2-86d15a3102c2" width="200" height="400" />

# How

Query updates  by `sdkVersion` instead of `runtimeVersion` in Graphql.

# Test Plan

- [ ] I loaded the JS into the unversioned Expo Go and it works
<img width="310" alt="Screenshot 2023-05-16 at 10 30 41 PM" src="https://github.com/expo/expo/assets/6380927/ebf9d783-c970-422b-bfca-3a370febe037">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
