### PR TITLE
[template fix] bug useColorScheme

### DIFF
--- a/templates/expo-template-tabs/components/Themed.tsx
+++ b/templates/expo-template-tabs/components/Themed.tsx
@@ -3,7 +3,8 @@
  * https://docs.expo.io/guides/color-schemes/
  */
 
-import { Text as DefaultText, useColorScheme, View as DefaultView } from 'react-native';
+import { Text as DefaultText, View as DefaultView } from 'react-native';
+import { useTheme } from '@react-navigation/native';
 
 import Colors from '../constants/Colors';
 
@@ -11,13 +12,13 @@ export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark
 ) {
-  const theme = useColorScheme() ?? 'light';
-  const colorFromProps = props[theme];
+  const { dark } = useTheme();
+  const colorFromProps = props[dark ? 'dark' : 'light'];
 
   if (colorFromProps) {
     return colorFromProps;
   } else {
-    return Colors[theme][colorName];
+    return Colors[dark ? 'dark' : 'light'][colorName];
   }
 }
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/assets/62757768/dd8b5d64-93fc-4133-a106-ddf04ab7f93d

There exists a bug where the system's dark mode does not activate once when a specific component is used.
(only in expo web, RNW)

# How

This template already uses @react-navigation/native, and as shown in the video above, the react-navigation area appears to work correctly. Therefore, the issue was resolved by using useTheme().


result

https://github.com/expo/expo/assets/62757768/f2114e6d-b16e-4704-8ad2-c6565b593815

# Checklist

N/A
