### PR TITLE
[dev-launcher] fix hermes inspector connection issue

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 - Fixed Home screen KeyboardAvoidingView. ([#22661](https://github.com/expo/expo/pull/22661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Refactored network inspector code and add unit tests. ([#22669](https://github.com/expo/expo/pull/22669), [#22693](https://github.com/expo/expo/pull/22693) by [@kudo](https://github.com/kudo))
+- Fixed `No compatible apps connected. JavaScript Debugging can only be used with the Hermes engine.` when using JavaScript debugger on Android. ([#20280](https://github.com/expo/expo/pull/20280) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.JSBundleLoader
 import com.facebook.react.devsupport.DevLauncherInternalSettings
 import expo.interfaces.devmenu.annotations.ContainsDevMenuExtension
 import expo.modules.devlauncher.react.DevLauncherDevSupportManagerSwapper
+import expo.modules.devlauncher.rncompatibility.DevLauncherDevSupportManager
 import okhttp3.HttpUrl
 
 fun injectReactInterceptor(
@@ -37,11 +38,7 @@ fun injectReactInterceptor(
     debugServerHost,
     appBundleName
   )
-
-  // inspector connection will create right after ReactInstanceManager construction,
-  // we should reconnect here to use intercepted inspector server host.
-  reactNativeHost.reactInstanceManager.devSupportManager.stopInspector()
-  reactNativeHost.reactInstanceManager.devSupportManager.startInspector()
+  (reactNativeHost.reactInstanceManager.devSupportManager as? DevLauncherDevSupportManager)?.startInspectorWhenDevLauncherReady()
 
   return result
 }

--- a/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-69/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -139,6 +139,18 @@ class DevLauncherDevSupportManager(
     )
   }
 
+  override fun startInspector() {
+    // no-op for the default `startInspector` which would be implicitly called
+    // right after `ReactInstanceManager` construction.
+    // For dev-launcher, we should inject the correct dev server address and
+    // call our customized `startInspectorWhenDevLauncherReady`.
+    // Check `DevLauncherReactUtils.injectReactInterceptor()` for details.
+  }
+
+  fun startInspectorWhenDevLauncherReady() {
+    super.startInspector()
+  }
+
   // copied from https://github.com/facebook/react-native/blob/aa4da248c12e3ba41ecc9f1c547b21c208d9a15f/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java#L158-L165
   private fun getExecutorConnectCallback(
     future: SimpleSettableFuture<Boolean>

--- a/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -132,6 +132,18 @@ class DevLauncherDevSupportManager(
     )
   }
 
+  override fun startInspector() {
+    // no-op for the default `startInspector` which would be implicitly called
+    // right after `ReactInstanceManager` construction.
+    // For dev-launcher, we should inject the correct dev server address and
+    // call our customized `startInspectorWhenDevLauncherReady`.
+    // Check `DevLauncherReactUtils.injectReactInterceptor()` for details.
+  }
+
+  fun startInspectorWhenDevLauncherReady() {
+    super.startInspector()
+  }
+
   // copied from https://github.com/facebook/react-native/blob/aa4da248c12e3ba41ecc9f1c547b21c208d9a15f/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java#L158-L165
   private fun getExecutorConnectCallback(
     future: SimpleSettableFuture<Boolean>


### PR DESCRIPTION
# Why

fixes #20280
close ENG-8769

# How

our original `stopInspector() -> startInspector()` is not reliable because of thread race condition issue. looking into the [react-native code](https://github.com/facebook/react-native/blob/7f22db8ea034d1aed74103542b04af2a8a11caa1/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java#L207-L241), it posts task to background AsyncTask thread pool. so it could happen two different error cases:

### Case 1 with empty inspector targets
`http://localhost:8081/json/list` returns empty array
  1. openInspectorConnection() from ReactInstanceManager posted task
  2. openInspectorConnection() from ReactInstanceManager executed in AsyncTask thread pool
  3. closeInspectorConnection() from DevLauncherReactUtils posted task
  4. openInspectorConnection() from DevLauncherReactUtils showing warning `Inspector connection already open, nooping.`  and just returns.
  5. closeInspectorConnection() from DevLauncherReactUtils executed in AsyncTask thread pool

### Case 2 with double inspector targets
`http://localhost:8081/json/list` returns 6 items for bare-expo (2 + 1) x 2.
  1. openInspectorConnection() from ReactInstanceManager posted task
  2. closeInspectorConnection() from DevLauncherReactUtils posted task
  3. openInspectorConnection() from DevLauncherReactUtils posted task
  4. closeInspectorConnection() from DevLauncherReactUtils executed in AsyncTask thread pool
  5. openInspectorConnection() from ReactInstanceManager executed in the AsyncTask thread pool
  6. openInspectorConnection() from DevLauncherReactUtils executed in the AsyncTask thread pool
that is my hypothesis, i did not confirm with logging. since it's a thread pool, so the out-of-order case may happen.

here is the example of doubled inspect items:

```json
[
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D18%26page%3D2",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "18-2",
        "title": "Reanimated Runtime",
        "type": "node",
        "vm": "Hermes",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=18&page=2"
    },
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D18%26page%3D1",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "18-1",
        "title": "Hermes React Native",
        "type": "node",
        "vm": "Hermes",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=18&page=1"
    },
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D18%26page%3D-1",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "18--1",
        "title": "React Native Experimental (Improved Chrome Reloads)",
        "type": "node",
        "vm": "don't use",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=18&page=-1"
    },
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D19%26page%3D2",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "19-2",
        "title": "Reanimated Runtime",
        "type": "node",
        "vm": "Hermes",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=19&page=2"
    },
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D19%26page%3D1",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "19-1",
        "title": "Hermes React Native",
        "type": "node",
        "vm": "Hermes",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=19&page=1"
    },
    {
        "description": "dev.expo.payments",
        "devtoolsFrontendUrl": "devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=%5B%3A%3A1%5D%3A8081%2Finspector%2Fdebug%3Fdevice%3D19%26page%3D-1",
        "faviconUrl": "https://reactjs.org/favicon.ico",
        "id": "19--1",
        "title": "React Native Experimental (Improved Chrome Reloads)",
        "type": "node",
        "vm": "don't use",
        "webSocketDebuggerUrl": "ws://[::1]:8081/inspector/debug?device=19&page=-1"
    }
]
```

# Test Plan

tested on bare-expo and turning on `USE_DEV_CLIENT = true` in **MainApplication.java** 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
