### PR TITLE
[gl] use jsi::Runtime from worklet only from UI thread

### DIFF
--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fix deadlock when creating and destroying GLViews in a quick succession. ([#22484](https://github.com/expo/expo/pull/22484) by [@wkozyra95](https://github.com/wkozyra95))
-- Move creating GL conext for worklet to UI thread. ([#22634](https://github.com/expo/expo/pull/22634) by [@wkozyra95](https://github.com/wkozyra95))
+- Move creating GL context for worklet to UI thread. ([#22634](https://github.com/expo/expo/pull/22634) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 💡 Others
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Require explicit prop `enableExperimentalWorkletSupport` to GLView from Reanimated worklet. ([#22613](https://github.com/expo/expo/pull/22613) by [@wkozyra95](https://github.com/wkozyra95))
+- Require explicit prop `enableExperimentalWorkletSupport` to use GLView from Reanimated worklet. ([#22613](https://github.com/expo/expo/pull/22613) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 🎉 New features
 
@@ -12,6 +12,7 @@
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fix deadlock when creating and destroying GLViews in a quick succession. ([#22484](https://github.com/expo/expo/pull/22484) by [@wkozyra95](https://github.com/wkozyra95))
+- Move creating GL conext for worklet to UI thread. ([#22634](https://github.com/expo/expo/pull/22634) by [@wkozyra95](https://github.com/wkozyra95))
 
 ### 💡 Others
 

--- a/packages/expo-gl/android/src/main/cpp/EXGLJniApi.cpp
+++ b/packages/expo-gl/android/src/main/cpp/EXGLJniApi.cpp
@@ -22,7 +22,7 @@ Java_expo_modules_gl_cpp_EXGL_EXGLContextCreate
 
 JNIEXPORT void JNICALL
 Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
-(JNIEnv *env, jclass clazz, jlong jsiPtr, jint exglCtxId, jobject glContext, jboolean enableExperimentalWorkletSupport) {
+(JNIEnv *env, jclass clazz, jlong jsiPtr, jint exglCtxId, jobject glContext) {
   threadLocalEnv = env;
   jclass GLContextClass = env->GetObjectClass(glContext);
   jobject glContextRef = env->NewGlobalRef(glContext);
@@ -31,7 +31,14 @@ Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
   std::function<void(void)> flushMethod = [glContextRef, flushMethodRef] {
     threadLocalEnv->CallVoidMethod(glContextRef, flushMethodRef);
   };
-  EXGLContextPrepare((void*) jsiPtr, exglCtxId, enableExperimentalWorkletSupport == JNI_TRUE, flushMethod);
+  EXGLContextPrepare((void*) jsiPtr, exglCtxId, flushMethod);
+}
+
+JNIEXPORT void JNICALL
+Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepareWorklet
+(JNIEnv *env, jclass clazz, jint exglCtxId) {
+  threadLocalEnv = env;
+  EXGLContextPrepareWorklet(exglCtxId);
 }
 
 JNIEXPORT void JNICALL
@@ -68,12 +75,6 @@ JNIEXPORT jint JNICALL
 Java_expo_modules_gl_cpp_EXGL_EXGLContextGetObject
 (JNIEnv *env, jclass clazz, jint exglCtxId, jint exglObjId) {
   return EXGLContextGetObject(exglCtxId, exglObjId);
-}
-
-JNIEXPORT void JNICALL
-Java_expo_modules_gl_cpp_EXGL_EXGLRegisterThread
-(JNIEnv *env, jclass clazz) {
-  threadLocalEnv = env;
 }
 
 JNIEXPORT bool JNICALL

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLContext.java
@@ -32,6 +32,7 @@ import expo.modules.core.Promise;
 import expo.modules.core.interfaces.JavaScriptContextProvider;
 import expo.modules.core.interfaces.RuntimeEnvironmentInterface;
 import expo.modules.core.interfaces.services.UIManager;
+import expo.modules.gl.cpp.EXGL;
 import expo.modules.gl.utils.FileSystemUtils;
 
 import static android.opengl.GLES30.*;
@@ -89,19 +90,28 @@ public class GLContext {
     final JavaScriptContextProvider jsContextProvider = moduleRegistry.getModule(JavaScriptContextProvider.class);
     final RuntimeEnvironmentInterface environment = moduleRegistry.getModule(RuntimeEnvironmentInterface.class);
 
-    EXGLRegisterThread();
     uiManager.runOnClientCodeQueueThread(new Runnable() {
       @Override
       public void run() {
         long jsContextRef = jsContextProvider.getJavaScriptContextRef();
         synchronized (uiManager) {
           if (jsContextRef != 0) {
-            EXGLRegisterThread();
-            EXGLContextPrepare(jsContextRef, mEXGLCtxId, glContext, enableExperimentalWorkletSupport);
+            EXGLContextPrepare(jsContextRef, mEXGLCtxId, glContext);
           }
         }
-        mManager.saveContext(glContext);
-        completionCallback.run();
+        if (enableExperimentalWorkletSupport) {
+          uiManager.runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                EXGLContextPrepareWorklet(mEXGLCtxId);
+                mManager.saveContext(glContext);
+                completionCallback.run();
+            }
+          });
+        } else {
+            mManager.saveContext(glContext);
+            completionCallback.run();
+        }
       }
     });
   }

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/cpp/EXGL.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/cpp/EXGL.java
@@ -8,12 +8,8 @@ public class EXGL {
     SoLoader.loadLibrary("expo-gl");
   }
   public static native int EXGLContextCreate();
-  public static native void EXGLContextPrepare(
-          long jsCtxPtr,
-          int exglCtxId,
-          Object glContext,
-          boolean enableExperimentalWorkletSupport
-  );
+  public static native void EXGLContextPrepare(long jsCtxPtr, int exglCtxId, Object glContext);
+  public static native void EXGLContextPrepareWorklet(int exglCtxId);
 
   public static native void EXGLContextDestroy(int exglCtxId);
   public static native void EXGLContextFlush(int exglCtxId);
@@ -22,7 +18,6 @@ public class EXGL {
   public static native void EXGLContextDestroyObject(int exglCtxId, int exglObjId);
   public static native void EXGLContextMapObject(int exglCtxId, int exglObjId, int glObj);
   public static native int EXGLContextGetObject(int exglCtxId, int exglObjId);
-  public static native void EXGLRegisterThread();
   public static native boolean EXGLContextNeedsRedraw(int exglCtxId);
   public static native void EXGLContextDrawEnded(int exglCtxId);
 }

--- a/packages/expo-gl/common/EXGLNativeApi.cpp
+++ b/packages/expo-gl/common/EXGLNativeApi.cpp
@@ -11,12 +11,17 @@ EXGLContextId EXGLContextCreate() {
 void EXGLContextPrepare(
     void *jsiPtr,
     EXGLContextId exglCtxId,
-    bool enableExperimentalWorkletSupport,
     std::function<void(void)> flushMethod) {
   auto [exglCtx, lock] = ContextGet(exglCtxId);
   if (exglCtx) {
-    exglCtx->prepareContext(
-        *reinterpret_cast<jsi::Runtime *>(jsiPtr), enableExperimentalWorkletSupport, flushMethod);
+    exglCtx->prepareContext(*reinterpret_cast<jsi::Runtime *>(jsiPtr), flushMethod);
+  }
+}
+
+void EXGLContextPrepareWorklet(EXGLContextId exglCtxId) {
+  auto [exglCtx, lock] = ContextGet(exglCtxId);
+  if (exglCtx) {
+    exglCtx->prepareWorkletContext();
   }
 }
 

--- a/packages/expo-gl/common/EXGLNativeApi.h
+++ b/packages/expo-gl/common/EXGLNativeApi.h
@@ -32,12 +32,11 @@ EXGLContextId EXGLContextCreate();
 // [JS thread] Create an EXGL context and return its id number. Saves the
 // JavaScript interface object (has a WebGLRenderingContext-style API) at
 // `global.__EXGLContexts[id]` in JavaScript.
-void EXGLContextPrepare(
-    void *runtime,
-    EXGLContextId exglCtxId,
-    bool enableExperimentalWorkletSupport,
-    std::function<void(void)> flushMethod);
+void EXGLContextPrepare(void *runtime, EXGLContextId exglCtxId, std::function<void(void)> flushMethod);
 #endif // __cplusplus
+
+// [UI thread] Creates an EXGL context inside Reanimated worklet.
+void EXGLContextPrepareWorklet(EXGLContextId exglCtxId);
 
 // [Any thread] Check whether we should redraw the surface
 bool EXGLContextNeedsRedraw(EXGLContextId exglCtxId);

--- a/packages/expo-gl/common/EXGLNativeContext.cpp
+++ b/packages/expo-gl/common/EXGLNativeContext.cpp
@@ -6,25 +6,20 @@ namespace gl_cpp {
 
 constexpr const char *OnJSRuntimeDestroyPropertyName = "__EXGLOnJsRuntimeDestroy";
 
-void EXGLContext::prepareContext(
-    jsi::Runtime &runtime,
-    bool enableExperimentalWorkletSupport,
-    std::function<void(void)> flushMethod) {
+void EXGLContext::prepareContext(jsi::Runtime &runtime, std::function<void(void)> flushMethod) {
   this->flushOnGLThread = flushMethod;
   try {
-    auto viewport = prepareOpenGLESContext();
-    createWebGLRenderer(runtime, this, viewport, runtime.global());
+    this->initialGlesContext = prepareOpenGLESContext();
+    createWebGLRenderer(runtime, this, this->initialGlesContext, runtime.global());
     tryRegisterOnJSRuntimeDestroy(runtime);
 
-    if (enableExperimentalWorkletSupport) {
-      maybePrepareWorkletContext(runtime, viewport);
-    }
+    maybeResolveWorkletContext(runtime);
   } catch (const std::runtime_error &err) {
     EXGLSysLog("Failed to setup EXGLContext [%s]", err.what());
   }
 }
 
-void EXGLContext::maybePrepareWorkletContext(jsi::Runtime &runtime, initGlesContext viewport) {
+void EXGLContext::maybeResolveWorkletContext(jsi::Runtime &runtime) {
   jsi::Value workletRuntimeValue = runtime.global().getProperty(runtime, "_WORKLET_RUNTIME");
   if (!workletRuntimeValue.isObject()) {
     return;
@@ -40,13 +35,18 @@ void EXGLContext::maybePrepareWorkletContext(jsi::Runtime &runtime, initGlesCont
   }
   uintptr_t rawWorkletRuntimePointer =
       *reinterpret_cast<uintptr_t *>(workletRuntimeArrayBuffer.data(runtime));
-  jsi::Runtime &workletRuntime = *reinterpret_cast<jsi::Runtime *>(rawWorkletRuntimePointer);
+  jsi::Runtime *workletRuntime = reinterpret_cast<jsi::Runtime *>(rawWorkletRuntimePointer);
+  this->maybeWorkletRuntime = workletRuntime;
+}
+
+void EXGLContext::prepareWorkletContext() {
+  if (maybeWorkletRuntime == nullptr) {
+    return;
+  }
+  jsi::Runtime &runtime = *this->maybeWorkletRuntime;
   createWebGLRenderer(
-      workletRuntime,
-      this,
-      viewport,
-      workletRuntime.global().getPropertyAsObject(workletRuntime, "global"));
-  tryRegisterOnJSRuntimeDestroy(workletRuntime);
+      runtime, this, initialGlesContext, runtime.global().getPropertyAsObject(runtime, "global"));
+  tryRegisterOnJSRuntimeDestroy(runtime);
 }
 
 void EXGLContext::endNextBatch() noexcept {
@@ -134,8 +134,8 @@ void EXGLContext::tryRegisterOnJSRuntimeDestroy(jsi::Runtime &runtime) {
           runtime, std::make_shared<InvalidateCacheOnDestroy>(runtime)));
 }
 
-initGlesContext EXGLContext::prepareOpenGLESContext() {
-  initGlesContext result;
+glesContext EXGLContext::prepareOpenGLESContext() {
+  glesContext result;
   // Clear everything to initial values
   addBlockingToNextBatch([&] {
     std::string version = reinterpret_cast<const char *>(glGetString(GL_VERSION));

--- a/packages/expo-gl/common/EXGLNativeContext.h
+++ b/packages/expo-gl/common/EXGLNativeContext.h
@@ -50,11 +50,9 @@ class EXGLContext {
 
  public:
   EXGLContext(EXGLContextId ctxId) : ctxId(ctxId) {}
-  void prepareContext(
-      jsi::Runtime &runtime,
-      bool enableExperimentalWorkletSupport,
-      std::function<void(void)> flushMethod);
-  void maybePrepareWorkletContext(jsi::Runtime &runtime, initGlesContext viewport);
+  void prepareContext(jsi::Runtime &runtime, std::function<void(void)> flushMethod);
+  void maybeResolveWorkletContext(jsi::Runtime &runtime);
+  void prepareWorkletContext();
 
   // --- Queue handling --------------------------------------------------------
 
@@ -109,7 +107,7 @@ class EXGLContext {
   GLuint lookupObject(EXGLObjectId exglObjId) noexcept;
 
   void tryRegisterOnJSRuntimeDestroy(jsi::Runtime &runtime);
-  initGlesContext prepareOpenGLESContext();
+  glesContext prepareOpenGLESContext();
   void maybeReadAndCacheSupportedExtensions();
 
  private:
@@ -120,6 +118,10 @@ class EXGLContext {
 
  public:
   EXGLContextId ctxId;
+  // Worklet runtime is storred here only to avoid it passing through Java/Obj-C.
+  // It should only be used in prepareContext and prepareWorkletContext.
+  jsi::Runtime *maybeWorkletRuntime = nullptr;
+  glesContext initialGlesContext;
 
   // Object mapping
   std::unordered_map<EXGLObjectId, GLuint> objects;

--- a/packages/expo-gl/common/EXGLNativeContext.h
+++ b/packages/expo-gl/common/EXGLNativeContext.h
@@ -118,7 +118,7 @@ class EXGLContext {
 
  public:
   EXGLContextId ctxId;
-  // Worklet runtime is storred here only to avoid it passing through Java/Obj-C.
+  // Worklet runtime is stored here only to avoid it passing through Java/Obj-C.
   // It should only be used in prepareContext and prepareWorkletContext.
   jsi::Runtime *maybeWorkletRuntime = nullptr;
   glesContext initialGlesContext;

--- a/packages/expo-gl/common/EXWebGLRenderer.cpp
+++ b/packages/expo-gl/common/EXWebGLRenderer.cpp
@@ -37,7 +37,7 @@ void installConstants(jsi::Runtime &runtime, jsi::Object &gl);
 void installWebGLMethods(jsi::Runtime &runtime, jsi::Object &gl);
 void installWebGL2Methods(jsi::Runtime &runtime, jsi::Object &gl);
 
-void createWebGLRenderer(jsi::Runtime &runtime, EXGLContext *ctx, initGlesContext viewport, jsi::Object&& global) {
+void createWebGLRenderer(jsi::Runtime &runtime, EXGLContext *ctx, glesContext viewport, jsi::Object&& global) {
   ensurePrototypes(runtime);
   jsi::Object gl = ctx->supportsWebGL2
     ? createWebGLObject(

--- a/packages/expo-gl/common/EXWebGLRenderer.h
+++ b/packages/expo-gl/common/EXWebGLRenderer.h
@@ -7,7 +7,7 @@
 namespace expo {
 namespace gl_cpp {
 
-struct initGlesContext {
+struct glesContext {
   int32_t viewportWidth;
   int32_t viewportHeight;
 };
@@ -37,7 +37,7 @@ enum class EXWebGLClass {
 };
 
 void ensurePrototypes(jsi::Runtime &runtime);
-void createWebGLRenderer(jsi::Runtime &runtime, EXGLContext *, initGlesContext, jsi::Object&& global);
+void createWebGLRenderer(jsi::Runtime &runtime, EXGLContext *, glesContext, jsi::Object&& global);
 jsi::Value createWebGLObject(
     jsi::Runtime &runtime,
     EXWebGLClass webglClass,

--- a/packages/expo-gl/ios/EXGLContext.mm
+++ b/packages/expo-gl/ios/EXGLContext.mm
@@ -124,11 +124,17 @@
       }
 
       EXGLContextSetDefaultFramebuffer(self->_contextId, [self defaultFramebuffer]);
-      EXGLContextPrepare(jsRuntimePtr, self->_contextId, enableExperimentalWorkletSupport, [self](){
+      EXGLContextPrepare(jsRuntimePtr, self->_contextId, [self](){
         [self flush];
       });
 
+      if (enableExperimentalWorkletSupport) {
+        dispatch_sync(dispatch_get_main_queue(), ^{
+          EXGLContextPrepareWorklet(self->_contextId);
+        });
+      }
       _isContextReady = YES;
+
       if ([self.delegate respondsToSelector:@selector(glContextInitialized:)]) {
         [self.delegate glContextInitialized:self];
       }


### PR DESCRIPTION
# Why

Follow up to https://github.com/expo/expo/pull/22613
Fixes issue described there when worklet support is enabled

# How

- When setting up gl context read worklet runtime and store it inside the context.
- Store info about the viewport inside GLContext
- Add separate cpp function to provision worklet context. 
  - This should only be called from UI thread
  - It creates gl object in js and attaches it to the global
  - It takes viewport and worklet runtime pointer from GLContext (values should be set when regular js context is created)
- Remove register thread function (it stores JNIEnv in local thread variable accessible from C++)
  - JS thread is already registered when we call ContextPrepare
  - UI thread will be registered when worklet context is created
  - I don't expect cpp code calling jni bridge from any other thread


# Test Plan

Tested with enableWorkletRuntimeSupport prop on NCL screen that simulates work on busy UI thread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
