### PR TITLE
[templates] Fix web support for templates

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -10,11 +10,14 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/webpack-config": "18.1.0",
     "expo": "~49.0.0-alpha.1",
     "expo-splash-screen": "~0.19.0",
     "expo-status-bar": "~1.5.0",
     "react": "18.2.0",
-    "react-native": "0.72.0-rc.6"
+    "react-dom": "18.2.0",
+    "react-native": "0.72.0-rc.6",
+    "react-native-web": "~0.18.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -10,10 +10,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/webpack-config": "18.1.0",
     "expo": "~49.0.0-alpha.1",
     "expo-status-bar": "~1.5.0",
     "react": "18.2.0",
-    "react-native": "0.72.0-rc.6"
+    "react-dom": "18.2.0",
+    "react-native": "0.72.0-rc.6",
+    "react-native-web": "~0.18.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -10,10 +10,13 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/webpack-config": "18.1.0",
     "expo": "~49.0.0-alpha.1",
     "expo-status-bar": "~1.5.0",
     "react": "18.2.0",
-    "react-native": "0.72.0-rc.6"
+    "react-dom": "18.2.0",
+    "react-native": "0.72.0-rc.6",
+    "react-native-web": "~0.18.10"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
# Why

Web server for the templates was not working due these missing dependencies: react-native-web, react-dom and @expo/webpack-config

![image](https://github.com/expo/expo/assets/48060426/88f2e5a8-5c38-4c0c-a3c0-82025fb0d327)
  
# How

Add the missing dependencies of react-native-web, react-dom and @expo/webpack-config to the templates that were not working with web dev server

![Screenshot from 2023-06-20 23-35-34](https://github.com/expo/expo/assets/48060426/8ec6b925-888b-4ef8-9654-1019a17c9c53)

# Test Plan
  
Run the following templates on the web:
- expo-template-bare-minimum
- expo-template-blank-typescript
- expo-template-blank

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
