### PR TITLE
[guides] Fix broken Writing Expo API documentation link

### DIFF
--- a/guides/README.md
+++ b/guides/README.md
@@ -4,7 +4,6 @@ Read these guides to begin contributing to Expo.
 
 - [Contributing to Expo](../CONTRIBUTING.md)
 - [Expo JavaScript Style Guide](Expo%20JavaScript%20Style%20Guide.md)
-- [Documentation writing style guide](Expo%20Documentation%20Writing%20Style%20Guide.md)
+- [Writing API documentation](Expo%20Documentation%20Writing%20Style%20Guide.md#writing-api-documentation)
 - [Git and Code Reviews](Git%20and%20Code%20Reviews.md)
 - [Expo Module Infrastructure](Expo%20Module%20Infrastructure.md)
-

--- a/guides/README.md
+++ b/guides/README.md
@@ -4,7 +4,7 @@ Read these guides to begin contributing to Expo.
 
 - [Contributing to Expo](../CONTRIBUTING.md)
 - [Expo JavaScript Style Guide](Expo%20JavaScript%20Style%20Guide.md)
-- [Writing API documentation](Writing%20API%20Documentation.md)
+- [Documentation writing style guide](Expo%20Documentation%20Writing%20Style%20Guide.md)
 - [Git and Code Reviews](Git%20and%20Code%20Reviews.md)
 - [Expo Module Infrastructure](Expo%20Module%20Infrastructure.md)
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, in `expo/guides/README.md` the link for "Writing API documentation" is broken since the page doesn't exist anymore. Now, we cover that info in the "Writing style guide".

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the correct link.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
