### PR TITLE
[docs] Fix minor typo in Expo Go page

### DIFF
--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -7,7 +7,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 
-Expo Go is a free, [open-source](https://github.com/expo/expo/tree/main/home) client for testing React Native apps on Android and iOS without needing to build anything locally. It is the fastest way to get up and running is to use the [Expo Go](https://expo.dev/client) client app on your Android or iOS device. It allows you to open up apps served through Expo CLI and run your projects faster when developing them.
+Expo Go is a free, [open-source](https://github.com/expo/expo/tree/main/home) client for testing React Native apps on Android and iOS without needing to build anything locally. The fastest way to get up and running is to use the [Expo Go](https://expo.dev/client) client app on your Android or iOS device. It allows you to open up apps served through Expo CLI and run your projects faster when developing them.
 
 ## Install Expo Go on your device
 

--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -7,7 +7,7 @@ import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 
-Expo Go is a free, [open-source](https://github.com/expo/expo/tree/main/home) client for testing React Native apps on Android and iOS without needing to build anything locally. The fastest way to get up and running is to use the [Expo Go](https://expo.dev/client) client app on your Android or iOS device. It allows you to open up apps served through Expo CLI and run your projects faster when developing them.
+[Expo Go](https://expo.dev/client) is a free, [open-source](https://github.com/expo/expo/tree/main/home) client for testing React Native apps on Android and iOS devices without building anything locally. It allows you to open up apps served through Expo CLI and run your projects faster when developing them.
 
 ## Install Expo Go on your device
 


### PR DESCRIPTION
# Why

Stumbled upon this minor typo while reading the docs.

# How

(Hopefully) made it easier to read the sentence by removing the typo.

# Test Plan

-

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
