### PR TITLE
chore(config-plugins, prebuild-config): bump xml2js

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `xml2js` version.
+
 ## 7.1.0 — 2023-06-13
 
 ### 🎉 New features

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `xml2js` version.
+- Update `xml2js` version. ([#22872](https://github.com/expo/expo/pull/22872) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 7.1.0 — 2023-06-13
 

--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -46,12 +46,12 @@
     "semver": "^7.3.5",
     "slash": "^3.0.0",
     "xcode": "^3.0.1",
-    "xml2js": "0.4.23"
+    "xml2js": "0.6.0"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/find-up": "^4.0.0",
-    "@types/xml2js": "^0.4.5"
+    "@types/xml2js": "~0.4.11"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Update `xml2js` version.
+- Update `xml2js` version. ([#22872](https://github.com/expo/expo/pull/22872) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 6.1.0 — 2023-06-13
 

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update `xml2js` version.
+
 ## 6.1.0 — 2023-06-13
 
 ### 🎉 New features

--- a/packages/@expo/prebuild-config/package.json
+++ b/packages/@expo/prebuild-config/package.json
@@ -32,7 +32,7 @@
   ],
   "devDependencies": {
     "@types/debug": "^4.1.5",
-    "@types/xml2js": "^0.4.5"
+    "@types/xml2js": "~0.4.11"
   },
   "dependencies": {
     "@expo/config": "~8.0.0",
@@ -44,7 +44,7 @@
     "fs-extra": "^9.0.0",
     "resolve-from": "^5.0.0",
     "semver": "7.3.2",
-    "xml2js": "0.4.23"
+    "xml2js": "0.6.0"
   },
   "peerDependencies": {
     "expo-modules-autolinking": ">=0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4549,7 +4549,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/xml2js@^0.4.5":
+"@types/xml2js@~0.4.11":
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/@types/xml2js/-/xml2js-0.4.11.tgz#bf46a84ecc12c41159a7bd9cf51ae84129af0e79"
   integrity sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==
@@ -19751,6 +19751,14 @@ xml2js@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
   integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xml2js@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
+  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
# Why

Hide NPM warnings

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
