### PR TITLE
[go] Improve onboarding messaging

### DIFF
--- a/home/menu/DevMenuOnboarding.tsx
+++ b/home/menu/DevMenuOnboarding.tsx
@@ -1,60 +1,71 @@
-import { borderRadius } from '@expo/styleguide-native';
-import { View, Text, Button, useExpoTheme, Spacer } from 'expo-dev-client-components';
+import { View, Text, Button, Spacer } from 'expo-dev-client-components';
 import { isDevice } from 'expo-device';
 import React from 'react';
-import { Platform, StyleSheet, TouchableOpacity as TouchableOpacityRN } from 'react-native';
-import { TouchableOpacity as TouchableOpacityGH } from 'react-native-gesture-handler';
+import { Platform, StyleSheet } from 'react-native';
 
 type Props = {
   onClose: () => void;
 };
 
-// When rendered inside bottom sheet, touchables from RN don't work on Android, but the ones from GH don't work on iOS.
-const TouchableOpacity = Platform.OS === 'android' ? TouchableOpacityGH : TouchableOpacityRN;
+const deviceMessage = Platform.select({
+  ios: `You can shake your device or long press anywhere on the screen with three fingers to get back to it at any time.`,
+  android: `You can shake your device to get back to it at any time.`,
+});
 
-const KEYBOARD_CODES: { [key: string]: string } = {
-  ios: '^\u2318Z',
-  android: '\u2318M on macOS or Ctrl+M on other platforms',
-};
-
-const ONBOARDING_MESSAGE = (() => {
-  let fragment;
-  if (isDevice) {
-    if (Platform.OS === 'ios') {
-      fragment =
-        'you can shake your device or long press anywhere on the screen with three fingers';
-    } else {
-      fragment = 'you can shake your device';
-    }
-  } else {
-    fragment = `in a simulator you can press ${KEYBOARD_CODES[Platform.OS]}`;
-  }
-  return `Since this is your first time opening Expo Go, we wanted to show you this menu and let you know that ${fragment} to get back to it at any time.`;
-})();
+const simulatorMessage = Platform.select({
+  ios: (
+    <Text size="medium">
+      You can open it at any time with the <Text weight="bold">{'\u2318 + d '}</Text> keyboard
+      shortcut{' '}
+      <Text color="secondary" size="medium">
+        ("Connect Hardware Keyboard" must be enabled on your simulator to use this shortcut, you can
+        toggle it with{' '}
+        <Text weight="bold" color="secondary" size="medium">
+          {'\u2318 + shift + K'}
+        </Text>
+        ).
+      </Text>
+    </Text>
+  ),
+  android: (
+    <Text size="medium">
+      You can press{' '}
+      <Text size="medium" weight="bold">
+        {'\u2318 + m'}
+      </Text>{' '}
+      on macOS or{' '}
+      <Text size="medium" weight="bold">
+        Ctrl + m
+      </Text>{' '}
+      on other platforms to get back to it at any time.
+    </Text>
+  ),
+});
 
 export function DevMenuOnboarding({ onClose }: Props) {
-  const theme = useExpoTheme();
-
   return (
     <View style={styles.onboardingContainer}>
-      <View style={styles.onboardingBackground} bg="default" />
-      <View style={styles.onboardingTopMargin} />
-      <View>
-        <Text type="InterBold" align="center" size="large">
-          Hello there, friend! 👋
-        </Text>
-        <Spacer.Vertical size="small" />
-        <Text type="InterRegular" align="center" style={styles.onboardingTooltip}>
-          {ONBOARDING_MESSAGE}
-        </Text>
-        <Spacer.Vertical size="medium" />
-        <TouchableOpacity
-          style={[styles.onboardingButton, { backgroundColor: theme.button.primary.background }]}
-          onPress={onClose}>
-          <Button.Text type="InterSemiBold" color="primary">
-            Got it
-          </Button.Text>
-        </TouchableOpacity>
+      <View flex="1" bg="default" py="medium" px="large">
+        <View>
+          <Text size="medium" maxFontSizeMultiplier={1.2}>
+            This is the developer menu. It gives you access to useful tools in your development
+            builds.
+          </Text>
+          <Spacer.Vertical size="medium" />
+          <Text size="medium" maxFontSizeMultiplier={1.2}>
+            {isDevice ? deviceMessage : simulatorMessage}
+          </Text>
+        </View>
+
+        <Spacer.Vertical size="large" />
+
+        <Button.FadeOnPressContainer bg="primary" onPress={onClose}>
+          <View py="small">
+            <Button.Text align="center" size="medium" color="primary" weight="medium">
+              Continue
+            </Button.Text>
+          </View>
+        </Button.FadeOnPressContainer>
       </View>
     </View>
   );
@@ -63,37 +74,11 @@ export function DevMenuOnboarding({ onClose }: Props) {
 const styles = StyleSheet.create({
   onboardingContainer: {
     flex: 1,
-    paddingHorizontal: 36,
     position: 'absolute',
     top: 0,
     right: 0,
     bottom: 0,
     left: 0,
     zIndex: 2,
-  },
-  onboardingBackground: {
-    borderTopLeftRadius: borderRadius.large,
-    borderTopRightRadius: borderRadius.large,
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    left: 0,
-    opacity: 0.9,
-  },
-  onboardingTopMargin: {
-    // Moves the actual onboarding content a little bit down.
-    // This percentage value is also a percentage of screen's height.
-    height: '20%',
-  },
-  onboardingTooltip: {
-    lineHeight: 20,
-    textAlign: 'center',
-  },
-  onboardingButton: {
-    alignItems: 'center',
-    marginVertical: 12,
-    paddingVertical: 12,
-    borderRadius: 4,
   },
 });

--- a/home/menu/DevMenuOnboarding.tsx
+++ b/home/menu/DevMenuOnboarding.tsx
@@ -48,8 +48,7 @@ export function DevMenuOnboarding({ onClose }: Props) {
       <View flex="1" bg="default" py="medium" px="large">
         <View>
           <Text size="medium" maxFontSizeMultiplier={1.2}>
-            This is the developer menu. It gives you access to useful tools in your development
-            builds.
+            This is the developer menu. It gives you access to useful tools in Expo Go.
           </Text>
           <Spacer.Vertical size="medium" />
           <Text size="medium" maxFontSizeMultiplier={1.2}>

--- a/home/menu/DevMenuServerInfo.tsx
+++ b/home/menu/DevMenuServerInfo.tsx
@@ -1,0 +1,44 @@
+import { Row, View, Text, Spacer } from 'expo-dev-client-components';
+import React from 'react';
+import { StyleSheet } from 'react-native';
+
+import DevIndicator from '../components/DevIndicator';
+import FriendlyUrls from '../legacy/FriendlyUrls';
+
+type Props = {
+  task: { [key: string]: any };
+};
+
+export function DevMenuServerInfo({ task }: Props) {
+  const manifest = task.manifestString && JSON.parse(task.manifestString);
+  const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
+  const devServerName =
+    manifest && manifest.extra?.expoGo?.developer ? manifest.extra.expoGo.developer.tool : null;
+
+  return (
+    <View bg="default" padding="medium">
+      {devServerName ? (
+        <>
+          <Text size="small" type="InterRegular">
+            Connected to {devServerName}
+          </Text>
+          <Spacer.Vertical size="tiny" />
+        </>
+      ) : null}
+      <Row align="center">
+        {devServerName ? (
+          <DevIndicator style={styles.taskDevServerIndicator} isActive isNetworkAvailable />
+        ) : null}
+        <Text type="InterRegular" size="medium" numberOfLines={1}>
+          {taskUrl}
+        </Text>
+      </Row>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  taskDevServerIndicator: {
+    marginRight: 8,
+  },
+});

--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -1,24 +1,17 @@
-import { Row, View, Text, Divider, Spacer } from 'expo-dev-client-components';
+import { Row, View, Text } from 'expo-dev-client-components';
 import React from 'react';
 import { Image, StyleSheet } from 'react-native';
-
-import DevIndicator from '../components/DevIndicator';
-import FriendlyUrls from '../legacy/FriendlyUrls';
 
 type Props = {
   task: { [key: string]: any };
 };
 
 export function DevMenuTaskInfo({ task }: Props) {
-  const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
   const manifest = task.manifestString && JSON.parse(task.manifestString);
   const iconUrl = manifest && (manifest.iconUrl ?? manifest.extra?.expoClient?.iconUrl);
   const taskName = manifest && (manifest.name ?? manifest.extra?.expoClient?.name);
   const sdkVersion = manifest && (manifest.sdkVersion ?? manifest.extra?.expoClient?.sdkVersion);
   const runtimeVersion = manifest && manifest.runtimeVersion;
-
-  const devServerName =
-    manifest && manifest.extra?.expoGo?.developer ? manifest.extra.expoGo.developer.tool : null;
 
   return (
     <View>
@@ -49,25 +42,6 @@ export function DevMenuTaskInfo({ task }: Props) {
           )}
         </View>
       </Row>
-      <Divider />
-      <View bg="default" padding="medium">
-        {devServerName ? (
-          <>
-            <Text size="small" type="InterRegular">
-              Connected to {devServerName}
-            </Text>
-            <Spacer.Vertical size="tiny" />
-          </>
-        ) : null}
-        <Row align="center">
-          {devServerName ? (
-            <DevIndicator style={styles.taskDevServerIndicator} isActive isNetworkAvailable />
-          ) : null}
-          <Text type="InterRegular" size="medium" numberOfLines={1}>
-            {taskUrl}
-          </Text>
-        </Row>
-      </View>
     </View>
   );
 }
@@ -80,8 +54,5 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignSelf: 'center',
     backgroundColor: 'transparent',
-  },
-  taskDevServerIndicator: {
-    marginRight: 8,
   },
 });

--- a/home/menu/DevMenuView.tsx
+++ b/home/menu/DevMenuView.tsx
@@ -12,6 +12,7 @@ import { DevMenuCloseButton } from './DevMenuCloseButton';
 import { DevMenuItem } from './DevMenuItem';
 import * as DevMenu from './DevMenuModule';
 import { DevMenuOnboarding } from './DevMenuOnboarding';
+import { DevMenuServerInfo } from './DevMenuServerInfo';
 import { DevMenuTaskInfo } from './DevMenuTaskInfo';
 
 type Props = {
@@ -158,58 +159,62 @@ export function DevMenuView({ uuid, task }: Props) {
 
   return (
     <View bg="secondary" flex="1" roundedTop="large" overflow="hidden" style={{ direction: 'ltr' }}>
-      {!isOnboardingFinished && <DevMenuOnboarding onClose={onOnboardingFinished} />}
       <DevMenuTaskInfo task={task} />
       <Divider />
-      <Row align="center" padding="medium">
-        <DevMenuButton
-          buttonKey="reload"
-          label="Reload"
-          onPress={onAppReload}
-          icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
-        />
-        <Spacer.Horizontal size="medium" />
-        {task && task.manifestUrl && (
-          <>
-            <DevMenuButton
-              buttonKey="copy"
-              label="Copy Link"
-              onPress={onCopyTaskUrl}
-              icon={<ClipboardIcon size={iconSize.regular} color={theme.icon.default} />}
-            />
-            <Spacer.Horizontal size="medium" />
-          </>
-        )}
-        <DevMenuButton
-          buttonKey="home"
-          label="Go Home"
-          onPress={onGoToHome}
-          icon={<HomeFilledIcon size={iconSize.regular} color={theme.icon.default} />}
-        />
-      </Row>
-      {enableDevMenuTools && devMenuItems && (
-        <View padding="medium" style={{ paddingTop: 0 }}>
-          <View bg="default" rounded="large">
-            {sortedDevMenuItems.map((key, i) => {
-              const item = devMenuItems[key];
+      <View>
+        {!isOnboardingFinished && <DevMenuOnboarding onClose={onOnboardingFinished} />}
+        <DevMenuServerInfo task={task} />
+        <Divider />
+        <Row align="center" padding="medium">
+          <DevMenuButton
+            buttonKey="reload"
+            label="Reload"
+            onPress={onAppReload}
+            icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
+          />
+          <Spacer.Horizontal size="medium" />
+          {task && task.manifestUrl && (
+            <>
+              <DevMenuButton
+                buttonKey="copy"
+                label="Copy Link"
+                onPress={onCopyTaskUrl}
+                icon={<ClipboardIcon size={iconSize.regular} color={theme.icon.default} />}
+              />
+              <Spacer.Horizontal size="medium" />
+            </>
+          )}
+          <DevMenuButton
+            buttonKey="home"
+            label="Go Home"
+            onPress={onGoToHome}
+            icon={<HomeFilledIcon size={iconSize.regular} color={theme.icon.default} />}
+          />
+        </Row>
+        {enableDevMenuTools && devMenuItems && (
+          <View padding="medium" style={{ paddingTop: 0 }}>
+            <View bg="default" rounded="large">
+              {sortedDevMenuItems.map((key, i) => {
+                const item = devMenuItems[key];
 
-              const { label, isEnabled } = item;
-              return (
-                <Fragment key={key}>
-                  <DevMenuItem
-                    buttonKey={key}
-                    label={label}
-                    onPress={onPressDevMenuButton}
-                    icon={MENU_ITEMS_ICON_MAPPINGS[key]}
-                    isEnabled={isEnabled}
-                  />
-                  {i < sortedDevMenuItems.length - 1 && <Divider />}
-                </Fragment>
-              );
-            })}
+                const { label, isEnabled } = item;
+                return (
+                  <Fragment key={key}>
+                    <DevMenuItem
+                      buttonKey={key}
+                      label={label}
+                      onPress={onPressDevMenuButton}
+                      icon={MENU_ITEMS_ICON_MAPPINGS[key]}
+                      isEnabled={isEnabled}
+                    />
+                    {i < sortedDevMenuItems.length - 1 && <Divider />}
+                  </Fragment>
+                );
+              })}
+            </View>
           </View>
-        </View>
-      )}
+        )}
+      </View>
       <DevMenuCloseButton onPress={collapseAndCloseDevMenuAsync} />
     </View>
   );


### PR DESCRIPTION
# Why

Follow up PR of https://github.com/expo/expo/pull/22712

# How

Update `home` DevMenu onboarding to look just like the new dev-client onboarding 

# Test Plan

Run Expo Go unversioned on Android and iOS  

<table>
  <thead>
    <tr>
      <th></th>
      <th>Android</th>
      <th>iOS</th> 
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>Simulator</th>
      <td><img width="417" alt="image" src="https://github.com/expo/expo/assets/11707729/6b9e0179-2051-4997-9320-aeb79f229182"></td> 
      <td><img width="417" alt="image" src="https://github.com/expo/expo/assets/11707729/3a97f47e-9680-477b-90b2-8f5f9ba363d3"></td>
    </tr>
    <tr>
      <th>Real Device</th>
      <td><img width="417" alt="image" src="https://github.com/expo/expo/assets/11707729/ec9c9cdb-24fa-473c-996e-dccd812b68ed"></td>
      <td><img width="417" alt="image" src="https://github.com/expo/expo/assets/11707729/7f12e156-cf3d-4b10-a6bd-242ef78b7fb2"></td> 
    </tr>
  </tbody>
</table>






# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
