### PR TITLE
[expo-tools] Check for unused transforms for vendored code.

### DIFF
--- a/tools/src/Transforms.ts
+++ b/tools/src/Transforms.ts
@@ -39,22 +39,25 @@ export function transformString(
   }, input);
 }
 
-async function getTransformedFileContentAsync(
+async function applyTransformsOnFileContentAsync(
   filePath: string,
-  transforms: FileTransform[],
-  unusedTransforms?: Set<FileTransform>
-): Promise<string> {
+  transforms: FileTransform[]
+): Promise<{
+  content: string;
+  transformsUsed: Set<FileTransform>;
+}> {
   // Transform source content.
   let result = await fs.readFile(filePath, 'utf8');
+  const transformsUsed = new Set<FileTransform>();
   for (const transform of transforms) {
     const beforeTransformation = result;
     result = applySingleTransform(result, transform);
     await maybePrintDebugInfoAsync(beforeTransformation, result, filePath, transform);
     if (result !== beforeTransformation) {
-      unusedTransforms?.delete(transform);
+      transformsUsed.add(transform);
     }
   }
-  return result;
+  return { content: result, transformsUsed };
 }
 
 /**
@@ -120,24 +123,32 @@ export async function transformFileAsync(
 /**
  * Transforms multiple files' content in-place.
  */
-export async function transformFilesAsync(files: string[], transforms: FileTransform[]) {
+export async function transformFilesAsync(
+  files: string[],
+  transforms: FileTransform[]
+): Promise<Set<FileTransform>> {
+  const transformsUsed = new Set<FileTransform>();
   for (const file of files) {
     const filteredContentTransforms = getFilteredContentTransforms(transforms ?? [], file);
 
     // Transform source content.
-    const content = await getTransformedFileContentAsync(file, filteredContentTransforms);
+    const transformedFile = await applyTransformsOnFileContentAsync(
+      file,
+      filteredContentTransforms
+    );
+    transformedFile.transformsUsed.forEach((transform) => transformsUsed.add(transform));
 
     // Save transformed content
-    await fs.outputFile(file, content);
+    await fs.outputFile(file, transformedFile.result);
   }
+  return transformsUsed;
 }
 
 /**
  * Copies a file from source directory to target directory with transformed relative path and content.
  */
 export async function copyFileWithTransformsAsync(
-  options: CopyFileOptions,
-  unusedTransforms: Set<FileTransform>
+  options: CopyFileOptions
 ): Promise<CopyFileResult> {
   const { sourceFile, sourceDirectory, targetDirectory, transforms } = options;
   const sourcePath = path.join(sourceDirectory, sourceFile);
@@ -152,10 +163,9 @@ export async function copyFileWithTransformsAsync(
   );
 
   // Transform source content.
-  const content = await getTransformedFileContentAsync(
+  const { content, transformsUsed } = await applyTransformsOnFileContentAsync(
     sourcePath,
-    filteredContentTransforms,
-    unusedTransforms
+    filteredContentTransforms
   );
 
   if (filteredContentTransforms.length > 0) {
@@ -175,6 +185,7 @@ export async function copyFileWithTransformsAsync(
 
   return {
     content,
+    transformsUsed,
     targetFile,
   };
 }

--- a/tools/src/Transforms.ts
+++ b/tools/src/Transforms.ts
@@ -139,7 +139,7 @@ export async function transformFilesAsync(
     transformedFile.transformsUsed.forEach((transform) => transformsUsed.add(transform));
 
     // Save transformed content
-    await fs.outputFile(file, transformedFile.result);
+    await fs.outputFile(file, transformedFile.content);
   }
   return transformsUsed;
 }

--- a/tools/src/Transforms.types.ts
+++ b/tools/src/Transforms.types.ts
@@ -98,4 +98,8 @@ export type CopyFileResult = {
    * The final target path after transformations. Relative to provided `targetDirectory`.
    */
   targetFile: string;
+  /**
+   * A set of transforms that were used to transform the file.
+   */
+  transformsUsed: Set<FileTransform>;
 };

--- a/tools/src/vendoring/common.ts
+++ b/tools/src/vendoring/common.ts
@@ -11,11 +11,24 @@ export async function copyVendoredFilesAsync(
   files: Set<string>,
   options: Omit<CopyFileOptions, 'sourceFile'>
 ): Promise<void> {
+  const unusedTransforms = new Set(options.transforms?.content);
   for (const sourceFile of files) {
-    const { targetFile } = await copyFileWithTransformsAsync({ sourceFile, ...options });
+    const { targetFile } = await copyFileWithTransformsAsync(
+      {
+        sourceFile,
+        ...options,
+      },
+      unusedTransforms
+    );
 
     if (sourceFile !== targetFile) {
       logger.log('📂 Renamed %s to %s', chalk.magenta(sourceFile), chalk.magenta(targetFile));
     }
+  }
+  for (const unusedTransform of unusedTransforms) {
+    logger.warn(
+      '⚠️ A transform was never applied to vendored code.\nThis can indicate outdated transforms or bugs in the vendored package.\nPath(s): %s',
+      chalk.magenta(String(unusedTransform.paths))
+    );
   }
 }

--- a/tools/src/versioning/android/versionCxx/index.ts
+++ b/tools/src/versioning/android/versionCxx/index.ts
@@ -81,8 +81,8 @@ function isVersionableCxxExpoModule(pkg: Package) {
   );
 }
 
-function transformPackageAsync(packageFiles: string[], abiName: string) {
-  return transformFilesAsync(packageFiles, baseTransforms(abiName));
+async function transformPackageAsync(packageFiles: string[], abiName: string) {
+  await transformFilesAsync(packageFiles, baseTransforms(abiName));
 }
 
 function revertTransformPackageAsync(packageFiles: string[]) {


### PR DESCRIPTION
# Why

I've made a PR (https://github.com/expo/expo/pull/22913) without noticing that one of my transforms is not applied. This is a different problem than verifying for correctness since correctness is often found by compilation errors.

Instead, we can check if all defined transforms are applied at some point, and we show a warning if some transform is never used.

# How

A tiny change to the current vendoring script. 

# Test Plan

Tested by making a change to vendoring config – a transform that was changed got thrown in a warning
<img width="647" alt="image" src="https://github.com/expo/expo/assets/5597580/9648c0e4-ff84-48bd-b470-5af7f6710bae">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
