### PR TITLE
[docs] EAS Update: split debugging guide

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -219,6 +219,7 @@ const general = [
     ]),
     makeGroup('Troubleshoot', [
       makePage('eas-update/debug.mdx'),
+      makePage('eas-update/debug-advanced.mdx'),
       makePage('eas-update/build-locally.mdx'),
     ]),
     makeGroup('Advanced', [

--- a/docs/pages/eas-update/build-locally.mdx
+++ b/docs/pages/eas-update/build-locally.mdx
@@ -215,7 +215,7 @@ The app should now appear as shown in the screenshot below:
 
 ## Testing updates with a debug build of your app
 
-It is possible to [create a debug build that will load updates from EAS instead of loading from a React Native packager](/eas-update/debug/#debugging-of-native-code-while-loading-the-app-through-expo-updates).
+It is possible to [create a debug build that will load updates from EAS instead of loading from a React Native packager](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates).
 
 To do this for the above app, modify step 4 above as follows:
 

--- a/docs/pages/eas-update/debug-advanced.mdx
+++ b/docs/pages/eas-update/debug-advanced.mdx
@@ -1,0 +1,191 @@
+---
+title: Advanced EAS Update Debugging
+sidebar_title: Advanced
+description: Learn advanced strategies on how to debug EAS Update.
+---
+
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
+
+After verifying `expo-updates` and EAS Update configurations in our [basic guide](/eas-update/debug), we can move on to debugging how our project is interacting with updates.
+
+## In-app debugging
+
+The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause. We can make a simulator build of the project and manually check to see if updates are available or if there are errors when fetching updates. See the code example to [check for updates manually](/versions/latest/sdk/updates/#check-for-updates-manually).
+
+## Viewing network requests
+
+Another way to identify the root cause of an issue is to look at the network requests that the app is making to EAS servers, then viewing the responses. We recommend using a program like [Proxyman](https://proxyman.io/) or [Charles Proxy](https://www.charlesproxy.com/) to watch network requests from our app.
+
+With either program, we'll need to follow their instructions for installing an SSL certificate, so that the program can decode HTTPS requests. Once that's set up in a simulator or on an actual device, we can open our app and watch requests.
+
+The requests we're interested in are from https://u.expo.dev and https://assets.eascdn.net. Responses from https://u.expo.dev will contain an update manifest, which specifies which assets the app will need to fetch to run the update. Responses from https://assets.eascdn.net will contain assets, like images, font files, etc that are required for the update to run.
+
+When inspecting the request to https://u.expo.dev, we can look for the following request headers:
+
+- `Expo-Runtime-Version`: this should make the runtime version we made our build and update with.
+- `expo-channel-name`: this should be the channel name specified in the **eas.json** build profile.
+- `Expo-Platform`: this should be either "android" or "ios".
+
+As for all requests, we expect to see either `200` response codes, or `304` if nothing has changed.
+
+Below is a screenshot showing the request of a successful update manifest request:
+
+<ImageSpotlight
+  alt="Successful manifest request"
+  src="/static/images/eas-update/network-request.png"
+/>
+
+## Inspecting a build manually
+
+When building a project into an app, there can be multiple steps that alter the output of `npx expo prebuild`. After making a build, it is possible to open the build's contents and inspect native files to see its final configuration.
+
+Here are the steps for inspecting an iOS Simulator build on macOS:
+
+1. Create an iOS Simulator build of the app using EAS Build. This is done by adding `"ios": { "simulator": true }` to a build profile.
+2. Once the build is finished, download the result and unzip it.
+3. Then, right click on the app and select "Show Package Contents".
+4. From there, we can inspect the **Expo.plist** file.
+
+Inside the **Expo.plist** file, we expect to see the following configurations:
+
+```xml
+...
+<key>EXUpdatesRequestHeaders</key>
+<dict>
+  <key>expo-channel-name</key>
+  <string>your-channel-name</string>
+</dict>
+<key>EXUpdatesRuntimeVersion</key>
+<string>your-runtime-version</string>
+<key>EXUpdatesURL</key>
+<string>https://u.expo.dev/your-project-id</string>
+...
+```
+
+## Inspecting the latest update locally
+
+When we publish an update with EAS Update, it creates a **/dist** folder in the root of our project locally, which includes the assets that were uploaded as a part of the update.
+
+<ImageSpotlight alt="Dist directory" src="/static/images/eas-update/dist.png" />
+
+## Inspecting manifests manually
+
+When an update is published with EAS Update, we create a manifest that end-user app's request. The manifest has information like which assets and versions are needed for an update to load. We can inspect the manifest by going to a specific URL in a browser or by using `curl`.
+
+Inside our project's app config (**app.json**/**app.config.json**), the URL we can GET is under `updates.url`.
+
+This `url` is EAS' "https://u.expo.dev" domain, followed by the project's ID on EAS' servers. If we go to the URL directly, we'll see an error about missing a header. We can view a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production` and a platform of `android`, the full URL you could visit would be similar to this:
+
+```
+https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production&platform=android
+```
+
+## Viewing all assets included in an update
+
+It may be helpful to see which assets are included in our update bundle. We can see a list of named assets by running:
+
+<Terminal cmd={['$ npx expo export']} />
+
+## Debugging of native code while loading the app through expo-updates
+
+By default, we need to make a release build for `expo-updates` to be enabled and to load updates rather than reading from a development server. This is because debug builds behave like normal React Native project debug builds.
+
+To make it easier to test and debug native code in an environment that is closer to production, follow the steps below to create a debug build of the app with `expo-updates` enabled.
+
+We also provide a [step-by-step guide to try out EAS Update quickly](/eas-update/build-locally) in a local development environment using Android Studio or Xcode, with either release or debug builds of the app.
+
+#### iOS local builds
+
+- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
+- Reinstall pods with `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
+- [Ensure the desired channel is set in your **Expo.plist**](/bare/updating-your-app/#configuring-the-channel-manually)
+- Modify the application Xcode project file to force bundling of the application JavaScript for both release and debug builds:
+
+```
+sed -i '' 's/SKIP_BUNDLING/FORCE_BUNDLING/g;' ios/&lt;project name&gt;.xcodeproj/project.pbxproj
+```
+
+- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Xcode or from the command line.
+
+#### Android local builds
+
+- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
+- [Ensure the desired channel is set in your **AndroidManifest.xml**](/bare/updating-your-app/#configuring-the-channel-manually)
+- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Android Studio or from the command line.
+
+#### EAS Build
+
+Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in **eas.json**, as shown in the example below:
+
+```json eas.json
+{
+  "build": {
+    "preview_debug": {
+      "env": {
+        "EX_UPDATES_NATIVE_DEBUG": "1"
+      },
+      "android": {
+        "distribution": "internal",
+        "withoutCredentials": true,
+        "gradleCommand": ":app:assembleDebug"
+      },
+      "ios": {
+        "simulator": true,
+        "buildConfiguration": "Debug"
+      },
+      "channel": "preview_debug"
+    }
+  }
+}
+```
+
+## Mitigation steps
+
+Once we've found the root cause of the issue, there are various mitigation steps we might want to take. One of the most common problems is pushing an update that has a bug inside it. When this happens, we can re-publish a previous update to resolve the issue.
+
+### Re-publishing a previous update
+
+The fastest way to "undo" a bad publish is to re-publish a known good update. Imagine we have a branch with two updates:
+
+```bash
+branch: "production"
+updates: [
+  update 2 (id: xyz2) "fixes typo"     // bad update
+  update 1 (id: abc1) "updates color"  // good update
+]
+```
+
+If "update 2" turned out to be a bad update, we can re-publish "update 1" with a command like this:
+
+<Terminal
+  cmd={[
+    '# eas update:republish --group [update-group-id]',
+    '',
+    '# eas update:republish --branch [branch-name]',
+    '',
+    '',
+    '# Example',
+    '$ eas update:republish --group abc1',
+    '$ eas update:republish --branch production',
+  ]}
+/>
+
+The example command above would result in a branch that now appears like this:
+
+```bash
+branch: "production"
+updates: [
+  update 3 (id: def3) "updates color"  // re-publish of update 1 (id: abc1)
+  update 2 (id: xyz2) "fixes typo"     // bad update
+  update 1 (id: abc1) "updates color"  // good update
+]
+```
+
+Since "update 3" is now the most recent update on the "production" branch, all users who query for an update in the future will receive "update 3" instead of the bad update, "update 2".
+
+While this will prevent all new users from seeing the bad update, users who've already received the bad update will run it until they can download the latest update. Since mobile networks are not always able to download the most recent update, sometimes users may run a bad update for a long time. When viewing error logs for our app, it's normal to see a lingering long tail of errors as our users' apps get the most recent update or build. We'll know we solved the bug when we see the error rate decline dramatically; however, it likely will not disappear completely if we have a diverse user base across many locations and mobile networks.
+
+## Wrap up
+
+Still having issues with EAS Update? Provide us with a reproduction repo in our [forums](https://forums.expo.dev/c/expo-application-services/56). Also, feel free to ask in the **#update** channel on our [community Discord](https://chat.expo.dev/), or [contact us](https://expo.dev/contact) directly.

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -1,6 +1,6 @@
 ---
 title: Debug EAS Update
-sidebar_title: Debug
+sidebar_title: Basic
 description: Learn how to debug EAS Update.
 ---
 
@@ -9,9 +9,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 It's important to tell the current state of our app at any given time. We built EAS Update with this in mind. Once we know which updates are running on which builds, we can make changes so that our apps are in the state we expect and desire. This guide sets out to show how we can verify our EAS Update and expo-updates configuration so that we can find the source of problems like an app not showing a published update.
 
-## expo-updates configuration
+## `expo-updates` configuration
 
-The expo-updates library runs inside an end-user's app and makes requests to an update server to get the latest update.
+The `expo-updates` library runs inside an end-user's app and makes requests to an update server to get the latest update.
 
 ### Verifying app configuration
 
@@ -155,187 +155,6 @@ If we've made builds and updates with EAS, we can view the state of our project 
 
 The EAS website has a page that shows the current state of our apps. We can view it at [https://expo.dev/accounts/[account]/projects/[project]/deployments](https://expo.dev/accounts/[account]/projects/[project]/deployments).
 
-## Debugging EAS Update
+## Next steps
 
-After verifying `expo-updates` and EAS Update configurations, we can move on to debugging how our project is interacting with updates.
-
-### In-app debugging
-
-The `expo-updates` library exports a variety of functions to interact with updates once the app is already running. In certain cases, making a call to fetch an update and seeing an error message can help us narrow down the root cause. We can make a simulator build of the project and manually check to see if updates are available or if there are errors when fetching updates. See the code example to [check for updates manually](/versions/latest/sdk/updates/#use-expo-updates-with-a-custom-server).
-
-### Viewing network requests
-
-Another way to identify the root cause of an issue is to look at the network requests that the app is making to EAS servers, then viewing the responses. We recommend using a program like [Proxyman](https://proxyman.io/) or [Charles Proxy](https://www.charlesproxy.com/) to watch network requests from our app.
-
-With either program, we'll need to follow their instructions for installing an SSL certificate, so that the program can decode HTTPS requests. Once that's set up in a simulator or on an actual device, we can open our app and watch requests.
-
-The requests we're interested in are from https://u.expo.dev and https://assets.eascdn.net. Responses from https://u.expo.dev will contain an update manifest, which specifies which assets the app will need to fetch to run the update. Responses from https://assets.eascdn.net will contain assets, like images, font files, etc that are required for the update to run.
-
-When inspecting the request to https://u.expo.dev, we can look for the following request headers:
-
-- `Expo-Runtime-Version`: this should make the runtime version we made our build and update with.
-- `expo-channel-name`: this should be the channel name specified in the **eas.json** build profile.
-- `Expo-Platform`: this should be either "android" or "ios".
-
-As for all requests, we expect to see either `200` response codes, or `304` if nothing has changed.
-
-Below is a screenshot showing the request of a successful update manifest request:
-
-<ImageSpotlight
-  alt="Successful manifest request"
-  src="/static/images/eas-update/network-request.png"
-/>
-
-### Inspecting a build manually
-
-When building a project into an app, there can be multiple steps that alter the output of `npx expo prebuild`. After making a build, it is possible to open the build's contents and inspect native files to see its final configuration.
-
-Here are the steps for inspecting an iOS Simulator build on macOS:
-
-1. Create an iOS Simulator build of the app using EAS Build. This is done by adding `"ios": { "simulator": true }` to a build profile.
-2. Once the build is finished, download the result and unzip it.
-3. Then, right click on the app and select "Show Package Contents".
-4. From there, we can inspect the **Expo.plist** file.
-
-Inside the **Expo.plist** file, we expect to see the following configurations:
-
-```xml
-...
-<key>EXUpdatesRequestHeaders</key>
-<dict>
-  <key>expo-channel-name</key>
-  <string>your-channel-name</string>
-</dict>
-<key>EXUpdatesRuntimeVersion</key>
-<string>your-runtime-version</string>
-<key>EXUpdatesURL</key>
-<string>https://u.expo.dev/your-project-id</string>
-...
-```
-
-### Inspecting the latest update locally
-
-When we publish an update with EAS Update, it creates a **/dist** folder in the root of our project locally, which includes the assets that were uploaded as a part of the update.
-
-<ImageSpotlight alt="Dist directory" src="/static/images/eas-update/dist.png" />
-
-### Inspecting manifests manually
-
-When an update is published with EAS Update, we create a manifest that end-user app's request. The manifest has information like which assets and versions are needed for an update to load. We can inspect the manifest by going to a specific URL in a browser or by using `curl`.
-
-Inside our project's app config (**app.json**/**app.config.json**), the URL we can GET is under `updates.url`.
-
-This `url` is EAS' "https://u.expo.dev" domain, followed by the project's ID on EAS' servers. If we go to the URL directly, we'll see an error about missing a header. We can view a manifest by adding three query parameters to the URL: `runtime-version`, `channel-name`, and `platform`. If we published an update with a runtime version of `1.0.0`, a channel of `production` and a platform of `android`, the full URL you could visit would be similar to this:
-
-```
-https://u.expo.dev/your-project-id?runtime-version=1.0.0&channel-name=production&platform=android
-```
-
-### Viewing all assets included in an update
-
-It may be helpful to see which assets are included in our update bundle. We can see a list of named assets by running:
-
-<Terminal cmd={['$ npx expo export']} />
-
-### Debugging of native code while loading the app through expo-updates
-
-By default, we need to make a release build for `expo-updates` to be enabled and to load updates rather than reading from a development server. This is because debug builds behave like normal React Native project debug builds.
-
-To make it easier to test and debug native code in an environment that is closer to production, follow the steps below to create a debug build of the app with `expo-updates` enabled.
-
-We also provide a [step-by-step guide to try out EAS Update quickly](/eas-update/build-locally) in a local development environment using Android Studio or Xcode, with either release or debug builds of the app.
-
-#### iOS local builds
-
-- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
-- Reinstall pods with `npx pod-install`. The `expo-updates` podspec now detects this environment variable, and makes changes so that the debug code that would normally load from the Metro packager is bypassed, and the app is built with the EXUpdates bundle and other dependencies needed to load updates from EAS.
-- [Ensure the desired channel is set in your **Expo.plist**](/bare/updating-your-app/#configuring-the-channel-manually)
-- Modify the application Xcode project file to force bundling of the application JavaScript for both release and debug builds:
-
-```
-sed -i '' 's/SKIP_BUNDLING/FORCE_BUNDLING/g;' ios/&lt;project name&gt;.xcodeproj/project.pbxproj
-```
-
-- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Xcode or from the command line.
-
-#### Android local builds
-
-- Set the debug environment variable: `export EX_UPDATES_NATIVE_DEBUG=1`
-- [Ensure the desired channel is set in your **AndroidManifest.xml**](/bare/updating-your-app/#configuring-the-channel-manually)
-- Execute a [debug build](/debugging/runtime-issues/#native-debugging) of the app with Android Studio or from the command line.
-
-#### EAS Build
-
-Alternatively, we can use EAS to create a debug build where `expo-updates` is enabled. The environment variable is set in **eas.json**, as shown in the example below:
-
-```json eas.json
-{
-  "build": {
-    "preview_debug": {
-      "env": {
-        "EX_UPDATES_NATIVE_DEBUG": "1"
-      },
-      "android": {
-        "distribution": "internal",
-        "withoutCredentials": true,
-        "gradleCommand": ":app:assembleDebug"
-      },
-      "ios": {
-        "simulator": true,
-        "buildConfiguration": "Debug"
-      },
-      "channel": "preview_debug"
-    }
-  }
-}
-```
-
-## Mitigation steps
-
-Once we've found the root cause of the issue, there are various mitigation steps we might want to take. One of the most common problems is pushing an update that has a bug inside it. When this happens, we can re-publish a previous update to resolve the issue.
-
-### Re-publishing a previous update
-
-The fastest way to "undo" a bad publish is to re-publish a known good update. Imagine we have a branch with two updates:
-
-```bash
-branch: "production"
-updates: [
-  update 2 (id: xyz2) "fixes typo"     // bad update
-  update 1 (id: abc1) "updates color"  // good update
-]
-```
-
-If "update 2" turned out to be a bad update, we can re-publish "update 1" with a command like this:
-
-<Terminal
-  cmd={[
-    '# eas update:republish --group [update-group-id]',
-    '',
-    '# eas update:republish --branch [branch-name]',
-    '',
-    '',
-    '# Example',
-    '$ eas update:republish --group abc1',
-    '$ eas update:republish --branch production',
-  ]}
-/>
-
-The example command above would result in a branch that now appears like this:
-
-```bash
-branch: "production"
-updates: [
-  update 3 (id: def3) "updates color"  // re-publish of update 1 (id: abc1)
-  update 2 (id: xyz2) "fixes typo"     // bad update
-  update 1 (id: abc1) "updates color"  // good update
-]
-```
-
-Since "update 3" is now the most recent update on the "production" branch, all users who query for an update in the future will receive "update 3" instead of the bad update, "update 2".
-
-While this will prevent all new users from seeing the bad update, users who've already received the bad update will run it until they can download the latest update. Since mobile networks are not always able to download the most recent update, sometimes users may run a bad update for a long time. When viewing error logs for our app, it's normal to see a lingering long tail of errors as our users' apps get the most recent update or build. We'll know we solved the bug when we see the error rate decline dramatically; however, it likely will not disappear completely if we have a diverse user base across many locations and mobile networks.
-
-## Wrap up
-
-Still having issues with EAS Update? Provide us with a reproduction repo in our [forums](https://forums.expo.dev/c/expo-application-services/56). Also, feel free to ask in the **#update** channel on our [community Discord](https://chat.expo.dev/), or [contact us](https://expo.dev/contact) directly.
+Read the [advanced guide](/eas-update/debug-advanced) to debug EAS Update when the basic steps don't work.

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -51,7 +51,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-in-an-app). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 

--- a/docs/pages/versions/v47.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/updates.mdx
@@ -21,7 +21,7 @@ The `expo-updates` library allows you to programmatically control and respond to
 
 ## Usage
 
-Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-in-an-app). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 

--- a/docs/pages/versions/v48.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/updates.mdx
@@ -51,7 +51,7 @@ Learn how to configure the native projects in the [installation instructions in 
 
 ## Usage
 
-Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug/#debugging-of-native-code-in-an-app). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
+Most of the methods and constants in this module can only be used or tested in release mode. In debug builds, the default behavior is to always load the latest JavaScript from a development server. It is possible to [build a debug version of your app with the same updates behavior as a release build](/eas-update/debug-advanced/#debugging-of-native-code-while-loading-the-app-through-expo-updates). Such an app will not open the latest JavaScript from your development server &mdash; it will load published updates just as a release build does. This may be useful for debugging the behavior of your app when it is not connected to a development server.
 
 **To test manual updates in the Expo Go app**, run [`eas update`](/eas-update/introduction) and then open the published version of your app with Expo Go.
 


### PR DESCRIPTION
# Why

The most common EAS Update report for users is to complete the 'get started' guide but not see their latest update. This PR refactors the Debugging guide into `Basic` and `Advanced`  articles to make it more approachable. 

Before, the Debugging guide was quite long. It outlined every strategy with varying amounts of difficulty, from checking your EAS Update configuration in the UI (very easy) to using Charles Proxy to monitor network traffic (difficult). This experience can be overwhelming. 

# UX
Debugging gets its dedicated section, split into 'Basic' and 'Advanced'.  When users have a problem, we want them to go to the `Basic` article first. This article should have concrete and simple steps to verify a user has the correct configuration. The 'Basic' and 'Advanced' article division also emphasizes the priority of each debugging strategy. We don't want users to try the 'Advanced' approaches before they try the simple ones in 'Basic'.

![Screenshot 2023-06-22 at 2 40 40 PM](https://github.com/expo/expo/assets/6380927/d536f1bc-81e5-4329-8d10-e9087158f4b1)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
