### PR TITLE
[docs] Update splash screen configuration guide to use config plugin

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -4,10 +4,12 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-splash-scre
 packageName: 'expo-splash-screen'
 ---
 
-import { ConfigReactNative } from '~/components/plugins/ConfigSection';
+import { ConfigReactNative, ConfigPluginExample } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
@@ -19,12 +21,28 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 <APIInstallSection />
 
+## Configuration
+
+You can configure `expo-splash-screen` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
+
+<ConfigPluginExample>
+
+```json app.json
+{
+  "expo": {
+    "plugins": ["expo-splash-screen"]
+  }
+}
+```
+
+</ConfigPluginExample>
+
 ## Usage
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```js App.js
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
@@ -81,23 +99,14 @@ export default function App() {
 }
 ```
 
-## Configuration
+### Animate the splash screen
 
-To configure `expo-splash-screen`, see the following [app config](/workflow/configuration/) properties.
-
-- [`splash`](../config/app.mdx#splash)
-- [`android.splash`](../config/app.mdx#splash-2)
-- [`ios.splash`](../config/app.mdx#splash-1)
-
-<ConfigReactNative>
-
-See how to configure the native projects in the [installation instructions in the `expo-splash-screen` repository](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
-
-</ConfigReactNative>
-
-### Animating the splash screen
-
-See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+<BoxLink
+  title="Animate splash screen example"
+  description="See with-splash-screen example on how to apply any arbitrary animations to your splash screen, such as a fade out."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-splash-screen"
+/>
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8789

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By removing the `splash` key recommendation and replacing it with the config plugin in `unversioned` docs. Preview:

<img width="893" alt="CleanShot 2023-06-08 at 18 09 12@2x" src="https://github.com/expo/expo/assets/10234615/1614d0c7-3f97-4ac4-93a7-5ece5bb43e06">

- Adds `BoxLink` for Animate splash screen example
- Adds a file name for code snippet in the Usage section
- Removed the following duplicated "bare workflow instructions" since that is already mentioned in the Installation section

<img width="900" alt="CleanShot 2023-06-08 at 18 15 28@2x" src="https://github.com/expo/expo/assets/10234615/736dd569-4155-4ebe-8e77-80379b6f9d1a">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
