### PR TITLE
[android][image-picker] use correct MIME types in ImageLibraryContract when mediaTypes is ALL

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed an issue that allowed picking non-image/video files when passing `MediaTypeOptions.All` ([#22606](https://github.com/expo/expo/pull/22606) by [@fobos531](https://github.com/fobos531))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -38,8 +38,6 @@ internal class ImageLibraryContract(
         }
         if (input.options.mediaTypes == MediaTypes.ALL) {
           putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MediaTypes.IMAGES.toMimeType(), MediaTypes.VIDEOS.toMimeType()))
-        } else {
-          putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(input.options.mediaTypes.toMimeType()))
         }
       }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import expo.modules.imagepicker.ImagePickerOptions
+import expo.modules.imagepicker.MediaTypes
 import expo.modules.imagepicker.getAllDataUris
 import expo.modules.imagepicker.toMediaType
 import expo.modules.kotlin.activityresult.AppContextActivityResultContract
@@ -34,6 +35,11 @@ internal class ImageLibraryContract(
       .apply {
         if (input.options.allowsMultipleSelection) {
           putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+        }
+        if (input.options.mediaTypes == MediaTypes.ALL) {
+          putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MediaTypes.IMAGES.toMimeType(), MediaTypes.VIDEOS.toMimeType()))
+        } else {
+          putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(input.options.mediaTypes.toMimeType()))
         }
       }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes https://github.com/expo/expo/issues/22602

The problem with the current contract implementation is that if you passed "ALL" as the accepted media types, it would allow `*/*`, which means anything would work, including e.g. `.pdf`s. I think we can safely assume that we should only accept `image/*` and `video/*` in that case. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR makes use of `Intent.EXTRA_MIME_TYPES` to achieve this functionality. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified that I can no longer select `.pdf`s when MediaTypes is ALL

![CleanShot 2023-05-22 at 21 00 36](https://github.com/expo/expo/assets/19533289/9d044587-e394-4624-acae-f17a585e93b7)

Also ensured that the tests pass (not sure why the `launchCameraAsync` one failed - I assume it has something to do with the fact that I was testing in an emulator).
![CleanShot 2023-05-22 at 21 01 45](https://github.com/expo/expo/assets/19533289/7d5d6c7f-f679-43ce-acb9-7202210e8a2e)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
