### PR TITLE
[docs] eas update: move dev client to troubleshoot section

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -219,12 +219,12 @@ const general = [
     ]),
     makeGroup('Troubleshoot', [
       makePage('eas-update/debug.mdx'),
+      makePage('eas-update/expo-dev-client.mdx'),
       makePage('eas-update/build-locally.mdx'),
     ]),
     makeGroup('Advanced', [
       makePage('eas-update/optimize-assets.mdx'),
       makePage('eas-update/environment-variables.mdx'),
-      makePage('eas-update/expo-dev-client.mdx'),
       makePage('eas-update/code-signing.mdx'),
       makePage('eas-update/rollouts.mdx'),
     ]),


### PR DESCRIPTION
# Why

the `expo-dev-client` article is better off in the troubleshooting section since it's not really advanced and is an invaluable way to debug

# Test Plan

manually tested

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
