### PR TITLE
chore(docs): `npx create-expo-app` -> `npm create expo`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -356,12 +356,12 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <Terminal cmd={[
   "# Create a new native project",
-  "$ npx create-expo-app --template bare-minimum",
+  "$ npm create expo --template bare-minimum",
   "",
   "# If you don’t have expo-cli yet, get it",
   "$ npm i -g expo-cli",
   "",
-]} cmdCopy="npx create-expo-app --template bare-minimum && npm i -g expo-cli" />
+]} cmdCopy="npm create expo --template bare-minimum && npm i -g expo-cli" />
 ```
 
 ### Prettier

--- a/docs/pages/archive/classic-updates/preloading-and-caching-assets.mdx
+++ b/docs/pages/archive/classic-updates/preloading-and-caching-assets.mdx
@@ -115,7 +115,7 @@ To use the local image asset, you can continue referencing the source of the ima
 <Image source={require('path/to/image.png')} />
 ```
 
-See the complete working example in [Expo's tabs template project](https://github.com/expo/expo/blob/main/templates/expo-template-tabs/App.tsx). You can also run `npx create-expo-app --template tabs` to set up a local project with the same template.
+See the complete working example in [Expo's tabs template project](https://github.com/expo/expo/blob/main/templates/expo-template-tabs/App.tsx). You can also run `npm create expo --template tabs` to set up a local project with the same template.
 
 ### Publishing Assets
 

--- a/docs/pages/archive/classic-updates/updating-your-app.mdx
+++ b/docs/pages/archive/classic-updates/updating-your-app.mdx
@@ -11,7 +11,7 @@ In this guide, an **update** refers to a single, atomic update, which may consis
 
 ## Setup
 
-If possible, we highly recommend starting with a boilerplate project that has the `expo-updates` library already installed, for example, by running: `npx create-expo-app -t bare-minimum`.
+If possible, we highly recommend starting with a boilerplate project that has the `expo-updates` library already installed, for example, by running: `npm create expo -t bare-minimum`.
 
 To install the `expo-updates` module in an existing bare workflow app, follow the [installation instructions in the package README](https://github.com/expo/expo/tree/main/packages/expo-updates/README.mdx#installation).
 

--- a/docs/pages/archive/expo-cli.mdx
+++ b/docs/pages/archive/expo-cli.mdx
@@ -708,7 +708,7 @@ In Expo SDK 46, we migrated to a new suite of tooling that is versioned in the `
 
 | Legacy               | New                    | Notes                                         |
 | -------------------- | ---------------------- | --------------------------------------------- |
-| `expo init`          | `npx create-expo-app`  | New CLI                                       |
+| `expo init`          | `npm create expo`  | New CLI                                       |
 | `expo start`         | `npx expo start`       | Versioned                                     |
 | `expo export`        | `npx expo export`      | Versioned, `--experimental-bundle` is default |
 | `expo install`       | `npx expo install`     | Versioned                                     |

--- a/docs/pages/bare/hello-world.mdx
+++ b/docs/pages/bare/hello-world.mdx
@@ -14,8 +14,8 @@ Before you get started with a React Native app, make sure you set up your enviro
 To bootstrap a new React Native project, you can use `create-expo-app`. If you have an existing project or want to bootstrap with `npx react-native init`, then you will need to [install the `expo` package](/bare/installing-expo-modules) manually.
 
 <Terminal
-  cmd={['# Create a new native project', '$ npx create-expo-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app --template bare-minimum"
+  cmd={['# Create a new native project', '$ npm create expo --template bare-minimum']}
+  cmdCopy="npm create expo --template bare-minimum"
 />
 
 Navigate into your project directory, then build the apps locally:

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-updates` library fetches and manages updates received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates for projects using the `expo-updates` library.
 
-> If you are creating a new project, we recommend using `npx create-expo-app --template bare-minimum` (or `yarn create expo-app --template bare-minimum`) instead of `npx react-native init` because it will handle the following configuration for you automatically. It includes the `expo-updates` [config plugin](/config-plugins/introduction/), which will handle the following steps for you.
+> If you are creating a new project, we recommend using `npm create expo --template bare-minimum` (or `yarn create expo-app --template bare-minimum`) instead of `npx react-native init` because it will handle the following configuration for you automatically. It includes the `expo-updates` [config plugin](/config-plugins/introduction/), which will handle the following steps for you.
 
 ## Installation
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -26,7 +26,7 @@ Start with the following commands:
 <Terminal
   cmd={[
     '# Initialize a new project',
-    '$ npx create-expo-app eas-tests-example',
+    '$ npm create expo eas-tests-example',
     '# cd into the project directory',
     '$ cd eas-tests-example',
     '# Install @config-plugins/detox',

--- a/docs/pages/build/introduction.mdx
+++ b/docs/pages/build/introduction.mdx
@@ -11,7 +11,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 It makes building your apps for distribution simple and easy to automate by providing defaults that work well for Expo and React Native projects out of the box, and by handling your app signing credentials for you (if you wish). It also makes sharing builds with your team easier than ever with [internal distribution](/build/internal-distribution/) (using ad hoc and/or enterprise "universal" provisioning), deeply integrates with EAS Submit for app store submissions, and has first-class support for the [`expo-updates`](/build/updates/) library.
 
-It's designed to work for any native project, whether or not you also use the managed workflow. It's the fastest way to get from `npx create-expo-app` or `npx react-native init` to app stores.
+It's designed to work for any native project, whether or not you also use the managed workflow. It's the fastest way to get from `npm create expo` or `npx react-native init` to app stores.
 
 ### Get started
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -28,7 +28,7 @@ Don't have a project yet? No problem. It's quick and easy to create a "Hello wor
 
 - Run the following command to create a new project:
 
-<Terminal cmd={['$ npx create-expo-app my-app']} />
+<Terminal cmd={['$ npm create expo my-app']} />
 
 EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -24,13 +24,13 @@ One way you can debug these issues is by looking at the [stack trace](/debugging
 
 - Search for the error message in Google and [Stack Overflow](https://stackoverflow.com/questions), it's likely you're not the first person to ever run into this.
 - **Isolate the code that's throwing the error**. This step is _vital_ in fixing obscure errors. To do this:
-  - Revert to a working version of your code. This may even be a completely blank `npx create-expo-app` project.
+  - Revert to a working version of your code. This may even be a completely blank `npm create expo` project.
   - Apply your recent changes piece by piece, until it breaks.
   - If the code you're adding in each "piece" is complex, you may want to simplify what you're doing. For example, if you use a state management library such as Redux, you can try removing that from the equation completely to see if the issue lies in your state management (which is common in React apps).
   - This should narrow down the possible sources of the error, and provide you with more information to search the internet for others who have had the same problem.
 - Use breakpoints (or `console.log`s) to check and make sure a certain piece of code is being run, or that a variable has a certain value. Using `console.log` for debugging isn't considered the best practice, however, it's fast, easy, and oftentimes provides some illuminating information.
 
-Simplifying code as much as possible to track down the source of error is a great way to debug your app and it gets exponentially easier. That's why many open-source repositories require a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) when you open an issue. It ensures you have isolated the issue and identified exactly where the problem occurs. If your app is too large and complex to do that, try and extract the functionality you're trying to add in a blank `npx create-expo-app` project, and go from there.
+Simplifying code as much as possible to track down the source of error is a great way to debug your app and it gets exponentially easier. That's why many open-source repositories require a [minimal reproducible example](https://stackoverflow.com/help/minimal-reproducible-example) when you open an issue. It ensures you have isolated the issue and identified exactly where the problem occurs. If your app is too large and complex to do that, try and extract the functionality you're trying to add in a blank `npm create expo` project, and go from there.
 
 ### Native debugging
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -135,7 +135,7 @@ When you load it on your device, you'll see something like this:
 
 To create a new project including this example, run in your terminal:
 
-<Terminal cmd={['$ npx create-expo-app --example with-custom-font']} />
+<Terminal cmd={['$ npm create expo --example with-custom-font']} />
 
 > The above example also uses [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) package. For more information on that, see [Waiting for fonts to load](#wait-for-fonts-to-load) section.
 

--- a/docs/pages/eas-update/eas-update-with-local-build.mdx
+++ b/docs/pages/eas-update/eas-update-with-local-build.mdx
@@ -27,7 +27,7 @@ You can also use the above command to check if a new version of EAS CLI is avail
 
 Create a project by running:
 
-<Terminal cmd={['$ npx create-expo-app']} />
+<Terminal cmd={['$ npm create expo']} />
 </Step>
 
 <Step label="3">

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -26,7 +26,7 @@ You can also use the above command to check if a new version of EAS CLI is avail
 
 Create a project by running:
 
-<Terminal cmd={['$ npx create-expo-app']} />
+<Terminal cmd={['$ npm create expo']} />
 </Step>
 
 <Step label="3">

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -20,15 +20,15 @@ To initialize a new project, use [`create-expo-app`](/more/glossary-of-terms/#cr
 <Terminal
   cmd={[
     '# Create a project named my-app',
-    '$ npx create-expo-app my-app',
+    '$ npm create expo my-app',
     '',
     '# Navigate to the project directory',
     '$ cd my-app',
   ]}
-  cmdCopy="npx create-expo-app my-app && cd my-app"
+  cmdCopy="npm create expo my-app && cd my-app"
 />
 
-> **info** You can also use the `--template` option with the `create-expo-app` command. Run `npx create-expo-app --template` to see the list of available templates.
+> **info** You can also use the `--template` option with the `create-expo-app` command. Run `npm create expo --template` to see the list of available templates.
 
 </Step>
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -8,7 +8,7 @@ As trendy as it is these days, not every app has to use emoji for all icons &mda
 
 ## @expo/vector-icons
 
-This library is installed by default on the template project using `npx create-expo-app` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets that you can browse at [icons.expo.fyi](https://icons.expo.fyi).
+This library is installed by default on the template project using `npm create expo` and is part of the `expo` package. It is built on top of [`react-native-vector-icons`](https://github.com/oblador/react-native-vector-icons) and uses a similar API. It includes popular icon sets that you can browse at [icons.expo.fyi](https://icons.expo.fyi).
 
 In the example below, the component loads the `Ionicons` font, and renders a checkmark icon.
 

--- a/docs/pages/guides/routing-and-navigation.mdx
+++ b/docs/pages/guides/routing-and-navigation.mdx
@@ -21,7 +21,7 @@ Routing and navigation refer to organizing an app into different screens, mappin
 
 To quickly get started with Expo Router, run the following command to create a project with `expo-router` setup:
 
-<Terminal cmd={['$ npx create-expo-app@latest -e with-router']} />
+<Terminal cmd={['$ npm create expo@latest -e with-router']} />
 
 <BoxLink
   title="Expo Router documentation"

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -68,8 +68,8 @@ Certain language features may require additional configuration, for example if y
 ## Starting from scratch: using a TypeScript template
 
 <Terminal
-  cmd={['$ npx create-expo-app -t expo-template-blank-typescript']}
-  cmdCopy="npx create-expo-app -t expo-template-blank-typescript"
+  cmd={['$ npm create expo -t expo-template-blank-typescript']}
+  cmdCopy="npm create expo -t expo-template-blank-typescript"
 />
 
 The easiest way to get started is to initialize your new project using a TypeScript template, then run `yarn tsc` or `npx tsc` to "typecheck" the project.

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -19,7 +19,7 @@ Using Expo with Next.js means you can share some of your existing components and
 
 To get started, create a new project with [the template](https://github.com/expo/examples/tree/master/with-nextjs):
 
-<Terminal cmd={["$ npx create-expo-app -e with-nextjs"]} />
+<Terminal cmd={["$ npm create expo -e with-nextjs"]} />
 
 - **Native**: `npx expo start` -- start the Expo project
 - **Web**: `npx next dev` -- start the Next.js project

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -75,7 +75,7 @@ const Home = () => {
                 <RawH2>
                   <QuickStartIcon /> Quick Start
                 </RawH2>
-                <Terminal includeMargin={false} cmd={['$ npx create-expo-app my-app']} />
+                <Terminal includeMargin={false} cmd={['$ npx create expo my-app']} />
               </div>
             </GridCell>
             <GridCell

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -183,7 +183,7 @@ use_expo_modules!({
 
 ### How to set up the autolinking in my app?
 
-All projects created with the `npx create-expo-app` command are already configured to use Expo Autolinking. If your project was created using different tools, please refer to [Installing Expo modules](/bare/installing-expo-modules) to make sure your project includes all necessary changes.
+All projects created with the `npm create expo` command are already configured to use Expo Autolinking. If your project was created using different tools, please refer to [Installing Expo modules](/bare/installing-expo-modules) to make sure your project includes all necessary changes.
 
 ### What do I need to have in my module to make it autolinkable?
 

--- a/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
+++ b/docs/pages/modules/use-standalone-expo-module-in-your-project.mdx
@@ -143,8 +143,8 @@ Apart from publishing your module to npm, there are other ways to use it in your
 To test the published module in a new project, create a new app and install the module as a dependency:
 
 <Terminal
-  cmdCopy="npx create-expo-app my-app && cd my-app && npx expo install expo-settings"
-  cmd={['$ npx create-expo-app my-app', '$ cd my-app', '$ npx expo install expo-settings']}
+  cmdCopy="npm create expo my-app && cd my-app && npx expo install expo-settings"
+  cmd={['$ npm create expo my-app', '$ cd my-app', '$ npx expo install expo-settings']}
 />
 
 You should now be able to use the module inside your app! To test it, edit the **App.js** in the app and render the text message from **expo-settings**.

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -77,7 +77,7 @@ A standalone command line tool (CLI) for bootstrapping new React Native apps wit
 
 This package can be used by running any of the following commands:
 
-- `npx create-expo-app`
+- `npm create expo`
 - `yarn create expo-app`
 - `npm create expo-app`
 
@@ -87,7 +87,7 @@ A standalone command line tool (CLI) for bootstrapping new React Native apps wit
 
 This package can be used by running any of the following commands:
 
-- `npx create-expo-app`
+- `npm create expo`
 - `yarn create expo-app`
 - `npm create expo-app`
 

--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -19,7 +19,7 @@ Find the steps below to create a new project with Expo Router library or add it 
 
 We recommend creating a new Expo app using `create-expo-app`. This will create a minimal project with the Expo Router library already installed. To create a project, run the command:
 
-<Terminal cmd={['$ npx create-expo-app@latest --example with-router']} />
+<Terminal cmd={['$ npm create expo@latest --example with-router']} />
 
 </Step>
 
@@ -47,7 +47,7 @@ Make sure your computer is [set up for running an Expo app](/get-started/install
 
 To create a new project, run the following command:
 
-<Terminal cmd={['$ npx create-expo-app']} />
+<Terminal cmd={['$ npm create expo']} />
 
 </Step>
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -31,12 +31,12 @@ It will create a new project directory and install all the necessary dependencie
 <Terminal
   cmd={[
     '# Create a project named StickerSmash',
-    '$ npx create-expo-app StickerSmash',
+    '$ npm create expo StickerSmash',
     '',
     '# Navigate to the project directory',
     '$ cd StickerSmash',
   ]}
-  cmdCopy="npx create-expo-app StickerSmash && cd StickerSmash"
+  cmdCopy="npm create expo StickerSmash && cd StickerSmash"
 />
 
 This command will create a new directory for the project with the name: **StickerSmash**.

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -29,8 +29,8 @@ This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/co
 The easiest way to create a bare React Native app with support for the Expo SDK is by running the command:
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={['# Create a project named my-app', '$ npm create expo my-app --template bare-minimum']}
+  cmdCopy="npm create expo my-app --template bare-minimum"
 />
 
 <BoxLink

--- a/docs/pages/versions/v46.0.0/index.mdx
+++ b/docs/pages/versions/v46.0.0/index.mdx
@@ -29,8 +29,8 @@ This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/co
 The easiest way to create a bare React Native app with support for the Expo SDK is by running the command:
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={['# Create a project named my-app', '$ npm create expo my-app --template bare-minimum']}
+  cmdCopy="npm create expo my-app --template bare-minimum"
 />
 
 <BoxLink

--- a/docs/pages/versions/v47.0.0/index.mdx
+++ b/docs/pages/versions/v47.0.0/index.mdx
@@ -29,8 +29,8 @@ This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/co
 The easiest way to create a bare React Native app with support for the Expo SDK is by running the command:
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={['# Create a project named my-app', '$ npm create expo my-app --template bare-minimum']}
+  cmdCopy="npm create expo my-app --template bare-minimum"
 />
 
 <BoxLink

--- a/docs/pages/versions/v48.0.0/index.mdx
+++ b/docs/pages/versions/v48.0.0/index.mdx
@@ -29,8 +29,8 @@ This allows you to write [`Contacts.getContactsAsync()`](/versions/latest/sdk/co
 The easiest way to create a bare React Native app with support for the Expo SDK is by running the command:
 
 <Terminal
-  cmd={['# Create a project named my-app', '$ npx create-expo-app my-app --template bare-minimum']}
-  cmdCopy="npx create-expo-app my-app --template bare-minimum"
+  cmd={['# Create a project named my-app', '$ npm create expo my-app --template bare-minimum']}
+  cmdCopy="npm create expo my-app --template bare-minimum"
 />
 
 <BoxLink

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -82,7 +82,7 @@ Create a project with the desired SDK version and open it in a simulator to inst
 <Terminal
   cmd={[
     '# Bootstrap an SDK 48 project',
-    '$ npx create-expo-app --template blank@48',
+    '$ npm create expo --template blank@48',
     '',
     '# Open the app on a simulator to install the required Expo Go app',
     '$ npx expo start --ios',

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -109,7 +109,7 @@ Now check the following:
 - Does the README mention linking?
 - Is it built specifically for Node.js, the web, electron, or another platform?
 
-If you answered yes to any of these questions and the library is not part of the Expo SDK, this library may not be supported in [Expo Go][expo-go]. You can go ahead and try it in a new project to be sure. Run `npx create-expo-app` and add the library to the new project and try to use it. This is a great way to experiment with a library before including it in your project in all circumstances.
+If you answered yes to any of these questions and the library is not part of the Expo SDK, this library may not be supported in [Expo Go][expo-go]. You can go ahead and try it in a new project to be sure. Run `npm create expo` and add the library to the new project and try to use it. This is a great way to experiment with a library before including it in your project in all circumstances.
 
 Many React Native libraries are not compatible with [Expo Go][expo-go]. For these libraries, you can create a [development build](/develop/development-builds/introduction/):
 

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -55,7 +55,7 @@ describe(Terminal, () => {
   });
 
   it('do not generate copyCmd if there is more than one command', () => {
-    render(<Terminal cmd={['$ npx create-expo-app init test', '$ cd test']} />);
+    render(<Terminal cmd={['$ npm create expo init test', '$ cd test']} />);
     expect(screen.queryByText('Copy')).toBe(null);
   });
 });


### PR DESCRIPTION
# Why

We now cross-publish `create-expo-app` to `create-expo` which means we can do the shorter `npm create expo` command to generate a project. This is nice because it's closer to how yarn and pnpm users work, e.g. `yarn create expo` and `pnpx create expo`. If users want to install packages with pnpm and yarn, they need to bootstrap this way. `npm create expo` appears to work with Node +14, and 18 is the LTS––so it should work for everyone.

# How

find → replace
