### PR TITLE
[image-picker] Fix AndroidManifest for Gradle 8

### DIFF
--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest package="expo.modules.imagepicker"
-          xmlns:tools="http://schemas.android.com/tools"
+<manifest xmlns:tools="http://schemas.android.com/tools"
           xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Required for picking images from camera directly -->
     <uses-permission android:name="android.permission.CAMERA"/>


### PR DESCRIPTION
# Why

Fixes a regression introduced by #22658, see #22609 for more context

# How

Removed the package name from AndroidManifest.xml

# Test Plan

`expo-image-picker` now builds without warnings from Gradle