### PR TITLE
[docs] fix mobile search dialog clip

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
     "@reach/tabs": "^0.17.0",
     "@sentry/react": "^7.24.1",
     "@sentry/tracing": "^7.24.1",
-    "cmdk": "^0.1.21",
+    "cmdk": "^0.2.0",
     "date-fns": "^2.29.3",
     "front-matter": "^4.0.2",
     "fs-extra": "^10.1.0",

--- a/docs/ui/components/CommandMenu/styles.ts
+++ b/docs/ui/components/CommandMenu/styles.ts
@@ -37,12 +37,12 @@ export const commandMenuStyles = css`
     z-index: 1001;
 
     @media screen and (max-width: ${breakpoints.medium}px) {
-      min-height: 100vh;
-      max-height: 100vh;
       width: 100vw;
       min-width: 100vw;
-      top: 50%;
-      border-radius: 0;
+      position: absolute;
+      min-height: 84vh;
+      max-height: 84vh;
+      margin-top: -16px;
     }
   }
 
@@ -119,8 +119,8 @@ export const commandMenuStyles = css`
     margin: ${spacing[3]}px 0 0;
 
     @media screen and (max-width: ${breakpoints.medium}px) {
-      height: calc(100vh - 50px - 50px - 20px);
-      max-height: calc(100vh - 50px - 50px - 20px);
+      height: calc(84vh - 50px - 50px - 20px);
+      max-height: calc(84vh - 50px - 50px - 20px);
     }
   }
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2478,10 +2478,10 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-cmdk@^0.1.21:
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.1.21.tgz#c4e0fbb032fdbcf487c003cc98e1a2ffcaecbb6b"
-  integrity sha512-O5oiYmoBdcoqmax4RMOsnJHrseaXlnkzfCSWgNdyBxneTaSCmUByBF5MliJbsveoHJsjkyL2uNUs2kTBBMmIaw==
+cmdk@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-0.2.0.tgz#53c52d56d8776c8bb8ced1055b5054100c388f7c"
+  integrity sha512-JQpKvEOb86SnvMZbYaFKYhvzFntWBeSZdyii0rZPhKJj9uwJBxu4DaVYDrRN7r3mPop56oPhRw+JYWTKs66TYw==
   dependencies:
     "@radix-ui/react-dialog" "1.0.0"
     command-score "0.1.2"


### PR DESCRIPTION
# Why

Fixes ENG-8686

# How

Adjust style overwrite to change the way we size and position search dialog on mobile. Since mobile browsers bechaviour varies and we have no native HTML mobile viewport resize due to keyboard appearing or browser UI there is no ideal solution, but now at least the search should be usable again on most of devices.

In the process I have also updated CMDK package to the latest release.

# Test Plan

The  changes have been developed locally and tested directly on mobile device.

# Preview

https://github.com/expo/expo/assets/719641/6e959472-82d3-496d-8377-6315cda60322

