### PR TITLE
[packages] fix another gradle 8 warnings

### DIFF
--- a/packages/expo-application/CHANGELOG.md
+++ b/packages/expo-application/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10` and `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10` and `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-application/android/build.gradle
+++ b/packages/expo-application/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.application"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-application/android/src/main/AndroidManifest.xml
+++ b/packages/expo-application/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest package="expo.modules.application"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -91,6 +91,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.av"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-av/android/src/main/AndroidManifest.xml
+++ b/packages/expo-av/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.av">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-background-fetch/android/build.gradle
+++ b/packages/expo-background-fetch/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.backgroundfetch"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-background-fetch/android/src/main/AndroidManifest.xml
+++ b/packages/expo-background-fetch/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest package="expo.modules.backgroundfetch" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
 </manifest>

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/android/build.gradle
+++ b/packages/expo-barcode-scanner/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.barcodescanner"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-barcode-scanner/android/src/main/AndroidManifest.xml
+++ b/packages/expo-barcode-scanner/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="expo.modules.barcodescanner" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.CAMERA" />
 </manifest>

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10` and `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10` and `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-battery/android/build.gradle
+++ b/packages/expo-battery/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.battery"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-battery/android/src/main/AndroidManifest.xml
+++ b/packages/expo-battery/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.battery">
+<manifest>
 </manifest>

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed Detox tests hanging when `BlurView` is present ([#22439](https://github.com/expo/expo/pull/22439) by [@behenate](https://github.com/behenate))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-blur/android/build.gradle
+++ b/packages/expo-blur/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.blur"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-blur/android/src/main/AndroidManifest.xml
+++ b/packages/expo-blur/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.blur">
+<manifest>
 </manifest>

--- a/packages/expo-branch/CHANGELOG.md
+++ b/packages/expo-branch/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-branch/android/build.gradle
+++ b/packages/expo-branch/android/build.gradle
@@ -73,6 +73,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.branch"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-branch/android/src/main/AndroidManifest.xml
+++ b/packages/expo-branch/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.branch">
+<manifest>
 </manifest>

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-brightness/android/build.gradle
+++ b/packages/expo-brightness/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.brightness"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-brightness/android/src/main/AndroidManifest.xml
+++ b/packages/expo-brightness/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.brightness">
+<manifest>
 </manifest>

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.calendar"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-calendar/android/src/main/AndroidManifest.xml
+++ b/packages/expo-calendar/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.calendar">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <queries>
     <intent>
       <!-- Required for opening event in calendar if targeting API 30 -->

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.camera"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-camera/android/src/main/AndroidManifest.xml
+++ b/packages/expo-camera/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="expo.modules.camera" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.CAMERA" />
 </manifest>

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-cellular/android/build.gradle
+++ b/packages/expo-cellular/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.cellular"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-cellular/android/src/main/AndroidManifest.xml
+++ b/packages/expo-cellular/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.cellular">
+<manifest>
 </manifest>

--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-clipboard/android/build.gradle
+++ b/packages/expo-clipboard/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.clipboard"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-clipboard/android/src/main/AndroidManifest.xml
+++ b/packages/expo-clipboard/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.clipboard"
-  xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
     <provider
       android:name=".ClipboardFileProvider"

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-constants/android/build.gradle
+++ b/packages/expo-constants/android/build.gradle
@@ -64,6 +64,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.constants"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-constants/android/src/main/AndroidManifest.xml
+++ b/packages/expo-constants/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.constants">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.contacts"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-contacts/android/src/main/AndroidManifest.xml
+++ b/packages/expo-contacts/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="expo.modules.contacts">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <intent>
             <action android:name="android.intent.action.SEND" />

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10` and `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10` and `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - Return lower case UUID on iOS. ([#22509](https://github.com/expo/expo/pull/22509) by [@LinusU](https://github.com/LinusU))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-crypto/android/build.gradle
+++ b/packages/expo-crypto/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.crypto"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-crypto/android/src/main/AndroidManifest.xml
+++ b/packages/expo-crypto/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.crypto">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-client/android/build.gradle
+++ b/packages/expo-dev-client/android/build.gradle
@@ -34,6 +34,7 @@ buildscript {
 
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
+  namespace "expo.modules.devclient"
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-dev-client/android/src/androidTest/AndroidManifest.xml
+++ b/packages/expo-dev-client/android/src/androidTest/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.devclient">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application>
     <activity

--- a/packages/expo-dev-client/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-client/android/src/main/AndroidManifest.xml
@@ -1,1 +1,2 @@
-<manifest package="expo.modules.devclient" />
+<manifest>
+</manifest>

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -14,7 +14,7 @@
 
 - Fix modern manifest serving for dev client without expo-updates. ([#22470](https://github.com/expo/expo/pull/22470) by [@wschurman](https://github.com/wschurman))
 - Fixed react-native nighlies `0.73.0-nightly-20230515-066f0b76d` build errors on Android. ([#22503](https://github.com/expo/expo/pull/22503) by [@kudo](https://github.com/kudo))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -36,6 +36,7 @@ buildscript {
 
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
+  namespace "expo.modules.devlauncher"
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/debug/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.devlauncher">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
     <meta-data
       android:name="expo.modules.updates.AUTO_SETUP"

--- a/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-launcher/android/src/main/AndroidManifest.xml
@@ -1,1 +1,2 @@
-<manifest package="expo.modules.devlauncher" />
+<manifest>
+</manifest>

--- a/packages/expo-dev-menu-interface/android/build.gradle
+++ b/packages/expo-dev-menu-interface/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.interfaces.devmenu"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-dev-menu-interface/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu-interface/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.interfaces.devmenu">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed react-native nighlies `0.73.0-nightly-20230515-066f0b76d` build errors on Android. ([#22503](https://github.com/expo/expo/pull/22503) by [@kudo](https://github.com/kudo))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.devmenu"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-dev-menu/android/src/debug/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/debug/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.devmenu">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application>
     <activity
       android:name=".DevMenuActivity"

--- a/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
+++ b/packages/expo-dev-menu/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.devmenu" />
-
+<manifest>
+</manifest>

--- a/packages/expo-device/CHANGELOG.md
+++ b/packages/expo-device/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-device/android/build.gradle
+++ b/packages/expo-device/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.device"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-device/android/src/main/AndroidManifest.xml
+++ b/packages/expo-device/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="expo.modules.device" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-document-picker/android/build.gradle
+++ b/packages/expo-document-picker/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.documentpicker"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-document-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-document-picker/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="expo.modules.documentpicker">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <!-- Query open documents -->
         <intent>

--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-eas-client/android/build.gradle
+++ b/packages/expo-eas-client/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.easclient"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-eas-client/android/src/main/AndroidManifest.xml
+++ b/packages/expo-eas-client/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.easclient">
+<manifest>
 </manifest>

--- a/packages/expo-face-detector/CHANGELOG.md
+++ b/packages/expo-face-detector/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-face-detector/android/build.gradle
+++ b/packages/expo-face-detector/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.facedetector"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-face-detector/android/src/main/AndroidManifest.xml
+++ b/packages/expo-face-detector/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.facedetector"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
 
@@ -10,4 +9,3 @@
     </application>
 
 </manifest>
-  

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.filesystem"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-file-system/android/src/main/AndroidManifest.xml
+++ b/packages/expo-file-system/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest package="expo.modules.filesystem"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-font/android/build.gradle
+++ b/packages/expo-font/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.font"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-font/android/src/main/AndroidManifest.xml
+++ b/packages/expo-font/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.font">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fix deadlock when creating and destroying GLViews in a quick succession. ([#22484](https://github.com/expo/expo/pull/22484) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 💡 Others

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -91,6 +91,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.gl"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-gl/android/src/main/AndroidManifest.xml
+++ b/packages/expo-gl/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest package="expo.modules.gl"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-feature android:glEsVersion="0x00020000" android:required="false" />
 </manifest>

--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-haptics/android/build.gradle
+++ b/packages/expo-haptics/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.haptics"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-haptics/android/src/main/AndroidManifest.xml
+++ b/packages/expo-haptics/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-<manifest package="expo.modules.haptics"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.VIBRATE"/>
 </manifest>

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.imageloader"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-image-loader/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-loader/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.imageloader">
+<manifest>
 </manifest>

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.imagemanipulator"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-image-manipulator/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-manipulator/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.imagemanipulator">
+<manifest>
 </manifest>

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fixed an issue that allowed picking non-image/video files when passing `MediaTypeOptions.All` ([#22606](https://github.com/expo/expo/pull/22606) by [@fobos531](https://github.com/fobos531))
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.imagepicker"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest package="expo.modules.imagepicker"
-          xmlns:android="http://schemas.android.com/apk/res/android"
-    >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Required for picking images from camera directly -->
     <uses-permission android:name="android.permission.CAMERA"/>
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🐛 Bug fixes
 
 - Uses prop spreading on web to pass all unused props to the native image component ([#22340](https://github.com/expo/expo/pull/22340) by [@makkarMeenu](https://github.com/makkarMeenu))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 🛠 Breaking changes
 

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -45,6 +45,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.image"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-image/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.image">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <!-- Begin Glide configuration -->
   <!-- Internet access (https://bumptech.github.io/glide/doc/download-setup.html#internet) -->
   <uses-permission android:name="android.permission.INTERNET" />

--- a/packages/expo-in-app-purchases/CHANGELOG.md
+++ b/packages/expo-in-app-purchases/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-in-app-purchases/android/build.gradle
+++ b/packages/expo-in-app-purchases/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.inapppurchases"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-in-app-purchases/android/src/main/AndroidManifest.xml
+++ b/packages/expo-in-app-purchases/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.inapppurchases">
+<manifest>
 </manifest>

--- a/packages/expo-insights/android/build.gradle
+++ b/packages/expo-insights/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.insights"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 31)

--- a/packages/expo-insights/android/src/main/AndroidManifest.xml
+++ b/packages/expo-insights/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.insights">
+<manifest>
 </manifest>

--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 
@@ -80,7 +80,7 @@ _This version does not introduce any user-facing changes._
 
 - Replace the stand-alone action constant strings with String Enum named `ActivityAction`. ([#14070](https://github.com/expo/expo/pull/14070) by [@Simek](https://github.com/Simek))
 
-```diff
+````diff
 - IntentLauncher.ACTION_* // ACTION_ACCESSIBILITY_SETTINGS
 + IntentLauncher.ActivityAction.* // ActivityAction.ACCESSIBILITY_SETTINGS
 ```## 9.1.0 — 2021-06-16
@@ -119,6 +119,8 @@ _This version does not introduce any user-facing changes._
 ## 8.2.0 — 2020-05-27
 
 *This version does not introduce any user-facing changes.*
-``````
+````
+
+```
 
 ```

--- a/packages/expo-intent-launcher/android/build.gradle
+++ b/packages/expo-intent-launcher/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.intentlauncher"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-intent-launcher/android/src/main/AndroidManifest.xml
+++ b/packages/expo-intent-launcher/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.intentlauncher">
+<manifest>
 </manifest>

--- a/packages/expo-json-utils/CHANGELOG.md
+++ b/packages/expo-json-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-json-utils/android/build.gradle
+++ b/packages/expo-json-utils/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.jsonutils"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-json-utils/android/src/main/AndroidManifest.xml
+++ b/packages/expo-json-utils/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest package="expo.modules.jsonutils"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-keep-awake/android/build.gradle
+++ b/packages/expo-keep-awake/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.keepawake"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-keep-awake/android/src/main/AndroidManifest.xml
+++ b/packages/expo-keep-awake/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.keepawake">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-linear-gradient/android/build.gradle
+++ b/packages/expo-linear-gradient/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.lineargradient"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-linear-gradient/android/src/main/AndroidManifest.xml
+++ b/packages/expo-linear-gradient/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.lineargradient">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.localauthentication"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-local-authentication/android/src/main/AndroidManifest.xml
+++ b/packages/expo-local-authentication/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="expo.modules.localauthentication">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-localization/android/build.gradle
+++ b/packages/expo-localization/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.localization"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-localization/android/src/main/AndroidManifest.xml
+++ b/packages/expo-localization/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.localization">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `com.google.android.gms:play-services-location` to `21.0.1` and `io.nlopez.smartlocation:library` to `3.3.3`  ([#22468](https://github.com/expo/expo/pull/22468) by [@josephyanks](https://github.com/josephyanks))
+- Updated `com.google.android.gms:play-services-location` to `21.0.1` and `io.nlopez.smartlocation:library` to `3.3.3` ([#22468](https://github.com/expo/expo/pull/22468) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.location"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-location/android/src/main/AndroidManifest.xml
+++ b/packages/expo-location/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.location">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-mail-composer/android/build.gradle
+++ b/packages/expo-mail-composer/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.mailcomposer"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
+++ b/packages/expo-mail-composer/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.mailcomposer"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->

--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.manifests"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-manifests/android/src/main/AndroidManifest.xml
+++ b/packages/expo-manifests/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest package="expo.modules.manifests"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.maps"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-maps/android/src/main/AndroidManifest.xml
+++ b/packages/expo-maps/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest package="expo.modules.maps"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed missing permissions error on Android when the user only requests write permissions ([#22457](https://github.com/expo/expo/pull/22457) by [@alanjhughes](https://github.com/alanjhughes))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/android/build.gradle
+++ b/packages/expo-media-library/android/build.gradle
@@ -63,6 +63,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.medialibrary"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-media-library/android/src/main/AndroidManifest.xml
+++ b/packages/expo-media-library/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-
-<manifest package="expo.modules.medialibrary" xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
   <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
   <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />

--- a/packages/expo-module-template-local/android/build.gradle
+++ b/packages/expo-module-template-local/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "<%- project.package %>"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-module-template-local/android/src/main/AndroidManifest.xml
+++ b/packages/expo-module-template-local/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="<%- project.package %>">
+<manifest>
 </manifest>

--- a/packages/expo-module-template/android/build.gradle
+++ b/packages/expo-module-template/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "<%- project.package %>"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-module-template/android/src/main/AndroidManifest.xml
+++ b/packages/expo-module-template/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="<%- project.package %>">
+<manifest>
 </manifest>

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10` and `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10` and `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -16,7 +16,7 @@
 ### 🐛 Bug fixes
 
 - Fix failing instrumentation tests in JavaScriptViewModule. ([#22518](https://github.com/expo/expo/pull/22518) by [@aleqsio](https://github.com/aleqsio))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -160,6 +160,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-modules-core/android/src/main/AndroidManifest.xml
+++ b/packages/expo-modules-core/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="expo.modules">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <meta-data

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "org.unimodules.test.core"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-modules-test-core/android/src/main/AndroidManifest.xml
+++ b/packages/expo-modules-test-core/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="org.unimodules.test.core">
+<manifest>
 
 </manifest>

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-navigation-bar/android/build.gradle
+++ b/packages/expo-navigation-bar/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.navigationbar"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-navigation-bar/android/src/main/AndroidManifest.xml
+++ b/packages/expo-navigation-bar/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.navigationbar">
+<manifest>
 </manifest>

--- a/packages/expo-network/CHANGELOG.md
+++ b/packages/expo-network/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-network/android/build.gradle
+++ b/packages/expo-network/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.network"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-network/android/src/main/AndroidManifest.xml
+++ b/packages/expo-network/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.network">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 
@@ -248,9 +248,11 @@ _This version does not introduce any user-facing changes._
 - Changed class responsible for handling Firebase events from `FirebaseMessagingService` to `.service.NotificationsService` on Android. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override `FirebaseMessagingService` to implement some custom handling logic.
+
 - Changed how you can override ways in which a notification is reinterpreted from a [`StatusBarNotification`](https://developer.android.com/reference/android/service/notification/StatusBarNotification) and in which a [`Notification`](https://developer.android.com/reference/android/app/Notification.html?hl=en) is built from defining an `expo.modules.notifications#NotificationsScoper` meta-data value in `AndroidManifest.xml` to implementing a `BroadcastReceiver` subclassing `NotificationsService` delegating those responsibilities to your custom `PresentationDelegate` instance. ([#10558](https://github.com/expo/expo/pull/10558) by [@sjchmiela](https://github.com/sjchmiela))
 
   > Note that this change most probably will not affect you — it only affects projects that override those methods to implement some custom handling logic.
+
 - Removed `removeAllNotificationListeners` method. You can (and should) still remove listeners using `remove` method on `Subscription` objects returned by `addNotification…Listener`. ([#10883](https://github.com/expo/expo/pull/10883) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier being used to fetch Expo push token being backed up on Android which resulted in multiple devices having the same `deviceId` (and eventually, Expo push token). ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))
 - Fixed device identifier used when fetching Expo push token being different than `Constants.installationId` in managed workflow apps which resulted in different Expo push tokens returned for the same experience across old and new Expo API and the device push token not being automatically updated on Expo push servers which lead to Expo push tokens corresponding to outdated Firebase tokens. ([#11005](https://github.com/expo/expo/pull/11005) by [@sjchmiela](https://github.com/sjchmiela))

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.notifications"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-notifications/android/src/main/AndroidManifest.xml
+++ b/packages/expo-notifications/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.notifications">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 

--- a/packages/expo-permissions/CHANGELOG.md
+++ b/packages/expo-permissions/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-permissions/android/build.gradle
+++ b/packages/expo-permissions/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.permissions"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-permissions/android/src/main/AndroidManifest.xml
+++ b/packages/expo-permissions/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.permissions">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-print/android/build.gradle
+++ b/packages/expo-print/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.print"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-print/android/src/main/AndroidManifest.xml
+++ b/packages/expo-print/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.print">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-random/CHANGELOG.md
+++ b/packages/expo-random/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-random/android/build.gradle
+++ b/packages/expo-random/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.random"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-random/android/src/main/AndroidManifest.xml
+++ b/packages/expo-random/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.random">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/android/build.gradle
+++ b/packages/expo-screen-capture/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.screencapture"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.screencapture">
+<manifest>
 </manifest>

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/android/build.gradle
+++ b/packages/expo-screen-orientation/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.screenorientation"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-screen-orientation/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-orientation/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.screenorientation">
+<manifest>
 </manifest>

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/android/build.gradle
+++ b/packages/expo-secure-store/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.securestore"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-secure-store/android/src/main/AndroidManifest.xml
+++ b/packages/expo-secure-store/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.securestore">
+<manifest>
 </manifest>

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/android/build.gradle
+++ b/packages/expo-sensors/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.sensors"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-sensors/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sensors/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.sensors">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sharing/android/build.gradle
+++ b/packages/expo-sharing/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.sharing"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-sharing/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sharing/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.sharing"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application>
         <provider
             android:name=".SharingFileProvider"

--- a/packages/expo-sms/CHANGELOG.md
+++ b/packages/expo-sms/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10` and `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10` and `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sms/android/build.gradle
+++ b/packages/expo-sms/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.sms"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-sms/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sms/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="expo.modules.sms">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <queries>
         <intent>
             <!-- Required for file sharing if targeting API 30 -->

--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-speech/android/build.gradle
+++ b/packages/expo-speech/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.speech"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-speech/android/src/main/AndroidManifest.xml
+++ b/packages/expo-speech/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest package="expo.modules.speech"
-  xmlns:android="http://schemas.android.com/apk/res/android">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <queries>
     <intent>
       <!-- Required for text-to-speech if targeting API 30 -->

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.splashscreen"
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-splash-screen/android/src/main/AndroidManifest.xml
+++ b/packages/expo-splash-screen/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.splashscreen">
+<manifest>
 </manifest>

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.sqlite"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-sqlite/android/src/main/AndroidManifest.xml
+++ b/packages/expo-sqlite/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.sqlite">
+<manifest>
 
 </manifest>
-  

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-store-review/android/build.gradle
+++ b/packages/expo-store-review/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.storereview"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-store-review/android/src/main/AndroidManifest.xml
+++ b/packages/expo-store-review/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
-
-<manifest package="expo.modules.storereview">
+<manifest>
 
 </manifest>
-

--- a/packages/expo-structured-headers/CHANGELOG.md
+++ b/packages/expo-structured-headers/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-structured-headers/android/build.gradle
+++ b/packages/expo-structured-headers/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.structuredheaders"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-structured-headers/android/src/main/AndroidManifest.xml
+++ b/packages/expo-structured-headers/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.structuredheaders">
+<manifest>
 </manifest>

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-system-ui/android/build.gradle
+++ b/packages/expo-system-ui/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.systemui"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-system-ui/android/src/main/AndroidManifest.xml
+++ b/packages/expo-system-ui/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.systemui">
+<manifest>
 </manifest>

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/android/build.gradle
+++ b/packages/expo-task-manager/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.taskManager"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-task-manager/android/src/main/AndroidManifest.xml
+++ b/packages/expo-task-manager/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="expo.modules.taskManager">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <receiver
             android:name=".TaskBroadcastReceiver"

--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-updates-interface/android/build.gradle
+++ b/packages/expo-updates-interface/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.updatesinterface"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-updates-interface/android/src/main/AndroidManifest.xml
+++ b/packages/expo-updates-interface/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.updatesinterface">
+<manifest>
 </manifest>

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Resolve up the project root when creating production manifest. ([#22044](https://github.com/expo/expo/pull/22044) by [@EvanBacon](https://github.com/EvanBacon))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fixed broken `create-manifest-android.gradle` on Android Gradle version 8. ([#22538](https://github.com/expo/expo/pull/22538) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -65,6 +65,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.updates"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-updates/android/src/main/AndroidManifest.xml
+++ b/packages/expo-updates/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest package="expo.modules.updates"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 </manifest>

--- a/packages/expo-video-thumbnails/CHANGELOG.md
+++ b/packages/expo-video-thumbnails/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-video-thumbnails/android/build.gradle
+++ b/packages/expo-video-thumbnails/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.videothumbnails"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-video-thumbnails/android/src/main/AndroidManifest.xml
+++ b/packages/expo-video-thumbnails/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
-<manifest package="expo.modules.videothumbnails">
+<manifest>
 </manifest>

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `robolectric` to `4.10`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `robolectric` to `4.10`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - On `iOS` fix browser session being kept alive after view controller is dismissed. ([#22415](https://github.com/expo/expo/pull/22415) by [@alanjhughes](https://github.com/alanjhughes))
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/android/build.gradle
+++ b/packages/expo-web-browser/android/build.gradle
@@ -63,6 +63,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.modules.webbrowser"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo-web-browser/android/src/main/AndroidManifest.xml
+++ b/packages/expo-web-browser/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="expo.modules.webbrowser">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <queries>
     <intent>
       <!-- Required for opening tabs if targeting API 30 -->

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `junit` to `4.13.2`.  ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
+- Updated `junit` to `4.13.2`. ([#22395](https://github.com/expo/expo/pull/22395) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -92,6 +92,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "expo.core"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/expo/android/src/main/AndroidManifest.xml
+++ b/packages/expo/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
-<manifest package="expo.core">
+<manifest>
 
 </manifest>

--- a/packages/expo/android/src/test/AndroidManifest.xml
+++ b/packages/expo/android/src/test/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.appauth"
-          xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools">
     <application>
 

--- a/packages/unimodules-app-loader/CHANGELOG.md
+++ b/packages/unimodules-app-loader/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
+- Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/unimodules-app-loader/android/build.gradle
+++ b/packages/unimodules-app-loader/android/build.gradle
@@ -62,6 +62,7 @@ android {
     jvmTarget = JavaVersion.VERSION_11.majorVersion
   }
 
+  namespace "org.unimodules.apploader"
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
     targetSdkVersion safeExtGet("targetSdkVersion", 33)

--- a/packages/unimodules-app-loader/android/src/main/AndroidManifest.xml
+++ b/packages/unimodules-app-loader/android/src/main/AndroidManifest.xml
@@ -1,1 +1,2 @@
-<manifest package="org.unimodules.apploader"></manifest>
+<manifest>
+</manifest>


### PR DESCRIPTION
# Why

there are other gradle 8 build warnings:

```
> Task :expo:processReleaseManifest
package="expo.core" found in source AndroidManifest.xml: /home/runner/work/expo/expo/packages/expo/android/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```

# How

migrate `package` in **AndroidManifest.xml** to `namespace` in **build.gradle**

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
