### PR TITLE
[dev-menu][ios] Force the notch height to be non-negative

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
 - Fix JS entry file in development builds. ([#21984](https://github.com/expo/expo/pull/21984) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Update the start script to dynamically locate the packager IP from any network interface. ([#21977](https://github.com/expo/expo/pull/21977) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix assert in `requestOverlayMetricsIfNeeded` failing when the device is rotated to landscape orientation.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Fixed reload crash when expo-dev-menu is turned off. ([#21279](https://github.com/expo/expo/pull/21279) by [@jayshah123](https://github.com/jayshah123))
 - Fix JS entry file in development builds. ([#21984](https://github.com/expo/expo/pull/21984) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Update the start script to dynamically locate the packager IP from any network interface. ([#21977](https://github.com/expo/expo/pull/21977) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Fix assert in `requestOverlayMetricsIfNeeded` failing when the device is rotated to landscape orientation.
+- [iOS] Fix assert in `requestOverlayMetricsIfNeeded` failing when the device is rotated to landscape orientation. ([#22598](https://github.com/expo/expo/pull/22598) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -95,7 +95,9 @@ class DevMenuWindow: UIWindow, OverlayContainerViewControllerDelegate {
   ) -> CGFloat {
     switch OverlayNotch.allCases[index] {
     case .fullscreen:
-      return availableSpace - 45
+    // Before the dev menu is opened for the first time the availableSpace equals zero (correct value is loaded while opening the dev menu).
+    // In order to avoid crashing the app because of returning a negative value make sure that the returned value is >= 0.
+    return max(availableSpace - 45, 0)
     case .open:
       return availableSpace * 0.6
     case .hidden:


### PR DESCRIPTION
# Why

While working on the screen orientation I've noticed that the `overlayContainerViewController(..., heightForNotchAt: ,...)` would return a negative value when the screen is rotated. This would cause an assert in `requestOverlayMetricsIfNeeded` in `OverlayContainerConfigurationImplementation.swift` to fail and the app to crash. This only happens before the dev menu is opened for the first time. 

# How

Used max to always return at least 0 as the height of the notch. This seems to be a viable workaround without any unwanted side-effects as the dev menu loads the correct value when opening.

# Test Plan

iOS simulator and a physical device. 

