### PR TITLE
[dev-menu] Improve onboarding messaging

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### 💡 Others
 
+- Update onboarding text to be more concise and clear, and fix compat with large text accessibiltiy settings. ([#22712](https://github.com/expo/expo/pull/22712) by [@brentvatne](https://github.com/brentvatne))
+
 ## 3.0.0 — 2023-05-08
 
 ### 🛠 Breaking changes

--- a/packages/expo-dev-menu/app/App.tsx
+++ b/packages/expo-dev-menu/app/App.tsx
@@ -27,8 +27,7 @@ export function App({
     <View style={{ flex: 1, direction: 'ltr' }}>
       <AppProviders appInfo={appInfo} devSettings={devSettings} menuPreferences={menuPreferences}>
         <LoadInitialData loader={<Splash />}>
-          <Main registeredCallbacks={registeredCallbacks} />
-          <Onboarding isDevice={isDevice} />
+          <Main registeredCallbacks={registeredCallbacks} isDevice={isDevice} />
         </LoadInitialData>
       </AppProviders>
     </View>

--- a/packages/expo-dev-menu/app/components/LoadInitialData.tsx
+++ b/packages/expo-dev-menu/app/components/LoadInitialData.tsx
@@ -5,7 +5,7 @@ import { loadFontsAsync } from '../native-modules/DevMenu';
 import { Splash } from './Splash';
 
 type LoadInitialDataProps = {
-  children: React.ReactElement<any>[];
+  children: React.ReactElement<any> | React.ReactElement<any>[];
   loader?: React.ReactElement<any>;
 };
 

--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -28,12 +28,14 @@ import { useClipboard } from '../hooks/useClipboard';
 import { useDevSettings } from '../hooks/useDevSettings';
 import { isDevLauncherInstalled } from '../native-modules/DevLauncher';
 import { hideMenu, fireCallbackAsync } from '../native-modules/DevMenu';
+import { Onboarding } from './Onboarding';
 
 type MainProps = {
   registeredCallbacks?: string[];
+  isDevice?: boolean;
 };
 
-export function Main({ registeredCallbacks = [] }: MainProps) {
+export function Main({ registeredCallbacks = [], isDevice }: MainProps) {
   const appInfo = useAppInfo();
   const { devSettings, actions } = useDevSettings();
 
@@ -125,238 +127,242 @@ export function Main({ registeredCallbacks = [] }: MainProps) {
       </View>
 
       <Divider />
-      <ScrollView nestedScrollEnabled>
-        {Boolean(appInfo.hostUrl) && (
-          <>
-            <View bg="default" padding="medium">
-              <Text color="secondary">Connected to:</Text>
-
-              <Spacer.Vertical size="small" />
-
-              <Row align="center">
-                <StatusIndicator style={{ width: 10, height: 10 }} status="success" />
-                <Spacer.Horizontal size="small" />
-                <View flex="1">
-                  <Text type="mono" numberOfLines={2} size="small">
-                    {appInfo.hostUrl}
-                  </Text>
-                </View>
-                <Spacer.Horizontal size="small" />
-              </Row>
-            </View>
-
-            <Divider />
-          </>
-        )}
-
-        <Row padding="small">
-          {isDevLauncherInstalled && (
-            <View flex="1">
-              <ActionButton
-                icon={<HomeFilledIcon />}
-                label="Go home"
-                onPress={actions.navigateToLauncher}
-              />
-            </View>
-          )}
-
-          <Spacer.Horizontal size="medium" />
-
-          <View flex="1">
-            <ActionButton icon={<ClipboardIcon />} label="Copy link" onPress={onCopyUrlPress} />
-          </View>
-
-          <Spacer.Horizontal size="medium" />
-
-          <View flex="1">
-            <ActionButton icon={<RefreshIcon />} label="Reload" onPress={actions.reload} />
-          </View>
-        </Row>
-
-        {registeredCallbacks.length > 0 && (
-          <View>
-            <View mx="large">
-              <Heading size="small" color="secondary">
-                Custom Menu Items
-              </Heading>
-            </View>
-
-            <Spacer.Vertical size="small" />
-
-            <View mx="small">
-              {registeredCallbacks.map((name, index, arr) => {
-                const isFirst = index === 0;
-                const isLast = index === arr.length - 1;
-                const onPress = () => fireCallbackAsync(name);
-
-                return (
-                  <View key={name + index}>
-                    <View
-                      bg="default"
-                      roundedTop={isFirst ? 'large' : 'none'}
-                      roundedBottom={isLast ? 'large' : 'none'}>
-                      <SettingsRowButton label={name} icon={null} onPress={onPress} />
-                    </View>
-                    {!isLast && <Divider />}
-                  </View>
-                );
-              })}
-            </View>
-
-            <Spacer.Vertical size="medium" />
-          </View>
-        )}
-
-        <View mx="small">
-          <View roundedTop="large" bg="default">
-            <SettingsRowButton
-              disabled={!devSettings.isPerfMonitorAvailable}
-              label="Toggle performance monitor"
-              icon={<PerformanceIcon />}
-              onPress={actions.togglePerformanceMonitor}
-            />
-          </View>
-          <Divider />
-          <View bg="default">
-            <SettingsRowButton
-              disabled={!devSettings.isElementInspectorAvailable}
-              label="Toggle element inspector"
-              icon={<InspectElementIcon />}
-              onPress={actions.toggleElementInspector}
-            />
-          </View>
-          <Divider />
-          {devSettings.isJSInspectorAvailable ? (
-            <View bg="default">
-              <SettingsRowButton
-                disabled={!devSettings.isJSInspectorAvailable}
-                label="Open JS debugger"
-                icon={<DebugIcon />}
-                onPress={actions.openJSInspector}
-              />
-            </View>
-          ) : (
-            <View bg="default">
-              <SettingsRowSwitch
-                disabled={
-                  appInfo?.sdkVersion && semver.lt(appInfo.sdkVersion, '49.0.0')
-                    ? !devSettings.isRemoteDebuggingAvailable
-                    : true
-                }
-                testID="remote-js-debugger"
-                label="Remote JS debugger"
-                icon={<DebugIcon />}
-                isEnabled={devSettings.isDebuggingRemotely}
-                setIsEnabled={actions.toggleDebugRemoteJS}
-                description={
-                  !appInfo?.sdkVersion || semver.lt(appInfo.sdkVersion, '49.0.0')
-                    ? `This is not compatible with ${
-                        appInfo?.engine ?? 'JSC'
-                      } in this SDK version, please use Hermes to debug.`
-                    : undefined
-                }
-              />
-            </View>
-          )}
-          <Divider />
-          <View bg="default" roundedBottom="large">
-            <SettingsRowSwitch
-              disabled={!devSettings.isHotLoadingAvailable}
-              testID="fast-refresh"
-              label="Fast refresh"
-              icon={<RunIcon />}
-              isEnabled={devSettings.isHotLoadingEnabled}
-              setIsEnabled={actions.toggleFastRefresh}
-            />
-          </View>
-        </View>
-
-        {appInfo.engine === 'Hermes' && (
-          <>
-            <Spacer.Vertical size="large" />
-
-            <View mx="small">
-              <View bg="warning" padding="medium" rounded="medium" border="warning">
-                <Row align="center">
-                  <WarningIcon />
-
-                  <Spacer.Horizontal size="tiny" />
-
-                  <Heading color="warning" size="small" style={{ top: 1 }}>
-                    Warning
-                  </Heading>
-                </Row>
+      <View style={{ flex: 1 }}>
+        <ScrollView nestedScrollEnabled>
+          {Boolean(appInfo.hostUrl) && (
+            <>
+              <View bg="default" padding="medium">
+                <Text color="secondary">Connected to:</Text>
 
                 <Spacer.Vertical size="small" />
 
-                <View>
-                  <Text size="small" color="warning">
-                    Debugging not working? Try manually reloading first
-                  </Text>
+                <Row align="center">
+                  <StatusIndicator style={{ width: 10, height: 10 }} status="success" />
+                  <Spacer.Horizontal size="small" />
+                  <View flex="1">
+                    <Text type="mono" numberOfLines={2} size="small">
+                      {appInfo.hostUrl}
+                    </Text>
+                  </View>
+                  <Spacer.Horizontal size="small" />
+                </Row>
+              </View>
+
+              <Divider />
+            </>
+          )}
+
+          <Row padding="small">
+            {isDevLauncherInstalled && (
+              <View flex="1">
+                <ActionButton
+                  icon={<HomeFilledIcon />}
+                  label="Go home"
+                  onPress={actions.navigateToLauncher}
+                />
+              </View>
+            )}
+
+            <Spacer.Horizontal size="medium" />
+
+            <View flex="1">
+              <ActionButton icon={<ClipboardIcon />} label="Copy link" onPress={onCopyUrlPress} />
+            </View>
+
+            <Spacer.Horizontal size="medium" />
+
+            <View flex="1">
+              <ActionButton icon={<RefreshIcon />} label="Reload" onPress={actions.reload} />
+            </View>
+          </Row>
+
+          {registeredCallbacks.length > 0 && (
+            <View>
+              <View mx="large">
+                <Heading size="small" color="secondary">
+                  Custom Menu Items
+                </Heading>
+              </View>
+
+              <Spacer.Vertical size="small" />
+
+              <View mx="small">
+                {registeredCallbacks.map((name, index, arr) => {
+                  const isFirst = index === 0;
+                  const isLast = index === arr.length - 1;
+                  const onPress = () => fireCallbackAsync(name);
+
+                  return (
+                    <View key={name + index}>
+                      <View
+                        bg="default"
+                        roundedTop={isFirst ? 'large' : 'none'}
+                        roundedBottom={isLast ? 'large' : 'none'}>
+                        <SettingsRowButton label={name} icon={null} onPress={onPress} />
+                      </View>
+                      {!isLast && <Divider />}
+                    </View>
+                  );
+                })}
+              </View>
+
+              <Spacer.Vertical size="medium" />
+            </View>
+          )}
+
+          <View mx="small">
+            <View roundedTop="large" bg="default">
+              <SettingsRowButton
+                disabled={!devSettings.isPerfMonitorAvailable}
+                label="Toggle performance monitor"
+                icon={<PerformanceIcon />}
+                onPress={actions.togglePerformanceMonitor}
+              />
+            </View>
+            <Divider />
+            <View bg="default">
+              <SettingsRowButton
+                disabled={!devSettings.isElementInspectorAvailable}
+                label="Toggle element inspector"
+                icon={<InspectElementIcon />}
+                onPress={actions.toggleElementInspector}
+              />
+            </View>
+            <Divider />
+            {devSettings.isJSInspectorAvailable ? (
+              <View bg="default">
+                <SettingsRowButton
+                  disabled={!devSettings.isJSInspectorAvailable}
+                  label="Open JS debugger"
+                  icon={<DebugIcon />}
+                  onPress={actions.openJSInspector}
+                />
+              </View>
+            ) : (
+              <View bg="default">
+                <SettingsRowSwitch
+                  disabled={
+                    appInfo?.sdkVersion && semver.lt(appInfo.sdkVersion, '49.0.0')
+                      ? !devSettings.isRemoteDebuggingAvailable
+                      : true
+                  }
+                  testID="remote-js-debugger"
+                  label="Remote JS debugger"
+                  icon={<DebugIcon />}
+                  isEnabled={devSettings.isDebuggingRemotely}
+                  setIsEnabled={actions.toggleDebugRemoteJS}
+                  description={
+                    !appInfo?.sdkVersion || semver.lt(appInfo.sdkVersion, '49.0.0')
+                      ? `This is not compatible with ${
+                          appInfo?.engine ?? 'JSC'
+                        } in this SDK version, please use Hermes to debug.`
+                      : undefined
+                  }
+                />
+              </View>
+            )}
+            <Divider />
+            <View bg="default" roundedBottom="large">
+              <SettingsRowSwitch
+                disabled={!devSettings.isHotLoadingAvailable}
+                testID="fast-refresh"
+                label="Fast refresh"
+                icon={<RunIcon />}
+                isEnabled={devSettings.isHotLoadingEnabled}
+                setIsEnabled={actions.toggleFastRefresh}
+              />
+            </View>
+          </View>
+
+          {appInfo.engine === 'Hermes' && (
+            <>
+              <Spacer.Vertical size="large" />
+
+              <View mx="small">
+                <View bg="warning" padding="medium" rounded="medium" border="warning">
+                  <Row align="center">
+                    <WarningIcon />
+
+                    <Spacer.Horizontal size="tiny" />
+
+                    <Heading color="warning" size="small" style={{ top: 1 }}>
+                      Warning
+                    </Heading>
+                  </Row>
+
+                  <Spacer.Vertical size="small" />
+
+                  <View>
+                    <Text size="small" color="warning">
+                      Debugging not working? Try manually reloading first
+                    </Text>
+                  </View>
                 </View>
               </View>
-            </View>
-          </>
-        )}
-
-        {!hasDisabledDevSettingOption && (
-          <>
-            <Spacer.Vertical size="large" />
-            <Text size="small" color="secondary" align="center">
-              Some settings are unavailable for this development build.
-            </Text>
-          </>
-        )}
-
-        <Spacer.Vertical size="large" />
-
-        <View mx="small" rounded="large" overflow="hidden">
-          <AppInfoRow title="Version" value={appInfo.appVersion} />
-          <Divider />
-          {Boolean(appInfo.runtimeVersion) && (
-            <>
-              <AppInfoRow title="Runtime version" value={appInfo.runtimeVersion} />
-              <Divider />
             </>
           )}
 
-          {Boolean(appInfo.sdkVersion) && !appInfo.runtimeVersion && (
+          {!hasDisabledDevSettingOption && (
             <>
-              <AppInfoRow title="SDK Version" value={appInfo.sdkVersion} />
-              <Divider />
-            </>
-          )}
-
-          <Button.FadeOnPressContainer
-            bg="default"
-            roundedTop="none"
-            roundedBottom="large"
-            onPress={onCopyAppInfoPress}
-            disabled={hasCopiedAppInfoContent}>
-            <Row px="medium" py="small" align="center" bg="default">
-              <Text color="link" size="medium">
-                {hasCopiedAppInfoContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
+              <Spacer.Vertical size="large" />
+              <Text size="small" color="secondary" align="center">
+                Some settings are unavailable for this development build.
               </Text>
-            </Row>
-          </Button.FadeOnPressContainer>
-        </View>
+            </>
+          )}
 
-        <Spacer.Vertical size="large" />
-        <View mx="small" rounded="large" overflow="hidden">
-          <Button.FadeOnPressContainer
-            bg="default"
-            roundedTop="none"
-            roundedBottom="large"
-            onPress={actions.openRNDevMenu}>
-            <Row px="medium" py="small" align="center" bg="default">
-              <Text>Open React Native dev menu</Text>
-            </Row>
-          </Button.FadeOnPressContainer>
-        </View>
+          <Spacer.Vertical size="large" />
 
-        {Platform.OS === 'android' && <View style={{ height: 50 }} />}
-        <Spacer.Vertical size="large" />
-      </ScrollView>
+          <View mx="small" rounded="large" overflow="hidden">
+            <AppInfoRow title="Version" value={appInfo.appVersion} />
+            <Divider />
+            {Boolean(appInfo.runtimeVersion) && (
+              <>
+                <AppInfoRow title="Runtime version" value={appInfo.runtimeVersion} />
+                <Divider />
+              </>
+            )}
+
+            {Boolean(appInfo.sdkVersion) && !appInfo.runtimeVersion && (
+              <>
+                <AppInfoRow title="SDK Version" value={appInfo.sdkVersion} />
+                <Divider />
+              </>
+            )}
+
+            <Button.FadeOnPressContainer
+              bg="default"
+              roundedTop="none"
+              roundedBottom="large"
+              onPress={onCopyAppInfoPress}
+              disabled={hasCopiedAppInfoContent}>
+              <Row px="medium" py="small" align="center" bg="default">
+                <Text color="link" size="medium">
+                  {hasCopiedAppInfoContent ? 'Copied to clipboard!' : 'Tap to Copy All'}
+                </Text>
+              </Row>
+            </Button.FadeOnPressContainer>
+          </View>
+
+          <Spacer.Vertical size="large" />
+          <View mx="small" rounded="large" overflow="hidden">
+            <Button.FadeOnPressContainer
+              bg="default"
+              roundedTop="none"
+              roundedBottom="large"
+              onPress={actions.openRNDevMenu}>
+              <Row px="medium" py="small" align="center" bg="default">
+                <Text>Open React Native dev menu</Text>
+              </Row>
+            </Button.FadeOnPressContainer>
+          </View>
+
+          {Platform.OS === 'android' && <View style={{ height: 50 }} />}
+          <Spacer.Vertical size="large" />
+        </ScrollView>
+
+        <Onboarding isDevice={isDevice} />
+      </View>
     </View>
   );
 }

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -15,7 +15,7 @@ const simulatorMessage = Platform.select({
       You can open it at any time with the <Text weight="bold">{'\u2318 + d '}</Text> keyboard
       shortcut{' '}
       <Text color="secondary" size="medium">
-        ('Connect Hardware Keyboard' must be enabled on your simulator to use this shortcut, you can
+        ("Connect Hardware Keyboard" must be enabled on your simulator to use this shortcut, you can
         toggle it with{' '}
         <Text weight="bold" color="secondary" size="medium">
           {'\u2318 + shift + K'}

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -57,13 +57,15 @@ export function Onboarding({ isDevice }: OnboardingProps) {
       <View style={StyleSheet.absoluteFill}>
         <View flex="1" bg="default" py="medium" px="large">
           <View>
-            <Text size="medium">
+            <Text size="medium" maxFontSizeMultiplier={1.2}>
               This is the developer menu. It gives you access to useful tools in your development
               builds.
             </Text>
 
             <Spacer.Vertical size="medium" />
-            <Text size="medium">{isDevice ? deviceMessage : simulatorMessage}</Text>
+            <Text size="medium" maxFontSizeMultiplier={1.2}>
+              {isDevice ? deviceMessage : simulatorMessage}
+            </Text>
           </View>
 
           <Spacer.Vertical size="large" />

--- a/packages/expo-dev-menu/app/components/Onboarding.tsx
+++ b/packages/expo-dev-menu/app/components/Onboarding.tsx
@@ -1,17 +1,42 @@
-import { Heading, View, Text, Spacer, Button } from 'expo-dev-client-components';
+import { View, Text, Spacer, Button } from 'expo-dev-client-components';
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 
 import { useMenuPreferences } from '../hooks/useMenuPreferences';
 
 const deviceMessage = Platform.select({
-  ios: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
-  android: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that you can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  ios: `You can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  android: `You can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
 });
 
 const simulatorMessage = Platform.select({
-  ios: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that in a simulator you can press \u2318D (make sure that 'I/O \u279E Input \u279E Send Keyboard Input to Device' is enabled on your simulator) to get back to it at any time.`,
-  android: `Since this is your first time opening this development build, we wanted to show you this menu and let you know that in an emulator you can press \u2318M on macOS or Ctrl+M on other platforms to get back to it at any time.`,
+  ios: (
+    <Text size="medium">
+      You can open it at any time with the <Text weight="bold">{'\u2318 + d '}</Text> keyboard
+      shortcut{' '}
+      <Text color="secondary" size="medium">
+        ('Connect Hardware Keyboard' must be enabled on your simulator to use this shortcut, you can
+        toggle it with{' '}
+        <Text weight="bold" color="secondary" size="medium">
+          {'\u2318 + shift + K'}
+        </Text>
+        ).
+      </Text>
+    </Text>
+  ),
+  android: (
+    <Text size="medium">
+      You can press{' '}
+      <Text size="medium" weight="bold">
+        {'\u2318 + m'}
+      </Text>{' '}
+      on macOS or{' '}
+      <Text size="medium" weight="bold">
+        Ctrl + m
+      </Text>{' '}
+      on other platforms to get back to it at any time.
+    </Text>
+  ),
 });
 
 type OnboardingProps = {
@@ -30,34 +55,26 @@ export function Onboarding({ isDevice }: OnboardingProps) {
   if (isVisible) {
     return (
       <View style={StyleSheet.absoluteFill}>
-        <View style={StyleSheet.absoluteFill}>
-          <View flex="1" bg="default" py="large" px="large">
-            <Heading size="large" weight="bold">
-              Hello there, friend! 👋
-            </Heading>
+        <View flex="1" bg="default" py="medium" px="large">
+          <View>
+            <Text size="medium">
+              This is the developer menu. It gives you access to useful tools in your development
+              builds.
+            </Text>
 
             <Spacer.Vertical size="medium" />
-
-            <View>
-              <Text size="large">{isDevice ? deviceMessage : simulatorMessage}</Text>
-
-              <Spacer.Vertical size="medium" />
-              <Text size="large">
-                Also, this menu is only available in development builds and won't be in any release
-                builds.
-              </Text>
-            </View>
-
-            <Spacer.Vertical size="xl" />
-
-            <Button.FadeOnPressContainer bg="primary" onPress={onOnboardingFinishedPress}>
-              <View py="small">
-                <Button.Text align="center" size="large" color="primary" weight="medium">
-                  Got It
-                </Button.Text>
-              </View>
-            </Button.FadeOnPressContainer>
+            <Text size="medium">{isDevice ? deviceMessage : simulatorMessage}</Text>
           </View>
+
+          <Spacer.Vertical size="large" />
+
+          <Button.FadeOnPressContainer bg="primary" onPress={onOnboardingFinishedPress}>
+            <View py="small">
+              <Button.Text align="center" size="medium" color="primary" weight="medium">
+                Continue
+              </Button.Text>
+            </View>
+          </Button.FadeOnPressContainer>
         </View>
       </View>
     );


### PR DESCRIPTION
# Why

Fixes ENG-7806 and also just generally makes the message more concise / clear, and updates the name of the keyboard option in the iOS simulator.

# How

- Rewrote a bunch of the text, using my own brain (not even ChatGPT)
- Made the header of the dev menu visible so there's some shared UI between onboarding and the regular dev menu (ie: I think it looks nice)
- Reducing the amount of text made it all fit on the maximum accessibility enlarged font size (multiplied by x1.69 on iOS). I changed the max multiplier to 1.2x to give a bit of a buffer.

See screenshots below, all done in iOS simulator by toggling the conditionals.

### iOS Simulator text

<img width="466" alt="Screen Shot 2023-05-31 at 3 35 36 PM" src="https://github.com/expo/expo/assets/90494/6587c804-53f7-4409-a7b0-2f8c02e59cc7">

### Android emulator text

<img width="466" alt="Screen Shot 2023-05-31 at 3 35 18 PM" src="https://github.com/expo/expo/assets/90494/6660874c-ca46-4dff-9c93-85d35dc84529">

### iOS/Android device text

<img width="466" alt="Screen Shot 2023-05-31 at 3 36 15 PM" src="https://github.com/expo/expo/assets/90494/db5aa824-d717-47f8-bab0-e5ed5408af21">

# Test Plan

- Try out the UI in iOS simulator in various scenarios
- I should also verify it on Android, but I haven't yet

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
