### PR TITLE
[scripts] Fix npx script failing when yarn is not installed

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `npx` script failing when `yarn` is not installed.
+
 ### 💡 Others
 
 ## 3.0.8 — 2023-05-08

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `npx` script failing when `yarn` is not installed.
+- Fixed `npx` script failing when `yarn` is not installed. ([#22582](https://github.com/expo/expo/pull/22582) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-module-scripts/bin/npx
+++ b/packages/expo-module-scripts/bin/npx
@@ -4,7 +4,7 @@
 # Yarn and npm.
 
 # shellcheck disable=SC2154
-if [[ ! "$npm_config_user_agent" =~ yarn ]]; then
+if [[ ! "$npm_config_user_agent" =~ yarn ]] && [ -x "$(command -v yarn)" ]; then
   yarn exec -- npx "$@"
 else
   npx "$@"


### PR DESCRIPTION
# Why

Fixes #22534

# How

`expo-module-scripts` was initially designed to work in our monorepo so we assumed that `yarn` is installed. Since that package is also used for Expo modules created with `create-expo-module`, that assumption is no longer correct.

# Test Plan

- `npm uninstall -g yarn`
- Ensured `yarn` command is not found
- `./packages/expo-module-scripts/bin/npx` doesn't fail
