### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,7 @@
 /packages/expo-firebase-analytics               @brentvatne
 /packages/expo-firebase-recaptcha               @brentvatne
 /packages/expo-font                             @tsapeta
-/packages/expo-gl                               @tsapeta @wkozyra95
+/packages/expo-gl                               @tsapeta
 /packages/expo-haptics                          @lukmccall
 /packages/expo-image                            @lukmccall @tsapeta @aleqsio
 /packages/expo-image-manipulator                @lukmccall


### PR DESCRIPTION
I'm removing myself from CODEOWNERS since I'll no longer work on Expo. I might work on expo-gl in the future, but I wanted to avoid e.g.  being added to review PRs that touch all packages.