### PR TITLE
[core][iOS] Add CoreModule defining the `global.expo` object

### DIFF
--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.h
@@ -4,7 +4,7 @@
 
 // Swift classes need forward-declaration in the headers.
 @class EXAppContext;
-@class EXJavaScriptRuntime;
+@class ExpoRuntime;
 
 @interface EXJavaScriptRuntimeManager : NSObject
 
@@ -12,7 +12,7 @@
  Gets the JS runtime from the given bridge. May return `nil` when
  the runtime is not available yet or the remote debugging is enabled.
  */
-+ (nullable EXJavaScriptRuntime *)runtimeFromBridge:(nonnull RCTBridge *)bridge NS_SWIFT_NAME(runtime(fromBridge:));
++ (nullable ExpoRuntime *)runtimeFromBridge:(nonnull RCTBridge *)bridge NS_SWIFT_NAME(runtime(fromBridge:));
 
 /**
  Installs ExpoModules host object in the runtime of the given app context.

--- a/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJSIInstaller.mm
@@ -27,15 +27,15 @@ static NSString *modulesHostObjectLegacyPropertyName = @"ExpoModules";
 
 @implementation EXJavaScriptRuntimeManager
 
-+ (nullable EXJavaScriptRuntime *)runtimeFromBridge:(nonnull RCTBridge *)bridge
++ (nullable ExpoRuntime *)runtimeFromBridge:(nonnull RCTBridge *)bridge
 {
   jsi::Runtime *jsiRuntime = [bridge respondsToSelector:@selector(runtime)] ? reinterpret_cast<jsi::Runtime *>(bridge.runtime) : nullptr;
-  return jsiRuntime ? [[EXJavaScriptRuntime alloc] initWithRuntime:jsiRuntime callInvoker:bridge.jsCallInvoker] : nil;
+  return jsiRuntime ? [[ExpoRuntime alloc] initWithRuntime:jsiRuntime callInvoker:bridge.jsCallInvoker] : nil;
 }
 
 + (BOOL)installExpoModulesHostObject:(nonnull EXAppContext *)appContext
 {
-  EXJavaScriptRuntime *runtime = [appContext _runtime];
+  ExpoRuntime *runtime = [appContext _runtime];
 
   // The runtime may be unavailable, e.g. remote debugger is enabled or it hasn't been set yet.
   if (!runtime) {
@@ -43,9 +43,9 @@ static NSString *modulesHostObjectLegacyPropertyName = @"ExpoModules";
   }
 
   EXJavaScriptObject *global = [runtime global];
-  EXJavaScriptObject *mainObject = [runtime mainObject];
+  EXJavaScriptObject *coreObject = [runtime coreObject];
 
-  if ([mainObject hasProperty:modulesHostObjectPropertyName]) {
+  if ([coreObject hasProperty:modulesHostObjectPropertyName]) {
     return false;
   }
 
@@ -53,7 +53,7 @@ static NSString *modulesHostObjectLegacyPropertyName = @"ExpoModules";
   EXJavaScriptObject *modulesHostObject = [runtime createHostObject:modulesHostObjectPtr];
 
   // Define the `global.expo.modules` object as a non-configurable, read-only and enumerable property.
-  [mainObject defineProperty:modulesHostObjectPropertyName
+  [coreObject defineProperty:modulesHostObjectPropertyName
                        value:modulesHostObject
                      options:EXJavaScriptObjectPropertyDescriptorEnumerable];
 

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.h
@@ -67,12 +67,6 @@ NS_SWIFT_NAME(JavaScriptRuntime)
 - (nonnull EXJavaScriptObject *)global;
 
 /**
- The main object of the Expo runtime that is used to scope native Expo-specific functionalities.
- It gets installed into the runtime as the `global.expo` object.
- */
-- (nonnull EXJavaScriptObject *)mainObject;
-
-/**
  Creates a new object for use in Swift.
  */
 - (nonnull EXJavaScriptObject *)createObject;

--- a/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
+++ b/packages/expo-modules-core/ios/JSI/EXJavaScriptRuntime.mm
@@ -20,16 +20,9 @@
 #import <ExpoModulesCore/EXJSIConversions.h>
 #import <ExpoModulesCore/Swift.h>
 
-
-/**
- Property name of the main object in the Expo JS runtime.
- */
-static NSString *mainObjectPropertyName = @"expo";
-
 @implementation EXJavaScriptRuntime {
   std::shared_ptr<jsi::Runtime> _runtime;
   std::shared_ptr<react::CallInvoker> _jsCallInvoker;
-  EXJavaScriptObject *_mainObject;
 }
 
 /**
@@ -46,7 +39,6 @@ static NSString *mainObjectPropertyName = @"expo";
     _runtime = jsc::makeJSCRuntime();
 #endif
     _jsCallInvoker = nil;
-    [self initializeMainObject];
   }
   return self;
 }
@@ -60,7 +52,6 @@ static NSString *mainObjectPropertyName = @"expo";
     // See explanation for constructor (8): https://en.cppreference.com/w/cpp/memory/shared_ptr/shared_ptr
     _runtime = std::shared_ptr<jsi::Runtime>(std::shared_ptr<jsi::Runtime>(), runtime);
     _jsCallInvoker = callInvoker;
-    [self initializeMainObject];
   }
   return self;
 }
@@ -91,11 +82,6 @@ static NSString *mainObjectPropertyName = @"expo";
 {
   auto jsGlobalPtr = std::make_shared<jsi::Object>(_runtime->global());
   return [[EXJavaScriptObject alloc] initWith:jsGlobalPtr runtime:self];
-}
-
-- (nonnull EXJavaScriptObject *)mainObject
-{
-  return _mainObject;
 }
 
 - (nonnull EXJavaScriptObject *)createSyncFunction:(nonnull NSString *)name
@@ -194,15 +180,6 @@ static NSString *mainObjectPropertyName = @"expo";
 }
 
 #pragma mark - Private
-
-- (void)initializeMainObject
-{
-  if (!_mainObject) {
-    // Add the main object to the runtime (`global.expo`).
-    _mainObject = [self createObject];
-    [[self global] defineProperty:mainObjectPropertyName value:_mainObject options:EXJavaScriptObjectPropertyDescriptorEnumerable];
-  }
-}
 
 - (nonnull EXJavaScriptObject *)createHostFunction:(nonnull NSString *)name
                                          argsCount:(NSInteger)argsCount

--- a/packages/expo-modules-core/ios/Swift/ExpoRuntime.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoRuntime.swift
@@ -1,0 +1,28 @@
+/**
+ Property name of the core object in the global scope of the Expo JS runtime.
+ */
+private let coreObjectPropertyName = "expo"
+
+@objc(ExpoRuntime)
+public final class ExpoRuntime: JavaScriptRuntime {
+  /**
+   The core object of the Expo runtime that is used to scope native Expo-specific functionalities.
+   It gets installed into the runtime as the `global.expo` object.
+   */
+  @objc
+  public private(set) var coreObject: JavaScriptObject?
+
+  internal func initializeCoreObject(_ coreObject: JavaScriptObject) throws {
+    guard self.coreObject == nil else {
+      throw CoreObjectInitializedException()
+    }
+    self.coreObject = coreObject
+    global().defineProperty(coreObjectPropertyName, value: coreObject, options: .enumerable)
+  }
+}
+
+private final class CoreObjectInitializedException: Exception {
+  override var reason: String {
+    "The core Expo object was already initialized"
+  }
+}

--- a/packages/expo-modules-core/ios/Swift/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Swift/Modules/CoreModule.swift
@@ -1,0 +1,7 @@
+// The core module that describes the `global.expo` object.
+internal final class CoreModule: Module {
+  internal func definition() -> ModuleDefinition {
+    // Nothing so far, but eventually we will expose some common classes
+    // and maybe even the `modules` host object.
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/CoreModuleSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/CoreModuleSpec.swift
@@ -1,0 +1,27 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class CoreModuleSpec: ExpoSpec {
+  override func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    describe("core module") {
+      it("is initialized") {
+        expect(appContext.coreModule).notTo(beNil())
+      }
+    }
+
+    describe("core object") {
+      it("is initialized") {
+        expect(runtime.coreObject).notTo(beNil())
+      }
+
+      it("is installed to global scope") {
+        let coreObjectValue = try runtime.eval("expo")
+        expect(coreObjectValue.kind) == .object
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

We want the `global.expo` object to be automatically built and decorated. The best and easiest approach is to introduce the `CoreModule` that will leave outside the module registry but will be used to build the object for `global.expo`.

So far the module can just be empty, but in the future we want to add the following:
- some common constants, including the version of `expo-modules-core`
- a new definition that will build the `ExpoModulesHostObject`
- (?) core classes such as EventEmitter, Blob, Stream

# How

- Added empty `CoreModule` module
- Refactored the code a little bit, by separating Expo-specific things from `JavaScriptRuntime` to the new `ExpoRuntime`
- Added new native tests

# Test Plan

- I built bare-expo app and confirmed that examples of the existing modules still work
- Using the inspector, I checked if the `global.expo` object is defined
- Native tests from `CoreModuleSpec` are passing

<!-- disable:changelog-checks -->