### PR TITLE
[docs] Step: prevent content shrinking

### DIFF
--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -12,7 +12,7 @@ export const Step = ({ children, label }: Props) => {
       <HEADLINE className="flex min-w-[28px] h-7 bg-element rounded-full items-center justify-center mt-1">
         {label}
       </HEADLINE>
-      <div className="pt-1.5 max-w-[calc(100%-44px)] prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
+      <div className="pt-1.5 w-full max-w-[calc(100%-44px)] prose-headings:!-mt-1 prose-ul:!mb-0 prose-ol:!mb-0">
         {children}
       </div>
     </div>


### PR DESCRIPTION
# Why

When there is not much text in step content and we use flex component inside the step wrapper to not stretch correctly.

# How

Make sure that we always stretch content.

# Test Plan

The changes have been tested by running docs website locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
