### PR TITLE
[docs] update styleguide packages, duotone icons in sidebar header

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -23,9 +23,9 @@
   },
   "dependencies": {
     "@emotion/react": "^11.10.5",
-    "@expo/styleguide": "^8.0.0-alpha.8",
-    "@expo/styleguide-base": "^1.0.0-alpha.2",
-    "@expo/styleguide-icons": "^1.0.0-alpha.4",
+    "@expo/styleguide": "^8.0.0",
+    "@expo/styleguide-base": "^1.0.0",
+    "@expo/styleguide-icons": "^1.0.0",
     "@mdx-js/loader": "^2.2.1",
     "@mdx-js/mdx": "^2.2.1",
     "@mdx-js/react": "^2.2.1",

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -3,10 +3,10 @@ import { theme, DocsLogo } from '@expo/styleguide';
 import { spacing } from '@expo/styleguide-base';
 import {
   ArrowLeftIcon,
-  BookOpen02Icon,
-  Home02Icon,
-  GraduationHat02Icon,
-  Stars02Icon,
+  GraduationHat02DuotoneIcon,
+  Stars02DuotoneIcon,
+  Home02DuotoneIcon,
+  BookOpen02DuotoneIcon,
 } from '@expo/styleguide-icons';
 
 import { shouldShowFeaturePreviewLink } from '~/constants/FeatureFlags.cjs';
@@ -36,13 +36,13 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
       <SidebarSingleEntry
         href="/"
         title="Home"
-        Icon={Home02Icon}
+        Icon={Home02DuotoneIcon}
         isActive={sidebarActiveGroup === 'home'}
       />
       <SidebarSingleEntry
         href="/workflow/customizing"
         title="Guides"
-        Icon={BookOpen02Icon}
+        Icon={BookOpen02DuotoneIcon}
         isActive={sidebarActiveGroup === 'general'}
       />
       <SidebarSingleEntry
@@ -54,14 +54,14 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
       <SidebarSingleEntry
         href="/tutorial/introduction/"
         title="Learn"
-        Icon={GraduationHat02Icon}
+        Icon={GraduationHat02DuotoneIcon}
         isActive={sidebarActiveGroup === 'learn'}
       />
       {shouldShowFeaturePreviewLink() && (
         <SidebarSingleEntry
           href="/feature-preview"
           title="Feature Preview"
-          Icon={Stars02Icon}
+          Icon={Stars02DuotoneIcon}
           isActive={sidebarActiveGroup === 'featurePreview' || sidebarActiveGroup === 'preview'}
         />
       )}

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -455,26 +455,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@expo/styleguide-base@^1.0.0-alpha.2":
-  version "1.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-1.0.0-alpha.2.tgz#ff581558974706079def453cfbf245e5bc3bb291"
-  integrity sha512-7sEdwU5KtKMF5NnmYw6KwgCuV/6CI1+UtFyX9v3DK9a6lfcqQpChk0Ac1nQB1E4daSq+1pHKxM2BcDh1BWtstA==
+"@expo/styleguide-base@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-base/-/styleguide-base-1.0.0.tgz#acdbbebba7fdc80b09fed9e7d73c512e5e0cf1d7"
+  integrity sha512-peDW75rMhPx/UnIExX4ZI96Qg0zKucsCbSQ3NQLcIMY1HSDi4ccolEWsFpHJSwjLobFaMOtgj6FBrLc8C/EPPA==
   dependencies:
     "@radix-ui/colors" "^0.1.8"
 
-"@expo/styleguide-icons@^1.0.0-alpha.4":
-  version "1.0.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-1.0.0-alpha.4.tgz#bfe7af426dd59f176ca533895900175ac308b400"
-  integrity sha512-DhEaBEJUXmY3DJPXEVltf++JQUmy+gWjlFXI7imweCQ52eAXkNrOrccsiyTrB3AlWPVipvSOKqTxlydYybo8Sw==
+"@expo/styleguide-icons@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide-icons/-/styleguide-icons-1.0.0.tgz#a99c134d8c31446118448356f1f8f8b2db4c4511"
+  integrity sha512-gqKMLuSPlMbL00BnGpA+patLbBC3YYMh4NxszlMJpNXz/qkb2T7lykmrJoQH6KpLXn/ViO65B1TX6a7pvdO+Nw==
   dependencies:
     tailwind-merge "^1.12.0"
 
-"@expo/styleguide@^8.0.0-alpha.8":
-  version "8.0.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.0.0-alpha.8.tgz#593cbba1c97280ad1e768c77e9537d583418f680"
-  integrity sha512-S8ixiuJ+N0YEODq1GOujQGOt6fDlXiynANWVdfm+aZDOSm+o8YClSTg7JC68o6uGOEcfTOkODdUnPG+p0C3TZw==
+"@expo/styleguide@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/styleguide/-/styleguide-8.0.0.tgz#cc37c3f4bc5a29dc9c9dc37587efa80200fdae0d"
+  integrity sha512-IIKReRslx7Ro3l7tjT2EO/Z9NE8ymkHzvJZnH+mcnXtGCBKFmIWA54E5gjYxA6ztUbRa0sW83o+igzA6PDhp5w==
   dependencies:
-    "@expo/styleguide-base" "^1.0.0-alpha.2"
+    "@expo/styleguide-base" "^1.0.0"
     tailwind-merge "^1.12.0"
 
 "@gitbeaker/core@^21.7.0":


### PR DESCRIPTION
# Why

We have release a stable version of styleguide packages, let's use them.

# How

Update styleguide packages, use duotone icons in sidebar header.

# Test Plan

The changes have been tested by running docs app locally.  Lint checks and tests are passing.

# Preview

<img width="318" alt="Screenshot 2023-05-29 at 15 38 52" src="https://github.com/expo/expo/assets/719641/20be3463-8466-4bd9-9a7a-72b749c40f69">
