### PR TITLE
[docs] Add a note about scenario for generating keystore for an existing app/release build

### DIFF
--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -42,7 +42,7 @@ There are three types of client IDs you can provide to the AuthSession API depen
 
 ### Setup consent screen
 
-On the Credentials page, click the **Create credentials** button, select **OAuth client ID** and then click **Configure Consent screen**. You will be prompted to select properties such as **User Type** and other app-related information on this page. Continue the process and when you are done, proceed with the next step.
+On the Credentials page, click the **Create credentials** button, select **OAuth Client Id** and then click **Configure Consent screen**. You will be prompted to select properties such as **User Type** and other app-related information on this page. Continue the process and when you are done, proceed with the next step.
 
 </Step>
 
@@ -60,7 +60,7 @@ For Android, install the [`expo-application`](/versions/latest/sdk/application/)
 
 Create a [`androidClientId`](/versions/latest/sdk/auth-session/#googleauthrequestconfig--properties) by following the steps below from the Google Cloud console:
 
-- In the Google Cloud console, go to **Credentials** > **Create OAuth client** page.
+- In the Google Cloud console, go to **Credentials** page and then click **Create credentials** > **OAuth Client Id**.
 - For **Application type**, select **Android** from the dropdown menu.
 - For **Name**, enter the name such as **Android Client ID** to identify different client IDs in case you have more than one for multiple platforms.
 - Under **Package name**, enter the package name of your app. This is the same package name you have set up in the app config file under [`android.package`](/versions/latest/config/app/#package) field, for example, `com.example.myapp`.

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -326,6 +326,7 @@ For bare workflow, your project needs to conform to the URI scheme matching your
 
 ## Learn more
 
+- [`react-native-google-signin`](https://github.com/react-native-google-signin/google-signin#expo-installation): A native library for Google authentication.
 - [AuthSession API reference](/versions/latest/sdk/auth-session/)
 - [How browser-based authentication works?](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work)
 - [Google authentication provider reference](/versions/latest/sdk/auth-session/#google)

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -66,7 +66,7 @@ Create a [`androidClientId`](/versions/latest/sdk/auth-session/#googleauthreques
 - Under **Package name**, enter the package name of your app. This is the same package name you have set up in the app config file under [`android.package`](/versions/latest/config/app/#package) field, for example, `com.example.myapp`.
 - Under **SHA-1 certificate fingerprint**, you'll need to add the signing certificate value. To get this value:
   > **warning** If you have an existing app or have uploaded a release build to the Google Play Store, you do not need to re-generate the keystore as described below. You can find the SHA-1 certificate fingerprint in the Google Play Console under **Release** > **Setup** > **App Integrity** > **App signing key certificate** and use that signing certificate value instead.
-  > However, if you are using a development build on a new project, you'll need to generate a new keystore by following the steps below.
+  > However, if you're creating new project, you'll need to generate a new keystore by following the steps below.
   - In the terminal window, run `eas credentials -p android`, then select the build profile. For example, if you are generating the credential for development, select the build profile for it.
   - Select **Keystore: Manage everything needed to build your project** > **Set up a new keystore** > select the default value for **Assign a name to your build credentials** > press <kbd>Y</kbd> to **Generate a new Android Keystore**.
   - This will generate a new keystore and print the SHA-1 certificate fingerprint.

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -65,12 +65,14 @@ Create a [`androidClientId`](/versions/latest/sdk/auth-session/#googleauthreques
 - For **Name**, enter the name such as **Android Client ID** to identify different client IDs in case you have more than one for multiple platforms.
 - Under **Package name**, enter the package name of your app. This is the same package name you have set up in the app config file under [`android.package`](/versions/latest/config/app/#package) field, for example, `com.example.myapp`.
 - Under **SHA-1 certificate fingerprint**, you'll need to add the signing certificate value. To get this value:
+  > **warning** If you have an existing app or have uploaded a release build to the Google Play Store, you do not need to re-generate the keystore as described below. You can find the SHA-1 certificate fingerprint in the Google Play Console under **Release** > **Setup** > **App Integrity** > **App signing key certificate** and use that signing certificate value instead.
+  > However, if you are using a development build on a new project, you'll need to generate a new keystore by following the steps below.
   - In the terminal window, run `eas credentials -p android`, then select the build profile. For example, if you are generating the credential for development, select the build profile for it.
   - Select **Keystore: Manage everything needed to build your project** > **Set up a new keystore** > select the default value for **Assign a name to your build credentials** > press <kbd>Y</kbd> to **Generate a new Android Keystore**.
-  - This will generate a new keystore and print the SHA-1 certificate fingerprint. Copy the value of **SHA1 Fingerprint** and paste it into the Google Cloud console.
-- Click **Save**.
+  - This will generate a new keystore and print the SHA-1 certificate fingerprint.
+- Copy the value of **SHA1 Fingerprint** and paste it into the Google Cloud console and click **Save**.
 
-> Whenever you change values in the app config file, you'll need to rebuild the native app.
+> Whenever you change values in the app config, you'll need to rebuild the native app.
 
 </Tab>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [forums](https://forums.expo.dev/t/potential-liability-with-instructions-for-google-authentication/71696?u=amanhimself) & [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1685008610982409)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding the note to clarify instructions on to only generate a keystone for a new project and not for existing projects/apps that already has a release build or a keystone generated.
- Update first instruction which was inaccurate.
- Add link to `react-native-google-signin` native library in the Learn more section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Following changes have been tested by running docs locally:

<img width="670" alt="CleanShot 2023-05-31 at 20 45 21@2x" src="https://github.com/expo/expo/assets/10234615/9ee7ea64-3faa-4bfc-bb88-dcb5e288590f">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
