### PR TITLE
[expo-updates][android] Use sealed class for UpdatesStateEvent

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesStateMachineInstrumentationTest.kt
@@ -68,7 +68,7 @@ class UpdatesStateMachineInstrumentationTest {
     Assert.assertEquals(UpdatesStateValue.Checking, machine.state)
     Assert.assertEquals(UpdatesStateEventType.Check, testStateChangeEventSender.lastEventType)
 
-    machine.processEvent(UpdatesStateEvent.CheckComplete())
+    machine.processEvent(UpdatesStateEvent.CheckCompleteUnavailable())
 
     Assert.assertEquals(UpdatesStateValue.Idle, machine.state)
     Assert.assertFalse(machine.context.isChecking)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -286,7 +286,7 @@ class UpdatesController private constructor(
         }
 
         override fun onRemoteCheckForUpdateFinished(result: LoaderTask.RemoteCheckResult) {
-          var event = UpdatesStateEvent.CheckComplete()
+          var event: UpdatesStateEvent = UpdatesStateEvent.CheckCompleteUnavailable()
           if (result.manifest != null) {
             event = UpdatesStateEvent.CheckCompleteWithUpdate(
               result.manifest
@@ -378,7 +378,7 @@ class UpdatesController private constructor(
               params.putString("manifestString", update.manifest.toString())
               sendLegacyUpdateEventToJS(UPDATE_AVAILABLE_EVENT, params)
               stateMachine.processEvent(
-                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
+                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest!!)
               )
             }
             RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -185,7 +185,7 @@ class UpdatesModule(
                 updateInfo.putBoolean("isAvailable", false)
                 promise.resolve(updateInfo)
                 updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckComplete()
+                  UpdatesStateEvent.CheckCompleteUnavailable()
                 )
                 return
               }
@@ -223,7 +223,7 @@ class UpdatesModule(
                 updateInfo.putBoolean("isAvailable", false)
                 promise.resolve(updateInfo)
                 updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckComplete()
+                  UpdatesStateEvent.CheckCompleteUnavailable()
                 )
               }
             }
@@ -329,7 +329,7 @@ class UpdatesModule(
                       updateEntity.manifest.toString()
                     )
                     updatesServiceLocal.stateMachine?.processEvent(
-                      UpdatesStateEvent.DownloadCompleteWithUpdate(loaderResult.updateEntity.manifest)
+                      UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest!!)
                     )
                   }
                 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateEvent.kt
@@ -5,50 +5,26 @@ import org.json.JSONObject
 /**
 Structure representing an event that can be sent to the machine.
  */
-data class UpdatesStateEvent(
-  val type: UpdatesStateEventType,
-  val manifest: JSONObject? = null,
-  private val errorMessage: String? = null,
-  val isRollback: Boolean = false
-) {
-  val error: UpdatesStateError?
-    get() {
-      return errorMessage?.let { UpdatesStateError(it) }
-    }
-
-  companion object {
-    fun Check(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.Check)
-    }
-    fun Download(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.Download)
-    }
-    fun CheckError(message: String): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.CheckError, errorMessage = message)
-    }
-    fun DownloadError(message: String): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.DownloadError, errorMessage = message)
-    }
-    fun CheckComplete(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.CheckCompleteUnavailable)
-    }
-    fun CheckCompleteWithUpdate(manifest: JSONObject?): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.CheckCompleteAvailable, manifest = manifest)
-    }
-    fun CheckCompleteWithRollback(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.CheckCompleteAvailable, isRollback = true)
-    }
-    fun DownloadComplete(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
-    }
-    fun DownloadCompleteWithUpdate(manifest: JSONObject?): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.DownloadComplete, manifest = manifest)
-    }
-    fun DownloadCompleteWithRollback(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.DownloadComplete, isRollback = true)
-    }
-    fun Restart(): UpdatesStateEvent {
-      return UpdatesStateEvent(UpdatesStateEventType.Restart)
-    }
+sealed class UpdatesStateEvent(val type: UpdatesStateEventType) {
+  class Check : UpdatesStateEvent(UpdatesStateEventType.Check)
+  class Download : UpdatesStateEvent(UpdatesStateEventType.Download)
+  class CheckError(private val errorMessage: String) : UpdatesStateEvent(UpdatesStateEventType.CheckError) {
+    val error: UpdatesStateError
+      get() {
+        return UpdatesStateError(errorMessage)
+      }
   }
+  class DownloadError(private val errorMessage: String) : UpdatesStateEvent(UpdatesStateEventType.DownloadError) {
+    val error: UpdatesStateError
+      get() {
+        return UpdatesStateError(errorMessage)
+      }
+  }
+  class CheckCompleteUnavailable : UpdatesStateEvent(UpdatesStateEventType.CheckCompleteUnavailable)
+  class CheckCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.CheckCompleteAvailable)
+  class CheckCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.CheckCompleteAvailable)
+  class DownloadComplete : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+  class DownloadCompleteWithUpdate(val manifest: JSONObject) : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+  class DownloadCompleteWithRollback : UpdatesStateEvent(UpdatesStateEventType.DownloadComplete)
+  class Restart : UpdatesStateEvent(UpdatesStateEventType.Restart)
 }


### PR DESCRIPTION
# Why

By using a sealed class (which acts like an enum with strictly-typed params), we can more concretely type `reduceContext`. This is the case because now not all types of `UpdatesStateEvent` have all fields. For example, only the error types have the error field and only the manifest types have a manifest.

In `reduceContext` this means we're less likely to have a mistake since we won't have access to fields that don't exist on the enum subtype.

# How

Convert, fix compilation errors.

# Test Plan

Build and run, run all tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
