### PR TITLE
[docs] Footer: fix mobile layout

### DIFF
--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -20,7 +20,7 @@ export const Footer = ({ title, sourceCodeUrl, packageName }: Props) => {
   const isExpoPackage = packageName && packageName.startsWith('expo-');
 
   return (
-    <footer className="flex flex-row border-t border-solid border-default mt-10 pt-10 max-medium:flex-col">
+    <footer className="flex flex-row border-t border-solid border-default mt-10 pt-10 max-md-gutters:flex-col">
       <UL className="flex-1 !mt-0 !ml-0 mb-5 !list-none">
         <ForumsLink isAPIPage={isAPIPage} title={title} />
         {isAPIPage && (

--- a/docs/ui/components/Footer/PageVote.tsx
+++ b/docs/ui/components/Footer/PageVote.tsx
@@ -15,7 +15,7 @@ export const PageVote = () => {
           Thank you for your vote! 💙
         </CALLOUT>
       ) : (
-        <div className="flex flex-row items-center gap-2 max-large:flex-col">
+        <div className="flex flex-row items-center gap-2 max-md-gutters:flex-col">
           <CALLOUT theme="secondary" weight="medium" className="px-2">
             Was this doc helpful?
           </CALLOUT>


### PR DESCRIPTION
# Why

Footer mobile layout seems broken, thanks @brentvatne for the report.

![IMG_4126](https://github.com/expo/expo/assets/719641/a2a486ac-e7d3-430a-b23a-2f186ecae0f3)

# How

Correct the TW scopes.

# Test Plan

The fixes have been tested by running docs locally.

# Preview

<img width="397" alt="Screenshot 2023-06-14 at 10 22 30" src="https://github.com/expo/expo/assets/719641/89d8f745-3f33-4440-b67e-11ed7d2e0937">
