### PR TITLE
[docs] Remove sidebar_title override for 'Update a screenshot'

### DIFF
--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -1,6 +1,5 @@
 ---
 title: Take a screenshot
-sidebar_title: Take screenshot
 ---
 
 import { SnackInline, Terminal } from '~/ui/components/Snippet';


### PR DESCRIPTION
# Why

This was the only page in the section with a sidebar_title override. Other pages in the same section contain indefinite articles and did not have this override, like 'Build **a** screen' and 'Create **a** modal' 

# How

Removed sidebar_title override.

# Test Plan

Mk I Eyeball

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
