### PR TITLE
[android][ios] Upgrade @shopify/flash-list to 1.4.3

### DIFF
--- a/android/vendored/unversioned/@shopify/flash-list/android/src/main/kotlin/com/shopify/reactnative/flash_list/AutoLayoutShadow.kt
+++ b/android/vendored/unversioned/@shopify/flash-list/android/src/main/kotlin/com/shopify/reactnative/flash_list/AutoLayoutShadow.kt
@@ -25,23 +25,27 @@ class AutoLayoutShadow {
         for (i in 0 until sortedItems.size - 1) {
             val cell = sortedItems[i]
             val neighbour = sortedItems[i + 1]
+            // Only apply correction if the next cell is consecutive.
+            val isNeighbourConsecutive = neighbour.index == cell.index + 1
             if (isWithinBounds(cell)) {
                 if (!horizontal) {
                     maxBound = kotlin.math.max(maxBound, cell.bottom);
                     minBound = kotlin.math.min(minBound, cell.top);
                     maxBoundNeighbour = maxBound
-                    if (cell.left < neighbour.left) {
-                        if (cell.right != neighbour.left) {
-                            neighbour.right = cell.right + neighbour.width
-                            neighbour.left = cell.right
+                    if (isNeighbourConsecutive) {
+                        if (cell.left < neighbour.left) {
+                            if (cell.right != neighbour.left) {
+                                neighbour.right = cell.right + neighbour.width
+                                neighbour.left = cell.right
+                            }
+                            if (cell.top != neighbour.top) {
+                                neighbour.bottom = cell.top + neighbour.height
+                                neighbour.top = cell.top
+                            }
+                        } else {
+                            neighbour.bottom = maxBound + neighbour.height
+                            neighbour.top = maxBound
                         }
-                        if (cell.top != neighbour.top) {
-                            neighbour.bottom = cell.top + neighbour.height
-                            neighbour.top = cell.top
-                        }
-                    } else {
-                        neighbour.bottom = maxBound + neighbour.height
-                        neighbour.top = maxBound
                     }
                     if (isWithinBounds(neighbour)) {
                         maxBoundNeighbour = kotlin.math.max(maxBound, neighbour.bottom)
@@ -50,18 +54,20 @@ class AutoLayoutShadow {
                     maxBound = kotlin.math.max(maxBound, cell.right);
                     minBound = kotlin.math.min(minBound, cell.left);
                     maxBoundNeighbour = maxBound
-                    if (cell.top < neighbour.top) {
-                        if (cell.bottom != neighbour.top) {
-                            neighbour.bottom = cell.bottom + neighbour.height
-                            neighbour.top = cell.bottom
+                    if (isNeighbourConsecutive) {
+                        if (cell.top < neighbour.top) {
+                            if (cell.bottom != neighbour.top) {
+                                neighbour.bottom = cell.bottom + neighbour.height
+                                neighbour.top = cell.bottom
+                            }
+                            if (cell.left != neighbour.left) {
+                                neighbour.right = cell.left + neighbour.width
+                                neighbour.left = cell.left
+                            }
+                        } else {
+                            neighbour.right = maxBound + neighbour.width
+                            neighbour.left = maxBound
                         }
-                        if (cell.left != neighbour.left) {
-                            neighbour.right = cell.left + neighbour.width
-                            neighbour.left = cell.left
-                        }
-                    } else {
-                        neighbour.right = maxBound + neighbour.width
-                        neighbour.left = maxBound
                     }
                     if (isWithinBounds(neighbour)) {
                         maxBoundNeighbour = kotlin.math.max(maxBound, neighbour.right)

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -804,7 +804,7 @@ PODS:
     - React-Core
   - RNDateTimePicker (6.7.3):
     - React-Core
-  - RNFlashList (1.4.0):
+  - RNFlashList (1.4.3):
     - React-Core
   - RNGestureHandler (2.10.1):
     - React-Core
@@ -1498,7 +1498,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDateTimePicker: 00247f26c34683c80be94207f488f6f13448586e
-  RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
+  RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: 42ec7c28dd02d540ed6c9159c57a98ff016492dc
   RNReanimated: b4f101902606e60b4b045e813e47204c2d7b38a7
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -67,7 +67,7 @@
     "@react-native-masked-view/masked-view": "0.2.8",
     "@react-native-picker/picker": "2.4.8",
     "@react-native-segmented-control/segmented-control": "2.4.0",
-    "@shopify/flash-list": "1.4.0",
+    "@shopify/flash-list": "1.4.3",
     "expo": "~49.0.0-alpha.1",
     "expo-camera": "~13.4.0",
     "expo-dev-client": "~2.3.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -55,7 +55,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@react-navigation/elements": "~1.3.6",
-    "@shopify/flash-list": "1.4.0",
+    "@shopify/flash-list": "1.4.3",
     "@shopify/react-native-skia": "0.1.172",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2234,7 +2234,7 @@ PODS:
     - React-perflogger (= 0.72.0-rc.5)
   - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNFlashList (1.4.0):
+  - RNFlashList (1.4.3):
     - React-Core
   - RNGestureHandler (2.10.1):
     - React-Core
@@ -3799,7 +3799,7 @@ SPEC CHECKSUMS:
   React-utils: cbbe99dc2e49db0a3fbb425c304f511a422f0ca2
   ReactCommon: 01b6643cfeef0d9078c8125378066d20cc34ddfe
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
+  RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: 42ec7c28dd02d540ed6c9159c57a98ff016492dc
   RNReanimated: 48794d0f278349ecb6d94490e7bb184c9cdcd86f
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f

--- a/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
+++ b/ios/vendored/unversioned/@shopify/flash-list/RNFlashList.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNFlashList",
-  "version": "1.4.0",
+  "version": "1.4.3",
   "summary": "FlashList is a more performant FlatList replacement",
   "homepage": "https://shopify.github.io/flash-list/",
   "license": "MIT",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/flash-list.git",
-    "tag": "v1.4.0"
+    "tag": "v1.4.3"
   },
   "source_files": "ios/Sources/**/*",
   "requires_arc": true,

--- a/ios/vendored/unversioned/@shopify/flash-list/ios/Sources/AutoLayoutView.swift
+++ b/ios/vendored/unversioned/@shopify/flash-list/ios/Sources/AutoLayoutView.swift
@@ -48,11 +48,9 @@ import UIKit
 
     override func layoutSubviews() {
         fixLayout()
-        fixFooter()
         super.layoutSubviews()
 
-        let scrollView = getScrollView()
-        guard enableInstrumentation, let scrollView = scrollView else { return }
+        guard enableInstrumentation, let scrollView = getScrollView() else { return }
 
         let scrollContainerSize = horizontal ? scrollView.frame.width : scrollView.frame.height
         let currentScrollOffset = horizontal ? scrollView.contentOffset.x : scrollView.contentOffset.y
@@ -103,6 +101,7 @@ import UIKit
             }
             .sorted(by: { $0.index < $1.index })
         clearGaps(for: cellContainers)
+        fixFooter()
     }
 
     /// Checks for overlaps or gaps between adjacent items and then applies a correction.
@@ -124,6 +123,8 @@ import UIKit
             let nextCellTop = nextCell.frame.minY
             let nextCellLeft = nextCell.frame.minX
 
+			// Only apply correction if the next cell is consecutive.
+			let isNextCellConsecutive = nextCell.index == cellContainer.index + 1
 
             guard
                 isWithinBounds(
@@ -149,16 +150,18 @@ import UIKit
                 maxBound = max(maxBound, cellRight)
                 minBound = min(minBound, cellLeft)
                 maxBoundNextCell = maxBound
-                if cellTop < nextCellTop {
-                    if cellBottom != nextCellTop {
-                        nextCell.frame.origin.y = cellBottom
-                    }
-                    if cellLeft != nextCellLeft {
-                        nextCell.frame.origin.x = cellLeft
-                    }
-                } else {
-                    nextCell.frame.origin.x = maxBound
-                }
+				if isNextCellConsecutive {
+					if cellTop < nextCellTop {
+						if cellBottom != nextCellTop {
+							nextCell.frame.origin.y = cellBottom
+						}
+						if cellLeft != nextCellLeft {
+							nextCell.frame.origin.x = cellLeft
+						}
+					} else {
+						nextCell.frame.origin.x = maxBound
+					}
+				}
                 if isNextCellVisible {
                     maxBoundNextCell = max(maxBound, nextCell.frame.maxX)
                 }
@@ -166,16 +169,18 @@ import UIKit
                 maxBound = max(maxBound, cellBottom)
                 minBound = min(minBound, cellTop)
                 maxBoundNextCell = maxBound
-                if cellLeft < nextCellLeft {
-                    if cellRight != nextCellLeft {
-                        nextCell.frame.origin.x = cellRight
-                    }
-                    if cellTop != nextCellTop {
-                        nextCell.frame.origin.y = cellTop
-                    }
-                } else {
-                    nextCell.frame.origin.y = maxBound
-                }
+				if isNextCellConsecutive {
+					if cellLeft < nextCellLeft {
+						if cellRight != nextCellLeft {
+							nextCell.frame.origin.x = cellRight
+						}
+						if cellTop != nextCellTop {
+							nextCell.frame.origin.y = cellTop
+						}
+					} else {
+						nextCell.frame.origin.y = maxBound
+					}
+				}
                 if isNextCellVisible {
                     maxBoundNextCell = max(maxBound, nextCell.frame.maxY)
                 }

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -100,6 +100,6 @@
   "unimodules-app-loader": "~4.1.2",
   "unimodules-image-loader-interface": "~6.1.0",
   "@shopify/react-native-skia": "0.1.172",
-  "@shopify/flash-list": "1.4.0",
+  "@shopify/flash-list": "1.4.3",
   "@sentry/react-native": "4.15.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,10 +3514,10 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@shopify/flash-list@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.4.0.tgz#cf299486ec9a7c97b7a8b1e8b6bf144a78141ed6"
-  integrity sha512-PvPOyk353LuETFnNA038+QaJsAFlCQ2TYC7DHP3YnYqTX72g2BM6qLoLsPaptXKuoXX+dinOo0MbEm7HDjTy1g==
+"@shopify/flash-list@1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.4.3.tgz#b7a4fe03d64f3c5ce9646859b49b9d95307f203d"
+  integrity sha512-jtIReAbwWzYBV0dQ6Io9wBX+pD0C4qQFMrb5/fkEvX8PYDgBl5KRYvpfr9WLLj8CV2Jsn1X0mYOsB+ysWrI/8g==
   dependencies:
     recyclerlistview "4.2.0"
     tslib "2.4.0"


### PR DESCRIPTION
# Why

Upgrades `@shopify/flash-list`  to `1.4.3`


# How

```sh
et uvm -m @shopify/flash-list -c "v1.4.3"
yarn 
et pods -f
```


# Test Plan

- [x] test using `bare-expo` Android + NCL FlashList Example 
- [x] test using `bare-expo` iOS + NCL FlashList Example
- [x] test unversioned expo go ios + NCL FlashList Example
- [x] test unversioned expo go android + NCL FlashList Example

# Checklist
 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
