### PR TITLE
[screen-orientation][ios] Fix crash when reading rootViewController value

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fix crash when reading rootViewController value. ([#23039](https://github.com/expo/expo/pull/23039) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix crash when reading `rootViewController` value. ([#23039](https://github.com/expo/expo/pull/23039) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix crash when reading rootViewController value. ([#23039](https://github.com/expo/expo/pull/23039) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 6.0.0 — 2023-06-21

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -20,7 +20,13 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   weak var currentTraitCollection: UITraitCollection?
   var lastOrientationMask: UIInterfaceOrientationMask
   var rootViewController: UIViewController? {
-    return UIApplication.shared.keyWindow?.rootViewController
+    let keyWindow = UIApplication
+      .shared
+      .connectedScenes
+      .flatMap { ($0 as? UIWindowScene)?.windows ?? [] }
+      .last { $0.isKeyWindow }
+
+    return keyWindow?.rootViewController
   }
 
   var currentOrientationMask: UIInterfaceOrientationMask {


### PR DESCRIPTION
# Why

Closes ENG-9051

# How

This PR replaces the screen-orientation `UIApplication.shared.keyWindow` call with `UIApplication.shared.connectedScenes` as 'keyWindow' was deprecated in iOS 13.0 and it returns a key window across all connected scenes, which makes the app crash when a new window is displayed, E.g. the StoreReview popup 

# Test Plan

Run Expo Go Unversioned locally and test StoreReview + ScrenOrientation on NCL


https://github.com/expo/expo/assets/11707729/17ee2704-79f9-409e-a46c-6a397df46383



# Checklist


<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
