### PR TITLE
[home] Better type dev menu, fix bugs, add verified indicator

### DIFF
--- a/home/menu/DevMenuApp.tsx
+++ b/home/menu/DevMenuApp.tsx
@@ -36,13 +36,19 @@ function useAppColorScheme(uuid: string): ColorTheme {
   return theme === 'light' ? ColorTheme.LIGHT : ColorTheme.DARK;
 }
 
-class DevMenuRoot extends React.PureComponent<{ task: { [key: string]: any }; uuid: string }, any> {
+class DevMenuRoot extends React.PureComponent<
+  { task: { manifestUrl: string; manifestString: string }; uuid: string },
+  any
+> {
   render() {
     return <DevMenuApp {...this.props} />;
   }
 }
 
-function DevMenuApp(props: { task: { [key: string]: any }; uuid: string }) {
+function DevMenuApp(props: {
+  task: { manifestUrl: string; manifestString: string };
+  uuid: string;
+}) {
   const theme = useAppColorScheme(props.uuid);
 
   return (

--- a/home/menu/DevMenuServerInfo.tsx
+++ b/home/menu/DevMenuServerInfo.tsx
@@ -1,3 +1,4 @@
+import Constants from 'expo-constants';
 import { Row, View, Text, Spacer } from 'expo-dev-client-components';
 import React from 'react';
 import { StyleSheet } from 'react-native';
@@ -6,11 +7,13 @@ import DevIndicator from '../components/DevIndicator';
 import FriendlyUrls from '../legacy/FriendlyUrls';
 
 type Props = {
-  task: { [key: string]: any };
+  task: { manifestUrl: string; manifestString: string };
 };
 
 export function DevMenuServerInfo({ task }: Props) {
-  const manifest = task.manifestString && JSON.parse(task.manifestString);
+  const manifest = task.manifestString
+    ? (JSON.parse(task.manifestString) as typeof Constants.manifest | typeof Constants.manifest2)
+    : null;
   const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
   const devServerName =
     manifest && manifest.extra?.expoGo?.developer ? manifest.extra.expoGo.developer.tool : null;

--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -1,7 +1,8 @@
+import Ionicons from '@expo/vector-icons/build/Ionicons';
 import Constants from 'expo-constants';
-import { Row, View, Text } from 'expo-dev-client-components';
+import { Row, View, Text, useExpoTheme } from 'expo-dev-client-components';
 import React from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image, Platform, StyleSheet } from 'react-native';
 
 type Props = {
   task: { manifestUrl: string; manifestString: string };
@@ -45,6 +46,8 @@ function getInfoFromManifest(
 }
 
 export function DevMenuTaskInfo({ task }: Props) {
+  const theme = useExpoTheme();
+
   const manifest = task.manifestString
     ? (JSON.parse(task.manifestString) as typeof Constants.manifest | typeof Constants.manifest2)
     : null;
@@ -77,9 +80,36 @@ export function DevMenuTaskInfo({ task }: Props) {
             </Text>
           )}
           {!manifestInfo?.isVerified && (
-            <Text size="small" type="InterRegular" color="error">
-              Unverified App
-            </Text>
+            <Row
+              bg="warning"
+              border="warning"
+              rounded="medium"
+              padding="0"
+              align="center"
+              style={{
+                alignSelf: 'flex-start',
+                marginTop: 3,
+              }}>
+              <Ionicons
+                name={Platform.select({ ios: 'ios-warning', default: 'md-warning' })}
+                size={14}
+                color={theme.text.warning}
+                lightColor={theme.text.warning}
+                darkColor={theme.text.warning}
+                style={{
+                  marginHorizontal: 4,
+                }}
+              />
+              <Text
+                color="warning"
+                type="InterRegular"
+                size="small"
+                style={{
+                  marginRight: 4,
+                }}>
+                Unverified
+              </Text>
+            </Row>
           )}
         </View>
       </Row>

--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -102,7 +102,7 @@ export function DevMenuTaskInfo({ task }: Props) {
               />
               <Text
                 color="warning"
-                type="InterRegular"
+                type="InterSemiBold"
                 size="small"
                 style={{
                   marginRight: 4,

--- a/home/menu/DevMenuView.tsx
+++ b/home/menu/DevMenuView.tsx
@@ -16,7 +16,7 @@ import { DevMenuServerInfo } from './DevMenuServerInfo';
 import { DevMenuTaskInfo } from './DevMenuTaskInfo';
 
 type Props = {
-  task: { [key: string]: any };
+  task: { manifestUrl: string; manifestString: string };
   uuid: string;
 };
 


### PR DESCRIPTION
# Why

Instead of showing the warning in the CLI about it not being signed, we want to show it here in expo go.

PR that removed the warning in the CLI: https://github.com/expo/expo/pull/22975

Closes ENG-9056.

# How

A few steps were needed:
1. Add better types (this is very hard to guarantee correctness in its current state with `any` types)
2. Fix bugs in existing code surrounding manifest.
3. Add isVerified indicator. Open to design suggestions.

# Test Plan

Load an experience:

<img width="565" alt="Screenshot 2023-06-23 at 9 04 21 AM" src="https://github.com/expo/expo/assets/189568/7992861a-4686-4f44-91de-79b66e374646">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
