### PR TITLE
[docs] Step: fix possible overflow on mobile in certain cases

### DIFF
--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -12,7 +12,7 @@ export const Step = ({ children, label }: Props) => {
       <HEADLINE className="flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1">
         {label}
       </HEADLINE>
-      <div className="pt-1 w-full prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
+      <div className="pt-1.5 max-w-[calc(100%-44px)] prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
         {children}
       </div>
     </div>


### PR DESCRIPTION
# Why

Fixes ENG-9002

# How

Make sure that `Step` component do not exceed the viewport on mobile, when it contains a flex base component in its content.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="476" alt="Screenshot 2023-06-19 at 21 17 04" src="https://github.com/expo/expo/assets/719641/acbaab95-c052-49f2-b12b-ca4a8a6e4d0b">

