### PR TITLE
[expo-camera] Play shutter click sound, when picture is taken.

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-
+- On Android, added sound of shutter click when picture is taken.
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🛠 Breaking changes
 
 ### 🎉 New features
-- On Android, added sound of shutter click when picture is taken.
+- On Android, added sound of shutter click when picture is taken. ([#22620](https://github.com/expo/expo/pull/22620) by [@pranavbabu](https://github.com/pranavbabu))
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -7,6 +7,7 @@ import android.graphics.SurfaceTexture
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.media.MediaActionSound
 import com.google.android.cameraview.CameraView
 import expo.modules.camera.CameraViewHelper.getCamcorderProfile
 import expo.modules.camera.CameraViewHelper.getCorrectCameraRotation
@@ -147,6 +148,8 @@ class ExpoCameraView(
     pictureTakenOptions[promise] = options
     pictureTakenDirectories[promise] = cacheDirectory
     try {
+      val sound = MediaActionSound()
+      sound.play(MediaActionSound.SHUTTER_CLICK)
       cameraView.takePicture()
     } catch (e: Exception) {
       pictureTakenPromises.remove(promise)


### PR DESCRIPTION
# Why
This pull request introduces a new feature that enables system sound playback in the Kotlin codebase. 



Please review this pull request and provide any feedback or suggestions for improvement.

# How

It leverages the MediaActionSound class from the Android framework to play predefined system sounds.
This feature enhances the application's user experience by providing audible feedback to take picture action.
# Test Plan

Build app, add expo-camera default setup, take picture, hear the shutter sound.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
