### PR TITLE
[expo] Disable autolinking if project do not have expo modules installed

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
+- Fixed build error when using Expo CLI on bare React Native projects without installing Expo Modules. ([#22649](https://github.com/expo/expo/pull/22649) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/react-native.config.js
+++ b/packages/expo/react-native.config.js
@@ -1,12 +1,54 @@
+const findProjectRoot = require('@react-native-community/cli-tools').findProjectRoot;
+const fs = require('fs');
 const path = require('path');
+
+const projectRoot = findProjectRoot();
+
+function isMatchedInFile(filePath, regexp) {
+  const contents = fs.readFileSync(filePath, 'utf8');
+  return !!contents.match(regexp);
+}
+
+/**
+ * Checks if expo-modules-autolinking is setup on iOS
+ */
+function isExpoModulesInstalledIos(projectRoot) {
+  const podfilePath = path.join(projectRoot, 'ios', 'Podfile');
+  if (!fs.existsSync(podfilePath)) {
+    // Assumes true for managed apps
+    return true;
+  }
+  return isMatchedInFile(
+    podfilePath,
+    /^\s*require File.join\(File\.dirname\(`node --print "require\.resolve\('expo\/package\.json'\)"`\), "scripts\/autolinking"\)\s*$/m
+  );
+}
+
+/**
+ * Checks if expo-modules-autolinking is setup on Android
+ */
+function isExpoModulesInstalledAndroid(projectRoot) {
+  const gradlePath = path.join(projectRoot, 'android', 'settings.gradle');
+  if (!fs.existsSync(gradlePath)) {
+    // Assumes true for managed apps
+    return true;
+  }
+  return isMatchedInFile(
+    gradlePath,
+    /^\s*apply from: (new File|file)\(\["node", "--print", "require\.resolve\('expo\/package.json'\)"\]\.execute\(null, rootDir\)\.text\.trim\(\), "\.\.\/scripts\/autolinking\.gradle"\);?\s*$/m
+  );
+}
 
 module.exports = {
   dependency: {
     platforms: {
-      ios: {},
-      android: {
-        packageImportPath: 'import expo.modules.ExpoModulesPackage;',
-      },
+      // To make Expo CLI works on bare react-native projects without installing Expo Modules, we disable autolinking in this case.
+      ios: !isExpoModulesInstalledIos(projectRoot) ? null : {},
+      android: !isExpoModulesInstalledAndroid(projectRoot)
+        ? null
+        : {
+            packageImportPath: 'import expo.modules.ExpoModulesPackage;',
+          },
     },
   },
 };

--- a/packages/expo/react-native.config.js
+++ b/packages/expo/react-native.config.js
@@ -49,6 +49,8 @@ module.exports = {
         : {
             packageImportPath: 'import expo.modules.ExpoModulesPackage;',
           },
+      macos: null,
+      windows: null,
     },
   },
 };


### PR DESCRIPTION
# Why

to make expo-cli works fine for bare react-native projects without setup expo-modules correctly.
there were errors like this when `pod install`
```
[!] Unable to find a specification for `ExpoModulesCore` depended upon by `Expo`

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.
```
close ENG-8606

# How

enable rn-cli autolinking only if it passes the simple check for Podfile and settings.gradle

# Test Plan

- ci passed
- tested on `npx react-native@latest init RN071 --version 0.71` project + `expo` package with this patch
- tested on `npx react-native@latest init RN071 --version 0.71` project + `install-expo-modules` with this patch
- tested on `yarn create expo -t blank@sdk-48 sdk48` with this patch

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
