### PR TITLE
[docs] make `large` resource class only available for paid tier plans

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -22,7 +22,7 @@ export default [
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
       '',
-      'The `large` resource class is not available for free plan.',
+      'The `large` resource class is not available on the free plan.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -21,6 +21,8 @@ export default [
       '- `default` maps to `medium`',
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
+      '',
+      'The `large` resource class is not available for free plan.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -53,7 +53,9 @@ export default [
     enum: ['default', 'medium', 'large'],
     description: [
       'The resource class that will be used to run this build.',
-      'To see mapping for `default` and `medium` resource classes for each platform, see [Android-specific resource class field](eas-json/#resourceclass-1) and [iOS-specific resource class field](eas-json/#resourceclass-2) documentation.',
+      'To see mapping for each platform, see [Android-specific resource class field](eas-json/#resourceclass-1) and [iOS-specific resource class field](eas-json/#resourceclass-2) documentation.',
+      '',
+      'The `large` resource class is not available for free plan.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -55,7 +55,7 @@ export default [
       'The resource class that will be used to run this build.',
       'To see mapping for each platform, see [Android-specific resource class field](eas-json/#resourceclass-1) and [iOS-specific resource class field](eas-json/#resourceclass-2) documentation.',
       '',
-      'The `large` resource class is not available for free plan.',
+      'The `large` resource class is not available on the free plan.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -40,6 +40,8 @@ export default [
       '- For SDK version >= 45 or React Native version >= 0.71.0 `medium` maps to `m-medium`, otherwise it maps to `intel-medium`',
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
+      '',
+      'The `large` resource class is not available for free plan.',
     ],
   },
   {

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -41,7 +41,7 @@ export default [
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
       '',
-      'The `large` resource class is not available for free plan.',
+      'The `large` resource class is not available on the free plan.',
     ],
   },
   {


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/universe/pull/12375

# How

Update `eas.json` schema docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
