### PR TITLE
fix(cli): add missing `minimatch` and `glob` dependencies

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix `EXPO_SKIP_MANIFEST_VALIDATION_TOKEN` usage. ([#23890](https://github.com/expo/expo/pull/23890) by [@EvanBacon](https://github.com/EvanBacon))
 - Prohibit dev client URLs containing `_` in protocol. ([#23519](https://github.com/expo/expo/pull/23519) by [@byCedric](https://github.com/byCedric))
 - Prevent writing unused bundles with static Metro web. ([#24092](https://github.com/expo/expo/pull/24092) by [@EvanBacon](https://github.com/EvanBacon))
+- Add missing dependencies to `@expo/cli`. ([#22941](https://github.com/expo/expo/pull/24092) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -68,6 +68,7 @@
     "freeport-async": "2.0.0",
     "fs-extra": "~8.1.0",
     "getenv": "^1.0.0",
+    "glob": "^7.1.7",
     "graphql": "15.8.0",
     "graphql-tag": "^2.10.1",
     "https-proxy-agent": "^5.0.1",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -143,6 +143,7 @@
     "expo-module-scripts": "^3.0.0",
     "find-process": "^1.4.7",
     "klaw-sync": "^6.0.0",
+    "memfs": "^3.2.0",
     "nock": "~13.2.2",
     "node-html-parser": "^6.1.5",
     "nullthrows": "^1.1.1",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -76,6 +76,7 @@
     "js-yaml": "^3.13.1",
     "json-schema-deref-sync": "^0.13.0",
     "md5hex": "^1.0.0",
+    "minimatch": "^3.0.4",
     "minipass": "3.1.6",
     "node-fetch": "^2.6.7",
     "node-forge": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10903,6 +10903,11 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+  integrity sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==
+
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
@@ -18998,7 +19003,28 @@ util.promisify@~1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-util@0.10.3, util@^0.10.3, util@^0.11.0, util@^0.12.0, util@~0.12.4:
+util@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  integrity sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==
+  dependencies:
+    inherits "2.0.1"
+
+util@^0.10.3:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
+  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
+  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
+  dependencies:
+    inherits "2.0.3"
+
+util@^0.12.0:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10903,11 +10903,6 @@ inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, i
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inherits@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
-  integrity sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==
-
 inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
@@ -19003,28 +18998,7 @@ util.promisify@~1.0.0:
     has-symbols "^1.0.1"
     object.getownpropertydescriptors "^2.1.0"
 
-util@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  integrity sha512-5KiHfsmkqacuKjkRkdV7SsfDJ2EGiPsK92s2MhNSY0craxjTdKTtqKsJaCWp4LW33ZZ0OPUv1WO/TFvNQRiQxQ==
-  dependencies:
-    inherits "2.0.1"
-
-util@^0.10.3:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
-  integrity sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.1.tgz#3236733720ec64bb27f6e26f421aaa2e1b588d61"
-  integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.12.0:
+util@0.10.3, util@^0.10.3, util@^0.11.0, util@^0.12.0, util@~0.12.4:
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
   integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==


### PR DESCRIPTION
# Why

Fixes #22884

# How

See PR #22939 for a list of all missing dependencies (including some "expected missing dependencies")

### `minimatch`

**`minimatch` was the original offender from #22884, added `minimatch@3.1.2` - notated as `minimatch@^3.0.4`.**

<details><summary>See output of <code>yarn why minimatch</code> - after fixing the issue</summary>

<img width="895" alt="image" src="https://github.com/expo/expo/assets/1203991/bc2aaf33-cb31-4150-8890-83404d0a4ef7">

</details>

<details><summary>See most used notations in repo</summary>

<img width="525" alt="image" src="https://github.com/expo/expo/assets/1203991/b65e899a-9d75-48bb-b156-072c4551d289">

</details>

### `glob`

**`glob` popped up in the list from PR #22939, added `glob@7.2.1` - notated as `glob@^7.1.7`**

<details><summary>See output of <code>yarn why glob</code> - after fixing the issue</summary>

<img width="880" alt="image" src="https://github.com/expo/expo/assets/1203991/07b71ec6-b08e-43ba-8c0a-4581928f2feb">

</details>

<details><summary>See most used notations in repo</summary>

<img width="527" alt="image" src="https://github.com/expo/expo/assets/1203991/8df1b0d0-e757-4017-8506-6a3a1ed55dde">

</details>

### `memfs`

**`memfs` although used as devDependency, it should also be listed as devDependency, added `memfs@3.4.12` - notated as `memfs@^3.2.0`**

<details><summary>See output of <code>yarn why memfs</code> - after fixing the issue</summary>

<img width="585" alt="image" src="https://github.com/expo/expo/assets/1203991/a9ecfdf8-293e-41f7-bb3a-30e79f0afd84">

</details>

<details><summary>See most used notations in repo</summary>

<img width="524" alt="image" src="https://github.com/expo/expo/assets/1203991/4f6d8e9a-44c9-45ca-88a3-d27e35569f0f">

</details>


# Test Plan

Hard to test, but you must install the package using [isolated modules](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md). Unfortunately, we don't fully support that yet.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
