### PR TITLE
[expo-print][ios] fix web urls and data strings support (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
-- Fixed a regression in `expo-print` after refactoring to Swift. ([#22997](https://github.com/expo/expo/pull/22997) by [@mroswald](https://github.com/mroswald), [@behenate](https://github.com/behenate))
-
 ### ⚠️ Notices
 
 - Removed the `Remote JS debugger` option from Expo Go menu when using SDK 49 or above. ([#22027](https://github.com/expo/expo/pull/22027) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- Fixed a regression in `expo-print` after refactoring to Swift. ([#22997](https://github.com/expo/expo/pull/22997) by [@mroswald](https://github.com/mroswald), [@behenate](https://github.com/behenate))
+
 ### ⚠️ Notices
 
 - Removed the `Remote JS debugger` option from Expo Go menu when using SDK 49 or above. ([#22027](https://github.com/expo/expo/pull/22027) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed a regression after refactoring to Swift (restore functionality to print from web url or data string). ([#22997](https://github.com/expo/expo/pull/22997) by [@mroswald](https://github.com/mroswald), [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 12.4.0 — 2023-06-21

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -4,11 +4,11 @@ public class ExpoPrintWithPrinter {
   var renderTasks: [ExpoWKPDFRenderer] = []
   var cachedPrinters: [String: UIPrinter] = [:]
   let delegate: ExpoPrintModuleDelegate
-  
+
   init(delegate: ExpoPrintModuleDelegate) {
     self.delegate = delegate
   }
-  
+
   func startPrint(options: PrintOptions, promise: Promise) {
     if let uri = options.uri {
       dataFromUri(uri: uri) { [self] data in
@@ -26,14 +26,14 @@ public class ExpoPrintWithPrinter {
       promise.reject(NoPrintDataException())
       return
     }
-    
+
     if !options.useMarkupFormatter {
       printFromHtmlWithoutMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
     } else {
       printFromHtmlWithMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
     }
   }
-  
+
   private func printFromHtmlWithoutMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
     let renderTask = ExpoWKPDFRenderer(
       htmlString: htmlString,
@@ -52,7 +52,7 @@ public class ExpoPrintWithPrinter {
     self.renderTasks.append(renderTask)
     renderTask.pdfWithHtml()
   }
-  
+
   private func printFromHtmlWithMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
     ExpoPrintToFile.pdfWithHtmlMarkupFormatter(
       htmlString: htmlString,
@@ -69,7 +69,7 @@ public class ExpoPrintWithPrinter {
       }
     }
   }
-  
+
   private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
     let printerUrl = options.printerUrl ?? ""
     let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
@@ -117,7 +117,7 @@ public class ExpoPrintWithPrinter {
       printInteractionController.present(animated: true, completionHandler: completionHandler)
     }
   }
-  
+
   private func makePrintInteractionController(options: PrintOptions) -> UIPrintInteractionController {
     let uri = options.uri ?? ""
     let printInteractionController = UIPrintInteractionController()
@@ -137,7 +137,7 @@ public class ExpoPrintWithPrinter {
     
     return printInteractionController
   }
-  
+
   private func dataFromUri(uri: String, completion: @escaping (Data?) -> Void) {
     if uri.hasPrefix("http") {
       // Handle HTTP URL asynchronously

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -20,7 +20,7 @@ public class ExpoPrintWithPrinter {
       }
       return
     }
-    
+
     // Do this for compatibility with deprecated markup formatter option
     guard let htmlString = options.markupFormatterIOS ?? options.html else {
       promise.reject(NoPrintDataException())
@@ -73,15 +73,15 @@ public class ExpoPrintWithPrinter {
   private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
     let printerUrl = options.printerUrl ?? ""
     let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
-    
+
     guard let rootController = UIApplication.shared.keyWindow?.rootViewController else {
       promise.reject(ViewControllerNotFoundException())
       return
     }
-    
+
     let printInteractionController = makePrintInteractionController(options: options)
     printInteractionController.printingItem = printingData
-    
+
     let completionHandler = { (_: UIPrintInteractionController, completed: Bool, error: Error?) in
       if error != nil {
         promise.reject(PrintingJobFailedException(error?.localizedDescription))
@@ -92,18 +92,18 @@ public class ExpoPrintWithPrinter {
         promise.reject(PrintIncompleteException())
       }
     }
-    
+
     if !printerUrl.isEmpty {
       // Found by @tsapeta
       // In older versions of iOS there is a bug, where finding the printer using UIPrinter(url:) will fail
       // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
       // the workaround is to use a printer saved during picking, fall back to this method if the regular one fails
-      
+
       // Also on ios 16 there is a bug when printing multiple files https://github.com/expo/expo/issues/19399.
       // Caching the previously used printer fixes the bug
       let printer = self.cachedPrinters[printerUrl] ?? UIPrinter(url: candidateUrl)
       self.cachedPrinters[printerUrl] = printer
-      
+
       printer.contactPrinter { available in
         if available {
           printInteractionController.print(to: printer, completionHandler: completionHandler)
@@ -122,7 +122,7 @@ public class ExpoPrintWithPrinter {
     let uri = options.uri ?? ""
     let printInteractionController = UIPrintInteractionController()
     printInteractionController.delegate = self.delegate
-    
+
     let printInfo = UIPrintInfo.printInfo()
     printInfo.outputType = UIPrintInfo.OutputType.general
     if let uri = options.uri {
@@ -130,11 +130,11 @@ public class ExpoPrintWithPrinter {
     }
     printInfo.duplex = UIPrintInfo.Duplex.longEdge
     printInfo.orientation = options.toUIPrintInfoOrientation()
-    
+
     printInteractionController.printInfo = printInfo
     printInteractionController.showsNumberOfCopies = true
     printInteractionController.showsPaperSelectionForLoadedPapers = true
-    
+
     return printInteractionController
   }
 
@@ -165,7 +165,7 @@ public class ExpoPrintWithPrinter {
     } else {
       // Handle local file path synchronously
       let adjustedUri = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
-      
+
       if let data = try? Data(contentsOf: URL(fileURLWithPath: adjustedUri)) {
         completion(data)
       } else {

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -166,7 +166,7 @@ public class ExpoPrintWithPrinter {
           return
         }
         completion(nil)
-      };
+      }
       dataTask?.resume()
     } else {
       let data = try? Data(contentsOf: url)

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -4,6 +4,8 @@ public class ExpoPrintWithPrinter {
   var renderTasks: [ExpoWKPDFRenderer] = []
   var cachedPrinters: [String: UIPrinter] = [:]
   let delegate: ExpoPrintModuleDelegate
+  let printURLSession = URLSession(configuration: .default)
+  var dataTask: URLSessionDataTask?
 
   init(delegate: ExpoPrintModuleDelegate) {
     self.delegate = delegate
@@ -137,9 +139,6 @@ public class ExpoPrintWithPrinter {
 
     return printInteractionController
   }
-
-  let printURLSession = URLSession(configuration: .default)
-  var dataTask: URLSessionDataTask?
 
   private func dataFromUri(uri: String, completion: @escaping (Data?) -> Void) {
     guard var url = URL(string: uri) else {

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -1,147 +1,176 @@
 import ExpoModulesCore
 
 public class ExpoPrintWithPrinter {
-  var renderTasks: [ExpoWKPDFRenderer] = []
-  var cachedPrinters: [String: UIPrinter] = [:]
-  let delegate: ExpoPrintModuleDelegate
-
-  init(delegate: ExpoPrintModuleDelegate) {
-    self.delegate = delegate
-  }
-
-  func startPrint(options: PrintOptions, promise: Promise) {
-    if let uri = options.uri {
-      guard let printingData = dataFromUri(uri: uri) else {
-        promise.reject(InvalidUrlException())
-        return
-      }
-      printWithData(printingData: printingData, options: options, promise: promise)
+    var renderTasks: [ExpoWKPDFRenderer] = []
+    var cachedPrinters: [String: UIPrinter] = [:]
+    let delegate: ExpoPrintModuleDelegate
+    
+    init(delegate: ExpoPrintModuleDelegate) {
+        self.delegate = delegate
     }
-
-    let pageSize = options.toPageSize()
-    let printableRect = options.toPrintableRect()
-    // Do this for compatibility with deprecated markup formatter option
-    guard let htmlString = options.markupFormatterIOS ?? options.html else {
-      promise.reject(NoPrintDataException())
-      return
-    }
-
-    if !options.useMarkupFormatter {
-      printFromHtmlWithoutMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
-    } else {
-      printFromHtmlWithMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
-    }
-  }
-
-  private func printFromHtmlWithoutMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
-    let renderTask = ExpoWKPDFRenderer(
-      htmlString: htmlString,
-      pageSize: options.toPageSize(),
-      printableRect: options.toPrintableRect()
-    ) { pdfData, _, error, task in
-      self.renderTasks.removeAll {
-        $0 == task
-      }
-      guard let pdfData = pdfData, error == nil else {
-        promise.reject(PdfNotRenderedException(error?.localizedDescription))
-        return
-      }
-      self.printWithData(printingData: pdfData, options: options, promise: promise)
-    }
-    self.renderTasks.append(renderTask)
-    renderTask.pdfWithHtml()
-  }
-
-  private func printFromHtmlWithMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
-    ExpoPrintToFile.pdfWithHtmlMarkupFormatter(
-      htmlString: htmlString,
-      pageSize: options.toPageSize(),
-      printableRect: options.toPrintableRect()
-    ) { pdfData, _, error, task in
-      self.renderTasks.removeAll {
-        $0 == task
-      }
-      if error == nil {
-        self.printWithData(printingData: pdfData, options: options, promise: promise)
-      } else {
-        promise.reject(PdfNotRenderedException(error?.localizedDescription))
-      }
-    }
-  }
-
-  private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
-    let printerUrl = options.printerUrl ?? ""
-    let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
-
-    guard let rootController = UIApplication.shared.keyWindow?.rootViewController else {
-      promise.reject(ViewControllerNotFoundException())
-      return
-    }
-
-    let printInteractionController = makePrintInteractionController(options: options)
-    printInteractionController.printingItem = printingData
-
-    let completionHandler = { (_: UIPrintInteractionController, completed: Bool, error: Error?) in
-      if error != nil {
-        promise.reject(PrintingJobFailedException(error?.localizedDescription))
-      }
-      if completed {
-        promise.resolve()
-      } else {
-        promise.reject(PrintIncompleteException())
-      }
-    }
-
-    if !printerUrl.isEmpty {
-      // Found by @tsapeta
-      // In older versions of iOS there is a bug, where finding the printer using UIPrinter(url:) will fail
-      // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
-      // the workaround is to use a printer saved during picking, fall back to this method if the regular one fails
-
-      // Also on ios 16 there is a bug when printing multiple files https://github.com/expo/expo/issues/19399.
-      // Caching the previously used printer fixes the bug
-      let printer = self.cachedPrinters[printerUrl] ?? UIPrinter(url: candidateUrl)
-      self.cachedPrinters[printerUrl] = printer
-
-      printer.contactPrinter { available in
-        if available {
-          printInteractionController.print(to: printer, completionHandler: completionHandler)
-        } else {
-          promise.reject(PrintingJobFailedException("Provided printer is not available."))
+    
+    func startPrint(options: PrintOptions, promise: Promise) {
+        if let uri = options.uri {
+            dataFromUri(uri: uri) { [self] data in
+                if let printingData = data {
+                    self.printWithData(printingData: printingData, options: options, promise: promise)
+                } else {
+                    promise.reject(InvalidUrlException())
+                }
+            }
+            return
         }
-      }
-    } else if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
-      printInteractionController.present(from: rootController.view.frame, in: rootController.view, animated: true, completionHandler: completionHandler)
-    } else {
-      printInteractionController.present(animated: true, completionHandler: completionHandler)
+        
+        // Do this for compatibility with deprecated markup formatter option
+        guard let htmlString = options.markupFormatterIOS ?? options.html else {
+            promise.reject(NoPrintDataException())
+            return
+        }
+        
+        if !options.useMarkupFormatter {
+            printFromHtmlWithoutMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+        } else {
+            printFromHtmlWithMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+        }
     }
-  }
-
-  private func makePrintInteractionController(options: PrintOptions) -> UIPrintInteractionController {
-    let uri = options.uri ?? ""
-    let printInteractionController = UIPrintInteractionController()
-    printInteractionController.delegate = self.delegate
-
-    let printInfo = UIPrintInfo.printInfo()
-    printInfo.outputType = UIPrintInfo.OutputType.general
-    if let uri = options.uri {
-      printInfo.jobName = uri.components(separatedBy: "/").last ?? uri
+    
+    private func printFromHtmlWithoutMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
+        let renderTask = ExpoWKPDFRenderer(
+            htmlString: htmlString,
+            pageSize: options.toPageSize(),
+            printableRect: options.toPrintableRect()
+        ) { pdfData, _, error, task in
+            self.renderTasks.removeAll {
+                $0 == task
+            }
+            guard let pdfData = pdfData, error == nil else {
+                promise.reject(PdfNotRenderedException(error?.localizedDescription))
+                return
+            }
+            self.printWithData(printingData: pdfData, options: options, promise: promise)
+        }
+        self.renderTasks.append(renderTask)
+        renderTask.pdfWithHtml()
     }
-    printInfo.duplex = UIPrintInfo.Duplex.longEdge
-    printInfo.orientation = options.toUIPrintInfoOrientation()
-
-    printInteractionController.printInfo = printInfo
-    printInteractionController.showsNumberOfCopies = true
-    printInteractionController.showsPaperSelectionForLoadedPapers = true
-
-    return printInteractionController
-  }
-
-  private func dataFromUri(uri: String) -> Data? {
-    do {
-      return try Data(contentsOf: URL(fileURLWithPath: uri))
-    } catch {
-      return nil
+    
+    private func printFromHtmlWithMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
+        ExpoPrintToFile.pdfWithHtmlMarkupFormatter(
+            htmlString: htmlString,
+            pageSize: options.toPageSize(),
+            printableRect: options.toPrintableRect()
+        ) { pdfData, _, error, task in
+            self.renderTasks.removeAll {
+                $0 == task
+            }
+            if error == nil {
+                self.printWithData(printingData: pdfData, options: options, promise: promise)
+            } else {
+                promise.reject(PdfNotRenderedException(error?.localizedDescription))
+            }
+        }
     }
-  }
+    
+    private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
+        let printerUrl = options.printerUrl ?? ""
+        let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
+        
+        guard let rootController = UIApplication.shared.keyWindow?.rootViewController else {
+            promise.reject(ViewControllerNotFoundException())
+            return
+        }
+        
+        let printInteractionController = makePrintInteractionController(options: options)
+        printInteractionController.printingItem = printingData
+        
+        let completionHandler = { (_: UIPrintInteractionController, completed: Bool, error: Error?) in
+            if error != nil {
+                promise.reject(PrintingJobFailedException(error?.localizedDescription))
+            }
+            if completed {
+                promise.resolve()
+            } else {
+                promise.reject(PrintIncompleteException())
+            }
+        }
+        
+        if !printerUrl.isEmpty {
+            // Found by @tsapeta
+            // In older versions of iOS there is a bug, where finding the printer using UIPrinter(url:) will fail
+            // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
+            // the workaround is to use a printer saved during picking, fall back to this method if the regular one fails
+            
+            // Also on ios 16 there is a bug when printing multiple files https://github.com/expo/expo/issues/19399.
+            // Caching the previously used printer fixes the bug
+            let printer = self.cachedPrinters[printerUrl] ?? UIPrinter(url: candidateUrl)
+            self.cachedPrinters[printerUrl] = printer
+            
+            printer.contactPrinter { available in
+                if available {
+                    printInteractionController.print(to: printer, completionHandler: completionHandler)
+                } else {
+                    promise.reject(PrintingJobFailedException("Provided printer is not available."))
+                }
+            }
+        } else if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
+            printInteractionController.present(from: rootController.view.frame, in: rootController.view, animated: true, completionHandler: completionHandler)
+        } else {
+            printInteractionController.present(animated: true, completionHandler: completionHandler)
+        }
+    }
+    
+    private func makePrintInteractionController(options: PrintOptions) -> UIPrintInteractionController {
+        let uri = options.uri ?? ""
+        let printInteractionController = UIPrintInteractionController()
+        printInteractionController.delegate = self.delegate
+        
+        let printInfo = UIPrintInfo.printInfo()
+        printInfo.outputType = UIPrintInfo.OutputType.general
+        if let uri = options.uri {
+            printInfo.jobName = uri.components(separatedBy: "/").last ?? uri
+        }
+        printInfo.duplex = UIPrintInfo.Duplex.longEdge
+        printInfo.orientation = options.toUIPrintInfoOrientation()
+        
+        printInteractionController.printInfo = printInfo
+        printInteractionController.showsNumberOfCopies = true
+        printInteractionController.showsPaperSelectionForLoadedPapers = true
+        
+        return printInteractionController
+    }
+    
+    private func dataFromUri(uri: String, completion: @escaping (Data?) -> Void) {
+        if uri.hasPrefix("http") {
+            // Handle HTTP URL asynchronously
+            DispatchQueue.global().async {
+                if let url = URL(string: uri), let data = try? Data(contentsOf: url) {
+                    DispatchQueue.main.async {
+                        completion(data)
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        completion(nil)
+                    }
+                }
+            }
+        } else if uri.hasPrefix("data:") {
+            // Handle base64 encoded data URI
+            if let commaIndex = uri.firstIndex(of: ",") {
+                let base64String = String(uri[uri.index(after: commaIndex)...])
+                if let data = Data(base64Encoded: base64String) {
+                    completion(data)
+                } else {
+                    completion(nil)
+                }
+            }
+        } else {
+            // Handle local file path synchronously
+            let adjustedUri = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
+            
+            if let data = try? Data(contentsOf: URL(fileURLWithPath: adjustedUri)) {
+                completion(data)
+            } else {
+                completion(nil)
+            }
+        }
+    }
 }

--- a/packages/expo-print/ios/ExpoPrintWithPrinter.swift
+++ b/packages/expo-print/ios/ExpoPrintWithPrinter.swift
@@ -1,176 +1,176 @@
 import ExpoModulesCore
 
 public class ExpoPrintWithPrinter {
-    var renderTasks: [ExpoWKPDFRenderer] = []
-    var cachedPrinters: [String: UIPrinter] = [:]
-    let delegate: ExpoPrintModuleDelegate
-    
-    init(delegate: ExpoPrintModuleDelegate) {
-        self.delegate = delegate
-    }
-    
-    func startPrint(options: PrintOptions, promise: Promise) {
-        if let uri = options.uri {
-            dataFromUri(uri: uri) { [self] data in
-                if let printingData = data {
-                    self.printWithData(printingData: printingData, options: options, promise: promise)
-                } else {
-                    promise.reject(InvalidUrlException())
-                }
-            }
-            return
-        }
-        
-        // Do this for compatibility with deprecated markup formatter option
-        guard let htmlString = options.markupFormatterIOS ?? options.html else {
-            promise.reject(NoPrintDataException())
-            return
-        }
-        
-        if !options.useMarkupFormatter {
-            printFromHtmlWithoutMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+  var renderTasks: [ExpoWKPDFRenderer] = []
+  var cachedPrinters: [String: UIPrinter] = [:]
+  let delegate: ExpoPrintModuleDelegate
+  
+  init(delegate: ExpoPrintModuleDelegate) {
+    self.delegate = delegate
+  }
+  
+  func startPrint(options: PrintOptions, promise: Promise) {
+    if let uri = options.uri {
+      dataFromUri(uri: uri) { [self] data in
+        if let printingData = data {
+          self.printWithData(printingData: printingData, options: options, promise: promise)
         } else {
-            printFromHtmlWithMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+          promise.reject(InvalidUrlException())
         }
+      }
+      return
     }
     
-    private func printFromHtmlWithoutMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
-        let renderTask = ExpoWKPDFRenderer(
-            htmlString: htmlString,
-            pageSize: options.toPageSize(),
-            printableRect: options.toPrintableRect()
-        ) { pdfData, _, error, task in
-            self.renderTasks.removeAll {
-                $0 == task
-            }
-            guard let pdfData = pdfData, error == nil else {
-                promise.reject(PdfNotRenderedException(error?.localizedDescription))
-                return
-            }
-            self.printWithData(printingData: pdfData, options: options, promise: promise)
-        }
-        self.renderTasks.append(renderTask)
-        renderTask.pdfWithHtml()
+    // Do this for compatibility with deprecated markup formatter option
+    guard let htmlString = options.markupFormatterIOS ?? options.html else {
+      promise.reject(NoPrintDataException())
+      return
     }
     
-    private func printFromHtmlWithMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
-        ExpoPrintToFile.pdfWithHtmlMarkupFormatter(
-            htmlString: htmlString,
-            pageSize: options.toPageSize(),
-            printableRect: options.toPrintableRect()
-        ) { pdfData, _, error, task in
-            self.renderTasks.removeAll {
-                $0 == task
-            }
-            if error == nil {
-                self.printWithData(printingData: pdfData, options: options, promise: promise)
-            } else {
-                promise.reject(PdfNotRenderedException(error?.localizedDescription))
-            }
-        }
+    if !options.useMarkupFormatter {
+      printFromHtmlWithoutMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+    } else {
+      printFromHtmlWithMarkupFormatter(htmlString: htmlString, options: options, promise: promise)
+    }
+  }
+  
+  private func printFromHtmlWithoutMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
+    let renderTask = ExpoWKPDFRenderer(
+      htmlString: htmlString,
+      pageSize: options.toPageSize(),
+      printableRect: options.toPrintableRect()
+    ) { pdfData, _, error, task in
+      self.renderTasks.removeAll {
+        $0 == task
+      }
+      guard let pdfData = pdfData, error == nil else {
+        promise.reject(PdfNotRenderedException(error?.localizedDescription))
+        return
+      }
+      self.printWithData(printingData: pdfData, options: options, promise: promise)
+    }
+    self.renderTasks.append(renderTask)
+    renderTask.pdfWithHtml()
+  }
+  
+  private func printFromHtmlWithMarkupFormatter(htmlString: String, options: PrintOptions, promise: Promise) {
+    ExpoPrintToFile.pdfWithHtmlMarkupFormatter(
+      htmlString: htmlString,
+      pageSize: options.toPageSize(),
+      printableRect: options.toPrintableRect()
+    ) { pdfData, _, error, task in
+      self.renderTasks.removeAll {
+        $0 == task
+      }
+      if error == nil {
+        self.printWithData(printingData: pdfData, options: options, promise: promise)
+      } else {
+        promise.reject(PdfNotRenderedException(error?.localizedDescription))
+      }
+    }
+  }
+  
+  private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
+    let printerUrl = options.printerUrl ?? ""
+    let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
+    
+    guard let rootController = UIApplication.shared.keyWindow?.rootViewController else {
+      promise.reject(ViewControllerNotFoundException())
+      return
     }
     
-    private func printWithData(printingData: Data, options: PrintOptions, promise: Promise) {
-        let printerUrl = options.printerUrl ?? ""
-        let candidateUrl = URL(string: printerUrl) ?? URL(fileURLWithPath: printerUrl)
-        
-        guard let rootController = UIApplication.shared.keyWindow?.rootViewController else {
-            promise.reject(ViewControllerNotFoundException())
-            return
-        }
-        
-        let printInteractionController = makePrintInteractionController(options: options)
-        printInteractionController.printingItem = printingData
-        
-        let completionHandler = { (_: UIPrintInteractionController, completed: Bool, error: Error?) in
-            if error != nil {
-                promise.reject(PrintingJobFailedException(error?.localizedDescription))
-            }
-            if completed {
-                promise.resolve()
-            } else {
-                promise.reject(PrintIncompleteException())
-            }
-        }
-        
-        if !printerUrl.isEmpty {
-            // Found by @tsapeta
-            // In older versions of iOS there is a bug, where finding the printer using UIPrinter(url:) will fail
-            // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
-            // the workaround is to use a printer saved during picking, fall back to this method if the regular one fails
-            
-            // Also on ios 16 there is a bug when printing multiple files https://github.com/expo/expo/issues/19399.
-            // Caching the previously used printer fixes the bug
-            let printer = self.cachedPrinters[printerUrl] ?? UIPrinter(url: candidateUrl)
-            self.cachedPrinters[printerUrl] = printer
-            
-            printer.contactPrinter { available in
-                if available {
-                    printInteractionController.print(to: printer, completionHandler: completionHandler)
-                } else {
-                    promise.reject(PrintingJobFailedException("Provided printer is not available."))
-                }
-            }
-        } else if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
-            printInteractionController.present(from: rootController.view.frame, in: rootController.view, animated: true, completionHandler: completionHandler)
+    let printInteractionController = makePrintInteractionController(options: options)
+    printInteractionController.printingItem = printingData
+    
+    let completionHandler = { (_: UIPrintInteractionController, completed: Bool, error: Error?) in
+      if error != nil {
+        promise.reject(PrintingJobFailedException(error?.localizedDescription))
+      }
+      if completed {
+        promise.resolve()
+      } else {
+        promise.reject(PrintIncompleteException())
+      }
+    }
+    
+    if !printerUrl.isEmpty {
+      // Found by @tsapeta
+      // In older versions of iOS there is a bug, where finding the printer using UIPrinter(url:) will fail
+      // https://stackoverflow.com/questions/34602302/creating-a-working-uiprinter-object-from-url-for-dialogue-free-printing
+      // the workaround is to use a printer saved during picking, fall back to this method if the regular one fails
+      
+      // Also on ios 16 there is a bug when printing multiple files https://github.com/expo/expo/issues/19399.
+      // Caching the previously used printer fixes the bug
+      let printer = self.cachedPrinters[printerUrl] ?? UIPrinter(url: candidateUrl)
+      self.cachedPrinters[printerUrl] = printer
+      
+      printer.contactPrinter { available in
+        if available {
+          printInteractionController.print(to: printer, completionHandler: completionHandler)
         } else {
-            printInteractionController.present(animated: true, completionHandler: completionHandler)
+          promise.reject(PrintingJobFailedException("Provided printer is not available."))
         }
+      }
+    } else if UIDevice.current.userInterfaceIdiom == UIUserInterfaceIdiom.pad {
+      printInteractionController.present(from: rootController.view.frame, in: rootController.view, animated: true, completionHandler: completionHandler)
+    } else {
+      printInteractionController.present(animated: true, completionHandler: completionHandler)
     }
+  }
+  
+  private func makePrintInteractionController(options: PrintOptions) -> UIPrintInteractionController {
+    let uri = options.uri ?? ""
+    let printInteractionController = UIPrintInteractionController()
+    printInteractionController.delegate = self.delegate
     
-    private func makePrintInteractionController(options: PrintOptions) -> UIPrintInteractionController {
-        let uri = options.uri ?? ""
-        let printInteractionController = UIPrintInteractionController()
-        printInteractionController.delegate = self.delegate
-        
-        let printInfo = UIPrintInfo.printInfo()
-        printInfo.outputType = UIPrintInfo.OutputType.general
-        if let uri = options.uri {
-            printInfo.jobName = uri.components(separatedBy: "/").last ?? uri
-        }
-        printInfo.duplex = UIPrintInfo.Duplex.longEdge
-        printInfo.orientation = options.toUIPrintInfoOrientation()
-        
-        printInteractionController.printInfo = printInfo
-        printInteractionController.showsNumberOfCopies = true
-        printInteractionController.showsPaperSelectionForLoadedPapers = true
-        
-        return printInteractionController
+    let printInfo = UIPrintInfo.printInfo()
+    printInfo.outputType = UIPrintInfo.OutputType.general
+    if let uri = options.uri {
+      printInfo.jobName = uri.components(separatedBy: "/").last ?? uri
     }
+    printInfo.duplex = UIPrintInfo.Duplex.longEdge
+    printInfo.orientation = options.toUIPrintInfoOrientation()
     
-    private func dataFromUri(uri: String, completion: @escaping (Data?) -> Void) {
-        if uri.hasPrefix("http") {
-            // Handle HTTP URL asynchronously
-            DispatchQueue.global().async {
-                if let url = URL(string: uri), let data = try? Data(contentsOf: url) {
-                    DispatchQueue.main.async {
-                        completion(data)
-                    }
-                } else {
-                    DispatchQueue.main.async {
-                        completion(nil)
-                    }
-                }
-            }
-        } else if uri.hasPrefix("data:") {
-            // Handle base64 encoded data URI
-            if let commaIndex = uri.firstIndex(of: ",") {
-                let base64String = String(uri[uri.index(after: commaIndex)...])
-                if let data = Data(base64Encoded: base64String) {
-                    completion(data)
-                } else {
-                    completion(nil)
-                }
-            }
+    printInteractionController.printInfo = printInfo
+    printInteractionController.showsNumberOfCopies = true
+    printInteractionController.showsPaperSelectionForLoadedPapers = true
+    
+    return printInteractionController
+  }
+  
+  private func dataFromUri(uri: String, completion: @escaping (Data?) -> Void) {
+    if uri.hasPrefix("http") {
+      // Handle HTTP URL asynchronously
+      DispatchQueue.global().async {
+        if let url = URL(string: uri), let data = try? Data(contentsOf: url) {
+          DispatchQueue.main.async {
+            completion(data)
+          }
         } else {
-            // Handle local file path synchronously
-            let adjustedUri = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
-            
-            if let data = try? Data(contentsOf: URL(fileURLWithPath: adjustedUri)) {
-                completion(data)
-            } else {
-                completion(nil)
-            }
+          DispatchQueue.main.async {
+            completion(nil)
+          }
         }
+      }
+    } else if uri.hasPrefix("data:") {
+      // Handle base64 encoded data URI
+      if let commaIndex = uri.firstIndex(of: ",") {
+        let base64String = String(uri[uri.index(after: commaIndex)...])
+        if let data = Data(base64Encoded: base64String) {
+          completion(data)
+        } else {
+          completion(nil)
+        }
+      }
+    } else {
+      // Handle local file path synchronously
+      let adjustedUri = uri.hasPrefix("file://") ? String(uri.dropFirst(7)) : uri
+      
+      if let data = try? Data(contentsOf: URL(fileURLWithPath: adjustedUri)) {
+        completion(data)
+      } else {
+        completion(nil)
+      }
     }
+  }
 }


### PR DESCRIPTION
# Why

I may be wrong, but it seems that the recent [refactoring to Swift](https://github.com/expo/expo/pull/21561) introduced a regression to the `printAsync` function. I could not simply upgrade to `expo-print` 12.3.0 without errors, so I started investigating.

Error and way to reproduce it are described in the issue: https://github.com/expo/expo/issues/22971

Disclaimer: I'm not an expert with Swift and happy for any feedback on this! Nor I am very sure this is really an issue with the code or if I simply missed something else. I used ChatGPT for coding assistance.

# How

I extended the data fetching function to also work with http(s) urls and data strings (base64 encoded).

# Test Plan

Use this snack: https://snack.expo.dev/@maki123/print-usage
It's important to note, that the current Expo Go app will not reproduce the issue, as it's bundled with the "old" EXPrint framework prior to the change that introduced the regression.
Download the snack to a local project and run it. Make sure to use `expo-print` >= 12.3.0

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
