### PR TITLE
[docs] Fix broken terminal commands

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -23,7 +23,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
   packageName="expo"
   cmd={[
     '# Install and configure the expo package automatically',
-    'npx install-expo-modules@latest',
+    '$ npx install-expo-modules@latest',
   ]}
   hideBareInstructions
 />
@@ -60,10 +60,10 @@ Save all of your changes. In Xcode, update the iOS Deployment Target under `Targ
   packageName="expo"
   cmd={[
     '# Install pods',
-    'npx pod-install',
+    '$ npx pod-install',
     '',
     '# Alternatively, the run command will install them for you',
-    'npx expo run:ios',
+    '$ npx expo run:ios',
   ]}
   hideBareInstructions
 />

--- a/docs/pages/guides/linking.mdx
+++ b/docs/pages/guides/linking.mdx
@@ -40,12 +40,12 @@ This renders an `<a />` on web and a interactive `<Text />` which uses the `Link
 
 There are some URL schemes for core functionality that exist on every platform. The following is a non-exhaustive list, but covers the most commonly used schemes.
 
-| Scheme           | Description                                   |
-| ---------------- | --------------------------------------------- |
-| `https` / `http` | Open web browser app, eg: `https://expo.dev`  |
+| Scheme           | Description                                  |
+| ---------------- | -------------------------------------------- |
+| `https` / `http` | Open web browser app, eg: `https://expo.dev` |
 | `mailto`         | Open mail app, eg: `mailto:support@expo.dev` |
-| `tel`            | Open phone app, eg: `tel:+123456789`          |
-| `sms`            | Open SMS app, eg: `sms:+123456789`            |
+| `tel`            | Open phone app, eg: `tel:+123456789`         |
+| `sms`            | Open SMS app, eg: `sms:+123456789`           |
 
 ### Custom URL schemes
 
@@ -179,11 +179,11 @@ You can test it to ensure it works like this:
 <Terminal
   cmd={[
     '# Rebuild the native apps, be sure to use an emulator',
-    'yarn android',
-    'yarn ios',
+    '$ yarn android',
+    '$ yarn ios',
     '',
     '# Open a URI scheme',
-    'npx uri-scheme open myapp://some/redirect',
+    '$ npx uri-scheme open myapp://some/redirect',
   ]}
   cmdCopy="yarn android && yarn ios && npx uri-scheme open myapp://some/redirect"
 />

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -108,7 +108,7 @@ const path = require('path');
 
 const projectRoot = __dirname;
 const workspaceRoot = path.resolve(projectRoot, '../..');
-  
+
 const config = getDefaultConfig(workspaceRoot);
 
 // Only list the packages within your monorepo that your app uses. No need to add anything else.
@@ -210,11 +210,11 @@ Let's go back to the root and create the **packages/** folder. This folder can c
 <Terminal
   cmd={[
     '# Create our new package folder',
-    'mkdir -p packages/cool-package',
-    'cd packages/cool-package',
+    '$ mkdir -p packages/cool-package',
+    '$ cd packages/cool-package',
     '',
     '# And create the new package',
-    'yarn init',
+    '$ yarn init',
   ]}
   cmdCopy="mkdir -p packages/cool-package && cd packages/cool-package && yarn init"
 />

--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -38,11 +38,11 @@ You can test it to ensure it works like this:
 <Terminal
   cmd={[
     '# Rebuild the native apps, be sure to use an emulator',
-    'yarn android',
-    'yarn ios',
+    '$ yarn android',
+    '$ yarn ios',
     '',
     '# Open a URI scheme',
-    'npx uri-scheme open mycoolredirect://some/redirect',
+    '$ npx uri-scheme open mycoolredirect://some/redirect',
   ]}
 />
 

--- a/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/auth-session.mdx
@@ -37,11 +37,11 @@ You can test it to ensure it works like this:
 <Terminal
   cmd={[
     '# Rebuild the native apps, be sure to use an emulator',
-    'yarn android',
-    'yarn ios',
+    '$ yarn android',
+    '$ yarn ios',
     '',
     '# Open a URI scheme',
-    'npx uri-scheme open mycoolredirect://some/redirect',
+    '$ npx uri-scheme open mycoolredirect://some/redirect',
   ]}
   cmdCopy="yarn android && yarn ios && npx uri-scheme open mycoolredirect://some/redirect"
 />

--- a/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/auth-session.mdx
@@ -38,11 +38,11 @@ You can test it to ensure it works like this:
 <Terminal
   cmd={[
     '# Rebuild the native apps, be sure to use an emulator',
-    'yarn android',
-    'yarn ios',
+    '$ yarn android',
+    '$ yarn ios',
     '',
     '# Open a URI scheme',
-    'npx uri-scheme open mycoolredirect://some/redirect',
+    '$ npx uri-scheme open mycoolredirect://some/redirect',
   ]}
 />
 

--- a/docs/pages/versions/v48.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/auth-session.mdx
@@ -38,11 +38,11 @@ You can test it to ensure it works like this:
 <Terminal
   cmd={[
     '# Rebuild the native apps, be sure to use an emulator',
-    'yarn android',
-    'yarn ios',
+    '$ yarn android',
+    '$ yarn ios',
     '',
     '# Open a URI scheme',
-    'npx uri-scheme open mycoolredirect://some/redirect',
+    '$ npx uri-scheme open mycoolredirect://some/redirect',
   ]}
 />
 


### PR DESCRIPTION
# Why

While reading the Expo Modules documentation I noticed that some Terminal commands were not being formatted properly

e.g. 
<img width="1084" alt="image" src="https://github.com/expo/expo/assets/11707729/809edf5e-9d51-40db-86d9-2a2a2a73364e">


# How

This adds `$ ` before commands so the `Terminal` component formats the text properly 

# Test Plan

Run docs locally

<img width="1080" alt="image" src="https://github.com/expo/expo/assets/11707729/e4ceafc1-abd3-48ac-a003-e789c4242e65">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
