### PR TITLE
[docs] Remove unused installation instruction since SDK 45 is already dropped

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -24,15 +24,6 @@ const InstallSection = ({
   href = getPackageLink(packageName),
 }: InstallSectionProps) => {
   const { sourceCodeUrl } = usePageMetadata();
-  const { version } = useContext(PageApiVersionContext);
-
-  // Recommend just `expo install` for SDK 45.
-  // TODO: remove this when we drop SDK 45 from docs
-  if (version.startsWith('v45')) {
-    if (cmd[0] === getInstallCmd(packageName)) {
-      cmd[0] = cmd[0].replace('npx expo', 'expo');
-    }
-  }
 
   return (
     <>

--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -1,6 +1,5 @@
-import { PropsWithChildren, useContext } from 'react';
+import { PropsWithChildren } from 'react';
 
-import { PageApiVersionContext } from '~/providers/page-api-version';
 import { usePageMetadata } from '~/providers/page-metadata';
 import { Terminal } from '~/ui/components/Snippet';
 import { A, P, DEMI } from '~/ui/components/Text';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Earlier, when we had SDK 45 docs, it was a requirement to be explicit about a library's installation instruction. For SDK 45 it was `expo install`. We've already dropped SDK 45 docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By removing unused installation instructions from the `APIInstallSection` component since SDK 45 is already removed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
