### PR TITLE
[jest-expo] fix dev-menu mock

### DIFF
--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -282,6 +282,7 @@ module.exports = {
             key: 'isRootedExperimentalAsync',
           },
         ],
+        ExpoDevMenu: [],
         ExpoDocumentPicker: [{ name: 'getDocumentAsync', argumentsCount: 1, key: 0 }],
         ExpoFaceDetector: [{ name: 'detectFaces', argumentsCount: 1, key: 0 }],
         ExpoFontLoader: [{ name: 'loadAsync', argumentsCount: 2, key: 0 }],


### PR DESCRIPTION
# Why

fix ci SDK / check-packages because of #22263

```
 FAIL   Android  src/__tests__/DevClient-test.ts
  ● Test suite failed to run

    Cannot find native module 'ExpoDevMenu'

      40 |
      41 |   if (!nativeModule) {
    > 42 |     throw new Error(`Cannot find native module '${moduleName}'`);
         |           ^
      43 |   }
      44 |   return nativeModule;
      45 | }

      at requireNativeModule (../expo-modules-core/src/requireNativeModule.ts:42:11)
      at Object.<anonymous> (../expo-dev-menu/src/ExpoDevMenu.ts:7:50)
      at Object.<anonymous> (../expo-dev-menu/src/DevMenu.ts:3:1)
      at Object.<anonymous> (src/DevClient.ts:2:1)
      at Object.<anonymous> (src/__tests__/DevClient-test.ts:1:1)
```

# How

add `ExpoDevMenu` jest mock. though i only generate a stub, formal mock will be updated before sdk release

# Test Plan

ci passed

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
  - i'll leave the changelog updating before formal mock generation for sdk 49 release  
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
