### PR TITLE
chore(cli): suppress EAS signing log in general workflow

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- Only show EAS signing log in debug.
+- Only show EAS signing log in debug. ([#22975](https://github.com/expo/expo/pull/22975) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.9.1 — 2023-06-13
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 💡 Others
 
+- Only show EAS signing log in debug.
+
 ## 0.9.1 — 2023-06-13
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -27,6 +27,8 @@ import * as Log from '../log';
 import { learnMore } from '../utils/link';
 import { CommandError } from './errors';
 
+const debug = require('debug')('expo:codesigning') as typeof console.log;
+
 export type CodeSigningInfo = {
   keyId: string;
   privateKey: string;
@@ -182,8 +184,8 @@ async function getExpoRootDevelopmentCodeSigningInfoAsync(
   // can't check for scope key validity since scope key is derived on the server from projectId and we may be offline.
   // we rely upon the client certificate check to validate the scope key
   if (!easProjectId) {
-    Log.warn(
-      `Expo Application Services (EAS) is not configured for your project. Configuring EAS enables a more secure development experience amongst many other benefits. ${learnMore(
+    debug(
+      `WARN: Expo Application Services (EAS) is not configured for your project. Configuring EAS enables a more secure development experience amongst many other benefits. ${learnMore(
         'https://docs.expo.dev/eas/'
       )}`
     );


### PR DESCRIPTION
# Why

Prevent prompting all users to setup EAS when starting the dev server.
