### PR TITLE
[expo cli] Changes for SSO user type and SSO login.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for SSO users. ([#22945](https://github.com/expo/expo/pull/22945) by [@lzkb](https://github.com/lzkb))
+
 ### 🐛 Bug fixes
 
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -6,7 +6,7 @@ export function getExpoApiBaseUrl(): string {
   if (env.EXPO_STAGING) {
     return `https://staging-api.expo.dev`;
   } else if (env.EXPO_LOCAL) {
-    return `http://api.expo.test`;
+    return `http://127.0.0.1:3000`;
   } else {
     return `https://api.expo.dev`;
   }
@@ -17,7 +17,7 @@ export function getExpoWebsiteBaseUrl(): string {
   if (env.EXPO_STAGING) {
     return `https://staging.expo.dev`;
   } else if (env.EXPO_LOCAL) {
-    return `http://expo.test`;
+    return `http://127.0.0.1:3001`;
   } else {
     return `https://expo.dev`;
   }

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -1,4 +1,5 @@
 import { env } from '../utils/env';
+import { getFreePortAsync } from '../utils/port';
 
 /** Get the URL for the expo.dev API. */
 export function getExpoApiBaseUrl(): string {
@@ -9,4 +10,20 @@ export function getExpoApiBaseUrl(): string {
   } else {
     return `https://api.expo.dev`;
   }
+}
+
+/** Get the URL for the expo.dev website. */
+export function getExpoWebsiteBaseUrl(): string {
+  if (env.EXPO_STAGING) {
+    return `https://staging.expo.dev`;
+  } else if (env.EXPO_LOCAL) {
+    return `http://expo.test`;
+  } else {
+    return `https://expo.dev`;
+  }
+}
+
+export async function getSsoLocalServerPortAsync(): Promise<number> {
+  const startPort = env.EXPO_SSO_LOCAL_SERVER_PORT;
+  return await getFreePortAsync(startPort);
 }

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -6,7 +6,7 @@ export function getExpoApiBaseUrl(): string {
   if (env.EXPO_STAGING) {
     return `https://staging-api.expo.dev`;
   } else if (env.EXPO_LOCAL) {
-    return `http://127.0.0.1:3000`;
+    return `http://api.expo.test`;
   } else {
     return `https://api.expo.dev`;
   }

--- a/packages/@expo/cli/src/api/graphql/queries/UserQuery.ts
+++ b/packages/@expo/cli/src/api/graphql/queries/UserQuery.ts
@@ -36,7 +36,7 @@ export const UserQuery = {
           `,
           /* variables */ undefined,
           {
-            additionalTypenames: ['User'],
+            additionalTypenames: ['User', 'SSOUser'],
           }
         )
         .toPromise()

--- a/packages/@expo/cli/src/api/user/UserSettings.ts
+++ b/packages/@expo/cli/src/api/user/UserSettings.ts
@@ -7,7 +7,7 @@ type SessionData = {
   // These fields are potentially used by Expo CLI.
   userId: string;
   username: string;
-  currentConnection: 'Username-Password-Authentication';
+  currentConnection: 'Username-Password-Authentication' | 'Browser-Flow-Authentication';
 };
 
 export type UserSettingsData = {

--- a/packages/@expo/cli/src/api/user/__mocks__/user.ts
+++ b/packages/@expo/cli/src/api/user/__mocks__/user.ts
@@ -1,3 +1,8 @@
 export const getUserAsync = jest.fn(async () => ({}));
 export const loginAsync = jest.fn();
 export const ANONYMOUS_USERNAME = 'anonymous';
+
+jest.mock('../user', () => ({
+  loginAsync: jest.fn(),
+  ssoLoginAsync: jest.fn(),
+}));

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -8,7 +8,7 @@ import { learnMore } from '../../utils/link';
 import promptAsync, { Question } from '../../utils/prompts';
 import { ApiV2Error } from '../rest/client';
 import { retryUsernamePasswordAuthWithOTPAsync } from './otp';
-import { Actor, getUserAsync, loginAsync } from './user';
+import { Actor, getUserAsync, loginAsync, ssoLoginAsync } from './user';
 
 /** Show login prompt while prompting for missing credentials. */
 export async function showLoginPromptAsync({
@@ -20,17 +20,28 @@ export async function showLoginPromptAsync({
   username?: string;
   password?: string;
   otp?: string;
+  sso?: boolean | undefined;
 } = {}): Promise<void> {
   if (env.EXPO_OFFLINE) {
     throw new CommandError('OFFLINE', 'Cannot authenticate in offline-mode');
   }
   const hasCredentials = options.username && options.password;
+  const sso = options.sso;
 
   if (printNewLine) {
     Log.log();
   }
 
-  Log.log(hasCredentials ? 'Logging in to EAS' : 'Log in to EAS');
+  if (sso) {
+    await ssoLoginAsync();
+    return;
+  }
+
+  Log.log(
+    hasCredentials
+      ? `Logging in to EAS with email or username (exit and run 'eas login' for other options)`
+      : `Log in to EAS with email or username (exit and run 'eas login' for other options)`
+  );
 
   let username = options.username;
   let password = options.password;

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -1,0 +1,78 @@
+import openBrowserAsync from 'better-opn';
+import http from 'http';
+import { Socket } from 'node:net';
+import querystring from 'querystring';
+
+import * as Log from '../../log';
+
+export async function getSessionUsingBrowserAuthFlowAsync(options: {
+  expoWebsiteUrl: string;
+  serverPort: number;
+}): Promise<string> {
+  const { expoWebsiteUrl, serverPort } = options;
+
+  const scheme = 'http';
+  const hostname = 'localhost';
+  const path = '/auth/callback';
+  const redirectUri = `${scheme}://${hostname}:${serverPort}${path}`;
+
+  const buildExpoSsoLoginUrl = (): string => {
+    const data = {
+      app_redirect_uri: redirectUri,
+    };
+    const params = querystring.stringify(data);
+    return `${expoWebsiteUrl}/sso-login?${params}`;
+  };
+
+  // Start server and begin auth flow
+  const executeAuthFlow = (): Promise<string> => {
+    return new Promise<string>(async (resolve, reject) => {
+      const connections = new Set<Socket>();
+
+      const server = http.createServer(
+        (request: http.IncomingMessage, response: http.ServerResponse) => {
+          try {
+            if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
+              throw new Error('Unexpected SSO login response.');
+            }
+            const url = new URL(request.url, `http:${request.headers.host}`);
+            const sessionSecret = url.searchParams.get('session_secret');
+
+            if (!sessionSecret) {
+              throw new Error('Request missing session_secret search parameter.');
+            }
+            resolve(sessionSecret);
+            response.writeHead(200, { 'Content-Type': 'text/plain' });
+            response.write(`Website login has completed. You can now close this tab.`);
+            response.end();
+          } catch (error) {
+            reject(error);
+          } finally {
+            server.close();
+            // Ensure that the server shuts down
+            for (const connection of connections) {
+              connection.destroy();
+            }
+          }
+        }
+      );
+
+      server.listen(serverPort, hostname, () => {
+        Log.log('Waiting for browser login...');
+      });
+
+      server.on('connection', (connection) => {
+        connections.add(connection);
+
+        connection.on('close', () => {
+          connections.delete(connection);
+        });
+      });
+
+      const authorizeUrl = buildExpoSsoLoginUrl();
+      openBrowserAsync(authorizeUrl);
+    });
+  };
+
+  return await executeAuthFlow();
+}

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -6,10 +6,12 @@ import * as Log from '../../log';
 import * as Analytics from '../../utils/analytics/rudderstackClient';
 import { getDevelopmentCodeSigningDirectory } from '../../utils/codesigning';
 import { env } from '../../utils/env';
+import { getExpoWebsiteBaseUrl, getSsoLocalServerPortAsync } from '../endpoint';
 import { graphqlClient } from '../graphql/client';
 import { UserQuery } from '../graphql/queries/UserQuery';
 import { fetchAsync } from '../rest/client';
 import UserSettings from './UserSettings';
+import { getSessionUsingBrowserAuthFlowAsync } from './expoSsoLauncher';
 
 export type Actor = NonNullable<CurrentUserQuery['meActor']>;
 
@@ -25,6 +27,8 @@ export const ANONYMOUS_USERNAME = 'anonymous';
 export function getActorDisplayName(user?: Actor): string {
   switch (user?.__typename) {
     case 'User':
+      return user.username;
+    case 'SSOUser':
       return user.username;
     case 'Robot':
       return user.firstName ? `${user.firstName} (robot)` : 'robot';
@@ -61,11 +65,52 @@ export async function loginAsync(json: {
   const {
     data: { sessionSecret },
   } = await res.json();
+
+  const userData = await fetchUserAsync({ sessionSecret });
+
+  await UserSettings.setSessionAsync({
+    sessionSecret,
+    userId: userData.id,
+    username: userData.username,
+    currentConnection: 'Username-Password-Authentication',
+  });
+}
+
+export async function ssoLoginAsync(): Promise<void> {
+  const config = {
+    expoWebsiteUrl: getExpoWebsiteBaseUrl(),
+    serverPort: await getSsoLocalServerPortAsync(),
+  };
+  const sessionSecret = await getSessionUsingBrowserAuthFlowAsync(config);
+  const userData = await fetchUserAsync({ sessionSecret });
+
+  await UserSettings.setSessionAsync({
+    sessionSecret,
+    userId: userData.id,
+    username: userData.username,
+    currentConnection: 'Browser-Flow-Authentication',
+  });
+}
+
+export async function logoutAsync(): Promise<void> {
+  currentUser = undefined;
+  await Promise.all([
+    fs.rm(getDevelopmentCodeSigningDirectory(), { recursive: true, force: true }),
+    UserSettings.setSessionAsync(undefined),
+  ]);
+  Log.log('Logged out');
+}
+
+async function fetchUserAsync({
+  sessionSecret,
+}: {
+  sessionSecret: string;
+}): Promise<{ id: string; username: string }> {
   const result = await graphqlClient
     .query(
       gql`
         query UserQuery {
-          viewer {
+          meUserActor {
             id
             username
           }
@@ -82,22 +127,9 @@ export async function loginAsync(json: {
       }
     )
     .toPromise();
-  const {
-    data: { viewer },
-  } = result;
-  await UserSettings.setSessionAsync({
-    sessionSecret,
-    userId: viewer.id,
-    username: viewer.username,
-    currentConnection: 'Username-Password-Authentication',
-  });
-}
-
-export async function logoutAsync(): Promise<void> {
-  currentUser = undefined;
-  await Promise.all([
-    fs.rm(getDevelopmentCodeSigningDirectory(), { recursive: true, force: true }),
-    UserSettings.setSessionAsync(undefined),
-  ]);
-  Log.log('Logged out');
+  const { data } = result;
+  return {
+    id: data.meUserActor.id,
+    username: data.meUserActor.username,
+  };
 }

--- a/packages/@expo/cli/src/graphql/generated.ts
+++ b/packages/@expo/cli/src/graphql/generated.ts
@@ -23,6 +23,19 @@ export type Scalars = {
   JSONObject: any;
 };
 
+export type AccountAppsFilterInput = {
+  sortByField: AccountAppsSortByField;
+};
+
+export enum AccountAppsSortByField {
+  LatestActivityTime = 'LATEST_ACTIVITY_TIME',
+  /**
+   * Name prefers the display name but falls back to full_name with @account/
+   * part stripped.
+   */
+  Name = 'NAME'
+}
+
 export type AccountDataInput = {
   name: Scalars['String'];
 };
@@ -40,6 +53,7 @@ export type AccountSsoConfigurationData = {
   authProviderIdentifier: Scalars['String'];
   clientIdentifier: Scalars['String'];
   clientSecret: Scalars['String'];
+  endSessionEndpoint?: InputMaybe<Scalars['String']>;
   issuer: Scalars['String'];
   jwksEndpoint?: InputMaybe<Scalars['String']>;
   revokeEndpoint?: InputMaybe<Scalars['String']>;
@@ -291,6 +305,10 @@ export type AppleDeviceInput = {
   softwareVersion?: InputMaybe<Scalars['String']>;
 };
 
+export type AppleDeviceUpdateInput = {
+  name?: InputMaybe<Scalars['String']>;
+};
+
 export type AppleDistributionCertificateInput = {
   appleTeamId?: InputMaybe<Scalars['ID']>;
   certP12: Scalars['String'];
@@ -338,11 +356,10 @@ export enum AuthProtocolType {
 }
 
 export type BuildCacheInput = {
-  cacheDefaultPaths?: InputMaybe<Scalars['Boolean']>;
   clear?: InputMaybe<Scalars['Boolean']>;
-  customPaths?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   disabled?: InputMaybe<Scalars['Boolean']>;
   key?: InputMaybe<Scalars['String']>;
+  paths?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export enum BuildCredentialsSource {
@@ -399,6 +416,7 @@ export type BuildMetadataInput = {
   channel?: InputMaybe<Scalars['String']>;
   cliVersion?: InputMaybe<Scalars['String']>;
   credentialsSource?: InputMaybe<BuildCredentialsSource>;
+  customWorkflowName?: InputMaybe<Scalars['String']>;
   distribution?: InputMaybe<DistributionType>;
   gitCommitHash?: InputMaybe<Scalars['String']>;
   gitCommitMessage?: InputMaybe<Scalars['String']>;
@@ -454,6 +472,14 @@ export enum BuildResourceClass {
   IosMLarge = 'IOS_M_LARGE',
   IosMMedium = 'IOS_M_MEDIUM',
   Legacy = 'LEGACY'
+}
+
+export enum BuildRetryDisabledReason {
+  AlreadyRetried = 'ALREADY_RETRIED',
+  InvalidStatus = 'INVALID_STATUS',
+  IsGithubBuild = 'IS_GITHUB_BUILD',
+  NotCompletedYet = 'NOT_COMPLETED_YET',
+  TooMuchTimeElapsed = 'TOO_MUCH_TIME_ELAPSED'
 }
 
 export enum BuildStatus {
@@ -539,6 +565,11 @@ export enum DistributionType {
   Internal = 'INTERNAL',
   Simulator = 'SIMULATOR',
   Store = 'STORE'
+}
+
+export enum EasBuildBillingResourceClass {
+  Large = 'LARGE',
+  Medium = 'MEDIUM'
 }
 
 export enum EasBuildDeprecationInfoType {
@@ -864,6 +895,15 @@ export enum Role {
   ViewOnly = 'VIEW_ONLY'
 }
 
+export type SsoUserDataInput = {
+  firstName?: InputMaybe<Scalars['String']>;
+  githubUsername?: InputMaybe<Scalars['String']>;
+  industry?: InputMaybe<Scalars['String']>;
+  lastName?: InputMaybe<Scalars['String']>;
+  location?: InputMaybe<Scalars['String']>;
+  twitterUsername?: InputMaybe<Scalars['String']>;
+};
+
 export type SecondFactorDeviceConfiguration = {
   isPrimary: Scalars['Boolean'];
   method: SecondFactorMethod;
@@ -1003,6 +1043,7 @@ export type UpdateRollBackToEmbeddedGroup = {
 export type UpdatesFilter = {
   platform?: InputMaybe<AppPlatform>;
   runtimeVersions?: InputMaybe<Array<Scalars['String']>>;
+  sdkVersions?: InputMaybe<Array<Scalars['String']>>;
 };
 
 export enum UploadSessionType {

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -11,10 +11,12 @@ export const expoLogin: Command = async (argv) => {
       '--username': String,
       '--password': String,
       '--otp': String,
+      '--sso': Boolean,
       // Aliases
       '-h': '--help',
       '-u': '--username',
       '-p': '--password',
+      '-s': '--sso',
     },
     argv
   );
@@ -27,6 +29,8 @@ export const expoLogin: Command = async (argv) => {
         `-u, --username <string>  Username`,
         `-p, --password <string>  Password`,
         `--otp <string>           One-time password from your 2FA device`,
+        // hiding from help until SSO is public
+        // `-s, --sso                Log in with SSO`,
         `-h, --help               Usage info`,
       ].join('\n')
     );
@@ -38,5 +42,6 @@ export const expoLogin: Command = async (argv) => {
     username: args['--username'],
     password: args['--password'],
     otp: args['--otp'],
+    sso: !!args['--sso'],
   }).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -151,6 +151,11 @@ class Env {
   get EXPO_NO_METRO_LAZY() {
     return boolish('EXPO_NO_METRO_LAZY', false);
   }
+
+  /** The start value for the port that the local server used for SSO login listens on. */
+  get EXPO_SSO_LOCAL_SERVER_PORT() {
+    return int('EXPO_SSO_LOCAL_SERVER_PORT', 19200);
+  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

These changes are to enable an SSO user to log in with expo cli via the Expo website.

# How

The changes are similar to changes made to eas-cli in [PR-1875](https://github.com/expo/eas-cli/pull/1875)

Added a -sso, -s flag to the login command for a user to select logging in with SSO. The CLI then opens a browser window and redirects the user to the Expo website to log in. The website takes them through the auth flow with their Auth Provider and logs them in to Expo before returning.

This CLI SSO user login follows Expo Go login behavior (which also logs in via the Expo website):

- if no user is logged into the website, the user gets logged in and the session is returned to the CLI
- if a user is already logged into the website then that user session is returned
- once a user is logged into the website, in order to change the logged-in user in the CLI, the current user has to be manually logged out in the website.
- 
Non-SSO user login behavior has not changed.

The expoSsoLauncher, also used by eas-cli, will be moved into a new package under eas-cli where it can be shared as a separate task.

# Test Plan

Tested manually against staging.

**A) With no user logged in to the website, checked whoami and tested logging in an SSO user:**

```
lizkaubisch@Lizs-MBP-2 cli % EXPO_STAGING=1 nexpo whoami
Not logged in
lizkaubisch@Lizs-MBP-2 cli % EXPO_STAGING=1 nexpo login --sso
Waiting for browser login...
lizkaubisch@Lizs-MBP-2 cli % EXPO_STAGING=1 nexpo whoami
liz-sso-viewer
```
**B) With the SSO user already logged in from the test above, tried logging in an SSO user again, and the website immediately returned the already logged-in user:**

```
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo login --sso
Waiting for browser login...
lizkaubisch@Lizs-MBP-2 
```

**C) Checked user identity:**

```
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo whoami  
liz-sso-viewer
lizkaubisch@lizs-mbp-2 cli %
```

**D) Also, with no user logged in in expo cli with the SSO user still logged in in the website, tried logging in a regular user in expo cli:**

```
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo logout
Logged out
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo login
Log in to EAS with email or username (exit and run 'eas login' for other options)
✔ Email or username … lktest
✔ Password … ********
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo whoami
lktest
```

liz-sso-viewer is still logged in in the website, as regular user login by the CLI bypasses the website and is done directly with www.

**E) with nobody logged in to the website or CLI, tested logging in a regular user in the website, by clicking on Continue with Password in the website sso-login page:**

```
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo logout
Logged out
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo login --sso
Waiting for browser login...
lizkaubisch@lizs-mbp-2 cli % EXPO_STAGING=1 nexpo whoami     
lktest
lizkaubisch@lizs-mbp-2 cli
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).