### PR TITLE
[docs] add icon to DiffBlock header

### DIFF
--- a/docs/ui/components/Snippet/blocks/DiffBlock.tsx
+++ b/docs/ui/components/Snippet/blocks/DiffBlock.tsx
@@ -1,3 +1,4 @@
+import { Copy07Icon } from '@expo/styleguide-icons';
 import { useEffect, useState, PropsWithChildren } from 'react';
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 
@@ -48,7 +49,7 @@ export const DiffBlock = ({ source, raw }: Props) => {
     newPath,
   }: RenderLine) => (
     <Snippet key={oldRevision + '-' + newRevision}>
-      <SnippetHeader title={newPath} />
+      <SnippetHeader title={newPath} Icon={Copy07Icon} />
       <SnippetContent className="p-0" hideOverflow>
         <Diff viewType="unified" diffType={type} hunks={hunks}>
           {(hunks: any[]) => hunks.map(hunk => <Hunk key={hunk.content} hunk={hunk} />)}


### PR DESCRIPTION
# Why

Follow up on #22495

# How

During the yesterday Snippets cleanup and tweak, I have forgot to add an icon for the `DiffBlock`s snippets, this PR corrects that.

# Test Plan

The changes have been tested by running docs locally.

# Preview

<img width="322" alt="Screenshot 2023-05-17 at 16 44 06" src="https://github.com/expo/expo/assets/719641/c9d20500-6da4-4c52-ba3a-b703718da8ea">
