### PR TITLE
[docs] fix SidebarLink layout shift issue

### DIFF
--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -68,7 +68,7 @@ export const SidebarLink = ({ info, children }: SidebarLinkProps) => {
         ref={ref}
         css={[STYLES_LINK, isSelected && STYLES_LINK_ACTIVE]}
         {...customDataAttributes}>
-        {isSelected && <div css={STYLES_ACTIVE_BULLET} />}
+        <div css={[STYLES_BULLET, isSelected && STYLES_ACTIVE_BULLET]} />
         {children}
         {isExternal && <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto" />}
       </LinkBase>
@@ -87,6 +87,7 @@ const STYLES_LINK = css`
   padding-left: ${spacing[2]}px;
   scroll-margin: 60px;
   width: 100%;
+  margin-left: -${spacing[4] + spacing[0.5]}px;
 
   &:hover {
     color: ${theme.text.link};
@@ -99,8 +100,6 @@ const STYLES_LINK = css`
 
 const STYLES_LINK_ACTIVE = css`
   color: ${theme.text.link};
-  padding-left: 0;
-  margin-left: -${spacing[2.5]}px;
 `;
 
 const STYLES_CONTAINER = css`
@@ -111,13 +110,16 @@ const STYLES_CONTAINER = css`
   padding-right: ${spacing[2]}px;
 `;
 
-const STYLES_ACTIVE_BULLET = css`
+const STYLES_BULLET = css`
   height: 6px;
   width: 6px;
   min-height: 6px;
   min-width: 6px;
-  background-color: ${theme.text.link};
   border-radius: 100%;
   margin: ${spacing[2]}px ${spacing[1.5]}px;
   align-self: self-start;
+`;
+
+const STYLES_ACTIVE_BULLET = css`
+  background-color: ${theme.text.link};
 `;


### PR DESCRIPTION
# Why

<img width="613" alt="Screenshot 2023-05-19 at 11 13 14" src="https://github.com/expo/expo/assets/719641/7dfe877e-b070-4d89-bb64-60b82f56e903">

Bug reported by Kim, thanks! 👍 

# How

Rewrite the way we apply active state style for `SidebarLink` component, so dot DOM is always present and padding/margin doesn't need to be updated, which was the cause for the shift.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

https://github.com/expo/expo/assets/719641/44be8f93-12dc-4a59-a8bd-3f2f3bfa5048

