### PR TITLE
[ios] Enable frame rates higher than 60 FPS

### DIFF
--- a/apps/bare-expo/ios/BareExpo/Info.plist
+++ b/apps/bare-expo/ios/BareExpo/Info.plist
@@ -113,5 +113,7 @@
 	<string>1696089354000816</string>
 	<key>FacebookDisplayName</key>
 	<string>Expo APIs</string>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/fabric-tester/ios/fabrictester/Info.plist
+++ b/apps/fabric-tester/ios/fabrictester/Info.plist
@@ -84,5 +84,7 @@
     <string>Light</string>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
   </dict>
 </plist>

--- a/ios/Exponent/Supporting/Info.plist
+++ b/ios/Exponent/Supporting/Info.plist
@@ -150,5 +150,7 @@
 	<string>Automatic</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld/Info.plist
@@ -51,5 +51,7 @@
 	<false/>
   <key>UIStatusBarStyle</key>
   <string>UIStatusBarStyleDefault</string>
+  <key>CADisableMinimumFrameDurationOnPhone</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
# Why

Right now Expo Go, bare-expo and prebuild template were capped to 60 FPS on iOS, even on devices with ProMotion display. To allow frame rates higher than 60 FPS, it's necessary to add `CADisableMinimumFrameDurationOnPhone` option to `Info.plist`.
Closes ENG-8814

# How

Added `CADisableMinimumFrameDurationOnPhone` set to true to `Info.plist` for the following projects:
- Expo Go
- bare-expo
- fabric-tester
- expo-template-bare-minimum (prebuilds)

# Test Plan

Checked the example provided in a PR from react-native-reanimated which does support 120 FPS: https://github.com/software-mansion/react-native-reanimated/pull/2636
It looks much smoother on iPhone 13 Pro too.