### PR TITLE
fix: [iOS][ExpoWebBrowser] don't crash with invalid url 

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `iOS`, fixed crash when opening an invalid URL in the web browser. ([#22986](https://github.com/expo/expo/pull/23084) by [@hirbod](https://github.com/hirbod))
+
 ### 💡 Others
 
 ## 12.3.0 — 2023-06-21

--- a/packages/expo-web-browser/ios/WebBrowserExceptions.swift
+++ b/packages/expo-web-browser/ios/WebBrowserExceptions.swift
@@ -7,3 +7,9 @@ final class WebBrowserAlreadyOpenException: Exception {
     "Another web browser is already open"
   }
 }
+
+final class WebBrowserInvalidURLException: Exception {
+  override var reason: String {
+    return "The provided URL is not valid."
+  }
+}

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -1,20 +1,14 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-import AuthenticationServices
-import ExpoModulesCore
 import SafariServices
+import ExpoModulesCore
+import AuthenticationServices
 
 final public class WebBrowserModule: Module {
   private var currentWebBrowserSession: WebBrowserSession?
   private var currentAuthSession: WebAuthSession?
-
-  private func isValidUrl(urlString: String?) -> Bool {
-    guard let urlString = urlString,
-      let url = URL(string: urlString)
-    else {
-      return false
-    }
-
+  
+  private func isValid(url: URL) -> Bool {
     return url.scheme == "http" || url.scheme == "https"
   }
 
@@ -25,8 +19,8 @@ final public class WebBrowserModule: Module {
       guard self.currentWebBrowserSession == nil else {
         throw WebBrowserAlreadyOpenException()
       }
-
-      guard self.isValidUrl(urlString: url.absoluteString) else {
+      
+      guard self.isValid(url: url) else {
         throw WebBrowserInvalidURLException()
       }
 
@@ -34,7 +28,7 @@ final public class WebBrowserModule: Module {
         promise.resolve(["type": type])
         self.currentWebBrowserSession = nil
       }
-
+      
       self.currentWebBrowserSession?.open()
     }
     .runOnQueue(.main)
@@ -51,8 +45,7 @@ final public class WebBrowserModule: Module {
       guard self.currentAuthSession?.isOpen != true else {
         throw WebBrowserAlreadyOpenException()
       }
-      self.currentAuthSession = WebAuthSession(
-        authUrl: authUrl, redirectUrl: redirectUrl, options: options)
+      self.currentAuthSession = WebAuthSession(authUrl: authUrl, redirectUrl: redirectUrl, options: options)
       self.currentAuthSession?.open(promise)
     }
     .runOnQueue(.main)

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -30,8 +30,7 @@ final public class WebBrowserModule: Module {
         throw WebBrowserInvalidURLException()
       }
 
-      self.currentWebBrowserSession = WebBrowserSession(url: url, options: options) {
-        [promise] type in
+      self.currentWebBrowserSession = WebBrowserSession(url: url, options: options) { [promise] type in
         promise.resolve(["type": type])
         self.currentWebBrowserSession = nil
       }
@@ -48,8 +47,7 @@ final public class WebBrowserModule: Module {
 
     // MARK: - AuthSession
 
-    AsyncFunction("openAuthSessionAsync") {
-      (authUrl: URL, redirectUrl: URL?, options: AuthSessionOptions, promise: Promise) throws in
+    AsyncFunction("openAuthSessionAsync") { (authUrl: URL, redirectUrl: URL?, options: AuthSessionOptions, promise: Promise) throws in
       guard self.currentAuthSession?.isOpen != true else {
         throw WebBrowserAlreadyOpenException()
       }

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -7,7 +7,7 @@ import AuthenticationServices
 final public class WebBrowserModule: Module {
   private var currentWebBrowserSession: WebBrowserSession?
   private var currentAuthSession: WebAuthSession?
-  
+
   private func isValid(url: URL) -> Bool {
     return url.scheme == "http" || url.scheme == "https"
   }
@@ -19,7 +19,7 @@ final public class WebBrowserModule: Module {
       guard self.currentWebBrowserSession == nil else {
         throw WebBrowserAlreadyOpenException()
       }
-      
+
       guard self.isValid(url: url) else {
         throw WebBrowserInvalidURLException()
       }
@@ -28,7 +28,7 @@ final public class WebBrowserModule: Module {
         promise.resolve(["type": type])
         self.currentWebBrowserSession = nil
       }
-      
+
       self.currentWebBrowserSession?.open()
     }
     .runOnQueue(.main)


### PR DESCRIPTION
# Why

An exception is thrown by the SFSafariViewController class when it receives a URL with a scheme other than HTTP or HTTPS which leads into a crash.

Unlike the Android implementation, which throws (as expected) an error of type `NoMatchingActivityException`. 

Fixes #22986 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

I've added a simple check to ensure that URLs start with http or https. While this is not 100% bulletproof, it should prevent crashes caused by mistakes with malformed URLs like `%5Bhttps://lemmy.ml/c/instance` or any other malicious input, which SFSafariViewController can't handle anyway. This is more aligned with the Android implementation.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Simulator and real device, running iOS 16.4 and 16.5, testing a bunch of different strings and URLs

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
