### PR TITLE
[docs] expo update: strings.xml diff block

### DIFF
--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -4,6 +4,7 @@ description: Learn how to add expo-updates to an existing React Native project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { DiffBlock } from '~/ui/components/Snippet';
 
 The `expo-updates` library fetches and manages updates received from a remote server. It supports [EAS Update](/eas-update/introduction), a hosted service that serves updates for projects using the `expo-updates` library.
 
@@ -52,7 +53,6 @@ The changes below add the updates URL to the Expo configuration.
  }
 ```
 
-
 ## Configuration for iOS
 
 Add the file **Podfile.properties.json** to the **ios** directory:
@@ -89,6 +89,7 @@ Modify **ios/Podfile** to check for the JS engine configuration (JSC or Hermes) 
      #
 
 ```
+
 Add the **Supporting** directory containing **Expo.plist** to your project in Xcode with the following content, to match the content in **app.json**:
 
 ```xml Expo.plist
@@ -152,15 +153,7 @@ Modify **android/app/src/main/AndroidManifest.xml** to add the `expo-updates` co
 
 Add the Expo runtime version string key to **android/app/src/main/res/values/strings.xml**:
 
-```diff android/app/src/main/res/values/strings.xml
---- a/android/app/src/main/res/values/strings.xml
-+++ b/android/app/src/main/res/values/strings.xml
-@@ -1,3 +1,4 @@
- <resources>
-     <string name="app_name">MyApp</string>
-+    <string name="expo_runtime_version">1.0.0</string>
- </resources>
-```
+<DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />
 
 ## Next Steps
 

--- a/docs/pages/bare/updating-your-app.mdx
+++ b/docs/pages/bare/updating-your-app.mdx
@@ -3,6 +3,8 @@ title: Use EAS Update in an existing project
 description: Learn how to use EAS Update in an existing React Native project.
 ---
 
+import { DiffBlock } from '~/ui/components/Snippet';
+
 EAS update works with bare React Native projects created with `react-native init`. These projects have **android** and **ios** directories that you can modify native files directly.
 
 The steps for configuring a bare React Native project are identical to the steps for configuring an Expo project. However, you may need to edit some of the code `eas update:configure` generates depending on how you build and run your project.
@@ -71,15 +73,7 @@ Inside **AndroidManifest.xml**, you'll see the following additions:
 
 Inside **android/app/src/main/res/values/strings.xml**, you'll see the `expo_runtime_version` string entry in the `resources` object:
 
-```diff android/app/src/main/res/values/strings.xml
---- a/android/app/src/main/res/values/strings.xml
-+++ b/android/app/src/main/res/values/strings.xml
-@@ -1,3 +1,4 @@
- <resources>
-     <string name="app_name">MyApp</string>
-+    <string name="expo_runtime_version">1.0.0</string>
- </resources>
-```
+<DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />
 
 The `EXPO_UPDATE_URL` value should contain your project's ID.
 

--- a/docs/pages/distribution/runtime-versions.mdx
+++ b/docs/pages/distribution/runtime-versions.mdx
@@ -3,6 +3,8 @@ title: Runtime Versions
 description: Learn how to set the runtime version for an app.
 ---
 
+import { DiffBlock } from '~/ui/components/Snippet';
+
 Every update targets one compatible runtime. Each time you build a binary for your app it includes the native code present at the time of the build and only that code, and this unique combination and configuration of the build is what is represented by the runtime version.
 
 By default, the runtime version is determined by the Expo SDK version, but this will not adequately describe the different runtime versions of your app if you build more than once per SDK release. In this case, you will need to specify a `runtimeVersion` to ensure your updates are delivered only to compatible builds. This `runtimeVersion` should be updated whenever you update your project's native modules and change the JS–native interface.
@@ -16,7 +18,7 @@ Updates published with the runtime version set in **app.json** will be delivered
 ```json app.json
 {
   "expo": {
-    "runtimeVersion": "2.718"
+    "runtimeVersion": "1.0.0"
   }
 }
 ```
@@ -30,7 +32,7 @@ If you are using the [managed workflow](/archive/managed-vs-bare/#managed-workfl
 ```json app.json
 {
   "expo": {
-    "runtimeVersion": "2.718"
+    "runtimeVersion": "1.0.0"
   }
 }
 ```
@@ -43,20 +45,12 @@ For an iOS build, add an entry to the **Expo.plist** with the key `EXUpdatesRunt
 
 ```diff
 + <key>EXUpdatesRuntimeVersion</key>
-+ <string>2.718</string>
++ <string>1.0.0</string>
 ```
 
 For an Android build, add an entry to **android/app/src/main/res/values/strings.xml** with the name `expo_runtime_version`. The value is a string that represents the runtime version.
 
-```diff android/app/src/main/res/values/strings.xml
---- a/android/app/src/main/res/values/strings.xml
-+++ b/android/app/src/main/res/values/strings.xml
-@@ -1,3 +1,4 @@
- <resources>
-     <string name="app_name">MyApp</string>
-+    <string name="expo_runtime_version">2.718</string>
- </resources>
-```
+<DiffBlock source="/static/diffs/expo-update-strings-xml.diff" />
 
 Then add a `<meta-data>` element to the **AndroidManifest.xml** whose `android:name` attribute is `expo.modules.updates.EXPO_RUNTIME_VERSION` and `android:value` attribute is a reference to the runtime version in `strings.xml`.
 

--- a/docs/public/static/diffs/expo-update-strings-xml.diff
+++ b/docs/public/static/diffs/expo-update-strings-xml.diff
@@ -1,0 +1,8 @@
+diff --git android/app/src/main/res/values/strings.xml
+--- a/android/app/src/main/res/values/strings.xml
++++ b/android/app/src/main/res/values/strings.xml
+@@ -1,3 +1,4 @@
+ <resources>
+     <string name="app_name">MyApp</string>
++    <string name="expo_runtime_version">1.0.0</string>
+ </resources>


### PR DESCRIPTION
# Why

Put strings.xml in a Diff block, followup from https://github.com/expo/expo/pull/22883/files#r1230532588

# Test Plan

- [ ] manually checked amended pages

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
