### PR TITLE
[core][iOS] Implement shared refs

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🎉 New features
 
 - Added `ReactActivityHandler.getDelayLoadAppHandler` interface on Android. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
+- [iOS] Introduced shared refs – a way to pass native objects among different independent modules.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🎉 New features
 
 - Added `ReactActivityHandler.getDelayLoadAppHandler` interface on Android. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
-- [iOS] Introduced shared refs – a way to pass native objects among different independent modules.
+- [iOS] Introduced shared refs – a way to pass native objects among different independent modules. ([#22583](https://github.com/expo/expo/pull/22583) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -127,7 +127,8 @@ public final class AppContext: NSObject {
    */
   internal func newObject(nativeClassId: ObjectIdentifier) throws -> JavaScriptObject? {
     guard let jsClass = classRegistry.getJavaScriptClass(nativeClassId: nativeClassId) else {
-      return nil
+      // TODO: Define a JS class for SharedRef in the CoreModule and then use it here instead of a raw object (?)
+      return try runtime.createObject()
     }
     let prototype = try jsClass.getProperty("prototype").asObject()
     let object = try runtime.createObject(withPrototype: prototype)

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedRef.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedRef.swift
@@ -1,0 +1,12 @@
+/**
+ Shared object (ref) that holds a pointer to any native object. Allows passing references
+ to native instances among different independent libraries.
+ */
+open class SharedRef<PointerType>: SharedObject {
+  public let pointer: PointerType
+
+  init(_ pointer: PointerType) {
+    self.pointer = pointer
+    super.init()
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/SharedRefSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedRefSpec.swift
@@ -1,0 +1,60 @@
+import ExpoModulesTestCore
+
+@testable import ExpoModulesCore
+
+final class SharedRefSpec: ExpoSpec {
+  override func spec() {
+    let appContext = AppContext.create()
+    let runtime = try! appContext.runtime
+
+    beforeSuite {
+      appContext.moduleRegistry.register(moduleType: FirstModule.self)
+      appContext.moduleRegistry.register(moduleType: SecondModule.self)
+    }
+
+    it("is a shared object") {
+      expect(SharedRef<UIImage>.self is SharedObject.Type)
+    }
+
+    it("has dynamic type for shared objects") {
+      let dynamicType = ~SharedRef<UIImage>.self
+
+      expect(dynamicType is DynamicSharedObjectType) == true
+    }
+
+    it("creates shared data") {
+      let result = try runtime.eval("expo.modules.FirstModule.createSharedData('\(sharedDataString)')")
+
+      expect(result.kind) == .object
+    }
+
+    it("shares Data object") {
+      let result = try runtime.eval([
+        "sharedData = expo.modules.FirstModule.createSharedData('\(sharedDataString)')",
+        "expo.modules.SecondModule.stringFromSharedData(sharedData)"
+      ])
+
+      expect(result.kind) == .string
+      expect(try result.asString()) == sharedDataString
+    }
+  }
+}
+
+private let sharedDataString = "I can be shared among independent modules"
+
+private class FirstModule: Module {
+  public func definition() -> ModuleDefinition {
+    Function("createSharedData") { (string: String) -> SharedRef<Data> in
+      let data = Data(string.utf8)
+      return SharedRef<Data>(data)
+    }
+  }
+}
+
+private class SecondModule: Module {
+  public func definition() -> ModuleDefinition {
+    Function("stringFromSharedData") { (data: SharedRef<Data>) -> String in
+      return String(decoding: data.pointer, as: UTF8.self)
+    }
+  }
+}


### PR DESCRIPTION
# Why

Closes ENG-8647

# How

Introduced a `SharedRef<PointerType>` class that inherits from `SharedObject` and allows passing references to native objects (usually platform-specific like `UIImage`) among independent modules.

# Test Plan

Added native unit tests. For now we won't use it in any module, but I'll start working on the image refs soon.
