### PR TITLE
[insights] Use CFBundleShortVersionString (aka: "version") rather than CFBundleVersion (aka: "build number")

### DIFF
--- a/packages/expo-insights/ios/InsightsModule.swift
+++ b/packages/expo-insights/ios/InsightsModule.swift
@@ -100,7 +100,7 @@ private func getLaunchEventData(projectId: String) -> [String: String?] {
     "event_name": "APP_LAUNCH",
     "eas_client_id": EASClientID.uuid().uuidString,
     "project_id": projectId,
-    "app_version": info?["CFBundleVersion"] as? String,
+    "app_version": info?["CFBundleShortVersionString"] as? String,
     "platform": "iOS",
     "os_version": UIDevice.current.systemVersion
   ]


### PR DESCRIPTION
# Why

This matches our intent from our spec, and it was an accident that we used CFBundleVersion.

# How

Change the symbol

# Test Plan

I applied this patch in my app and verified the payload includes the expected data
