### PR TITLE
feat(docs): use custom layout icon for Expo Router Layout Routes

### DIFF
--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { theme, typography } from '@expo/styleguide';
 import { borderRadius, spacing } from '@expo/styleguide-base';
-import { FileCode01Icon } from '@expo/styleguide-icons';
+import { FileCode01Icon, LayoutAlt01Icon } from '@expo/styleguide-icons';
 import { Language, Prism } from 'prism-react-renderer';
 import * as React from 'react';
 import tippy, { roundArrow } from 'tippy.js';
@@ -219,7 +219,7 @@ export class Code extends React.Component<React.PropsWithChildren<Props>> {
 
     return value?.title ? (
       <Snippet>
-        <SnippetHeader title={value.title} Icon={FileCode01Icon}>
+        <SnippetHeader title={value.title} Icon={getIconForFile(value.title)}>
           <CopyAction text={cleanCopyValue(value.value)} />
         </SnippetHeader>
         <SnippetContent className="p-0">
@@ -277,3 +277,10 @@ export const CodeBlock = ({ children, inline = false }: CodeBlockProps) => {
     </Element>
   );
 };
+
+function getIconForFile(filename: string) {
+  if (/_layout\.[jt]sx?$/.test(filename)) {
+    return LayoutAlt01Icon;
+  }
+  return FileCode01Icon;
+}

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -1,4 +1,4 @@
-import { FileCode01Icon, FolderIcon } from '@expo/styleguide-icons';
+import { FileCode01Icon, LayoutAlt01Icon, FolderIcon } from '@expo/styleguide-icons';
 import { HTMLAttributes, ReactNode } from 'react';
 
 type FileTreeProps = HTMLAttributes<HTMLDivElement> & {
@@ -27,6 +27,7 @@ function generateStructure(files: string[]): FileObject {
 
 function renderStructure(structure: FileObject, level = 0): ReactNode {
   return Object.entries(structure).map(([key, value]) => {
+    const FileIcon = getIconForFile(key);
     return Object.keys(value).length ? (
       <div className="mt-1 pt-1 px-2 rounded-sm flex flex-col">
         <div className="flex items-center">
@@ -39,9 +40,16 @@ function renderStructure(structure: FileObject, level = 0): ReactNode {
     ) : (
       <div className="mt-1 pl-3 pt-1 px-2 rounded-sm flex items-center">
         {' '.repeat(level - 1)}
-        <FileCode01Icon className="text-icon-tertiary mr-2" />
+        <FileIcon className="text-icon-tertiary mr-2" />
         <code className="text-default">{key}</code>
       </div>
     );
   });
+}
+
+function getIconForFile(filename: string) {
+  if (/_layout\.[jt]sx?/.test(filename)) {
+    return LayoutAlt01Icon;
+  }
+  return FileCode01Icon;
 }


### PR DESCRIPTION
# Why

- Help visually distinguish Layout Routes from other files. The `_layout` file format may be the first exposure that many native developers get to magic file naming.


<img width="984" alt="Screenshot 2023-06-15 at 6 35 26 PM" src="https://github.com/expo/expo/assets/9664363/5c33108c-d9da-4037-8dbf-a4967dde9588">
