### PR TITLE
[ENG-8871][docs] Codepush to EAS Update migration guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -222,6 +222,7 @@ const general = [
     makePage('eas-update/code-signing.mdx'),
     makeGroup('More', [
       makePage('eas-update/migrate-to-eas-update.mdx'),
+      makePage('eas-update/migrate-codepush-to-eas-update.mdx'),
       makePage('eas-update/rollouts.mdx'),
       makePage('eas-update/faq.mdx'),
       makePage('eas-update/known-issues.mdx'),

--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -66,7 +66,19 @@ Inside **AndroidManifest.xml**, you'll see the following additions:
 
 ```xml
 <meta-data android:name="expo.modules.updates.EXPO_UPDATE_URL" android:value="https://u.expo.dev/your-project-id"/>
-<meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="1.0.0"/>
+<meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
+```
+
+Inside **android/app/src/main/res/values/strings.xml**, you'll see the following additions:
+
+```diff android/app/src/main/res/values/strings.xml
+--- a/android/app/src/main/res/values/strings.xml
++++ b/android/app/src/main/res/values/strings.xml
+@@ -1,3 +1,4 @@
+ <resources>
+     <string name="app_name">MyApp</string>
++    <string name="expo_runtime_version">1.0.0</string>
+ </resources>
 ```
 
 The `EXPO_UPDATE_URL` value should contain your project's ID.

--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -69,7 +69,7 @@ Inside **AndroidManifest.xml**, you'll see the following additions:
 <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
 ```
 
-Inside **android/app/src/main/res/values/strings.xml**, you'll see the following additions:
+Inside **android/app/src/main/res/values/strings.xml**, you'll see the `expo_runtime_version` string entry in the `resources` object:
 
 ```diff android/app/src/main/res/values/strings.xml
 --- a/android/app/src/main/res/values/strings.xml

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -51,7 +51,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/distribution/runtime-versions.mdx
+++ b/docs/pages/distribution/runtime-versions.mdx
@@ -54,7 +54,7 @@ For an Android build, add an entry to **android/app/src/main/res/values/strings.
 @@ -1,3 +1,4 @@
  <resources>
      <string name="app_name">MyApp</string>
-+    <string name="expo_runtime_version">1.0.0</string>
++    <string name="expo_runtime_version">2.718</string>
  </resources>
 ```
 

--- a/docs/pages/distribution/runtime-versions.mdx
+++ b/docs/pages/distribution/runtime-versions.mdx
@@ -46,10 +46,22 @@ For an iOS build, add an entry to the **Expo.plist** with the key `EXUpdatesRunt
 + <string>2.718</string>
 ```
 
-For an Android build, add a `<meta-data>` element to the **AndroidManifest.xml** whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is a string that represents the desired runtime version.
+For an Android build, add an entry to **android/app/src/main/res/values/strings.xml** with the name `expo_runtime_version`. The value is a string that represents the runtime version.
+
+```diff android/app/src/main/res/values/strings.xml
+--- a/android/app/src/main/res/values/strings.xml
++++ b/android/app/src/main/res/values/strings.xml
+@@ -1,3 +1,4 @@
+ <resources>
+     <string name="app_name">MyApp</string>
++    <string name="expo_runtime_version">1.0.0</string>
+ </resources>
+```
+
+Then add a `<meta-data>` element to the **AndroidManifest.xml** whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is a reference to the runtime version in `strings.xml`.
 
 ```diff
-+ <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="2.718"/>
++ <meta-data android:name="expo.modules.updates.EXPO_RUNTIME_VERSION" android:value="@string/expo_runtime_version"/>
 ```
 
 ## FAQ

--- a/docs/pages/eas-update/eas-update-with-local-build.mdx
+++ b/docs/pages/eas-update/eas-update-with-local-build.mdx
@@ -18,7 +18,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -17,7 +17,7 @@ EAS CLI is the command line app you will use to interact with EAS services from 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`; remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`; remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -22,6 +22,17 @@ You can also use the above command to check if a new version of EAS CLI is avail
 </Step>
 
 <Step label="2">
+## Log in to your Expo account
+
+If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
+
+<Terminal cmd={['$ eas login']} />
+
+You can check whether you are logged in by running `eas whoami`.
+
+</Step>
+
+<Step label="3">
 ## Create a project
 
 Create a project by running:
@@ -29,7 +40,7 @@ Create a project by running:
 <Terminal cmd={['$ npx create-expo-app']} />
 </Step>
 
-<Step label="3">
+<Step label="4">
 ## Configure your project
 
 To configure your project, run the following commands in the order they are specified:
@@ -73,7 +84,7 @@ The `channel` allows you to point updates at builds of that profile. For example
 
 </Step>
 
-<Step label="4">
+<Step label="5">
 ## Create a build for the project
 
 You need to create a build for Android or iOS. We recommend creating a build with the `preview` build profile first. See [Creating your first build](/build/setup/) on how to get started and set up [Internal distribution](/build/internal-distribution/#setting-up-internal-distribution) for your device or simulator.
@@ -82,7 +93,7 @@ Once you have a build running on your device or a simulator, you are ready to se
 
 </Step>
 
-<Step label="5">
+<Step label="6">
 ## Make changes locally
 
 After creating the build, you are ready to iterate on the project. Start a local development server with the following command:
@@ -93,7 +104,7 @@ Then, make any desired changes to your project's JavaScript, styling, or image a
 
 </Step>
 
-<Step label="6">
+<Step label="7">
 ## Publish an update
 
 To publish an update to the build, run the following command:

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-description: Learn how to get started with EAS Update and use in your project.
+description: Learn how to get started with EAS Update and use it in your project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -5,6 +5,8 @@ hideTOC: true
 description: An introduction to EAS Update which is a hosted service for projects using the expo-updates library.
 ---
 
+import { BoxLink } from '~/ui/components/BoxLink';
+
 **EAS Update** is a hosted service that serves updates for projects using the `expo-updates` library.
 
 EAS Update makes fixing small bugs and pushing quick fixes a snap in between app store submissions. It accomplishes this by allowing an end-user's app to swap out the non-native parts of their app (for example, JS, styling, and image changes) with a new update that contains bug fixes and other updates.
@@ -12,3 +14,41 @@ EAS Update makes fixing small bugs and pushing quick fixes a snap in between app
 All apps running the `expo-updates` library have the ability to receive updates. To start using EAS Update, continue to the [Getting Started](/eas-update/getting-started.mdx) guide.
 
 Still using Classic Updates? We moved those docs to [the archive](/archive/classic-updates/introduction).
+
+### Get started
+
+<BoxLink
+  title="Creating your first update"
+  description="Get started with EAS Update and use it in your project."
+  href="/eas-update/getting-started"
+/>
+
+<BoxLink
+  title="Using GitHub Actions"
+  description="Publish an update and preview with a QR code after a commit."
+  href="/eas-update/github-actions"
+/>
+
+<BoxLink
+  title="Developing with EAS Update"
+  description="View your teammate's changes with EAS Update."
+  href="/eas-update/developing-with-eas-update"
+/>
+
+<BoxLink
+  title="Deployment Patterns"
+  description="Release processes that balance update safety and speed."
+  href="/eas-update/deployment-patterns"
+/>
+
+<BoxLink
+  title="Migrating from CodePush"
+  description="Transition a bare React Native project from CodePush."
+  href="/eas-update/migrate-codepush-to-eas-update"
+/>
+
+<BoxLink
+  title="Debugging EAS Updates"
+  description="When your app doesn't update as expected."
+  href="/eas-update/debug-updates"
+/>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -1,0 +1,120 @@
+---
+title: Migrating from CodePush to EAS Update
+description: A guide to help migrate from CodePush to EAS Update.
+---
+
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+
+Transition a [bare](https://docs.expo.dev/archive/managed-vs-bare/#bare-workflow) React Native project with CodePush to use EAS Update. This guide assumes that you are using the default React Native project structure.
+
+## Prerequisites
+
+<Collapsible summary="An Expo user account">
+
+EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use our free tier. You can sign up at [https://expo.dev/signup](https://expo.dev/signup).
+
+Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
+
+</Collapsible>
+
+<Step label="1">
+## Uninstall CodePush
+
+To avoid conflicts and unexpected behavior, it's recommended to uninstall CodePush if you're using EAS Update. This is because your app could periodically fetch updates from both services, leading to issues, especially if you're using different configurations for each service.
+
+Remove the CodePush SDK from your project by uninstalling the `react-native-code-push` package:
+
+<Terminal cmd={['$ npm uninstall react-native-code-push']} />
+
+You'll also need to remove CodePush references from JS and native code. Follow this [guide](https://github.com/Microsoft/react-native-code-push/issues/1101#issuecomment-350204507) for more detailed instructions.
+
+</Step>
+
+<Step label="2">
+## Ensure `app.json` exists
+
+Ensure that your project has an `app.json` file. If you don't have one, you can create one by running the command:
+
+<Terminal
+  cmd={[
+    "# If app.json doesn't exist, create a basic one",
+    '[ -f app.json ] || echo "{}" > app.json',
+  ]}
+/>
+
+</Step>
+
+<Step label="3">
+## Install the `expo` package
+
+Install the `expo` package by running the command:
+
+<Terminal cmd={['npx install-expo-modules@latest']} />
+
+If the command fails, follow the installation instructions [here](https://docs.expo.dev/bare/installing-expo-modules/#manual-installation)
+
+</Step>
+
+<Step label="4">
+## Turn off resource bundle signing (XCode 14+ only)
+
+In Xcode 14 and higher, resource bundles are signed by default, which requires setting the development team for each resource bundle target.
+To resolve this issue, downgrade to an older Xcode version using the `image` field in eas.json, or turn off signing resource bundles in your Podfile: https://expo.fyi/r/disable-bundle-resource-signing
+
+</Step>
+
+<Step label="5">
+## Install the latest EAS CLI
+
+EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
+
+<Terminal cmd={['$ npm install -g eas-cli']} />
+
+You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
+
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+
+</Step>
+
+<Step label="6">
+## Log in to your Expo account
+
+If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
+
+<Terminal cmd={['$ eas login']} />
+
+You can check whether you are logged in by running `eas whoami`.
+
+</Step>
+
+<Step label="7">
+## Configure your project
+
+To configure your project, run the following commands in the order they are specified:
+
+<Terminal
+  cmd={[
+    '# Install the latest `expo-updates` library',
+    '$ npx expo install expo-updates',
+    '',
+    '# Initialize your project with EAS Update',
+    '$ eas update:configure',
+    '',
+    '# Set up the configuration file for builds',
+    '$ eas build:configure',
+  ]}
+  cmdCopy="expo install expo-updates && eas update:configure && eas build:configure"
+/>
+
+You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
+
+</Step>
+
+<Step label="8">
+## Deploying Builds, Publishing Updates and Beyond
+
+We have completed all the steps specific to a CodePush and bare React Native project. Follow the remaining steps to create a build and publish updates in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project)
+
+</Step>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Transition a [bare](https://docs.expo.dev/archive/managed-vs-bare/#bare-workflow) React Native project with CodePush to use EAS Update. This guide assumes that you are using the default React Native project structure.
+Transition a [bare](/bare/hello-world/) React Native project with CodePush to use EAS Update. This guide assumes that you are using the default React Native project structure.
 
 ## Prerequisites
 
@@ -53,7 +53,7 @@ Install the `expo` package by running the command:
 
 <Terminal cmd={['npx install-expo-modules@latest']} />
 
-If the command fails, follow the installation instructions [here](https://docs.expo.dev/bare/installing-expo-modules/#manual-installation)
+If the command fails, follow the installation instructions [here](/bare/installing-expo-modules/#manual-installation)
 
 </Step>
 
@@ -61,15 +61,15 @@ If the command fails, follow the installation instructions [here](https://docs.e
 ## Turn off resource bundle signing (XCode 14+ only)
 
 In Xcode 14 and higher, resource bundles are signed by default, which requires setting the development team for each resource bundle target.
-To resolve this issue, downgrade to an older Xcode version using the `image` field in eas.json, or turn off signing resource bundles in your Podfile: https://expo.fyi/r/disable-bundle-resource-signing
+To resolve this issue, downgrade to an older Xcode version using the `image` field in `eas.json`, or turn off signing resource bundles in your Podfile. See this [example here](https://expo.fyi/r/disable-bundle-resource-signing).
 
 </Step>
 
 <Step label="5">
-## Follow the main 'Getting Started' guide
+## Follow the Getting Started guide
 
-We have completed all the steps specific to a CodePush and bare React Native project. Follow the remaining steps to create a build and publish updates in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project)
+We have completed all the steps specific to a CodePush and bare React Native project. Follow the steps in [the main guide](/eas-update/getting-started) to complete your setup.
 
-You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
+> You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
 
 </Step>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Transition a [bare](/bare/hello-world/) React Native project with CodePush to use EAS Update. This guide assumes that you are using the default React Native project structure.
+Transition a [bare](/bare/hello-world/) React Native project with CodePush to use EAS Update. This guide assumes that you are using the default React Native project structure. For assistance with migrating brownfield native apps to EAS Update––[reach out to us directly](https://chat.expo.dev/).
 
 ## Prerequisites
 

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -95,10 +95,30 @@ You can check whether you are logged in by running `eas whoami`.
 </Step>
 
 <Step label="7">
-## Configure project, deploy builds and beyond
+## Configure project, deploy builds and publish updates
 
 We have finished all the steps tailored for a CodePush-enabled bare React Native project. To proceed with the configuration of your project, please begin with Step 4 in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project) and follow it through to completion.
 
 > You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
+
+</Step>
+
+<Step label="8">
+## Verifying the migration and resubmitting your app
+
+After completing the migration and setting up your project with EAS Update, you should test your app to ensure that over-the-air updates are working correctly. To do this:
+
+1. Install the currently published version of your app on a device or simulator.
+2. Deploy a new update to your app using EAS Update.
+3. Launch the app and ensure that it loads the latest update from EAS. Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.
+
+Keep in mind that since you have changed the update provider from CodePush to EAS Update, you will need to rebuild your app and submit the new build to the respective app stores (Apple App Store and Google Play Store) to ensure the update mechanism works as expected for your end-users.
+
+Please follow the respective store guidelines for submitting a new build of your application:
+
+- [Submitting to Apple App Store](/submit/ios)
+- [Submitting to Google Play Store](/submit/android)
+
+After successfully submitting your app, users will be able to download and use the latest build with EAS Update integration.
 
 </Step>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -35,13 +35,18 @@ You'll also need to remove CodePush references from JS and native code. Follow t
 <Step label="2">
 ## Ensure `app.json` exists
 
-Ensure that your project has an `app.json` file. If you don't have one, you can create one by running the command:
+Ensure that your project has an `app.json` file with an `expo` object. If you don't have one, you can create one by running the command:
 
 <Terminal
   cmd={[
-    "# If app.json doesn't exist, create a basic one",
-    '[ -f app.json ] || echo "{}" > app.json',
+    `if [ ! -f app.json ] || [ ! -s app.json ]; then`,
+    `  echo '{"expo": {}}' > app.json;`,
+    `else`,
+    `  jq '.' app.json &> /dev/null || { echo "Error: Malformed JSON in app.json" >&2; }`,
+    `  jq 'if .expo == null then .expo = {} else . end' app.json > app.json.tmp && mv app.json.tmp app.json`,
+    `fi`,
   ]}
+  cmdCopy={`if [ ! -f app.json ] || [ ! -s app.json ]; then echo '{"expo": {}}' > app.json; else jq '.' app.json &> /dev/null || { echo "Error: Malformed JSON in app.json" >&2; }; jq 'if .expo == null then .expo = {} else . end' app.json > app.json.tmp && mv app.json.tmp app.json; fi`}
 />
 
 </Step>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -66,9 +66,33 @@ To resolve this issue, downgrade to an older Xcode version using the `image` fie
 </Step>
 
 <Step label="5">
-## Follow the Getting Started guide
+## Install the latest EAS CLI
 
-We have completed all the steps specific to a CodePush and bare React Native project. Follow the steps in [the main guide](/eas-update/getting-started) to complete your setup.
+EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
+
+<Terminal cmd={['$ npm install -g eas-cli']} />
+
+You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
+
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+
+</Step>
+
+<Step label="6">
+## Log in to your Expo account
+
+If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
+
+<Terminal cmd={['$ eas login']} />
+
+You can check whether you are logged in by running `eas whoami`.
+
+</Step>
+
+<Step label="7">
+## Configure project, deploy builds and beyond
+
+We have finished all the steps tailored for a CodePush-enabled bare React Native project. To proceed with the configuration of your project, please begin with Step 4 in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project) and follow it through to completion.
 
 > You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
 

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -39,7 +39,9 @@ Ensure that your project has an `app.json` file with an `expo` object. If you do
 
 ```json app.json
 {
-  "expo": {}
+  "expo": {
+    //... any other existing keys you have
+  }
 }
 ```
 

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -66,55 +66,10 @@ To resolve this issue, downgrade to an older Xcode version using the `image` fie
 </Step>
 
 <Step label="5">
-## Install the latest EAS CLI
-
-EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
-
-<Terminal cmd={['$ npm install -g eas-cli']} />
-
-You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
-
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
-
-</Step>
-
-<Step label="6">
-## Log in to your Expo account
-
-If you are already signed in to an Expo account using Expo CLI, you can skip the steps described in this section. If you are not, run the following command to log in:
-
-<Terminal cmd={['$ eas login']} />
-
-You can check whether you are logged in by running `eas whoami`.
-
-</Step>
-
-<Step label="7">
-## Configure your project
-
-To configure your project, run the following commands in the order they are specified:
-
-<Terminal
-  cmd={[
-    '# Install the latest `expo-updates` library',
-    '$ npx expo install expo-updates',
-    '',
-    '# Initialize your project with EAS Update',
-    '$ eas update:configure',
-    '',
-    '# Set up the configuration file for builds',
-    '$ eas build:configure',
-  ]}
-  cmdCopy="expo install expo-updates && eas update:configure && eas build:configure"
-/>
-
-You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
-
-</Step>
-
-<Step label="8">
-## Deploying Builds, Publishing Updates and Beyond
+## Follow the main 'Getting Started' guide
 
 We have completed all the steps specific to a CodePush and bare React Native project. Follow the remaining steps to create a build and publish updates in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project)
+
+You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
 
 </Step>

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -79,7 +79,7 @@ EAS CLI is the command-line app that you will use to interact with EAS services 
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
-> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli`, just remember to use that instead of `eas` whenever it's called for in the documentation.
+> We recommend using `npm` instead of `yarn` for global package installations. You may alternatively use `npx eas-cli@latest`, just remember to use that instead of `eas` whenever it's called for in the documentation.
 
 </Step>
 

--- a/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-codepush-to-eas-update.mdx
@@ -33,21 +33,15 @@ You'll also need to remove CodePush references from JS and native code. Follow t
 </Step>
 
 <Step label="2">
-## Ensure `app.json` exists
+## Ensure proper `app.json`
 
-Ensure that your project has an `app.json` file with an `expo` object. If you don't have one, you can create one by running the command:
+Ensure that your project has an `app.json` file with an `expo` object. If you don't have anything specific to configure in your `app.json` file yet, you can simply create a minimal `app.json` file with an empty `expo` object like this:
 
-<Terminal
-  cmd={[
-    `if [ ! -f app.json ] || [ ! -s app.json ]; then`,
-    `  echo '{"expo": {}}' > app.json;`,
-    `else`,
-    `  jq '.' app.json &> /dev/null || { echo "Error: Malformed JSON in app.json" >&2; }`,
-    `  jq 'if .expo == null then .expo = {} else . end' app.json > app.json.tmp && mv app.json.tmp app.json`,
-    `fi`,
-  ]}
-  cmdCopy={`if [ ! -f app.json ] || [ ! -s app.json ]; then echo '{"expo": {}}' > app.json; else jq '.' app.json &> /dev/null || { echo "Error: Malformed JSON in app.json" >&2; }; jq 'if .expo == null then .expo = {} else . end' app.json > app.json.tmp && mv app.json.tmp app.json; fi`}
-/>
+```json app.json
+{
+  "expo": {}
+}
+```
 
 </Step>
 
@@ -122,3 +116,4 @@ Please follow the respective store guidelines for submitting a new build of your
 After successfully submitting your app, users will be able to download and use the latest build with EAS Update integration.
 
 </Step>
+```


### PR DESCRIPTION
# Why

Improve the docs for transitioning from Codepush to EAS Update. This PR does the following:
- Add a migration guide for a bare React native app with Codepush
- Fix bare React Native app docs (since Codepush only works for a bare React Native app, need to make sure these are correct)
- Nits to the main EAS Update 'getting started' guide

# How you can help
Look through the comments I made about the bits I wasn't too sure about, in addition to your regular feedback :)

# Test Plan

1. Make starter bare React Native app: `npx react-native@latest init AwesomeProject`
2. Follow steps in my migration guide
3. Builds for ios and android succeed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
