### PR TITLE
[docs] ToC Sidebar: add scroll to top, allow multiline entries, UI tweaks

### DIFF
--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -111,7 +111,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
             theme="quaternary"
             size="xs"
             className={mergeClasses(
-              'ml-auto mr-2 px-2 transition-opacity opacity-1',
+              'ml-auto mr-2 px-2 transition-opacity duration-300',
               !this.state.showScrollTop && 'opacity-0 pointer-events-none'
             )}
             onClick={e => this.handleTopClick(e)}>

--- a/docs/components/DocumentationSidebarRight.tsx
+++ b/docs/components/DocumentationSidebarRight.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
+import { Button, mergeClasses } from '@expo/styleguide';
 import { breakpoints, spacing } from '@expo/styleguide-base';
+import { ArrowCircleUpIcon, LayoutAlt03Icon } from '@expo/styleguide-icons';
 import * as React from 'react';
 
 import DocumentationSidebarRightLink from './DocumentationSidebarRightLink';
@@ -12,16 +14,13 @@ import { CALLOUT } from '~/ui/components/Text';
 
 const sidebarStyle = css({
   padding: spacing[6],
+  paddingTop: spacing[14],
+  paddingBottom: spacing[12],
   width: 280,
 
   [`@media screen and (max-width: ${breakpoints.medium + 124}px)`]: {
     width: '100%',
   },
-});
-
-const sidebarTitleStyle = css({
-  marginBottom: spacing[2],
-  userSelect: 'none',
 });
 
 const UPPER_SCROLL_LIMIT_FACTOR = 1 / 4;
@@ -51,6 +50,7 @@ type PropsWithHM = Props & { headingManager: HeadingManager };
 
 type State = {
   activeSlug: string | null;
+  showScrollTop: boolean;
 };
 
 class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
@@ -60,6 +60,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
 
   state = {
     activeSlug: null,
+    showScrollTop: false,
   };
 
   private slugScrollingTo: string | null = null;
@@ -72,6 +73,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
       if (!ref || !ref.current) {
         continue;
       }
+      this.setState({ showScrollTop: contentScrollPosition > 120 });
       if (
         ref.current.offsetTop >=
           contentScrollPosition + window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR &&
@@ -101,8 +103,20 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
 
     return (
       <nav css={sidebarStyle} data-sidebar>
-        <CALLOUT weight="medium" css={sidebarTitleStyle}>
-          On this page
+        <CALLOUT
+          weight="medium"
+          className="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none">
+          <LayoutAlt03Icon className="icon-sm" /> On this page
+          <Button
+            theme="quaternary"
+            size="xs"
+            className={mergeClasses(
+              'ml-auto mr-2 px-2 transition-opacity opacity-1',
+              !this.state.showScrollTop && 'opacity-0 pointer-events-none'
+            )}
+            onClick={e => this.handleTopClick(e)}>
+            <ArrowCircleUpIcon className="icon-sm text-icon-secondary" />
+          </Button>
         </CALLOUT>
         {displayedHeadings.map(heading => {
           const isActive = heading.slug === this.state.activeSlug;
@@ -149,7 +163,7 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
     }
 
     event.preventDefault();
-    const { title, slug, ref } = heading;
+    const { slug, ref } = heading;
 
     // disable sidebar scrolling until we reach that slug
     this.slugScrollingTo = slug;
@@ -158,7 +172,23 @@ class DocumentationSidebarRight extends React.Component<PropsWithHM, State> {
       behavior: 'smooth',
       top: ref.current?.offsetTop - window.innerHeight * ACTIVE_ITEM_OFFSET_FACTOR,
     });
-    history.replaceState(history.state, title, '#' + slug);
+    history.replaceState(history.state, '', '#' + slug);
+  };
+
+  private handleTopClick = (
+    event: React.MouseEvent<HTMLButtonElement> | React.MouseEvent<HTMLAnchorElement>
+  ) => {
+    if (!isDynamicScrollAvailable()) {
+      return;
+    }
+
+    event.preventDefault();
+
+    this.props.contentRef?.current?.getScrollRef().current?.scrollTo({
+      behavior: 'smooth',
+      top: 0,
+    });
+    history.replaceState(history.state, '', ' ');
   };
 }
 

--- a/docs/components/DocumentationSidebarRightLink.tsx
+++ b/docs/components/DocumentationSidebarRightLink.tsx
@@ -20,9 +20,6 @@ const STYLES_LINK = css`
 `;
 
 const STYLES_LINK_LABEL = css`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   color: ${theme.text.secondary};
 
   :hover {
@@ -31,6 +28,9 @@ const STYLES_LINK_LABEL = css`
 `;
 
 const STYLES_LINK_MONOSPACE = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   ${typography.fontSizes[13]}
 `;
 
@@ -142,15 +142,15 @@ const DocumentationSidebarRightLink = React.forwardRef<HTMLAnchorElement, Sideba
 
     return (
       <>
-        {tooltipVisible && (
+        {tooltipVisible && isCode && (
           <Tooltip topOffset={tooltipOffset} isCode={isCode}>
             {displayTitle}
           </Tooltip>
         )}
         <Link
           ref={ref}
-          onMouseOver={onMouseOver}
-          onMouseOut={onMouseOut}
+          onMouseOver={isCode ? onMouseOver : undefined}
+          onMouseOut={isCode ? onMouseOut : undefined}
           href={'#' + slug}
           onClick={onClick}
           css={[STYLES_LINK, paddingLeft && { paddingLeft }]}>

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -3,21 +3,70 @@
 exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
 <div>
   <nav
-    class="css-133zsmp"
+    class="css-wc5n09"
     data-sidebar="true"
   >
     <p
-      class="css-odhvsj-TextComponent"
+      class="absolute -mt-14 bg-default w-[248px] flex min-h-[32px] pt-4 pb-2 gap-2 mb-2 items-center select-none css-1t1p06f-TextComponent"
       data-text="true"
     >
-      On this page
+      <svg
+        class="text-icon-default icon-sm"
+        fill="none"
+        role="img"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          id="layout-alt-03"
+        >
+          <path
+            d="M17.5 17H6.5M17.5 13H6.5M3 9H21M7.8 3H16.2C17.8802 3 18.7202 3 19.362 3.32698C19.9265 3.6146 20.3854 4.07354 20.673 4.63803C21 5.27976 21 6.11984 21 7.8V16.2C21 17.8802 21 18.7202 20.673 19.362C20.3854 19.9265 19.9265 20.3854 19.362 20.673C18.7202 21 17.8802 21 16.2 21H7.8C6.11984 21 5.27976 21 4.63803 20.673C4.07354 20.3854 3.6146 19.9265 3.32698 19.362C3 18.7202 3 17.8802 3 16.2V7.8C3 6.11984 3 5.27976 3.32698 4.63803C3.6146 4.07354 4.07354 3.6146 4.63803 3.32698C5.27976 3 6.11984 3 7.8 3Z"
+            id="Icon"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+        </g>
+      </svg>
+       On this page
+      <button
+        class="cursor-pointer inline-flex border border-solid rounded-md font-medium gap-2 items-center whitespace-nowrap h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity opacity-0 pointer-events-none"
+        type="button"
+      >
+        <span
+          class="flex self-center text-inherit leading-none"
+        >
+          <svg
+            class="icon-sm text-icon-secondary"
+            fill="none"
+            role="img"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              id="arrow-circle-up"
+            >
+              <path
+                d="M16 12L12 8M12 8L8 12M12 8V16M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12Z"
+                id="Icon"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </g>
+          </svg>
+        </span>
+      </button>
     </p>
     <a
       class="css-1qdw8ng"
       href="#base-level-heading"
     >
       <p
-        class="css-rzbmfj-TextComponent"
+        class="css-dhipyq-TextComponent"
         data-text="true"
       >
         Base level heading
@@ -28,7 +77,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#level-3-subheading"
     >
       <p
-        class="css-rzbmfj-TextComponent"
+        class="css-dhipyq-TextComponent"
         data-text="true"
       >
         Level 3 subheading
@@ -39,7 +88,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       href="#code-heading-depth-1"
     >
       <code
-        class="css-13j9lyg-TextComponent"
+        class="css-1jai1da-TextComponent"
         data-text="true"
       >
         Code heading depth 1

--- a/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
+++ b/docs/components/__snapshots__/DocumentationSidebarRight.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`DocumentationSidebarRight correctly matches snapshot 1`] = `
       </svg>
        On this page
       <button
-        class="cursor-pointer inline-flex border border-solid rounded-md font-medium gap-2 items-center whitespace-nowrap h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity opacity-0 pointer-events-none"
+        class="cursor-pointer inline-flex border border-solid rounded-md font-medium gap-2 items-center whitespace-nowrap h-8 text-3xs border-button-quaternary bg-button-quaternary text-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 ml-auto mr-2 px-2 transition-opacity duration-300 opacity-0 pointer-events-none"
         type="button"
       >
         <span


### PR DESCRIPTION
# Why

We can improve the usefulness of our ToC sidebar a bit by adding scroll to top feature and being a bit more loose when it comes for headers content trimming.

# How

Add scroll to top button appearing after a certain portion of page has been scrolled down, allow multiline entries for generic headers, still leave the previous log for API entries headers, add an icon separating ToC header label from the regular ToC link entries.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

<img width="346" alt="Screenshot 2023-06-22 at 14 55 06" src="https://github.com/expo/expo/assets/719641/7ba01c5d-7ce7-4e98-910b-47b95120cac2" align="left">
<img width="346" alt="Screenshot 2023-06-22 at 15 15 08" src="https://github.com/expo/expo/assets/719641/865baa75-dfbb-48f7-ab52-7e02ad9032de">

https://github.com/expo/expo/assets/719641/70f228b4-2d70-4f2f-9524-a817fb31354f