### PR TITLE
[dev-launcher][dev-menu] Add contributing section to README

### DIFF
--- a/packages/expo-dev-launcher/README.md
+++ b/packages/expo-dev-launcher/README.md
@@ -5,3 +5,66 @@
 ## Documentation
 
 You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
+
+## Contributing
+
+The `expo-dev-launcher` repository consists of two different parts, the exported package, which includes the native functions, located in the `android`, `ios` and `src` folders and the Dev Launcher interface, located under the `bundle` folder.
+
+Local development is usually done through `bare-expo`.
+
+To use `dev-client` when running `bare-expo` on Android, open [MainApplication.java](/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java) and set the `USE_DEV_CLIENT` value to `true`.
+
+```diff
+- static final boolean USE_DEV_CLIENT = false;
++ static final boolean USE_DEV_CLIENT = true;
+```
+
+To use `dev-client` when running `bare-expo` on iOS, open [AppDelegate.mm](/apps/bare-expo/ios/BareExpo/AppDelegate.mm) and set the `USE_DEV_CLIENT` value to `YES`.
+
+```diff
+- BOOL useDevClient = NO;
++ BOOL useDevClient = YES;
+```
+
+### Making JavaScript changes inside the `bundle` folder
+
+To update the JavaScript code inside the `bundle` folder, you need to run the `dev-launcher` bundler locally.
+
+1. Navigate to the `dev-launcher` package: `cd packages/expo-dev-launcher`
+2. Start the Metro bundler: `yarn start`
+3. Adjust the dev-launcher URL to point to your local bundler
+
+<details>
+
+#### On Android
+
+Open [DevLauncherController.kt](/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt) and update the `DEV_LAUNCHER_HOST` value to your bundler URL.
+
+E.g.
+
+```diff
+- private val DEV_LAUNCHER_HOST: String? = null
++ private val DEV_LAUNCHER_HOST: String? = "10.0.2.2:8090";
+```
+
+#### On iOS
+
+3.1. Open another terminal window and navigate to the `ios` folder inside `bare-expo`
+
+3.2. Export the `EX_DEV_LAUNCHER_URL` variable in your shell before running `pod install`.
+
+E.g.
+
+```
+export EX_DEV_LAUNCHER_URL=http://localhost:8090
+```
+
+This will cause the controller to see if the `expo-launcher` packager is running, and if so, use that instead of the prebuilt bundle.
+
+3.3. Run `pod install`
+
+</details>
+
+4. Recompile `bare-expo`
+5. Play with your changes on a simulator or device
+6. Once you've made all the necessary changes run `yarn bundle` to update the embedded bundle

--- a/packages/expo-dev-menu/README.md
+++ b/packages/expo-dev-menu/README.md
@@ -5,3 +5,39 @@ Expo/React Native module to add developer menu to Debug builds of your applicati
 ## Documentation
 
 You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
+
+## Contributing
+
+The `expo-dev-menu` repository consists of two different parts, the exported package, which includes the native functions, located in the `android`, `ios` and `src` folders and the Dev Menu interface, located under the `app` folder.
+
+Local development is usually done through `bare-expo`.
+
+To use `dev-client` when running `bare-expo` on Android, open [MainApplication.java](/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.java) and set the `USE_DEV_CLIENT` value to `true`.
+
+```diff
+- static final boolean USE_DEV_CLIENT = false;
++ static final boolean USE_DEV_CLIENT = true;
+```
+
+To use `dev-client` when running `bare-expo` on iOS, open [AppDelegate.mm](/apps/bare-expo/ios/BareExpo/AppDelegate.mm) and set the `USE_DEV_CLIENT` value to `YES`.
+
+```diff
+- BOOL useDevClient = NO;
++ BOOL useDevClient = YES;
+```
+
+### Making JavaScript changes inside the `app` folder
+
+To update the JavaScript code inside the `app` folder, you need to run the `dev-menu` bundler locally.
+
+1. Navigate to the `dev-menu` package: `cd packages/expo-dev-menu`
+2. Start the Metro bundler: `yarn start`
+3. To use your local bundler on Android, open [DevMenuHost.java](/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuHost.kt) and set `getUseDeveloperSupport` to `true`.
+
+```diff
+- override fun getUseDeveloperSupport() = false
++ override fun getUseDeveloperSupport() = true
+```
+
+4. Play with your changes on a simulator or device through `bare-expo`
+5. Once you've made all the necessary changes run `yarn bundle:prod:ios && yarn bundle:prod:android` to update the embedded bundle


### PR DESCRIPTION
# Why

Closes ENG-8784

# How

This PR adds a `Contributing` section to `dev-launcher` and `dev-menu` READMEs 

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
