### PR TITLE
[docs] Update callout in reference docs for third party libraries

### DIFF
--- a/docs/pages/versions/unversioned/sdk/captureRef.mdx
+++ b/docs/pages/versions/unversioned/sdk/captureRef.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.mdx#takesnapshotasyncoptions) instead.

--- a/docs/pages/versions/unversioned/sdk/flash-list.mdx
+++ b/docs/pages/versions/unversioned/sdk/flash-list.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/flash-list`** is a "Fast & performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/unversioned/sdk/lottie.mdx
+++ b/docs/pages/versions/unversioned/sdk/lottie.mdx
@@ -6,7 +6,9 @@ packageName: 'lottie-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -10,6 +10,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -10,9 +10,9 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-A component that provides access to the system UI for picking between several options.
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+A component that provides access to the system UI for picking between several options.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
@@ -39,7 +41,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 {/* prettier-ignore */}
 ```js babel.config.js
-plugins: [    
+plugins: [
   '@babel/plugin-proposal-export-namespace-from',
   'react-native-reanimated/plugin',
 ],

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-safe-area-context'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/unversioned/sdk/shared-element.mdx
+++ b/docs/pages/versions/unversioned/sdk/shared-element.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-shared-element`** provides a set of building blocks to help you build shared element transitions &mdash; animations where you transition an element in one scene smoothly into another.
 
 > Note: this library is still in alpha. Please refer to [the issue tracker](https://github.com/IjzerenHein/react-native-shared-element/issues) if you encounter any problems.

--- a/docs/pages/versions/unversioned/sdk/skia.mdx
+++ b/docs/pages/versions/unversioned/sdk/skia.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/react-native-skia`** brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/unversioned/sdk/view-pager.mdx
+++ b/docs/pages/versions/unversioned/sdk/view-pager.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={'sdk/viewpager.mp4'} loop={false} />

--- a/docs/pages/versions/v46.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/captureRef.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.mdx#takesnapshotasyncoptions) instead.

--- a/docs/pages/versions/v46.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/flash-list.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/flash-list`** is a "Fast & performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v46.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/lottie.mdx
@@ -6,7 +6,9 @@ packageName: 'lottie-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -10,6 +10,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/v46.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/picker.mdx
@@ -10,9 +10,9 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-A component that provides access to the system UI for picking between several options.
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+A component that provides access to the system UI for picking between several options.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v46.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/reanimated.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-reanimated`** provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with react-native-reanimated, you will need to use the [Hermes JavaScript engine](/guides/using-hermes.mdx) and the [JavaScript Inspector for Hermes](/guides/using-hermes.mdx#javascript-inspector-for-hermes).

--- a/docs/pages/versions/v46.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/safe-area-context.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-safe-area-context'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/shared-element.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-shared-element`** provides a set of building blocks to help you build shared element transitions &mdash; animations where you transition an element in one scene smoothly into another.
 
 > Note: this library is still in alpha. Please refer to [the issue tracker](https://github.com/IjzerenHein/react-native-shared-element/issues) if you encounter any problems.

--- a/docs/pages/versions/v46.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/skia.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/react-native-skia`** brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v46.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/svg.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v46.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/view-pager.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={'sdk/viewpager.mp4'} loop={false} />

--- a/docs/pages/versions/v47.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/captureRef.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.mdx#takesnapshotasyncoptions) instead.

--- a/docs/pages/versions/v47.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/flash-list.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/flash-list`** is a "Fast & performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v47.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/lottie.mdx
@@ -6,7 +6,9 @@ packageName: 'lottie-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v47.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/map-view.mdx
@@ -11,6 +11,8 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/v47.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/picker.mdx
@@ -10,9 +10,9 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-A component that provides access to the system UI for picking between several options.
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+A component that provides access to the system UI for picking between several options.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
@@ -39,7 +41,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 {/* prettier-ignore */}
 ```js babel.config.js
-plugins: [    
+plugins: [
   '@babel/plugin-proposal-export-namespace-from',
   'react-native-reanimated/plugin',
 ],

--- a/docs/pages/versions/v47.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/safe-area-context.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-safe-area-context'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v47.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/shared-element.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-shared-element`** provides a set of building blocks to help you build shared element transitions &mdash; animations where you transition an element in one scene smoothly into another.
 
 > Note: this library is still in alpha. Please refer to [the issue tracker](https://github.com/IjzerenHein/react-native-shared-element/issues) if you encounter any problems.

--- a/docs/pages/versions/v47.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/skia.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/react-native-skia`** brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v47.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/svg.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v47.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/view-pager.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={'sdk/viewpager.mp4'} loop={false} />

--- a/docs/pages/versions/v48.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/captureRef.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-view-shot'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 Given a view, `captureRef` will essentially screenshot that view and return an image for you. This is very useful for things like signature pads, where the user draws something and then you want to save an image from it.
 
 If you're interested in taking snapshots from the GLView, we recommend you use [GLView's takeSnapshotAsync](gl-view.mdx#takesnapshotasyncoptions) instead.

--- a/docs/pages/versions/v48.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/flash-list.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/flash-list'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/flash-list`** is a "Fast & performant React Native list" component that is a drop-in replacement for React Native's `<FlatList>` component. It "recycles components under the hood to maximize performance."
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v48.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/lottie.mdx
@@ -6,7 +6,9 @@ packageName: 'lottie-react-native'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
+
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
 [Lottie](https://airbnb.design/lottie/) renders After Effects animations in real time, allowing apps to use animations as easily as they use static images.
 

--- a/docs/pages/versions/v48.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/map-view.mdx
@@ -10,6 +10,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/v48.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/picker.mdx
@@ -10,9 +10,9 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
-A component that provides access to the system UI for picking between several options.
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
-> **info** This library was formerly known as `@react-native-community/picker`. If you have that library in your SDK 40+ project, you can uninstall it and install this one instead.
+A component that provides access to the system UI for picking between several options.
 
 <PlatformsSection android emulator ios simulator web />
 

--- a/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-reanimated'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 `react-native-reanimated` provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 
 > **Reanimated uses React Native APIs that are incompatible with "Remote JS Debugging" for JavaScriptCore**. In order to use a debugger with your app with `react-native-reanimated`, you'll need to use the [Hermes JavaScript engine](/guides/using-hermes) and the [JavaScript Inspector for Hermes](/guides/using-hermes#javascript-inspector-for-hermes).
@@ -39,7 +41,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 {/* prettier-ignore */}
 ```js babel.config.js
-plugins: [    
+plugins: [
   '@babel/plugin-proposal-export-namespace-from',
   'react-native-reanimated/plugin',
 ],

--- a/docs/pages/versions/v48.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/safe-area-context.mdx
@@ -7,6 +7,8 @@ packageName: 'react-native-safe-area-context'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-safe-area-context`** provides a flexible API for accessing device safe area inset information. This allows you to position your content appropriately around notches, status bars, home indicators, and other such device and operating system interface elements. It also provides a `SafeAreaView` component that you can use in place of `View` to automatically inset your views to account for safe areas.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v48.0.0/sdk/shared-element.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/shared-element.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-shared-element`** provides a set of building blocks to help you build shared element transitions &mdash; animations where you transition an element in one scene smoothly into another.
 
 > Note: this library is still in alpha. Please refer to [the issue tracker](https://github.com/IjzerenHein/react-native-shared-element/issues) if you encounter any problems.

--- a/docs/pages/versions/v48.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/skia.mdx
@@ -7,6 +7,8 @@ packageName: '@shopify/react-native-skia'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`@shopify/react-native-skia`** brings the Skia Graphics Library to React Native. Skia serves as the graphics engine for Google Chrome and Chrome OS, Android, Flutter, Mozilla Firefox and Firefox OS, and many other products.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v48.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/svg.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-svg`** allows you to use SVGs in your app, with support for interactivity and animation.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v48.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/view-pager.mdx
@@ -8,6 +8,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 **`react-native-pager-view`** exposes a component that provides the layout and gestures to scroll between pages of content, like a carousel.
 
 <Video file={'sdk/viewpager.mp4'} loop={false} />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Having third party libraries as part of our official API reference docs suggest we recommend a certain library over other solutions. However, the case is that these third-party libraries are included in Expo Go but my an means we are not recommending them. Original issue [context in slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1685641621092159).

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a callout that describes that the library is included in Expo Go and that is why it is part of Expo SDK reference docs.

This PR adds the callout in the following reference pages:
- MapView
- Picker
- captureRef
- ViewPager
- Lottie
- Reanimated
- SafeAreaContext
- flash-list
- Skia
- Svg
- SharedElements

Changes backported from unversioned to all existing SDKs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

**Preview**

<img width="912" alt="CleanShot 2023-06-13 at 17 31 04@2x" src="https://github.com/expo/expo/assets/10234615/6aa964e6-cc29-4459-bde9-6d25bc8f4720">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
