### PR TITLE
[docs] Fix link with firebase example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -160,7 +160,7 @@ See [Amplify documentation](https://docs.amplify.aws/) guide to set up your proj
   title="Firebase storage example"
   description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
   Icon={GithubIcon}
-  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+  href="https://github.com/expo/examples/tree/master/with-firebase-storage-upload"
 />
 
 See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.


### PR DESCRIPTION
# Why

The link was pointing to the wrong example

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
