### PR TITLE
[android][location] Remove usage of deprecated api

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 💡 Others
 
-- On Android, removed use of deprecated `LocationRequest` constructor and replaced with `LocationRequest.Builder`.
+- On Android, removed use of deprecated `LocationRequest` constructor and replaced with `LocationRequest.Builder`. ([#22653](https://github.com/expo/expo/pull/22653) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 15.2.0 — 2023-05-08
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `com.google.android.gms:play-services-location` to `21.0.1` and `io.nlopez.smartlocation:library` to `3.3.3`  ([#22468](https://github.com/expo/expo/pull/22468) by [@josephyanks](https://github.com/josephyanks))
+- Updated `com.google.android.gms:play-services-location` to `21.0.1` and `io.nlopez.smartlocation:library` to `3.3.3` ([#22468](https://github.com/expo/expo/pull/22468) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🛠 Breaking changes
 
@@ -15,6 +15,8 @@
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
+
+- On Android, removed use of deprecated `LocationRequest` constructor and replaced with `LocationRequest.Builder`.
 
 ## 15.2.0 — 2023-05-08
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
@@ -119,16 +119,15 @@ public class LocationHelpers {
     return heading;
   }
 
-  public static LocationRequest prepareLocationRequest(Map<String, Object> options) {
+  public static LocationRequest.Builder prepareLocationRequest(Map<String, Object> options) {
     LocationParams locationParams = LocationHelpers.mapOptionsToLocationParams(options);
     int accuracy = LocationHelpers.getAccuracyFromOptions(options);
 
-    return new LocationRequest()
-        .setFastestInterval(locationParams.getInterval())
-        .setInterval(locationParams.getInterval())
-        .setMaxWaitTime(locationParams.getInterval())
-        .setSmallestDisplacement(locationParams.getDistance())
-        .setPriority(mapAccuracyToPriority(accuracy));
+    return new LocationRequest.Builder(locationParams.getInterval())
+      .setMinUpdateIntervalMillis(locationParams.getInterval())
+      .setMaxUpdateDelayMillis(locationParams.getInterval())
+      .setMinUpdateDistanceMeters(locationParams.getDistance())
+      .setPriority(mapAccuracyToPriority(accuracy));
   }
 
   public static LocationParams mapOptionsToLocationParams(Map<String, Object> options) {
@@ -147,14 +146,14 @@ public class LocationHelpers {
     return locationParamsBuilder.build();
   }
 
-  static void requestSingleLocation(final LocationModule locationModule, final LocationRequest locationRequest, final Promise promise) {
+  static void requestSingleLocation(final LocationModule locationModule, final LocationRequest.Builder locationRequest, final Promise promise) {
     // we want just one update
-    locationRequest.setNumUpdates(1);
+    locationRequest.setMaxUpdates(1);
 
-    locationModule.requestLocationUpdates(locationRequest, null, new LocationRequestCallbacks() {
+    locationModule.requestLocationUpdates(locationRequest.build(), null, new LocationRequestCallbacks() {
       @Override
       public void onLocationChanged(Location location) {
-        promise.resolve(LocationHelpers.locationToBundle(location, Bundle.class));
+          promise.resolve(LocationHelpers.locationToBundle(location, Bundle.class));
       }
 
       @Override

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -275,7 +275,7 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
   @ExpoMethod
   public void getCurrentPositionAsync(final Map<String, Object> options, final Promise promise) {
     // Read options
-    final LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(options);
+    final LocationRequest.Builder builder = LocationHelpers.prepareLocationRequest(options);
     boolean showUserSettingsDialog = !options.containsKey(SHOW_USER_SETTINGS_DIALOG_KEY) || (boolean) options.get(SHOW_USER_SETTINGS_DIALOG_KEY);
 
     // Check for permissions
@@ -285,12 +285,12 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     }
 
     if (LocationHelpers.hasNetworkProviderEnabled(mContext) || !showUserSettingsDialog) {
-      LocationHelpers.requestSingleLocation(this, locationRequest, promise);
+      LocationHelpers.requestSingleLocation(this, builder, promise);
     } else {
       // Pending requests can ask the user to turn on improved accuracy mode in user's settings.
-      addPendingLocationRequest(locationRequest, resultCode -> {
+      addPendingLocationRequest(builder.build(), resultCode -> {
         if (resultCode == Activity.RESULT_OK) {
-          LocationHelpers.requestSingleLocation(LocationModule.this, locationRequest, promise);
+          LocationHelpers.requestSingleLocation(LocationModule.this, builder, promise);
         } else {
           promise.reject(new LocationSettingsUnsatisfiedException());
         }
@@ -336,16 +336,16 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
       return;
     }
 
-    final LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(options);
+    final LocationRequest.Builder locationRequest = LocationHelpers.prepareLocationRequest(options);
     boolean showUserSettingsDialog = !options.containsKey(SHOW_USER_SETTINGS_DIALOG_KEY) || (boolean) options.get(SHOW_USER_SETTINGS_DIALOG_KEY);
 
     if (LocationHelpers.hasNetworkProviderEnabled(mContext) || !showUserSettingsDialog) {
-      LocationHelpers.requestContinuousUpdates(this, locationRequest, watchId, promise);
+      LocationHelpers.requestContinuousUpdates(this, locationRequest.build(), watchId, promise);
     } else {
       // Pending requests can ask the user to turn on improved accuracy mode in user's settings.
-      addPendingLocationRequest(locationRequest, resultCode -> {
+      addPendingLocationRequest(locationRequest.build(), resultCode -> {
         if (resultCode == Activity.RESULT_OK) {
-          LocationHelpers.requestContinuousUpdates(LocationModule.this, locationRequest, watchId, promise);
+          LocationHelpers.requestContinuousUpdates(LocationModule.this, locationRequest.build(), watchId, promise);
         } else {
           promise.reject(new LocationSettingsUnsatisfiedException());
         }
@@ -443,9 +443,9 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
       return;
     }
 
-    LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(new HashMap<>());
+    LocationRequest.Builder locationRequest = LocationHelpers.prepareLocationRequest(new HashMap<>());
 
-    addPendingLocationRequest(locationRequest, resultCode -> {
+    addPendingLocationRequest(locationRequest.build(), resultCode -> {
       if (resultCode == Activity.RESULT_OK) {
         promise.resolve(null);
       } else {

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -181,7 +181,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
       return;
     }
 
-    mLocationRequest = LocationHelpers.prepareLocationRequest(mTask.getOptions());
+    mLocationRequest = LocationHelpers.prepareLocationRequest(mTask.getOptions()).build();
     mPendingIntent = preparePendingIntent();
 
     try {


### PR DESCRIPTION
# Why
As reported in #20663, we seem to resolving a promise twice. I cannot reproduce this but checking Sentry logs on one of the apps I work on where we are using `expo-location`, I can see that it does occur rarely, under specific conditions. It comes from the `LocationRequestCallbacks` in `requestSingleLocation`. Even though we request only a single update, there seems to be some instances where another is received and we try to resolve again. 

Currently, we create a `LocationRequest`by constructing it but this has been deprecated. The docs also mention that methods like `setInterval` and `setNumUpdates` on this object are `hints` and not guarantees. 

# How
Replaced using the `LocationRequest` constructor with its `Builder`. The [documentation](https://developer.android.com/reference/android/location/LocationRequest.Builder#setMaxUpdates(int)) for the method `setMaxUpdates` says that it will only ever receive the specified number of updates and then be removed. 

# Test Plan
NCL ✅

Because I can't reproduce I can't say for sure this fixes the issue, but at least it removes the deprecated API and the documentation seems firmer on the expected behaviour. 