### PR TITLE
[expo-manifests][android] Convert to data classes

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import android.os.AsyncTask
 import android.text.TextUtils
 import android.util.LruCache
-import expo.modules.manifests.core.InternalJSONMutator
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.generated.ExponentBuildConstants
@@ -267,29 +266,27 @@ class ExponentManifest @Inject constructor(
     private var hasShownKernelManifestLog = false
 
     @Throws(JSONException::class)
-    fun normalizeManifestInPlace(manifest: Manifest, manifestUrl: String) {
-      manifest.mutateInternalJSONInPlace(object : InternalJSONMutator {
-        override fun updateJSON(json: JSONObject) {
-          if (!json.has(MANIFEST_ID_KEY)) {
-            json.put(MANIFEST_ID_KEY, manifestUrl)
-          }
-          if (!json.has(MANIFEST_NAME_KEY)) {
-            json.put(MANIFEST_NAME_KEY, "My New Experience")
-          }
-          if (!json.has(MANIFEST_PRIMARY_COLOR_KEY)) {
-            json.put(MANIFEST_PRIMARY_COLOR_KEY, "#023C69")
-          }
-          if (!json.has(MANIFEST_ICON_URL_KEY)) {
-            json.put(
-              MANIFEST_ICON_URL_KEY,
-              "https://d3lwq5rlu14cro.cloudfront.net/ExponentEmptyManifest_192.png"
-            )
-          }
-          if (!json.has(MANIFEST_ORIENTATION_KEY)) {
-            json.put(MANIFEST_ORIENTATION_KEY, "default")
-          }
-        }
-      })
+    fun normalizeManifest(manifest: Manifest, manifestUrl: String): Manifest {
+      val json = manifest.getRawJson()
+      if (!json.has(MANIFEST_ID_KEY)) {
+        json.put(MANIFEST_ID_KEY, manifestUrl)
+      }
+      if (!json.has(MANIFEST_NAME_KEY)) {
+        json.put(MANIFEST_NAME_KEY, "My New Experience")
+      }
+      if (!json.has(MANIFEST_PRIMARY_COLOR_KEY)) {
+        json.put(MANIFEST_PRIMARY_COLOR_KEY, "#023C69")
+      }
+      if (!json.has(MANIFEST_ICON_URL_KEY)) {
+        json.put(
+          MANIFEST_ICON_URL_KEY,
+          "https://d3lwq5rlu14cro.cloudfront.net/ExponentEmptyManifest_192.png"
+        )
+      }
+      if (!json.has(MANIFEST_ORIENTATION_KEY)) {
+        json.put(MANIFEST_ORIENTATION_KEY, "default")
+      }
+      return Manifest.fromManifestJson(json)
     }
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -470,7 +470,7 @@ abstract class ReactNativeActivity :
     if (devSettings != null) {
       devSettings.setField("exponentActivityId", activityId)
       if (devSettings.call("isRemoteJSDebugEnabled") as Boolean) {
-        if (manifest?.jsEngine == "hermes") {
+        if (manifest?.getJSEngine() == "hermes") {
           // Disable remote debugging when running on Hermes
           devSettings.call("setRemoteJSDebugEnabled", false)
         }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -372,7 +372,7 @@ class Kernel : KernelInterface() {
       val appName = manifest.getName() ?: ""
       val deviceName = AndroidInfoHelpers.getFriendlyDeviceName()
 
-      val jsEngineFromManifest = manifest.jsEngine
+      val jsEngineFromManifest = manifest.getJSEngine()
       return if (jsEngineFromManifest == "hermes") HermesExecutorFactory() else JSCExecutorFactory(
         appName,
         deviceName
@@ -739,13 +739,13 @@ class Kernel : KernelInterface() {
   @Throws(JSONException::class)
   private fun openManifestUrlStep2(
     manifestUrl: String,
-    manifest: Manifest,
+    unnormalizedManifest: Manifest,
     existingTask: AppTask?
   ) {
-    val bundleUrl = toHttp(manifest.getBundleURL())
+    val bundleUrl = toHttp(unnormalizedManifest.getBundleURL())
     val task = getExperienceActivityTask(manifestUrl)
     task.bundleUrl = bundleUrl
-    ExponentManifest.normalizeManifestInPlace(manifest, manifestUrl)
+    val manifest = ExponentManifest.normalizeManifest(unnormalizedManifest, manifestUrl)
     if (existingTask == null) {
       sendManifestToExperienceActivity(manifestUrl, manifest, bundleUrl)
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -260,7 +260,7 @@ object VersionedUtils {
     val appName = instanceManagerBuilderProperties.manifest.getName() ?: ""
     val deviceName = AndroidInfoHelpers.getFriendlyDeviceName()
 
-    val jsEngineFromManifest = instanceManagerBuilderProperties.manifest.jsEngine
+    val jsEngineFromManifest = instanceManagerBuilderProperties.manifest.getJSEngine()
     return if (jsEngineFromManifest == "hermes") HermesExecutorFactory() else JSCExecutorFactory(
       appName,
       deviceName

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BareManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BareManifest.kt
@@ -4,7 +4,16 @@ import expo.modules.jsonutils.require
 import org.json.JSONException
 import org.json.JSONObject
 
-class BareManifest(json: JSONObject) : BaseLegacyManifest(json) {
+data class BareManifest(private val json: JSONObject) : BaseLegacyManifest {
+  override fun getRawJson(): JSONObject {
+    return json
+  }
+
+  @Deprecated(message = "Prefer to use specific field getters")
+  override fun toString(): String {
+    return getRawJson().toString()
+  }
+
   /**
    * A UUID for this manifest.
    */

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/BaseLegacyManifest.kt
@@ -6,31 +6,31 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-abstract class BaseLegacyManifest(json: JSONObject) : Manifest(json) {
-  override fun getStableLegacyID(): String = json.getNullable("originalFullName") ?: getLegacyID()
+interface BaseLegacyManifest : Manifest {
+  override fun getStableLegacyID(): String = getRawJson().getNullable("originalFullName") ?: getLegacyID()
 
-  override fun getScopeKey(): String = json.getNullable("scopeKey") ?: getStableLegacyID()
+  override fun getScopeKey(): String = getRawJson().getNullable("scopeKey") ?: getStableLegacyID()
 
-  override fun getEASProjectID(): String? = json.getNullable("projectId")
+  override fun getEASProjectID(): String? = getRawJson().getNullable("projectId")
 
-  override fun getAssets(): JSONArray? = json.getNullable("assets")
+  override fun getAssets(): JSONArray? = getRawJson().getNullable("assets")
 
   @Throws(JSONException::class)
-  override fun getBundleURL(): String = json.require("bundleUrl")
+  override fun getBundleURL(): String = getRawJson().require("bundleUrl")
 
-  override fun getExpoGoSDKVersion(): String? = json.getNullable("sdkVersion")
+  override fun getExpoGoSDKVersion(): String? = getRawJson().getNullable("sdkVersion")
 
   override fun getExpoGoConfigRootObject(): JSONObject? {
-    return json
+    return getRawJson()
   }
 
   override fun getExpoClientConfigRootObject(): JSONObject? {
-    return json
+    return getRawJson()
   }
 
-  override fun getSlug(): String? = json.getNullable("slug")
+  override fun getSlug(): String? = getRawJson().getNullable("slug")
 
-  override fun getAppKey(): String? = json.getNullable("appKey")
+  override fun getAppKey(): String? = getRawJson().getNullable("appKey")
 
-  fun getCommitTime(): String? = json.getNullable("commitTime")
+  fun getCommitTime(): String? = getRawJson().getNullable("commitTime")
 }

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/LegacyManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/LegacyManifest.kt
@@ -6,7 +6,16 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-open class LegacyManifest(json: JSONObject) : BaseLegacyManifest(json) {
+data class LegacyManifest(private val json: JSONObject) : BaseLegacyManifest {
+  override fun getRawJson(): JSONObject {
+    return json
+  }
+
+  @Deprecated(message = "Prefer to use specific field getters")
+  override fun toString(): String {
+    return getRawJson().toString()
+  }
+
   @Throws(JSONException::class)
   fun getBundleKey(): String? = json.getNullable("bundleKey")
 

--- a/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
+++ b/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/NewManifest.kt
@@ -8,7 +8,16 @@ import org.json.JSONObject
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-class NewManifest(json: JSONObject) : Manifest(json) {
+data class NewManifest(private val json: JSONObject) : Manifest {
+  override fun getRawJson(): JSONObject {
+    return json
+  }
+
+  @Deprecated(message = "Prefer to use specific field getters")
+  override fun toString(): String {
+    return getRawJson().toString()
+  }
+
   /**
    * An ID representing this manifest, not the ID for the experience.
    */


### PR DESCRIPTION
# Why

Closes ENG-8966.

These are meant to be data classes (just hold data, immutable, etc). Unfortunately doing JSONObject equality isn't so simple so equality is still based on exact object equality, but this opens the door for better equality semantics in the future if we change this to extract the fields upon construct.

# How

convert to interfaces and data classes (data classes don't do well with inheritance but do fine with interfaces and traits)

# Test Plan

Build and run app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
