### PR TITLE
[docs] remove information related to outdated global Expo CLI options

### DIFF
--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -70,9 +70,7 @@ import Constants from 'expo-constants';
 Constants.expoConfig.extra.fact === 'kittens are cool';
 ```
 
-You can access and modify incoming config values by exporting a function that returns an object. This is useful if your project also has an **app.json**. By default, Expo CLI will read the **app.json** first and send the normalized results to the **app.config.js**. This functionality is disabled when the `--config` is used to specify a custom config.
-
-> **warning** The `--config` flag is deprecated. For more information, see [Migration from `--config` in Expo CLI](https://expo.fyi/config-flag-migration).
+You can access and modify incoming config values by exporting a function that returns an object. This is useful if your project also has an **app.json**. By default, Expo CLI will read the **app.json** first and send the normalized results to the **app.config.js**.
 
 For example, your **app.json** could look like this:
 


### PR DESCRIPTION
# Why

The `--config` option does not exist in the local CLI. We should not actively refer to options that were available in the global CLI anymore. The deprecation noticed refered to the fact that is was already deprecated in the _global_ CLI before.

# How

Removed the mention.

# Test Plan

Mk I Eyeball.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
