### PR TITLE
[docs] Remove duplicate "how" words

### DIFF
--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using expo-dev-client with EAS Update
-description: Learn how how to use the expo-dev-client library to preview a published EAS Update inside a development build.
+description: Learn how to use the expo-dev-client library to preview a published EAS Update inside a development build.
 ---
 
 import { Step } from '~/ui/components/Step';


### PR DESCRIPTION
# Why

It seems that “how” is repeated.

![image](https://github.com/expo/expo/assets/63455218/174cfe2a-de1e-4518-945d-37362fc0976f)

# How

Remove duplicate word.

# Test Plan

![image](https://github.com/expo/expo/assets/63455218/96a82057-d864-4d92-99b5-65b41331bd81)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
