### PR TITLE
[core][Android] Change the order of initialization to allow earlier access to the app context

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -17,8 +17,10 @@ class ModuleRegistry(
   internal val registry = mutableMapOf<String, ModuleHolder>()
 
   fun register(module: Module) {
-    val holder = ModuleHolder(module)
     module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
+
+    val holder = ModuleHolder(module)
+
     module.coroutineScopeDelegate = lazy {
       CoroutineScope(
         Dispatchers.Default +
@@ -26,19 +28,24 @@ class ModuleRegistry(
           CoroutineName(holder.definition.name)
       )
     }
-    holder.post(EventName.MODULE_CREATE)
-    holder.registerContracts()
-    // The initial invocation of `declaredMemberProperties` appears to be slow,
-    // as Kotlin must deserialize metadata internally.
-    // This is a known issue that may be resolved by the new K2 compiler in the future.
-    // However, until then, we must find a way to address this problem.
-    // Therefore, we have decided to dispatch a lambda
-    // that invokes `declaredMemberProperties` during module creation.
-    holder.viewClass()?.let { viewType ->
-      appContext.get()?.backgroundCoroutineScope?.launch {
-        viewType.declaredMemberProperties
+
+    holder.apply {
+      post(EventName.MODULE_CREATE)
+      registerContracts()
+
+      // The initial invocation of `declaredMemberProperties` appears to be slow,
+      // as Kotlin must deserialize metadata internally.
+      // This is a known issue that may be resolved by the new K2 compiler in the future.
+      // However, until then, we must find a way to address this problem.
+      // Therefore, we have decided to dispatch a lambda
+      // that invokes `declaredMemberProperties` during module creation.
+      viewClass()?.let { viewType ->
+        appContext.get()?.backgroundCoroutineScope?.launch {
+          viewType.declaredMemberProperties
+        }
       }
     }
+
     registry[holder.name] = holder
   }
 


### PR DESCRIPTION
# Why

Changed the order of initialization to allow access to the app context in the root of the module definition. 

# How

Bind the `AppContex` with the module before accessing the module definition. 

# Test Plan

- bare-expo ✅