### PR TITLE
[docs] Remove Archive > Introduction from the sidebar

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -406,7 +406,6 @@ const preview = [
 ];
 
 const archive = [
-  makeSection('Archive', [makePage('archive/index.mdx')]),
   makeSection('Classic Builds', [
     makePage('archive/classic-updates/building-standalone-apps.mdx'),
     makePage('archive/classic-updates/turtle-cli.mdx'),

--- a/docs/pages/archive/index.js
+++ b/docs/pages/archive/index.js
@@ -1,3 +1,0 @@
-import redirect from '~/common/redirect';
-
-export default redirect('/archive/classic-updates/building-standalone-apps/');

--- a/docs/pages/archive/index.js
+++ b/docs/pages/archive/index.js
@@ -1,0 +1,3 @@
+import redirect from '~/common/redirect';
+
+export default redirect('/archive/classic-updates/building-standalone-apps/');

--- a/docs/pages/archive/index.mdx
+++ b/docs/pages/archive/index.mdx
@@ -1,0 +1,8 @@
+---
+title: Archive
+sidebar_title: Introduction
+hideTOC: true
+hideInSidebar: true
+---
+
+This section of the docs is dedicated to archived content. Archived content will not receive any further updates, but may be useful to developers still using legacy features and services.

--- a/docs/pages/archive/index.mdx
+++ b/docs/pages/archive/index.mdx
@@ -1,7 +1,0 @@
----
-title: Archive
-sidebar_title: Introduction
-hideTOC: true
----
-
-This section of the docs is dedicated to archived content. Archived content will not receive any further updates, but may be useful to developers still using legacy features and services.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8877

# How

<!--
How did you build this feature or fix this bug and why?
-->

~~Remove the Introduction page in the Archive section and a common redirect to navigate to the first page when the path `/archive/` becomes active.~~

**Update**

After more discussion, we decided to keep the Archive > Introduction page as a landing page instead of redirecting to a random sub path when docs.expo.dev/archive is called. However, the Introduction page is now hidden from the sidebar navigation since the page doesn't have much information.

# Test Plan

Changes can be tested by running docs locally and visiting `http://localhost:3002/archive/`

**Preview**

<img width="1510" alt="CleanShot 2023-06-15 at 18 11 53@2x" src="https://github.com/expo/expo/assets/10234615/0186a9bf-7bc0-4821-a0c1-caaca2ff7c58">


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
