### PR TITLE
Update react-native-view-shot to 3.7.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/RNViewShotModule.java
@@ -23,6 +23,8 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import host.exp.exponent.utils.ScopedContext;
 import versioned.host.exp.exponent.modules.api.viewshot.ViewShot.Formats;
@@ -34,6 +36,8 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
 
     private final ReactApplicationContext reactContext;
     private final ScopedContext mScopedContext;
+
+    private final Executor executor = Executors.newCachedThreadPool();
 
     public RNViewShotModule(ReactApplicationContext reactContext, ScopedContext scopedContext) {
         super(reactContext);
@@ -103,7 +107,7 @@ public class RNViewShotModule extends ReactContextBaseJavaModule {
             uiManager.addUIBlock(new ViewShot(
                     tag, extension, imageFormat, quality,
                     scaleWidth, scaleHeight, outputFile, resultStreamFormat,
-                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise)
+                    snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise, executor)
             );
         } catch (final Throwable ex) {
             Log.e(RNVIEW_SHOT, "Failed to snapshot view tag " + tag, ex);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/ViewShot.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/viewshot/ViewShot.java
@@ -14,9 +14,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringDef;
 
-import android.os.Build;
-import android.os.Handler;
-import android.os.HandlerThread;
 import android.os.Looper;
 import android.util.Base64;
 import android.util.Log;
@@ -27,7 +24,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ScrollView;
 
-import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.NativeViewHierarchyManager;
@@ -49,6 +45,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.Deflater;
 
@@ -59,7 +57,7 @@ import static android.view.View.VISIBLE;
 /**
  * Snapshot utility class allow to screenshot a view.
  */
-public class ViewShot implements UIBlock, LifecycleEventListener {
+public class ViewShot implements UIBlock {
     //region Constants
     /**
      * Tag fort Class logs.
@@ -81,30 +79,6 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
      * Wait timeout for surface view capture.
      */
     private static final int SURFACE_VIEW_READ_PIXELS_TIMEOUT = 5;
-
-    private HandlerThread mBgThread;
-    private Handler mBgHandler;
-
-    @Override
-    public void onHostResume() {
-
-    }
-
-    @Override
-    public void onHostPause() {
-
-    }
-
-    @Override
-    public void onHostDestroy() {
-        this.reactContext.removeLifecycleEventListener(this);
-        mBgHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                cleanup();
-            }
-        });
-    }
 
     @SuppressWarnings("WeakerAccess")
     @IntDef({Formats.JPEG, Formats.PNG, Formats.WEBP, Formats.RAW})
@@ -169,6 +143,7 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
     private final ReactApplicationContext reactContext;
     private final boolean handleGLSurfaceView;
     private final Activity currentActivity;
+    private final Executor executor;
     //endregion
 
     //region Constructors
@@ -186,7 +161,8 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
             final ReactApplicationContext reactContext,
             final Activity currentActivity,
             final boolean handleGLSurfaceView,
-            final Promise promise) {
+            final Promise promise,
+            final Executor executor) {
         this.tag = tag;
         this.extension = extension;
         this.format = format;
@@ -200,32 +176,14 @@ public class ViewShot implements UIBlock, LifecycleEventListener {
         this.currentActivity = currentActivity;
         this.handleGLSurfaceView = handleGLSurfaceView;
         this.promise = promise;
-
-        reactContext.addLifecycleEventListener(this);
-
-        // bg hanadler for non UI heavy work
-        mBgThread = new HandlerThread("RNViewShot-Handler-Thread");
-        mBgThread.start();
-        mBgHandler = new Handler(mBgThread.getLooper());
+        this.executor = executor;
     }
     //endregion
-
-    private void cleanup() {
-        if (mBgThread != null) {
-            if (Build.VERSION.SDK_INT < 18) {
-                mBgThread.quit();
-            } else {
-                mBgThread.quitSafely();
-            }
-
-            mBgThread = null;
-        }
-    }
 
     //region Overrides
     @Override
     public void execute(final NativeViewHierarchyManager nativeViewHierarchyManager) {
-        mBgHandler.post(new Runnable() {
+        executor.execute(new Runnable () {
             @Override
             public void run() {
                 try {

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -686,7 +686,7 @@ PODS:
     - React-Core
   - react-native-slider (4.4.2):
     - React-Core
-  - react-native-view-shot (3.6.0):
+  - react-native-view-shot (3.7.0):
     - React-Core
   - react-native-webview (13.2.2):
     - React-Core
@@ -1482,7 +1482,7 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
-  react-native-view-shot: 705f999ac2a24e4e6c909c0ca65c732ed33ca2ff
+  react-native-view-shot: f5507655f122e6b104888a11130f267a427f0d57
   react-native-webview: b8ec89966713985111a14d6e4bf98d8b54bced0d
   React-NativeModulesApple: 038cd625999ff352fc13d11fd335ea7509794599
   React-perflogger: 684a11499a0589cc42135d6d5cc04d0e4e0e261a

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -88,7 +88,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.9.0",
-    "react-native-view-shot": "3.6.0",
+    "react-native-view-shot": "3.7.0",
     "react-native-webview": "13.2.2",
     "test-suite": "*"
   },

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-shared-element": "0.8.8",
     "react-native-svg": "13.9.0",
-    "react-native-view-shot": "3.6.0",
+    "react-native-view-shot": "3.7.0",
     "react-native-web": "~0.18.10",
     "react-native-webview": "13.2.2",
     "react-navigation": "^4.4.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-native-safe-area-context": "4.6.3",
   "react-native-shared-element": "0.8.8",
   "react-native-svg": "13.9.0",
-  "react-native-view-shot": "3.6.0",
+  "react-native-view-shot": "3.7.0",
   "react-native-webview": "13.2.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5811,6 +5811,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -7392,6 +7397,13 @@ css-in-js-utils@^2.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@~3.6.0:
   version "3.6.0"
@@ -10620,6 +10632,14 @@ html-webpack-plugin@~4.3.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlparser2@^4.1.0:
   version "4.1.0"
@@ -15951,10 +15971,12 @@ react-native-svg@13.9.0:
     css-select "^5.1.0"
     css-tree "^1.1.3"
 
-react-native-view-shot@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.6.0.tgz#2c5febd03cb1effb9923372b29aed227c680d9fd"
-  integrity sha512-QUYGaIaAxQwOTydUzqGMooBwrg455cuOQgTloZ+gPO1QCUuLRdncCqrEMwKW5eUnN5U8JGMKeFRll2m6egOxtA==
+react-native-view-shot@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.7.0.tgz#0c773500e7aac5d115a9dee3b83fa5156c950ed0"
+  integrity sha512-tQruLNjs7Ee/p6xUgJqF6glnatHaq/UqaIQ6KdYIFG0+XpUZdhqmEM4WMLsYfayfFEhdlF86G1S3eXMOfDNzFg==
+  dependencies:
+    html2canvas "^1.4.1"
 
 react-native-web@~0.18.10:
   version "0.18.12"
@@ -18021,6 +18043,13 @@ text-encoding@^0.7.0:
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
   integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -18792,6 +18821,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid@^3.0.1, uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
# Why

Update `react-native-view-shot` to 3.7.0 for SDK 49

# How

1. `et uvm -m react-native-view-shot -c 'v3.7.0'`
2. Restored some Expo-specific changes related to the scoped context (like https://github.com/expo/expo/pull/19405/commits/43dc5c22c9b71508b833b859ec197aed573057a3 and https://github.com/expo/expo/pull/19405/commits/1ba030c5171d329cc911feb1eb388d1ba2604ba6). I've decided not to move this package to the new vendoring script where we could easily apply these transformations because I'm more in favor of just removing this lib in the next release.

# Test Plan

Expo Go compiles on iOS and Android