### PR TITLE
Update vendored gesture handler to 2.12.0

### DIFF
--- a/android/vendored/unversioned/react-native-gesture-handler/android/build.gradle
+++ b/android/vendored/unversioned/react-native-gesture-handler/android/build.gradle
@@ -202,7 +202,7 @@ android {
             var appProject = rootProject.allprojects.find {it.plugins.hasPlugin('com.android.application')}
             externalNativeBuild {
                 cmake {
-                    cppFlags "-O2", "-frtti", "-fexceptions", "-Wall", "-Werror", "-std=c++17"
+                    cppFlags "-O2", "-frtti", "-fexceptions", "-Wall", "-Werror", "-std=c++17", "-DANDROID"
                     arguments "-DAPP_BUILD_DIR=${appProject.buildDir}",
                         "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
                         "-DANDROID_STL=c++_shared"

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -684,7 +684,7 @@ PODS:
     - React-Core
   - react-native-view-shot (3.6.0):
     - React-Core
-  - react-native-webview (11.26.0):
+  - react-native-webview (13.2.2):
     - React-Core
   - React-NativeModulesApple (0.72.0-rc.5):
     - hermes-engine
@@ -798,13 +798,13 @@ PODS:
     - React-perflogger (= 0.72.0-rc.5)
   - RNCAsyncStorage (1.17.11):
     - React-Core
-  - RNCMaskedView (0.2.9):
+  - RNCMaskedView (0.2.8):
     - React-Core
   - RNCPicker (2.4.8):
     - React-Core
   - RNDateTimePicker (6.7.3):
     - React-Core
-  - RNFlashList (1.4.3):
+  - RNFlashList (1.4.0):
     - React-Core
   - RNGestureHandler (2.10.1):
     - React-Core
@@ -839,7 +839,7 @@ PODS:
     - React-RCTImage
   - RNSharedElement (0.8.8):
     - React-Core
-  - RNSVG (13.9.0):
+  - RNSVG (13.4.0):
     - React-Core
   - SDWebImage (5.15.8):
     - SDWebImage/Core (= 5.15.8)
@@ -1476,7 +1476,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-view-shot: 705f999ac2a24e4e6c909c0ca65c732ed33ca2ff
-  react-native-webview: 994b9f8fbb504d6314dc40d83f94f27c6831b3bf
+  react-native-webview: b8ec89966713985111a14d6e4bf98d8b54bced0d
   React-NativeModulesApple: ae27f95a2a84a877785a20ce4c689995dd5f4a64
   React-perflogger: fdd8c2969761105b1c85432fecdfff0616100cc6
   React-RCTActionSheet: 5aaa270460794991553f80d393bcdcb97a372273
@@ -1495,15 +1495,15 @@ SPEC CHECKSUMS:
   React-utils: cbbe99dc2e49db0a3fbb425c304f511a422f0ca2
   ReactCommon: 01b6643cfeef0d9078c8125378066d20cc34ddfe
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
-  RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
+  RNCMaskedView: bc0170f389056201c82a55e242e5d90070e18e5a
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDateTimePicker: 00247f26c34683c80be94207f488f6f13448586e
-  RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
+  RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNGestureHandler: 42ec7c28dd02d540ed6c9159c57a98ff016492dc
   RNReanimated: b4f101902606e60b4b045e813e47204c2d7b38a7
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSharedElement: 504fa28a235b12505b6daedbb452a9ec96809bd0
-  RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
+  RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
   SDWebImageAVIFCoder: 4aeea8fdf65af5c18525ecb5bdd8b8ed9bb45019
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -81,7 +81,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.0-rc.6",
-    "react-native-gesture-handler": "~2.10.1",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-pager-view": "6.2.0",
     "react-native-reanimated": "~3.1.0",
     "react-native-safe-area-context": "4.5.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -143,7 +143,7 @@
     "react-dom": "18.2.0",
     "react-native": "0.72.0-rc.6",
     "react-native-dropdown-picker": "^5.3.0",
-    "react-native-gesture-handler": "~2.10.1",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-maps": "1.7.1",
     "react-native-pager-view": "6.2.0",
     "react-native-paper": "^4.0.1",

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -53,7 +53,7 @@
     "lodash": "^4.17.19",
     "react": "18.2.0",
     "react-native": "0.72.0-rc.6",
-    "react-native-gesture-handler": "~2.10.1",
+    "react-native-gesture-handler": "~2.12.0",
     "sinon": "^7.1.1"
   },
   "devDependencies": {

--- a/home/package.json
+++ b/home/package.json
@@ -58,7 +58,7 @@
     "react": "18.2.0",
     "react-native": "0.72.0-rc.6",
     "react-native-fade-in-image": "^1.6.1",
-    "react-native-gesture-handler": "~2.10.1",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-maps": "1.7.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2236,7 +2236,7 @@ PODS:
     - React-Core
   - RNFlashList (1.4.3):
     - React-Core
-  - RNGestureHandler (2.10.1):
+  - RNGestureHandler (2.12.0):
     - React-Core
   - RNReanimated (3.1.0):
     - DoubleConversion
@@ -3800,7 +3800,7 @@ SPEC CHECKSUMS:
   ReactCommon: 01b6643cfeef0d9078c8125378066d20cc34ddfe
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
-  RNGestureHandler: 42ec7c28dd02d540ed6c9159c57a98ff016492dc
+  RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNReanimated: 48794d0f278349ecb6d94490e7bb184c9cdcd86f
   RNScreens: 218801c16a2782546d30bd2026bb625c0302d70f
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315

--- a/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
+++ b/ios/vendored/unversioned/react-native-gesture-handler/RNGestureHandler.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNGestureHandler",
-  "version": "2.10.1",
+  "version": "2.12.0",
   "summary": "Experimental implementation of a new declarative API for gesture handling in react-native",
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler",
   "license": "MIT",
@@ -9,7 +9,7 @@
   },
   "source": {
     "git": "https://github.com/software-mansion/react-native-gesture-handler",
-    "tag": "2.10.1"
+    "tag": "2.12.0"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "requires_arc": true,

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -30,7 +30,7 @@
     "esbuild": "^0.12.15",
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
-    "react-native-gesture-handler": "~2.10.1",
+    "react-native-gesture-handler": "~2.12.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.9.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -85,7 +85,7 @@
   "react-native": "0.72.0-rc.6",
   "react-native-web": "~0.18.10",
   "react-native-branch": "^5.4.0",
-  "react-native-gesture-handler": "~2.10.1",
+  "react-native-gesture-handler": "~2.12.0",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.7.1",
   "react-native-pager-view": "6.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15862,10 +15862,10 @@ react-native-fade-in-image@^1.6.1:
     react-mixin "^3.0.5"
     react-timer-mixin "^0.13.3"
 
-react-native-gesture-handler@~2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.10.1.tgz#ca5f0f09bfa8d0560f492fc599fa64a64dcdd231"
-  integrity sha512-vDJx3KnheMLEPg35chQW6aiNGqfv3tmWGRRzmfVvqnvvIt5pNkxXe8+x7CYpfIAAnqNLaK1xiozvMkzZPRw1vw==
+react-native-gesture-handler@~2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.12.0.tgz#59ca9d97e4c71f70b9c258f14a1a081f4c689976"
+  integrity sha512-rr+XwVzXAVpY8co25ukvyI38fKCxTQjz7WajeZktl8qUPdh1twnSExgpT47DqDi4n+m+OiJPAnHfZOkqqAQMOg==
   dependencies:
     "@egjs/hammerjs" "^2.0.17"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
# Why

Preparing for SDK49

# How

```
et uvm -m react-native-gesture-handler -c "2.12.0"
```

# Test Plan

Tested manually on both platforms.
For some reason the pinch screen seems to be behaving weird and all the remaining screens work great – investigating if this is an issue with our old example or brought in this minor update.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
