### PR TITLE
[docs] Update guideline about using Libraries over module & add internal link

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -143,7 +143,7 @@ Do not add extra space between preceding and succeeding words and "/" just to em
 
 Try splitting phrases into separate sentences. Our goal is to make documentation easier to read and understand.
 
-In rare cases when it is necessary to split phrases, use em dashes (—) or use connections (such as then, however, and so on) rather than commas to split phrases that read as separate sentences.
+In rare cases when it is necessary to split phrases, [use em dashes](#use-mdash) (—) or use connections (such as then, however, and so on) rather than commas to split phrases that read as separate sentences.
 
 - Correct: JavaScript has come a long way since it was originally written in 10 days.
 - Incorrect: JavaScript has come a long way, it was originally written in 10 days.
@@ -282,7 +282,7 @@ Terms referred in this section are meant to be used consistently throughout the 
   - A Swift module is a namespaced unit of code that can be distributed. It includes a module map and conforms to some other technical details.
 - Library
   - An overarching name for code that application developers call into as a part of their apps. Examples of libraries are Expo modules, npm packages, and iOS APIs.
-  - **"Expo libraries" is a synonym for Expo modules** but for consistency reasons, let’s stick to **Expo modules.**
+  - **"Expo libraries" is a synonym for Expo modules** and for consistency reasons, let’s use **Expo Libraries**.
 - Package
   - **npm packages** are units of code that include a file named package.json and are typically installed with npm or Yarn. They almost always include JavaScript code.
   - Expo modules are distributed as npm packages.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Since we've started making references to "Libraries" and "Modules" (based on this [task](https://linear.app/expo/issue/ENG-8637/unify-usage-of-library-vs-package-in-docs)), let's update the Writing Style Guideline about using "Libraries".
- Also, when referencing the "use em dash", internally link to "Use `&mdash;`" section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
