### PR TITLE
[docs] Update Using Bugsnag section

### DIFF
--- a/docs/pages/guides/using-bugsnag.mdx
+++ b/docs/pages/guides/using-bugsnag.mdx
@@ -70,5 +70,5 @@ Type definitions are provided and will be picked up automatically by the TypeScr
 
 - Read the [full integration guide](https://docs.bugsnag.com/platforms/react-native/expo/)
 - View [`@bugsnag/js`](https://github.com/bugsnag/bugsnag-js), the library powering Bugsnag’s JavaScript error reporting, on GitHub
-- Explore [the example project](https://github.com/bugsnag/bugsnag-js/tree/next/examples/js/expo)
+- Explore [the example project](https://github.com/bugsnag/bugsnag-expo/tree/v48/next/examples/expo48)
 - Get [support](https://docs.bugsnag.com/#support) for your questions and feature requests


### PR DESCRIPTION

# Why

Currently in the Using Bugsnag section link to Example project is broken.
# How

Updated to correct working link.

# Test Plan

`yarn dev
`


# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
