### PR TITLE
[docs] more eas update sidebar renames

### DIFF
--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using GitHub Actions
+title: Use GitHub Actions
 description: Learn how to use GitHub Actions to automate publishing updates with EAS Update.
 ---
 

--- a/docs/pages/eas-update/how-eas-update-works.mdx
+++ b/docs/pages/eas-update/how-eas-update-works.mdx
@@ -1,5 +1,6 @@
 ---
 title: How EAS Update works
+sidebar_title: How it works
 description: A conceptual overview of how EAS Update works.
 ---
 


### PR DESCRIPTION
# Why

Some renaming I missed from https://github.com/expo/expo/pull/22978 , based on the conventions we've established

# How

- `Using GitHub Actions` -> `Use GitHub Actions`. We prefer short form verbs
- `sidebar_title: How it works`. The article is already under the `EAS Update` section, so the subject is already known. Replace with `it` to improve readability

# Test Plan

Manually tested:
![Screenshot 2023-06-21 at 1 10 39 PM](https://github.com/expo/expo/assets/6380927/e73368f3-0f21-424b-9d52-9540f595cf8a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
