### PR TITLE
[dev-launcher][dev-menu][ios] Add support for Fabric - Part 2

### DIFF
--- a/packages/expo-dev-launcher/ios/EXDevLauncherBridgeDelegate.mm
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherBridgeDelegate.mm
@@ -44,9 +44,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 
     RCTAppSetupPrepareApp(application, enableTM);
 
-    if (!self.bridge) {
         self.bridge = [self createBridgeWithDelegate:self launchOptions:launchOptions];
-    }
 
 #ifdef RCT_NEW_ARCH_ENABLED
     _contextContainer = std::make_shared<facebook::react::ContextContainer const>();

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -276,6 +276,7 @@
   [self _removeInitModuleObserver];
   UIApplication *application = [UIApplication sharedApplication];
   UIView *rootView = [_bridgeDelegate createRootViewWithModuleName:@"main" launchOptions:_launchOptions application:application];
+  _launcherBridge = _bridgeDelegate.bridge;
 
   [self _ensureUserInterfaceStyleIsInSyncWithTraitEnv:rootView];
 

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherBridgeDelegateHandler.h
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherBridgeDelegateHandler.h
@@ -1,0 +1,8 @@
+#import <React-RCTAppDelegate/RCTAppDelegate.h>
+#import <React/RCTRootView.h>
+
+@interface ExpoDevLauncherBridgeDelegateHandler : RCTAppDelegate
+
+- (RCTBridge *)createBridgeWithAdapter:(NSDictionary *_Nullable)launchOptions;
+
+@end

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherBridgeDelegateHandler.mm
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherBridgeDelegateHandler.mm
@@ -1,0 +1,54 @@
+#import "ExpoDevLauncherBridgeDelegateHandler.h"
+#import "EXDevLauncherController.h"
+
+#import <React/RCTBundleURLProvider.h>
+#import "RCTAppSetupUtils.h"
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#import <memory>
+
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+#import <react/config/ReactNativeConfig.h>
+#import <React/RCTCxxBridgeDelegate.h>
+
+
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+#import <React-RCTAppDelegate/RCTAppDelegate.h>
+
+static NSString *const kRNConcurrentRoot = @"concurrentRoot";
+
+@interface ExpoDevLauncherBridgeDelegateHandler () <RCTTurboModuleManagerDelegate, RCTCxxBridgeDelegate> {
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+
+#endif
+
+@implementation ExpoDevLauncherBridgeDelegateHandler
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+  return [[EXDevLauncherController sharedInstance] sourceUrl];
+}
+
+- (RCTBridge *)createBridgeWithAdapter:(NSDictionary * _Nullable)launchOptions {
+    self.bridge = [self createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#ifdef RCT_NEW_ARCH_ENABLED
+    _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+    _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+    _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+    self.bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:self.bridge
+                                                                 contextContainer:_contextContainer];
+    self.bridge.surfacePresenter = self.bridgeAdapter.surfacePresenter;
+#endif
+
+    return self.bridge;
+}
+
+@end

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -85,8 +85,8 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       launchOptions[key] = value
     }
 
-     let bridge = self.bridgeDelegateHandler.createBridge(withAdapter: launchOptions)
-     developmentClientController.appBridge = bridge
+    let bridge = self.bridgeDelegateHandler.createBridge(withAdapter: launchOptions)
+    developmentClientController.appBridge = bridge
 
     guard let rootView = self.bridgeDelegateHandler.createRootView(with: bridge, moduleName: self.rootViewModuleName!, initProps: self.rootViewInitialProperties)  else {
         return

--- a/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
+++ b/packages/expo-dev-menu/app/hooks/useDevSettings.tsx
@@ -88,8 +88,7 @@ export function useDevSettings() {
   }, []);
 
   const openRNDevMenu = React.useCallback(async () => {
-    await DevMenu.openDevMenuFromReactNative();
-    DevMenu.closeMenu();
+    DevMenu.openDevMenuFromReactNative();
   }, []);
 
   const openJSInspector = React.useCallback(async () => {

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -24,7 +24,9 @@ class DevMenuDevOptionsDelegate {
     // No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.
     DevMenuManager.shared.hideMenu()
 
-    bridge?.requestReload()
+    DispatchQueue.main.async {
+      RCTTriggerReloadCommandListeners("Dev menu - reload")
+    }
   }
 
   internal func toggleElementInsector() {
@@ -53,7 +55,7 @@ class DevMenuDevOptionsDelegate {
     }
 
     DevMenuManager.shared.hideMenu()
-    
+
     DispatchQueue.main.async {
       devSettings.isDebuggingRemotely = !devSettings.isDebuggingRemotely
       (DevMenuManager.shared.window?.rootViewController as? DevMenuViewController)?.updateProps() // We have to force props to reflect changes on the UI

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -163,13 +163,13 @@ open class DevMenuManager: NSObject {
    */
   @objc
   @discardableResult
-  public func closeMenu() -> Bool {
+  public func closeMenu(completion: (() -> Void)? = nil) -> Bool {
     if isVisible {
       if Thread.isMainThread {
-        window?.closeBottomSheet()
+          window?.closeBottomSheet(completion: completion)
       } else {
         DispatchQueue.main.async { [self] in
-          window?.closeBottomSheet()
+            window?.closeBottomSheet(completion: completion)
         }
       }
       return true

--- a/packages/expo-dev-menu/ios/DevMenuWindow.swift
+++ b/packages/expo-dev-menu/ios/DevMenuWindow.swift
@@ -115,7 +115,7 @@ class DevMenuWindow: UIWindow, OverlayContainerViewControllerDelegate {
     }
   }
 
-  func closeBottomSheet() {
-    bottomSheetController.moveOverlay(toNotchAt: OverlayNotch.hidden.rawValue, animated: true)
+  func closeBottomSheet(completion: (() -> Void)? = nil) {
+    bottomSheetController.moveOverlay(toNotchAt: OverlayNotch.hidden.rawValue, animated: true, completion: completion)
   }
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuInternalModule.swift
@@ -56,8 +56,10 @@ public class DevMenuInternalModule: Module {
         return
       }
 
-      DispatchQueue.main.async {
-        rctDevMenu.show()
+      DevMenuManager.shared.closeMenu {
+        DispatchQueue.main.async {
+          rctDevMenu.show()
+        }
       }
     }
 


### PR DESCRIPTION
# Why

Closes ENG-7955

This PR is Part 2 of a series of PRs that will add dev-launcher support for the new architecture. 

Part 1 #22184

# How

- Fix `EXDevLauncherBridgeDelegate` not able to relaunch DevLauncher 
- Add `ExpoDevLauncherBridgeDelegateHandler` to handle opening apps from `ExpoDevLauncherReactDelegateHandler`
- Update `openDevMenuFromReactNative` to ensure the DevMenu is closed before opening the react-native dev menu


# Test Plan

Run `fabric-tester` and `bare-expo` on iOS
 

<table>
    <tr><th>fabric-tester</th><th>bare-expo</th></tr>
    <tr>
    <td>
        <video src="https://github.com/expo/expo/assets/11707729/69e80f31-3d8e-4135-afd7-0f4264052a79"/>
   </td>
   <td>
   <video src="https://github.com/expo/expo/assets/11707729/99b10d00-45b3-4b3e-b7c0-2cc7599ebad7"   />  
    </td>
</tr> 
</table> 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
