### PR TITLE
[docs] Fix link for Electron adapter example in Developer for web guide

### DIFF
--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -57,7 +57,7 @@ The ability to use Expo web with these other React frameworks is what makes it t
 - [Storybook](https://github.com/expo/examples/tree/master/with-storybook)
 - [Preact](https://github.com/expo/examples/tree/master/with-preact)
 - [Gatsby](https://github.com/expo/examples/tree/master/with-gatsby)
-- [Electron](https://github.com/expo/examples/tree/master/with-electron)
+- [Electron](https://github.com/expo/expo-electron-adapter/tree/main/example)
 
 > Alternative framework implementations are maintained by the Expo community.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fix link for Electron adapter example in Developer for web guide

# How

<!--
How did you build this feature or fix this bug and why?
-->

By fixing the broken link and pointing it towards the https://github.com/expo/expo-electron-adapter/tree/main/example

# Test Plan

Changes can be tested by running docs locally.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
