### PR TITLE
[dev-client][android] Add support for the new architecture

### DIFF
--- a/apps/fabric-tester/android/build.gradle
+++ b/apps/fabric-tester/android/build.gradle
@@ -10,6 +10,8 @@ buildscript {
             kotlinVersion = findProperty('android.kotlinVersion')
         }
         frescoVersion = findProperty('expo.frescoVersion') ?: '2.5.0'
+        // for expo-dev-client
+        expoUpdatesVersion = null
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"

--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -14,14 +14,15 @@
     "expo-av": "~13.3.0",
     "expo-blur": "~12.3.0",
     "expo-camera": "~13.3.0",
+    "expo-dev-client": "~2.3.0",
     "expo-image": "^1.0.0-alpha.4",
     "expo-linear-gradient": "~12.2.0",
     "expo-splash-screen": "~0.19.0",
+    "expo-status-bar": "~1.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.71.7",
-    "react-native-web": "~0.18.10",
-    "expo-status-bar": "~1.5.0"
+    "react-native-web": "~0.18.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- [Android] Added support for the new architecture. ([#22607](https://github.com/expo/expo/pull/22607) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/DevLauncherClientHost.kt
@@ -5,8 +5,10 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
+import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.config.ReactFeatureFlags
+import com.facebook.react.defaults.DefaultJSIModulePackage
 import com.facebook.react.shell.MainReactPackage
 import devmenu.com.th3rdwave.safeareacontext.SafeAreaContextPackage
 import expo.modules.adapters.react.ModuleRegistryAdapter
@@ -79,4 +81,11 @@ class DevLauncherClientHost(
     method.isAccessible = true
     return method.invoke(appHost) as ReactPackageTurboModuleManagerDelegate.Builder
   }
+
+  override fun getJSIModulePackage(): JSIModulePackage? =
+    if (ReactFeatureFlags.enableFabricRenderer) {
+      DefaultJSIModulePackage(this)
+    } else {
+      null
+    }
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- [Android] Added support for the new architecture. ([#22607](https://github.com/expo/expo/pull/22607) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fixed react-native nighlies `0.73.0-nightly-20230515-066f0b76d` build errors on Android. ([#22503](https://github.com/expo/expo/pull/22503) by [@kudo](https://github.com/kudo))

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt
@@ -8,8 +8,10 @@ import com.facebook.react.ReactInstanceManager
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
+import com.facebook.react.bridge.JSIModulePackage
 import com.facebook.react.bridge.JavaScriptExecutorFactory
 import com.facebook.react.config.ReactFeatureFlags
+import com.facebook.react.defaults.DefaultJSIModulePackage
 import com.facebook.react.devsupport.DevMenuReactInternalSettings
 import com.facebook.react.devsupport.DevServerHelper
 import com.facebook.react.shell.MainReactPackage
@@ -120,4 +122,10 @@ class DevMenuHost(application: Application) : ReactNativeHost(application) {
     method.isAccessible = true
     return method.invoke(appHost) as ReactPackageTurboModuleManagerDelegate.Builder
   }
+  override fun getJSIModulePackage(): JSIModulePackage? =
+    if (ReactFeatureFlags.enableFabricRenderer) {
+      DefaultJSIModulePackage(this)
+    } else {
+      null
+    }
 }


### PR DESCRIPTION
# Why

Closes ENG-7955

# How

Implement the missing `getJSIModulePackage` methods to both `ReactNativeHost`s in order to support the new architecture. `ReactPackageTurboModuleManagerDelegate` was already implemented on https://github.com/expo/expo/pull/19931

# Test Plan

Run `fabric-tester` and `bare-expo` apps on Android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
