### PR TITLE
[docs] Add callout in Slider reference docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -10,6 +10,8 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v46.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/slider.mdx
@@ -10,6 +10,8 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v47.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/slider.mdx
@@ -10,6 +10,8 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 <PlatformsSection android emulator ios simulator web />

--- a/docs/pages/versions/v48.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/slider.mdx
@@ -10,6 +10,8 @@ import Video from '~/components/plugins/Video';
 
 {/* todo: add video */}
 
+> **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
+
 A component that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 <PlatformsSection android emulator ios simulator web />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for https://github.com/expo/expo/pull/22861

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a callout that describes that the library is included in Expo Go and that is why it is part of Expo SDK reference docs for Slider pages. Changes backported from unversioned to all existing SDKs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Changes have been tested by running docs locally.



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
