### PR TITLE
[ios][android] Update react-native-safe-area-context to 4.5.3

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -672,7 +672,7 @@ PODS:
     - React-Core
   - react-native-pager-view (6.2.0):
     - React-Core
-  - react-native-safe-area-context (4.5.0):
+  - react-native-safe-area-context (4.5.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -1472,7 +1472,7 @@ SPEC CHECKSUMS:
   React-logger: 51643121d274c21ca716923edee5fd5189428487
   react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
-  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
+  react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-view-shot: 705f999ac2a24e4e6c909c0ca65c732ed33ca2ff

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -84,7 +84,7 @@
     "react-native-gesture-handler": "~2.12.0",
     "react-native-pager-view": "6.2.0",
     "react-native-reanimated": "~3.1.0",
-    "react-native-safe-area-context": "4.5.0",
+    "react-native-safe-area-context": "4.5.3",
     "react-native-screens": "~3.20.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.9.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -148,7 +148,7 @@
     "react-native-pager-view": "6.2.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.1.0",
-    "react-native-safe-area-context": "4.5.0",
+    "react-native-safe-area-context": "4.5.3",
     "react-native-screens": "~3.20.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.9.0",

--- a/home/package.json
+++ b/home/package.json
@@ -64,7 +64,7 @@
     "react-native-maps": "1.7.1",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.1.0",
-    "react-native-safe-area-context": "4.5.0",
+    "react-native-safe-area-context": "4.5.3",
     "react-native-screens": "~3.20.0",
     "react-redux": "^7.2.0",
     "react-string-replace": "^0.4.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2081,7 +2081,7 @@ PODS:
     - React-Core
   - react-native-pager-view (6.2.0):
     - React-Core
-  - react-native-safe-area-context (4.5.0):
+  - react-native-safe-area-context (4.5.3):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -3776,7 +3776,7 @@ SPEC CHECKSUMS:
   React-logger: 4e8c28425ddc27abb6cde80eece89cc765da7d86
   react-native-netinfo: ccbe1085dffd16592791d550189772e13bf479e2
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
-  react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc
+  react-native-safe-area-context: b8979f5eda6ed5903d4dbc885be3846ea3daa753
   react-native-segmented-control: 06607462630512ff8eef652ec560e6235a30cc3e
   react-native-skia: ff2265fb802b2a3e1bf4a3c5a86d46936dd20354
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaViewEdges.h
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaViewEdges.h
@@ -6,4 +6,5 @@ typedef NS_ENUM(NSInteger, RNCSafeAreaViewEdges) {
   RNCSafeAreaViewEdgesBottom = 0b0010,
   RNCSafeAreaViewEdgesLeft = 0b0001,
   RNCSafeAreaViewEdgesAll = 0b1111,
+  RNCSafeAreaViewEdgesNone = 0b0000,
 };

--- a/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaViewEdges.m
+++ b/ios/vendored/unversioned/react-native-safe-area-context/ios/RNCSafeAreaViewEdges.m
@@ -11,7 +11,7 @@ RCT_MULTI_ENUM_CONVERTER(
       @"bottom" : @(RNCSafeAreaViewEdgesBottom),
       @"left" : @(RNCSafeAreaViewEdgesLeft),
     }),
-    RNCSafeAreaViewEdgesAll,
+    RNCSafeAreaViewEdgesNone,
     integerValue);
 
 @end

--- a/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
+++ b/ios/vendored/unversioned/react-native-safe-area-context/react-native-safe-area-context.podspec.json
@@ -1,17 +1,17 @@
 {
   "name": "react-native-safe-area-context",
-  "version": "4.5.0",
+  "version": "4.5.3",
   "summary": "A flexible way to handle safe area, also works on Android and web.",
   "license": "MIT",
   "authors": "Janic Duplessis <janicduplessis@gmail.com>",
   "homepage": "https://github.com/th3rdwave/react-native-safe-area-context#readme",
   "platforms": {
-    "ios": "11.0",
+    "ios": "12.4",
     "tvos": "11.0"
   },
   "source": {
     "git": "https://github.com/th3rdwave/react-native-safe-area-context.git",
-    "tag": "v4.5.0"
+    "tag": "v4.5.3"
   },
   "source_files": "ios/**/*.{h,m,mm}",
   "exclude_files": "ios/Fabric",

--- a/packages/expo-stories/package.json
+++ b/packages/expo-stories/package.json
@@ -31,7 +31,7 @@
     "fs-extra": "^9.1.0",
     "glob": "^7.1.7",
     "react-native-gesture-handler": "~2.12.0",
-    "react-native-safe-area-context": "4.5.0",
+    "react-native-safe-area-context": "4.5.3",
     "react-native-screens": "~3.20.0",
     "react-native-svg": "13.9.0",
     "sane": "^5.0.1"

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -91,7 +91,7 @@
   "react-native-pager-view": "6.2.0",
   "react-native-reanimated": "~3.1.0",
   "react-native-screens": "~3.20.0",
-  "react-native-safe-area-context": "4.5.0",
+  "react-native-safe-area-context": "4.5.3",
   "react-native-shared-element": "0.8.8",
   "react-native-svg": "13.9.0",
   "react-native-view-shot": "3.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15921,10 +15921,10 @@ react-native-reanimated@~3.1.0:
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
 
-react-native-safe-area-context@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz#9208313236e8f49e1920ac1e2a2c975f03aed284"
-  integrity sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==
+react-native-safe-area-context@4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.3.tgz#e98eb1a73a6b3846d296545fe74760754dbaaa69"
+  integrity sha512-ihYeGDEBSkYH+1aWnadNhVtclhppVgd/c0tm4mj0+HV11FoiWJ8N6ocnnZnRLvM5Fxc+hUqxR9bm5AXU3rXiyA==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"


### PR DESCRIPTION
# Why
Updates `react-native-safe-area-context` to `4.5.3`

# How

```bash 
et uvm -m react-native-safe-area-context -c "v4.5.3"
yarn 
et pods -f
```

# Test Plan

- [x] test using `bare-expo` Android + NCL SafeAreaContext example
- [x] test using `bare-expo` iOS + NCL SafeAreaContext example
- [x] test unversioned expo go ios + NCL SafeAreaContext example
- [x] test unversioned expo go android + NCL  SafeAreaContext example