### PR TITLE
[docs] Document `eas device:rename`

### DIFF
--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -163,3 +163,36 @@ It's possible to run internal distribution builds non-interactively in CI using 
 {/* (@dsokal) this is not implemented yet */}
 
 {/* When using iOS ad hoc provisioning managed by Expo, if a teammate navigates to this URL on an iOS device that is not yet registered, they will be able to register their device and initiate a new build to include the updated profile that will run on their device. If the ad hoc provisioning profile is not managed by Expo, the user will be asked to contact the organization admin in order to add their device UDID and create a new build compatible with their device. */}
+
+## Managing devices
+You can see any devices registered via `eas device:create` by running:
+<Terminal
+  cmd={[
+    '# List devices registered for ad hoc provisioning',
+    '$ eas device:list',
+  ]}
+  cmdCopy="eas device:list"
+/>
+
+Devices registered with Expo for ad hoc provisioning will only appear on your Apple Developer Portal once they are used when generating a provisioning profile for a new internal build with EAS Build or for resigning an existing build with `eas build:resign`.
+
+### Remove devices
+If a device is no longer in use, it can be removed from this list by running:
+<Terminal
+  cmd={[
+    '# Delete devices from your Expo account, optionally disable them on the Apple Developer Portal',
+    '$ eas device:delete',
+  ]}
+  cmdCopy="eas device:delete"
+/>
+This command will also optionally disable to device on the Apple Developer Portal. Note that disabled devices may still count against Apple's limit of 100 devices for ad hoc distribution per app.
+
+### Rename devices
+Devices added via the website URL/ QR code will default to displaying their UDID when selecting them for an EAS Build. You can assign friendly names to your devices with the following command:
+<Terminal
+  cmd={[
+    '# Rename devices on Expo and the Apple Developer Portal',
+    '$ eas device:rename',
+  ]}
+  cmdCopy="eas device:delete"
+/>

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -174,7 +174,7 @@ You can see any devices registered via `eas device:create` by running:
   cmdCopy="eas device:list"
 />
 
-Devices registered with Expo for ad hoc provisioning will only appear on your Apple Developer Portal once they are used when generating a provisioning profile for a new internal build with EAS Build or for resigning an existing build with `eas build:resign`.
+Devices registered with Expo for ad hoc provisioning will appear on your Apple Developer Portal after they are used to generate a provisioning profile for a new internal build with EAS Build or to [resign an existing build](/app-signing/app-credentials/#re-signing-new-credentials) with `eas build:resign`.
 
 ### Remove devices
 If a device is no longer in use, it can be removed from this list by running:

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -185,7 +185,7 @@ If a device is no longer in use, it can be removed from this list by running:
   ]}
   cmdCopy="eas device:delete"
 />
-This command will also optionally disable to device on the Apple Developer Portal. Note that disabled devices may still count against Apple's limit of 100 devices for ad hoc distribution per app.
+This command will also prompt you to disable the device on the Apple Developer Portal. Disabled devices still count against [Apple's limit of 100 devices](https://developer.apple.com/support/account/#:~:text=Resetting%20your%20device%20list%20annually) for ad hoc distribution per app.
 
 ### Rename devices
 Devices added via the website URL/ QR code will default to displaying their UDID when selecting them for an EAS Build. You can assign friendly names to your devices with the following command:

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -188,7 +188,7 @@ If a device is no longer in use, it can be removed from this list by running:
 This command will also prompt you to disable the device on the Apple Developer Portal. Disabled devices still count against [Apple's limit of 100 devices](https://developer.apple.com/support/account/#:~:text=Resetting%20your%20device%20list%20annually) for ad hoc distribution per app.
 
 ### Rename devices
-Devices added via the website URL/ QR code will default to displaying their UDID when selecting them for an EAS Build. You can assign friendly names to your devices with the following command:
+Devices added via the website URL/QR code will default to displaying their UDID when selecting them for an EAS Build. You can assign friendly names to your devices with the following command:
 <Terminal
   cmd={[
     '# Rename devices on Expo and the Apple Developer Portal',


### PR DESCRIPTION
# Why
Fulfills https://linear.app/expo/issue/ENG-8525/document-eas-devicerename.

# How
Wasn't sure where to put this, except somewhere with Internal Distribution. At this point, it made sense to me to make a whole section at the bottom about managing devices after they're created, so that's what I did.

# Test Plan
Ran docs locally, looked OK

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
