### PR TITLE
[docs] Fix issues in Google auth guide

### DIFF
--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using Google authentication
+title: Use Google authentication
 description: A guide on using @react-native-google-signin/google-signin library to integrate Google authentication in your Expo project.
 ---
 
@@ -13,7 +13,6 @@ This guide provides additional information on how to configure the library for y
 ## Prerequisites
 
 The `@react-native-google-signin/google-signin` library can't be used in the Expo Go app because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
-
 
 ## Installation
 
@@ -53,7 +52,7 @@ Once you've uploaded your app, you can provide an SHA-1 certificate fingerprint 
 For more instructions on how to configure your Google project for Android with Firebase:
 
 <BoxLink
-  title="Firebase guide"
+  title="Firebase"
   href="https://github.com/react-native-google-signin/google-signin/blob/master/docs/get-config-file.md"
 />
 
@@ -68,7 +67,7 @@ For more instructions on how to configure your Google project for iOS with Fireb
 
 #### Upload google-services.json and GoogleService-Info.plist to EAS
 
-If you use the Firebase method for Android and iOS (as shared below), you'll need to upload **google-services.json** and **GoogleService-Info.plist** to EAS and add them to **.gitignore** to avoid checking them in the repository.
+If you use the Firebase method for Android and iOS (as shared in sections above), you'll need to upload **google-services.json** and **GoogleService-Info.plist** to EAS and add them to **.gitignore** to avoid checking them in the repository.
 
 <BoxLink
   title="Upload a secret file to EAS and use in the app config"
@@ -83,7 +82,7 @@ For more instructions on how to configure your Google project for Android with G
 
 <BoxLink
   title="Google API"
-  href="https://github.com/react-native-google-signin/google-signin/blob/master/docs/android-guide.md#1b---if-youre-not-using-firebase"
+  href="https://developers.google.com/identity/sign-in/android/start#configure-a-google-api-console-project"
 />
 
 #### iOS
@@ -92,7 +91,7 @@ For iOS, if you use Google API instead of Firebase, you'll need to generate an O
 
 <BoxLink
   title="Google API"
-  href="https://github.com/react-native-google-signin/google-signin/blob/master/docs/get-config-file.md#without-firebase"
+  href="https://developers.google.com/identity/sign-in/ios/start-integrating#get_an_oauth_client_id"
 />
 
 After you have created the iOS client id, you'll also need to provide the iOS URL scheme value in the app config. You can find the value in the Google API console under **API and Services** > **Credentials** > **OAuth 2.0 Client IDs** > **name of your iOS client id** > **Additional information** > **iOS URL scheme**.

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -76,12 +76,14 @@ If you use the Firebase method for Android and iOS (as shared in sections above)
 
 ### With Google API
 
+This is an alternate method to configure a Google project when you are not using [Firebase](#with-firebase).
+
 #### Android
 
 For more instructions on how to configure your Google project for Android with Google API:
 
 <BoxLink
-  title="Google API"
+  title="Configure a Google API Console project"
   href="https://developers.google.com/identity/sign-in/android/start#configure-a-google-api-console-project"
 />
 
@@ -90,7 +92,7 @@ For more instructions on how to configure your Google project for Android with G
 For iOS, if you use Google API instead of Firebase, you'll need to generate an OAuth client id. Follow the instructions below to generate the client id:
 
 <BoxLink
-  title="Google API"
+  title="Get an OAuth client ID from a Google API Console project"
   href="https://developers.google.com/identity/sign-in/ios/start-integrating#get_an_oauth_client_id"
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Following issues with the guide
- The external links in Google API sections for Android and iOS do not point to specific Google doc links
- Google API section doesn't make it clear that it is an alternate to configuring a project with FIrebase

# How

<!--
How did you build this feature or fix this bug and why?
-->


- Update the links to redirect to specific sections in Google docs and the context about "With Google API" section is an alternate to Firebase.
<img width="918" alt="CleanShot 2023-06-25 at 15 10 11@2x" src="https://github.com/expo/expo/assets/10234615/9ccd5af0-4e9d-4915-8aff-de1675595741">

- Use short form verb for the page title

- Remove "guide" (typo) from external link in Android

<img width="912" alt="CleanShot 2023-06-25 at 15 14 50@2x" src="https://github.com/expo/expo/assets/10234615/939743f8-bff2-4ea5-93ea-d61421d1b5de">

- Fix typo: sections below

<img width="877" alt="CleanShot 2023-06-25 at 15 15 17@2x" src="https://github.com/expo/expo/assets/10234615/91ba1cfe-8716-42c7-b525-5c39ee826a6a">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting: http://localhost:3002/guides/google-authentication/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
