### PR TITLE
[docs] Fix android and ios directory names not following styleguide convention

### DIFF
--- a/docs/pages/bare/hello-world.mdx
+++ b/docs/pages/bare/hello-world.mdx
@@ -7,7 +7,7 @@ description: An overview of bare React Native app with Expo tools.
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-A bare React Native app is a project where developers make direct changes to their native **android and **ios** project directories rather than continuously generating them on demand using the [Expo config (**app.json\*\*) and prebuild](/workflow/prebuild). All tools and services offered by Expo including [EAS](/eas), Expo CLI, and the libraries in the Expo SDK, are built around bare React Native apps.
+A bare React Native app is a project where developers make direct changes to their native **android and **ios** project directories rather than continuously generating them on demand using the [Expo config (**app.json**) and prebuild](/workflow/prebuild). All tools and services offered by Expo including [EAS](/eas), Expo CLI, and the libraries in the Expo SDK, are built around bare React Native apps.
 
 Before you get started with a React Native app, make sure you set up your environment for [React Native CLI](https://reactnative.dev/docs/environment-setup).
 

--- a/docs/pages/bare/hello-world.mdx
+++ b/docs/pages/bare/hello-world.mdx
@@ -7,7 +7,7 @@ description: An overview of bare React Native app with Expo tools.
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-A bare React Native app is a project where developers make direct changes to their native `ios` and `android` project directories rather than continuously generating them on demand using the [Expo config (**app.json**) and prebuild](/workflow/prebuild). All tools and services offered by Expo including [EAS](/eas), Expo CLI, and the libraries in the Expo SDK, are built around bare React Native apps.
+A bare React Native app is a project where developers make direct changes to their native **android and **ios** project directories rather than continuously generating them on demand using the [Expo config (**app.json\*\*) and prebuild](/workflow/prebuild). All tools and services offered by Expo including [EAS](/eas), Expo CLI, and the libraries in the Expo SDK, are built around bare React Native apps.
 
 Before you get started with a React Native app, make sure you set up your environment for [React Native CLI](https://reactnative.dev/docs/environment-setup).
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -4,7 +4,12 @@ description: A list of common questions and limitations about Expo and related s
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasMetadataIcon, LayersTwo02Icon, BellRinging04Icon } from '@expo/styleguide-icons';
+import {
+  BuildIcon,
+  EasMetadataIcon,
+  LayersTwo02Icon,
+  BellRinging04Icon,
+} from '@expo/styleguide-icons';
 
 This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [ Forums](https://forums.expo.io) for more common questions.
 
@@ -94,7 +99,7 @@ Regardless of which CLI you use, you can use any part of the [Expo SDK](/version
 
 ## Is Expo Go open source?
 
-Yes, the source for Expo Go can be found in the [expo/expo GitHub repository](https://github.com/expo/expo) in the `home`, `android`, and `ios` directories. The Expo Go app is also built with Expo and React Native.
+Yes, the source for Expo Go can be found in the [expo/expo GitHub repository](https://github.com/expo/expo) in the **home**, **android**, and **ios** directories. The Expo Go app is also built with Expo and React Native.
 
 ## Is Expo eject deprecated?
 

--- a/docs/pages/guides/splash-screens.mdx
+++ b/docs/pages/guides/splash-screens.mdx
@@ -136,7 +136,7 @@ Depending on the `resizeMode` you will get the following behavior:
 
 ### Bare workflow apps
 
-If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _managed workflow_) to generate the native `ios` and `android` directories, then changes in the [Expo config][expo-config] will have no effect. To setup and customize your splash screen manually, refer to [this guide](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
+If your app does not use [Expo Prebuild](/workflow/prebuild) (formerly the _managed workflow_) to generate the native **android** and **ios** directories, then changes in the [Expo config][expo-config] will have no effect. To setup and customize your splash screen manually, refer to [this guide](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
 
 ### iOS Caching
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -17,11 +17,9 @@ Sets the initial React component to render natively in the app's root React Nati
 
 ### Manual Android setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `android` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the Android `MainActivity.java` file to use the name `"main"` in the `getMainComponentName` function.
-
-`android/app/src/main/<package>/MainActivity.java`
+Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,9 +30,9 @@ Update the Android `MainActivity.java` file to use the name `"main"` in the `get
 
 ### Manual iOS setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `ios` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS `ios/<name>/AppDelegate.(m|mm|swift)` file to use the **moduleName** `"main"` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/register-root-component.mdx
+++ b/docs/pages/versions/unversioned/sdk/register-root-component.mdx
@@ -19,7 +19,7 @@ Sets the initial React component to render natively in the app's root React Nati
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
+Update the **android/app/src/main/your-package/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,7 +32,7 @@ Update the **android/app/src/main/<package>/MainActivity.java** file to use the 
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/your-name/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/register-root-component.mdx
@@ -17,11 +17,9 @@ Sets the initial React component to render natively in the app's root React Nati
 
 ### Manual Android setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `android` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the Android `MainActivity.java` file to use the name `"main"` in the `getMainComponentName` function.
-
-`android/app/src/main/<package>/MainActivity.java`
+Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,9 +30,9 @@ Update the Android `MainActivity.java` file to use the name `"main"` in the `get
 
 ### Manual iOS setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `ios` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS `ios/<name>/AppDelegate.(m|mm|swift)` file to use the **moduleName** `"main"` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/register-root-component.mdx
@@ -19,7 +19,7 @@ Sets the initial React component to render natively in the app's root React Nati
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
+Update the **android/app/src/main/your-package/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,7 +32,7 @@ Update the **android/app/src/main/<package>/MainActivity.java** file to use the 
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/your-name/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/register-root-component.mdx
@@ -17,11 +17,9 @@ Sets the initial React component to render natively in the app's root React Nati
 
 ### Manual Android setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `android` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the Android `MainActivity.java` file to use the name `"main"` in the `getMainComponentName` function.
-
-`android/app/src/main/<package>/MainActivity.java`
+Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,9 +30,9 @@ Update the Android `MainActivity.java` file to use the name `"main"` in the `get
 
 ### Manual iOS setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `ios` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS `ios/<name>/AppDelegate.(m|mm|swift)` file to use the **moduleName** `"main"` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/register-root-component.mdx
@@ -19,7 +19,7 @@ Sets the initial React component to render natively in the app's root React Nati
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
+Update the **android/app/src/main/your-package/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,7 +32,7 @@ Update the **android/app/src/main/<package>/MainActivity.java** file to use the 
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/your-name/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/register-root-component.mdx
@@ -17,11 +17,9 @@ Sets the initial React component to render natively in the app's root React Nati
 
 ### Manual Android setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `android` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the Android `MainActivity.java` file to use the name `"main"` in the `getMainComponentName` function.
-
-`android/app/src/main/<package>/MainActivity.java`
+Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,9 +30,9 @@ Update the Android `MainActivity.java` file to use the name `"main"` in the `get
 
 ### Manual iOS setup
 
-> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the `ios` directory.
+> This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS `ios/<name>/AppDelegate.(m|mm|swift)` file to use the **moduleName** `"main"` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/register-root-component.mdx
@@ -19,7 +19,7 @@ Sets the initial React component to render natively in the app's root React Nati
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **android** directory.
 
-Update the **android/app/src/main/<package>/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
+Update the **android/app/src/main/your-package/MainActivity.java** file to use the name `main` in the `getMainComponentName` function.
 
 ```diff
   @Override
@@ -32,7 +32,7 @@ Update the **android/app/src/main/<package>/MainActivity.java** file to use the 
 
 > This is only required if your app does **not** use [Expo Prebuild](/workflow/prebuild) to continuously generate the **ios** directory.
 
-Update the iOS **ios/<name>/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
+Update the iOS **ios/your-name/AppDelegate.(m|mm|swift)** file to use the **moduleName** `main` in the `createRootViewWithBridge:bridge moduleName:@"main" initialProperties:initProps` line of the `application:didFinishLaunchingWithOptions:` function.
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some pages where I found that filenames/directories name weren't bold or following writing style guideline.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the references and apply the writing styleguide convention.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
