### PR TITLE
[Expo Go][iOS] add missing stub implementation of AppLoaderTaskDelegate

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -194,6 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Implement empty stubs
 - (void)didStartCheckingForRemoteUpdate {}
 - (void)didFinishCheckingForRemoteUpdate:(NSDictionary<NSString *,id> *)body {}
+- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)_ didLoadAsset:(EXUpdatesAsset *)asset successfulAssetCount:(NSInteger)successfulAssetCount failedAssetCount:(NSInteger)failedAssetCount totalAssetCount:(NSInteger)totalAssetCount {}
 
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update
 {


### PR DESCRIPTION
# Why

Fix crash due to missing stub implementation of new required `AppLoaderTaskDelegate` method.

# Test Plan

See Linear task for repro -- NCL on iOS should work now.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
