### PR TITLE
[image] Update SDWebImage dependencies

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -155,10 +155,10 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.2.3):
     - ExpoModulesCore
-    - SDWebImage (~> 5.15.0)
+    - SDWebImage (~> 5.15.8)
     - SDWebImageAVIFCoder (~> 0.10.0)
-    - SDWebImageSVGCoder (~> 1.6.1)
-    - SDWebImageWebPCoder (~> 0.9.1)
+    - SDWebImageSVGCoder (~> 1.7.0)
+    - SDWebImageWebPCoder (~> 0.11.0)
   - ExpoImageManipulator (11.2.0):
     - EXImageLoader
     - ExpoModulesCore
@@ -296,15 +296,15 @@ PODS:
     - libavif/core
   - libevent (2.1.12)
   - libvmaf (2.3.1)
-  - libwebp (1.2.3):
-    - libwebp/demux (= 1.2.3)
-    - libwebp/mux (= 1.2.3)
-    - libwebp/webp (= 1.2.3)
-  - libwebp/demux (1.2.3):
+  - libwebp (1.2.4):
+    - libwebp/demux (= 1.2.4)
+    - libwebp/mux (= 1.2.4)
+    - libwebp/webp (= 1.2.4)
+  - libwebp/demux (1.2.4):
     - libwebp/webp
-  - libwebp/mux (1.2.3):
+  - libwebp/mux (1.2.4):
     - libwebp/demux
-  - libwebp/webp (1.2.3)
+  - libwebp/webp (1.2.4)
   - MLImage (1.0.0-beta2)
   - MLKitCommon (5.0.0):
     - GoogleDataTransport (~> 9.0)
@@ -746,17 +746,17 @@ PODS:
     - React-Core
   - RNSVG (13.4.0):
     - React-Core
-  - SDWebImage (5.15.0):
-    - SDWebImage/Core (= 5.15.0)
-  - SDWebImage/Core (5.15.0)
+  - SDWebImage (5.15.8):
+    - SDWebImage/Core (= 5.15.8)
+  - SDWebImage/Core (5.15.8)
   - SDWebImageAVIFCoder (0.10.0):
     - libavif (>= 0.11.0)
     - SDWebImage (~> 5.10)
-  - SDWebImageSVGCoder (1.6.1):
+  - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageWebPCoder (0.9.1):
+  - SDWebImageWebPCoder (0.11.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.13)
+    - SDWebImage/Core (~> 5.15)
   - UMAppLoader (4.1.2)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
@@ -1282,7 +1282,7 @@ SPEC CHECKSUMS:
   ExpoDocumentPicker: 2dfcc5935532a3193818017da5e2f3dfda0dbf3b
   ExpoGL: 66d0342641c28a0abbe382e2ca905c556442c7fc
   ExpoHaptics: fb64dfe302cba07591bf1679ecb9531dadfc13cf
-  ExpoImage: 60f8d8182e8e13b5f5c2bb6bc860c933b2fe6c25
+  ExpoImage: f19f918d2ff1c9c9fbedc266e6a28d10aa335800
   ExpoImageManipulator: b8d510b4d15689d8f276dff3482df5707836035b
   ExpoImagePicker: 432af66697986cc210bc814dee782a07b2037a61
   ExpoInsights: 55e764c08fe52d6cb5f926d8e9223df54ed0e9f4
@@ -1331,7 +1331,7 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
-  libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
+  libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   MLImage: a454f9f8ecfd537783a12f9488f5be1a68820829
   MLKitCommon: 3bc17c6f7d25ce3660f030350b46ae7ec9ebca6e
   MLKitFaceDetection: 617cb847441868a8bfd4b48d751c9b33c1104948
@@ -1386,10 +1386,10 @@ SPEC CHECKSUMS:
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSharedElement: 504fa28a235b12505b6daedbb452a9ec96809bd0
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
-  SDWebImage: 9bec4c5cdd9579e1f57104735ee0c37df274d593
+  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
   SDWebImageAVIFCoder: 4aeea8fdf65af5c18525ecb5bdd8b8ed9bb45019
-  SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
-  SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
+  SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
+  SDWebImageWebPCoder: 295a6573c512f54ad2dd58098e64e17dcf008499
   UMAppLoader: d1cd37524ea948f9e695722994496784a6d6213c
   Yoga: d56980c8914db0b51692f55533409e844b66133c
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1389,10 +1389,10 @@ PODS:
     - ABI48_0_0ExpoModulesCore
   - ABI48_0_0ExpoImage (1.0.0):
     - ABI48_0_0ExpoModulesCore
-    - SDWebImage (~> 5.15.0)
+    - SDWebImage (~> 5.15.8)
     - SDWebImageAVIFCoder (~> 0.10.0)
-    - SDWebImageSVGCoder (~> 1.6.1)
-    - SDWebImageWebPCoder (~> 0.9.1)
+    - SDWebImageSVGCoder (~> 1.7.0)
+    - SDWebImageWebPCoder (~> 0.11.0)
   - ABI48_0_0ExpoImageManipulator (11.1.1):
     - ABI48_0_0EXImageLoader
     - ABI48_0_0ExpoModulesCore
@@ -2151,10 +2151,10 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.2.3):
     - ExpoModulesCore
-    - SDWebImage (~> 5.15.0)
+    - SDWebImage (~> 5.15.8)
     - SDWebImageAVIFCoder (~> 0.10.0)
-    - SDWebImageSVGCoder (~> 1.6.1)
-    - SDWebImageWebPCoder (~> 0.9.1)
+    - SDWebImageSVGCoder (~> 1.7.0)
+    - SDWebImageWebPCoder (~> 0.11.0)
   - ExpoImageManipulator (11.2.0):
     - EXImageLoader
     - ExpoModulesCore
@@ -2902,11 +2902,11 @@ PODS:
   - SDWebImageAVIFCoder (0.10.0):
     - libavif (>= 0.11.0)
     - SDWebImage (~> 5.10)
-  - SDWebImageSVGCoder (1.6.1):
+  - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageWebPCoder (0.9.1):
+  - SDWebImageWebPCoder (0.11.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.13)
+    - SDWebImage/Core (~> 5.15)
   - Stripe (23.3.0):
     - StripeApplePay (= 23.3.0)
     - StripeCore (= 23.3.0)
@@ -4621,7 +4621,7 @@ SPEC CHECKSUMS:
   ABI48_0_0ExpoDevice: c119dd7e98df279cb9d06f58eede18289be95ea1
   ABI48_0_0ExpoGL: 158cdc822ab1831c6c91a0e62524c1a004b61b31
   ABI48_0_0ExpoHaptics: 4ece00d4b8aa47a1d45abc46ac9ae1d3e0a5edfb
-  ABI48_0_0ExpoImage: c9ae0f538744ed9b4b66870b767a75d6d3086016
+  ABI48_0_0ExpoImage: 24bf210cc71f3d8c8f804032b25b7c6f8088babf
   ABI48_0_0ExpoImageManipulator: 9d61e40b13268e04e51e868c770fea324dd5ac8d
   ABI48_0_0ExpoImagePicker: f55b4ae78f26481bec5a769f2b23c864c22f2608
   ABI48_0_0ExpoKeepAwake: 956461c0639ea092f296010edf75e17a7b827336
@@ -4740,7 +4740,7 @@ SPEC CHECKSUMS:
   ExpoDocumentPicker: 2dfcc5935532a3193818017da5e2f3dfda0dbf3b
   ExpoGL: 66d0342641c28a0abbe382e2ca905c556442c7fc
   ExpoHaptics: fb64dfe302cba07591bf1679ecb9531dadfc13cf
-  ExpoImage: 60f8d8182e8e13b5f5c2bb6bc860c933b2fe6c25
+  ExpoImage: f19f918d2ff1c9c9fbedc266e6a28d10aa335800
   ExpoImageManipulator: b8d510b4d15689d8f276dff3482df5707836035b
   ExpoImagePicker: 432af66697986cc210bc814dee782a07b2037a61
   ExpoKeepAwake: 6604830433e76ce03306b82054e634e81a6b9bbb
@@ -4862,8 +4862,8 @@ SPEC CHECKSUMS:
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
   SDWebImageAVIFCoder: 4aeea8fdf65af5c18525ecb5bdd8b8ed9bb45019
-  SDWebImageSVGCoder: 6fc109f9c2a82ab44510fff410b88b1a6c271ee8
-  SDWebImageWebPCoder: 18503de6621dd2c420d680e33d46bf8e1d5169b0
+  SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
+  SDWebImageWebPCoder: 295a6573c512f54ad2dd58098e64e17dcf008499
   Stripe: 8a2e7c77fc28bff1d0961a129fac0cb2ed91ddcb
   stripe-react-native: c71683ecc56c63eecbb7172c2f97c8ac737fa37c
   StripeApplePay: 7b7a5e10891d2ea428cf1a3a737a07fe874f7e7d

--- a/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
+++ b/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
@@ -16,16 +16,16 @@
   "static_framework": true,
   "dependencies": {
     "SDWebImage": [
-      "~> 5.15.0"
+      "~> 5.15.8"
     ],
     "SDWebImageWebPCoder": [
-      "~> 0.9.1"
+      "~> 0.11.0"
     ],
     "SDWebImageAVIFCoder": [
       "~> 0.10.0"
     ],
     "SDWebImageSVGCoder": [
-      "~> 1.6.1"
+      "~> 1.7.0"
     ],
     "ABI48_0_0ExpoModulesCore": []
   },

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 💡 Others
 
+- Updated `SDWebImage` to `5.15.8`, `SDWebImageWebPCoder` to `0.11.0` and `SDWebImageSVGCoder` to `1.7.0`.
+
 ## 1.2.3 — 2023-05-16
 
 ### 🐛 Bug fixes

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- Updated `SDWebImage` to `5.15.8`, `SDWebImageWebPCoder` to `0.11.0` and `SDWebImageSVGCoder` to `1.7.0`.
+- Updated `SDWebImage` to `5.15.8`, `SDWebImageWebPCoder` to `0.11.0` and `SDWebImageSVGCoder` to `1.7.0`. ([#22576](https://github.com/expo/expo/pull/22576) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.2.3 — 2023-05-16
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -16,10 +16,10 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'SDWebImage', '~> 5.15.0'
-  s.dependency 'SDWebImageWebPCoder', '~> 0.9.1'
+  s.dependency 'SDWebImage', '~> 5.15.8'
+  s.dependency 'SDWebImageWebPCoder', '~> 0.11.0'
   s.dependency 'SDWebImageAVIFCoder', '~> 0.10.0'
-  s.dependency 'SDWebImageSVGCoder', '~> 1.6.1'
+  s.dependency 'SDWebImageSVGCoder', '~> 1.7.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why

Keeping up-to-date with SDWebImage releases

# How

- Updated dependencies in the podspec
- Backported version bumps in local podspecs for SDK 48 (Expo Go)
- Reinstalled pods in Expo Go and bare-expo

# Test Plan

NCL examples work fine
