### PR TITLE
[docs] Fix typo in Introduction page

### DIFF
--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -77,7 +77,7 @@ const styles = StyleSheet.create({
 ## Next step
 
 <BoxLink
-  title="Create your first app with"
+  title="Create your first app with Expo"
   Icon={BookOpen02Icon}
   description="If you're already familiar with Expo, feel free to jump ahead to specific chapters. However, if you'd like to start from scratch, continue to the next chapter in which we will learn how to create your first app with Expo."
   href="/tutorial/create-your-first-app"


### PR DESCRIPTION
# Why

Quick fix for the typo link on [the intro page](https://docs.expo.dev/tutorial/introduction/)

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
