### PR TITLE
[docs] Development builds introduction wording tweak

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -23,7 +23,7 @@ A **development build** of your app is a Debug build that contains the `expo-dev
 
 You can think of a development build as your version of the Expo Go client.
 
-## What is an expo-dev-client
+## What is expo-dev-client
 
 The [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) package is used to create a development build. It is a library designed to support any workflow, release process, or set of dependencies in the Expo/React Native ecosystem. Whatever your project needs, either now or in the future, you'll be able to create a development build for it and get the productivity and quality of life improvements of JavaScript-driven development.
 


### PR DESCRIPTION
# Why

Noticed the header '[What is an expo-dev-client](https://docs.expo.dev/develop/development-builds/introduction/#what-is-an-expo-dev-client)' and thought 'What is expo-dev-client' would be better to emphasize the difference more between 'a development build' and 'the expo-dev-client package'.

# How

Changed the header text.

# Test Plan

Mk I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
