### PR TITLE
[docs] Fix not able to find download assets step in Tutorial

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -41,13 +41,19 @@ It will create a new project directory and install all the necessary dependencie
 
 This command will create a new directory for the project with the name: **StickerSmash**.
 
-Let's also <A href="/static/images/tutorial/sticker-smash-assets.zip" download>download the assets</A> that we will need throughout this tutorial. After downloading the archive, unzip it and replace the existing **assets** directory with it in the project directory. This will override the default assets when the new project is initialized.
+</Step>
+
+<Step label="2">
+
+## Download assets
+
+We'll need some assets to build the app. Let's <A href="/static/images/tutorial/sticker-smash-assets.zip" download>download these assets</A> that we will need throughout this tutorial. After downloading the archive, unzip it and replace the existing **assets** directory with it in the project directory. This will override the default assets when the new project is initialized.
 
 Now, let's open the project directory in our favorite code editor or IDE. Throughout this tutorial, we will use VS Code for our examples.
 
 </Step>
 
-<Step label="2">
+<Step label="3">
 
 ## Install dependencies
 
@@ -57,7 +63,7 @@ To run the project on the web, we need to install the following dependencies tha
 
 </Step>
 
-<Step label="3">
+<Step label="4">
 
 ## Run the app on mobile and web
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -7,7 +7,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { A } from '~/ui/components/Text';
 import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon, Download03Icon } from '@expo/styleguide-icons';
 
 In this chapter, let's learn how to create a new Expo project and how to get it running.
 
@@ -47,7 +47,14 @@ This command will create a new directory for the project with the name: **Sticke
 
 ## Download assets
 
-We'll need some assets to build the app. Let's <A href="/static/images/tutorial/sticker-smash-assets.zip" download>download these assets</A> that we will need throughout this tutorial. After downloading the archive, unzip it and replace the existing **assets** directory with it in the project directory. This will override the default assets when the new project is initialized.
+<BoxLink
+  title="Download assets archive"
+  Icon={Download03Icon}
+  description="We'll be using these assets throughout this tutorial."
+  href="/static/images/tutorial/sticker-smash-assets.zip"
+/>
+
+After downloading the archive, unzip it and replace the existing **assets** directory with it in the project directory. This will override the default assets when the new project is initialized.
 
 Now, let's open the project directory in our favorite code editor or IDE. Throughout this tutorial, we will use VS Code for our examples.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #22514 

Also, there have been some concerns in regards to find the downloadable link for assets that I had to point manually before.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the Create your first app page to include a step to download assets (so that it isn't skimmable).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally:

<img width="888" alt="CleanShot 2023-05-17 at 17 15 45@2x" src="https://github.com/expo/expo/assets/10234615/6ca30b1f-19a4-48a2-b5a5-f885e72c212b">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
