### PR TITLE
[docs] Format SplashScreen API docs

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/splash-screen.mdx
@@ -7,6 +7,8 @@ packageName: 'expo-splash-screen'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
@@ -22,7 +24,7 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
+```js App.js
 import React, { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
@@ -80,9 +82,14 @@ export default function App() {
 }
 ```
 
-### Animating the splash screen
+### Animate the splash screen
 
-See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+<BoxLink
+  title="Animate splash screen example"
+  description="See with-splash-screen example on how to apply any arbitrary animations to your splash screen, such as a fade out."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-splash-screen"
+/>
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/splash-screen.mdx
@@ -8,6 +8,8 @@ import { ConfigReactNative } from '~/components/plugins/ConfigSection';
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 The `SplashScreen` module from the `expo-splash-screen` library is used to tell the splash screen to remain visible until it has been explicitly told to hide. This is useful to do tasks that will happen behind the scenes such as making API calls, pre-loading fonts, animating the splash screen and so on.
 
@@ -23,8 +25,8 @@ Also, see the guide on [creating a splash screen image](/develop/user-interface/
 
 This example shows how to keep the splash screen visible while loading app resources and then hide the splash screen when the app has rendered some initial content.
 
-```js
-import React, { useCallback, useEffect, useState } from 'react';
+```js App.js
+import { useCallback, useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import Entypo from '@expo/vector-icons/Entypo';
 import * as SplashScreen from 'expo-splash-screen';
@@ -89,15 +91,14 @@ To configure `expo-splash-screen`, see the following [app Config](/workflow/conf
 - [`android.splash`](../config/app.mdx#splash-2)
 - [`ios.splash`](../config/app.mdx#splash-1)
 
-<ConfigReactNative>
+### Animate the splash screen
 
-See how to configure the native projects in the [installation instructions in the `expo-splash-screen` repository](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
-
-</ConfigReactNative>
-
-### Animating the splash screen
-
-See the [with-splash-screen](https://github.com/expo/examples/tree/master/with-splash-screen) example on how to apply any arbitrary animations to your splash screen, such as a fade out. You can initialize a new project from this example by running `npx create-react-native-app -t with-splash-screen`.
+<BoxLink
+  title="Animate splash screen example"
+  description="See with-splash-screen example on how to apply any arbitrary animations to your splash screen, such as a fade out."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-splash-screen"
+/>
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While working on the SplashScreen API docs for SDK 49 (https://github.com/expo/expo/pull/22798), I noticed a couple of formatting inconsistencies. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a filename to the example in the Usage:

<img width="939" alt="CleanShot 2023-06-08 at 18 37 39@2x" src="https://github.com/expo/expo/assets/10234615/a6a337c2-b3f6-46bb-b33b-a58159f75401">

- Use the `BoxLink` component for the Example

<img width="914" alt="CleanShot 2023-06-08 at 18 37 35@2x" src="https://github.com/expo/expo/assets/10234615/3d4ca68f-a5c6-4061-9c08-82671d3d82e3">

These changes are applied to SDK 48 and 47 versions.

# Test Plan

Changes can be tested by running docs locally.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
