### PR TITLE
Remove unnecessary "supports" check that breaks SSR on the BlurView.

### DIFF
--- a/packages/expo-blur/src/BlurView.web.tsx
+++ b/packages/expo-blur/src/BlurView.web.tsx
@@ -12,27 +12,15 @@ export default class BlurView extends React.Component<BlurViewProps> {
   }
 }
 
-function isBlurSupported(): boolean {
-  // https://developer.mozilla.org/en-US/docs/Web/API/CSS/supports
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter#Browser_compatibility
-  return (
-    typeof CSS !== 'undefined' &&
-    (CSS.supports('-webkit-backdrop-filter', 'blur(1px)') ||
-      CSS.supports('backdrop-filter', 'blur(1px)'))
-  );
-}
-
 function getBlurStyle({ intensity, tint }): Record<string, string> {
   const style: Record<string, string> = {
     backgroundColor: getBackgroundColor(intensity, tint),
   };
 
-  if (isBlurSupported()) {
-    const blur = `saturate(180%) blur(${intensity * 0.2}px)`;
-    style.backdropFilter = blur;
-    // Safari support
-    style['-webkit-backdrop-filter'] = blur;
-  }
+  const blur = `saturate(180%) blur(${intensity * 0.2}px)`;
+  style.backdropFilter = blur;
+  // Safari support
+  style['-webkit-backdrop-filter'] = blur;
 
   return style;
 }


### PR DESCRIPTION
# Why

Expo Blur doesn't work with SSR because it includes an unnecessary client-only check for supported CSS properties.

# How

Removed code.

# Test Plan

Using this in my app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
