### PR TITLE
[expo-updates][ios][rfc] Use swift enum for AppLoaderTask delegate

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -192,8 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - EXUpdatesAppLoaderTaskDelegate
 
 // Implement empty stubs
-- (void)didStartCheckingForRemoteUpdate {}
-- (void)didFinishCheckingForRemoteUpdate:(NSDictionary<NSString *,id> *)body {}
+- (void)appLoaderTaskDidStartCheckingForRemoteUpdate:(EXUpdatesAppLoaderTask *)_ {}
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)_ didLoadAsset:(EXUpdatesAsset *)asset successfulAssetCount:(NSInteger)successfulAssetCount failedAssetCount:(NSInteger)failedAssetCount totalAssetCount:(NSInteger)totalAssetCount {}
 
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -191,10 +191,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - EXUpdatesAppLoaderTaskDelegate
 
-// Implement empty stubs
-- (void)appLoaderTaskDidStartCheckingForRemoteUpdate:(EXUpdatesAppLoaderTask *)_ {}
-- (void)appLoaderTask:(EXUpdatesAppLoaderTask *)_ didLoadAsset:(EXUpdatesAsset *)asset successfulAssetCount:(NSInteger)successfulAssetCount failedAssetCount:(NSInteger)failedAssetCount totalAssetCount:(NSInteger)totalAssetCount {}
-
 - (BOOL)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didLoadCachedUpdate:(EXUpdatesUpdate *)update
 {
   [self _setShouldShowRemoteUpdateStatus:update.manifest];

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- [iOS] Use swift enum for AppLoaderTask delegate. ([#23064](https://github.com/expo/expo/pull/23064) by [@wschurman](https://github.com/wschurman))
+
 ## 0.18.3 — 2023-06-24
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -18,9 +18,7 @@ public protocol AppLoaderTaskDelegate: AnyObject {
    * AppLoaderTask proceed as usual.
    */
   func appLoaderTask(_: AppLoaderTask, didLoadCachedUpdate update: Update) -> Bool
-  func appLoaderTaskDidStartCheckingForRemoteUpdate(_: AppLoaderTask)
   func appLoaderTask(_: AppLoaderTask, didStartLoadingUpdate update: Update?)
-  func appLoaderTask(_: AppLoaderTask, didLoadAsset asset: UpdateAsset, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int)
   func appLoaderTask(_: AppLoaderTask, didFinishWithLauncher launcher: AppLauncher, isUpToDate: Bool)
   func appLoaderTask(_: AppLoaderTask, didFinishWithError error: Error)
   func appLoaderTask(
@@ -38,7 +36,9 @@ public enum RemoteCheckResult {
 }
 
 public protocol AppLoaderTaskSwiftDelegate: AnyObject {
+  func appLoaderTaskDidStartCheckingForRemoteUpdate(_: AppLoaderTask)
   func appLoaderTask(_: AppLoaderTask, didFinishCheckingForRemoteUpdateWithRemoteCheckResult remoteCheckResult: RemoteCheckResult)
+  func appLoaderTask(_: AppLoaderTask, didLoadAsset asset: UpdateAsset, successfulAssetCount: Int, failedAssetCount: Int, totalAssetCount: Int)
 }
 
 @objc(EXUpdatesBackgroundUpdateStatus)
@@ -338,9 +338,9 @@ public final class AppLoaderTask: NSObject {
       completionQueue: loaderTaskQueue
     )
 
-    if let delegate = self.delegate {
+    if let swiftDelegate = self.swiftDelegate {
       self.delegateQueue.async {
-        delegate.appLoaderTaskDidStartCheckingForRemoteUpdate(self)
+        swiftDelegate.appLoaderTaskDidStartCheckingForRemoteUpdate(self)
       }
     }
     remoteAppLoader!.loadUpdate(
@@ -423,9 +423,9 @@ public final class AppLoaderTask: NSObject {
         return false
       }
     } asset: { asset, successfulAssetCount, failedAssetCount, totalAssetCount in
-      if let delegate = self.delegate {
+      if let swiftDelegate = self.swiftDelegate {
         self.delegateQueue.async {
-          delegate.appLoaderTask(
+          swiftDelegate.appLoaderTask(
             self,
             didLoadAsset: asset,
             successfulAssetCount: successfulAssetCount,


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/22845#discussion_r1236184780

This should help us use the type checker / compiler to ensure correctness of our delegates. 

This also fixes the naming of delegate methods to adhere to standard conventions.

Closes ENG-9040.

# How

Move to a swift-only delegate since it's only used in swift.

While we lose the ability to use this in objective-c, we gain correctness in our app. (type checking acts as a test here, and we don't have any other tests for this class).

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
