### PR TITLE
[expo-tools] macros: hacky modern to classic manifest conversion

### DIFF
--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -4,7 +4,6 @@ import { ExponentTools, Project, UrlUtils } from '@expo/xdl';
 import chalk from 'chalk';
 import crypto from 'crypto';
 import ip from 'ip';
-import M from 'minimatch';
 import fetch from 'node-fetch';
 import os from 'os';
 import path from 'path';

--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -165,7 +165,11 @@ export default {
     const url = await UrlUtils.constructManifestUrlAsync(path.join(EXPO_DIR, pathToHome));
 
     try {
-      const manifest = await getManifestAsync(url, platform, null);
+      // hack to convert modern manifest to classic
+      let manifest = (await getManifestAsync(url, platform, null)) as any;
+      const bundleUrl = manifest.launchAsset.url;
+      manifest = manifest.extra.expoClient;
+      manifest.bundleUrl = bundleUrl;
 
       if (manifest.name !== 'expo-home') {
         console.log(


### PR DESCRIPTION

# Background
We've started deprecating Classic Updates (`expo publish`). We will continue supporting it through SDK 49, but will shut it off by SDK 50. 

AFAICT, Expo Go relies on publishing a Classic Manifest. However, we've started moving away from classic workflows. `npx expo start` has been changed to return a [Modern Manifest](https://docs.expo.dev/technical-specs/expo-updates-1/).

# Why
When developing JS changes in Expo Go, it is bundled and served by `npx expo start` which returns the Modern Manifest. However, Expo Go is configured to accept Classic Manifest formats. This PR is a 'hack' to convert a Modern Manifest into the Classic format that Expo Go expects so it can unblock other developers trying to view their JS changes.

# Future Work

When we shut off Classic Updates in `www`, Expo Go will need to publish the manifest through `eas update`.  We will need to change native logic to accept Modern Manifests in `expo/ios` and `expo/android`. For example, [logic like this](https://github.com/expo/expo/blob/main/ios/Exponent/Kernel/AppLoader/EXApiUtil.m#L20) will need to change.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
