### PR TITLE
[home][ncl] fix loading or exporting bundles

### DIFF
--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -9,7 +9,7 @@ if (process.env.EXPO_USE_EXOTIC) {
 }
 
 // To test NCL from Expo Go, the react-native js source is from our fork.
-const reactNativeRoot = path.join(__dirname, '..', '..', 'react-native-lab', 'react-native');
+const reactNativeRoot = path.join(__dirname, '..', '..', 'react-native-lab', 'react-native', 'packages', 'react-native');
 
 module.exports = {
   ...baseConfig,

--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-952ab1ffab1a5cc42baa92d33ca41b78cd686bd5"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-08559626fd1b2000cdc491d9cfd82de83063d077"
 }

--- a/home/metro.config.js
+++ b/home/metro.config.js
@@ -4,7 +4,7 @@ const path = require('path');
 const baseConfig = createMetroConfiguration(__dirname);
 
 // To test home from Expo Go, the react-native js source is from our fork.
-const reactNativeRoot = path.join(__dirname, '..', 'react-native-lab', 'react-native');
+const reactNativeRoot = path.join(__dirname, '..', 'react-native-lab', 'react-native', 'packages', 'react-native');
 
 module.exports = {
   ...baseConfig,


### PR DESCRIPTION
# Why

fix the following errors when publishing dev home

```
Error: Cannot find module '/Users/kudo/expo/expo/react-native-lab/react-native/rn-get-polyfills'
Require stack:
- /Users/kudo/expo/expo/home/metro.config.js
- /Users/kudo/expo/expo/node_modules/cosmiconfig/node_modules/import-fresh/index.js
- /Users/kudo/expo/expo/node_modules/cosmiconfig/dist/loaders.js
- /Users/kudo/expo/expo/node_modules/cosmiconfig/dist/createExplorer.js
- /Users/kudo/expo/expo/node_modules/cosmiconfig/dist/index.js
- /Users/kudo/expo/expo/node_modules/metro-config/src/loadConfig.js
- /Users/kudo/expo/expo/node_modules/metro-config/src/index.js
- /Users/kudo/expo/expo/node_modules/metro/src/commands/build.js
- /Users/kudo/expo/expo/node_modules/metro/src/index.flow.js
- /Users/kudo/expo/expo/node_modules/metro/src/index.js
- /Users/kudo/expo/expo/packages/@expo/dev-server/build/metro/importMetroFromProject.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/src/export/fork-bundleAsync.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/src/export/createBundles.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/src/export/exportApp.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/src/export/exportAsync.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/src/export/index.js
- /Users/kudo/expo/expo/packages/@expo/cli/build/bin/cli
```

# How

- since the react-native monorepo changes, we should use the `react-native-lab/react-native/packages/react-native` as root.
- republish dev home

# Test Plan

- unversioned expo go + ncl

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
