### PR TITLE
[expo-updates][android] restrict property visibility on state machine objects

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Use weak delegate for state machine. ([#23060](https://github.com/expo/expo/pull/23060) by [@wschurman](https://github.com/wschurman))
 - [Android] Convert LoaderTask.RemoteCheckResult to sealed class. ([#23061](https://github.com/expo/expo/pull/23061) by [@wschurman](https://github.com/wschurman))
+- [Android] Restrict property visibility on state machine objects. ([#23063](https://github.com/expo/expo/pull/23063) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
@@ -8,16 +8,16 @@ import org.json.JSONObject
 The state machine context, with information intended to be consumed by application JS code.
  */
 data class UpdatesStateContext(
-  val isUpdateAvailable: Boolean = false,
-  val isUpdatePending: Boolean = false,
-  val isRollback: Boolean = false,
-  val isChecking: Boolean = false,
-  val isDownloading: Boolean = false,
-  val isRestarting: Boolean = false,
-  val latestManifest: JSONObject? = null,
-  val downloadedManifest: JSONObject? = null,
-  val checkError: UpdatesStateError? = null,
-  val downloadError: UpdatesStateError? = null
+  private val isUpdateAvailable: Boolean = false,
+  private val isUpdatePending: Boolean = false,
+  private val isRollback: Boolean = false,
+  private val isChecking: Boolean = false,
+  private val isDownloading: Boolean = false,
+  private val isRestarting: Boolean = false,
+  private val latestManifest: JSONObject? = null,
+  private val downloadedManifest: JSONObject? = null,
+  private val checkError: UpdatesStateError? = null,
+  private val downloadError: UpdatesStateError? = null
 ) {
 
   val json: Map<String, Any>

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateError.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateError.kt
@@ -5,7 +5,7 @@ package expo.modules.updates.statemachine
  * For now, we just have the "message" property.
  */
 data class UpdatesStateError(
-  val message: String
+  private val message: String
 ) {
   val json: Map<String, String>
     get() {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -18,11 +18,13 @@ class UpdatesStateMachine(
    * The current state
    */
   var state: UpdatesStateValue = UpdatesStateValue.Idle
+    private set
 
   /**
    * The context
    */
   var context: UpdatesStateContext = UpdatesStateContext()
+    private set
 
   /**
    Called after the app restarts (reloadAsync()) to reset the machine to its


### PR DESCRIPTION
# Why

These don't need to be public (having the setters public could corrupt state).

# How

Make private where possible.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
