### PR TITLE
[docs] Mark slider as supported on web

### DIFF
--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video';
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v46.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/slider.mdx
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video';
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v47.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/slider.mdx
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video';
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v48.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/slider.mdx
@@ -12,7 +12,7 @@ import Video from '~/components/plugins/Video';
 
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The slider component is [supported on web](https://github.com/callstack/react-native-slider#readme), but the Expo docs don't indicate that that is the case.

# How

<!--
How did you build this feature or fix this bug and why?
-->
I updated the `PlatformsSection` for this component across all SDK versions to include `web`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I built and verified the docs locally using `yarn dev`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
