### PR TITLE
[android] fix versioned build error

### DIFF
--- a/android/vendored/sdk47/react-native-reanimated/android/build.gradle
+++ b/android/vendored/sdk47/react-native-reanimated/android/build.gradle
@@ -648,7 +648,7 @@ task downloadBoost(dependsOn: resolveBoost, type: Download) {
 }
 
 task prepareBoost(dependsOn: boostPath ? [] : [downloadBoost], type: Copy) {
-    from(boostPath ?: tarTree(resources.gzip(downloadBoost.dest)))
+    // from(boostPath ?: tarTree(resources.gzip(downloadBoost.dest)))
     from("$reactNativeThirdParty/boost/Android.mk")
     include("Android.mk", "boost_${BOOST_VERSION}/boost/**/*.hpp", "boost/boost/**/*.hpp")
     includeEmptyDirs = false
@@ -666,7 +666,7 @@ task downloadDoubleConversion(dependsOn: resolveDoubleConversion, type: Download
 }
 
 task prepareDoubleConversion(dependsOn: dependenciesPath ? [] : [downloadDoubleConversion], type: Copy) {
-    from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
+    // from(dependenciesPath ?: tarTree(downloadDoubleConversion.dest))
     from("$reactNativeThirdParty/double-conversion/Android.mk")
     include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "Android.mk")
     filesMatching("*/src/**/*", { fname -> fname.path = "double-conversion/${fname.name}" })
@@ -682,7 +682,7 @@ task downloadFolly(dependsOn: resolveFolly, type: Download) {
 }
 
 task prepareFolly(dependsOn: dependenciesPath ? [] : [downloadFolly], type: Copy) {
-    from(dependenciesPath ?: tarTree(downloadFolly.dest))
+    // from(dependenciesPath ?: tarTree(downloadFolly.dest))
     from("$reactNativeThirdParty/folly/Android.mk")
     include("folly-${FOLLY_VERSION}/folly/**/*", "Android.mk")
     eachFile { fname -> fname.path = (fname.path - "folly-${FOLLY_VERSION}/") }
@@ -704,7 +704,7 @@ task downloadGlog(dependsOn: resolveGlog, type: Download) {
 // executed by automake. This way we can avoid dependencies on make/automake
 task prepareGlog(dependsOn: dependenciesPath ? [] : [downloadGlog], type: Copy) {
     duplicatesStrategy = "include"
-    from(dependenciesPath ?: tarTree(downloadGlog.dest))
+    // from(dependenciesPath ?: tarTree(downloadGlog.dest))
     from("$reactNativeThirdParty/glog/")
     include("glog-${GLOG_VERSION}/src/**/*", "Android.mk", "config.h")
     includeEmptyDirs = false

--- a/android/vendored/sdk48/react-native-reanimated/android/build.gradle
+++ b/android/vendored/sdk48/react-native-reanimated/android/build.gradle
@@ -1113,13 +1113,12 @@ afterEvaluate {
         nativeBuildDependsOn(prepareThirdPartyNdkHeaders)
         nativeBuildDependsOn(extractAARHeaders)
         nativeBuildDependsOn(extractSOFiles)
-
-        tasks.forEach({ task ->
-            if (task.name.contains("JniLibFolders")) {
-                task.dependsOn(packageNdkLibs)
-            }
-        })
     }
+    tasks.forEach({ task ->
+        if (task.name.contains("JniLibFolders")) {
+            task.dependsOn(packageNdkLibs)
+        }
+    })
 
     if (JS_RUNTIME == "hermes") {
         if (REACT_NATIVE_MINOR_VERSION < 71) {


### PR DESCRIPTION
# Why

fixed android versioned expo go build error after updating to gradle 8:

```
> Task :packages:react-native:ReactAndroid:buildCMakeDebug[x86_64][fabricjni,folly_runtime,etc]

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':vendored_sdk47_react-native-reanimated:prepareBoost' (type 'Copy').
  - Gradle detected a problem with the following location: '/home/runner/.gradle/react-native-downloads/boost_1_76_0.tar.gz'.
    
    Reason: Task ':vendored_sdk47_react-native-reanimated:prepareBoost' uses this output of task ':packages:react-native:ReactAndroid:downloadBoost' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':packages:react-native:ReactAndroid:downloadBoost' as an input of ':vendored_sdk47_react-native-reanimated:prepareBoost'.
      2. Declare an explicit dependency on ':packages:react-native:ReactAndroid:downloadBoost' from ':vendored_sdk47_react-native-reanimated:prepareBoost' using Task#dependsOn.
      3. Declare an explicit dependency on ':packages:react-native:ReactAndroid:downloadBoost' from ':vendored_sdk47_react-native-reanimated:prepareBoost' using Task#mustRunAfter.
    
    Please refer to https://docs.gradle.org/8.0.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

# How

comment out unused code causing gradle dependency error

# Test Plan

android client ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
