### PR TITLE
[expo] bump bundled native version for sentry

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -96,10 +96,10 @@
   "react-native-svg": "13.4.0",
   "react-native-view-shot": "3.5.0",
   "react-native-webview": "11.26.0",
-  "sentry-expo": "~6.1.0",
+  "sentry-expo": "~6.2.0",
   "unimodules-app-loader": "~4.1.1",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.172",
   "@shopify/flash-list": "1.4.0",
-  "@sentry/react-native": "4.13.0"
+  "@sentry/react-native": "4.15.2"
 }


### PR DESCRIPTION
# Why

Sentry 6.2.0 is released, which includes a bump in `@sentry/react-native` version.

# How

Updated both `sentry-expo` and `@sentry/react-native` to match.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
