### PR TITLE
[docs] link to FYI for additional Firebase JS auth setup

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -94,6 +94,8 @@ You do not have to install other plugins or configurations to use Firebase JS SD
 
 Firebase version 9 provides a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
 
+> Using Firebase Authentication? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
+
 </Step>
 
 <Step label="3">


### PR DESCRIPTION
# Why
When updating an example using the Firebase JS SDK, I found out that it wasn't persisting the auth session, meaning you had to login again every time you refreshed. At some point after `firebase` 9.1.3, it started defaulting to in-memory storage**. Between all the pre-9.x instructions still out there and the tendency for internet searches to return instructions that work for web but not React Native, but without saying they don't work for React Native, it's tricky to find what you need.

Further, once you find the needed `reactNativeLocalPersistence` persistence provider, you'll find that it doesn't work in SDK 48, as it uses the now-removed core local storage. [This at least will be fixed soon](https://github.com/firebase/firebase-js-sdk/pull/7128). While the custom persistence code should be short-lived, at least overriding the default persistence could be necessary indefinitely. It took me several hours to figure this all out, the Firebase JS SDK can otherwise be a splendid way to quickly bootstrap an app, so would like to save others the trouble with a concise, complete, and confirmed-working code example.

** EDIT: as I read me, it seems possible that this is instead fallback behavior due to local persistence not working, so don't want to presume it's an intentional default. Depending on how I apply `reactNativeLocalPersistence`, I can get actual errors about missing local storage functionality, or it fails silently, and the silent failure scenario is the exact same code that used to give me a deprecation warning, so it's unclear.

# How
Created an FYI with the details, added a callout for additional auth configuration in the Using Firebase guide.

# Test Plan
Looked at the doc, tried the link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
