### PR TITLE
[docs] EAS Build: add docs about set-env

### DIFF
--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -55,8 +55,7 @@ You can also set environment variables dynamically during the build process. The
 
 For example, you can add the following in one of the [EAS Build hooks](/build-reference/npm-hooks/) and the environment variable `EXAMPLE_ENV` will be available until the end of the build job.
 
-```bash
-set-env EXAMPLE_ENV "example value"
+<Terminal cmd={[ 'set-env EXAMPLE_ENV "example value"' ]} />
 
 ## Environment variables and app.config.js
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -51,13 +51,12 @@ See the [eas.json reference](/build/eas-json) for more information.
 
 ### Setting environment variables dynamically
 
-You can also set environment variables dynamically during the build process. Executable `set-env` is available in the PATH on EAS Build worker, and can be used to set environment variables that will be visible in the next build phases.
+You can also set environment variables dynamically during the build process. The `set-env` executable is available in the `PATH` on EAS Build workers, and can be used to set environment variables that will be visible in the next build phases.
 
-For example, you can add
+For example, you can add the following in one of the [EAS Build hooks](/build-reference/npm-hooks/) and the environment variable `EXAMPLE_ENV` will be available until the end of the build job.
+
 ```bash
 set-env EXAMPLE_ENV "example value"
-```
-in one of the EAS Build [hooks](/build-reference/npm-hooks/) and environment variable `EXAMPLE_ENV` will be available until the end of the build.
 
 ## Environment variables and app.config.js
 

--- a/docs/pages/build-reference/variables.mdx
+++ b/docs/pages/build-reference/variables.mdx
@@ -49,6 +49,16 @@ You can access these variables in your application using the techniques describe
 
 See the [eas.json reference](/build/eas-json) for more information.
 
+### Setting environment variables dynamically
+
+You can also set environment variables dynamically during the build process. Executable `set-env` is available in the PATH on EAS Build worker, and can be used to set environment variables that will be visible in the next build phases.
+
+For example, you can add
+```bash
+set-env EXAMPLE_ENV "example value"
+```
+in one of the EAS Build [hooks](/build-reference/npm-hooks/) and environment variable `EXAMPLE_ENV` will be available until the end of the build.
+
 ## Environment variables and app.config.js
 
 Environment variables used in your build profile will also be used to evaluate **app.config.js** when you run `eas build`. This is important to ensure that the result of evaluating **app.config.js** is the same when it's done locally while initiating the build (to gather metadata for the build job) and when it occurs on the remote builder, for example, to configure the project during `npx expo prebuild` or to embed the configuration data in the app.


### PR DESCRIPTION
# Why

Add docs about set-env executable

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
