### PR TITLE
[expo-updates][ios] Use weak delegate for state machine

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Use weak delegate for state machine. ([#23060](https://github.com/expo/expo/pull/23060) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.18.3 — 2023-06-24

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -259,7 +259,7 @@ internal class UpdatesStateMachine {
   /**
    In production, this is the AppController instance.
    */
-  internal let changeEventDelegate: (any UpdatesStateChangeDelegate)
+  private weak var changeEventDelegate: (any UpdatesStateChangeDelegate)?
 
   /**
    The current state
@@ -377,7 +377,7 @@ internal class UpdatesStateMachine {
    On each state change, all context properties are sent to JS
    */
   private func sendChangeEventToJS(_ event: UpdatesStateEvent? = nil) {
-    changeEventDelegate.sendUpdateStateChangeEventToBridge(event?.type ?? .restart, body: [
+    changeEventDelegate?.sendUpdateStateChangeEventToBridge(event?.type ?? .restart, body: [
       "context": context.json
     ])
   }


### PR DESCRIPTION
# Why

https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting#Strong-Reference-Cycles-Between-Class-Instances

https://github.com/expo/expo/pull/22845#discussion_r1238755147

Closes ENG-9047.

# How

Make it weak and nullable for when it is dereferenced.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
