### PR TITLE
update template gitignores

### DIFF
--- a/templates/expo-template-bare-minimum/gitignore
+++ b/templates/expo-template-bare-minimum/gitignore
@@ -1,58 +1,36 @@
-# OSX
-#
-.DS_Store
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
 
-# Xcode
-#
-build/
-*.pbxuser
-!default.pbxuser
-*.mode1v3
-!default.mode1v3
-*.mode2v3
-!default.mode2v3
-*.perspectivev3
-!default.perspectivev3
-xcuserdata
-*.xccheckout
-*.moved-aside
-DerivedData
-*.hmap
-*.ipa
-*.xcuserstate
-project.xcworkspace
-
-# Android/IntelliJ
-#
-build/
-.idea
-.gradle
-local.properties
-*.iml
-*.hprof
-.cxx/
-*.keystore
-!debug.keystore
-
-# node.js
-#
+# dependencies
 node_modules/
-npm-debug.log
-yarn-error.log
-
-# Bundle artifacts
-*.jsbundle
-
-# CocoaPods
-/ios/Pods/
-
-# Temporary files created by Metro to check the health of the file watcher
-.metro-health-check*
 
 # Expo
 .expo/
-web-build/
 dist/
+web-build/
+
+# Native
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+
+# macOS
+.DS_Store
+*.pem
 
 # local env files
 .env*.local
+
+# typescript
+*.tsbuildinfo

--- a/templates/expo-template-bare-minimum/gitignore
+++ b/templates/expo-template-bare-minimum/gitignore
@@ -24,7 +24,6 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
-
 # macOS
 .DS_Store
 *.pem

--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -1,20 +1,36 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
 node_modules/
+
+# Expo
 .expo/
 dist/
-npm-debug.*
+web-build/
+
+# Native
+*.orig.*
 *.jks
 *.p8
 *.p12
 *.key
 *.mobileprovision
-*.orig.*
-web-build/
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
 
 # macOS
 .DS_Store
-
-# Temporary files created by Metro to check the health of the file watcher
-.metro-health-check*
+*.pem
 
 # local env files
 .env*.local
+
+# typescript
+*.tsbuildinfo

--- a/templates/expo-template-blank-typescript/gitignore
+++ b/templates/expo-template-blank-typescript/gitignore
@@ -24,7 +24,6 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
-
 # macOS
 .DS_Store
 *.pem

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -1,20 +1,36 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
 node_modules/
+
+# Expo
 .expo/
 dist/
-npm-debug.*
+web-build/
+
+# Native
+*.orig.*
 *.jks
 *.p8
 *.p12
 *.key
 *.mobileprovision
-*.orig.*
-web-build/
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
 
 # macOS
 .DS_Store
-
-# Temporary files created by Metro to check the health of the file watcher
-.metro-health-check*
+*.pem
 
 # local env files
 .env*.local
+
+# typescript
+*.tsbuildinfo

--- a/templates/expo-template-blank/gitignore
+++ b/templates/expo-template-blank/gitignore
@@ -24,7 +24,6 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
-
 # macOS
 .DS_Store
 *.pem

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -1,20 +1,36 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
 node_modules/
+
+# Expo
 .expo/
 dist/
-npm-debug.*
+web-build/
+
+# Native
+*.orig.*
 *.jks
 *.p8
 *.p12
 *.key
 *.mobileprovision
-*.orig.*
-web-build/
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
 
 # macOS
 .DS_Store
-
-# Temporary files created by Metro to check the health of the file watcher
-.metro-health-check*
+*.pem
 
 # local env files
 .env*.local
+
+# typescript
+*.tsbuildinfo

--- a/templates/expo-template-tabs/gitignore
+++ b/templates/expo-template-tabs/gitignore
@@ -24,7 +24,6 @@ npm-debug.*
 yarn-debug.*
 yarn-error.*
 
-
 # macOS
 .DS_Store
 *.pem


### PR DESCRIPTION
# Why

- Add learn more link https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
- Drop duplicates in the bare template in favor of the platform-specific gitignores
- Add typescript generated files
- Add more package manager files: npm-debug.* yarn-debug.* yarn-error.*

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
