### PR TITLE
[docs] Add info about known `UIImagePickerController` iOS issue in Image Picker and minor fix in usage section

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -16,6 +16,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -141,13 +143,27 @@ When you run this example and pick an image, you will see the image that you pic
 }
 ```
 
-### Using with AWS S3
+### With AWS S3
 
-Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+<BoxLink
+  title="AWS storage example"
+  description="An example of how to use AWS storage can be found in with-aws-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
 
-### Using with Firebase
+See [Amplify documentation](https://docs.amplify.aws/) guide to set up your project correctly.
 
-Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
+### With Firebase
+
+<BoxLink
+  title="Firebase storage example"
+  description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
+
+See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -176,3 +176,7 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
+
+## Known issues
+
+There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -193,6 +193,6 @@ The following usage description keys are used by the APIs in this library.
   ]}
 />
 
-## Known issues
+## Known issue
 
 There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -164,3 +164,7 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
+
+## Known issues
+
+There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -181,6 +181,6 @@ The following usage description keys are used by the APIs in this library.
   ]}
 />
 
-## Known issues
+## Known issue
 
 There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -16,6 +16,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -129,13 +131,27 @@ When you run this example and pick an image, you will see the image that you pic
 }
 ```
 
-### Using with AWS S3
+### With AWS S3
 
-Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+<BoxLink
+  title="AWS storage example"
+  description="An example of how to use AWS storage can be found in with-aws-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
 
-### Using with Firebase
+See [Amplify documentation](https://docs.amplify.aws/) guide to set up your project correctly.
 
-Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
+### With Firebase
+
+<BoxLink
+  title="Firebase storage example"
+  description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
+
+See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -16,6 +16,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -141,13 +143,27 @@ When you run this example and pick an image, you will see the image that you pic
 }
 ```
 
-### Using with AWS S3
+### With AWS S3
 
-Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+<BoxLink
+  title="AWS storage example"
+  description="An example of how to use AWS storage can be found in with-aws-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
 
-### Using with Firebase
+See [Amplify documentation](https://docs.amplify.aws/) guide to set up your project correctly.
 
-Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
+### With Firebase
+
+<BoxLink
+  title="Firebase storage example"
+  description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
+
+See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -176,3 +176,7 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
+
+## Known issues
+
+There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -193,6 +193,6 @@ The following usage description keys are used by the APIs in this library.
   ]}
 />
 
-## Known issues
+## Known issue
 
 There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
@@ -16,6 +16,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -141,13 +143,27 @@ When you run this example and pick an image, you will see the image that you pic
 }
 ```
 
-### Using with AWS S3
+### With AWS S3
 
-Refer the [with-aws-storage-upload example](https://github.com/expo/examples/tree/master/with-aws-storage-upload). Follow [Amplify docs](https://docs.amplify.aws/) to set your project up correctly.
+<BoxLink
+  title="AWS storage example"
+  description="An example of how to use AWS storage can be found in with-aws-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
 
-### Using with Firebase
+See [Amplify documentation](https://docs.amplify.aws/) guide to set up your project correctly.
 
-Refer the [with-firebase-storage-upload example](https://github.com/expo/examples/tree/master/with-firebase-storage-upload). Make sure you follow the [Using Firebase](/guides/using-firebase/) guide to set your project up correctly.
+### With Firebase
+
+<BoxLink
+  title="Firebase storage example"
+  description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
+  Icon={GithubIcon}
+  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+/>
+
+See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
@@ -176,3 +176,7 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
+
+## Known issues
+
+There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
@@ -193,6 +193,6 @@ The following usage description keys are used by the APIs in this library.
   ]}
 />
 
-## Known issues
+## Known issue
 
 There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Document why (in some cases) the cropped image picked from camera roll in iOS, doesn't match provide the exact result (expected result).

Context: https://github.com/expo/expo/issues/22459#issuecomment-1556026654 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding a **Known issue** section
- Also, update the example links in **Usage** section to use BoxLink component (a pattern we follow to add links from docs to example repo)

Changes backported from unversioned to all existing SDKs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested locally.

**Preview**

<img width="918" alt="CleanShot 2023-06-18 at 01 13 48@2x" src="https://github.com/expo/expo/assets/10234615/0599f709-0130-4569-a10d-eb7f9cf63b41">

**Second preview of usage section**

<img width="899" alt="CleanShot 2023-06-18 at 01 13 39@2x" src="https://github.com/expo/expo/assets/10234615/36fd7e0d-5154-401d-9eba-2407dbffaf20">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
