### PR TITLE
[docs][ENG-8521] Rearrange information about VM specs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "watch": "tsc --noEmit -w",
     "test": "yarn generate-static-resoures && node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "schema-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/schema-sync.cjs",
+    "resource-specs-sync": "node --async-stack-traces --unhandled-rejections=strict ./scripts/resource-specs-sync.mjs",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
     "generate-static-resoures": "rimraf public/static/constants && node --unhandled-rejections=strict ./scripts/generate-static-resources.js",
     "postinstall": "node --async-stack-traces --unhandled-rejections=strict ./scripts/copy-latest.js && yarn generate-static-resoures"

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -6,6 +6,8 @@ description: Learn about the current build server infrastructure when using EAS.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import al from '@mdx-js/react';
+import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
 > This document was last updated on **May 5, 2023**.
 
@@ -31,9 +33,10 @@ When selecting an image for the build you can use the full name provided below o
 
 Android builders run on virtual machines in an isolated environment. Every build gets its own dedicated VM instance.
 
-- Build resources:
-  - [`medium`](eas-json/#resourceclass-1): 4 CPU, 16 GB RAM ([`n2-standard-4`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)
-  - [`large`](eas-json/#resourceclass-1): 8 CPU, 32 GB RAM ([`n2-standard-8`](https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines) Google Cloud machine type)
+- Hardware:
+
+  <HardwareList platform="android" />
+
 - [npm cache deployed with Kubernetes](caching/#javascript-dependencies)
 - [Maven cache deployed with Kubernetes](caching/#android-dependencies)
 - Global Gradle configuration in **~/.gradle/gradle.properties**:
@@ -148,17 +151,17 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ## iOS build server configurations
 
-iOS builder VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM:
+iOS builder VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM.
+[Learn more about it here](eas-json/#resourceclass-2)
 
 - Hardware:
-  - Intel: Intel(R) Core(TM) i7-8700B CPU (6 cores/12 threads), 64 GB RAM
-  - M1: 3.2GHz 8-Core M1 (4 performance and 4 efficiency cores), 16 GB RAM
-  - M2: 3.4GHz 12-Core M2 (8 performance and 4 efficiency cores), 24 GB RAM
-  - M2 Pro: 3.4GHz 10-Core M2 Pro (6 performance and 4 efficiency cores), 32 GB RAM
+
+  <HardwareList platform="ios" />
+
 - Build resources:
-  - [`intel-medium`](eas-json/#resourceclass-2): 3 cores, 12 GB RAM, 2 builder VMs per host
-  - [`m-medium`](eas-json/#resourceclass-2): 2 cores, 8 GB RAM, 2 builder VMs per host
-  - [`large`](eas-json/#resourceclass-2): 4 cores, 12 GB RAM, 2 builder VMs per host (for builds running on M2 Pro hosts) or 4 cores, 22 GB RAM, 1 builder VM per host (for builds running on M2 hosts)
+
+  <BuildResourceList platform="ios" />
+
 - [npm cache](caching/#javascript-dependencies)
 - [CocoaPods cache](caching/#ios-dependencies)
 - [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -151,7 +151,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ## iOS build server configurations
 
-iOS builder VMs run on Mac Mini 8.1 hosts in an isolated environment. Every build gets its own fresh macOS VM.
+iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build gets its own fresh macOS VM.
 [Learn more about it here](eas-json/#resourceclass-2)
 
 - Hardware:

--- a/docs/public/static/resource-specs.json
+++ b/docs/public/static/resource-specs.json
@@ -1,0 +1,112 @@
+{
+    "hardware": {
+        "gcp-n2-standard-4": {
+            "name": "n2-standard-4",
+            "cpu": "4 CPU",
+            "memory": "16 GB RAM",
+            "description": "n2-standard-4 Google Cloud machine type"
+        },
+        "gcp-n2-standard-8": {
+            "name": "n2-standard-8",
+            "cpu": "8 CPU",
+            "memory": "32 GB RAM",
+            "description": "n2-standard-8 Google Cloud machine type"
+        },
+        "apple-intel": {
+            "name": "Apple Intel",
+            "cpu": "Intel(R) Core(TM) i7-8700B CPU",
+            "memory": "64 GB RAM",
+            "description": "6 cores/12 threads"
+        },
+        "apple-m1": {
+            "name": "Apple M1",
+            "cpu": "M1 3.2GHz 8-Core",
+            "memory": "16 GB RAM",
+            "description": "4 performance and 4 efficiency cores"
+        },
+        "apple-m2": {
+            "name": "Apple M2",
+            "cpu": "M2 3.4GHz 12-Core ",
+            "memory": "24 GB RAM",
+            "description": "8 performance and 4 efficiency cores"
+        },
+        "apple-m2-pro": {
+            "name": "Apple M2 Pro",
+            "cpu": "M2 Pro 3.4GHz 10-Core",
+            "memory": "32 GB RAM",
+            "description": "6 performance and 4 efficiency cores"
+        }
+    },
+    "vm": {
+        "apple-0": {
+            "cpu": "3 cores",
+            "memory": "12 GB RAM"
+        },
+        "apple-1": {
+            "cpu": "2 cores",
+            "memory": "8 GB RAM"
+        },
+        "apple-2": {
+            "cpu": "4 cores",
+            "memory": "12 GB RAM"
+        },
+        "apple-3": {
+            "cpu": "4 cores",
+            "memory": "22 GB RAM"
+        }
+    },
+    "resources": {
+        "ios": {
+            "intel-medium": {
+                "name": "Intel Medium",
+                "symbol": "intel-medium",
+                "hardware": {
+                    "apple-intel": {
+                        "vm": "apple-0",
+                        "extra": "2 builder VMs per host"
+                    }
+                }
+            },
+            "medium": {
+                "name": "Medium",
+                "symbol": "m-medium",
+                "hardware": {
+                    "apple-m1": {
+                        "vm": "apple-1",
+                        "extra": "2 builder VMs per host"
+                    }
+                }
+            },
+            "large": {
+                "name": "Large",
+                "symbol": "large",
+                "hardware": {
+                    "apple-m2": {
+                        "vm": "apple-2",
+                        "extra": "2 builder VMs per host"
+                    },
+                    "apple-m2-pro": {
+                        "vm": "apple-3",
+                        "extra": "1 builder VMs per host"
+                    }
+                }
+            }
+        },
+        "android": {
+            "medium": {
+                "name": "Medium",
+                "symbol": "medium",
+                "hardware": {
+                    "gcp-n2-standard-4": {}
+                }
+            },
+            "large": {
+                "name": "Large",
+                "symbol": "large",
+                "hardware": {
+                    "gcp-n2-standard-8": {}
+                }
+            }
+        }
+    }
+}

--- a/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-android-schema.js
@@ -1,3 +1,7 @@
+import { androidResources, androidResourceClasses } from '~/ui/components/utils/infrastructure';
+
+const androidResourcesList = androidResources.map(({symbol, description}) => `- \`${symbol}\`: ${description}`);
+
 export default [
   {
     name: 'withoutCredentials',
@@ -15,9 +19,14 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'medium', 'large'],
+    enum: ['default', ...androidResourceClasses],
     description: [
-      'The Android-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#android-build-server-configurations)',
+      'The Android-specific resource class that will be used to run this build.',
+      '',
+      'Android builders run on virtual machines in an isolated environment. Every build gets its own dedicated VM instance.',
+      '',
+      'Build resources:',
+      ...androidResourcesList,
       '- `default` maps to `medium`',
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -1,3 +1,7 @@
+import { iosResourceClasses, iosResources } from '~/ui/components/utils/infrastructure';
+
+const iosResourcesList = iosResources.map(({symbol, description}) => `- \`${symbol}\`: ${description}`);
+
 export default [
   {
     name: 'simulator',
@@ -33,11 +37,14 @@ export default [
   },
   {
     name: 'resourceClass',
-    enum: ['default', 'medium', 'large', 'm-medium', 'intel-medium'],
+    enum: ['default', 'medium', ...iosResourceClasses],
     description: [
-      'The iOS-specific resource class that will be used to run this build. [Learn more](../../build-reference/infrastructure#ios-build-server-configurations)',
+      'The iOS-specific resource class that will be used to run this build.',
       '- For SDK version >= 45 or React Native version >= 0.71.0 `default` maps to `m-medium`, otherwise it maps to `intel-medium`',
       '- For SDK version >= 45 or React Native version >= 0.71.0 `medium` maps to `m-medium`, otherwise it maps to `intel-medium`',
+      '',
+      'Build resources:',
+      ...iosResourcesList,
       '',
       'This can change over time. To ensure you stay on the same configuration even when we change our defaults, use the specific resource class name.',
       '',

--- a/docs/scripts/resource-specs-sync.mjs
+++ b/docs/scripts/resource-specs-sync.mjs
@@ -1,0 +1,27 @@
+import fs from 'fs';
+import fetch from 'node-fetch';
+
+async function run() {
+  const resourceSpecsSource =
+    'https://raw.githubusercontent.com/expo/eas-build/main/public/resource-specs/current.json';
+
+  console.log(`Fetching resource specs from ${resourceSpecsSource}`);
+
+  const response = await fetch(resourceSpecsSource);
+  if (!response.ok) {
+    console.error(`Failed to fetch resource specs from ${resourceSpecsSource}`);
+    console.error(`Response status: ${response.status}`);
+    console.error(`Response body: ${await response.text()}`);
+    return;
+  }
+
+  const data = await response.text();
+
+  // TODO: is public the correct place for this?
+  const resourcePath = 'public/static/resource-specs.json';
+
+  console.log(`Writing resource specs to ${resourcePath}`);
+  await fs.writeFile(resourcePath, data, { encoding: 'utf8' }, () => {});
+}
+
+run();

--- a/docs/types/resourceSpecs.d.ts
+++ b/docs/types/resourceSpecs.d.ts
@@ -1,0 +1,50 @@
+export enum ResourcePlatform {
+  ANDROID = 'android',
+  IOS = 'ios',
+}
+
+export enum ResourceTier {
+  MEDIUM = 'medium',
+  LARGE = 'large',
+}
+
+type HardwareSpec = {
+  cpu: string;
+  memory: string;
+  description: string;
+  name: string;
+};
+
+export type HardwareSpecs = Record<string, HardwareSpec>;
+
+export type HardwareSpecKey = keyof HardwareSpecs;
+
+type HardwareLSpec = {
+  vm: string;
+  extra: string;
+};
+
+export type HardwareRSpec = object | Record<HardwareSpecKey, HardwareLSpec>;
+
+type ResourceSpec = {
+  name: string;
+  symbol: string;
+  hardware: HardwareRSpec;
+};
+
+type PlatformSpec = Record<string, ResourceSpec>;
+
+type ResourceSpecs = {
+  [keyof in ResourcePlatform]: PlatformSpec;
+};
+
+type VMSpec = {
+  cpu: string;
+  memory: string;
+};
+
+type ResourceSpecData = {
+  resources: ResourceSpecs;
+  hardware: HardwareSpecs;
+  vm: Record<string, VMSpec>;
+};

--- a/docs/ui/components/Markdown/index.tsx
+++ b/docs/ui/components/Markdown/index.tsx
@@ -96,7 +96,9 @@ const markdownStyles: Record<string, Config | null> = {
   },
 };
 
-export const markdownComponents = Object.keys(markdownStyles).reduce(
+type MarkdownComponent = Record<keyof typeof markdownStyles, any>;
+
+export const markdownComponents: MarkdownComponent = Object.keys(markdownStyles).reduce(
   (all, key) => ({
     ...all,
     [key]: markdownStyles[key] ? createMarkdownComponent(markdownStyles[key]!) : null,
@@ -109,7 +111,7 @@ function componentName({ Component }: Config) {
   return Component.displayName || Component.name || 'Anonymous';
 }
 
-function createMarkdownComponent(config: Config) {
+function createMarkdownComponent(config: Config): ComponentType<ComponentProps> {
   const { Component, css: cssClassname, style } = config;
   const MDXComponent = (props: ComponentProps) => (
     <Component {...props} css={css(cssClassname)} style={style}>

--- a/docs/ui/components/utils/infrastructure.tsx
+++ b/docs/ui/components/utils/infrastructure.tsx
@@ -1,0 +1,108 @@
+import entries from 'lodash/entries';
+import keys from 'lodash/keys';
+import size from 'lodash/size';
+import values from 'lodash/values';
+
+import resourceSpecs from '~/public/static/resource-specs.json';
+import {
+  HardwareRSpec,
+  HardwareSpecKey,
+  ResourcePlatform,
+  ResourceSpecData,
+} from '~/types/resourceSpecs';
+import { markdownComponents } from '~/ui/components/Markdown';
+
+const {
+  hardware: hardwareSpecs,
+  vm: vmSpecs,
+  resources: { android, ios },
+} = resourceSpecs as ResourceSpecData;
+
+function formatHardware(hardwares: HardwareRSpec) {
+  return keys(hardwares).map(hardware => {
+    const { cpu, memory, description } = hardwareSpecs[hardware];
+    return `${cpu}, ${memory} (${description})`;
+  });
+}
+
+function formatVMs(hardwares: HardwareRSpec) {
+  return entries(hardwares)
+    .map(([hardware, { vm, extra }]) => {
+      const { cpu, memory } = vmSpecs[vm];
+      if (size(hardwares) === 1) return `${cpu}, ${memory}, ${extra}`;
+      return `${cpu}, ${memory}, ${extra} (for builds runnning on ${hardwareSpecs[hardware].name})`;
+    })
+    .join(' or ');
+}
+
+export const iosResourceClasses = values(ios).map(({ symbol }) => symbol);
+export const iosResources = values(ios).map(({ symbol, hardware }) => ({
+  symbol,
+  description: formatVMs(hardware),
+}));
+export const iosHardware = values(ios).flatMap(({ symbol, hardware }) =>
+  keys(hardware).map(name => ({ ...hardwareSpecs[name], symbol }))
+);
+
+export const androidResourceClasses = values(android).map(({ symbol }) => symbol);
+export const androidResources = values(android).map(({ symbol, hardware }) => ({
+  symbol,
+  description: formatHardware(hardware),
+}));
+export const androidHardware = values(android).flatMap(({ symbol, hardware }) =>
+  keys(hardware).map((name: HardwareSpecKey) => ({ ...hardwareSpecs[name], symbol }))
+);
+
+function buildResourceLink(symbol: string, platform: ResourcePlatform) {
+  const platformId = platform === 'ios' ? 2 : 1;
+  return (
+    <>
+      <markdownComponents.code>
+        <markdownComponents.a href={`eas-json/#resourceclass-${platformId}`}>
+          {symbol}
+        </markdownComponents.a>
+      </markdownComponents.code>
+      :
+    </>
+  );
+}
+
+function gcpLink(description: string) {
+  return description
+    .split(/(n2-standard-\d+)/)
+    .map((part: string) =>
+      part.match(/n2-standard-\d+/) ? (
+        <markdownComponents.a href="https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines">
+          {part}
+        </markdownComponents.a>
+      ) : (
+        part
+      )
+    );
+}
+
+type HardwareListProps = { platform: ResourcePlatform };
+type BuildResourceListProps = { platform: ResourcePlatform };
+
+export function HardwareList({ platform }: HardwareListProps) {
+  const data = platform === 'ios' ? iosHardware : androidHardware;
+  const hardwareList = data.map(({ symbol, cpu, memory, description }, i) => {
+    const prefix = platform !== 'ios' && buildResourceLink(symbol, platform);
+    return (
+      <markdownComponents.li key={i}>
+        {prefix} {cpu}, {memory} ({gcpLink(description)})
+      </markdownComponents.li>
+    );
+  });
+  return <markdownComponents.ul>{hardwareList}</markdownComponents.ul>;
+}
+
+export function BuildResourceList({ platform }: BuildResourceListProps) {
+  const data = platform === 'ios' ? iosResources : androidResources;
+  const buildResources = data.map(({ symbol, description }, i) => (
+    <markdownComponents.li key={i}>
+      {buildResourceLink(symbol, platform)} {description}
+    </markdownComponents.li>
+  ));
+  return <markdownComponents.ul>{buildResources}</markdownComponents.ul>;
+}


### PR DESCRIPTION
# Why

Docs should use data from `eas-build` repo (https://github.com/expo/eas-build/pull/250) to generate hardware and vm specs.

# Deploy Plan

1. https://github.com/expo/eas-build/pull/250
2. https://github.com/expo/expo/pull/22601
3. https://github.com/expo/universe/pull/12701