### PR TITLE
[docs] Fix firebase storage example link and known issue section position in ImagePicker

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -18,6 +18,7 @@ import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -28,6 +29,10 @@ import { GithubIcon } from '@expo/styleguide-icons';
 ## Installation
 
 <APIInstallSection />
+
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
+
+On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
 ## Configuration in app.json/app.config.js
 
@@ -192,7 +197,3 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
-
-## Known issue
-
-There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -148,7 +148,7 @@ See [Amplify documentation](https://docs.amplify.aws/) guide to set up your proj
   title="Firebase storage example"
   description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
   Icon={GithubIcon}
-  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+  href="https://github.com/expo/examples/tree/master/with-firebase-storage-upload"
 />
 
 See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.

--- a/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/imagepicker.mdx
@@ -18,6 +18,7 @@ import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -28,6 +29,10 @@ import { GithubIcon } from '@expo/styleguide-icons';
 ## Installation
 
 <APIInstallSection />
+
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
+
+On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
 ## Configuration in app.json/app.config.js
 
@@ -180,7 +185,3 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
-
-## Known issue
-
-There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -18,6 +18,7 @@ import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -28,6 +29,10 @@ import { GithubIcon } from '@expo/styleguide-icons';
 ## Installation
 
 <APIInstallSection />
+
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
+
+On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
 ## Configuration in app.json/app.config.js
 
@@ -192,7 +197,3 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
-
-## Known issue
-
-There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/imagepicker.mdx
@@ -160,7 +160,7 @@ See [Amplify documentation](https://docs.amplify.aws/) guide to set up your proj
   title="Firebase storage example"
   description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
   Icon={GithubIcon}
-  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+  href="https://github.com/expo/examples/tree/master/with-firebase-storage-upload"
 />
 
 See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.

--- a/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
@@ -18,6 +18,7 @@ import Video from '~/components/plugins/Video';
 import { SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { GithubIcon } from '@expo/styleguide-icons';
+import { PlatformTags } from '~/ui/components/Tag';
 
 **`expo-image-picker`** provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 
@@ -28,6 +29,10 @@ import { GithubIcon } from '@expo/styleguide-icons';
 ## Installation
 
 <APIInstallSection />
+
+#### Known issues&ensp;<PlatformTags platforms={['ios']} />
+
+On iOS, when an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is with the underlying `UIImagePickerController` due to a bug in the closed-source tools built into iOS.
 
 ## Configuration in app.json/app.config.js
 
@@ -192,7 +197,3 @@ The following usage description keys are used by the APIs in this library.
     'NSCameraUsageDescription',
   ]}
 />
-
-## Known issue
-
-There is a known issue on iOS with the underlying `UIImagePickerController`. When an image (usually of a [higher resolution](http://www.openradar.me/49866214)) is picked from the camera roll, the result of the cropped image gives the wrong value for the cropped rectangle in some cases. Unfortunately, this issue is due to a bug in the closed source tools built into iOS.

--- a/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/imagepicker.mdx
@@ -160,7 +160,7 @@ See [Amplify documentation](https://docs.amplify.aws/) guide to set up your proj
   title="Firebase storage example"
   description="An example of how to use Firebase storage can be found in with-firebase-storage-upload."
   Icon={GithubIcon}
-  href="https://github.com/expo/examples/tree/master/with-aws-storage-upload"
+  href="https://github.com/expo/examples/tree/master/with-firebase-storage-upload"
 />
 
 See [Using Firebase](/guides/using-firebase/) guide to set up your project correctly.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Follow up PR for #22990
- Known issues section on this page is placed as the last section. In other SDK docs, it is placed at the top under installation (example, BackgroundFetch).

# How

- By backporting changes to SDK 48, 47, & 46.
- Fix position of the Known issues section to be consistent with other SDK docs. Backport this change to `unversioned`, and other existing SDKs. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally.

**Preview**

<img width="876" alt="CleanShot 2023-06-21 at 16 42 25@2x" src="https://github.com/expo/expo/assets/10234615/bac33563-905f-4d31-868f-69a815dae2e6">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
