### PR TITLE
[expo-updates][iOS] Fix crash when both dev-client and updates enabled

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- [Android] fix instrumentation tests. ([#23037](https://github.com/expo/expo/pull/23037) by [@douglowder](https://github.com/douglowder))
+- [iOS] Fix crash when dev-client and updates used together. ([#23070](https://github.com/expo/expo/pull/23070) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 0.18.2 — 2023-06-23

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -147,7 +147,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
     let controller = AppController.sharedInstance
     var updatesConfiguration: UpdatesConfig
     do {
-      updatesConfiguration = try UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: nil)
+      updatesConfiguration = try UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: configuration as? [String: Any] ?? [:])
     } catch {
       errorBlock(NSError(
         domain: DevLauncherController.ErrorDomain,

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -239,3 +239,5 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
     }
   }
 }
+
+// swiftlint:enable force_unwrapping

--- a/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
@@ -49,7 +49,7 @@ internal final class LegacyUpdate: Update {
     if let manifestRuntimeVersion = manifestRuntimeVersion as? String {
       runtimeVersion = manifestRuntimeVersion
     } else {
-      runtimeVersion = manifest.expoGoSDKVersion().require("Manifest JSON must have a valid sdkVersion property defined")
+      runtimeVersion = manifest.expoGoSDKVersion().require("Manifest JSON must have either a valid runtimeVersion property or a valid sdkVersion property")
     }
 
     let bundleUrl = URL(string: bundleUrlString).require("Manifest JSON must have a valid URL as the bundleUrl property")
@@ -135,13 +135,13 @@ internal final class LegacyUpdate: Update {
       // The URL is valid and constant, so it'll never throw
       // swiftlint:disable:next force_unwrapping
       return URL(string: EXUpdatesExpoAssetBaseUrl)!
-    } else {
-      let assetsPathOrUrl = withManifest.assetUrlOverride() ?? "assets"
-      // assetUrlOverride may be an absolute or relative URL
-      // if relative, we should resolve with respect to the manifest URL
-      return URL(string: assetsPathOrUrl, relativeTo: manifestUrl).require(
-        "Invalid assetUrlOverride"
-      ).absoluteURL.standardized
     }
+
+    let assetsPathOrUrl = withManifest.assetUrlOverride() ?? "assets"
+    // assetUrlOverride may be an absolute or relative URL
+    // if relative, we should resolve with respect to the manifest URL
+    return URL(string: assetsPathOrUrl, relativeTo: manifestUrl).require(
+      "Invalid assetUrlOverride"
+    ).absoluteURL.standardized
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
@@ -46,8 +46,8 @@ internal final class LegacyUpdate: Update {
 
     var runtimeVersion: String
     let manifestRuntimeVersion = manifest.runtimeVersion()
-    if let manifestRuntimeVersion = manifestRuntimeVersion {
-      runtimeVersion = assertType(value: manifestRuntimeVersion, description: "Manifest JSON runtime version must be string")
+    if let manifestRuntimeVersion = manifestRuntimeVersion as? String {
+      runtimeVersion = manifestRuntimeVersion
     } else {
       runtimeVersion = manifest.expoGoSDKVersion().require("Manifest JSON must have a valid sdkVersion property defined")
     }


### PR DESCRIPTION
# Why

During release testing, a regression was found. The flow below would lead to a crash on iOS, but not on Android. The crash did not occur when testing with SDK 48.

```
yarn create expo repro-updates-issue --template blank@beta
cd repro-updates-issue
yarn expo install expo-dev-client expo-updates
eas update:configure
npx expo run:ios
```

# How

- Found and fixed an error in the conversion of `EXUpdatesDevLauncherController` to Swift
- Adjusted the code in `LegacyUpdate.swift` to allow either a valid `runtimeVersion` string, or an `sdkVersion` string if the `runtimeVersion` is missing or is a policy object

# Test Plan

The flow that originally reproduced the bug no longer crashes, and brings up the app with the dev client as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
