### PR TITLE
feat(cli): Add `--no-minify` flag to `npx expo export` to prevent minifying output JavaScript.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 - Add `npx expo add` as an alias to `npx expo install`. ([#22510](https://github.com/expo/expo/pull/22510) by [@EvanBacon](https://github.com/EvanBacon))
+- Add `--no-minify` flag to `npx expo export` to prevent minifying output JavaScript.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🎉 New features
 
 - Add `npx expo add` as an alias to `npx expo install`. ([#22510](https://github.com/expo/expo/pull/22510) by [@EvanBacon](https://github.com/EvanBacon))
-- Add `--no-minify` flag to `npx expo export` to prevent minifying output JavaScript.
+- Add `--no-minify` flag to `npx expo export` to prevent minifying output JavaScript. ([#22544](https://github.com/expo/expo/pull/22544) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-test.ts
@@ -65,6 +65,7 @@ it('runs `npx expo export --help`', async () => {
         --dump-assetmap            Dump the asset map for further processing
         --dump-sourcemap           Dump the source map for debugging the JS bundle
         -p, --platform <platform>  Options: android, ios, web, all. Default: all
+        --no-minify                Prevent minifying source
         -c, --clear                Clear the bundler cache
         -h, --help                 Usage info
     "

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -35,6 +35,7 @@ describe(resolveOptionsAsync, () => {
     ).resolves.toEqual({
       clear: true,
       dev: true,
+      minify: true,
       dumpAssetmap: true,
       dumpSourcemap: true,
       maxWorkers: 2,
@@ -47,6 +48,7 @@ describe(resolveOptionsAsync, () => {
     await expect(resolveOptionsAsync('/', {})).resolves.toEqual({
       clear: false,
       dev: false,
+      minify: true,
       dumpAssetmap: false,
       dumpSourcemap: false,
       maxWorkers: undefined,

--- a/packages/@expo/cli/src/export/createBundles.ts
+++ b/packages/@expo/cli/src/export/createBundles.ts
@@ -15,7 +15,7 @@ export type PublishOptions = {
 export async function createBundlesAsync(
   projectRoot: string,
   publishOptions: PublishOptions = {},
-  bundleOptions: { platforms: Platform[]; dev?: boolean }
+  bundleOptions: { platforms: Platform[]; dev?: boolean; minify?: boolean }
 ): Promise<Partial<Record<Platform, BundleOutput>>> {
   if (!bundleOptions.platforms.length) {
     return {};
@@ -43,6 +43,7 @@ export async function createBundlesAsync(
     bundleOptions.platforms.map((platform: Platform) => ({
       platform,
       entryPoint: getEntryWithServerRoot(projectRoot, projectConfig, platform),
+      minify: bundleOptions.minify,
       dev: bundleOptions.dev,
     }))
   );

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -42,7 +42,11 @@ export async function exportAppAsync(
     dev,
     dumpAssetmap,
     dumpSourcemap,
-  }: Pick<Options, 'dumpAssetmap' | 'dumpSourcemap' | 'dev' | 'clear' | 'outputDir' | 'platforms'>
+    minify,
+  }: Pick<
+    Options,
+    'dumpAssetmap' | 'dumpSourcemap' | 'dev' | 'clear' | 'outputDir' | 'platforms' | 'minify'
+  >
 ): Promise<void> {
   setNodeEnv(dev ? 'development' : 'production');
   require('@expo/env').load(projectRoot);
@@ -68,6 +72,7 @@ export async function exportAppAsync(
     { resetCache: !!clear },
     {
       platforms,
+      minify,
       // TODO: Breaks asset exports
       // platforms: useWebSSG ? platforms.filter((platform) => platform !== 'web') : platforms,
       dev,
@@ -108,7 +113,7 @@ export async function exportAppAsync(
       await unstable_exportStaticAsync(projectRoot, {
         outputDir: outputPath,
         // TODO: Expose
-        minify: true,
+        minify,
       });
       Log.log('Finished saving static files');
     } else {

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -81,16 +81,17 @@ export async function getFilesToExportFromServerAsync(
 export async function exportFromServerAsync(
   projectRoot: string,
   devServerManager: DevServerManager,
-  { outputDir }: Options
+  { outputDir, minify }: Options
 ): Promise<void> {
   const devServer = devServerManager.getDefaultDevServer();
   assert(devServer instanceof MetroBundlerDevServer);
 
   const [manifest, resources, renderAsync] = await Promise.all([
     devServer.getRoutesAsync(),
-    devServer.getStaticResourcesAsync({ mode: 'production' }),
+    devServer.getStaticResourcesAsync({ mode: 'production', minify }),
     devServer.getStaticRenderFunctionAsync({
       mode: 'production',
+      minify,
     }),
   ]);
 

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -46,7 +46,7 @@ export const expoExport: Command = async (argv) => {
         `--dump-assetmap            Dump the asset map for further processing`,
         `--dump-sourcemap           Dump the source map for debugging the JS bundle`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
-        chalk`--no-minify           Prevent minifying source`,
+        `--no-minify                Prevent minifying source`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -17,6 +17,7 @@ export const expoExport: Command = async (argv) => {
       '--max-workers': Number,
       '--output-dir': String,
       '--platform': String,
+      '--no-minify': Boolean,
 
       // Hack: This is added because EAS CLI always includes the flag.
       // If supplied, we'll do nothing with the value, but at least the process won't crash.
@@ -45,6 +46,7 @@ export const expoExport: Command = async (argv) => {
         `--dump-assetmap            Dump the asset map for further processing`,
         `--dump-sourcemap           Dump the source map for debugging the JS bundle`,
         chalk`-p, --platform <platform>  Options: android, ios, web, all. {dim Default: all}`,
+        chalk`--no-minify           Prevent minifying source`,
         `-c, --clear                Clear the bundler cache`,
         `-h, --help                 Usage info`,
       ].join('\n')

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -9,6 +9,7 @@ export type Options = {
   maxWorkers?: number;
   dev: boolean;
   clear: boolean;
+  minify: boolean;
   dumpAssetmap: boolean;
   dumpSourcemap: boolean;
 };
@@ -67,6 +68,7 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
   return {
     outputDir: args['--output-dir'] ?? 'dist',
     platforms,
+    minify: !args['--no-minify'],
     clear: !!args['--clear'],
     dev: !!args['--dev'],
     maxWorkers: args['--max-workers'],

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -68,12 +68,14 @@ export function createBundleUrlPath({
   mode,
   minify = mode === 'production',
   environment,
+  serializerOutput,
 }: {
   platform: string;
   mainModuleName: string;
   mode: string;
   minify?: boolean;
   environment?: string;
+  serializerOutput?: 'static';
 }): string {
   const queryParams = new URLSearchParams({
     platform: encodeURIComponent(platform),
@@ -88,6 +90,9 @@ export function createBundleUrlPath({
   if (environment) {
     queryParams.append('resolver.environment', environment);
     queryParams.append('transform.environment', environment);
+  }
+  if (serializerOutput) {
+    queryParams.append('serializer.output', serializerOutput);
   }
 
   return `/${encodeURI(mainModuleName)}.bundle?${queryParams.toString()}`;


### PR DESCRIPTION
# Why

Nice feature to have for debugging.

# How

- Add the `--no-minify` flag to `npx expo export`.
- Forward the flag to all Metro invocations.
- Also noticed that in some places, we were minifying Node.js code which doesn't matter, so now we always skip minification when creating static functions.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `npx expo export --no-minify` -> JS and CSS is not minified.