### PR TITLE
[docs] Add description to Development builds > Introduction page

### DIFF
--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Development builds: Introduction'
 sidebar_title: Introduction
-description:
+description: Development builds of your app are Debug builds of your project. It includes the expo-dev-client library, which allows you to develop and debug projects using Expo CLI.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-5864

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding `description` to the page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
