### PR TITLE
[docs] eas update: link to debug page in 'getting started'

### DIFF
--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -119,7 +119,7 @@ To publish an update to the build, run the following command:
   cmdCopy={null}
 />
 
-Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update.
+Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. If your app is not updating as expected, validate your configuration [here](/eas-update/debug).
 
 </Step>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -119,7 +119,7 @@ To publish an update to the build, run the following command:
   cmdCopy={null}
 />
 
-Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. If your app is not updating as expected, validate your configuration [here](/eas-update/debug).
+Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. If your app is not updating as expected, [validate your configuration](/eas-update/debug).
 
 </Step>
 


### PR DESCRIPTION
# Why

link to the debug page from the 'getting started' guide if people's apps are not updating as expected

# Test Plan

tested manually

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
