### PR TITLE
[dev-launcher] Mitigate unit tests flakiness

### DIFF
--- a/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
+++ b/packages/expo-dev-launcher/bundle/screens/__tests__/BranchesScreen.test.tsx
@@ -68,7 +68,7 @@ describe('<BranchesScreen />', () => {
     const { queryByText, getByText } = renderBranchesScreen(mockNavigation);
 
     await act(async () => {
-      await waitFor(() => getByText(/testBranch/i));
+      await waitFor(() => getByText(/testBranch/i), { timeout: 5000 });
       expect(queryByText(/testBranch/i)).not.toBe(null);
       expect(queryByText(/test update/i)).not.toBe(null);
     });


### PR DESCRIPTION
# Why

Recently we've been experiencing a lot of failed `check-packages` runs due to `expo-dev-launcher`
<img width="585" alt="image" src="https://github.com/expo/expo/assets/11707729/4bea387e-d28b-4171-994a-03e77e9bbb16">


# How

This PR attempts to mitigate unit tests flakiness by increasing the `render` test `waitFor`  from 1000ms to 5000ms

# Test Plan

Check if CI is no longer flaky 

<img width="333" alt="image" src="https://github.com/expo/expo/assets/11707729/e43234bf-fa60-4899-b640-5c155f3ce4a9">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
