### PR TITLE
[docs] Update vscode plugin to new publisher

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -84,7 +84,7 @@ const { /* @hide ...*//* @end */ } = require('@expo/config-plugins');
 
 ### Tooling
 
-We highly recommend installing the [Expo Tools VS Code plugin](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo)
+We highly recommend installing the [Expo Tools VS Code plugin][vscode-expo]
 as this will perform automatic validation on the plugins and surface error information along with other quality of life improvements for Config Plugin development.
 
 ### Setup up a playground environment
@@ -686,7 +686,7 @@ Please add the following to your Expo config
 [configplugin]: https://github.com/expo/expo-cli/blob/3a0ef962a27525a0fe4b7e5567fb7b3fb18ec786/packages/config-plugins/src/Plugin.types.ts#L76
 [source-template]: https://github.com/expo/expo/tree/main/templates/expo-template-bare-minimum
 [expo-beta-docs]: https://github.com/expo/expo/tree/main/guides/releasing/Release%20Workflow.mdx#stage-5---beta-release
-[vscode-expo]: https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo
+[vscode-expo]: https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools
 [ems-plugin]: https://github.com/expo/expo/tree/main/packages/expo-module-scripts#-config-plugin
 [xml2js]: https://www.npmjs.com/package/xml2js
 [expo-plist]: https://www.npmjs.com/package/@expo/plist

--- a/docs/pages/get-started/installation.mdx
+++ b/docs/pages/get-started/installation.mdx
@@ -32,7 +32,7 @@ To use Expo CLI, you need to have the following tools installed on your develope
 ### Recommended tools
 
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
-- [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) for easier debugging and Expo config autocomplete.
+- [VS Code Editor](https://code.visualstudio.com/download) and [VS Code Expo Extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) for easier debugging and Expo config autocomplete.
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-windows) (the default terminal in VS Code) or Bash via WSL for developers who prefer Windows.
 
 ### Use Expo CLI

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -128,7 +128,7 @@ Prebuild is the tip of the automation iceberg, here are some features you can ad
 - [Expo Dev Client][dev-client]: Create your own personal "Expo Go" type app around your native runtime.
 - [Expo native module API][expo-modules-core]: Write modules with Swift and Kotlin. This is automatically supported when using `npx expo prebuild`.
 
-[vs-code-expo]: https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo
+[vs-code-expo]: https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools
 [expo-modules-core]: /modules/module-api
 [dev-client]: /develop/development-builds/introduction/
 [config-plugins]: /config-plugins/introduction/

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -354,7 +354,7 @@ Traditionally, apps for Android and iOS are updated by submitting an updated bin
 
 ### VS Code Expo
 
-The VS Code extension for improving the developer experience of working with Expo config files. This extension provides autocomplete and intellisense for the [Expo Config](#expo-config), [Store Config](#store-config), [Expo Module Config](#expo-module-config), and [EAS Config](#eas-config). For more information, see the [VS Code Expo extension](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo).
+The VS Code extension for improving the developer experience of working with Expo config files. This extension provides autocomplete and intellisense for the [Expo Config](#expo-config), [Store Config](#store-config), [Expo Module Config](#expo-module-config), and [EAS Config](#eas-config). For more information, see the [VS Code Expo extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools).
 
 ### Watchman
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -27,7 +27,7 @@ Most configuration from the Expo config is accessible at runtime from the JavaSc
 
 The Expo config configures many things such as app name, icon, splash screen, deep linking scheme, API keys to use for some services and so on. For a complete list of available properties, see [app.json/app.config.js reference](/versions/latest/config/app/).
 
-> **info** Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) extension to get auto-completion of properties in **app.json** files.
+> **info** Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) extension to get auto-completion of properties in **app.json** files.
 
 ## Extending configuration
 


### PR DESCRIPTION
# Why

See https://github.com/expo/vscode-expo/issues/178

# How

Updated all `byCedric.vscode-expo` references to `expo.vscode-expo-tools`.

# Test Plan

Docs change only.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
