### PR TITLE
[docs] Add instructions for static config and EAS builds

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -14,7 +14,6 @@ Environment variables are key-value pairs configured outside your source code th
 
 In the app config, there is an `extra` property. If your variables are non-sensitive and can be checked into source code, you can just add them to the app.json `extra` property for local builds.
 
-For EAS builds, also add your environment variables to build.production.env in eas.json.
 
 ### Dynamic app config
 

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -12,7 +12,9 @@ Environment variables are key-value pairs configured outside your source code th
 
 ## Using the `extra` field
 
-In the app config, there is an `extra` property. This property is available when you publish your project with EAS Update and when you build with EAS Build.
+In the app config, there is an `extra` property. If your variables are non-sensitive and can be checked into source code, you can just add them to the app.json `extra` property for local builds.
+
+For EAS builds, also add your environment variables to build.production.env in eas.json.
 
 ### Dynamic app config
 


### PR DESCRIPTION
1. Static config is appropriate if variables can be in source code
2. EAS builds appear to require env variables in eas.json, not app config

# Why

The instructions seem incomplete with respect to static builds and EAS.

# How

N/A

# Test Plan

N/A

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
