### PR TITLE
[docs] Use short form verb for page titles in Guides section

### DIFF
--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -1,5 +1,5 @@
 ---
-title: Working Together
+title: Work Together
 ---
 
 You can grant other users access to the projects belonging to your Personal Account or Organizations. The type of access depends on the granted role.

--- a/docs/pages/app-signing/existing-credentials.mdx
+++ b/docs/pages/app-signing/existing-credentials.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using existing credentials
+title: Use existing credentials
 description: Learn about different options for supplying your app signing credentials to EAS Build.
 ---
 

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using local credentials
+title: Use local credentials
 description: Learn how to configure and use local credentials when using EAS.
 ---
 
@@ -40,21 +40,22 @@ If you opt-in to local credentials configuration, you'll need to create a **cred
 
 If you want to build an Android app binary you'll need to have a keystore. If you don't have a release keystore yet, you can generate it on your own using the following command (replace `KEYSTORE_PASSWORD`, `KEY_PASSWORD`, `KEY_ALIAS` and `com.expo.your.android.package` with the values of your choice):
 
-
-<Terminal cmd={[
-  '$ keytool \\',
-  '  -genkey -v \\',
-  '  -storetype JKS \\',
-  '  -keyalg RSA \\',
-  '  -keysize 2048 \\',
-  '  -validity 10000 \\',
-  '  -storepass KEYSTORE_PASSWORD \\',
-  '  -keypass KEY_PASSWORD \\',
-  '  -alias KEY_ALIAS \\',
-  '  -keystore release.keystore \\',
-  '  -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"',
-]}
-cmdCopy='keytool -genkey -v -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -storepass KEYSTORE_PASSWORD -keypass KEY_PASSWORD -alias KEY_ALIAS -keystore release.keystore -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"'/>
+<Terminal
+  cmd={[
+    '$ keytool \\',
+    '  -genkey -v \\',
+    '  -storetype JKS \\',
+    '  -keyalg RSA \\',
+    '  -keysize 2048 \\',
+    '  -validity 10000 \\',
+    '  -storepass KEYSTORE_PASSWORD \\',
+    '  -keypass KEY_PASSWORD \\',
+    '  -alias KEY_ALIAS \\',
+    '  -keystore release.keystore \\',
+    '  -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"',
+  ]}
+  cmdCopy='keytool -genkey -v -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -storepass KEYSTORE_PASSWORD -keypass KEY_PASSWORD -alias KEY_ALIAS -keystore release.keystore -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"'
+/>
 
 Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the `android/keystores` directory. **Remember to git-ignore all your release keystores!** If you've run the above keytool command and placed the keystore at `android/keystores/release.keystore`, you can ignore that file by adding the following line to `.gitignore`:
 
@@ -75,7 +76,8 @@ Create **credentials.json** and configure it with the credentials:
     }
   },
   "ios": {
-    /* @hide ... */ /* @end */
+    /* @hide ... */
+    /* @end */
   }
 }
 ```
@@ -104,7 +106,8 @@ Create (or edit) **credentials.json** and configure it with the credentials:
 ```json credentials.json
 {
   "android": {
-    /* @hide ... */ /* @end */
+    /* @hide ... */
+    /* @end */
   },
   "ios": {
     "provisioningProfilePath": "ios/certs/profile.mobileprovision",

--- a/docs/pages/app-signing/managed-credentials.mdx
+++ b/docs/pages/app-signing/managed-credentials.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using automatically managed credentials
+title: Use automatically managed credentials
 description: Learn how to automatically manage your app credentials with EAS.
 ---
 

--- a/docs/pages/app-signing/syncing-credentials.mdx
+++ b/docs/pages/app-signing/syncing-credentials.mdx
@@ -1,5 +1,5 @@
 ---
-title: Syncing credentials between remote and local sources
+title: Sync credentials between remote and local sources
 description: Learn how to sync credentials between remote and local sources.
 ---
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Expo CLI
+title: Use Expo CLI
 description: Learn how and why you can use Expo CLI instead of @react-native-community/cli in any React Native project.
 ---
 
@@ -93,7 +93,11 @@ With the `expo` package installed and configured in your project, you can start 
 />
 <BoxLink
   title="Adopting Prebuild"
-  description={<>Automate your native directories using the <DEMI>app.json</DEMI>.</>}
+  description={
+    <>
+      Automate your native directories using the <DEMI>app.json</DEMI>.
+    </>
+  }
   href="/guides/adopting-prebuild"
 />
 <BoxLink

--- a/docs/pages/build-reference/build-with-monorepos.mdx
+++ b/docs/pages/build-reference/build-with-monorepos.mdx
@@ -1,5 +1,5 @@
 ---
-title: Setting up EAS Build with a monorepo
+title: Set up EAS Build with a monorepo
 hideTOC: true
 description: Learn how to set up EAS Build with a monorepo.
 ---

--- a/docs/pages/build-reference/caching.mdx
+++ b/docs/pages/build-reference/caching.mdx
@@ -1,5 +1,5 @@
 ---
-title: Caching dependencies
+title: Cache dependencies
 description: Learn how to speed up your builds by caching dependencies.
 ---
 

--- a/docs/pages/build-reference/e2e-tests.mdx
+++ b/docs/pages/build-reference/e2e-tests.mdx
@@ -1,6 +1,6 @@
 ---
-title: Running E2E tests on EAS Build
-sidebar_title: Running E2E tests
+title: Run E2E tests on EAS Build
+sidebar_title: Run E2E tests
 description: Learn how to set up and run E2E tests on EAS Build with popular libraries such as Detox.
 ---
 

--- a/docs/pages/build-reference/git-submodules.mdx
+++ b/docs/pages/build-reference/git-submodules.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Git Submodules
+title: Use Git Submodules
 description: Learn how to configure EAS Build to use git submodules.
 ---
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -1,5 +1,5 @@
 ---
-title: Running builds on your own infrastructure
+title: Run builds on your own infrastructure
 description: Learn how to run EAS Build on your own custom infrastructure.
 ---
 
@@ -7,7 +7,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that we run on the EAS Build servers directly on your machine with the `--local` flag.
 
-<Terminal cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']} />
+<Terminal
+  cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
+/>
 
 > Note: if you use [Continuous Native Generation](/workflow/continuous-native-generation.mdx), you can run [prebuild](/workflow/prebuild.mdx) to generate your **android** and **ios** directories and then proceed open the projects in the respective IDEs and build them just like any native project. It's not necessary to run `eas build --local`, but it handles more of the build process for you — see ["Use cases for local builds"](#use-cases-for-local-builds).
 

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -1,5 +1,5 @@
 ---
-title: Migrating from "expo build"
+title: Migrate from "expo build"
 description: A reference for migrating from "expo build" (classic builds) to EAS Build.
 ---
 

--- a/docs/pages/build-reference/npm-cache-with-yarn.mdx
+++ b/docs/pages/build-reference/npm-cache-with-yarn.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using npm cache with Yarn Classic
+title: Use npm cache with Yarn Classic
 hideTOC: true
 description: Learn how to use npm cache by overriding the registry in Yarn Classic.
 ---

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using private npm packages
+title: Use private npm packages
 description: Learn how to configure EAS Build to use private npm packages.
 ---
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting build errors and crashes
+title: Troubleshoot build errors and crashes
 description: A reference for troubleshooting build errors and crashes when using EAS Build.
 ---
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -1,5 +1,5 @@
 ---
-title: Installing app variants on the same device
+title: Install app variants on the same device
 maxHeadingDepth: 4
 description: Learn how to install multiple instances of an app on the same device.
 ---

--- a/docs/pages/build/automating-submissions.mdx
+++ b/docs/pages/build/automating-submissions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Automating submissions
+title: Automate submissions
 description: Learn how to enable automatic submissions with EAS Build.
 ---
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -1,5 +1,5 @@
 ---
-title: Triggering builds from CI
+title: Trigger builds from CI
 description: Learn how to trigger builds on EAS for your app from a CI environment such as GitHub Action and more.
 ---
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -1,5 +1,5 @@
 ---
-title: Creating your first build
+title: Create your first build
 description: Learn how to create a build for your app with EAS Build.
 ---
 

--- a/docs/pages/build/updates.mdx
+++ b/docs/pages/build/updates.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using EAS Update
+title: Use EAS Update
 description: Learn how to use EAS Update with EAS Build.
 ---
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Getting started
+title: Get started
 description: Learn how to get started with EAS Update and use it in your project.
 ---
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
-title: Getting started with EAS Metadata
-sidebar_title: Getting started
+title: Get started with EAS Metadata
+sidebar_title: Get started
 description: Learn how to automate and maintain your app store presence from the command line with EAS Metadata.
 ---
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -1,5 +1,5 @@
 ---
-title: Adopting Prebuild
+title: Adopt Prebuild
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -1,6 +1,6 @@
 ---
 title: Metro bundler
-sidebar_title: Bundling with Metro
+sidebar_title: Bundle with Metro
 maxHeadingDepth: 4
 description: Learn about different Metro bundler configurations that can be customized.
 ---

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -1,5 +1,5 @@
 ---
-title: Bundling with webpack
+title: Bundle with webpack
 description: Learn about different webpack bundler configurations that can be customized.
 ---
 

--- a/docs/pages/guides/delaying-code.mdx
+++ b/docs/pages/guides/delaying-code.mdx
@@ -1,6 +1,6 @@
 ---
-title: Delaying your code to run later
-sidebar_title: Delaying your code
+title: Delay your code to run later
+sidebar_title: Delay your code
 description: Learn about different techniques to delay running the code when the app is in the foreground or the background.
 ---
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication with Facebook and AuthSession API
-sidebar_title: Using Facebook authentication
+sidebar_title: Use Facebook authentication
 description: A guide on setting up and using Facebook authentication with AuthSession API in your Expo app.
 ---
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication with Google and AuthSession API
-sidebar_title: Using Google authentication
+sidebar_title: Use Google authentication
 description: A guide on setting up and using Google authentication with AuthSession API in your Expo app.
 ---
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -1,5 +1,5 @@
 ---
-title: Working with monorepos
+title: Work with monorepos
 description: Learn about setting up Expo projects in a monorepo with Yarn v1 workspaces.
 ---
 

--- a/docs/pages/guides/sharing-preview-releases.mdx
+++ b/docs/pages/guides/sharing-preview-releases.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sharing pre-release versions of your app
-sidebar_title: Sharing preview releases
+title: Share pre-release versions of your app
+sidebar_title: Share preview releases
 ---
 
 import Video from '~/components/plugins/Video';

--- a/docs/pages/guides/troubleshooting-proxies.mdx
+++ b/docs/pages/guides/troubleshooting-proxies.mdx
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting proxies
+title: Troubleshoot proxies
 description: Learn about troubleshooting proxies with a set of recommended tools.
 ---
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -76,7 +76,8 @@ The easiest way to get started is to initialize your new project using a TypeScr
 
 When you create new source files in your project you should use the **.ts** extension or the **.tsx** if the file includes React components.
 
-{/\*
+{/* prettier-ignore */}
+{/*
 
 ## Path Aliases
 
@@ -165,7 +166,7 @@ The base directory can be modified in the **tsconfig.json** (or **jsconfig.json*
 
 [baseurl]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url
 
-\*/}
+*/}
 
 ## TypeScript for config files
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using TypeScript
+title: Use TypeScript
 description: An in-depth guide on configuring an Expo project with TypeScript.
 ---
 
@@ -76,7 +76,7 @@ The easiest way to get started is to initialize your new project using a TypeScr
 
 When you create new source files in your project you should use the **.ts** extension or the **.tsx** if the file includes React components.
 
-{/*
+{/\*
 
 ## Path Aliases
 
@@ -165,7 +165,7 @@ The base directory can be modified in the **tsconfig.json** (or **jsconfig.json*
 
 [baseurl]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url
 
-*/}
+\*/}
 
 ## TypeScript for config files
 

--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Analytics
+title: Use Analytics
 description: An overview of analytics services available in the Expo and React Native ecosystem.
 ---
 

--- a/docs/pages/guides/using-bugsnag.mdx
+++ b/docs/pages/guides/using-bugsnag.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Bugsnag
+title: Use Bugsnag
 description: A guide on installing and configuring Bugsnag for end-to-end error reporting and analytics.
 ---
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Firebase
+title: Use Firebase
 maxHeadingDepth: 4
 description: A guide on getting started and using Firebase JS SDK and React Native Firebase library.
 ---

--- a/docs/pages/guides/using-flipper.mdx
+++ b/docs/pages/guides/using-flipper.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Flipper
+title: Use Flipper
 description: A guide on installing and configuring Flipper for debugging an Expo project.
 ---
 

--- a/docs/pages/guides/using-graphql.mdx
+++ b/docs/pages/guides/using-graphql.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using GraphQL
+title: Use GraphQL
 description: An overview of using GraphQL in an Expo project.
 ---
 
@@ -142,6 +142,7 @@ Learn how to build a GraphQL server, check out this [tutorial](https://www.howto
 ## Next steps and resources
 
 **GraphQL server basics** &mdash; check out this tutorial series about GraphQL servers:
-  - [GraphQL Server Basics (Part 1): The Schema](https://www.prisma.io/blog/graphql-server-basics-the-schema-ac5e2950214e)
-  - [GraphQL Server Basics (Part 2): The Network Layer](https://www.prisma.io/blog/graphql-server-basics-the-network-layer-51d97d21861)
-  - [GraphQL Server Basics (Part 3): Demystifying the info Argument in GraphQL Resolvers](https://www.prisma.io/blog/graphql-server-basics-demystifying-the-info-argument-in-graphql-resolvers-6f26249f613a)
+
+- [GraphQL Server Basics (Part 1): The Schema](https://www.prisma.io/blog/graphql-server-basics-the-schema-ac5e2950214e)
+- [GraphQL Server Basics (Part 2): The Network Layer](https://www.prisma.io/blog/graphql-server-basics-the-network-layer-51d97d21861)
+- [GraphQL Server Basics (Part 3): Demystifying the info Argument in GraphQL Resolvers](https://www.prisma.io/blog/graphql-server-basics-demystifying-the-info-argument-in-graphql-resolvers-6f26249f613a)

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -1,6 +1,6 @@
 ---
-title: Using Hermes Engine
-sidebar_title: Using Hermes
+title: Use Hermes Engine
+sidebar_title: Use Hermes
 description: A guide on configuring Hermes for both Android and iOS in an Expo project.
 ---
 

--- a/docs/pages/guides/using-nextjs.mdx
+++ b/docs/pages/guides/using-nextjs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Using Next.js with Expo for Web
-sidebar_title: Using Next.js
+title: Use Next.js with Expo for Web
+sidebar_title: Use Next.js
 description: A guide for integrating Next.js with Expo for the web.
 ---
 
@@ -19,7 +19,7 @@ Using Expo with Next.js means you can share some of your existing components and
 
 To get started, create a new project with [the template](https://github.com/expo/examples/tree/master/with-nextjs):
 
-<Terminal cmd={["$ npx create-expo-app -e with-nextjs"]} />
+<Terminal cmd={['$ npx create-expo-app -e with-nextjs']} />
 
 - **Native**: `npx expo start` -- start the Expo project
 - **Web**: `npx next dev` -- start the Next.js project
@@ -30,7 +30,7 @@ To get started, create a new project with [the template](https://github.com/expo
 
 Ensure you have `expo`, `next`, `@expo/next-adapter` installed in your project:
 
-<Terminal cmd={["$ yarn add expo next @expo/next-adapter"]} />
+<Terminal cmd={['$ yarn add expo next @expo/next-adapter']} />
 
 ### Transpilation
 

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Sentry
+title: Use Sentry
 maxHeadingDepth: 4
 description: A guide on installing and configuring Sentry for crash reporting.
 ---

--- a/docs/pages/guides/using-styled-components.mdx
+++ b/docs/pages/guides/using-styled-components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Styled Components
+title: Use Styled Components
 description: A guide for using Styled Components with Expo.
 ---
 

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -1,5 +1,5 @@
 ---
-title: Integrating in an existing library
+title: Integrate in an existing library
 description: Learn how to integrate Expo Modules API into an existing React Native library.
 ---
 

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -1,6 +1,6 @@
 ---
-title: Submitting to the Google Play Store
-sidebar_title: Submitting to Google
+title: Submit to the Google Play Store
+sidebar_title: Submit to Google
 description: Learn how to submit your app to the Google Play Store from your computer and CI.
 ---
 

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -1,6 +1,6 @@
 ---
-title: Submitting to the Apple App Store
-sidebar_title: Submitting to Apple
+title: Submit to the Apple App Store
+sidebar_title: Submit to Apple
 description: Learn how to submit your app to the Apple App Store from your computer and CI.
 ---
 


### PR DESCRIPTION
# Why

Use short form verbs across the rest of our doc titles and sidebar titles, where it makes sense. This makes our navbar more readable and consistent. 

# UX
Before:
![Screenshot 2023-06-21 at 2 35 12 PM](https://github.com/expo/expo/assets/6380927/462338b9-b7d6-47a1-831f-0c6db65e26d2)

After:
![Screenshot 2023-06-21 at 2 34 55 PM](https://github.com/expo/expo/assets/6380927/f8398616-ffdb-4388-9d9c-54ef635bdb7c)



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
