### PR TITLE
[dev-launcher] Use http:// as the default scheme to load apps

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🎉 New features
 
 - [Android] Added support for the new architecture. ([#22607](https://github.com/expo/expo/pull/22607) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Allow users to manually load apps without specifying a URL scheme. ([#22637](https://github.com/expo/expo/pull/22637) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/modules/DevLauncherInternalModule.kt
@@ -85,7 +85,13 @@ class DevLauncherInternalModule(reactContext: ReactApplicationContext?) :
   }
 
   private fun sanitizeUrlString(url: String): Uri {
-    return Uri.parse(url.trim())
+    var sanitizedUrl = url.trim()
+    // If the url does contain a scheme use "http://"
+    if(!sanitizedUrl.contains("://")) {
+      sanitizedUrl = "http://" + sanitizedUrl
+    }
+
+    return Uri.parse(sanitizedUrl)
   }
 
   @ReactMethod

--- a/packages/expo-dev-launcher/ios/DevLauncherInternal.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherInternal.swift
@@ -102,7 +102,12 @@ public class DevLauncherInternal: Module, EXDevLauncherPendingDeepLinkListener {
 }
 
 private func sanitizeUrlString(_ urlString: String) -> URL? {
-  let sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+  var sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+  // If the url does contain a scheme use "http://"
+  if !sanitizedUrl.contains("://") {
+    sanitizedUrl = "http://" + sanitizedUrl
+  }
+
   return URL(string: sanitizedUrl)
 }
 


### PR DESCRIPTION
# Why

When entering a URL manually, users always have to include the scheme, even when testing in their local machine (e.g. 192.168.0.12:19000), otherwise we display an error saying that the URL is not supported. 
Closes ENG-7623

# How

To improve the DX, we can automatically add `http://` to URLs that do not include a scheme 

# Test Plan

Run dev-client through bare-expo on Android and iOS
 
<table>
    <tr><th>iOS</th><th>Android</th></tr>
    <tr>
    <td>
        <video src="https://user-images.githubusercontent.com/11707729/50dbf302-948e-4013-aebb-7b4aeea5e8b5.mp4"/>
   </td>
   <td>
   <video src="https://github.com/expo/expo/assets/11707729/b18ba454-b2a3-4e0a-81e8-35e653ce2ca3"   />  
    </td>
</tr> 
</table> 

# Checklist


<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
