### PR TITLE
chore: improve missing asset error message

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -139,7 +139,8 @@ public final class EmbeddedAppLoader: AppLoader {
         let mainBundleFilename = asset.mainBundleFilename.require("embedded asset mainBundleFilename must be nonnull")
         let bundlePath = UpdatesUtils.path(forBundledAsset: asset).require(
           String(
-            format: "Could not find the expected embedded asset in NSBundle %@.%@. Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
+            format: "Could not find the expected embedded asset in NSBundle %@.%@. " +
+                    "Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
             mainBundleFilename,
             asset.type ?? ""
           )

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -140,7 +140,7 @@ public final class EmbeddedAppLoader: AppLoader {
         let bundlePath = UpdatesUtils.path(forBundledAsset: asset).require(
           String(
             format: "Could not find the expected embedded asset in NSBundle %@.%@. " +
-                    "Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
+              "Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
             mainBundleFilename,
             asset.type ?? ""
           )

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/EmbeddedAppLoader.swift
@@ -139,7 +139,7 @@ public final class EmbeddedAppLoader: AppLoader {
         let mainBundleFilename = asset.mainBundleFilename.require("embedded asset mainBundleFilename must be nonnull")
         let bundlePath = UpdatesUtils.path(forBundledAsset: asset).require(
           String(
-            format: "Could not find the expected embedded asset in NSBundle %@.%@. Check that expo-updates is installed correctly.",
+            format: "Could not find the expected embedded asset in NSBundle %@.%@. Check that expo-updates is installed correctly, and verify that assets are present in the ipa file.",
             mainBundleFilename,
             asset.type ?? ""
           )


### PR DESCRIPTION
# Why

I was migrating a vanilla RN app to expo and encountered this issue. It happened because the app was using `react-native-vector-image` which also happens to remove assets from the bundle because they are not needed: https://github.com/oblador/react-native-vector-image#ios


However, expo updates doesn't like that and crashes with the above error. If I had this improved error message, it would take me less time to debug.

# How

expand the error message

# Test Plan

If it compiles, it will work :D

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
