### PR TITLE
[docs] Add embedded video links in different docs

### DIFF
--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -4,6 +4,7 @@ description: Learn about different version types and how to manage them remotely
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import Video from '~/components/plugins/Video';
 
 Android and iOS each expose two values that identify the version of an application; one that is visible in stores, and another that is visible only to developers.
 
@@ -16,9 +17,11 @@ In managed projects, we use fields `version`/`android.versionCode`/`ios.buildNum
 
 One of the most frequent causes of app store rejections is submitting a build with a duplicate version number. This happens when a developer forgets to increment the version number prior to running a build.
 
-EAS Build can manage automatically incrementing these versions for you if you opt in to using the "remote" app version source. The default behavior is to use a "local" app version source, which means you control versions manually in their respective config files.
+EAS Build can manage automatically incrementing these versions for you if you opt into using the "remote" app version source. The default behavior is to use a "local" app version source, which means you control versions manually in their respective config files.
 
 To simplify the descriptions, we will use **app.json** terminology (`version`/`versionCode`/`buildNumber`) for the rest of this page, but unless stated otherwise, the same applies to bare projects.
+
+<Video url="https://www.youtube.com/embed/Gk7RHDWsLsQ" />
 
 ## Examples
 

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -7,8 +7,11 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { EasSubmitIcon, EasMetadataIcon } from '@expo/styleguide-icons';
+import Video from '~/components/plugins/Video';
 
 **EAS Submit** is a hosted service that allows uploading and submitting app binaries to the app stores using EAS CLI. This guide describes how to submit your app to the Google Play Store and Apple App Store using EAS Submit.
+
+<Video url="https://www.youtube.com/embed/-KZjr576tuE" />
 
 ## Google Play Store
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -9,8 +9,11 @@ import { Tab, Tabs } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import Video from '~/components/plugins/Video';
 
 Development builds can be created with [EAS Build](/build/introduction/) or [locally](/develop/development-builds/development-workflows/#build-locally-with-android-studio-and-xcode) on your computer if you have Android Studio and Xcode installed.
+
+<Video url="https://www.youtube.com/embed/LUFHXsBcW6w" />
 
 In this guide, you'll find information on how to create a development build and then install them on an emulator/simulator or a physical device to continue developing your app.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add videos recently created by Keith (that are already published on our official YT channel).

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By using `Video` component to embed videos on different pages.
- Also, fix a typo in one doc.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Following changes have been tested by running docs locally:

<img width="1340" alt="CleanShot 2023-05-31 at 21 25 25@2x" src="https://github.com/expo/expo/assets/10234615/1f5f4de9-2660-438b-977a-ed634645c095">

<img width="1341" alt="CleanShot 2023-05-31 at 21 25 55@2x" src="https://github.com/expo/expo/assets/10234615/5ca0a363-e0b6-4339-9610-7dddf74678a0">

<img width="1320" alt="CleanShot 2023-05-31 at 21 26 19@2x" src="https://github.com/expo/expo/assets/10234615/a31bf19e-c4c5-429f-bc23-7fc9c836b2c1">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
