### PR TITLE
[docs] configuration -> configure

### DIFF
--- a/docs/pages/build/eas-json.mdx
+++ b/docs/pages/build/eas-json.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configuring EAS Build with eas.json
-sidebar_title: Configuration with eas.json
+title: Configure EAS Build with eas.json
+sidebar_title: Configure with eas.json
 description: Learn how a project using EAS services is configured with eas.json.
 ---
 

--- a/docs/pages/submit/eas-json.mdx
+++ b/docs/pages/submit/eas-json.mdx
@@ -1,6 +1,6 @@
 ---
-title: Configuring EAS Submit with eas.json
-sidebar_title: Configuration with eas.json
+title: Configure EAS Submit with eas.json
+sidebar_title: Configure with eas.json
 description: Learn how to configure your project for EAS Submit with eas.json.
 ---
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: Configuration with app.json/app.config.js
+title: Configure with app.json/app.config.js
 description: Learn about what is app config and how you can dynamically use it by customizing it.
 ---
 


### PR DESCRIPTION
# Why

Another small optimization to make navbar more readable. If a title or `sidebar_title` uses 'Configuration' or `Configuring`, change to `Configure` where it makes sense. 

This is good because:
- We have quite a few sidebar titles like `Configuration with app.json`. When we change it to `Configure with app.json`, it retains the same meaning but is shorter. This gives us a better UX.  

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
