### PR TITLE
[ENG-8954][docs] EAS Update: add pitch and revamp intro page

### DIFF
--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-This guide explains how to transition a React Native project that uses CodePush to use EAS Update, offering [many advantages](/eas-update/introduction/#pitch). It assumes that you are using the default React Native project structure. For assistance with migrating brownfield native apps to EAS Update, [reach out to us directly](https://expo.dev/contact).
+This guide explains how to transition a React Native project that uses CodePush to use EAS Update which offers [many advantages](/eas-update/introduction/#pitch). It assumes that you're using the default React Native project structure. For assistance with migrating brownfield native apps to EAS Update, [reach out to us directly](https://expo.dev/contact).
 
 ## Prerequisites
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -7,7 +7,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-This guide explains how to transition a React Native project that uses CodePush to use EAS Update. It assumes that you are using the default React Native project structure. For assistance with migrating brownfield native apps to EAS Update, [reach out to us directly](https://expo.dev/contact).
+This guide explains how to transition a React Native project that uses CodePush to use EAS Update, offering [many advantages](/eas-update/introduction/#pitch). It assumes that you are using the default React Native project structure. For assistance with migrating brownfield native apps to EAS Update, [reach out to us directly](https://expo.dev/contact).
 
 ## Prerequisites
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -23,7 +23,7 @@ EAS Update allows you to release hotfixes and enhancements in response to user f
 
 ### Broad Compatibility
 
-EAS Update works with vanilla React Native apps, all you need to do is install the lightweight `expo` npm package as a prerequisite, making it a compelling alternative to solutions like [Codepush](/eas-update/codepush).
+EAS Update works with vanilla React Native apps. All you need to do is install the lightweight `expo` npm package as a prerequisite, making it a compelling alternative to solutions such as [Codepush](/eas-update/codepush).
 
 ### Tailored for Expo
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -19,7 +19,7 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
 
 ### Improve User Experience
 
-With EAS Update, you can release hotfixes and enhancements in response to user feedback or market trends, keeping your users engaged and satisfied with your app. Don't wait for the next planned update or manual update request.
+EAS Update allows you to release hotfixes and enhancements in response to user feedback or market trends. It helps you keep users engaged and satisfied with your app. Don't wait for the next planned update or manual update request.
 
 ### Broad Compatibility
 
@@ -31,7 +31,7 @@ EAS Update is designed for Expo apps, making integration easy and workflows effi
 
 ### Customizable Update Strategies
 
-Apply updates through our [expo-updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
+Apply updates through [`expo-updates` API](/versions/latest/sdk/updates) and [app config](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
 
 ## Get started
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -17,19 +17,19 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
 
 ## Pitch
 
-#### Improve User Experience
+### Improve User Experience
 
 With EAS Update, you can release hotfixes and enhancements in response to user feedback or market trends, keeping your users engaged and satisfied with your app. Don't wait for the next planned update or manual update request.
 
-#### Broad Compatibility
+### Broad Compatibility
 
 EAS Update works with vanilla React Native apps, all you need to do is install the lightweight `expo` npm package as a prerequisite, making it a compelling alternative to solutions like [Codepush](/eas-update/codepush).
 
-#### Tailored for Expo
+### Tailored for Expo
 
 EAS Update is designed for Expo apps, making integration easy and workflows efficient. Use the website UIs to check app status and debug, especially for developers using EAS Build.
 
-#### Customizable Update Strategies
+### Customizable Update Strategies
 
 Apply updates through our [expo-updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -31,7 +31,7 @@ EAS Update is designed for Expo apps, making integration easy and workflows effi
 
 #### Customizable Update Strategies
 
-Customizable Update Strategies: Apply updates through our [expo-updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
+Apply updates through our [expo-updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
 
 ## Get started
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -15,7 +15,25 @@ All apps running the `expo-updates` library have the ability to receive updates.
 
 Still using Classic Updates? We moved those docs to [the archive](/archive/classic-updates/introduction).
 
-### Get started
+## Pitch
+
+#### Improve User Experience
+
+With EAS Update, you can release hotfixes and enhancements in response to user feedback or market trends, keeping your users engaged and satisfied with your app. Don't wait for the next planned update or manual update request.
+
+#### Broad Compatibility
+
+EAS Update works with vanilla React Native apps, all you need to do is install the lightweight `expo` npm package as a prerequisite, making it a compelling alternative to solutions like [Codepush](/eas-update/codepush).
+
+#### Tailored for Expo
+
+EAS Update is designed for Expo apps, making integration easy and workflows efficient. Use the website UIs to check app status and debug, especially for developers using EAS Build.
+
+#### Customizable Update Strategies
+
+Customizable Update Strategies: Apply updates through our [expo-updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates) if the default behavior is not suitable for you. You’ll always have the upper hand in shaping the update process without compromising your users' experience.
+
+## Get started
 
 <BoxLink
   title="Creating your first update"
@@ -33,22 +51,4 @@ Still using Classic Updates? We moved those docs to [the archive](/archive/class
   title="Develop faster"
   description="View your teammate's changes with EAS Update."
   href="/eas-update/develop-faster"
-/>
-
-<BoxLink
-  title="Deployment patterns"
-  description="Release processes that balance update safety and speed."
-  href="/eas-update/deployment-patterns"
-/>
-
-<BoxLink
-  title="Migrate from CodePush"
-  description="Transition a bare React Native project from CodePush."
-  href="/eas-update/codepush"
-/>
-
-<BoxLink
-  title="Debug"
-  description="When your app doesn't update as expected."
-  href="/eas-update/debug"
 />


### PR DESCRIPTION
# Why

When I ask GPT what the advantages between EAS Update vs our competitors are and to talk about the tradeoffs, it lists some reasons that are no longer true. This signals to me that there is outdated information in our community and our pitch should aim to clarify these, in addition to talking about the value propositions of the product.

# How

The pitch is meant to be a succinct 3-5 point blurb on why people should use EAS Update. Here are the reasons why I chose each of the points:

1. Improve User Experience: the main value proposition of our product
2. Broad Compatibility: people think that you are 'locked in' to the expo ecosystem if you use EAS Update, or that you cannot use EAS Update if you have a bare RN app.
3. Tailored for Expo: explain that you do get extra value if you do use other services like EAS Build, and what exactly those benefits are. 
4. Customizable Update Strategies: GPT implies that EAS Update doesnt give the user fined grained control via an API, which is not true (asked over multiple prompts). We may need to do a better job of linking our API/config in our docs so folks know they can create a custom update strategy. 

This PR also shortens the boxlink list to the main usecases of EAS Update and the get started guide, in order to keep things brief.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
