### PR TITLE
add plugin-proposal-export-namespace-from by default

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `@babel/plugin-proposal-export-namespace-from`.
+- Add `@babel/plugin-proposal-export-namespace-from`. ([#22899](https://github.com/expo/expo/pull/22899) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `@babel/plugin-proposal-export-namespace-from`.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-preset-expo/__tests__/__snapshots__/index-test.js.snap
@@ -275,6 +275,8 @@ return React.createElement(_reactNative.View,null,React.createElement(_reactNati
 }"
 `;
 
+exports[`metro transpiles non-standard exports 1`] = `"Object.defineProperty(exports,"__esModule",{value:true});exports.default=void 0;var _default=_interopRequireWildcard(require("./Animated"));exports.default=_default;function _getRequireWildcardCache(nodeInterop){if(typeof WeakMap!=="function")return null;var cacheBabelInterop=new WeakMap();var cacheNodeInterop=new WeakMap();return(_getRequireWildcardCache=function _getRequireWildcardCache(nodeInterop){return nodeInterop?cacheNodeInterop:cacheBabelInterop;})(nodeInterop);}function _interopRequireWildcard(obj,nodeInterop){if(!nodeInterop&&obj&&obj.__esModule){return obj;}if(obj===null||typeof obj!=="object"&&typeof obj!=="function"){return{default:obj};}var cache=_getRequireWildcardCache(nodeInterop);if(cache&&cache.has(obj)){return cache.get(obj);}var newObj={};var hasPropertyDescriptor=Object.defineProperty&&Object.getOwnPropertyDescriptor;for(var key in obj){if(key!=="default"&&Object.prototype.hasOwnProperty.call(obj,key)){var desc=hasPropertyDescriptor?Object.getOwnPropertyDescriptor(obj,key):null;if(desc&&(desc.get||desc.set)){Object.defineProperty(newObj,key,desc);}else{newObj[key]=obj[key];}}}newObj.default=obj;if(cache){cache.set(obj,newObj);}return newObj;}"`;
+
 exports[`metro uses the platform's react-native import 1`] = `
 "
 var _reactNative=require("react-native");"
@@ -308,6 +310,11 @@ exports[`webpack supports classic JSX runtime 1`] = `
 export default function App(){
 return React.createElement(View,null,React.createElement(Text,null,"Hello World"));
 }"
+`;
+
+exports[`webpack transpiles non-standard exports 1`] = `
+"import*as _default from"./Animated";export{_default as
+default};"
 `;
 
 exports[`webpack uses the platform's react-native import 1`] = `"import View from"react-native-web/dist/exports/View";"`;

--- a/packages/babel-preset-expo/__tests__/index-test.js
+++ b/packages/babel-preset-expo/__tests__/index-test.js
@@ -45,6 +45,24 @@ import { View } from 'react-native';
     expect(code).toMatchSnapshot();
   });
 
+  it(`transpiles non-standard exports`, () => {
+    const options = {
+      babelrc: false,
+      presets: [preset],
+      filename: 'unknown',
+      // Make the snapshot easier to read
+      retainLines: true,
+      caller,
+    };
+
+    const sourceCode = `
+export * as default from './Animated';
+`;
+    const { code } = babel.transform(sourceCode, options);
+
+    expect(code).toMatchSnapshot();
+  });
+
   it(`supports automatic JSX runtime`, () => {
     const options = {
       babelrc: false,

--- a/packages/babel-preset-expo/index.js
+++ b/packages/babel-preset-expo/index.js
@@ -111,6 +111,7 @@ module.exports = function (api, options = {}) {
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
       platform === 'web' && [require.resolve('babel-plugin-react-native-web')],
       isWebpack && platform !== 'web' && [require.resolve('./plugins/disable-ambiguous-requires')],
+      require.resolve('@babel/plugin-proposal-export-namespace-from'),
     ].filter(Boolean),
   };
 };

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-decorators": "^7.12.9",
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-proposal-object-rest-spread": "^7.12.13",
     "@babel/plugin-transform-react-jsx": "^7.12.17",
     "@babel/preset-env": "^7.20.0",


### PR DESCRIPTION
# Why

- We'll now make every user transpile reanimated since it isn't shipping working code.
- Too many users get stuck on this. Having to reset the metro cache multiple times to get animations working is a bad UX.