### PR TITLE
[core] send CDP type by mime type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Supported other network CDP types like `Image` and `Media` rather than `Fetch`. ([#23058](https://github.com/expo/expo/pull/23058) by [@kudo](https://github.com/kudo))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/cdp/CdpNetworkTypes.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/cdp/CdpNetworkTypes.kt
@@ -21,7 +21,16 @@ enum class ResourceType(val value: String) {
   FONT("Font"),
   SCRIPT("Script"),
   FETCH("Fetch"),
-  OTHER("Other")
+  OTHER("Other");
+
+  companion object {
+    fun fromMimeType(mimeType: String): ResourceType = when {
+      mimeType.startsWith("image/") -> IMAGE
+      mimeType.startsWith("audio") || mimeType.startsWith("video") -> MEDIA
+      mimeType.startsWith("font") -> FONT
+      else -> OTHER
+    }
+  }
 }
 
 interface JsonSerializable {
@@ -120,7 +129,7 @@ data class RequestWillBeSentParams(
     wallTime = now,
     redirectHasExtraInfo = redirectResponse != null,
     redirectResponse = redirectResponse?.let { Response(it) },
-    type = ResourceType.FETCH,
+    type = ResourceType.OTHER,
   )
 
   override fun toJSONObject(): JSONObject {
@@ -172,11 +181,11 @@ data class ResponseReceivedParams(
   val response: Response,
   val hasExtraInfo: Boolean = false,
 ) : JsonSerializable {
-  constructor(now: BigDecimal, requestId: RequestId, request: okhttp3.Request, repsonse: okhttp3.Response) : this(
+  constructor(now: BigDecimal, requestId: RequestId, request: okhttp3.Request, okhttpResponse: okhttp3.Response) : this(
     requestId = requestId,
     timestamp = now,
-    type = ResourceType.FETCH,
-    response = Response(repsonse),
+    type = ResourceType.fromMimeType(okhttpResponse.header("Content-Type", "") ?: ""),
+    response = Response(okhttpResponse),
   )
 
   override fun toJSONObject(): JSONObject {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptorTest.kt
@@ -133,4 +133,23 @@ class ExpoRequestCdpInterceptorTest {
     Truth.assertThat(params.getString("body")).isNotEmpty()
     Truth.assertThat(params.getBoolean("base64Encoded")).isTrue()
   }
+
+  @Test
+  fun `respect image mimeType to CDP event`() {
+    client.newCall(Request.Builder().url("https://avatars.githubusercontent.com/u/12504344").build()).execute()
+    Truth.assertThat(mockDelegate.events.size).isEqualTo(5)
+
+    // Network.requestWillBeSent
+    // Network.requestWillBeSentExtraInfo
+
+    // Network.responseReceived
+    val json = JSONObject(mockDelegate.events[2])
+    val method = json.getString("method")
+    val params = json.getJSONObject("params")
+    val response = params.getJSONObject("response")
+    Truth.assertThat(method).isEqualTo("Network.responseReceived")
+    Truth.assertThat(response.getInt("status")).isEqualTo(200)
+    Truth.assertThat(response.getString("mimeType")).isEqualTo("image/png")
+    Truth.assertThat(params.getString("type")).isEqualTo("Image")
+  }
 }

--- a/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
@@ -19,13 +19,13 @@ struct CdpNetwork {
     case other = "Other"
 
     static func fromMimeType(_ mimeType: String) -> ResourceType {
-      if (mimeType.starts(with: "image/")) {
+      if mimeType.starts(with: "image/") {
         return image
       }
-      if (mimeType.starts(with: "audio/") || mimeType.starts(with: "video/")) {
+      if mimeType.starts(with: "audio/") || mimeType.starts(with: "video/") {
         return media
       }
-      if (mimeType.starts(with: "font/")) {
+      if mimeType.starts(with: "font/") {
         return font
       }
       return other

--- a/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
@@ -17,6 +17,19 @@ struct CdpNetwork {
     case script = "Script"
     case fetch = "Fetch"
     case other = "Other"
+
+    static func fromMimeType(_ mimeType: String) -> ResourceType {
+      if (mimeType.starts(with: "image/")) {
+        return image
+      }
+      if (mimeType.starts(with: "audio/") || mimeType.starts(with: "video/")) {
+        return media
+      }
+      if (mimeType.starts(with: "font/")) {
+        return font
+      }
+      return other
+    }
   }
 
   struct ConnectTiming: Encodable {
@@ -91,7 +104,7 @@ struct CdpNetwork {
       } else {
         self.redirectResponse = nil
       }
-      self.type = ResourceType.fetch
+      self.type = ResourceType.other
     }
   }
 
@@ -119,8 +132,8 @@ struct CdpNetwork {
     init(now: TimeInterval, requestId: RequestId, request: URLRequest, response: HTTPURLResponse) {
       self.requestId = requestId
       self.timestamp = now
-      self.type = ResourceType.fetch
       self.response = Response(response)
+      self.type = ResourceType.fromMimeType(self.response.mimeType)
     }
   }
 

--- a/packages/expo-modules-core/ios/Tests/ExpoRequestCdpInterceptorSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoRequestCdpInterceptorSpec.swift
@@ -161,5 +161,31 @@ final class ExpoRequestCdpInterceptorSpec: ExpoSpec {
         }.resume()
       }
     }
+
+
+    it("respect image mimeType to CDP event") {
+      waitUntil(timeout: .seconds(2)) { done in
+        self.session.dataTask(with: URL(string: "https://avatars.githubusercontent.com/u/12504344")!) { (data, response, error) in
+          DispatchQueue.main.async {
+            expect(self.mockDelegate.events.count).to(equal(5))
+
+            // Network.requestWillBeSent
+            // Network.requestWillBeSentExtraInfo
+
+            // Network.responseReceived
+            let json = self.parseJSON(data: self.mockDelegate.events[2])
+            let method = json["method"] as! String
+            let params = json["params"] as! [String: Any]
+            let response = params["response"] as! [String: Any]
+            expect(method).to(equal("Network.responseReceived"))
+            expect(response["status"] as? Int).to(equal(200))
+            expect(response["mimeType"] as? String).to(equal("image/png"))
+            expect(params["type"] as? String).to(equal("Image"))
+
+            done()
+          }
+        }.resume()
+      }
+    }
   }
 }


### PR DESCRIPTION
# Why

previously we send the CDP request/response type as `fetch` always. we should send other types like `image` when the resources are images
close ENG-8609

# How

based on mime type to send the corresponding CDP type. for unknown data, we will send `other`. so we will never send `fetch` type anymore, because we cannot differentiate whether the requests are coming from fetch or other requests like image or native calls.

# Test Plan

- tested on bare-expo
![Screenshot 2023-06-24 at 12 57 46 AM](https://github.com/expo/expo/assets/46429/aab0b66c-d5c4-4fec-aaff-c74f899068b7)

- added unit test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
