### PR TITLE
[docs] fix robots meta tag logic

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -124,11 +124,10 @@ export default function DocumentationPage(props: Props) {
             content={RoutesUtils.isReferencePath(pathname) ? version : 'none'}
           />
         )}
-        {version === 'unversioned' ? (
-          (RoutesUtils.isPreviewPath(pathname) || RoutesUtils.isArchivePath(pathname)) && (
-            <meta name="robots" content="noindex" />
-          )
-        ) : (
+        {(version === 'unversioned' ||
+          RoutesUtils.isPreviewPath(pathname) ||
+          RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
+        {version !== 'latest' && version !== 'unversioned' && (
           <link rel="canonical" href={getCanonicalUrl(pathname)} />
         )}
       </Head>


### PR DESCRIPTION
# Why

Prevents unversioned pages from appearing in the search results. Thanks Kim for the report! 👍 

![image_720](https://github.com/expo/expo/assets/719641/5c634bfb-bd92-4f60-98d0-2cb1c8817310)

# How

Correct the logic responsible for adding robots meta tag.

# Test Plan

I have made sure that correct meta tags are added to pages, while runinning docs app locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
