### PR TITLE
Upgrade vendored lottie to 5.1.6

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -134,7 +134,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "5.1.4",
+    "lottie-react-native": "5.1.6",
     "moment": "^2.29.4",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1760,7 +1760,7 @@ PODS:
     - libwebp/demux
   - libwebp/webp (1.2.4)
   - lottie-ios (3.4.4)
-  - lottie-react-native (5.1.4):
+  - lottie-react-native (5.1.6):
     - lottie-ios (~> 3.4.0)
     - React-Core
   - MBProgressHUD (1.2.0)
@@ -3751,7 +3751,7 @@ SPEC CHECKSUMS:
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
-  lottie-react-native: b702fab740cdb952a8e2354713d3beda63ff97b0
+  lottie-react-native: 8f9d4be452e23f6e5ca0fdc11669dc99ab52be81
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: d954d0accfd082f2225e62d71008440493e318f4

--- a/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
+++ b/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "5.1.4",
+  "version": "5.1.6",
   "summary": "Lottie component for React Native (iOS and Android)",
   "authors": {
     "intelligibabble": "leland.m.richardson@gmail.com"
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/react-community/lottie-react-native.git",
-    "tag": "v5.1.4"
+    "tag": "v5.1.6"
   },
   "source_files": "src/ios/**/*.{h,m,swift}",
   "requires_arc": true,

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -79,7 +79,7 @@
   "expo-updates": "~0.17.0",
   "expo-video-thumbnails": "~7.3.0",
   "expo-web-browser": "~12.2.0",
-  "lottie-react-native": "5.1.4",
+  "lottie-react-native": "5.1.6",
   "react": "18.2.0",
   "react-dom": "18.2.0",
   "react-native": "0.72.0-rc.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12860,10 +12860,10 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lottie-react-native@5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-5.1.4.tgz#9340a4f63ed115d5f050f1af69e53242e6e63840"
-  integrity sha512-Lu6mSG92Wck+vXEX6gfj/9ciqqoz0tJQZqgX0SumGvX/oZu4MbKO/oLApyHdy2V9Rb7qvwF9whOtitADxTswPA==
+lottie-react-native@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/lottie-react-native/-/lottie-react-native-5.1.6.tgz#6ae72829c3c0b95952dddd3d78c043f4dfbcb487"
+  integrity sha512-vhdeZstXMfuVKwnddYWjJgQ/1whGL58IJEJu/iSf0XQ5gAb4pp/+vy91mdYQLezlb8Aw4Vu3fKnqErJL2hwchg==
   dependencies:
     invariant "^2.2.2"
     react-native-safe-modules "^1.0.3"


### PR DESCRIPTION
# Why
Upgrades `lottie-react-native` to `5.1.6`

# How

`et uvm -m lottie-react-native -c e94eca6a718ce6211011a0afcdac3e151de563fb`

# Test Plan
Tested in unversioned expo go on both platforms
