### PR TITLE
[Android][iOS] @react-native-community/netinfo 9.3.10, react-native-pager-view to 6.2.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/netinfo/ConnectivityReceiver.java
@@ -142,7 +142,10 @@ public abstract class ConnectivityReceiver {
 
         // Add if WiFi is ON or OFF
         if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
-            boolean isEnabled = mWifiManager.isWifiEnabled();
+            boolean isEnabled = false;
+            if (mWifiManager != null) {
+              isEnabled = mWifiManager.isWifiEnabled();
+            }
             event.putBoolean("isWifiEnabled", isEnabled);
         }
 
@@ -208,7 +211,7 @@ public abstract class ConnectivityReceiver {
                 }
                 break;
             case "wifi":
-                if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext())) {
+                if (NetInfoUtils.isAccessWifiStatePermissionGranted(getReactContext()) && mWifiManager != null) {
                     WifiInfo wifiInfo = mWifiManager.getConnectionInfo();
                     if (wifiInfo != null) {
                         // Get the SSID

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -668,9 +668,9 @@ PODS:
   - React-jsinspector (0.72.0-rc.5)
   - React-logger (0.72.0-rc.5):
     - glog
-  - react-native-netinfo (9.3.7):
+  - react-native-netinfo (9.3.10):
     - React-Core
-  - react-native-pager-view (6.1.2):
+  - react-native-pager-view (6.2.0):
     - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
@@ -1470,8 +1470,8 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 98c1b1c1e60e137703597e5c5025f2ce3e4700fe
   React-jsinspector: 04038f19b6269374640d90371796f63d034d3542
   React-logger: 4e8c28425ddc27abb6cde80eece89cc765da7d86
-  react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
-  react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
+  react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
+  react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -62,7 +62,7 @@
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-community/datetimepicker": "6.7.3",
-    "@react-native-community/netinfo": "9.3.7",
+    "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -82,7 +82,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.0-rc.5",
     "react-native-gesture-handler": "~2.10.1",
-    "react-native-pager-view": "6.1.2",
+    "react-native-pager-view": "6.2.0",
     "react-native-reanimated": "~3.1.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -145,7 +145,7 @@
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.10.1",
     "react-native-maps": "1.3.2",
-    "react-native-pager-view": "6.1.2",
+    "react-native-pager-view": "6.2.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.1.0",
     "react-native-safe-area-context": "4.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -44,7 +44,7 @@
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-native-community/datetimepicker": "6.7.3",
-    "@react-native-community/netinfo": "9.3.7",
+    "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",

--- a/home/package.json
+++ b/home/package.json
@@ -24,7 +24,7 @@
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
     "@react-native-async-storage/async-storage": "1.17.11",
-    "@react-native-community/netinfo": "9.3.7",
+    "@react-native-community/netinfo": "9.3.10",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/elements": "~1.3.6",
     "@react-navigation/material-bottom-tabs": "~6.2.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2077,7 +2077,7 @@ PODS:
   - React-jsinspector (0.72.0-rc.5)
   - React-logger (0.72.0-rc.5):
     - glog
-  - react-native-netinfo (9.3.7):
+  - react-native-netinfo (9.3.10):
     - React-Core
   - react-native-pager-view (6.1.2):
     - React-Core
@@ -3716,7 +3716,7 @@ SPEC CHECKSUMS:
   EXSplashScreen: 8d00c7b625ec0f952a17ab685e1f03ac0e5c1795
   EXStructuredHeaders: f3a6d417d5d12ef369fd1a31320d1c188a1b0f4b
   EXTaskManager: a7a387c4e222176988261341680aa7e3f621a335
-  EXUpdates: d01f25d40e711ac9b52f64c36410c1b30ac54e3b
+  EXUpdates: 61a44f682e0805d64953017f411918d7acbb1041
   EXUpdatesInterface: c08eaa7e4d1fdafff3820e0539a6d42a75fa0258
   FBAEMKit: c7efe06720a8b15b1d25b68921ba46dee20996e0
   FBAudienceNetwork: e0fcc9091fced34910ed0b6da06f129db46ac9e6
@@ -3774,7 +3774,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 98c1b1c1e60e137703597e5c5025f2ce3e4700fe
   React-jsinspector: 04038f19b6269374640d90371796f63d034d3542
   React-logger: 4e8c28425ddc27abb6cde80eece89cc765da7d86
-  react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
+  react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
   react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2079,7 +2079,7 @@ PODS:
     - glog
   - react-native-netinfo (9.3.10):
     - React-Core
-  - react-native-pager-view (6.1.2):
+  - react-native-pager-view (6.2.0):
     - React-Core
   - react-native-safe-area-context (4.5.0):
     - RCT-Folly
@@ -3775,7 +3775,7 @@ SPEC CHECKSUMS:
   React-jsinspector: 04038f19b6269374640d90371796f63d034d3542
   React-logger: 4e8c28425ddc27abb6cde80eece89cc765da7d86
   react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
-  react-native-pager-view: 54bed894cecebe28cede54c01038d9d1e122de43
+  react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-skia: ff2265fb802b2a3e1bf4a3c5a86d46936dd20354

--- a/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
+++ b/ios/vendored/unversioned/@react-native-community/netinfo/react-native-netinfo.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-netinfo",
-  "version": "9.3.7",
+  "version": "9.3.10",
   "summary": "React Native Network Info API for iOS & Android",
   "license": "MIT",
   "authors": "Matt Oakes <hello@mattoakes.net>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-community/react-native-netinfo.git",
-    "tag": "v9.3.7"
+    "tag": "v9.3.10"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
+++ b/ios/vendored/unversioned/react-native-pager-view/react-native-pager-view.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-pager-view",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "summary": "React Native wrapper for Android and iOS ViewPager",
   "homepage": "https://github.com/callstack/react-native-pager-view#readme",
   "license": "MIT",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/callstack/react-native-pager-view.git",
-    "tag": "6.1.2"
+    "tag": "6.2.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -88,7 +88,7 @@
   "react-native-gesture-handler": "~2.10.1",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.3.2",
-  "react-native-pager-view": "6.1.2",
+  "react-native-pager-view": "6.2.0",
   "react-native-reanimated": "~3.1.0",
   "react-native-screens": "~3.20.0",
   "react-native-safe-area-context": "4.5.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -3,7 +3,7 @@
   "@react-native-async-storage/async-storage": "1.17.11",
   "@react-native-community/datetimepicker": "6.7.3",
   "@react-native-masked-view/masked-view": "0.2.8",
-  "@react-native-community/netinfo": "9.3.7",
+  "@react-native-community/netinfo": "9.3.10",
   "@react-native-community/slider": "4.4.2",
   "@react-native-community/viewpager": "5.0.11",
   "@react-native-picker/picker": "2.4.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3303,10 +3303,10 @@
   dependencies:
     invariant "^2.2.4"
 
-"@react-native-community/netinfo@9.3.7":
-  version "9.3.7"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.7.tgz#92407f679f00bae005c785a9284e61d63e292b34"
-  integrity sha512-+taWmE5WpBp0uS6kf+bouCx/sn89G9EpR4s2M/ReLvctVIFL2Qh8WnWfBxqK9qwgmFha/uqjSr2Gq03OOtiDcw==
+"@react-native-community/netinfo@9.3.10":
+  version "9.3.10"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.10.tgz#9b6cc2aec9329b5ccf35e866094c43aa420d927a"
+  integrity sha512-OwnqoJUp/4sa9e3ju+wQavAa8l0fiA3DheeLMKzKxtKeAe0CA7bNxWRM752JvRQ6A/igPnt1V0zSlu5owvQEuA==
 
 "@react-native-community/slider@4.4.2":
   version "4.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15897,10 +15897,10 @@ react-native-maps@1.3.2:
   dependencies:
     "@types/geojson" "^7946.0.8"
 
-react-native-pager-view@6.1.2:
-  version "6.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.1.2.tgz#3522079b9a9d6634ca5e8d153bc0b4d660254552"
-  integrity sha512-qs2KSFc+7N7B+UZ6SG2sTvCkppagm5fVyRclv1KFKc7lDtrhXLzN59tXJw575LDP/dRJoXsNwqUAhZJdws6ABQ==
+react-native-pager-view@6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.0.tgz#51380d93fbe47f6380dc71d613a787bf27a4ca37"
+  integrity sha512-pf9OnL/Tkr+5s4Gjmsn7xh91PtJLDa6qxYa/bmtUhd/+s4cQdWQ8DIFoOFghwZIHHHwVdWtoXkp6HtpjN+r20g==
 
 react-native-paper@^4.0.1:
   version "4.12.0"


### PR DESCRIPTION
# Why

ENG-8933

# How

```sh
et uvm -m @react-native-community/netinfo -c 'v9.3.10'
et pods -f
yarn
et uvm -m react-native-pager-view -c 6.2.0
et pods -f
yarn
```

# Test Plan

CI tests pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
