### PR TITLE
[android][ios] Upgrade @react-native-community/datetimepicker to 7.2.0

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -138,7 +138,7 @@ class ExponentPackage : ReactPackage {
         nativeModules.add(RNSharedElementModule(reactContext))
         nativeModules.addAll(SvgPackage().getNativeModuleIterator(reactContext).map { it.module })
         nativeModules.addAll(MapsPackage().createNativeModules(reactContext))
-        nativeModules.addAll(RNDateTimePickerPackage().createNativeModules(reactContext))
+        nativeModules.addAll(RNDateTimePickerPackage().getNativeModuleIterator(reactContext).map { it.module })
         nativeModules.addAll(stripePackage.createNativeModules(reactContext))
         nativeModules.addAll(skiaPackage.createNativeModules(reactContext))
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/datetimepicker/RNDateTimePickerPackage.java
@@ -1,7 +1,6 @@
 package versioned.host.exp.exponent.modules.api.components.datetimepicker;
 
 
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.facebook.react.TurboReactPackage;
@@ -10,9 +9,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import host.exp.expoview.BuildConfig;
@@ -59,15 +56,5 @@ public class RNDateTimePickerPackage extends TurboReactPackage {
         ));
       return moduleInfos;
     };
-  }
-
-  @NonNull
-  @Override
-  public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    List<NativeModule> modules = new ArrayList<>();
-    modules.add(new DatePickerModule(reactContext));
-    modules.add(new TimePickerModule(reactContext));
-
-    return modules;
   }
 }

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -806,7 +806,7 @@ PODS:
     - React-Core
   - RNCPicker (2.4.10):
     - React-Core
-  - RNDateTimePicker (7.1.0):
+  - RNDateTimePicker (7.2.0):
     - React-Core
   - RNFlashList (1.4.3):
     - React-Core
@@ -1504,7 +1504,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
   RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
-  RNDateTimePicker: 7ecd54a97fc3749f38c3c89a171f6cbd52f3c142
+  RNDateTimePicker: 3942382593f104af226ad9c56e16166960c7ae30
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5
   RNReanimated: 11ef210bd11e80668ed3708f7a9dd846ae29e99c

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@babel/runtime": "^7.20.0",
     "@react-native-async-storage/async-storage": "1.18.2",
-    "@react-native-community/datetimepicker": "7.1.0",
+    "@react-native-community/datetimepicker": "7.2.0",
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.9",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.8.0",
     "@react-native-async-storage/async-storage": "1.18.2",
-    "@react-native-community/datetimepicker": "7.1.0",
+    "@react-native-community/datetimepicker": "7.2.0",
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.9",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -1,7 +1,7 @@
 {
   "@expo/vector-icons": "^13.0.0",
   "@react-native-async-storage/async-storage": "1.18.2",
-  "@react-native-community/datetimepicker": "7.1.0",
+  "@react-native-community/datetimepicker": "7.2.0",
   "@react-native-masked-view/masked-view": "0.2.9",
   "@react-native-community/netinfo": "9.3.10",
   "@react-native-community/slider": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3313,10 +3313,10 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
-"@react-native-community/datetimepicker@7.1.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.1.0.tgz#627c2be65256c87b25bef0ca373e0d2aae69ece5"
-  integrity sha512-bXK1/UnutKgJMbHKcbh6TQN3GmzOWROo6Hc9z6tfVG6KIwq5MrdvxZTFJA97PB6xwW8p3v9ddkaSfkFa1pelPA==
+"@react-native-community/datetimepicker@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.2.0.tgz#db8c03dbf49bf3c24b06b617a8467d8b05511f62"
+  integrity sha512-dO1sQy83M/EvnHE2egto05iwXZX7EYn5f/VDMp6afZFRFXRiRo7CzB3VFg4B55gJRJMNBv06NYMLPM3SlpnEGQ==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
# Why

Upgrades `@react-native-community/datetimepicker`  to `7.2.0`
 

# How

```sh
et uvm -m @react-native-community/datetimepicker -c "v7.2.0"
yarn 
et pods -f
```


# Test Plan

- [x] test using `bare-expo` Android + NCL DateTimePicker Example 
- [x] test using `bare-expo` iOS + NCL DateTimePickerExample
- [x] test unversioned expo go ios + NCL DateTimePicker Example
- [x] test unversioned expo go android + NCL DateTimePicker Example

# Checklist
 

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `expo prebuild` & EAS Build (eg: updated a module plugin).
