### PR TITLE
[home] Add support for SSO users

### DIFF
--- a/home/HomeApp.tsx
+++ b/home/HomeApp.tsx
@@ -17,9 +17,9 @@ import {
   HomeScreenDataDocument,
   HomeScreenDataQuery,
   HomeScreenDataQueryVariables,
-  Home_CurrentUserDocument,
-  Home_CurrentUserQuery,
-  Home_CurrentUserQueryVariables,
+  Home_CurrentUserActorDocument,
+  Home_CurrentUserActorQuery,
+  Home_CurrentUserActorQueryVariables,
 } from './graphql/types';
 import Navigation from './navigation/Navigation';
 import HistoryActions from './redux/HistoryActions';
@@ -103,8 +103,8 @@ export default function HomeApp() {
       }
 
       const [currentUserQueryResult, persistedCurrentAccount] = await Promise.all([
-        ApolloClient.query<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>({
-          query: Home_CurrentUserDocument,
+        ApolloClient.query<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>({
+          query: Home_CurrentUserActorDocument,
           context: { headers: { 'expo-session': storedSession?.sessionSecret } },
         }),
         AsyncStorage.getItem('currentAccount'),
@@ -134,14 +134,14 @@ export default function HomeApp() {
         }),
       ]);
 
-      if (currentUserQueryResult.data && currentUserQueryResult.data.viewer) {
+      if (currentUserQueryResult.data && currentUserQueryResult.data.meUserActor) {
         let firstLoadAccountName = persistedCurrentAccount;
         if (firstLoadAccountName) {
           // if there was a persisted account, and it matches the accounts available to the current user, use it
           if (
             [
-              currentUserQueryResult.data.viewer.username,
-              ...currentUserQueryResult.data.viewer.accounts.map((account) => account.name),
+              currentUserQueryResult.data.meUserActor.username,
+              ...currentUserQueryResult.data.meUserActor.accounts.map((account) => account.name),
             ].includes(firstLoadAccountName)
           ) {
             setAccountName(firstLoadAccountName);
@@ -151,7 +151,7 @@ export default function HomeApp() {
           }
         } else {
           // if there was no persisted account, use the current user's personal account
-          firstLoadAccountName = currentUserQueryResult.data.viewer.username;
+          firstLoadAccountName = currentUserQueryResult.data.meUserActor.username;
           setAccountName(firstLoadAccountName);
         }
 

--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { ApolloClient, InMemoryCache, from } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
 import { HttpLink } from '@apollo/client/link/http';
 import { offsetLimitPagination } from '@apollo/client/utilities';
@@ -7,63 +7,74 @@ import Store from '../redux/Store';
 import Config from './Config';
 import Connectivity from './Connectivity';
 
-const httpLink = new HttpLink({
-  uri: `${Config.api.origin}/--/graphql`,
-});
+export function createApolloClient() {
+  const httpLink = new HttpLink({
+    uri: `${Config.api.origin}/--/graphql`,
+  });
 
-const connectivityLink = setContext(async (): Promise<any> => {
-  const isConnected = await Connectivity.isAvailableAsync();
-  if (!isConnected) {
-    throw new Error('No connection available');
-  }
-});
+  const connectivityLink = setContext(async (): Promise<any> => {
+    const isConnected = await Connectivity.isAvailableAsync();
+    if (!isConnected) {
+      throw new Error('No connection available');
+    }
+  });
 
-const authMiddlewareLink = setContext((): any => {
-  const { sessionSecret } = Store.getState().session;
+  const authMiddlewareLink = setContext((_request, previousContext): any => {
+    const { sessionSecret } = Store.getState().session;
 
-  if (sessionSecret) {
-    return {
-      headers: { 'expo-session': sessionSecret },
-    };
-  }
-});
+    if (sessionSecret) {
+      return {
+        headers: { 'expo-session': sessionSecret },
+      };
+    }
 
-const link = connectivityLink.concat(authMiddlewareLink.concat(httpLink));
+    return previousContext;
+  });
 
-const cache = new InMemoryCache({
-  possibleTypes: {
-    ActivityTimelineProjectActivity: ['Build', 'BuildJob'],
-    BuildOrBuildJob: ['Build', 'BuildJob'],
-    BaseSearchResult: ['UserSearchResult', 'AppSearchResult'],
-    Project: ['App', 'Snack'],
-  },
-  addTypename: true,
-  typePolicies: {
-    Query: {
-      fields: {
-        account: {
-          merge: false,
+  const link = from([connectivityLink, authMiddlewareLink, httpLink]);
+
+  const cache = new InMemoryCache({
+    possibleTypes: {
+      AccountUsageMetadata: ['AccountUsageEASBuildMetadata'],
+      ActivityTimelineProjectActivity: ['Build', 'BuildJob', 'Submission', 'Update'],
+      Actor: ['Robot', 'SSOUser', 'User'],
+      BuildOrBuildJob: ['Build', 'BuildJob'],
+      EASBuildOrClassicBuildJob: ['Build', 'BuildJob'],
+      FcmSnippet: ['FcmSnippetLegacy', 'FcmSnippetV1'],
+      PlanEnablement: ['Concurrencies', 'EASTotalPlanEnablement'],
+      Project: ['App', 'Snack'],
+      UserActor: ['SSOUser', 'User'],
+    },
+    addTypename: true,
+    typePolicies: {
+      Query: {
+        fields: {
+          account: {
+            merge: false,
+          },
+          app: {
+            merge: false,
+          },
         },
-        app: {
-          merge: false,
+      },
+      Account: {
+        fields: {
+          apps: offsetLimitPagination(),
+          snacks: offsetLimitPagination(),
+        },
+      },
+      App: {
+        fields: {
+          updateBranches: offsetLimitPagination(),
         },
       },
     },
-    Account: {
-      fields: {
-        apps: offsetLimitPagination(),
-        snacks: offsetLimitPagination(),
-      },
-    },
-    App: {
-      fields: {
-        updateBranches: offsetLimitPagination(),
-      },
-    },
-  },
-});
+  });
 
-export default new ApolloClient({
-  link,
-  cache,
-});
+  return new ApolloClient({
+    link,
+    cache,
+  });
+}
+
+export default createApolloClient();

--- a/home/graphql.schema.json
+++ b/home/graphql.schema.json
@@ -7253,6 +7253,18 @@
                 "deprecationReason": null
               },
               {
+                "name": "filter",
+                "description": null,
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ChannelFilterInput",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
                 "name": "first",
                 "description": null,
                 "type": {
@@ -9250,6 +9262,22 @@
         "name": "AppInsights",
         "description": null,
         "fields": [
+          {
+            "name": "hasEventsFromExpoInsightsClientModule",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "totalUniqueUsers",
             "description": null,
@@ -13471,6 +13499,277 @@
       },
       {
         "kind": "OBJECT",
+        "name": "BackgroundJobReceipt",
+        "description": null,
+        "fields": [
+          {
+            "name": "account",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "createdAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errorCode",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "errorMessage",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resultId",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "ID",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "resultType",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BackgroundJobResultType",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "state",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "BackgroundJobState",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "tries",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "updatedAt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "willRetry",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "BackgroundJobReceiptQuery",
+        "description": null,
+        "fields": [
+          {
+            "name": "byId",
+            "description": "Look up background job receipt by ID",
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BackgroundJobResultType",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "GITHUB_BUILD",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "ENUM",
+        "name": "BackgroundJobState",
+        "description": null,
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": [
+          {
+            "name": "FAILURE",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "IN_PROGRESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "QUEUED",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "SUCCESS",
+            "description": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "Billing",
         "description": null,
         "fields": [
@@ -17034,6 +17333,29 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ChannelFilterInput",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "searchTerm",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -20686,7 +21008,7 @@
         "fields": [
           {
             "name": "createGitHubBuild",
-            "description": "Create a GitHub build for an app",
+            "description": "Create a GitHub build for an app. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job.",
             "args": [
               {
                 "name": "buildInput",
@@ -20709,8 +21031,8 @@
               "kind": "NON_NULL",
               "name": null,
               "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceipt",
                 "ofType": null
               }
             },
@@ -28680,6 +29002,22 @@
             "deprecationReason": null
           },
           {
+            "name": "backgroundJobReceipt",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "BackgroundJobReceiptQuery",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "buildJobs",
             "description": null,
             "args": [],
@@ -32908,6 +33246,22 @@
         "description": null,
         "fields": [
           {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "appId",
             "description": null,
             "args": [],
@@ -33319,6 +33673,22 @@
         "name": "UpdateChannel",
         "description": null,
         "fields": [
+          {
+            "name": "app",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "App",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
           {
             "name": "appId",
             "description": null,

--- a/home/graphql/fragments/CurrentUserActorData.fragment.graphql
+++ b/home/graphql/fragments/CurrentUserActorData.fragment.graphql
@@ -1,4 +1,5 @@
 fragment CurrentUserActorData on UserActor {
+  __typename
   id
   username
   firstName

--- a/home/graphql/fragments/CurrentUserActorData.fragment.graphql
+++ b/home/graphql/fragments/CurrentUserActorData.fragment.graphql
@@ -1,4 +1,4 @@
-fragment CurrentUserData on User {
+fragment CurrentUserActorData on UserActor {
   id
   username
   firstName
@@ -7,7 +7,7 @@ fragment CurrentUserData on User {
   accounts {
     id
     name
-    owner {
+    ownerUserActor {
       id
       username
       profilePhoto

--- a/home/graphql/queries/CurrentUserActorQuery.query.graphql
+++ b/home/graphql/queries/CurrentUserActorQuery.query.graphql
@@ -1,0 +1,5 @@
+query Home_CurrentUserActor {
+  meUserActor {
+    ...CurrentUserActorData
+  }
+}

--- a/home/graphql/queries/CurrentUserQuery.query.graphql
+++ b/home/graphql/queries/CurrentUserQuery.query.graphql
@@ -1,5 +1,0 @@
-query Home_CurrentUser {
-  viewer {
-    ...CurrentUserData
-  }
-}

--- a/home/graphql/queries/ProfileDataQuery.query.graphql
+++ b/home/graphql/queries/ProfileDataQuery.query.graphql
@@ -1,5 +1,5 @@
 query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
-  me {
+  meUserActor {
     id
     username
     firstName

--- a/home/graphql/queries/ProfileProjectsQuery.query.graphql
+++ b/home/graphql/queries/ProfileProjectsQuery.query.graphql
@@ -1,5 +1,5 @@
 query Home_MyApps($limit: Int!, $offset: Int!) {
-  me {
+  meUserActor {
     id
     appCount
     apps(limit: $limit, offset: $offset, includeUnpublished: true) {

--- a/home/graphql/queries/ProfileSnacksQuery.query.graphql
+++ b/home/graphql/queries/ProfileSnacksQuery.query.graphql
@@ -1,5 +1,5 @@
 query Home_ProfileSnacks($limit: Int!, $offset: Int!) {
-  me {
+  meUserActor {
     id
     snacks(limit: $limit, offset: $offset) {
       ...CommonSnackData

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -5432,9 +5432,9 @@ export type CommonAppDataFragment = { __typename?: 'App', id: string, fullName: 
 
 export type CommonSnackDataFragment = { __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean };
 
-type CurrentUserActorData_SsoUser_Fragment = { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+type CurrentUserActorData_SsoUser_Fragment = { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
 
-type CurrentUserActorData_User_Fragment = { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+type CurrentUserActorData_User_Fragment = { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
 
 export type CurrentUserActorDataFragment = CurrentUserActorData_SsoUser_Fragment | CurrentUserActorData_User_Fragment;
 
@@ -5471,7 +5471,7 @@ export type BranchesForProjectQuery = { __typename?: 'RootQuery', app: { __typen
 export type Home_CurrentUserActorQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
+export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
 
 export type Home_ProfileData2QueryVariables = Exact<{
   appLimit: Scalars['Int'];
@@ -5479,7 +5479,7 @@ export type Home_ProfileData2QueryVariables = Exact<{
 }>;
 
 
-export type Home_ProfileData2Query = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
+export type Home_ProfileData2Query = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, appCount: number, accounts: Array<{ __typename?: 'Account', id: string, name: string }>, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
 
 export type Home_MyAppsQueryVariables = Exact<{
   limit: Scalars['Int'];
@@ -5487,7 +5487,7 @@ export type Home_MyAppsQueryVariables = Exact<{
 }>;
 
 
-export type Home_MyAppsQuery = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }> } | null };
+export type Home_MyAppsQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }> } | { __typename?: 'User', id: string, appCount: number, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }> } | null };
 
 export type Home_ProfileSnacksQueryVariables = Exact<{
   limit: Scalars['Int'];
@@ -5495,7 +5495,7 @@ export type Home_ProfileSnacksQueryVariables = Exact<{
 }>;
 
 
-export type Home_ProfileSnacksQuery = { __typename?: 'RootQuery', me?: { __typename?: 'User', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
+export type Home_ProfileSnacksQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | { __typename?: 'User', id: string, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } | null };
 
 export type WebContainerProjectPage_QueryVariables = Exact<{
   appId: Scalars['String'];
@@ -5555,7 +5555,7 @@ export type HomeScreenDataQueryVariables = Exact<{
 }>;
 
 
-export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
+export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
 export const CommonAppDataFragmentDoc = gql`
     fragment CommonAppData on App {
@@ -5589,6 +5589,7 @@ export const CommonSnackDataFragmentDoc = gql`
     `;
 export const CurrentUserActorDataFragmentDoc = gql`
     fragment CurrentUserActorData on UserActor {
+  __typename
   id
   username
   firstName
@@ -5861,7 +5862,7 @@ export function refetchHome_CurrentUserActorQuery(variables?: Home_CurrentUserAc
     }
 export const Home_ProfileData2Document = gql`
     query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
-  me {
+  meUserActor {
     id
     username
     firstName
@@ -5916,7 +5917,7 @@ export function refetchHome_ProfileData2Query(variables: Home_ProfileData2QueryV
     }
 export const Home_MyAppsDocument = gql`
     query Home_MyApps($limit: Int!, $offset: Int!) {
-  me {
+  meUserActor {
     id
     appCount
     apps(limit: $limit, offset: $offset, includeUnpublished: true) {
@@ -5959,7 +5960,7 @@ export function refetchHome_MyAppsQuery(variables: Home_MyAppsQueryVariables) {
     }
 export const Home_ProfileSnacksDocument = gql`
     query Home_ProfileSnacks($limit: Int!, $offset: Int!) {
-  me {
+  meUserActor {
     id
     snacks(limit: $limit, offset: $offset) {
       ...CommonSnackData

--- a/home/graphql/types.ts
+++ b/home/graphql/types.ts
@@ -1160,6 +1160,7 @@ export type AppBuildsPaginatedArgs = {
 export type AppChannelsPaginatedArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
+  filter?: InputMaybe<ChannelFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
 };
@@ -1359,6 +1360,7 @@ export type AppInput = {
 
 export type AppInsights = {
   __typename?: 'AppInsights';
+  hasEventsFromExpoInsightsClientModule: Scalars['Boolean'];
   totalUniqueUsers?: Maybe<Scalars['Int']>;
   uniqueUsersByAppVersionOverTime: UniqueUsersOverTimeData;
   uniqueUsersByPlatformOverTime: UniqueUsersOverTimeData;
@@ -1976,6 +1978,43 @@ export enum AuthProtocolType {
   Oidc = 'OIDC'
 }
 
+export type BackgroundJobReceipt = {
+  __typename?: 'BackgroundJobReceipt';
+  account: Account;
+  createdAt: Scalars['DateTime'];
+  errorCode?: Maybe<Scalars['String']>;
+  errorMessage?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  resultId?: Maybe<Scalars['ID']>;
+  resultType: BackgroundJobResultType;
+  state: BackgroundJobState;
+  tries: Scalars['Int'];
+  updatedAt: Scalars['DateTime'];
+  willRetry: Scalars['Boolean'];
+};
+
+export type BackgroundJobReceiptQuery = {
+  __typename?: 'BackgroundJobReceiptQuery';
+  /** Look up background job receipt by ID */
+  byId: BackgroundJobReceipt;
+};
+
+
+export type BackgroundJobReceiptQueryByIdArgs = {
+  id: Scalars['ID'];
+};
+
+export enum BackgroundJobResultType {
+  GithubBuild = 'GITHUB_BUILD'
+}
+
+export enum BackgroundJobState {
+  Failure = 'FAILURE',
+  InProgress = 'IN_PROGRESS',
+  Queued = 'QUEUED',
+  Success = 'SUCCESS'
+}
+
 export type Billing = {
   __typename?: 'Billing';
   /** History of invoices */
@@ -2474,6 +2513,10 @@ export type Card = {
   expMonth?: Maybe<Scalars['Int']>;
   expYear?: Maybe<Scalars['Int']>;
   last4?: Maybe<Scalars['String']>;
+};
+
+export type ChannelFilterInput = {
+  searchTerm?: InputMaybe<Scalars['String']>;
 };
 
 export type Charge = {
@@ -3007,8 +3050,8 @@ export enum GitHubAppInstallationStatus {
 
 export type GitHubAppMutation = {
   __typename?: 'GitHubAppMutation';
-  /** Create a GitHub build for an app */
-  createGitHubBuild: Scalars['Boolean'];
+  /** Create a GitHub build for an app. Returns the ID of the background job receipt. Use BackgroundJobReceiptQuery to get the status of the job. */
+  createGitHubBuild: BackgroundJobReceipt;
 };
 
 
@@ -4118,6 +4161,7 @@ export type RootQuery = {
   /** Top-level query object for querying Apple Teams. */
   appleTeam: AppleTeamQuery;
   asset: AssetQuery;
+  backgroundJobReceipt: BackgroundJobReceiptQuery;
   buildJobs: BuildJobQuery;
   buildOrBuildJob: BuildOrBuildJobQuery;
   /** Top-level query object for querying BuildPublicData publicly. */
@@ -4745,6 +4789,7 @@ export type Update = ActivityTimelineProjectActivity & {
 
 export type UpdateBranch = {
   __typename?: 'UpdateBranch';
+  app: App;
   appId: Scalars['ID'];
   createdAt: Scalars['DateTime'];
   id: Scalars['ID'];
@@ -4806,6 +4851,7 @@ export type UpdateBranchMutationPublishUpdateGroupsArgs = {
 
 export type UpdateChannel = {
   __typename?: 'UpdateChannel';
+  app: App;
   appId: Scalars['ID'];
   branchMapping: Scalars['String'];
   createdAt: Scalars['DateTime'];
@@ -5386,7 +5432,11 @@ export type CommonAppDataFragment = { __typename?: 'App', id: string, fullName: 
 
 export type CommonSnackDataFragment = { __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean };
 
-export type CurrentUserDataFragment = { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, owner?: { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+type CurrentUserActorData_SsoUser_Fragment = { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+
+type CurrentUserActorData_User_Fragment = { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> };
+
+export type CurrentUserActorDataFragment = CurrentUserActorData_SsoUser_Fragment | CurrentUserActorData_User_Fragment;
 
 export type Home_AccountDataQueryVariables = Exact<{
   accountName: Scalars['String'];
@@ -5418,10 +5468,10 @@ export type BranchesForProjectQueryVariables = Exact<{
 
 export type BranchesForProjectQuery = { __typename?: 'RootQuery', app: { __typename?: 'AppQuery', byId: { __typename?: 'App', id: string, name: string, slug: string, fullName: string, username: string, published: boolean, description: string, githubUrl?: string | null, playStoreUrl?: string | null, appStoreUrl?: string | null, sdkVersion: string, iconUrl?: string | null, privacy: string, icon?: { __typename?: 'AppIcon', url: string } | null, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string, group: string, message?: string | null, createdAt: any, runtimeVersion: string, platform: string, manifestPermalink: string }> }> } } };
 
-export type Home_CurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
+export type Home_CurrentUserActorQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type Home_CurrentUserQuery = { __typename?: 'RootQuery', viewer?: { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, owner?: { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
+export type Home_CurrentUserActorQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null };
 
 export type Home_ProfileData2QueryVariables = Exact<{
   appLimit: Scalars['Int'];
@@ -5505,7 +5555,7 @@ export type HomeScreenDataQueryVariables = Exact<{
 }>;
 
 
-export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, owner?: { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, owner?: { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
+export type HomeScreenDataQuery = { __typename?: 'RootQuery', account: { __typename?: 'AccountQuery', byName: { __typename?: 'Account', id: string, name: string, isCurrent: boolean, appCount: number, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, profilePhoto: string, accounts: Array<{ __typename?: 'Account', id: string, name: string, ownerUserActor?: { __typename?: 'SSOUser', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | { __typename?: 'User', id: string, username: string, profilePhoto: string, firstName?: string | null, fullName?: string | null, lastName?: string | null } | null }> } | null, apps: Array<{ __typename?: 'App', id: string, fullName: string, name: string, iconUrl?: string | null, packageName: string, username: string, description: string, sdkVersion: string, privacy: string, updateBranches: Array<{ __typename?: 'UpdateBranch', id: string, name: string, updates: Array<{ __typename?: 'Update', id: string }> }> }>, snacks: Array<{ __typename?: 'Snack', id: string, name: string, description: string, fullName: string, slug: string, isDraft: boolean }> } } };
 
 export const CommonAppDataFragmentDoc = gql`
     fragment CommonAppData on App {
@@ -5537,8 +5587,8 @@ export const CommonSnackDataFragmentDoc = gql`
   isDraft
 }
     `;
-export const CurrentUserDataFragmentDoc = gql`
-    fragment CurrentUserData on User {
+export const CurrentUserActorDataFragmentDoc = gql`
+    fragment CurrentUserActorData on UserActor {
   id
   username
   firstName
@@ -5547,7 +5597,7 @@ export const CurrentUserDataFragmentDoc = gql`
   accounts {
     id
     name
-    owner {
+    ownerUserActor {
       id
       username
       profilePhoto
@@ -5772,42 +5822,42 @@ export type BranchesForProjectQueryResult = Apollo.QueryResult<BranchesForProjec
 export function refetchBranchesForProjectQuery(variables: BranchesForProjectQueryVariables) {
       return { query: BranchesForProjectDocument, variables: variables }
     }
-export const Home_CurrentUserDocument = gql`
-    query Home_CurrentUser {
-  viewer {
-    ...CurrentUserData
+export const Home_CurrentUserActorDocument = gql`
+    query Home_CurrentUserActor {
+  meUserActor {
+    ...CurrentUserActorData
   }
 }
-    ${CurrentUserDataFragmentDoc}`;
+    ${CurrentUserActorDataFragmentDoc}`;
 
 /**
- * __useHome_CurrentUserQuery__
+ * __useHome_CurrentUserActorQuery__
  *
- * To run a query within a React component, call `useHome_CurrentUserQuery` and pass it any options that fit your needs.
- * When your component renders, `useHome_CurrentUserQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * To run a query within a React component, call `useHome_CurrentUserActorQuery` and pass it any options that fit your needs.
+ * When your component renders, `useHome_CurrentUserActorQuery` returns an object from Apollo Client that contains loading, error, and data properties
  * you can use to render your UI.
  *
  * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
  *
  * @example
- * const { data, loading, error } = useHome_CurrentUserQuery({
+ * const { data, loading, error } = useHome_CurrentUserActorQuery({
  *   variables: {
  *   },
  * });
  */
-export function useHome_CurrentUserQuery(baseOptions?: Apollo.QueryHookOptions<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>) {
+export function useHome_CurrentUserActorQuery(baseOptions?: Apollo.QueryHookOptions<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useQuery<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>(Home_CurrentUserDocument, options);
+        return Apollo.useQuery<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>(Home_CurrentUserActorDocument, options);
       }
-export function useHome_CurrentUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>) {
+export function useHome_CurrentUserActorLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>) {
           const options = {...defaultOptions, ...baseOptions}
-          return Apollo.useLazyQuery<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>(Home_CurrentUserDocument, options);
+          return Apollo.useLazyQuery<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>(Home_CurrentUserActorDocument, options);
         }
-export type Home_CurrentUserQueryHookResult = ReturnType<typeof useHome_CurrentUserQuery>;
-export type Home_CurrentUserLazyQueryHookResult = ReturnType<typeof useHome_CurrentUserLazyQuery>;
-export type Home_CurrentUserQueryResult = Apollo.QueryResult<Home_CurrentUserQuery, Home_CurrentUserQueryVariables>;
-export function refetchHome_CurrentUserQuery(variables?: Home_CurrentUserQueryVariables) {
-      return { query: Home_CurrentUserDocument, variables: variables }
+export type Home_CurrentUserActorQueryHookResult = ReturnType<typeof useHome_CurrentUserActorQuery>;
+export type Home_CurrentUserActorLazyQueryHookResult = ReturnType<typeof useHome_CurrentUserActorLazyQuery>;
+export type Home_CurrentUserActorQueryResult = Apollo.QueryResult<Home_CurrentUserActorQuery, Home_CurrentUserActorQueryVariables>;
+export function refetchHome_CurrentUserActorQuery(variables?: Home_CurrentUserActorQueryVariables) {
+      return { query: Home_CurrentUserActorDocument, variables: variables }
     }
 export const Home_ProfileData2Document = gql`
     query Home_ProfileData2($appLimit: Int!, $snackLimit: Int!) {
@@ -6296,8 +6346,8 @@ export const HomeScreenDataDocument = gql`
       id
       name
       isCurrent
-      owner {
-        ...CurrentUserData
+      ownerUserActor {
+        ...CurrentUserActorData
       }
       apps(limit: 5, offset: 0, includeUnpublished: true) {
         ...CommonAppData
@@ -6309,7 +6359,7 @@ export const HomeScreenDataDocument = gql`
     }
   }
 }
-    ${CurrentUserDataFragmentDoc}
+    ${CurrentUserActorDataFragmentDoc}
 ${CommonAppDataFragmentDoc}
 ${CommonSnackDataFragmentDoc}`;
 

--- a/home/screens/AccountModal/LoggedInAccountView.tsx
+++ b/home/screens/AccountModal/LoggedInAccountView.tsx
@@ -6,13 +6,13 @@ import React from 'react';
 import { FlatList } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
-import { Home_CurrentUserQuery } from '../../graphql/types';
+import { Home_CurrentUserActorQuery } from '../../graphql/types';
 import { useDispatch } from '../../redux/Hooks';
 import SessionActions from '../../redux/SessionActions';
 import { useAccountName } from '../../utils/AccountNameContext';
 
 type Props = {
-  accounts: Exclude<Home_CurrentUserQuery['viewer'], undefined | null>['accounts'];
+  accounts: Exclude<Home_CurrentUserActorQuery['meUserActor'], undefined | null>['accounts'];
 };
 
 export function LoggedInAccountView({ accounts }: Props) {
@@ -72,9 +72,13 @@ export function LoggedInAccountView({ accounts }: Props) {
                   borderBottomWidth: index === accounts.length - 1 ? 1 : 0,
                   borderTopWidth: index === 0 ? 1 : 0,
                 }}>
-                <Row flex="1" align={!account.owner?.fullName ? 'center' : 'start'}>
-                  {account?.owner?.profilePhoto ? (
-                    <Image size="xl" rounded="full" source={{ uri: account.owner.profilePhoto }} />
+                <Row flex="1" align={!account.ownerUserActor?.fullName ? 'center' : 'start'}>
+                  {account?.ownerUserActor?.profilePhoto ? (
+                    <Image
+                      size="xl"
+                      rounded="full"
+                      source={{ uri: account.ownerUserActor.profilePhoto }}
+                    />
                   ) : (
                     <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
                       <UsersIcon color={theme.icon.default} size={iconSize.small} />
@@ -82,15 +86,15 @@ export function LoggedInAccountView({ accounts }: Props) {
                   )}
                   <Spacer.Horizontal size="small" />
                   <View flex="1">
-                    {account.owner ? (
+                    {account.ownerUserActor ? (
                       <>
-                        {account.owner.fullName ? (
+                        {account.ownerUserActor.fullName ? (
                           <>
                             <Text
                               type="InterBold"
                               style={{ paddingRight: spacing[4] }}
                               numberOfLines={1}>
-                              {account.owner.fullName}
+                              {account.ownerUserActor.fullName}
                             </Text>
                             <Spacer.Vertical size="tiny" />
                             <Text
@@ -99,7 +103,7 @@ export function LoggedInAccountView({ accounts }: Props) {
                               type="InterRegular"
                               numberOfLines={1}
                               size="small">
-                              {account.owner.username}
+                              {account.ownerUserActor.username}
                             </Text>
                           </>
                         ) : (
@@ -107,7 +111,7 @@ export function LoggedInAccountView({ accounts }: Props) {
                             type="InterBold"
                             style={{ paddingRight: spacing[4] }}
                             numberOfLines={1}>
-                            {account.owner.username}
+                            {account.ownerUserActor.username}
                           </Text>
                         )}
                       </>

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import url from 'url';
 
-import ApolloClient from '../../api/ApolloClient';
+import { createApolloClient } from '../../api/ApolloClient';
 import Config from '../../api/Config';
 import {
   Home_ViewerPrimaryAccountNameDocument,
@@ -111,13 +111,7 @@ export function LoggedOutAccountView({ refetch }: Props) {
 
         const sessionSecret = decodeURIComponent(encodedSessionSecret);
 
-        dispatch(
-          SessionActions.setSession({
-            sessionSecret,
-          })
-        );
-
-        const viewerPrimaryAccountNameResult = await ApolloClient.query<
+        const viewerPrimaryAccountNameResult = await createApolloClient().query<
           Home_ViewerPrimaryAccountNameQuery,
           Home_ViewerPrimaryAccountNameQueryVariables
         >({
@@ -132,6 +126,12 @@ export function LoggedOutAccountView({ refetch }: Props) {
         if (!primaryAccountName) {
           throw new Error('Logged in user must have a primary account');
         }
+
+        dispatch(
+          SessionActions.setSession({
+            sessionSecret,
+          })
+        );
 
         setAccountName(primaryAccountName);
         setIsFinishedAuthenticating(true);

--- a/home/screens/AccountModal/index.tsx
+++ b/home/screens/AccountModal/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { ActivityIndicator, Platform } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
-import { useHome_CurrentUserQuery } from '../../graphql/types';
+import { useHome_CurrentUserActorQuery } from '../../graphql/types';
 import { LoggedInAccountView } from './LoggedInAccountView';
 import { LoggedOutAccountView } from './LoggedOutAccountView';
 import { ModalHeader } from './ModalHeader';
@@ -13,7 +13,7 @@ import { ModalHeader } from './ModalHeader';
 export function AccountModal() {
   const theme = useExpoTheme();
 
-  const { data, loading, error, refetch } = useHome_CurrentUserQuery();
+  const { data, loading, error, refetch } = useHome_CurrentUserActorQuery();
 
   if (loading) {
     return (
@@ -84,8 +84,8 @@ export function AccountModal() {
   return (
     <View flex="1">
       {Platform.OS === 'ios' && <ModalHeader />}
-      {data?.viewer?.accounts ? (
-        <LoggedInAccountView accounts={data.viewer.accounts} />
+      {data?.meUserActor?.accounts ? (
+        <LoggedInAccountView accounts={data.meUserActor.accounts} />
       ) : (
         <LoggedOutAccountView
           refetch={async () => {

--- a/home/screens/HomeScreen/HomeScreenData.query.graphql
+++ b/home/screens/HomeScreen/HomeScreenData.query.graphql
@@ -4,8 +4,8 @@ query HomeScreenData($accountName: String!) {
       id
       name
       isCurrent
-      owner {
-        ...CurrentUserData
+      ownerUserActor {
+        ...CurrentUserActorData
       }
       apps(limit: 5, offset: 0, includeUnpublished: true) {
         ...CommonAppData

--- a/home/screens/HomeScreen/HomeScreenHeader.tsx
+++ b/home/screens/HomeScreen/HomeScreenHeader.tsx
@@ -11,10 +11,10 @@ import { HomeStackRoutes } from '../../navigation/Navigation.types';
 import { useTheme } from '../../utils/useTheme';
 
 type Props = {
-  currentUser?: Exclude<HomeScreenDataQuery['account']['byName'], null>;
+  currentAccount?: Exclude<HomeScreenDataQuery['account']['byName'], null>;
 };
 
-export function HomeScreenHeader({ currentUser }: Props) {
+export function HomeScreenHeader({ currentAccount }: Props) {
   const { theme, themeType } = useTheme();
   const navigation = useNavigation<NavigationProp<HomeStackRoutes>>();
 
@@ -25,12 +25,16 @@ export function HomeScreenHeader({ currentUser }: Props) {
 
   let rightContent: React.ReactNode | null = null;
 
-  if (currentUser) {
+  if (currentAccount) {
     rightContent = (
       <Button.Container onPress={onAccountButtonPress}>
         {/* Show profile picture for personal accounts / accounts with members */}
-        {currentUser?.owner?.profilePhoto ? (
-          <Image size="xl" rounded="full" source={{ uri: currentUser.owner.profilePhoto }} />
+        {currentAccount?.ownerUserActor?.profilePhoto ? (
+          <Image
+            size="xl"
+            rounded="full"
+            source={{ uri: currentAccount.ownerUserActor.profilePhoto }}
+          />
         ) : (
           <View rounded="full" height="xl" width="xl" bg="secondary" align="centered">
             <UsersIcon color={theme.icon.default} size={iconSize.small} />

--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -104,7 +104,7 @@ export class HomeScreenView extends React.Component<Props, State> {
 
     return (
       <View style={styles.container}>
-        <HomeScreenHeader currentUser={data} />
+        <HomeScreenHeader currentAccount={data} />
         <ScrollView
           refreshControl={
             <RefreshControl refreshing={isRefreshing} onRefresh={this._handleRefreshAsync} />

--- a/home/screens/SettingsScreen/index.tsx
+++ b/home/screens/SettingsScreen/index.tsx
@@ -35,7 +35,7 @@ export function SettingsScreen() {
           </>
         )}
         <ConstantsSection />
-        {data?.meUserActor ? (
+        {data?.meUserActor && data.meUserActor.__typename === 'User' ? (
           <>
             <Spacer.Vertical size="xl" />
             <DeleteAccountSection viewerUsername={data.meUserActor.username} />

--- a/home/screens/SettingsScreen/index.tsx
+++ b/home/screens/SettingsScreen/index.tsx
@@ -1,6 +1,6 @@
 import { Spacer, View } from 'expo-dev-client-components';
 import * as Tracking from 'expo-tracking-transparency';
-import { useHome_CurrentUserQuery } from 'graphql/types';
+import { useHome_CurrentUserActorQuery } from 'graphql/types';
 import * as React from 'react';
 import { Platform, StyleSheet } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
@@ -12,7 +12,7 @@ import { ThemeSection } from './ThemeSection';
 import { TrackingSection } from './TrackingSection';
 
 export function SettingsScreen() {
-  const { data } = useHome_CurrentUserQuery();
+  const { data } = useHome_CurrentUserActorQuery();
 
   return (
     <KeyboardAwareScrollView
@@ -35,10 +35,10 @@ export function SettingsScreen() {
           </>
         )}
         <ConstantsSection />
-        {data?.viewer ? (
+        {data?.meUserActor ? (
           <>
             <Spacer.Vertical size="xl" />
-            <DeleteAccountSection viewerUsername={data.viewer.username} />
+            <DeleteAccountSection viewerUsername={data.meUserActor.username} />
           </>
         ) : null}
       </View>

--- a/home/utils/InitialDataContext.tsx
+++ b/home/utils/InitialDataContext.tsx
@@ -1,12 +1,12 @@
 import React, { useState, createContext, useContext } from 'react';
 
-import { HomeScreenDataQuery, Home_CurrentUserQuery } from '../graphql/types';
+import { HomeScreenDataQuery, Home_CurrentUserActorQuery } from '../graphql/types';
 
 type ContextValue = {
   homeScreenData?: HomeScreenDataQuery;
   setHomeScreenData: (d?: HomeScreenDataQuery) => void;
-  currentUserData?: Home_CurrentUserQuery;
-  setCurrentUserData: (d?: Home_CurrentUserQuery) => void;
+  currentUserData?: Home_CurrentUserActorQuery;
+  setCurrentUserData: (d?: Home_CurrentUserActorQuery) => void;
 };
 
 const InitialDataContext = createContext<ContextValue | null>(null);
@@ -23,7 +23,7 @@ export function useInitialData() {
 
 export function InitialDataProvider({ children }: { children: React.ReactNode }) {
   const [homeScreenData, setHomeScreenData] = useState<HomeScreenDataQuery | undefined>();
-  const [currentUserData, setCurrentUserData] = useState<Home_CurrentUserQuery | undefined>();
+  const [currentUserData, setCurrentUserData] = useState<Home_CurrentUserActorQuery | undefined>();
 
   return (
     <InitialDataContext.Provider


### PR DESCRIPTION
# Why

This PR adds support for SSO users to Expo Go and also fixes a race condition for fetching the username during login. (blame: https://github.com/expo/expo/pull/22735)

# How

- Use `UserActor` union type for both SSO and regular users.
- Create a new instance of the apollo client for use in this circumstance. It's super unclear that HTTP link `setContext`s are not re-evaluated on each request.

# Test Plan

1. Point at staging in Config.ts
2. `nexpo start -p 80`
3. Build in xcode (setting native config to use local manifest)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
