### PR TITLE
[ci][android] fix versioned expo go build error

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
   ndk-version:
     description: 'NDK version used'
-    default: '21.4.7075529'
+    default: '23.1.7779620'
     required: false
   git-lfs:
     description: 'Restore Git LFS cache'

--- a/android/versioned-abis/expoview-abi47_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi47_0_0/build.gradle
@@ -179,6 +179,10 @@ dependencies {
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'
 
+  // expo-barcode-scanner
+  implementation "com.google.android.gms:play-services-vision:19.0.0"
+  implementation "com.google.zxing:core:3.3.3"
+
   // expo-store-review
   implementation "com.google.android.play:review:2.0.1"
   implementation "com.google.android.play:review-ktx:2.0.0"

--- a/android/versioned-abis/expoview-abi48_0_0/build.gradle
+++ b/android/versioned-abis/expoview-abi48_0_0/build.gradle
@@ -176,6 +176,10 @@ dependencies {
   // expo-application
   api 'com.android.installreferrer:installreferrer:1.0'
 
+  // expo-barcode-scanner
+  implementation "com.google.android.gms:play-services-vision:19.0.0"
+  implementation "com.google.zxing:core:3.3.3"
+
   // expo-store-review
   implementation "com.google.android.play:review:2.0.1"
   implementation "com.google.android.play:review-ktx:2.0.0"


### PR DESCRIPTION
# Why

regression from #22107
this happens only on versioned variant: https://github.com/expo/expo/actions/runs/5206380027/jobs/9392879045

# How

- backport necessary dependency to sdk 47/48 code.
- though it's unrelated, also bump default ndk version in our cache. we now build from ndk r23. original ndk r21 will always be cache missed.

# Test Plan

`./gradlew :app:assembleVersionedDebug`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
