### PR TITLE
[docs] fix Terminal content layout shift, remove unused page imports

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -4,8 +4,6 @@ sidebar_title: Install development builds in bare React Native
 description: Learn how to configure development builds for bare React Native projects.
 ---
 
-import { DiffBlock } from '~/ui/components/Snippet';
-import { Tab, Tabs } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -3,8 +3,7 @@ title: Add expo-updates to an existing project
 description: Learn how to add expo-updates to an existing React Native project.
 ---
 
-import { DiffBlock, Terminal } from '~/ui/components/Snippet';
-import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-updates` library fetches and manages updates received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates for projects using the `expo-updates` library.
 

--- a/docs/pages/build-reference/ios-capabilities.mdx
+++ b/docs/pages/build-reference/ios-capabilities.mdx
@@ -4,7 +4,6 @@ description: Learn about built-in iOS capabilities supported in EAS Build and ho
 ---
 
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
-import { Terminal } from '~/ui/components/Snippet';
 
 When you make a change to your iOS entitlements, this change needs to be updated remotely on Apple's servers before making a production build. EAS Build automatically synchronizes capabilities on the Apple Developer Console with your local entitlements configuration when you run `eas build`. Capabilities are web services provided by Apple, think of them like AWS or Firebase services.
 

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -5,7 +5,6 @@ sidebar_title: Development and debugging
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import { BoxLink } from '~/ui/components/BoxLink';
 
 Developing a plugin is a great way to extend the Expo ecosystem. However, there are times you'll want to debug your plugin. This page provides some of the best practices for developing and debugging a plugin.
 

--- a/docs/pages/distribution/app-stores.mdx
+++ b/docs/pages/distribution/app-stores.mdx
@@ -3,7 +3,6 @@ title: App stores best practices
 description: Learn about the best practices when submitting an app to the app stores.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 
 This guide offers best practices for submitting your app to the app stores. To learn how to generate native binaries for submission, see [Creating your first build](/build/setup/).

--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -5,7 +5,6 @@ description: Different ways to publish the Expo web app with third-party service
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Collapsible } from '~/ui/components/Collapsible';
 
 A web app created using Expo can be served locally for testing out the production behavior. Once the testing phase checks out, you can choose from a variety of third-party services to host it.
 

--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -31,7 +31,7 @@ View all channels:
 View a specific channel:
 
 <Terminal
-  cmd={['$ eas channel:view [channel-name]', '', '', '# Example', '$ eas channel:view production']}
+  cmd={['$ eas channel:view [channel-name]', '', '# Example', '$ eas channel:view production']}
   cmdCopy="eas channel:view [channel-name]"
 />
 
@@ -40,7 +40,6 @@ Create a channel:
 <Terminal
   cmd={[
     '$ eas channel:create [channel-name]',
-    '',
     '',
     '# Example',
     '$ eas channel:create production',
@@ -69,7 +68,6 @@ View a specific update:
   cmd={[
     '$ eas update:view [update-group-id]',
     '',
-    '',
     '# Example',
     '$ eas update:view dbfd479f-d981-44ce-8774-f2fbcc386aa',
   ]}
@@ -83,7 +81,6 @@ View a specific update:
 <Terminal
   cmd={[
     '$ eas update --branch [branch-name] --message "..."',
-    '',
     '',
     '# Example',
     '$ eas update --branch version-1.0 --message "Fixes typo"',
@@ -101,7 +98,6 @@ If you're using Git, we can use the `--auto` flag to auto-fill the branch name a
   cmd={[
     '$ eas branch:delete [branch-name]',
     '',
-    '',
     '# Example',
     '$ eas branch:delete version-1.0',
   ]}
@@ -115,7 +111,6 @@ Renaming branches do not disconnect any channel–branch links. If you had a cha
 <Terminal
   cmd={[
     '$ eas branch:rename --from [branch-name] --to [branch-name]',
-    '',
     '',
     '# Example',
     '$ eas branch:rename --from version-1.0 --to version-1.0-new',
@@ -133,7 +128,6 @@ We can make a previous update immediately available to all users. This command t
   cmd={[
     '$ eas update:republish --group [update-group-id]',
     '$ eas update:republish --branch [branch-name]',
-    '',
     '',
     '# Example',
     '$ eas update:republish --group dbfd479f-d981-44ce-8774-f2fbcc386aa',

--- a/docs/pages/eas-update/eas-update-with-local-build.mdx
+++ b/docs/pages/eas-update/eas-update-with-local-build.mdx
@@ -81,7 +81,6 @@ This runs automatically when executing `npx expo run:android` or `npx expo run:i
   cmd={[
     '# Run prebuild to install and configure the ios and android directories, and install Cocoapods for iOS.',
     '$ npx expo prebuild',
-    '',
   ]}
   cmdCopy="npx expo prebuild"
 />
@@ -237,7 +236,6 @@ To do this for the above app, modify step 4 above as follows:
     '',
     '# Android: Build and run the app on a local Android Emulator',
     '$ npx expo run:android --variant debug',
-    '',
   ]}
   cmdCopy={null}
 />

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -7,7 +7,6 @@ description: Learn about different Metro bundler configurations that can be cust
 
 import { Terminal } from '~/ui/components/Snippet';
 import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Step } from '~/ui/components/Step';
 
 Expo CLI uses Metro during [`npx expo start`](/more/expo-cli/#develop) and [`npx expo export`](/more/expo-cli/#exporting) to bundle your JavaScript code and assets. Metro is built and optimized for React Native, and used for large-scale applications such as Facebook and Instagram.

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -3,7 +3,6 @@ title: Bundling with webpack
 description: Learn about different webpack bundler configurations that can be customized.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 
 When you run `npx expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -5,7 +5,6 @@ description: Learn how to use deep links to open your app from a web browser or 
 
 import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -5,7 +5,6 @@ description: Learn about different ways to use environment variables in an Expo 
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-import { Collapsible } from '~/ui/components/Collapsible';
 
 Environment variables are key-value pairs configured outside your source code that allow your app to behave differently depending on the environment. For example, you can enable or disable certain features when building a testing version of your app, or you can switch to a different API endpoint when building for production.
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -7,7 +7,6 @@ description: A guide on setting up and using Facebook authentication with AuthSe
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { CODE } from '~/ui/components/Text';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Step } from '~/ui/components/Step';
 

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -3,10 +3,8 @@ title: Localization
 description: Learn about getting started and configuring localization in an Expo project using expo-localization.
 ---
 
-import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { Terminal } from '~/ui/components/Snippet';
-import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 
 If you want your app to be easy to use for users who speak different languages or come from different cultures, you should localize it.
@@ -179,7 +177,7 @@ Now, iOS knows to set the display name of your app to `こんにちは` whenever
 
 Several regions around the world write text from right to left. If you want to localize your app, so it looks as expected in RTL languages, you need to make sure your app handles these layout and text direction changes accordingly.
 
-To enable RTL support in your application using SDK 48 or later, install the `expo-localization` package and add the following properties in Expo config: 
+To enable RTL support in your application using SDK 48 or later, install the `expo-localization` package and add the following properties in Expo config:
 
 <Terminal cmd={['$ npx expo install expo-localization']} />
 

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -5,7 +5,6 @@ description: A guide on configuring Hermes for both Android and iOS in an Expo p
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
 
 [Hermes](https://hermesengine.dev/) is a JavaScript engine optimized for React Native. By compiling JavaScript into bytecode ahead of time, Hermes can improve your app start-up time. The binary size of Hermes is also smaller than other JavaScript engines, such as JavaScriptCore (JSC). It also uses less memory at runtime, which is particularly valuable on lower-end Android devices.
 

--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -4,9 +4,6 @@ sidebar_title: Create a module with a config plugin
 description: A tutorial on creating a native module with a config plugin using Expo modules API.
 ---
 
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-import { PlatformTag } from '~/ui/components/Tag';
-import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 
 Config plugins allow you to customize native Android and iOS projects when they are generated with `npx expo prebuild`. It is often useful to add properties in native config files, to copy assets to native projects, and for advanced configurations such as adding an app extension target. As an app developer, applying customizations not exposed in the default [Expo config](/workflow/configuration) can be helpful. As a library author, it allows you to configure native projects for the developers using your library automatically.

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -4,7 +4,6 @@ description: Learn how to integrate Expo Modules API into an existing React Nati
 ---
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-import { Terminal } from '~/ui/components/Snippet';
 
 There are cases where you may want to integrate the Expo Modules API into an existing React Native library. For example, this may be useful to incrementally rewrite the library or to take advantage of [iOS AppDelegate subscribers](/modules/appdelegate-subscribers/) and [Android Lifecycle listeners](/modules/android-lifecycle-listeners/) to automatically set up your library.
 

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -4,9 +4,6 @@ sidebar_title: Create a native module
 description: A tutorial on creating a native module with Expo modules API.
 ---
 
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-import { PlatformTag } from '~/ui/components/Tag';
-import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon, Grid01Icon } from '@expo/styleguide-icons';

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -4,9 +4,6 @@ sidebar_title: Create a native view
 description: A tutorial on creating a native view that renders a WebView with Expo modules API.
 ---
 
-import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
-import { PlatformTag } from '~/ui/components/Tag';
-import { APIBox } from '~/components/plugins/APIBox';
 import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -4,7 +4,6 @@ sidebar_title: Setup
 description: Learn how to setup push notifications, get credentials for development and production, and test sending push notifications.
 ---
 
-import { Tab, Tabs } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -7,7 +7,6 @@ packageName: 'react-native-maps'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -7,7 +7,6 @@ packageName: 'react-native-maps'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 

--- a/docs/pages/versions/v48.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/map-view.mdx
@@ -7,7 +7,6 @@ packageName: 'react-native-maps'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
-import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -5,7 +5,6 @@ description: Learn about what is Expo config and how you can dynamically use it 
 
 import PossibleRedirectNotification from '~/components/plugins/PossibleRedirectNotification';
 import { Terminal } from '~/ui/components/Snippet';
-import { Collapsible } from '~/ui/components/Collapsible';
 
 <PossibleRedirectNotification newUrl="/versions/latest/config/app/" />
 

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -12,8 +12,8 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
     <div
       ref={ref}
       className={mergeClasses(
-        'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4',
-        'prose-code:!px-0 prose-code:!leading-snug',
+        'text-default bg-subtle border border-default rounded-b-md overflow-x-auto p-4 !leading-[19px]',
+        'prose-code:!px-0',
         alwaysDark && 'dark-theme bg-palette-black border-transparent whitespace-nowrap',
         hideOverflow && 'overflow-hidden prose-code:!whitespace-nowrap',
         className


### PR DESCRIPTION
# Why

Fixes ENG-8566

Fixes the pages layout shift caused by Terminal content.

# How

Make sure line height is applied to all kind of children tags, switch line height to arbitrary pixel value.

Additionally, during Terminal display validation I have fixed few block content and removed unused components import on several pages.

# Test Plan

The changes have been developed locally and tested by running app in serve mode via `yarn export && yarn export-server`.

# Preview

https://github.com/expo/expo/assets/719641/189d6dc9-77eb-46ba-af2b-430faa01397d
