### PR TITLE
[docs] Fix minor issues in development build docs

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
-Development builds can be created with [EAS Build](/build/introduction/) or locally on your computer if you have Android Studio and Xcode installed.
+Development builds can be created with [EAS Build](/build/introduction/) or [locally](/develop/development-builds/development-workflows/#build-locally-with-android-studio-and-xcode) on your computer if you have Android Studio and Xcode installed.
 
 In this guide, you'll find information on how to create a development build and then install them on an emulator/simulator or a physical device to continue developing your app.
 
@@ -48,7 +48,7 @@ The `development` profile sets the following options:
 
 <Step label="2">
 
-## Create a development build for emulator/simulator
+## Create a build for emulator/simulator
 
 Follow the steps below to create and install the development build on an Android Emulator or an iOS Simulator.
 
@@ -106,7 +106,7 @@ See [Installing build on the simulator](/build-reference/simulators/#installing-
 
 <Step label="3">
 
-## Create a development build for the device
+## Create a build for the device
 
 Follow the steps below to create and install the development build on an Android or an iOS device. Each platform has specific instructions you'll have to follow:
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -144,7 +144,7 @@ To enforce an API contract between the JavaScript and native layers of your app,
 
 > **warning** We do not recommend this method or modifying these **android** and **ios** directories directly, especially when creating a development build with EAS Build. For more information, see [Prebuild](/workflow/prebuild/).
 
-If you need to debug native code or you prefer to manage your native projects, you can build and distribute your project using the `npx expo run` commands. You'll need to set up or have access to Android Studio, Xcode, and related dependencies on your local computer.
+If you need to debug native code or you prefer to manage your native projects, you can build and distribute your project using the `npx expo run` commands. You do not need an Expo account to run these commands. However, you'll need to set up or have access to Android Studio, Xcode, and related dependencies on your local computer.
 
 The [`npx expo run` commands](/more/expo-cli/#compiling) will create a new build, install it on your emulator/simulator or device, and start running it.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the create a development build doc mentions that there is a way to build locally but doesn't link to the that step (which is in another document). 

Also, in the local development build part, we do not explicitly mention that to run `npx expo run` commands, one doesn't need an Expo account.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add link to the section that describes creating development builds locally in the Create a development build introduction paragraph
- Add context about not needing an Expo account when building locally

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1237" alt="CleanShot 2023-05-18 at 12 39 04@2x" src="https://github.com/expo/expo/assets/10234615/9fc2bc01-b628-4db3-85d0-242aae55f989">

<img width="879" alt="CleanShot 2023-05-18 at 12 44 45@2x" src="https://github.com/expo/expo/assets/10234615/4d0728e5-d019-4660-87d5-3d4a3604a0df">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
