### PR TITLE
[docs] Fix image max width in CNG doc

### DIFF
--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -42,7 +42,7 @@ Expo Config Plugins have first-class support for building locally and adding to 
   <ImageSpotlight
     alt="Expo Config Plugins downloads."
     src="https://img.shields.io/npm/dm/@expo/config-plugins.svg?style=flat-square&labelColor=gray&color=33CC12&label=Downloads"
-    style={{ maxWidth: 480 }}
+    style={{ maxWidth: 180 }}
   />
 </a>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up PR for https://github.com/expo/expo/pull/22963#discussion_r1233721740

# How

<!--
How did you build this feature or fix this bug and why?
-->

By reducing the `maxWidth` value on `ImageSpotlight` component to `180`.

<img width="884" alt="CleanShot 2023-06-19 at 14 21 16@2x" src="https://github.com/expo/expo/assets/10234615/9a70e330-a6cb-4e49-bea8-9bd63d28b85f">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To rest changes, run docs locally and visit http://localhost:3002/workflow/continuous-native-generation/#community-adoption

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
