### PR TITLE
[home] Remove use of app redirect username

### DIFF
--- a/home/graphql.schema.json
+++ b/home/graphql.schema.json
@@ -4882,6 +4882,39 @@
             "deprecationReason": null
           },
           {
+            "name": "deleteAndroidAppCredentials",
+            "description": "Delete a set of credentials for an Android app",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "DeleteAndroidAppCredentialsResult",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "setFcm",
             "description": "Set the FCM push key to be used in an Android app",
             "args": [
@@ -7520,6 +7553,22 @@
             "deprecationReason": null
           },
           {
+            "name": "insights",
+            "description": "App query field for querying EAS Insights about this app",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "AppInsights",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "iosAppCredentials",
             "description": "iOS app credentials for the project",
             "args": [
@@ -9193,6 +9242,112 @@
           }
         ],
         "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "AppInsights",
+        "description": null,
+        "fields": [
+          {
+            "name": "totalUniqueUsers",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUsersByAppVersionOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "uniqueUsersByPlatformOverTime",
+            "description": null,
+            "args": [
+              {
+                "name": "timespan",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "InsightsTimespan",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "UniqueUsersOverTimeData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
         "enumValues": null,
         "possibleTypes": null
       },
@@ -13500,6 +13655,22 @@
             "deprecationReason": null
           },
           {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appBuildVersion",
             "description": null,
             "args": [],
@@ -16710,6 +16881,12 @@
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "PENDING_CANCEL",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "possibleTypes": null
@@ -17811,6 +17988,33 @@
       {
         "kind": "OBJECT",
         "name": "DeleteAccountSSOConfigurationResult",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteAndroidAppCredentialsResult",
         "description": null,
         "fields": [
           {
@@ -21865,6 +22069,49 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "InsightsTimespan",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "end",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "start",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
@@ -23307,50 +23554,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "OBJECT",
-        "name": "IosAppCredentialsQuery",
-        "description": null,
-        "fields": [
-          {
-            "name": "byId",
-            "description": null,
-            "args": [
-              {
-                "name": "iosAppCredentialsId",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "IosAppCredentials",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "ENUM",
         "name": "IosBuildType",
         "description": "@deprecated Use developmentClient option instead.",
@@ -24575,6 +24778,128 @@
         "possibleTypes": null
       },
       {
+        "kind": "OBJECT",
+        "name": "LineChartData",
+        "description": null,
+        "fields": [
+          {
+            "name": "datasets",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LineDataset",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "labels",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "LineDataset",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "label",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "ENUM",
         "name": "MailchimpAudience",
         "description": null,
@@ -25358,6 +25683,12 @@
         "enumValues": [
           {
             "name": "BUILD_COMPLETE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED",
             "description": null,
             "isDeprecated": false,
             "deprecationReason": null
@@ -28461,22 +28792,6 @@
             "deprecationReason": null
           },
           {
-            "name": "iosAppCredentials",
-            "description": "Top-level query object for querying IosAppCredentials.",
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "IosAppCredentialsQuery",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "me",
             "description": "If authenticated as a typical end user, this is the appropriate top-level\nquery object",
             "args": [],
@@ -28999,8 +29314,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -29209,8 +29524,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "id",
@@ -29237,8 +29552,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -29277,8 +29592,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -29415,8 +29730,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -29470,55 +29785,7 @@
             "deprecationReason": null
           },
           {
-            "name": "githubUsername",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "industry",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "lastName",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "twitterUsername",
             "description": null,
             "type": {
               "kind": "SCALAR",
@@ -32262,6 +32529,33 @@
       },
       {
         "kind": "OBJECT",
+        "name": "UniqueUsersOverTimeData",
+        "description": null,
+        "fields": [
+          {
+            "name": "data",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "LineChartData",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "UnsubscribeFromNotificationResult",
         "description": null,
         "fields": [
@@ -32316,6 +32610,22 @@
               "kind": "INTERFACE",
               "name": "Actor",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -34055,8 +34365,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -34293,8 +34603,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "hasPendingUserInvitations",
@@ -34337,8 +34647,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -34370,7 +34680,7 @@
               }
             },
             "isDeprecated": true,
-            "deprecationReason": "This field no longer exists"
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isSecondFactorAuthenticationEnabled",
@@ -34409,8 +34719,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -34595,8 +34905,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -34782,8 +35092,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "apps",
@@ -34992,8 +35302,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "id",
@@ -35020,8 +35330,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "isExpoAdmin",
@@ -35060,8 +35370,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "notificationSubscriptions",
@@ -35198,8 +35508,8 @@
               "name": "String",
               "ofType": null
             },
-            "isDeprecated": false,
-            "deprecationReason": null
+            "isDeprecated": true,
+            "deprecationReason": "No longer supported"
           },
           {
             "name": "username",
@@ -35324,18 +35634,6 @@
         "fields": null,
         "inputFields": [
           {
-            "name": "appetizeCode",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "email",
             "description": null,
             "type": {
@@ -35372,35 +35670,11 @@
             "deprecationReason": null
           },
           {
-            "name": "githubUsername",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "id",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "ID",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "industry",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
               "ofType": null
             },
             "defaultValue": null,
@@ -35420,31 +35694,7 @@
             "deprecationReason": null
           },
           {
-            "name": "location",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "profilePhoto",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "twitterUsername",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/home/graphql/queries/ViewerPrimaryAccountNameQuery.query.graphql
+++ b/home/graphql/queries/ViewerPrimaryAccountNameQuery.query.graphql
@@ -1,0 +1,9 @@
+query Home_ViewerPrimaryAccountName {
+  meUserActor {
+    id
+    primaryAccount {
+      id
+      name
+    }
+  }
+}

--- a/home/graphql/queries/ViewerUsernameQuery.query.graphql
+++ b/home/graphql/queries/ViewerUsernameQuery.query.graphql
@@ -1,6 +1,0 @@
-query Home_ViewerUsername {
-  me {
-    id
-    username
-  }
-}

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -755,6 +755,8 @@ export type AndroidAppCredentialsMutation = {
   __typename?: 'AndroidAppCredentialsMutation';
   /** Create a set of credentials for an Android app */
   createAndroidAppCredentials: AndroidAppCredentials;
+  /** Delete a set of credentials for an Android app */
+  deleteAndroidAppCredentials: DeleteAndroidAppCredentialsResult;
   /** Set the FCM push key to be used in an Android app */
   setFcm: AndroidAppCredentials;
   /** Set the Google Service Account Key to be used for submitting an Android app */
@@ -766,6 +768,11 @@ export type AndroidAppCredentialsMutationCreateAndroidAppCredentialsArgs = {
   androidAppCredentialsInput: AndroidAppCredentialsInput;
   appId: Scalars['ID'];
   applicationIdentifier: Scalars['String'];
+};
+
+
+export type AndroidAppCredentialsMutationDeleteAndroidAppCredentialsArgs = {
+  id: Scalars['ID'];
 };
 
 
@@ -1015,6 +1022,8 @@ export type App = Project & {
   /** @deprecated No longer supported */
   iconUrl?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** App query field for querying EAS Insights about this app */
+  insights: AppInsights;
   /** iOS app credentials for the project */
   iosAppCredentials: Array<IosAppCredentials>;
   /** Whether the latest classic update publish is using a deprecated SDK version */
@@ -1346,6 +1355,28 @@ export type AppInput = {
   appInfo?: InputMaybe<AppInfoInput>;
   privacy: AppPrivacy;
   projectName: Scalars['String'];
+};
+
+export type AppInsights = {
+  __typename?: 'AppInsights';
+  totalUniqueUsers?: Maybe<Scalars['Int']>;
+  uniqueUsersByAppVersionOverTime: UniqueUsersOverTimeData;
+  uniqueUsersByPlatformOverTime: UniqueUsersOverTimeData;
+};
+
+
+export type AppInsightsTotalUniqueUsersArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppInsightsUniqueUsersByAppVersionOverTimeArgs = {
+  timespan: InsightsTimespan;
+};
+
+
+export type AppInsightsUniqueUsersByPlatformOverTimeArgs = {
+  timespan: InsightsTimespan;
 };
 
 export type AppMutation = {
@@ -1968,6 +1999,7 @@ export type Build = ActivityTimelineProjectActivity & BuildOrBuildJob & {
   __typename?: 'Build';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
+  app: App;
   appBuildVersion?: Maybe<Scalars['String']>;
   appVersion?: Maybe<Scalars['String']>;
   artifacts?: Maybe<BuildArtifacts>;
@@ -2416,7 +2448,8 @@ export enum BuildStatus {
   Finished = 'FINISHED',
   InProgress = 'IN_PROGRESS',
   InQueue = 'IN_QUEUE',
-  New = 'NEW'
+  New = 'NEW',
+  PendingCancel = 'PENDING_CANCEL'
 }
 
 export enum BuildTrigger {
@@ -2561,6 +2594,11 @@ export type DeleteAccountResult = {
 
 export type DeleteAccountSsoConfigurationResult = {
   __typename?: 'DeleteAccountSSOConfigurationResult';
+  id: Scalars['ID'];
+};
+
+export type DeleteAndroidAppCredentialsResult = {
+  __typename?: 'DeleteAndroidAppCredentialsResult';
   id: Scalars['ID'];
 };
 
@@ -3158,6 +3196,11 @@ export type GoogleServiceAccountKeyMutationDeleteGoogleServiceAccountKeyArgs = {
   id: Scalars['ID'];
 };
 
+export type InsightsTimespan = {
+  end: Scalars['DateTime'];
+  start: Scalars['DateTime'];
+};
+
 export type Invoice = {
   __typename?: 'Invoice';
   /** The total amount due for the invoice, in cents */
@@ -3355,16 +3398,6 @@ export type IosAppCredentialsMutationSetPushKeyArgs = {
   pushKeyId: Scalars['ID'];
 };
 
-export type IosAppCredentialsQuery = {
-  __typename?: 'IosAppCredentialsQuery';
-  byId: IosAppCredentials;
-};
-
-
-export type IosAppCredentialsQueryByIdArgs = {
-  iosAppCredentialsId: Scalars['ID'];
-};
-
 /** @deprecated Use developmentClient option instead. */
 export enum IosBuildType {
   DevelopmentClient = 'DEVELOPMENT_CLIENT',
@@ -3508,6 +3541,19 @@ export type KeystoreGenerationUrlMutation = {
 export type LeaveAccountResult = {
   __typename?: 'LeaveAccountResult';
   success: Scalars['Boolean'];
+};
+
+export type LineChartData = {
+  __typename?: 'LineChartData';
+  datasets: Array<LineDataset>;
+  labels: Array<Scalars['String']>;
+};
+
+export type LineDataset = {
+  __typename?: 'LineDataset';
+  data: Array<Maybe<Scalars['Int']>>;
+  id: Scalars['ID'];
+  label: Scalars['String'];
 };
 
 export enum MailchimpAudience {
@@ -3662,6 +3708,7 @@ export type MeteredBillingStatus = {
 
 export enum NotificationEvent {
   BuildComplete = 'BUILD_COMPLETE',
+  BuildPlanCreditThresholdExceeded = 'BUILD_PLAN_CREDIT_THRESHOLD_EXCEEDED',
   SubmissionComplete = 'SUBMISSION_COMPLETE'
 }
 
@@ -4082,8 +4129,6 @@ export type RootQuery = {
   githubApp: GitHubAppQuery;
   /** Top-level query object for querying Stripe Invoices. */
   invoice: InvoiceQuery;
-  /** Top-level query object for querying IosAppCredentials. */
-  iosAppCredentials: IosAppCredentialsQuery;
   /**
    * If authenticated as a typical end user, this is the appropriate top-level
    * query object
@@ -4172,6 +4217,7 @@ export type SsoUser = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published. If this user is the viewer, this field returns the apps the user has access to. */
   apps: Array<App>;
@@ -4189,11 +4235,14 @@ export type SsoUser = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Associated accounts */
@@ -4201,6 +4250,7 @@ export type SsoUser = Actor & UserActor & {
   profilePhoto: Scalars['String'];
   /** Snacks associated with this account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -4242,11 +4292,7 @@ export type SsoUserSnacksArgs = {
 
 export type SsoUserDataInput = {
   firstName?: InputMaybe<Scalars['String']>;
-  githubUsername?: InputMaybe<Scalars['String']>;
-  industry?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-  location?: InputMaybe<Scalars['String']>;
-  twitterUsername?: InputMaybe<Scalars['String']>;
 };
 
 export type SsoUserQuery = {
@@ -4662,6 +4708,11 @@ export type TimelineActivityFilterInput = {
   types?: InputMaybe<Array<ActivityTimelineProjectActivityType>>;
 };
 
+export type UniqueUsersOverTimeData = {
+  __typename?: 'UniqueUsersOverTimeData';
+  data: LineChartData;
+};
+
 export type UnsubscribeFromNotificationResult = {
   __typename?: 'UnsubscribeFromNotificationResult';
   notificationSubscription: NotificationSubscription;
@@ -4671,6 +4722,7 @@ export type Update = ActivityTimelineProjectActivity & {
   __typename?: 'Update';
   activityTimestamp: Scalars['DateTime'];
   actor?: Maybe<Actor>;
+  app: App;
   awaitingCodeSigningInfo: Scalars['Boolean'];
   branch: UpdateBranch;
   branchId: Scalars['ID'];
@@ -4905,6 +4957,7 @@ export type User = Actor & UserActor & {
   /** Coalesced project activity for all apps belonging to all accounts this user belongs to. Only resolves for the viewer. */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
   apps: Array<App>;
@@ -4924,16 +4977,19 @@ export type User = Actor & UserActor & {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   /** Whether this user has any pending user invitations. Only resolves for the viewer. */
   hasPendingUserInvitations: Scalars['Boolean'];
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
-  /** @deprecated This field no longer exists */
+  /** @deprecated No longer supported */
   isLegacy: Scalars['Boolean'];
   isSecondFactorAuthenticationEnabled: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Pending UserInvitations for this user. Only resolves for the viewer. */
@@ -4945,6 +5001,7 @@ export type User = Actor & UserActor & {
   secondFactorDevices: Array<UserSecondFactorDevice>;
   /** Snacks associated with this account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -4995,6 +5052,7 @@ export type UserActor = {
    */
   activityTimelineProjectActivities: Array<ActivityTimelineProjectActivity>;
   appCount: Scalars['Int'];
+  /** @deprecated No longer supported */
   appetizeCode?: Maybe<Scalars['String']>;
   /** Apps this user has published */
   apps: Array<App>;
@@ -5016,11 +5074,14 @@ export type UserActor = {
   fullName?: Maybe<Scalars['String']>;
   /** GitHub account linked to a user */
   githubUser?: Maybe<GitHubUser>;
+  /** @deprecated No longer supported */
   githubUsername?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
+  /** @deprecated No longer supported */
   industry?: Maybe<Scalars['String']>;
   isExpoAdmin: Scalars['Boolean'];
   lastName?: Maybe<Scalars['String']>;
+  /** @deprecated No longer supported */
   location?: Maybe<Scalars['String']>;
   notificationSubscriptions: Array<NotificationSubscription>;
   /** Associated accounts */
@@ -5028,6 +5089,7 @@ export type UserActor = {
   profilePhoto: Scalars['String'];
   /** Snacks associated with this user's personal account */
   snacks: Array<Snack>;
+  /** @deprecated No longer supported */
   twitterUsername?: Maybe<Scalars['String']>;
   username: Scalars['String'];
 };
@@ -5086,17 +5148,12 @@ export type UserActorQueryByUsernameArgs = {
 };
 
 export type UserDataInput = {
-  appetizeCode?: InputMaybe<Scalars['String']>;
   email?: InputMaybe<Scalars['String']>;
   firstName?: InputMaybe<Scalars['String']>;
   fullName?: InputMaybe<Scalars['String']>;
-  githubUsername?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
-  industry?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
-  location?: InputMaybe<Scalars['String']>;
   profilePhoto?: InputMaybe<Scalars['String']>;
-  twitterUsername?: InputMaybe<Scalars['String']>;
   username?: InputMaybe<Scalars['String']>;
 };
 
@@ -5417,10 +5474,10 @@ export type Home_AccountSnacksQueryVariables = Exact<{
 
 export type Home_AccountSnacksQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
-export type Home_ViewerUsernameQueryVariables = Exact<{ [key: string]: never; }>;
+export type Home_ViewerPrimaryAccountNameQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type Home_ViewerUsernameQuery = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, username: string } | null };
+export type Home_ViewerPrimaryAccountNameQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, primaryAccount: { __typename?: 'Account', id: string, name: string } } | { __typename?: 'User', id: string, primaryAccount: { __typename?: 'Account', id: string, name: string } } | null };
 
 export type DeleteAccountPermissionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -6062,43 +6119,46 @@ export type Home_AccountSnacksQueryResult = Apollo.QueryResult<Home_AccountSnack
 export function refetchHome_AccountSnacksQuery(variables: Home_AccountSnacksQueryVariables) {
       return { query: Home_AccountSnacksDocument, variables: variables }
     }
-export const Home_ViewerUsernameDocument = gql`
-    query Home_ViewerUsername {
-  me {
+export const Home_ViewerPrimaryAccountNameDocument = gql`
+    query Home_ViewerPrimaryAccountName {
+  meUserActor {
     id
-    username
+    primaryAccount {
+      id
+      name
+    }
   }
 }
     `;
 
 /**
- * __useHome_ViewerUsernameQuery__
+ * __useHome_ViewerPrimaryAccountNameQuery__
  *
- * To run a query within a React component, call `useHome_ViewerUsernameQuery` and pass it any options that fit your needs.
- * When your component renders, `useHome_ViewerUsernameQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useHome_ViewerPrimaryAccountNameQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_ViewerPrimaryAccountNameQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useHome_ViewerUsernameQuery({
+ * const { data, loading, error } = useHome_ViewerPrimaryAccountNameQuery({
  *   variables: {
  *   },
  * });
  */
-export function useHome_ViewerUsernameQuery(baseOptions?: Apollo.QueryHookOptions<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>) {
+export function useHome_ViewerPrimaryAccountNameQuery(baseOptions?: Apollo.QueryHookOptions<Home_ViewerPrimaryAccountNameQuery, Home_ViewerPrimaryAccountNameQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>(Home_ViewerUsernameDocument, options);
+        return Apollo.useQuery<Home_ViewerPrimaryAccountNameQuery, Home_ViewerPrimaryAccountNameQueryVariables>(Home_ViewerPrimaryAccountNameDocument, options);
       }
-export function useHome_ViewerUsernameLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>) {
+export function useHome_ViewerPrimaryAccountNameLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_ViewerPrimaryAccountNameQuery, Home_ViewerPrimaryAccountNameQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>(Home_ViewerUsernameDocument, options);
+          return Apollo.useLazyQuery<Home_ViewerPrimaryAccountNameQuery, Home_ViewerPrimaryAccountNameQueryVariables>(Home_ViewerPrimaryAccountNameDocument, options);
         }
-export type Home_ViewerUsernameQueryHookResult = ReturnType<typeof useHome_ViewerUsernameQuery>;
-export type Home_ViewerUsernameLazyQueryHookResult = ReturnType<typeof useHome_ViewerUsernameLazyQuery>;
-export type Home_ViewerUsernameQueryResult = Apollo.QueryResult<Home_ViewerUsernameQuery, Home_ViewerUsernameQueryVariables>;
-export function refetchHome_ViewerUsernameQuery(variables?: Home_ViewerUsernameQueryVariables) {
-      return { query: Home_ViewerUsernameDocument, variables: variables }
+export type Home_ViewerPrimaryAccountNameQueryHookResult = ReturnType<typeof useHome_ViewerPrimaryAccountNameQuery>;
+export type Home_ViewerPrimaryAccountNameLazyQueryHookResult = ReturnType<typeof useHome_ViewerPrimaryAccountNameLazyQuery>;
+export type Home_ViewerPrimaryAccountNameQueryResult = Apollo.QueryResult<Home_ViewerPrimaryAccountNameQuery, Home_ViewerPrimaryAccountNameQueryVariables>;
+export function refetchHome_ViewerPrimaryAccountNameQuery(variables?: Home_ViewerPrimaryAccountNameQueryVariables) {
+      return { query: Home_ViewerPrimaryAccountNameDocument, variables: variables }
     }
 export const DeleteAccountPermissionsDocument = gql`
     query DeleteAccountPermissions {

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -6,7 +6,13 @@ import * as React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import url from 'url';
 
+import ApolloClient from '../../api/ApolloClient';
 import Config from '../../api/Config';
+import {
+  Home_ViewerPrimaryAccountNameDocument,
+  Home_ViewerPrimaryAccountNameQuery,
+  Home_ViewerPrimaryAccountNameQueryVariables,
+} from '../../graphql/types';
 import { useDispatch, useSelector } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
@@ -98,20 +104,36 @@ export function LoggedOutAccountView({ refetch }: Props) {
 
       if (result.type === 'success') {
         const resultURL = url.parse(result.url, true);
-        const sessionSecret = resultURL.query['session_secret'] as string;
-        // usernameOrEmail is always the username https://github.com/expo/universe/blob/d3332f3b48964853191c5035fceae37aeebb1e64/server/website/scenes/_app/helpers.tsx#L119
-        const usernameOrEmail = resultURL.query['username_or_email'] as string;
-
-        if (!sessionSecret) {
+        const encodedSessionSecret = resultURL.query['session_secret'] as string;
+        if (!encodedSessionSecret) {
           throw new Error('session_secret is missing in auth redirect query');
         }
 
+        const sessionSecret = decodeURIComponent(encodedSessionSecret);
+
         dispatch(
           SessionActions.setSession({
-            sessionSecret: decodeURIComponent(sessionSecret),
+            sessionSecret,
           })
         );
-        setAccountName(usernameOrEmail);
+
+        const viewerPrimaryAccountNameResult = await ApolloClient.query<
+          Home_ViewerPrimaryAccountNameQuery,
+          Home_ViewerPrimaryAccountNameQueryVariables
+        >({
+          query: Home_ViewerPrimaryAccountNameDocument,
+          context: {
+            headers: { 'expo-session': sessionSecret },
+          },
+        });
+
+        const primaryAccountName =
+          viewerPrimaryAccountNameResult.data.meUserActor?.primaryAccount.name;
+        if (!primaryAccountName) {
+          throw new Error('Logged in user must have a primary account');
+        }
+
+        setAccountName(primaryAccountName);
         setIsFinishedAuthenticating(true);
       }
     } catch (e) {


### PR DESCRIPTION
# Why

This was changed in https://github.com/expo/expo/commit/3f25432d34978d8da3e8effd306c8ad1d3ace68d to also set the account name from the username or email (and erroneously assumed it was only ever username). We hotfixed this on the server in https://github.com/expo/universe/pull/12497. 

This PR removes the blame code and just replaces it with the code that fetches the primary account name. 

# How

At this point the session isn't set in the store so we need to pass session manually.

# Test Plan

Log in with email/username in local build of Expo Go. See query works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
