### PR TITLE
[client][Android] Bump Koin to `3.4.0`

### DIFF
--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -146,26 +146,18 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
 
-  api "io.insert-koin:koin-core:3.1.2"
+  def koinVersion = "3.4.0"
+
+  api "io.insert-koin:koin-core:${koinVersion}"
 
   testImplementation 'androidx.test:core:1.4.0'
   testImplementation 'androidx.test:core-ktx:1.4.0'
   testImplementation "com.google.truth:truth:1.1.2"
   testImplementation 'com.squareup.okhttp3:mockwebserver:4.3.1'
-  testImplementation "io.insert-koin:koin-test:3.1.2"
-  testImplementation "io.insert-koin:koin-test-junit4:3.1.2"
+  testImplementation "io.insert-koin:koin-test:${koinVersion}"
+  testImplementation "io.insert-koin:koin-test-junit4:${koinVersion}"
   testImplementation 'io.mockk:mockk:1.12.3'
   testImplementation "org.robolectric:robolectric:4.10"
-}
-
-// Koin uses a different version of Kotlin under the hood.
-configurations.all {
-  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-    def requested = details.requested
-    if (requested.group == 'org.jetbrains.kotlin') {
-      details.useVersion safeExtGet('kotlinVersion', '1.8.10')
-    }
-  }
 }
 
 def versionToNumber(major, minor, patch) {


### PR DESCRIPTION
# Why

Closes ENG-7640.

# How

Bump the Koin version to `3.4.0`

# Test Plan

- bare-expo ✅