### PR TITLE
[docs] refactor SidebarSingleEntry in preparation for more top sections

### DIFF
--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -11,7 +11,7 @@ export const SidebarFooter = () => {
   const router = useRouter();
   const isArchive = router?.pathname ? getPageSection(router.pathname) === 'archive' : false;
   return (
-    <div className="flex flex-col p-4 border-t border-t-default bg-default">
+    <div className="flex flex-col p-4 border-t border-t-default bg-default gap-0.5">
       <SidebarSingleEntry
         secondary
         href="/archive"

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
-import { mergeClasses, theme, typography } from '@expo/styleguide';
-import { borderRadius, spacing } from '@expo/styleguide-base';
+import { mergeClasses } from '@expo/styleguide';
 import { ArrowUpRightIcon } from '@expo/styleguide-icons';
 import type { ComponentType, HTMLAttributes } from 'react';
 
@@ -26,80 +24,21 @@ export const SidebarSingleEntry = ({
   return (
     <A
       href={href}
-      css={[containerStyle, secondary && secondaryContainerStyle, isActive && activeContainerStyle]}
+      className={mergeClasses(
+        'flex items-center gap-3 text-secondary rounded-md text-xs min-h-[32px] px-2 py-1 !leading-[100%] !opacity-100',
+        'hocus:bg-element',
+        secondary && 'text-xs',
+        isActive && 'bg-palette-blue3 text-link font-medium hocus:text-link hocus:bg-palette-blue4'
+      )}
       isStyled>
-      <span
-        css={[
-          iconWrapperStyle,
-          secondary && secondaryIconWrapperStyle,
-          isActive && activeIconWrapperStyle,
-        ]}>
-        <Icon
-          className={mergeClasses(
-            'icon-sm',
-            isActive ? 'text-palette-blue11' : 'text-icon-secondary'
-          )}
-        />
-      </span>
+      <Icon
+        className={mergeClasses(
+          secondary ? 'icon-xs' : 'icon-sm',
+          isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
+        )}
+      />
       {title}
       {isExternal && <ArrowUpRightIcon className="icon-sm text-icon-secondary ml-auto" />}
     </A>
   );
 };
-
-const containerStyle = css({
-  ...typography.fontSizes[14],
-  minHeight: 38,
-  lineHeight: '100%',
-  padding: `${spacing[1]}px ${spacing[1]}px`,
-  color: theme.text.secondary,
-  cursor: 'pointer',
-  display: 'flex',
-  alignItems: 'center',
-  userSelect: 'none',
-  transition: 'color 150ms, opacity 150ms',
-  textDecoration: 'none',
-  borderRadius: borderRadius.md,
-  fontWeight: 500,
-  gap: spacing[2.5],
-
-  '&:hover': {
-    color: theme.text.default,
-    opacity: 1,
-  },
-});
-
-const secondaryContainerStyle = css({
-  fontWeight: 400,
-
-  '&:hover': {
-    color: theme.text.secondary,
-    opacity: 0.8,
-  },
-});
-
-const activeContainerStyle = css({
-  color: theme.text.link,
-
-  '&:hover': {
-    color: theme.text.link,
-  },
-});
-
-const iconWrapperStyle = css({
-  display: 'flex',
-  backgroundColor: theme.background.element,
-  width: spacing[6],
-  height: spacing[6],
-  borderRadius: borderRadius.sm,
-  alignItems: 'center',
-  justifyContent: 'center',
-});
-
-const activeIconWrapperStyle = css({
-  backgroundColor: theme.palette.blue4,
-});
-
-const secondaryIconWrapperStyle = css({
-  backgroundColor: 'transparent',
-});


### PR DESCRIPTION
# Why

In near future we plan one or even few more top docs sections, so this PR focuses on reducing the space taken by main categories links.

# How

Refactor SidebarSingleEntry styles to TW, add more prominent active section styling and hover effect, condense entries a bit.

# Test Plan

The changes have been developed and tested by running docs app locally.

# Preview

https://github.com/expo/expo/assets/719641/973d6de7-a733-465f-88dc-967e416a77af

