### PR TITLE
chore: fix pointer type

### DIFF
--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -766,7 +766,7 @@ EX_EXPORT_METHOD_AS(networkTaskCancelAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  NSURLSessionDownloadTask *task = [_taskHandlersManager taskForId:uuid];
+  NSURLSessionTask *task = [_taskHandlersManager taskForId:uuid];
   if (task) {
     [task cancel];
   }


### PR DESCRIPTION
# Why

tiny fix: 

<img width="868" alt="Screenshot 2023-05-30 at 17 43 46" src="https://github.com/expo/expo/assets/1566403/cc9ce1d6-72e7-472f-9190-b794731c38b6">

# How

fix the pointer type 

# Test Plan

the warning in xcode is gone

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
