### PR TITLE
[updates] add brotli support on android

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Load updates in background thread and prevent ANR from initial launch. ([#20273](https://github.com/expo/expo/pull/20273) by [@kudo](https://github.com/kudo))
 - Added support for React Native 0.72. ([#22588](https://github.com/expo/expo/pull/22588) by [@kudo](https://github.com/kudo))
+- Added the Brotli compression support for EAS Update on Android. ([#22982](https://github.com/expo/expo/pull/22982) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -120,6 +120,7 @@ dependencies {
 
   implementation("com.squareup.okhttp3:okhttp:4.9.2")
   implementation("com.squareup.okhttp3:okhttp-urlconnection:4.9.2")
+  implementation("com.squareup.okhttp3:okhttp-brotli:4.9.2")
   implementation("com.squareup.okio:okio:2.9.0")
   implementation("commons-codec:commons-codec:1.10")
   implementation("commons-io:commons-io:2.6")

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -37,11 +37,13 @@ import java.security.cert.CertificateException
  * and assets, using an instance of [OkHttpClient].
  */
 open class FileDownloader(context: Context, private val client: OkHttpClient) {
-  constructor(context: Context) : this(context,
+  constructor(context: Context) : this(
+    context,
     OkHttpClient.Builder()
       .cache(getCache(context))
       .addInterceptor(BrotliInterceptor)
-      .build())
+      .build()
+  )
   private val logger = UpdatesLogger(context)
 
   interface FileDownloadCallback {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -9,6 +9,7 @@ import expo.modules.structuredheaders.Dictionary
 import expo.modules.updates.launcher.NoDatabaseLauncher
 import expo.modules.updates.selectionpolicy.SelectionPolicies
 import okhttp3.*
+import okhttp3.brotli.BrotliInterceptor
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -36,7 +37,11 @@ import java.security.cert.CertificateException
  * and assets, using an instance of [OkHttpClient].
  */
 open class FileDownloader(context: Context, private val client: OkHttpClient) {
-  constructor(context: Context) : this(context, OkHttpClient.Builder().cache(getCache(context)).build())
+  constructor(context: Context) : this(context,
+    OkHttpClient.Builder()
+      .cache(getCache(context))
+      .addInterceptor(BrotliInterceptor)
+      .build())
   private val logger = UpdatesLogger(context)
 
   interface FileDownloadCallback {


### PR DESCRIPTION
# Why

add brotli compression support for eas-updates
close ENG-538

# How

add okhttp brotli interceptor

# Test Plan

- tested on versioned expo go to load sdk 48 eas updates project and use mitmproxy to check the request/response
![Screenshot 2023-06-20 at 10 38 48 AM](https://github.com/expo/expo/assets/46429/0a22884f-c7d7-49de-859b-c9a2061ff4ca)
![Screenshot 2023-06-20 at 10 39 04 AM](https://github.com/expo/expo/assets/46429/830827e1-6385-4fcb-8741-eea39fdffb67)
seeing the `accept-encoding`  and `content-encoding`
  - needs to add android network security config to allow `<certificates src="user" />`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
