### PR TITLE
[docs] eas update: better navigation titles

### DIFF
--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from CodePush to EAS Update
+title: Migrating from CodePush
 description: A guide to help migrate from CodePush to EAS Update.
 ---
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from CodePush
+title: Migrate from CodePush
 description: A guide to help migrate from CodePush to EAS Update.
 ---
 

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -1,5 +1,6 @@
 ---
-title: Debugging
+title: Debug EAS Update
+sidebar_title: Debug
 description: Learn how to debug EAS Update.
 ---
 

--- a/docs/pages/eas-update/debug-updates.mdx
+++ b/docs/pages/eas-update/debug-updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Debugging EAS Update
+title: Debugging
 description: Learn how to debug EAS Update.
 ---
 

--- a/docs/pages/eas-update/developing-with-eas-update.mdx
+++ b/docs/pages/eas-update/developing-with-eas-update.mdx
@@ -1,5 +1,6 @@
 ---
-title: Developing Faster
+title: Develop with EAS Update
+sidebar_title: Develop faster
 description: Learn how to iterate your development faster with EAS Update.
 ---
 

--- a/docs/pages/eas-update/developing-with-eas-update.mdx
+++ b/docs/pages/eas-update/developing-with-eas-update.mdx
@@ -1,5 +1,5 @@
 ---
-title: Developing with EAS Update
+title: Developing Faster
 description: Learn how to iterate your development faster with EAS Update.
 ---
 

--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -1,5 +1,6 @@
 ---
-title: Using EAS CLI
+title: Use EAS Update with EAS CLI
+sidebar_title: Use EAS CLI
 description: Learn how to use link a branch to a channel and publish updates with EAS CLI.
 ---
 

--- a/docs/pages/eas-update/eas-update-and-eas-cli.mdx
+++ b/docs/pages/eas-update/eas-update-and-eas-cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using EAS Update with EAS CLI
+title: Using EAS CLI
 description: Learn how to use link a branch to a channel and publish updates with EAS CLI.
 ---
 
@@ -38,12 +38,7 @@ View a specific channel:
 Create a channel:
 
 <Terminal
-  cmd={[
-    '$ eas channel:create [channel-name]',
-    '',
-    '# Example',
-    '$ eas channel:create production',
-  ]}
+  cmd={['$ eas channel:create [channel-name]', '', '# Example', '$ eas channel:create production']}
   cmdCopy="eas channel:create [channel-name]"
 />
 
@@ -95,12 +90,7 @@ If you're using Git, we can use the `--auto` flag to auto-fill the branch name a
 ### Delete a branch
 
 <Terminal
-  cmd={[
-    '$ eas branch:delete [branch-name]',
-    '',
-    '# Example',
-    '$ eas branch:delete version-1.0',
-  ]}
+  cmd={['$ eas branch:delete [branch-name]', '', '# Example', '$ eas branch:delete version-1.0']}
   cmdCopy="eas branch:delete [branch-name]"
 />
 

--- a/docs/pages/eas-update/eas-update-with-local-build.mdx
+++ b/docs/pages/eas-update/eas-update-with-local-build.mdx
@@ -1,5 +1,5 @@
 ---
-title: EAS Update with a local build
+title: Building Locally
 description: Learn how to use EAS update directly with a local build environment.
 ---
 

--- a/docs/pages/eas-update/eas-update-with-local-build.mdx
+++ b/docs/pages/eas-update/eas-update-with-local-build.mdx
@@ -1,5 +1,6 @@
 ---
-title: Building Locally
+title: EAS Update with a local build
+sidebar_title: Build locally
 description: Learn how to use EAS update directly with a local build environment.
 ---
 

--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -1,5 +1,6 @@
 ---
-title: Environment variables
+title: Use environment variables with EAS Update
+sidebar_title: Environment variables
 description: Learn how to set up and use environment variables with EAS Update.
 ---
 

--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using environment variables with EAS Update
+title: Environment variables
 description: Learn how to set up and use environment variables with EAS Update.
 ---
 

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -1,5 +1,6 @@
 ---
-title: Using expo-dev-client
+title: Use expo-dev-client with EAS Update
+sidebar_title: Use expo-dev-client
 description: Learn how to use the expo-dev-client library to preview a published EAS Update inside a development build.
 ---
 

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using expo-dev-client with EAS Update
+title: Using expo-dev-client
 description: Learn how to use the expo-dev-client library to preview a published EAS Update inside a development build.
 ---
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -24,31 +24,31 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
 />
 
 <BoxLink
-  title="Using GitHub Actions"
+  title="Use GitHub Actions"
   description="Publish an update and preview with a QR code after a commit."
   href="/eas-update/github-actions"
 />
 
 <BoxLink
-  title="Developing Faster"
+  title="Develop faster"
   description="View your teammate's changes with EAS Update."
   href="/eas-update/developing-with-eas-update"
 />
 
 <BoxLink
-  title="Deployment Patterns"
+  title="Deployment patterns"
   description="Release processes that balance update safety and speed."
   href="/eas-update/deployment-patterns"
 />
 
 <BoxLink
-  title="Migrating from CodePush"
+  title="Migrate from CodePush"
   description="Transition a bare React Native project from CodePush."
   href="/eas-update/codepush"
 />
 
 <BoxLink
-  title="Debugging"
+  title="Debug"
   description="When your app doesn't update as expected."
   href="/eas-update/debug-updates"
 />

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -30,7 +30,7 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
 />
 
 <BoxLink
-  title="Developing with EAS Update"
+  title="Developing Faster"
   description="View your teammate's changes with EAS Update."
   href="/eas-update/developing-with-eas-update"
 />
@@ -48,7 +48,7 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
 />
 
 <BoxLink
-  title="Debugging EAS Updates"
+  title="Debugging"
   description="When your app doesn't update as expected."
   href="/eas-update/debug-updates"
 />

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from Classic Updates to EAS Update
+title: Migrating from Classic Updates
 description: A guide to help migrate from Classic Updates to EAS Update.
 ---
 

--- a/docs/pages/eas-update/migrate-to-eas-update.mdx
+++ b/docs/pages/eas-update/migrate-to-eas-update.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from Classic Updates
+title: Migrate from Classic Updates
 description: A guide to help migrate from Classic Updates to EAS Update.
 ---
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to optimize assets for EAS Update
+title: Optimizing assets
 description: Learn how EAS Update downloads assets and how to optimize them for download size.
 ---
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -1,5 +1,6 @@
 ---
-title: Optimizing assets
+title: Optimize assets for EAS Update
+sidebar_title: Optimize assets
 description: Learn how EAS Update downloads assets and how to optimize them for download size.
 ---
 


### PR DESCRIPTION
# Why

Improve the readability of the navigation sidebar for EAS Update, similar to EAS Build

# How

- Most articles under the `EAS Update` section should not have `EAS Update` in the article title because it is already placed in the relevant category. EAS Build does this, and it makes it easier to navigate the docs.
- Avoid long titles. For example `How to optimize assets with EAS Update` can be shortened to `Optimizing Assets`

# UX
Before: 
![Screenshot 2023-06-19 at 5 02 14 PM](https://github.com/expo/expo/assets/6380927/6ebd9463-55cb-4721-a748-710a915df326)

After:
![Screenshot 2023-06-19 at 5 02 37 PM](https://github.com/expo/expo/assets/6380927/cf0aad51-bd08-4e2d-9c39-efdea3dc4a8d)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
