### PR TITLE
[docs] Fix warning text to use `Callout` in Version Redirect Notification

### DIFF
--- a/docs/components/plugins/VersionedRedirectNotification.tsx
+++ b/docs/components/plugins/VersionedRedirectNotification.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/compat/router';
 import { useEffect, useState } from 'react';
 
-import { P } from '~/ui/components/Text';
+import { Callout } from '~/ui/components/Callout';
 
 export default function VersionedRedirectNotification({ showForQuery = 'redirected' }) {
   const router = useRouter();
@@ -15,12 +15,10 @@ export default function VersionedRedirectNotification({ showForQuery = 'redirect
 
   if (visible) {
     return (
-      <div className="bg-warning border border-solid border-warning p-4 mt-1 rounded-sm">
-        <P className="mb-0">
-          ⚠️ The page you are looking for does not exist in this SDK version. It may have been
-          deprecated or added in a newer SDK version.
-        </P>
-      </div>
+      <Callout type="warning">
+        The page you are looking for does not exist in this SDK version. It may have been deprecated
+        or added in a newer SDK version.
+      </Callout>
     );
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the when the version redirect happens in the Reference docs, the following warning callout is shown:

 
<img width="1121" alt="CleanShot 2023-06-19 at 13 45 17@2x" src="https://github.com/expo/expo/assets/10234615/4fe59a18-8b5e-4ad9-977e-a921dde2fefb">

This callout uses emoji and doesn't have margin-bottom.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Replace the `P` component with `Callout` to use the current presentational component to display warning with acceptable margins around the UI element and icon.

<img width="1153" alt="CleanShot 2023-06-19 at 14 02 04@2x" src="https://github.com/expo/expo/assets/10234615/eeea0f39-c832-4b33-be3a-1576357d5e04">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting: http://localhost:3002/versions/latest/?redirected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
