### PR TITLE
[docs] Update docs under Routing

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -373,6 +373,7 @@ const preview = [
       makePage('routing/introduction.mdx'),
       makePage('routing/installation.mdx'),
       makePage('routing/create-pages.mdx'),
+      makePage('routing/navigating-pages.mdx'),
       makePage('routing/shared-routes-and-layouts.mdx'),
       makePage('routing/appearance.mdx'),
       makePage('routing/styling.mdx'),

--- a/docs/pages/routing/create-pages.mdx
+++ b/docs/pages/routing/create-pages.mdx
@@ -32,7 +32,7 @@ export default function Page() {
 }
 ```
 
-The above example will match the `/` route in the app and the browser Files named **index** adds no path segment to the URL. The route file named **index** at the route of the directory is automatically considered the "index" route for that directory. For example, **app/settings/index.js** will match `/settings` in the app.
+The above example will match the `/` route in the app and the browser. Files named **index** adds no path segment to the URL. The route file named **index** at the root of the directory is automatically considered the "index" route for that directory. For example, **app/settings/index.js** will match `/settings` in the app.
 
 > Metro platform extensions (for example, **.ios.js**, **.native.ts**) are not supported. The page can re-export a component from a platform extension file.
 
@@ -45,7 +45,7 @@ Dynamic routes match any unmatched path at a given segment level.
 | **app/blog/[slug].js**    | `/blog/123`          |
 | **app/blog/[...rest].js** | `/blog/123/settings` |
 
-Routes with higher specificity will be matched before a dynamic route. For example, `/blog/bacon` will match **blog/bacon.js** before **blog/[id].js**.
+Routes with higher specificity will be matched before a dynamic route. For example, `/blog/bacon` route will match **blog/bacon.js** before **blog/[id].js**.
 
 Multiple slugs can be matched in a single route by using the rest syntax (`...`). For example, **app/blog/[...id].js** will match `/blog/123/settings`.
 

--- a/docs/pages/routing/error-handling.mdx
+++ b/docs/pages/routing/error-handling.mdx
@@ -6,6 +6,8 @@ hideFromSearch: true
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { APIBox } from '~/components/plugins/APIBox';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 This guide specifies how to handle unmatched routes and errors in your app when using Expo Router.
 
@@ -17,14 +19,15 @@ This guide specifies how to handle unmatched routes and errors in your app when 
   style={{ maxWidth: 720 }}
 />
 
-Native apps don't have a server so there are technically no 404s. However, if you're implementing a router universally, then it makes sense to handle missing routes. This is done automatically for each app, but you can also customize it.
+Native apps don't have a server, so there are technically no 404s. However, if you're implementing a router universally, handling missing routes makes sense. It is done automatically for each app. However, you can also customize it.
 
 ```js app/[...unmatched].js
 import { Unmatched } from 'expo-router';
+
 export default Unmatched;
 ```
 
-This will render the default `Unmatched`. You can export any component you want to render instead. We recommend having a link to `/` so users can navigate back to the home screen.
+The above example will render the default `Unmatched`. You can export any component you want to render instead. We recommend having a link to `/` so users can navigate back to the home screen.
 
 ## Error handling
 
@@ -41,6 +44,7 @@ You can export a nested `ErrorBoundary` component from any route to intercept an
 {/* prettier-ignore */}
 ```tsx app/home.tsx
 import { View, Text } from 'react-native';
+
 /* @info */
 export function ErrorBoundary(props: ErrorBoundaryProps) {
 /* @end */
@@ -51,7 +55,6 @@ export function ErrorBoundary(props: ErrorBoundaryProps) {
     </View>
   );
 }
-export default function Page() { ... }
 ```
 
 When you export an `ErrorBoundary` the route will be wrapped with a React Error Boundary effectively:
@@ -72,7 +75,7 @@ When `ErrorBoundary` is not present, the error will be thrown to the nearest par
 
 <APIBox header="ErrorBoundaryProps">
 
-Each `ErrorBoundary` is passed the following props:
+Following props are passed to each `ErrorBoundary`:
 
 - **error:** `Error` &mdash; The error that was thrown.
 - **retry:** `() => Promise<void>` &mdash; A function that will rerender the route component.
@@ -93,8 +96,4 @@ export { ErrorBoundary } from 'expo-router';
 ### Work in progress
 
 - Metro errors need to be symbolicated to show the correct file name and line number on the web.
-- React Native LogBox needs to be presented less aggressively to develop with errors. Currently, it shows for `console.error` and `console.warn`. However, it should ideally only show for uncaught errors.
-
-## Next steps
-
-{/* Add link to the Advance section which is inside the "Guides". */}
+- React Native [LogBox](/debugging/errors-and-warnings/) needs to be presented less aggressively to develop with errors. Currently, it shows for `console.error` and `console.warn`. However, it should only show for uncaught errors.

--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -25,11 +25,11 @@ We recommend creating a new Expo app using `create-expo-app`. This will create a
 
 <Step label="2">
 
-Once setup, you can start your project by running:
+Once setup, you can start your project by running the development server with the following command:
 
 <Terminal cmd={['$ npx expo start']} />
 
-To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/expo-go). As your application grows in complexity and you need more control, you can create a [development build](/develop/development-builds/introduction/).
+To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/expo-go). As your application grows in complexity and you need more control and for that you can create a [development build](/develop/development-builds/introduction/).
 
 </Step>
 
@@ -63,7 +63,7 @@ You'll need to install the following dependencies:
   ]}
 />
 
-The above command will install versions of these libraries that are compatible with the Expo SDK version your project is using.
+The above command will install versions of these libraries that are compatible with your project's [Expo SDK version](/versions/latest/).
 
 </Step>
 
@@ -91,9 +91,9 @@ import 'expo-router/entry';
 
 ### Modify project configuration
 
-Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#web-support-how) in your app config (**app.json** or **app.config.js**):
+Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#web-support-how) in your [app config](/versions/latest/config/app/):
 
-```diff
+```diff app.json
 {
   "expo": {
 +   "scheme": "myapp",
@@ -102,6 +102,26 @@ Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#we
 +   }
   }
 }
+```
+
+</Step>
+
+<Step label="5">
+
+### Modify babel.config.js
+
+Add `expo-router/babel` plugin in the `plugins` array to your project's **babel.config.js**:
+
+```js babel.config.js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    /* @info Add it in the plugins list as the last plugin.*/
+    plugins: [require.resolve('expo-router/babel')],
+    /* @end */
+  };
+};
 ```
 
 </Step>

--- a/docs/pages/routing/introduction.mdx
+++ b/docs/pages/routing/introduction.mdx
@@ -38,7 +38,7 @@ It brings the best file-system routing concepts from the web to a universal appl
   href="/routing/installation/#manual-installation"
 />
 <BoxLink
-  title="Example app"
+  title="Example"
   Icon={GithubIcon}
   description="See the source code for the example app on GitHub."
   href="https://github.com/expo/examples/tree/master/with-router"

--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -1,11 +1,287 @@
 ---
 title: Navigate between pages
 description: Learn how to use Expo Router library to navigate between different pages.
-hideFromSearch: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { APIBox } from '~/components/plugins/APIBox';
+import { FileTree } from '~/ui/components/FileTree';
+
+To navigate between different pages, use the `Link` component. It is conceptually similar to the `<a>` element in HTML.
+
+## Using `Link`
+
+For example, your project has two pages: **app/index.js** and **settings.js**. You can navigate from **index** to **settings** using the `Link` component as shown below:
+
+```js app/home.js
+/* @info */ import { Link } from 'expo-router'; /* @end */
+
+export default function Page() {
+  return (
+    <View>
+      /* @info */
+      <Link href="/settings">Settings</Link>
+      /* @end */
+    </View>
+  );
+}
+```
+
+The `href` attribute on the `Link` component:
+
+- Accepts relative paths such as `../settings` or full paths such as `/profile/settings`. Relative paths are useful for shared routes.
+- Also accepts an object such as `{ pathname: 'profile', params: { id: '123' } }` to navigate to dynamic routes.
+- Use the `replace` prop to replace the current route in the history instead of pushing a new route.
+
+The `Link` component renders a `<Text>` component by default. You can customize the component by passing `asChild`, which forwards all props to the first child of the `Link` component. The child component must support the `onPress` and `onClick` props. The `href` and `accessibilityRole` will also be passed down.
+
+{/* prettier-ignore */}
+```js app/page.js
+import { Pressable, Text } from 'react-native';
+import { Link } from 'expo-router';
+
+function Home() {
+  return (
+    /* @info */
+    <Link href="/other" asChild>
+    /* @end */
+      <Pressable>{({ hovered, pressed }) => <Text>Home</Text>}</Pressable>
+    </Link>
+  );
+}
+```
+
+## Hooks
+
+<APIBox header="useRouter">
+
+For more advanced use cases, you can use the imperative `useRouter` hook to navigate imperatively. Here is an example:
+
+{/* prettier-ignore */}
+```js app/page.js
+import { View, Text } from 'react-native';
+/* @info */
+import { useRouter } from 'expo-router';
+/* @end */
+
+export default function Page() {
+  /* @info */
+  const router = useRouter();
+  /* @end */
+  return (
+    <View>
+      <Text onPress={() => {/* @info */ router.push('/profile/settings'); /* @end */}}>
+        Settings
+      </Text>
+    </View>
+  );
+}
+```
+
+- **push**: `(href: Href) => void` &mdash; Navigate to a route. You can provide a full path such as `/profile/settings` or a relative path such as `../settings`. Navigate to dynamic routes by passing an object such as `{ pathname: 'profile', params: { id: '123' } }`.
+- **replace**: `(href: Href) => void` &mdash; Same API as `push`. Replaces the current route in history instead of pushing a new one. This is useful for redirects.
+- **back**: `() => void` &mdash; Navigate back to previous route.
+- **setParams**: `(params: Record<string, string>) => void` &mdash; Update the query params for the currently selected route.
+
+</APIBox>
+
+<APIBox header="usePathname">
+
+Returns the currently selected route location without search parameters. For example, `/acme?foo=bar` to `/acme`. Segments will be normalized. For example, `/[id]?id=normal` to`/normal`.
+
+**Example route:** `/profile/baconbrix?extra=info`
+
+```js app/profile/[user].tsx
+import { Text } from 'react-native';
+/* @info */
+import { usePathname } from 'expo-router';
+/* @end */
+
+export default function Route() {
+  /* @info pathname = "/profile/baconbrix"*/
+  const pathname = usePathname();
+  /* @end */
+  return <Text>User: {user}</Text>;
+}
+```
+
+</APIBox>
+
+<APIBox header="useSearchParams">
+
+Returns the URL search parameters for the globally selected route. For example, `/acme?foo=bar` as `{ foo: "bar" }`.
+
+**Example route:** `/profile/baconbrix?extra=info`
+
+```js app/profile/[user].js
+import { Text } from 'react-native';
+import { useSearchParams } from 'expo-router';
+export default function Route() {
+  /* @info */
+  const { user, extra } = useSearchParams();
+  /* @end */
+  return <Text>User: {user}</Text>;
+}
+```
+
+If a route is at **[first]/home/.tsx**, a hook is called when the URL is `/abc/home`, in this case, the results of `useSearchParams` are:
+
+```js
+{
+  id: '123';
+}
+```
+
+`useSearchParams` is used for the global URL. When `/abc/home` pushes `/123/shop`, it returns `{ first: undefined, second: '123' }` on **/app/[first]/home.tsx**.
+
+<FileTree files={['app/_layout.js', 'app/[first]/home.tsx', 'app/[second]/home.tsx']} />
+
+If you want the params on **/app/[first]/home.tsx** to remain as `{ first: 'abc' }` you can use [`useLocalSearchParams`](#uselocalsearchparams).
+
+</APIBox>
+
+<APIBox header="useLocalSearchParams">
+
+Returns the URL search parameters for the contextually selected route. For example, `/acme?foo=bar` as `{ foo: "bar" }`. This is useful for stacks where the previous screen is still mounted.
+
+<FileTree files={['app/_layout.js', 'app/[first]/home.tsx', 'app/[second]/home.tsx']} />
+
+**Example route:** `/profile/baconbrix?extra=info`
+
+```js app/profile/[user].tsx
+import { Text } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function Route() {
+  /* @info */
+  const { user, extra } = useLocalSearchParams();
+  /* @end */
+
+  return <Text>User: {user}</Text>;
+}
+```
+
+If a route is at **[first]/home/.tsx** and the hook is called when the URL is `/abc/home`, in this case, the results of `useLocalSearchParams` are:
+
+```js
+{
+  home: 'abc';
+}
+```
+
+When `/abc/home` pushes `/123/shop`, this hook returns `{ home: "abc" }`.
+
+</APIBox>
+
+<APIBox header="useSegments">
+
+Returns a list of segments for the currently selected route. Segments are not normalized so that they will be the same as the file path. For example, `/[id]?id=normal` as `["[id]"]`.
+
+```js app/profile/[user].js
+import { Text } from 'react-native';
+/* @info */
+import { useSegments } from 'expo-router';
+/* @end */
+
+export default function Route() {
+  /* @info */
+  const segments = useSegments();
+  /* @end */
+  // segments = ["profile", "[user]"]
+
+  return <Text>Hello</Text>;
+}
+```
+
+</APIBox>
+
+<APIBox header="useNavigation">
+
+Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. See [Navigator dependent functions](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions) for more information.
+
+{/* prettier-ignore */}
+```js app/profile.js
+/* @info */
+import { useNavigation } from 'expo-router';
+/* @end */
+
+export default function Route() {
+  /* @info */
+  const navigation = useNavigation();
+  /* @end */
+
+  return (
+    <View>
+      <Text onPress={() => {/* @info */navigation.openDrawer();/* @end */}}>
+        Open Drawer
+      </Text>
+    </View>
+  );
+}
+```
+
+</APIBox>
+
+## Types
+
+<APIBox header="Href">
+
+The `Href` type is a union of the following types:
+
+- **string**: A full path like `/profile/settings` or a relative path like `../settings`.
+- **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
+
+</APIBox>
+
+## Redirect
+
+You can immediately redirect from a particular screen by using the `Redirect` component:
+
+```js app/page.js
+import { View, Text } from 'react-native';
+/* @info */
+import { Redirect } from 'expo-router';
+/* @end */
+
+export default function Page() {
+  /* @info Some logic to determine if the user is logged in.*/
+  const { user } = useAuth();
+  /* @end */
+
+  if (!user) {
+    /* @info Redirect to the login screen if the user is not authenticated.*/
+    return <Redirect href="/login" />;
+    /* @end */
+  }
+
+  return (
+    <View>
+      <Text>Welcome Back!</Text>
+    </View>
+  );
+}
+```
+
+You can also redirect imperatively using the `useRouter` hook:
+
+```js app/page.js
+import { Text } from 'react-native';
+import { useRouter, useFocusEffect } from 'expo-router';
+
+export default function Page() {
+  const router = useRouter();
+
+  useFocusEffect(() => {
+    // Call the replace method to redirect to a new route without adding to the history.
+    // We do this in a useFocusEffect to ensure the redirect happens every time
+    // the screen is focused.
+    router.replace('/profile/settings');
+  });
+
+  return <Text>My Screen</Text>;
+}
+```
 
 ## Next steps
 

--- a/docs/pages/routing/shared-routes-and-layouts.mdx
+++ b/docs/pages/routing/shared-routes-and-layouts.mdx
@@ -17,7 +17,7 @@ This is useful for adding layouts without adding additional segments to the URL.
 
 ## Shared routes
 
-To match the same URL with different layouts, use **groups** with overlapping child routes. This pattern is very common in native apps. For example, in the Twitter app, a profile can be viewed in every tab (such as home, search, and profile). However, there is only one URL that is required to access this route.
+Use **groups** with overlapping child routes to match the same URL with different layouts. This pattern is common in native apps. For example, in the Twitter app, the profile is viewable in every tab (such as home, search, and profile). However, only one URL is required to access this route.
 
 In the example below, **app/\_layout.js** is the tab bar and each route has its own header. The **app/(profile)/[user].js** route is shared between each tab.
 
@@ -33,8 +33,7 @@ In the example below, **app/\_layout.js** is the tab bar and each route has its 
   ]}
 />
 
-> When reloading the page, the first match (alphabetically) will be rendered.
-> Shared routes can be navigated directly by including the group name in the route. For example, `/(search)/baconbrix` navigates to `/baconbrix` in the "search" layout.
+> When you reload a page, the first match in alphabetical order will appear. You can access shared routes by including the group name to the route. For example, if you want to go to `/baconbrix` in the "search" layout, navigate to `/(search)/baconbrix`.
 
 ## Arrays
 
@@ -53,7 +52,7 @@ export default function DynamicLayout({ segment }) {
 
 ## Layouts
 
-Pages on their own fill the entire screen. Moving between them is a full-page transition with no animation. In native apps, users expect shared elements like headers and tab bars to persist between pages. These can be created using **layout routes**.
+Pages on their own fill the entire screen. Moving between them is a full-page transition with no animation. In native apps, users expect shared elements such as headers and tab bars to persist between pages. These can be created using **layout routes**.
 
 ### Create a layout route
 
@@ -61,6 +60,7 @@ To create a layout route for a directory, create a file named **\_layout.js** in
 
 ```js app/home/_layout.js
 import { Slot } from 'expo-router';
+
 export default function HomeLayout() {
   return <Slot />;
 }
@@ -70,6 +70,7 @@ From the above example, `Slot` will render the selected child route. This compon
 
 ```js app/home/_layout.js
 import { Slot } from 'expo-router';
+
 export default function HomeLayout() {
   return (
     <>
@@ -83,14 +84,15 @@ export default function HomeLayout() {
 
 ### Native layouts
 
-Mobile app users expect a refined platform-specific look and native feel for layouts. Expo Router provides a few drop-in native layouts that you can use to easily achieve familiar native behavior.
+Mobile app users expect a refined platform-specific look and native feel for layouts. Expo Router provides a few drop-in native layouts that you can use to achieve familiar native behavior.
 
-- `Stack`: Render a stack of screens like a deck of cards with a header on top. This is a native stack navigator that uses native animations and gestures. Extends the [`@react-navigation/native-stack`](https://reactnavigation.org/docs/native-stack-navigator) library.
-- `Tabs`: Render screens with a tab bar below. Extends the [`@react-navigation/bottom-tabs`](https://reactnavigation.org/docs/bottom-tab-navigator/) library.
+- `Stack`: Render a stack of screens like a deck of cards with a header on top. This is a native stack navigator that uses native animations and gestures. It extends the [`@react-navigation/native-stack`](https://reactnavigation.org/docs/native-stack-navigator) library.
+- `Tabs`: Render screens with a tab bar below. It extends the [`@react-navigation/bottom-tabs`](https://reactnavigation.org/docs/bottom-tab-navigator/) library.
 - `Navigator`: Render screens in a generic, unstyled wrapper. This is useful for creating custom layouts.
 
 ```js app/home/_layout.js
 import { Stack } from 'expo-router';
+
 export default function HomeLayout() {
     return (
         <Stack screenOptions={{ ... }} />
@@ -98,7 +100,7 @@ export default function HomeLayout() {
 }
 ```
 
-{/* Note: this was marked TODO so we decided to comment it out for now. */}
+{/* Note(@aman): this was marked TODO so we decided to comment it out for now. */}
 {/* ## Custom layouts */}
 
 ## Next steps

--- a/docs/pages/routing/styling.mdx
+++ b/docs/pages/routing/styling.mdx
@@ -9,32 +9,29 @@ import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 ## React Native Stylesheet API
 
-Expo Router supports styling using React Native's `StyleSheet.create` method as well as inline styles.
+Expo Router supports styling using React Native's [`StyleSheet` API](https://reactnative.dev/docs/stylesheet#create) and inline styles.
 
 ### Limits of React Native styling
 
-React Native's in-built `StyleSheet` API was designed as a low-level API and does not provide support for modern features that simplify building universal applications.
-
-When targeting the web, we highly recommend using a different method of styling. Methods such as ([CSS](/router/styling/css_web/)) allow responsive styling while streaming and avoid flashes of unstyled content.
+The `StyleSheet` API is designed as a low-level API and does not support modern features that simplify building universal applications. When targeting the web, we highly recommend using a different method of styling such as [CSS](#css) that allows responsive styling while streaming and avoids flashes of unstyled content.
 
 ## CSS
 
-> The following sections refer to upcoming Expo Router features which are experimental, not covered by semantic versioning and you may need to be using the latest version on `main`.
+> **warning** The following sections refer to upcoming Expo Router features that are experimental, not covered by semantic versioning, and you may need to use the latest version on `main`.
 
-Expo Router provides a CSS interop for your application. This allows you to style your application using the CSS language or use a styling solution that compiles to CSS. This is not a full CSS implementation. Think of it as "CSS with the good bits".
+Expo Router provides a CSS interop for your application. This allows you to style your application using the CSS language or use a styling solution that compiles to CSS. This is not a full CSS implementation. Think of it as **CSS with the good bits**.
 
 ### Features
 
-The CSS-interop provides React Native polyfills for the following common CSS features:
+The CSS interop provides React Native polyfills for the following common CSS features:
 
-- Additional relative units
-  - `vw`,`vh`
+- Additional relative units: `vw`,`vh`
 - [Media Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
   - [Media features](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#targeting_media_features)
-  - [prefered-color-scheme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+  - [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
   - [Accessibility](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility)
 - [Container Queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries)
-  - Dimentions
+  - Dimensions
   - Styles
 - Style variables
 - Psuedo classes
@@ -42,8 +39,8 @@ The CSS-interop provides React Native polyfills for the following common CSS fea
 
 Additionally, it includes the following bundling features:
 
-- When developing locally, changes to stylesheets will instantly reflect changes as edits are made.
-- When building for production, CSS files will be minified and common styles grouped.
+- When working on the development stage, any changes made to the stylesheet are immediately reflected.
+- When building for production, CSS files are minified and common styles are grouped.
 
 ### Usage
 
@@ -53,9 +50,10 @@ Expo Router supports styling components via the `className` prop. Simply `import
 
 ```js app/_layout.js
 import { Slot } from 'expo-router';
-/* @info Import your styles! */
+/* @info Import your styles. */
 import 'global.css';
 /* @end */
+
 export default function RootLayout() {
   return <Slot />;
 }
@@ -73,6 +71,7 @@ CSS Modules are available by using the `.module.css` extension. They locally sco
 
 ```js app/index.js
 import styles from './styles.module.css';
+
 export default function MyApp() {
   return <div styles={styles.container} />;
 }
@@ -82,7 +81,7 @@ export default function MyApp() {
 
 #### Flexbox
 
-Yoga (React Native's layout engine) uses a slightly different Flexbox model than web browsers, as such there are minor behavioral differences.
+Yoga (React Native's layout engine) uses a slightly different Flexbox model than web browsers, and there are minor behavioral differences.
 
 | Feature        | Difference                                                | Solution                         |
 | -------------- | --------------------------------------------------------- | -------------------------------- |
@@ -102,10 +101,10 @@ flex-basis: 0;
 
 #### No style inheritance
 
-The CSS interop does not support [CSS Cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade). As such, allow CSS rules should be written as single selectors. We recommend using a CSS methodology such as:
+CSS interop does not support [CSS Cascade](https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade). CSS rules should be written as single selectors. We recommend using a CSS methodology such as:
 
-- Atomic CSS (https://css-tricks.com/lets-define-exactly-atomic-css/)
-- BEM (https://getbem.com/introduction/)
+- [Atomic CSS](https://css-tricks.com/lets-define-exactly-atomic-css/)
+- [BEM](https://getbem.com/introduction/)
 
 #### Selectors
 
@@ -120,13 +119,13 @@ div {
 .container .text {
   color: red;
 }
-// ✔️
+// ✅
 .text-red {
   color: red;
 }
 ```
 
-You can still specify them, as they are still valid for web, but we recommend limiting usage to only `html`/`body`
+Since they are valid for the web, you can still specify them. However, we recommend limiting usage to only `html` or `body` tags.
 
 #### Specificity
 
@@ -136,13 +135,27 @@ Native styles are resolved right-to-left, while Web styles are resolved via [CSS
 
 #### rem
 
-`rem` is the relative CSS unit for the Font size of the root element. On native, the font size defaults to `14` and is _not relative_ to your root element. If you which to dynamically change the `rem` value, you need to set `inlineRem: false` in your **metro.config.js** file. Now the value of `rem` can be set by calling `StyleSheet.rem.set(<number>)`.
+Relative CSS unit `rem` refers to the font size of the root element. However, on native platforms, the font size defaults to `14` and is _not relative_ to your root element. If you want to dynamically change the `rem` value, you need to set `inlineRem: false` in **metro.config.js**. This allows the value of `rem` to be set by calling `StyleSheet.rem.set(<number>)`.
+
+{/* prettier-ignore */}
+```js metro.config.js
+module.exports = {
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        /* @hide ... */ /* @end */
+        inlineRequires: true,
+      },
+    }),
+  },
+};
+```
 
 ## Troubleshooting
 
-### Elements are not appearing on Native
+### Elements are not appearing on native
 
-This is most likely due to minor differences in [React Native's flexbox model](#flexbox). A common offender is the differences between `flex-shrink` and simply setting `flex: 1` will resolve your issue.
+This is most likely due to minor differences in [React Native's flexbox model](#flexbox). A common offender is the differences between `flex-shrink` and setting `flex: 1` resolves the issue.
 
 ## Next steps
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the pages under "Routing" section were missing:
- Formatting as per [our writing styleguide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#glossary)
- Missing Navigating between pages ([as per the docs organization proposal](https://www.notion.so/expo/Expo-Router-Docs-organization-cf48a23686a447c69bc1e00b2dfc8308))

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add the missing "Navigating between pages" guide
- Format other pages as per writing styleguide
- Add missing code snippet on modifying **metro.config.js** file when using `rem` dynamically
- Use `FileTree` component to represent file trees
- Add missing step about modifying **babel.config.js** in the Manual installation

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
