### PR TITLE
refactor(cli): only add `react` and `react-native` when missing in prebuild

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove entry file modification/index.js generation from `expo prebuild`. Arbitrary entry files in development only work when using `expo-dev-client` or `.expo/.virtual-metro-entry` (SDK +49). ([#22044](https://github.com/expo/expo/pull/22044) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop `metro.config.js` copy step in `expo prebuild` in favor of `expo export:embed` and the new Xcode start script using Expo CLI--this only works when using Expo CLI for all bundling (SDK +49). ([#22045](https://github.com/expo/expo/pull/22045) by [@EvanBacon](https://github.com/EvanBacon))
+- Skip overwriting `react` and `react-native` dependencies during `expo prebuild`. ([#22624](https://github.com/expo/expo/pull/22624) by [@byCedric](https://github.com/byCedric))
 
 ### 🎉 New features
 

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -149,6 +149,11 @@ export function updatePkgDependencies(
         continue;
       }
 
+      // Do not modify manually skipped dependencies
+      if (skipDependencyUpdate.includes(dependenciesKey)) {
+        continue;
+      }
+
       // Ensure the package only needs to be added when missing
       if (addWhenMissingDependencies.includes(dependenciesKey)) {
         let projectHasRecommended: boolean | null = null;
@@ -166,11 +171,6 @@ export function updatePkgDependencies(
           nonRecommendedPackages.push(`${dependenciesKey}@${defaultDependencies[dependenciesKey]}`);
         }
         // Do not modify add-only dependencies
-        continue;
-      }
-
-      // Do not modify manually skipped dependencies
-      if (skipDependencyUpdate.includes(dependenciesKey)) {
         continue;
       }
     }

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import { intersects as semverIntersects } from 'semver';
 
 import * as Log from '../log';
 import { isModuleSymlinked } from '../utils/isModuleSymlinked';
@@ -128,25 +129,47 @@ export function updatePkgDependencies(
     ...pkg.dependencies,
   });
 
+  const addWhenMissingDependencies = ['react', 'react-native'].filter(
+    (depKey) => !!defaultDependencies[depKey]
+  );
   const requiredDependencies = ['expo', 'expo-splash-screen', 'react', 'react-native'].filter(
     (depKey) => !!defaultDependencies[depKey]
   );
 
   const symlinkedPackages: string[] = [];
+  const nonRecommendedPackages: string[] = [];
 
   for (const dependenciesKey of requiredDependencies) {
-    if (
-      // If the local package.json defined the dependency that we want to overwrite...
-      pkg.dependencies?.[dependenciesKey]
-    ) {
-      if (
-        // Then ensure it isn't symlinked (i.e. the user has a custom version in their yarn workspace).
-        isModuleSymlinked(projectRoot, { moduleId: dependenciesKey, isSilent: true })
-      ) {
+    // If the local package.json defined the dependency that we want to overwrite...
+    if (pkg.dependencies?.[dependenciesKey]) {
+      // Then ensure it isn't symlinked (i.e. the user has a custom version in their yarn workspace).
+      if (isModuleSymlinked(projectRoot, { moduleId: dependenciesKey, isSilent: true })) {
         // If the package is in the project's package.json and it's symlinked, then skip overwriting it.
         symlinkedPackages.push(dependenciesKey);
         continue;
       }
+
+      // Ensure the package only needs to be added when missing
+      if (addWhenMissingDependencies.includes(dependenciesKey)) {
+        let projectHasRecommended: boolean | null = null;
+        // Check if the version intersects with the recommended versions
+        try {
+          projectHasRecommended = semverIntersects(
+            pkg.dependencies[dependenciesKey],
+            String(defaultDependencies[dependenciesKey])
+          );
+        } catch {
+          // If the version is invalid, just warn the user
+        }
+        // When the versions can't be parsed `null`, or does not intersect `false`, warn the user
+        if (projectHasRecommended !== true) {
+          nonRecommendedPackages.push(`${dependenciesKey}@${defaultDependencies[dependenciesKey]}`);
+        }
+        // Do not modify add-only dependencies
+        continue;
+      }
+
+      // Do not modify manually skipped dependencies
       if (skipDependencyUpdate.includes(dependenciesKey)) {
         continue;
       }
@@ -159,6 +182,14 @@ export function updatePkgDependencies(
       `\u203A Using symlinked ${symlinkedPackages
         .map((pkg) => chalk.bold(pkg))
         .join(', ')} instead of recommended version(s).`
+    );
+  }
+
+  if (nonRecommendedPackages.length) {
+    Log.warn(
+      `\u203A Using current versions instead of recommended ${nonRecommendedPackages
+        .map((pkg) => chalk.bold(pkg))
+        .join(', ')}.`
     );
   }
 


### PR DESCRIPTION
# Why

Fixes ENG-8480

This prevents accidental overwrites during `expo prebuild`. It's particularly painful in monorepos where users might want to use a specific react-native version, and not use the patch update.

# How

Marked both `react` and `react-native` as "add when missing" packages. Meaning that if it's not defined, we still add it. But once it's defined, we only warn when the semver range DOES NOT intersect (`react` and `react-native` are defined as exact versions in the templates). 

Note, that this still bumps `expo` and `expo-splash-screen`, which I think makes sense due to us releasing patch fixes regularly. But we can opt into fully disabling any bumps during prebuild in general.

# Test Plan

See added tests, and:

- `$ yarn create expo ./test-app && cd ./test-app`
- Modify the React / React Native version to a lower patch/minor bump
- `$ yarn expo prebuild`
- This should warn with `using current versions instead of the recommended react@<version>, react-native@<version>`, it should not change the versions anymore.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
