### PR TITLE
[docs] fix Terminal issue while rendering unmarked lines

### DIFF
--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -28,10 +28,7 @@ export const Terminal = ({
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
-    <SnippetContent
-      alwaysDark
-      hideOverflow={hideOverflow}
-      className="grid grid-cols-auto-min-1">
+    <SnippetContent alwaysDark hideOverflow={hideOverflow} className="grid grid-cols-auto-min-1">
       {cmd.map(cmdMapper)}
     </SnippetContent>
   </Snippet>

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -28,7 +28,10 @@ export const Terminal = ({
     <SnippetHeader alwaysDark title={title} Icon={TerminalSquareIcon}>
       {renderCopyButton({ cmd, cmdCopy })}
     </SnippetHeader>
-    <SnippetContent alwaysDark hideOverflow={hideOverflow}>
+    <SnippetContent
+      alwaysDark
+      hideOverflow={hideOverflow}
+      className="grid grid-cols-auto-min-1">
       {cmd.map(cmdMapper)}
     </SnippetContent>
   </Snippet>


### PR DESCRIPTION
# Why

![image](https://github.com/expo/expo/assets/719641/af4d89b7-ea36-4899-bd91-899a52c4fbce)

After latest changes to the Snippet code unmarked lines in Terminal blocks were not rendered correctly. Thanks Kim for the report! 👍 

# How

Arrange Terminal mapped lines in grid layout, so blockiness of given line element doesn't matter.

# Test Plan

Changes have been tested locally.

# Preview

<img width="716" alt="Screenshot 2023-05-20 at 13 42 28" src="https://github.com/expo/expo/assets/719641/03e51bf8-1fa9-425c-9cee-b199df1c5257">
