### PR TITLE
[docs] Fix environment variable boxlink icon

### DIFF
--- a/docs/pages/develop/development-builds/next-steps.mdx
+++ b/docs/pages/develop/development-builds/next-steps.mdx
@@ -4,7 +4,7 @@ description:
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, Lock01Icon } from '@expo/styleguide-icons';
+import { BuildIcon, BookOpen02Icon } from '@expo/styleguide-icons';
 
 The following resources are useful when learning more about development builds or EAS Build:
 
@@ -19,7 +19,7 @@ The following resources are useful when learning more about development builds o
   title="Environment variables"
   description="Learn about different ways to use environment variables in an Expo project."
   href="/guides/environment-variables/"
-  Icon={Lock01Icon}
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1686076409680839)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By using a more generic BookOpen icon which we use for different pages and guides.

# Test Plan

Following changes have been tested by running docs locally:

<img width="882" alt="CleanShot 2023-06-07 at 16 37 07@2x" src="https://github.com/expo/expo/assets/10234615/f0d06955-51ae-4bfb-b9f7-ec1ef8964467">

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
