### PR TITLE
[docs] Update final snack link in Tutorial

### DIFF
--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -32,7 +32,7 @@ Before we get started, take a look at what we'll build. It's an app named **Stic
 
 <Video file="tutorial/final.mp4" />
 
-> **info** The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@amanhimself/complete-expo-tutorial-example).
+> **info** The complete source code for this tutorial is available on [Snack](https://snack.expo.dev/@expo-team-snacks/image-app).
 
 ## How to use this tutorial
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've uploaded all the tutorial/example snacks on the Expo team Snack account.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By changing the complete Snack link from personal account to Expo team's Snack account.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting: http://localhost:3002/tutorial/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
