### PR TITLE
[docs] Fix minor issues across different docs

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -61,7 +61,7 @@ For more information, see [uri-scheme package](https://www.npmjs.com/package/uri
 
 ## Optional configuration
 
-There are a few more changes you can make to get the best experience, but you [can skip ahead to building](//develop/development-builds/create-a-build/#create-a-development-build-for-the-device) if you prefer.
+There are a few more changes you can make to get the best experience, but you [can skip ahead to building](/develop/development-builds/create-a-build/#create-a-development-build-for-the-device) if you prefer.
 
 ### Disable packager autostart when building for iOS
 

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -9,9 +9,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 **EAS Build** is a hosted service for building app binaries for your Expo and React Native projects.
 
-It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](internal-distribution.mdx) (using ad hoc and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](updates.mdx) library.
+It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using ad hoc and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
-It's designed to work for any native project, whether or not you also use the managed workflow. It's the fastest way to get from `npx create-expo-app`, `expo init` or `npx react-native init` to app stores.
+It's designed to work for any native project, whether or not you also use the managed workflow. It's the fastest way to get from `npx create-expo-app` or `npx react-native init` to app stores.
 
 ### Get started
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -5,7 +5,6 @@ description: Learn about getting started with Expo modules API.
 ---
 
 import { BookOpen02Icon, Grid01Icon } from '@expo/styleguide-icons';
-
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -8,6 +8,7 @@ import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
+import { BoxLink } from '~/ui/components/BoxLink';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 
@@ -457,6 +458,20 @@ We can see from the last line of the error message that `not-a-real-theme` is no
 
 ## Next steps
 
-Congratulations, you have created your first simple yet non-trivial Expo module for iOS and Android! Learn more about the API in the [Expo Module API reference](/modules/module-api).
+Congratulations! You have created your first simple yet non-trivial Expo module for Android and iOS.
 
-If you enjoyed this tutorial and haven't done the native view tutorial, go to the ["Creating a native view" tutorial](/modules/native-view-tutorial) next.
+You can con continue to the next tutorial to learn how to create a native view or see the Expo module API reference.
+
+<BoxLink
+  title="Creating a native view"
+  description="A tutorial on creating a native view that renders a WebView with Expo modules API."
+  href="/modules/native-view-tutorial/"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
+  title="Module API Reference"
+  description="Outline for the Expo Module API and common patterns like sending events from native code to JavaScript."
+  href="/modules/module-api/"
+  Icon={Grid01Icon}
+/>

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -9,6 +9,7 @@ import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -9,7 +9,7 @@ import { PlatformTag } from '~/ui/components/Tag';
 import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { BookOpen02Icon, Grid01Icon } from '@expo/styleguide-icons';
 
 In this tutorial, we are going to build a module that stores the user's preferred app theme - either dark, light, or system. We'll use [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults) on iOS and [`SharedPreferences`](https://developer.android.com/reference/android/content/SharedPreferences) on Android. It is possible to implement web support using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage), but we'll leave that as an exercise for the reader.
 

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -52,7 +52,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
         isActive={sidebarActiveGroup === 'reference'}
       />
       <SidebarSingleEntry
-        href="/tutorial/create-your-first-app/"
+        href="/tutorial/introduction/"
         title="Learn"
         Icon={GraduationHat02Icon}
         isActive={sidebarActiveGroup === 'learn'}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There have been multiple minor issues I came across in last week:
- Mention of `expo init` in EAS Build intro doc
- Expo Modules API tutorial not using `BoxLink` under "Next Steps"
- On clicking "Learn", directs the reader to the second page of tutorial instead of first (which is the introduction).

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing the above mentioned issues, and formatting links or text wherever necessary.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
