### PR TITLE
[ios][android] Update @react-native-async-storage to 1.18.2

### DIFF
--- a/android/vendored/unversioned/@react-native-async-storage/async-storage/android/build.gradle
+++ b/android/vendored/unversioned/@react-native-async-storage/async-storage/android/build.gradle
@@ -39,18 +39,14 @@ buildscript {
             ? rootProject.ext['kotlinVersion']
             : rootProject.hasProperty('AsyncStorage_kotlinVersion')
             ? rootProject.properties['AsyncStorage_kotlinVersion']
-            : '1.6.10'
+            : '1.8.10'
 
     repositories {
         mavenCentral()
         google()
     }
     dependencies {
-        def projectExampleDir = Paths.get(project.projectDir.getParent(), "example", "android").toString()
-        def rootProjectDir = rootProject.projectDir.getPath()
-        if (projectExampleDir == rootProjectDir) {
-            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
-        }
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$asyncStorageKtVersion"
     }
 }
 
@@ -78,10 +74,10 @@ if (useNextStorage) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    compileSdkVersion safeExtGet('compileSdkVersion', 32)
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 21)
-        targetSdkVersion safeExtGet('targetSdkVersion', 31)
+        minSdkVersion safeExtGet('minSdkVersion', 23)
+        targetSdkVersion safeExtGet('targetSdkVersion', 32)
         buildConfigField "Long", "AsyncStorage_db_size", "${dbSizeInMB}L"
         buildConfigField "boolean", "AsyncStorage_useDedicatedExecutor", "${useDedicatedExecutor}"
         buildConfigField "boolean", "AsyncStorage_useNextStorage", "${useNextStorage}"
@@ -112,15 +108,15 @@ repositories {
 dependencies {
 
     if (useNextStorage) {
-        def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.2')
-        def coroutines_version = "1.6.0"
-        def coroutinesTest_version = "1.6.0"
+        def room_version = getVersionOrDefault('AsyncStorage_next_roomVersion', '2.4.3')
+        def coroutines_version = "1.6.4"
+        def coroutinesTest_version = "1.6.4"
         // if we don't provide explicit dependency on reflection, kotlin plugin
         // would add one automatically, probably a version that is not compatible with
         // used kotlin
         def kotlinReflect_version = project.ext.asyncStorageKtVersion
         def junit_version = "4.13.2"
-        def robolectric_version = "4.10"
+        def robolectric_version = "4.7.3"
         def truth_version = "1.1.3"
         def androidxtest_version = "1.4.0"
         def androidtest_junit_version = "1.1.3"

--- a/android/vendored/unversioned/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
+++ b/android/vendored/unversioned/@react-native-async-storage/async-storage/android/src/main/java/com/reactnativecommunity/asyncstorage/next/StorageSupplier.kt
@@ -105,7 +105,7 @@ private object MIGRATION_TO_NEXT : Migration(1, 2) {
     }
 }
 
-@Database(entities = [Entry::class], version = DATABASE_VERSION, exportSchema = true)
+@Database(entities = [Entry::class], version = DATABASE_VERSION, exportSchema = false)
 internal abstract class StorageDb : RoomDatabase() {
     abstract fun storage(): StorageDao
 

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -796,7 +796,7 @@ PODS:
     - React-jsi (= 0.72.0-rc.6)
     - React-logger (= 0.72.0-rc.6)
     - React-perflogger (= 0.72.0-rc.6)
-  - RNCAsyncStorage (1.17.11):
+  - RNCAsyncStorage (1.18.2):
     - React-Core
   - RNCMaskedView (0.2.9):
     - React-Core
@@ -1494,7 +1494,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: db65884681ac1783322cd68883754743b306e774
   React-utils: d60ffef504983522e67ea57af91b9b06221e016f
   ReactCommon: 60d83b96ccf3ee5921a1ca908afcf686691f306c
-  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: 0bf8ef8f7800524f32d2bb2a8bcadd53eda0ecd1
   RNDateTimePicker: 00247f26c34683c80be94207f488f6f13448586e

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.0",
-    "@react-native-async-storage/async-storage": "1.17.11",
+    "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
-    "@react-native-async-storage/async-storage": "1.17.11",
+    "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/datetimepicker": "6.7.3",
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",

--- a/home/package.json
+++ b/home/package.json
@@ -23,7 +23,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@gorhom/bottom-sheet": "4.4.6",
     "@graphql-codegen/introspection": "^2.1.1",
-    "@react-native-async-storage/async-storage": "1.17.11",
+    "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-community/netinfo": "9.3.10",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/elements": "~1.3.6",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2232,7 +2232,7 @@ PODS:
     - React-jsi (= 0.72.0-rc.5)
     - React-logger (= 0.72.0-rc.5)
     - React-perflogger (= 0.72.0-rc.5)
-  - RNCAsyncStorage (1.17.11):
+  - RNCAsyncStorage (1.18.2):
     - React-Core
   - RNFlashList (1.4.3):
     - React-Core
@@ -3798,7 +3798,7 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 7c3287c689ba5bbff52ef95400fb8d6964cc8eae
   React-utils: cbbe99dc2e49db0a3fbb425c304f511a422f0ca2
   ReactCommon: 01b6643cfeef0d9078c8125378066d20cc34ddfe
-  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNReanimated: 48794d0f278349ecb6d94490e7bb184c9cdcd86f

--- a/ios/vendored/unversioned/@react-native-async-storage/async-storage/RNCAsyncStorage.podspec.json
+++ b/ios/vendored/unversioned/@react-native-async-storage/async-storage/RNCAsyncStorage.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "RNCAsyncStorage",
-  "version": "1.17.11",
+  "version": "1.18.2",
   "summary": "Asynchronous, persistent, key-value storage system for React Native.",
   "license": "MIT",
   "authors": "Krzysztof Borowy <hello@krizzu.dev>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-async-storage/async-storage.git",
-    "tag": "v1.17.11"
+    "tag": "v1.18.2"
   },
   "source_files": "ios/**/*.{h,m}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,6 +1,6 @@
 {
   "@expo/vector-icons": "^13.0.0",
-  "@react-native-async-storage/async-storage": "1.17.11",
+  "@react-native-async-storage/async-storage": "1.18.2",
   "@react-native-community/datetimepicker": "6.7.3",
   "@react-native-masked-view/masked-view": "0.2.9",
   "@react-native-community/netinfo": "9.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3125,10 +3125,10 @@
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.0"
 
-"@react-native-async-storage/async-storage@1.17.11":
-  version "1.17.11"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.17.11.tgz#7ec329c1b9f610e344602e806b04d7c928a2341d"
-  integrity sha512-bzs45n5HNcDq6mxXnSsOHysZWn1SbbebNxldBXCQs8dSvF8Aor9KCdpm+TpnnGweK3R6diqsT8lFhX77VX0NFw==
+"@react-native-async-storage/async-storage@1.18.2":
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.18.2.tgz#ec8fd487a0b6c9500b43ece4b8779d1561f12e91"
+  integrity sha512-dM8AfdoeIxlh+zqgr0o5+vCTPQ0Ru1mrPzONZMsr7ufp5h+6WgNxQNza7t0r5qQ6b04AJqTlBNixTWZxqP649Q==
   dependencies:
     merge-options "^3.0.4"
 


### PR DESCRIPTION
# Why
Updates `@react-native-async-storage/async-storage` to `1.18.2`

# How

```bash 
et uvm -m @react-native-async-storage/async-storage -c "v1.18.2"
yarn 
et pods -f
```

# Test Plan

- [x] test using `bare-expo` Android + NCL asyncStorage example
- [x] test using `bare-expo` iOS + NCL asyncStorage example
- [x] test unversioned expo go ios + NCL asyncStorage example
- [x] test unversioned expo go android + NCL  asyncStorage example