### PR TITLE
[use-updates] Config / config-plugins/metro-config deps should not be direct deps

### DIFF
--- a/packages/@expo/use-updates/package.json
+++ b/packages/@expo/use-updates/package.json
@@ -37,11 +37,6 @@
       "@testing-library/jest-native/extend-expect"
     ]
   },
-  "dependencies": {
-    "@expo/config": "~8.0.0",
-    "@expo/config-plugins": "~7.0.0",
-    "@expo/metro-config": "~0.8.0"
-  },
   "devDependencies": {
     "@testing-library/jest-native": "^4.0.4",
     "@testing-library/react": "^13.4.0",
@@ -59,7 +54,6 @@
   },
   "peerDependencies": {
     "expo": "*",
-    "expo-constants": "*",
     "expo-updates": "*"
   }
 }


### PR DESCRIPTION
# Why

We should only depend on these packages in the` expo` package and then import from there if we need them.
https://docs.expo.dev/config-plugins/development-and-debugging/#install-dependencies

I also removed `expo-constants` here  as a peer dependency because it is installed by the `expo` package.

# How

Remove deps, they aren't used so it's fine.