### PR TITLE
[docs] Hide TOC in metro.config.js doc

### DIFF
--- a/docs/pages/versions/v46.0.0/config/metro.mdx
+++ b/docs/pages/versions/v46.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).

--- a/docs/pages/versions/v47.0.0/config/metro.mdx
+++ b/docs/pages/versions/v47.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).

--- a/docs/pages/versions/v48.0.0/config/metro.mdx
+++ b/docs/pages/versions/v48.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+hideTOC: true
 ---
 
 See more information about **metro.config.js** in the [customizing Metro guide](/guides/customizing-metro/).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The **metro.config.js** page in Reference doesn't have content and there is no need to show TOC.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Use `hideTOC` in frontmatter of the doc. Changes only applied to SDK 48, 47, and 46.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes tested locally.

**Preview**


<img width="1508" alt="CleanShot 2023-06-18 at 01 48 13@2x" src="https://github.com/expo/expo/assets/10234615/875455e2-fe33-48bb-a0bc-0c85f4449d51">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
