### PR TITLE
[docs] add FileTree component, replace ASCII file structures

### DIFF
--- a/docs/pages/archive/classic-updates/hosting-your-app.mdx
+++ b/docs/pages/archive/classic-updates/hosting-your-app.mdx
@@ -3,6 +3,7 @@ title: Hosting Updates on Your Servers
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { FileTree } from "~/ui/components/FileTree";
 
 > This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
 
@@ -14,16 +15,13 @@ For simplicity, the rest of this article will refer to hosting an update for the
 
 First, you’ll need to export all the static files of your update so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the MD5 hash of their content. Your output directory should look something like this now:
 
-```
-.
-├── android-index.json
-├── ios-index.json
-├── assets
-│   └── 1eccbc4c41d49fd81840aef3eaabe862
-└── bundles
-      ├── android-01ee6e3ab3e8c16a4d926c91808d5320.js
-      └── ios-ee8206cc754d3f7aa9123b7f909d94ea.js
-```
+<FileTree files={[
+  './android-index.json',
+  './ios-index.json',
+  './assets/1eccbc4c41d49fd81840aef3eaabe862',
+  './bundles/android-01ee6e3ab3e8c16a4d926c91808d5320.js',
+  './bundles/ios-ee8206cc754d3f7aa9123b7f909d94ea.js',
+]} />
 
 ## Hosting your static files
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -5,6 +5,7 @@ description: Learn how to set up and configure the jest-expo package to write un
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { FileTree } from "~/ui/components/FileTree";
 
 [Jest](https://jestjs.io) is the most widely used JavaScript unit testing framework. In this guide, you'll learn how to set up Jest in your project, write a unit test, write a snapshot test, and best practices for structuring your tests when using Jest with React Native.
 
@@ -81,46 +82,33 @@ Right now, you have a single test file in the project directory. Adding more tes
 
 An example structure is shown below:
 
-```sh
-__tests__/
-├─ components/
-│  └─ button.test.js
-├─ navigation/
-│  └─ mainstack.test.js
-└─ screens/
-  └─ home.test.js
-src/
-├─ components/
-│  └─ button.js
-├─ navigation/
-│  └─ mainstack.js
-└─ screens/
-  └─ home.js
-```
+<FileTree files={[
+  '__tests__/components/button.test.js',
+  '__tests__/navigation/mainstack.test.js',
+  '__tests__/screens/home.test.js',
+  'src/components/button.js',
+  'src/navigation/mainstack.js',
+  'src/screens/home.js'
+]}/>
 
 However, this approach causes a lot of long import paths, such as `../../src/components/button`.
 
 Alternatively, you can have multiple **\_\_tests\_\_** sub-directories for different areas of your project. For example, create a separate test directory for **components**, **navigation**, and so on:
 
-```sh
-src/
-├─ components/
-├─ __tests__/
-│  │  └─ button.test.js
-│  └─ button.js
-```
+<FileTree files={[
+  'src/components/button.js',
+  'src/components/__tests__/button.test.js'
+]}/>
 
 Now, if you move **\_\_tests\_\_** within the **components** directory, the import path of `<Button>` in the the **button.test.js** will be `../button`.
 
 Another option for test/file structure:
 
-```sh
-src/
-├─ components/
-│  ├─ button.js
-│  ├─ button.style.js
-│  └─ button.test.js
-```
+<FileTree files={[
+  'src/components/button.js',
+  'src/components/button.style.js',
+  'src/components/button.test.js',
+]}/>
 
 It's all about preferences and up to you to decide how you want to organize your project directory.
 

--- a/docs/pages/guides/testing-with-jest.mdx
+++ b/docs/pages/guides/testing-with-jest.mdx
@@ -4,6 +4,7 @@ description: Learn how to set up and configure the jest-expo package to write un
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { FileTree } from "~/ui/components/FileTree";
 
 [Jest](https://jestjs.io) is the most widely used JavaScript unit testing framework. In this guide, you'll learn how to set up Jest in your project, write a unit test, write a snapshot test, and common problems generally encountered when using Jest with React Native.
 
@@ -121,46 +122,34 @@ Right now, you have a single test file in the project directory. Adding more tes
 
 An example structure is shown below:
 
-```sh
-__tests__/
-├─ components/
-│  └─ button.test.js
-├─ navigation/
-│  └─ mainstack.test.js
-└─ screens/
-   └─ home.test.js
-src/
-├─ components/
-│  └─ button.js
-├─ navigation/
-│  └─ mainstack.js
-└─ screens/
-   └─ home.js
-```
+
+<FileTree files={[
+  '__tests__/components/button.test.js',
+  '__tests__/navigation/mainstack.test.js',
+  '__tests__/screens/home.test.js',
+  'src/components/button.js',
+  'src/navigation/mainstack.js',
+  'src/screens/home.js'
+]}/>
 
 However, this approach causes a lot of long import paths, such as `../../src/components/button`.
 
 Alternatively, you can have multiple **\_\_tests\_\_** sub-directories for different areas of your project. For example, create a separate test directory for **components**, **navigation**, and so on:
 
-```sh
-src/
-├─ components/
-├─ __tests__/
-│  │  └─ button.test.js
-│  └─ button.js
-```
+<FileTree files={[
+  'src/components/button.js',
+  'src/components/__tests__/button.test.js'
+]}/>
 
 Now, if you move **\_\_tests\_\_** within the **components** directory, the import path of `<Button />` in the the **button.test.js** will be `../button`.
 
 Another option for test/file structure:
 
-```sh
-src/
-├─ components/
-│  ├─ button.js
-│  ├─ button.style.js
-│  └─ button.test.js
-```
+<FileTree files={[
+  'src/components/button.js',
+  'src/components/button.style.js',
+  'src/components/button.test.js',
+]}/>
 
 It's all about preferences and up to you to decide how you want to organize your project directory.
 

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -19,11 +19,9 @@ export function FileTree({ files = [], ...rest }: FileTreeProps) {
 
 function generateStructure(files: string[]): FileObject {
   const structure = {};
-  files.forEach(path => {
-    path.split('/').reduce(function (acc: any, key) {
-      return acc[key] ?? (acc[key] = {});
-    }, structure);
-  });
+  files.forEach(path =>
+    path.split('/').reduce((acc: FileObject, key) => acc[key] ?? (acc[key] = {}), structure)
+  );
   return structure;
 }
 
@@ -31,19 +29,19 @@ function renderStructure(structure: FileObject, level = 0): ReactNode {
   return Object.entries(structure).map(([key, value]) => {
     return Object.keys(value).length ? (
       <div className="mt-1 pt-1 px-2 rounded-sm flex flex-col">
-        <code className="flex items-center">
+        <div className="flex items-center">
           {' '.repeat(level)}
           <FolderIcon className="text-icon-tertiary mr-2 opacity-60" />
-          <span className="text-secondary">{key}</span>
-        </code>
+          <code className="text-secondary">{key}</code>
+        </div>
         {renderStructure(value, level + 1)}
       </div>
     ) : (
-      <code className="mt-1 pl-3 pt-1 px-2 rounded-sm flex items-center">
+      <div className="mt-1 pl-3 pt-1 px-2 rounded-sm flex items-center">
         {' '.repeat(level - 1)}
         <FileCode01Icon className="text-icon-tertiary mr-2" />
-        <span className="text-default">{key}</span>
-      </code>
+        <code className="text-default">{key}</code>
+      </div>
     );
   });
 }

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -1,0 +1,49 @@
+import { FileCode01Icon, FolderIcon } from '@expo/styleguide-icons';
+import { HTMLAttributes, ReactNode } from 'react';
+
+type FileTreeProps = HTMLAttributes<HTMLDivElement> & {
+  files?: string[];
+};
+
+type FileObject = {
+  [key: string]: FileObject;
+};
+
+export function FileTree({ files = [], ...rest }: FileTreeProps) {
+  return (
+    <div className="text-xs border border-default rounded-md bg-default mb-4 p-2 pb-4" {...rest}>
+      {renderStructure(generateStructure(files))}
+    </div>
+  );
+}
+
+function generateStructure(files: string[]): FileObject {
+  const structure = {};
+  files.forEach(path => {
+    path.split('/').reduce(function (acc: any, key) {
+      return acc[key] ?? (acc[key] = {});
+    }, structure);
+  });
+  return structure;
+}
+
+function renderStructure(structure: FileObject, level = 0): ReactNode {
+  return Object.entries(structure).map(([key, value]) => {
+    return Object.keys(value).length ? (
+      <div className="mt-1 pt-1 px-2 rounded-sm flex flex-col">
+        <code className="flex items-center">
+          {' '.repeat(level)}
+          <FolderIcon className="text-icon-tertiary mr-2 opacity-60" />
+          <span className="text-secondary">{key}</span>
+        </code>
+        {renderStructure(value, level + 1)}
+      </div>
+    ) : (
+      <code className="mt-1 pl-3 pt-1 px-2 rounded-sm flex items-center">
+        {' '.repeat(level - 1)}
+        <FileCode01Icon className="text-icon-tertiary mr-2" />
+        <span className="text-default">{key}</span>
+      </code>
+    );
+  });
+}


### PR DESCRIPTION
# Why

After latest migration to new Next font packages it looks like Inter version which is fetched differs from the one we have used  from static files in the past, which leads to some display issues of ASCII based content, like file structure graphs.

# How

To fix the problem, and improve the readability of those examples I have implemented a new `FileTree` component, which converts the given file paths to visual representation of the file tree.

# Test Plan

The changes have been tested by running docs app locally. All lint checks and tests are passing.

# Preivew

<img width="869" alt="Screenshot 2023-05-17 at 09 55 45" src="https://github.com/expo/expo/assets/719641/bb7e0225-a15a-4601-b5f2-a96d37a1b4ce">
<img width="869" alt="Screenshot 2023-05-17 at 09 56 58" src="https://github.com/expo/expo/assets/719641/577ab470-092e-437e-b7a3-213723f9f220">