### PR TITLE
[docs] document new custom builds features

### DIFF
--- a/docs/pages/preview/custom-build-config-schema.mdx
+++ b/docs/pages/preview/custom-build-config-schema.mdx
@@ -448,7 +448,7 @@ functions:
   greetings:
     name: Say Hi!
     # @info #
-    command: echo "Hello world"
+    command: echo "Hi!"
     # @end #
 ```
 
@@ -463,7 +463,41 @@ functions:
     # @info #
     shell: /bin/sh
     # @end #
+    command: echo "Hi!"
 ```
+
+## `import`
+
+A config file path list used to import functions from other config files. Imported files cannot have the `build` section.
+
+For example, the following workflow imports two files and calls two imported functions - `say_hi` and `say_bye`.
+
+```yaml workflow.yml
+import:
+  - common-functions.yml
+  - another-file.yml
+
+build:
+  steps:
+    - say_hi
+    - say_bye
+```
+
+```yaml common-functions.yml
+functions:
+  say_hi:
+    name: Say Hi!
+    command: echo "Hi!"
+```
+
+```yaml another-file.yml
+functions:
+  say_bye:
+    name: Say bye :(
+    command: echo "Bye!"
+```
+
+## Functions
 
 ### Built-in EAS functions
 
@@ -497,7 +531,7 @@ The `eas/upload_artifact` function has the following properties
 | `inputs.path` | **Required**. The path to the artifact that is uploaded to the EAS servers. |
 | `inputs.type` | The type of artifact that is uploaded to the EAS servers.                   |
 
-## Use a reusable function in a `build`
+### Use a reusable function in a `build`
 
 For example, a workflow with the following reusable function contains a single command to print a message that is echoed.
 

--- a/docs/pages/preview/custom-build-config-schema.mdx
+++ b/docs/pages/preview/custom-build-config-schema.mdx
@@ -528,7 +528,7 @@ EAS provides a set of built-in reusable functions that you can use in a workflow
 
 Checks out you project source files.
 
-For example, a workflow with the following `steps` will check out the project and list the files in the `assets` directory:
+For example, a workflow with the following `steps` will check out the project and list the files in the **assets** directory:
 
 ```yaml upload.yml
 build:

--- a/docs/pages/preview/custom-build-config-schema.mdx
+++ b/docs/pages/preview/custom-build-config-schema.mdx
@@ -466,6 +466,20 @@ functions:
     command: echo "Hi!"
 ```
 
+### `functions.[function_name].supported_platforms`
+
+Used to define the supported platforms for a function. Defaults to all platforms. Allowed platforms: `darwin`, `linux`.
+
+For example, the function's supported platform is `darwin` (macOS):
+
+```yaml
+functions:
+  greetings:
+    name: Say Hi!
+    supported_platforms: [darwin]
+    command: echo "Hi!"
+```
+
 ## `import`
 
 A config file path list used to import functions from other config files. Imported files cannot have the `build` section.

--- a/docs/pages/preview/custom-build-config-schema.mdx
+++ b/docs/pages/preview/custom-build-config-schema.mdx
@@ -27,6 +27,7 @@ build:
   name: Run tests
   # @end #
   steps:
+    - eas/checkout
     - run:
         name: Install dependencies
         command: npm install
@@ -46,6 +47,7 @@ The `run` key is used to trigger a set of instructions. For example, a `run` key
 build:
   name: Install npm dependencies
   steps:
+    - eas/checkout
     # @info #
     - run:
         name: Install dependencies
@@ -69,16 +71,14 @@ build:
 
 #### Use a single step
 
-For example, a workflow with the following `steps` will run a single command to install npm dependencies:
+For example, a workflow with the following `steps` will print "Hello world":
 
 ```yaml
 build:
-  name: Install npm dependencies
+  name: Greeting
   steps:
     # @info #
-    - run:
-        name: Install dependencies
-        command: npm install
+    - run: echo "Hello world"
     # @end #
 ```
 
@@ -86,13 +86,14 @@ build:
 
 #### Use multiple steps
 
-When multiple `steps` are defined, they are executed sequentially. For example, a workflow with the following `steps` will first run a single command to install npm dependencies and then run a command to run tests:
+When multiple `steps` are defined, they are executed sequentially. For example, a workflow with the following `steps` will first check out the project, install npm dependencies, and then run a command to run tests:
 
 ```yaml
 build:
   name: Run tests
   steps:
     # @info #
+    - eas/checkout
     - run:
         name: Install dependencies
         command: npm install
@@ -116,6 +117,7 @@ The `command` defines a custom shell command to run when a step is executed. It 
 build:
   name: Run tests
   steps:
+    - eas/checkout
     - run:
         name: Run tests
         # @info #
@@ -133,6 +135,7 @@ The `working_directory` is used to define an existing directory from the project
 build:
   name: Demo
   steps:
+    - eas/checkout
     - run:
         name: List assets
         # @info #
@@ -476,7 +479,9 @@ For example, the function's supported platform is `darwin` (macOS):
 functions:
   greetings:
     name: Say Hi!
+    # @info #
     supported_platforms: [darwin]
+    # @end #
     command: echo "Hi!"
 ```
 
@@ -515,7 +520,29 @@ functions:
 
 ### Built-in EAS functions
 
-EAS provides a built-in reusable function called `upload_artifact` that you can use in a workflow without defining the function definition.
+EAS provides a set of built-in reusable functions that you can use in a workflow without defining the function definition.
+
+> **info** **Tip:** Any function that is built-in and provided by EAS must start with the prefix `eas/`.
+
+#### `eas/checkout`
+
+Checks out you project source files.
+
+For example, a workflow with the following `steps` will check out the project and list the files in the `assets` directory:
+
+```yaml upload.yml
+build:
+  name: List files
+  steps:
+    - eas/checkout
+    - run:
+        name: List assets
+        run: ls assets
+```
+
+#### `eas/upload_artifact`
+
+Uploads a build artifact.
 
 For example, a workflow with the following `steps` will upload an artifact to the EAS servers:
 
@@ -523,6 +550,8 @@ For example, a workflow with the following `steps` will upload an artifact to th
 build:
   name: Upload artifacts
   steps:
+    - eas/checkout
+    # - ...
     - eas/upload_artifact:
         name: Upload application archive
         inputs:
@@ -534,16 +563,14 @@ build:
           path: assets/icon.png
 ```
 
-> **info** **Tip:** Any function that is built-in and provided by EAS must start with the prefix `eas/`.
-
 The `eas/upload_artifact` function has the following properties
 
-| Property      | Description                                                                 |
-| ------------- | --------------------------------------------------------------------------- |
-| `name`        | The name of the step in the reusable function that shows in the build logs. |
-| `inputs`      | Requires input providers (such as `path` or `type`) to be defined.          |
-| `inputs.path` | **Required**. The path to the artifact that is uploaded to the EAS servers. |
-| `inputs.type` | The type of artifact that is uploaded to the EAS servers.                   |
+| Property      | Description                                                                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | The name of the step in the reusable function that shows in the build logs.                                                                          |
+| `inputs`      | Requires input providers (such as `path` or `type`) to be defined.                                                                                   |
+| `inputs.path` | **Required**. The path to the artifact that is uploaded to the EAS servers.                                                                          |
+| `inputs.type` | The type of artifact that is uploaded to the EAS servers. Allowed values: `application-archive`, `build-artifact`. Defaults to `application-archive` |
 
 ### Use a reusable function in a `build`
 
@@ -599,6 +626,7 @@ build:
   name: List files
   # @info #
   steps:
+    - eas/checkout
     - list_files
   # @end #
 ```
@@ -610,7 +638,8 @@ build:
   name: List files
     steps:
       # @info #
+      - eas/checkout
       - list_files:
-        working_directory: /a/b/c
+          working_directory: /a/b/c
       # @end #
 ```

--- a/docs/pages/preview/custom-build-config.mdx
+++ b/docs/pages/preview/custom-build-config.mdx
@@ -12,7 +12,7 @@ import { GithubIcon } from '@expo/styleguide-icons';
 
 > **Warning** All content in this document is experimental, under active development, and likely to change. Use at your own risk. If you're looking to execute custom code before or after certain steps in the build process, but don't need to actually modify any of the steps, you may want to use the stable [build lifecycle hooks API](/build-reference/npm-hooks/).
 
-Custom workflows allow running tests on the cloud, adding instructions for native platforms, resigning a build to share with your team or multiple test devices, and so on. With EAS Build, you can create build configs to customize the process for adding your workflows. It helps saving time especially when working in teams.
+Custom workflows allow running tests on the cloud, adding instructions for native platforms, resigning a build to share with your team or multiple test devices, and so on. With EAS Build, you can create build configs to customize the process by adding your workflows. It helps saving time especially when working in teams.
 
 This guide shows how to create and use a custom build config with EAS. It follows a scenario where you create a custom workflow to run tests on EAS Build. You can also use the defined steps in other scenarios.
 
@@ -77,6 +77,7 @@ Add the following workflow steps in the file:
 build:
   name: Run tests
   steps:
+    - eas/checkout
     - run:
         name: Install dependencies
         command: npm install


### PR DESCRIPTION
# Why

We recently released a few new features for custom builds:
- Importing functions from other files.
- Limiting functions to run only on supported platforms. (If someone attempts to run it on an unsupported one, it'll throw an error).
- Checking out the project directory. This is a breaking change! If you don't call `eas/checkout`, you don't have access to the project sources and your workflow works with an empty working directory.

# How

Document the new features.

# Test Plan

`yarn dev`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
