### PR TITLE
[github] Add react-native-core invalid issue label

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -200,9 +200,9 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Hi there! It looks like your issue is related to the react-native core.
+              body: `Hi there! It looks like your issue concerns code in react-native core, rather than Expo tools.
 
-              We recommend posting this issue directly to the react-native repository by [clicking here](https://github.com/facebook/react-native/issues/new/choose).
+              We recommend posting this issue directly to the [react-native repository](https://github.com/facebook/react-native/issues/new/choose).
             `})
             github.rest.issues.update({
               issue_number: context.issue.number,

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -188,3 +188,25 @@ jobs:
               repo: context.repo.repo,
               state: 'closed'
             })
+  react-native-core:
+    runs-on: ubuntu-20.04
+    if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Hi there! It looks like your issue is related to the react-native core.
+
+              We recommend posting this issue directly to the react-native repository by [clicking here](https://github.com/facebook/react-native/issues/new/choose).
+            `})
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })


### PR DESCRIPTION
# Why

Adding a new `invalid issue: react-native-core` label should help us closing issues that are related to the react-native-core

# How

Add a new `invalid issue: react-native-core` label and bot comment

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
