### PR TITLE
[manifests] introduce getPluginProperties

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🎉 New features
 
+- Added `Manifests.getPluginProperties()` helper to query dedicated package's properties inside the `plugins` config. ([#22701](https://github.com/expo/expo/pull/22701) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))

--- a/packages/expo-manifests/android/build.gradle
+++ b/packages/expo-manifests/android/build.gradle
@@ -90,15 +90,11 @@ dependencies {
   implementation project(':expo-json-utils')
 
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'androidx.test:core:1.4.0'
-  testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'io.mockk:mockk:1.12.3'
-
-  androidTestImplementation 'androidx.test:runner:1.4.0'
-  androidTestImplementation 'androidx.test:core:1.4.0'
-  androidTestImplementation 'androidx.test:rules:1.4.0'
-  androidTestImplementation 'org.mockito:mockito-android:3.7.7'
-  androidTestImplementation 'io.mockk:mockk-android:1.12.3'
+  testImplementation 'androidx.test:core:1.5.0'
+  testImplementation 'org.mockito:mockito-core:4.0.0'
+  testImplementation 'io.mockk:mockk:1.13.5'
+  testImplementation 'org.json:json:20230227'
+  testImplementation "com.google.truth:truth:1.1.2"
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/JSONObjectExtension.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/JSONObjectExtension.kt
@@ -8,16 +8,10 @@ import org.json.JSONObject
  * Convert a [JSONObject] to Map<String, Any> recursively
  */
 fun JSONObject.toMap(): Map<String, Any> {
-  return mutableMapOf<String, Any>().apply {
-    keys().forEach {
-      when (val value = this@toMap[it]) {
-        is JSONObject -> {
-          put(it, value.toMap())
-        }
-        else -> {
-          put(it, value)
-        }
-      }
+  return keys().asSequence().associateWith {
+    when (val value = this@toMap[it]) {
+      is JSONObject -> value.toMap()
+      else -> value
     }
   }
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/JSONObjectExtension.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/JSONObjectExtension.kt
@@ -1,0 +1,23 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.manifests.core
+
+import org.json.JSONObject
+
+/**
+ * Convert a [JSONObject] to Map<String, Any> recursively
+ */
+fun JSONObject.toMap(): Map<String, Any> {
+  return mutableMapOf<String, Any>().apply {
+    keys().forEach {
+      when (val value = this@toMap[it]) {
+        is JSONObject -> {
+          put(it, value.toMap())
+        }
+        else -> {
+          put(it, value)
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt
@@ -285,14 +285,14 @@ internal sealed class PluginType {
     }
 
     @Throws(IllegalArgumentException::class)
-    fun fromRawArrayValue(value: JSONArray): List<PluginType>? {
-      val result = ArrayList<PluginType>()
-      for (i in 0 until value.length()) {
-        fromRawValue(value.get(i))?.let {
-          result.add(it)
+    fun fromRawArrayValue(value: JSONArray): List<PluginType> {
+      return mutableListOf<PluginType>().apply {
+        for (i in 0 until value.length()) {
+          fromRawValue(value.get(i))?.let {
+            add(it)
+          }
         }
       }
-      return result
     }
   }
 }

--- a/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/ManifestTest.kt
+++ b/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/ManifestTest.kt
@@ -1,0 +1,59 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+package expo.modules.manifests.core
+
+import com.google.common.truth.Truth
+import org.json.JSONObject
+import org.junit.Test
+
+class ManifestTest {
+  @Test
+  fun getPluginProperties_emptyManifest_returnsNull() {
+    val manifestJson = JSONObject(emptyMap<String, Any>())
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    Truth.assertThat(manifest.getPluginProperties("test")).isNull()
+  }
+
+  @Test
+  fun getPluginProperties_emptyPlugins_returnsNull() {
+    val manifestJson = JSONObject(mapOf<String, Any>("plugins" to emptyArray<Any>()))
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    Truth.assertThat(manifest.getPluginProperties("test")).isNull()
+  }
+
+  @Test
+  fun getPluginProperties_nonMatchedPlugins_returnsNull() {
+    val manifestJson = JSONObject(mapOf<String, Any>("plugins" to arrayOf("hello")))
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    Truth.assertThat(manifest.getPluginProperties("test")).isNull()
+  }
+
+  @Test
+  fun getPluginProperties_matchedPluginWithoutProps_returnsNull() {
+    val manifestJson = JSONObject(mapOf<String, Any>("plugins" to arrayOf("test")))
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    Truth.assertThat(manifest.getPluginProperties("test")).isNull()
+  }
+
+  @Test
+  fun getPluginProperties_matchedPluginWithProps_returnsProps() {
+    val props = mapOf<String, Any>("foo" to "bar")
+    val pluginWithProp = arrayOf("test", props)
+    val manifestJson = JSONObject(mapOf<String, Any>("plugins" to arrayOf(pluginWithProp)))
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    val result = manifest.getPluginProperties("test")
+    Truth.assertThat(result).isNotNull()
+    Truth.assertThat(result).containsExactlyEntriesIn(props)
+  }
+
+  @Test
+  fun getPluginProperties_matchedPluginWithNestedProps_returnsNestedProps() {
+    val props = mapOf<String, Any>("nested" to mapOf<String, Any>("insideNested" to true))
+    val pluginWithProp = arrayOf("test", props)
+    val manifestJson = JSONObject(mapOf<String, Any>("plugins" to arrayOf(pluginWithProp)))
+    val manifest = Manifest.fromManifestJson(manifestJson)
+    val result = manifest.getPluginProperties("test")
+    Truth.assertThat(result).isNotNull()
+    Truth.assertThat(result).containsExactlyEntriesIn(props)
+  }
+}

--- a/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/NewManifestTest.kt
+++ b/packages/expo-manifests/android/src/test/java/expo/modules/manifests/core/NewManifestTest.kt
@@ -1,12 +1,9 @@
 package expo.modules.manifests.core
 
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4ClassRunner::class)
 class NewManifestTest {
   @Test
   @Throws(Exception::class)

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -357,7 +357,7 @@ public class Manifest: NSObject {
       }
     }
 
-    guard let pluginsRawValue = expoClientConfigRootObject()?["plugins"] as? [Any],
+    guard let pluginsRawValue = expoClientConfigRootObject()?.optionalValue(forKey: "plugins") as [Any]?,
       let plugins = PluginType.fromRawArrayValue(pluginsRawValue) else {
       return nil
     }

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -325,7 +325,6 @@ public class Manifest: NSObject {
   /**
    Queries the dedicated package properties in `plugins`
    */
-  @objc
   public func getPluginProperties(packageName: String) -> [String: Any]? {
     typealias PluginWithProps = (String, [String: Any])
     typealias PluginWithoutProps = String

--- a/packages/expo-manifests/ios/Tests/ManifestSpec.swift
+++ b/packages/expo-manifests/ios/Tests/ManifestSpec.swift
@@ -1,0 +1,38 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesTestCore
+
+@testable import EXManifests
+
+final class ManifestSpec: ExpoSpec {
+  override func spec() {
+    describe("getPluginProperties") {
+      it("should return nil when plugin is not matched") {
+        var manifestJson: [String: Any] = [:]
+        var manifest = ManifestFactory.manifest(forManifestJSON: manifestJson)
+        expect(manifest.getPluginProperties(packageName: "test")).to(beNil())
+
+        manifestJson = ["plugins": []]
+        manifest = ManifestFactory.manifest(forManifestJSON: manifestJson)
+        expect(manifest.getPluginProperties(packageName: "test")).to(beNil())
+
+        manifestJson = ["plugins": ["hello"]]
+        manifest = ManifestFactory.manifest(forManifestJSON: manifestJson)
+        expect(manifest.getPluginProperties(packageName: "test")).to(beNil())
+      }
+
+      it("should return nil when the matched plugin has no properties") {
+        let manifestJson = ["plugins": ["test"]]
+        let manifest = ManifestFactory.manifest(forManifestJSON: manifestJson)
+        expect(manifest.getPluginProperties(packageName: "test")).to(beNil())
+      }
+
+      it("should return matched plugin properties") {
+        let manifestJson = ["plugins": [["test", ["foo": "bar"]]]]
+        let manifest = ManifestFactory.manifest(forManifestJSON: manifestJson)
+        let props = manifest.getPluginProperties(packageName: "test")
+        expect(props as? [String: String]) == ["foo": "bar"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Why

currently we enable the network inspector through `expo-build-properties`, e.g. in app.json

```json
{
  "expo": {
    "plugins": [
      [
        "expo-build-properties",
        {
          "android": {
            "unstable_networkInspector": true
          },
          "ios": {
            "unstable_networkInspector": true
          }
        }
      ]
    ]
  }
}
```

to support this feature on expo go, i want to leverage the same configuration without introducing new properties to app.json schema. this pr adds `Manifests.getPluginProperties` to query properties from the `plugins` array.

# How

- introduce `Manifests.getPluginProperties(packageName: String): [String: Any]?` that will return the matched `packageName` inside the plugins. for package setting without extra properties, e.g. `plugins: ["expo-camera"]`, this function will also return nil.
- also move the original android instrumentation tests as unit tests. that would be faster without android emulator.


#### Usage example

for instance, to get the `unstable_networkInspector`, we can call it like:

```objc
    NSDictionary<NSString *, id> *buildProps = [_appRecord.appLoader.manifest getPluginPropertiesWithPackageName:@"expo-build-properties"];
    BOOL networkInspector = [[[buildProps objectForKey:@"ios"] objectForKey:@"unstable_networkInspector"] boolValue];
```

```kotlin
    val buildProps = (instanceManagerBuilderProperties.manifest.getPluginProperties("expo-build-properties")?.get("android") as? Map<*, *>)
      ?.mapKeys { it.key.toString() }
    val networkInspector = buildProps?.get("unstable_networkInspector") as? Boolean ?: false
```

# Test Plan

- add unit tests both on android and ios

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).