### PR TITLE
[ci] cleanup intermediate build files to fix limited disk space

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
   ndk-version:
     description: 'NDK version used'
-    default: '21.4.7075529'
+    default: '23.1.7779620'
     required: false
   git-lfs:
     description: 'Restore Git LFS cache'

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -175,7 +175,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: android/prebuiltHermes
-        key: hermes-engine-aar-v2-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
+        key: hermes-engine-aar-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
     - name: Check hermes-engine cache-hit
       if: inputs.hermes-engine-aar == 'true'
       id: cache-hermes-engine-aar

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -200,6 +200,7 @@ runs:
         ./gradlew :packages:react-native:ReactAndroid:hermes-engine:assembleDebug
         cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-release.aar prebuiltHermes/
         cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-debug.aar prebuiltHermes/
+        ./gradlew clean
       env:
         # Reset reactNativeArchitectures to build all architectures
         ORG_GRADLE_PROJECT_reactNativeArchitectures:

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -172,7 +172,7 @@ runs:
 
     - name: ♻️ Restore hermes-engine AAR cache
       if: inputs.hermes-engine-aar == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache/restore@v3
       with:
         path: android/prebuiltHermes
         key: hermes-engine-aar-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
@@ -205,6 +205,12 @@ runs:
         # Reset reactNativeArchitectures to build all architectures
         ORG_GRADLE_PROJECT_reactNativeArchitectures:
       working-directory: android
+    - name: ♻️ Save hermes-engine AAR cache
+      if: inputs.hermes-engine-aar == 'true' && inputs.rebuild-hermes-engine-aar-if-needed == 'true' && steps.cache-hermes-engine-aar.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: android/prebuiltHermes
+        key: hermes-engine-aar-${{ hashFiles('react-native-lab/react-native/packages/react-native/sdks/.hermesversion') }}
 
     - name: 🛠 Setup "REACT_NATIVE_DOWNLOADS_DIR" environment variable
       if: inputs.react-native-gradle-downloads == 'true'

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -200,7 +200,7 @@ runs:
         ./gradlew :packages:react-native:ReactAndroid:hermes-engine:assembleDebug
         cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-release.aar prebuiltHermes/
         cp -f ../react-native-lab/react-native/packages/react-native/ReactAndroid/hermes-engine/build/outputs/aar/hermes-engine-debug.aar prebuiltHermes/
-        ./gradlew clean
+        pushd ../react-native-lab/react-native && git clean -fdx && popd
       env:
         # Reset reactNativeArchitectures to build all architectures
         ORG_GRADLE_PROJECT_reactNativeArchitectures:

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
     steps:

--- a/android/versioned-abis/expoview-abi47_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi47_0_0/build.gradle
@@ -179,6 +179,10 @@ dependencies {
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'
 
+  // expo-barcode-scanner
+  implementation "com.google.android.gms:play-services-vision:19.0.0"
+  implementation "com.google.zxing:core:3.3.3"
+
   // expo-store-review
   implementation "com.google.android.play:review:2.0.1"
   implementation "com.google.android.play:review-ktx:2.0.0"

--- a/android/versioned-abis/expoview-abi48_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi48_0_0/build.gradle
@@ -176,6 +176,10 @@ dependencies {
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'
 
+  // expo-barcode-scanner
+  implementation "com.google.android.gms:play-services-vision:19.0.0"
+  implementation "com.google.zxing:core:3.3.3"
+
   // expo-store-review
   implementation "com.google.android.play:review:2.0.1"
   implementation "com.google.android.play:review-ktx:2.0.0"


### PR DESCRIPTION
# Why

fix the "running out of disk space" failures for android-client and android-unit-test ci jobs, e.g. https://github.com/expo/expo/actions/runs/5197293597

# How

it happens on ubuntu runner and i left a comment for it: https://github.com/expo/expo/pull/22741#issuecomment-1576753441. i noticed the problem happening only when prebuilt hermes cache missed and then building hermes. this pr tries to clean up intermediate build files of hermes building.

# Test Plan

- android client ci passed
- android unit test ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
