### PR TITLE
[core][Android] Bind `JNIDeallocator` to the context

### DIFF
--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JNIDeallocatorTest.kt
@@ -14,7 +14,10 @@ class JNIDeallocatorTest {
     }
   ) {
     val moduleObject = evaluateScript("expo.modules.TestModule")
-    Truth.assertThat(JNIDeallocator.inspectMemory()).contains(moduleObject)
+
+    val deallocator = appContextHolder.get()!!.jniDeallocator
+
+    Truth.assertThat(deallocator.inspectMemory()).contains(moduleObject)
   }
 
   @Test
@@ -22,11 +25,13 @@ class JNIDeallocatorTest {
     withJSIInterop(
       inlineModule {
         Name("TestModule")
+      },
+      block = {
+        evaluateScript("expo.modules.TestModule")
+      },
+      afterCleanup = {
+        Truth.assertThat(it.inspectMemory()).isEmpty()
       }
-    ) {
-      evaluateScript("expo.modules.TestModule")
-    }
-    // JNIDeallocator.deallocate() is automatically call in the end of `withJSIInterop` scope
-    Truth.assertThat(JNIDeallocator.inspectMemory()).isEmpty()
+    )
   }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -21,6 +21,9 @@ ExpoModulesHostObject::~ExpoModulesHostObject() {
   facebook::react::LongLivedObjectCollection::get().clear();
   installer->jsRegistry.reset();
   installer->runtimeHolder.reset();
+  installer->jsInvoker.reset();
+  installer->nativeInvoker.reset();
+  installer->jniDeallocator.reset();
 }
 
 jsi::Value ExpoModulesHostObject::get(jsi::Runtime &runtime, const jsi::PropNameID &name) {

--- a/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.cpp
@@ -1,0 +1,17 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#include "JNIDeallocator.h"
+
+namespace expo {
+
+void JNIDeallocator::addReference(
+  jni::local_ref<Destructible::javaobject> jniObject
+) {
+  const static auto method = JNIDeallocator::javaClassLocal()
+    ->getMethod<void(jni::local_ref<Destructible>)>(
+      "addReference"
+    );
+  method(self(), std::move(jniObject));
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.h
@@ -1,0 +1,25 @@
+// Copyright © 2021-present 650 Industries, Inc. (aka Expo)
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace jni = facebook::jni;
+
+namespace expo {
+
+class Destructible : public jni::JavaClass<Destructible> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/Destructible;";
+};
+
+class JNIDeallocator : public jni::JavaClass<JNIDeallocator> {
+public:
+  static auto constexpr kJavaDescriptor = "Lexpo/modules/kotlin/jni/JNIDeallocator;";
+
+  void addReference(
+    jni::local_ref<Destructible::javaobject> jniObject
+  );
+};
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.cpp
@@ -37,9 +37,12 @@ JSIInteropModuleRegistry::JSIInteropModuleRegistry(jni::alias_ref<jhybridobject>
 
 void JSIInteropModuleRegistry::installJSI(
   jlong jsRuntimePointer,
+  jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator,
   jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
   jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
 ) {
+  this->jniDeallocator = jni::make_global(jniDeallocator);
+
   auto runtime = reinterpret_cast<jsi::Runtime *>(jsRuntimePointer);
 
   jsRegistry = std::make_unique<JSReferencesCache>(*runtime);
@@ -73,10 +76,14 @@ void JSIInteropModuleRegistry::installJSI(
     );
 }
 
-void JSIInteropModuleRegistry::installJSIForTests() {
+void JSIInteropModuleRegistry::installJSIForTests(
+  jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator
+) {
 #if !UNIT_TEST
   throw std::logic_error("The function is only available when UNIT_TEST is defined.");
 #else
+  this->jniDeallocator = jni::make_global(jniDeallocator);
+
   runtimeHolder = std::make_shared<JavaScriptRuntime>(this);
   jsi::Runtime &jsiRuntime = runtimeHolder->get();
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIInteropModuleRegistry.h
@@ -8,6 +8,7 @@
 #include "JavaScriptObject.h"
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
+#include "JNIDeallocator.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -39,6 +40,7 @@ public:
    */
   void installJSI(
     jlong jsRuntimePointer,
+    jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator,
     jni::alias_ref<react::CallInvokerHolder::javaobject> jsInvokerHolder,
     jni::alias_ref<react::CallInvokerHolder::javaobject> nativeInvokerHolder
   );
@@ -46,7 +48,9 @@ public:
   /**
    * Initializes the test runtime. Shouldn't be used in the production.
    */
-  void installJSIForTests();
+  void installJSIForTests(
+    jni::alias_ref<JNIDeallocator::javaobject> jniDeallocator
+  );
 
   /**
    * Gets a module for a given name. It will throw an exception if the module doesn't exist.
@@ -97,6 +101,7 @@ public:
   std::shared_ptr<react::CallInvoker> nativeInvoker;
   std::shared_ptr<JavaScriptRuntime> runtimeHolder;
   std::unique_ptr<JSReferencesCache> jsRegistry;
+  jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
 private:
   friend HybridBase;
   jni::global_ref<JSIInteropModuleRegistry::javaobject> javaPart_;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
 #include "JavaCallback.h"
+#include "JSIInteropModuleRegistry.h"
 
 namespace expo {
 
@@ -21,6 +22,14 @@ void JavaCallback::registerNatives() {
                  });
 }
 
+jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  Callback callback
+) {
+  auto object = JavaCallback::newObjectCxxArgs(std::move(callback));
+  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  return object;
+}
 
 void JavaCallback::invoke() {
   callback(nullptr);

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "JNIDeallocator.h"
+
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
 
@@ -12,18 +14,26 @@ namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 namespace expo {
-class JavaCallback : public jni::HybridClass<JavaCallback> {
+class JSIInteropModuleRegistry;
+
+class JavaCallback : public jni::HybridClass<JavaCallback, Destructible> {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaCallback;";
   static auto constexpr TAG = "JavaCallback";
 
+  using Callback = std::function<void(folly::dynamic)>;
+
   static void registerNatives();
+
+  static jni::local_ref<JavaCallback::javaobject> newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    Callback callback
+  );
 
 private:
   friend HybridBase;
 
-  using Callback = std::function<void(folly::dynamic)>;
 
   JavaCallback(Callback callback);
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.cpp
@@ -53,4 +53,17 @@ jobject JavaScriptFunction::invoke(
   auto convertedResult = converter->convert(rt, env, moduleRegistry, result);
   return convertedResult;
 }
+
+jni::local_ref<JavaScriptFunction::javaobject> JavaScriptFunction::newInstance(
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::Function> jsFunction
+) {
+  auto function = JavaScriptFunction::newObjectCxxArgs(
+    std::move(runtime),
+    std::move(jsFunction)
+  );
+  jsiInteropModuleRegistry->jniDeallocator->addReference(function);
+  return function;
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
@@ -18,13 +18,19 @@ namespace expo {
 /**
  * Represents any JavaScript function. Its purpose is to expose the `jsi::Function` API back to Kotlin.
  */
-class JavaScriptFunction : public jni::HybridClass<JavaScriptFunction>, JSIFunctionWrapper {
+class JavaScriptFunction : public jni::HybridClass<JavaScriptFunction, Destructible>, JSIFunctionWrapper {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptFunction;";
   static auto constexpr TAG = "JavaScriptFunction";
 
   static void registerNatives();
+
+  static jni::local_ref<JavaScriptFunction::javaobject> newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Function> jsFunction
+  );
 
   JavaScriptFunction(
     std::weak_ptr<JavaScriptRuntime> runtime,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.cpp
@@ -199,7 +199,8 @@ std::shared_ptr<jsi::Object> JavaScriptModuleObject::getJSIObject(jsi::Runtime &
             JavaReferencesCache::instance()->getJClass(
               "expo/modules/kotlin/sharedobjects/SharedObject").clazz
           )) {
-            auto jsThisObject = JavaScriptObject::newObjectCxxArgs(
+            auto jsThisObject = JavaScriptObject::newInstance(
+              jsiInteropModuleRegistry,
               jsiInteropModuleRegistry->runtimeHolder,
               thisObject
             );

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.cpp
@@ -7,6 +7,7 @@
 #include "JSITypeConverter.h"
 #include "ObjectDeallocator.h"
 #include "JavaReferencesCache.h"
+#include "JSIInteropModuleRegistry.h"
 
 namespace expo {
 void JavaScriptObject::registerNatives() {
@@ -73,7 +74,11 @@ jni::local_ref<JavaScriptValue::javaobject> JavaScriptObject::jniGetProperty(
   jni::alias_ref<jstring> name
 ) {
   auto result = std::make_shared<jsi::Value>(getProperty(name->toStdString()));
-  return JavaScriptValue::newObjectCxxArgs(runtimeHolder, result);
+  return JavaScriptValue::newInstance(
+    runtimeHolder.getModuleRegistry(),
+    runtimeHolder,
+    result
+  );
 }
 
 std::vector<std::string> JavaScriptObject::getPropertyNames() {
@@ -107,7 +112,7 @@ jni::local_ref<jni::JArrayClass<jstring>> JavaScriptObject::jniGetPropertyNames(
 jni::local_ref<JavaScriptFunction::javaobject> JavaScriptObject::jniAsFunction() {
   auto &jsRuntime = runtimeHolder.getJSRuntime();
   auto jsFuncion = std::make_shared<jsi::Function>(jsObject->asFunction(jsRuntime));
-  return JavaScriptFunction::newObjectCxxArgs(runtimeHolder, jsFuncion);
+  return JavaScriptFunction::newInstance(runtimeHolder.getModuleRegistry(), runtimeHolder, jsFuncion);
 }
 
 void JavaScriptObject::setProperty(const std::string &name, jsi::Value value) {
@@ -157,6 +162,16 @@ void JavaScriptObject::defineProperty(
     jsi::String::createFromUtf8(runtime, name),
     std::move(descriptor),
   });
+}
+
+jni::local_ref<JavaScriptObject::javaobject> JavaScriptObject::newInstance(
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::Object> jsObject
+) {
+  auto object = JavaScriptObject::newObjectCxxArgs(std::move(runtime), std::move(jsObject));
+  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  return object;
 }
 
 void JavaScriptObject::defineNativeDeallocator(

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -7,6 +7,7 @@
 #include "JavaScriptRuntime.h"
 #include "WeakRuntimeHolder.h"
 #include "JNIFunctionBody.h"
+#include "JNIDeallocator.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -24,13 +25,19 @@ class JavaScriptFunction;
 /**
  * Represents any JavaScript object. Its purpose is to exposes `jsi::Object` API back to Kotlin.
  */
-class JavaScriptObject : public jni::HybridClass<JavaScriptObject>, JSIObjectWrapper {
+class JavaScriptObject : public jni::HybridClass<JavaScriptObject, Destructible>, JSIObjectWrapper {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptObject;";
   static auto constexpr TAG = "JavaScriptObject";
 
   static void registerNatives();
+
+  static jni::local_ref<JavaScriptObject::javaobject> newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject
+  );
 
   JavaScriptObject(
     std::weak_ptr<JavaScriptRuntime> runtime,
@@ -84,13 +91,13 @@ private:
 
   bool jniHasProperty(jni::alias_ref<jstring> name);
 
-  jni::local_ref<jni::HybridClass<JavaScriptValue>::javaobject> jniGetProperty(
+  jni::local_ref<jni::HybridClass<JavaScriptValue, Destructible>::javaobject> jniGetProperty(
     jni::alias_ref<jstring> name
   );
 
   jni::local_ref<jni::JArrayClass<jstring>> jniGetPropertyNames();
 
-  jni::local_ref<jni::HybridClass<JavaScriptFunction>::javaobject> jniAsFunction();
+  jni::local_ref<jni::HybridClass<JavaScriptFunction, Destructible>::javaobject> jniAsFunction();
 
   /**
    * Unsets property with the given name.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -4,7 +4,7 @@
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
 #include "Exceptions.h"
-#include "JavaScriptRuntime.h"
+#include "JSIInteropModuleRegistry.h"
 
 #if UNIT_TEST
 
@@ -125,7 +125,8 @@ jni::local_ref<JavaScriptValue::javaobject>
 JavaScriptRuntime::evaluateScript(const std::string &script) {
   auto scriptBuffer = std::make_shared<jsi::StringBuffer>(script);
   try {
-    return JavaScriptValue::newObjectCxxArgs(
+    return JavaScriptValue::newInstance(
+      jsiInteropModuleRegistry,
       weak_from_this(),
       std::make_shared<jsi::Value>(runtime->evaluateJavaScript(scriptBuffer, "<<evaluated>>"))
     );
@@ -148,12 +149,12 @@ JavaScriptRuntime::evaluateScript(const std::string &script) {
 
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::global() {
   auto global = std::make_shared<jsi::Object>(runtime->global());
-  return JavaScriptObject::newObjectCxxArgs(weak_from_this(), global);
+  return JavaScriptObject::newInstance(jsiInteropModuleRegistry, weak_from_this(), global);
 }
 
 jni::local_ref<JavaScriptObject::javaobject> JavaScriptRuntime::createObject() {
   auto newObject = std::make_shared<jsi::Object>(*runtime);
-  return JavaScriptObject::newObjectCxxArgs(weak_from_this(), newObject);
+  return JavaScriptObject::newInstance(jsiInteropModuleRegistry, weak_from_this(), newObject);
 }
 
 void JavaScriptRuntime::drainJSEventLoop() {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "JNIDeallocator.h"
+
 #include <jsi/jsi.h>
 #include <fbjni/fbjni.h>
 #include <ReactCommon/CallInvoker.h>
@@ -65,19 +67,19 @@ public:
    * @throws if the input format is unknown, or evaluation causes an error,
    * a jni::JniException<JavaScriptEvaluateException> will be thrown.
    */
-  jni::local_ref<jni::HybridClass<JavaScriptValue>::javaobject> evaluateScript(
+  jni::local_ref<jni::HybridClass<JavaScriptValue, Destructible>::javaobject> evaluateScript(
     const std::string &script
   );
 
   /**
    * Returns the runtime global object for use in Kotlin.
    */
-  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> global();
+  jni::local_ref<jni::HybridClass<JavaScriptObject, Destructible>::javaobject> global();
 
   /**
    * Creates a new object for use in Kotlin.
    */
-  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> createObject();
+  jni::local_ref<jni::HybridClass<JavaScriptObject, Destructible>::javaobject> createObject();
 
   /**
    * Drains the JavaScript VM internal Microtask (a.k.a. event loop) queue.

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.cpp
@@ -1,6 +1,7 @@
 #include "JavaScriptTypedArray.h"
 
 #include "JavaScriptRuntime.h"
+#include "JSIInteropModuleRegistry.h"
 
 namespace expo {
 
@@ -87,5 +88,18 @@ void JavaScriptTypedArray::writeBuffer(
 ) {
   auto region = buffer->getRegion(0, size);
   memcpy(rawPointer + position, region.get(), size);
+}
+
+jni::local_ref<JavaScriptTypedArray::javaobject> JavaScriptTypedArray::newInstance(
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  std::weak_ptr<JavaScriptRuntime> runtime,
+  std::shared_ptr<jsi::Object> jsObject
+) {
+  auto object = JavaScriptTypedArray::newObjectCxxArgs(
+    std::move(runtime),
+    std::move(jsObject)
+  );
+  jsiInteropModuleRegistry->jniDeallocator->addReference(object);
+  return object;
 }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
@@ -25,6 +25,12 @@ public:
 
   static void registerNatives();
 
+  static jni::local_ref<JavaScriptTypedArray::javaobject> newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Object> jsObject
+  );
+
   JavaScriptTypedArray(
     std::weak_ptr<JavaScriptRuntime> runtime,
     std::shared_ptr<jsi::Object> jsObject

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -5,6 +5,7 @@
 #include "JSIObjectWrapper.h"
 #include "WeakRuntimeHolder.h"
 #include "JavaScriptTypedArray.h"
+#include "JNIDeallocator.h"
 
 #include <fbjni/fbjni.h>
 #include <jsi/jsi.h>
@@ -26,13 +27,19 @@ class JavaScriptFunction;
 /**
  * Represents any JavaScript value. Its purpose is to expose the `jsi::Value` API back to Kotlin.
  */
-class JavaScriptValue : public jni::HybridClass<JavaScriptValue>, JSIValueWrapper {
+class JavaScriptValue : public jni::HybridClass<JavaScriptValue, Destructible>, JSIValueWrapper {
 public:
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/JavaScriptValue;";
   static auto constexpr TAG = "JavaScriptValue";
 
   static void registerNatives();
+
+  static jni::local_ref<JavaScriptValue::javaobject> newInstance(
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    std::weak_ptr<JavaScriptRuntime> runtime,
+    std::shared_ptr<jsi::Value> jsValue
+  );
 
   JavaScriptValue(
     std::weak_ptr<JavaScriptRuntime> runtime,
@@ -74,13 +81,13 @@ public:
 
   std::string getString();
 
-  jni::local_ref<jni::HybridClass<JavaScriptObject>::javaobject> getObject();
+  jni::local_ref<jni::HybridClass<JavaScriptObject, Destructible>::javaobject> getObject();
 
   jni::local_ref<jni::JArrayClass<JavaScriptValue::javaobject>> getArray();
 
   jni::local_ref<JavaScriptTypedArray::javaobject> getTypedArray();
 
-  jni::local_ref<jni::HybridClass<JavaScriptFunction>::javaobject> jniGetFunction();
+  jni::local_ref<jni::HybridClass<JavaScriptFunction, Destructible>::javaobject> jniGetFunction();
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -102,7 +102,7 @@ jni::local_ref<JavaCallback::JavaPart> createJavaCallbackFromJSIFunction(
       wrapperWasCalled = true;
     };
 
-  return JavaCallback::newObjectCxxArgs(std::move(fn));
+  return JavaCallback::newInstance(moduleRegistry, std::move(fn));
 }
 
 jobjectArray MethodMetadata::convertJSIArgsToJNI(

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -159,7 +159,8 @@ jobject TypedArrayFrontendConverter::convert(
   JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
-  return JavaScriptTypedArray::newObjectCxxArgs(
+  return JavaScriptTypedArray::newInstance(
+    moduleRegistry,
     moduleRegistry->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Object>(value.getObject(rt))
   ).release();
@@ -178,7 +179,8 @@ jobject JavaScriptValueFrontendConverter::convert(
   JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
-  return JavaScriptValue::newObjectCxxArgs(
+  return JavaScriptValue::newInstance(
+    moduleRegistry,
     moduleRegistry->runtimeHolder->weak_from_this(),
     // TODO(@lukmccall): make sure that copy here is necessary
     std::make_shared<jsi::Value>(jsi::Value(rt, value))
@@ -195,7 +197,8 @@ jobject JavaScriptObjectFrontendConverter::convert(
   JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
-  return JavaScriptObject::newObjectCxxArgs(
+  return JavaScriptObject::newInstance(
+    moduleRegistry,
     moduleRegistry->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Object>(value.getObject(rt))
   ).release();
@@ -214,7 +217,8 @@ jobject JavaScriptFunctionFrontendConverter::convert(
   JSIInteropModuleRegistry *moduleRegistry,
   const jsi::Value &value
 ) const {
-  return JavaScriptFunction::newObjectCxxArgs(
+  return JavaScriptFunction::newInstance(
+    moduleRegistry,
     moduleRegistry->runtimeHolder->weak_from_this(),
     std::make_shared<jsi::Function>(value.getObject(rt).asFunction(rt))
   ).release();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -91,6 +91,8 @@ class AppContext(
       CoroutineName("expo.modules.MainQueue")
   )
 
+  val jniDeallocator: JNIDeallocator = JNIDeallocator()
+
   internal var legacyModulesProxyHolder: WeakReference<NativeModulesProxy>? = null
 
   private val activityResultsManager = ActivityResultsManager(this)
@@ -130,6 +132,7 @@ class AppContext(
         ?.let {
           jsiInterop.installJSI(
             it,
+            jniDeallocator,
             jsContextProvider.jsCallInvokerHolder,
             catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
           )
@@ -275,7 +278,7 @@ class AppContext(
     modulesQueue.cancel(ContextDestroyedException())
     mainQueue.cancel(ContextDestroyedException())
     backgroundCoroutineScope.cancel(ContextDestroyedException())
-    JNIDeallocator.deallocate()
+    jniDeallocator.deallocate()
     logger.info("✅ AppContext was destroyed")
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -44,7 +44,7 @@ class ModuleHolder(val module: Module) {
       definition.classData.forEach { clazz ->
         val clazzModuleObject = JavaScriptModuleObject(jniDeallocator, clazz.name)
           .initUsingObjectDefinition(module.appContext, clazz.objectDefinition)
-        appContext.jniDeallocator.addReference(clazzModuleObject);
+        appContext.jniDeallocator.addReference(clazzModuleObject)
 
         val constructor = clazz.constructor
         registerClass(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleHolder.kt
@@ -24,13 +24,16 @@ class ModuleHolder(val module: Module) {
    */
   val jsObject by lazy {
     val appContext = module.appContext
+    val jniDeallocator = appContext.jniDeallocator
 
-    JavaScriptModuleObject(name).apply {
+    JavaScriptModuleObject(jniDeallocator, name).apply {
       initUsingObjectDefinition(appContext, definition.objectDefinition)
 
       val viewFunctions = definition.viewManagerDefinition?.asyncFunctions
       if (viewFunctions?.isNotEmpty() == true) {
-        val viewPrototype = JavaScriptModuleObject("${name}_${definition.viewManagerDefinition?.viewType?.name}")
+        val viewPrototype = JavaScriptModuleObject(jniDeallocator, "${name}_${definition.viewManagerDefinition?.viewType?.name}")
+        appContext.jniDeallocator.addReference(viewPrototype)
+
         viewFunctions.forEach { function ->
           function.attachToJSObject(appContext, viewPrototype)
         }
@@ -39,8 +42,9 @@ class ModuleHolder(val module: Module) {
       }
 
       definition.classData.forEach { clazz ->
-        val clazzModuleObject = JavaScriptModuleObject(clazz.name)
+        val clazzModuleObject = JavaScriptModuleObject(jniDeallocator, clazz.name)
           .initUsingObjectDefinition(module.appContext, clazz.objectDefinition)
+        appContext.jniDeallocator.addReference(clazzModuleObject);
 
         val constructor = clazz.constructor
         registerClass(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIInteropModuleRegistry.kt
@@ -31,6 +31,7 @@ class JSIInteropModuleRegistry(appContext: AppContext) : Destructible {
    */
   external fun installJSI(
     jsRuntimePointer: Long,
+    jniDeallocator: JNIDeallocator,
     jsInvokerHolder: CallInvokerHolderImpl,
     nativeInvokerHolder: CallInvokerHolderImpl
   )
@@ -38,7 +39,13 @@ class JSIInteropModuleRegistry(appContext: AppContext) : Destructible {
   /**
    * Initializes the test runtime. Shouldn't be used in the production.
    */
-  external fun installJSIForTests()
+  external fun installJSIForTests(
+    jniDeallocator: JNIDeallocator,
+  )
+
+  fun installJSIForTests() = installJSIForTests(
+    JNIDeallocator(shouldCreateDestructorThread = false)
+  )
 
   /**
    * Evaluates given JavaScript source code.

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaCallback.kt
@@ -9,10 +9,6 @@ import expo.modules.kotlin.exception.UnexpectedException
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaCallback @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
-  init {
-    JNIDeallocator.addReference(this)
-  }
-
   operator fun invoke(result: Any?) {
     if (result == null) {
       invoke()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -11,10 +11,6 @@ import kotlin.reflect.typeOf
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
-  init {
-    JNIDeallocator.addReference(this)
-  }
-
   @PublishedApi
   internal var returnType: KType? = null
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -16,7 +16,10 @@ import expo.modules.kotlin.objects.ObjectDefinitionData
  */
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
-class JavaScriptModuleObject(val name: String) : Destructible {
+class JavaScriptModuleObject(
+  jniDeallocator: JNIDeallocator,
+  val name: String
+) : Destructible {
   // Has to be called "mHybridData" - fbjni uses it via reflection
   @DoNotStrip
   private val mHybridData = initHybrid()
@@ -24,7 +27,7 @@ class JavaScriptModuleObject(val name: String) : Destructible {
   private external fun initHybrid(): HybridData
 
   init {
-    JNIDeallocator.addReference(this)
+    jniDeallocator.addReference(this)
   }
 
   fun initUsingObjectDefinition(appContext: AppContext, definition: ObjectDefinitionData) = apply {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptObject.kt
@@ -10,11 +10,6 @@ import expo.modules.core.interfaces.DoNotStrip
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 open class JavaScriptObject @DoNotStrip internal constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
-  init {
-    @Suppress("LeakingThis")
-    JNIDeallocator.addReference(this)
-  }
-
   /**
    * The property descriptor options for the property being defined or modified.
    */

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -11,10 +11,6 @@ import kotlin.reflect.typeOf
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
-  init {
-    JNIDeallocator.addReference(this)
-  }
-
   fun isValid() = mHybridData.isValid
   external fun kind(): String
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -361,7 +361,7 @@ inline fun ModuleDefinitionBuilder.Object(block: ObjectDefinitionBuilder.() -> U
 
 inline fun Module.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptModuleObject {
   val objectData = ObjectDefinitionBuilder().also(block).buildObject()
-  return JavaScriptModuleObject("[Anonymous Object]")
+  return JavaScriptModuleObject(appContext.jniDeallocator, "[Anonymous Object]")
     .apply {
       val constants = objectData.constantsProvider()
       val convertedConstants = Arguments.makeNativeMap(constants)


### PR DESCRIPTION
# Why

Binds the `JNIDeallocator` to the current context. 

# How

I've discovered that making `JNIDeallocator` static wasn't a good decision. This approach failed to function properly when we migrated to our API in the dev-launcher context. Whenever the user switches between the app and launcher, the app will crash since the dev-launcher remains in memory, but the app context's destruction causes all registered objects inside the `JNIDeallocator` to deallocate. Consequently, we're removing js objects associated with the dev-launcher context, even if it's still valid.

# Test Plan

- bare-expo with and without dev-client ✅
- unit tests ✅