### PR TITLE
[expo-modules] Fix failing instrumentation test

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix failing instrumentation tests in JavaScriptViewModule. ([#22518](https://github.com/expo/expo/pull/22518) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 1.3.2 — 2023-05-09

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -1,5 +1,9 @@
 package expo.modules.kotlin.jni
 
+import com.facebook.react.bridge.CatalystInstance
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.UIBlock
+import com.facebook.react.uimanager.UIManagerModule
 import com.google.common.truth.Truth
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleRegistry
@@ -10,9 +14,13 @@ import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import java.lang.ref.WeakReference
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Sets up a test jsi environment with provided modules.
@@ -23,11 +31,29 @@ internal inline fun withJSIInterop(
   block: JSIInteropModuleRegistry.(methodQueue: TestScope) -> Unit
 ) {
   val appContextMock = mockk<AppContext>()
-
   val methodQueue = TestScope()
+
+  val uiManagerModuleMock = mockk<UIManagerModule>()
+  val slot = slot<UIBlock>()
+  every {uiManagerModuleMock.addUIBlock(capture(slot)) } answers {
+    methodQueue.launch() {
+      slot.captured.execute(mockk())
+    }
+  }
+
+  val catalystInstanceMock = mockk<CatalystInstance>()
+  every { catalystInstanceMock.getNativeModule(UIManagerModule::class.java) } answers { uiManagerModuleMock }
+
+  val reactContextMock = mockk<ReactContext>()
+  every { reactContextMock.hasCatalystInstance() } answers { true }
+  every { reactContextMock.hasActiveReactInstance() } answers { true }
+
+  every { reactContextMock.catalystInstance } answers { catalystInstanceMock }
+
   every { appContextMock.modulesQueue } answers { methodQueue }
   every { appContextMock.mainQueue } answers { methodQueue }
   every { appContextMock.backgroundCoroutineScope } answers { methodQueue }
+  every { appContextMock.reactContext } answers { reactContextMock }
 
   val registry = ModuleRegistry(WeakReference(appContextMock)).apply {
     modules.forEach {

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -15,12 +15,10 @@ import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import java.lang.ref.WeakReference
-import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Sets up a test jsi environment with provided modules.
@@ -35,7 +33,7 @@ internal inline fun withJSIInterop(
 
   val uiManagerModuleMock = mockk<UIManagerModule>()
   val slot = slot<UIBlock>()
-  every {uiManagerModuleMock.addUIBlock(capture(slot)) } answers {
+  every { uiManagerModuleMock.addUIBlock(capture(slot)) } answers {
     methodQueue.launch() {
       slot.captured.execute(mockk())
     }

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -45,6 +45,7 @@ internal inline fun withJSIInterop(
   every { catalystInstanceMock.getNativeModule(UIManagerModule::class.java) } answers { uiManagerModuleMock }
 
   val reactContextMock = mockk<ReactContext>()
+  every { reactContextMock.isBridgeless } answers { false }
   every { reactContextMock.hasCatalystInstance() } answers { true }
   every { reactContextMock.hasActiveReactInstance() } answers { true }
 


### PR DESCRIPTION
# Why

Fixes failing instrumentation tests

# How

Added additional mocking logic in expo-modules-core

# Test Plan

Passes CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
