### PR TITLE
chore(template): drop missing reference to main.jsbundle

### DIFF
--- a/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = HelloWorld/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = HelloWorld/AppDelegate.mm; sourceTree = "<group>"; };

--- a/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -49,7 +49,6 @@
 			isa = PBXGroup;
 			children = (
 				BB2F792B24A3F905000567C9 /* Supporting */,
-				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,


### PR DESCRIPTION
# Why

- Unclear why we have this here, I remember apps wouldn't build without it in the past. Works now.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="267" alt="Screenshot 2023-06-08 at 1 54 35 PM" src="https://github.com/expo/expo/assets/9664363/72289e2d-b138-4dd1-ba5a-d8eebd5b3b20">
<img width="269" alt="Screenshot 2023-06-08 at 1 55 06 PM" src="https://github.com/expo/expo/assets/9664363/9e88e1fe-f7ac-4ecd-856a-bd2913be439a">


# How

- Delete reference to `main.jsbundle`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `yarn expo run:ios` works.
- `yarn expo run:ios --configuration Release` works.
- `EXPO_DEBUG=1 yarn expo run:ios --configuration Release` shows the output path, visiting will show a `main.jsbundle` included in the app bundle.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
