### PR TITLE
[screen-orientation][android] Fix `Exceptions.MissingActivity` exception when module is deallocated

### DIFF
--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -17,8 +17,12 @@ import expo.modules.screenorientation.enums.OrientationAttr
 import expo.modules.screenorientation.enums.OrientationLock
 
 class ScreenOrientationModule : Module(), LifecycleEventListener {
+  private val weakCurrentActivity
+    get() = appContext.activityProvider?.currentActivity
+
   private val currentActivity
-    get() = appContext.activityProvider?.currentActivity ?: throw Exceptions.MissingActivity()
+    get() = weakCurrentActivity ?: throw Exceptions.MissingActivity()
+
   private val uiManager
     get() = appContext.legacyModuleRegistry.getModule(UIManager::class.java)
       ?: throw IllegalStateException("Could not find implementation for UIManager.")
@@ -71,13 +75,13 @@ class ScreenOrientationModule : Module(), LifecycleEventListener {
     OnDestroy {
       uiManager.unregisterLifecycleEventListener(this@ScreenOrientationModule)
       initialOrientation?.let {
-        currentActivity.requestedOrientation = it
+        weakCurrentActivity?.requestedOrientation = it
       }
     }
   }
 
   override fun onHostResume() {
-    initialOrientation = initialOrientation ?: currentActivity.requestedOrientation
+    initialOrientation = initialOrientation ?: weakCurrentActivity?.requestedOrientation
   }
 
   override fun onHostPause() = Unit


### PR DESCRIPTION
# Why

Fixes the `Exceptions.MissingActivity` exception when a module is deallocated.

# How

The current activity may not be available when the module is deallocated or the host was resumed. It's not happening often, but that is the normal flow. Instead of throwing, we can just ignore those cases. 

# Test Plan

- bare-expo ✅