### PR TITLE
[docs] clarify "VS Code Terminal"

### DIFF
--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -33,7 +33,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for easier debugging and Expo config autocomplete.
-- [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows), Bash via WSL, or the VS Code terminal for developers who prefer Windows.
+- [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows) (the default terminal in VS Code) or Bash via WSL for developers who prefer Windows.
 
 ### Use Expo CLI
 


### PR DESCRIPTION
# Why
"or the VS Code terminal" always confused me, as it seemed to imply a VS Code terminal that exists separately from Powershell, WSL, or cmd.exe, when, AFAIK, VS Code doesn't ship its own terminal, but provides an embedded view letting you choose amongst the terminals available on your Windows install.

# How
Tweaked this wording to clarify that, if you're in VS Code, you're probably good, since VS Code defaults to PowerShell.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
