### PR TITLE
[docs] fix CodeBlocksTable appearance after latest header changes

### DIFF
--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -1,10 +1,13 @@
 import { css } from '@emotion/react';
 import { breakpoints, spacing } from '@expo/styleguide-base';
+import { FileCode01Icon } from '@expo/styleguide-icons';
 import { PropsWithChildren } from 'react';
 
+import { cleanCopyValue } from '~/components/base/code';
 import { Snippet } from '~/ui/components/Snippet/Snippet';
 import { SnippetContent } from '~/ui/components/Snippet/SnippetContent';
 import { SnippetHeader } from '~/ui/components/Snippet/SnippetHeader';
+import { CopyAction } from '~/ui/components/Snippet/actions/CopyAction';
 
 const MDX_CLASS_NAME_TO_TAB_NAME: Record<string, string> = {
   'language-swift': 'Swift',
@@ -34,12 +37,16 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
       return MDX_CLASS_NAME_TO_TAB_NAME[className] || className.replace('language-', '');
     });
 
+  console.warn(codeBlocks);
+
   return (
     <div css={[codeBlocksWrapperStyle, connected && codeBlockConnectedWrapperStyle]} {...rest}>
       {codeBlocks.map((codeBlock, index) => (
         <Snippet key={index} css={snippetWrapperStyle}>
-          <SnippetHeader title={tabNames[index]} />
-          <SnippetContent className="p-0">{codeBlock}</SnippetContent>
+          <SnippetHeader title={tabNames[index]} Icon={FileCode01Icon}>
+            <CopyAction text={cleanCopyValue(codeBlock.props.children.props.children)} />
+          </SnippetHeader>
+          <SnippetContent className="p-0 h-full">{codeBlock}</SnippetContent>
         </Snippet>
       ))}
     </div>

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -15,22 +15,20 @@ export const SnippetHeader = ({
   Icon,
   alwaysDark = false,
 }: SnippetHeaderProps) => (
-  <div className={mergeClasses(alwaysDark && 'dark-theme')}>
-    <div
+  <div
+    className={mergeClasses(
+      'flex pl-4 overflow-hidden justify-between bg-default border border-default rounded-t-md border-b-0 min-h-[40px]',
+      Icon && 'pl-3',
+      alwaysDark && 'dark-theme pr-2 dark:border-transparent !bg-palette-gray3'
+    )}>
+    <LABEL
       className={mergeClasses(
-        'flex pl-4 overflow-hidden justify-between bg-default border border-default rounded-t-md border-b-0',
-        Icon && 'pl-3',
-        alwaysDark && 'pr-2 dark:border-transparent !bg-palette-gray3'
+        'flex items-center gap-2 h-10 !leading-10 pr-4 select-none font-medium text-ellipsis whitespace-nowrap overflow-hidden',
+        alwaysDark && 'text-palette-white'
       )}>
-      <LABEL
-        className={mergeClasses(
-          'flex items-center gap-2 h-10 !leading-10 pr-4 select-none font-medium text-ellipsis whitespace-nowrap overflow-hidden',
-          alwaysDark && 'text-palette-white'
-        )}>
-        {Icon && <Icon className="icon-sm" />}
-        {title}
-      </LABEL>
-      {!!children && <div className="flex justify-end items-center">{children}</div>}
-    </div>
+      {Icon && <Icon className="icon-sm" />}
+      {title}
+    </LABEL>
+    {!!children && <div className="flex justify-end items-center">{children}</div>}
   </div>
 );


### PR DESCRIPTION
# Why

With latest changes to the Snippet headers there were few small regressions introduced for `CodeBlocksTable` component, let's address them.

# How

Add icon and "Copy" functionality to the `CodeBlocksTable` snippets.

Ensure that tables styles can properly overwrite the existing ones, make sure that header have the appropriate height, even when there is no action buttons.

# Test Plan

The changes have been developed and tested by running docs app locally.

# Preview

<img width="1168" alt="Screenshot 2023-05-19 at 18 01 51" src="https://github.com/expo/expo/assets/719641/4ee6d0aa-2ff0-4635-8bac-7163fdf3fb89">

