### PR TITLE
[docs] EAS Update: add more links to api

### DIFF
--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -4,6 +4,10 @@ sidebar_title: FAQ
 description: Frequently asked questions about EAS Update.
 ---
 
+### How can I implement a custom update strategy for my app?
+
+The default update strategy for `expo-updates` is to check for updates every time the app is loaded. You can implement a custom update strategy with the [Updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates).
+
 ### What guidelines must I follow when publishing updates?
 
 One of the rules of EAS Update is that you need to follow the rules of the platforms and app stores you are building for. This means your updates need to follow the App Store and Play Store guidelines, including the content of the updates and how you use them. This usually means changes to your app’s behavior need to be reviewed.

--- a/docs/pages/eas-update/faq.mdx
+++ b/docs/pages/eas-update/faq.mdx
@@ -6,7 +6,7 @@ description: Frequently asked questions about EAS Update.
 
 ### How can I implement a custom update strategy for my app?
 
-The default update strategy for `expo-updates` is to check for updates every time the app is loaded. You can implement a custom update strategy with the [Updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates).
+By default, `expo-updates` checks for updates every time the app is loaded. You can implement a custom update strategy with the [Updates API](/versions/latest/sdk/updates) and [app config](/versions/latest/config/app/#updates).
 
 ### What guidelines must I follow when publishing updates?
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -119,7 +119,7 @@ To publish an update to the build, run the following command:
   cmdCopy={null}
 />
 
-Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. If your app is not updating as expected, [validate your configuration](/eas-update/debug).
+Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. The default strategy for `expo-updates` is to check for updates every time the app is loaded, but you can also implement a custom strategy with the [Updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates). If your app is not updating as expected, [validate your configuration](/eas-update/debug).
 
 </Step>
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -119,7 +119,7 @@ To publish an update to the build, run the following command:
   cmdCopy={null}
 />
 
-Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. The default strategy for `expo-updates` is to check for updates every time the app is loaded, but you can also implement a custom strategy with the [Updates API](/versions/latest/sdk/updates) and [app.json configuration](/versions/latest/config/app/#updates). If your app is not updating as expected, [validate your configuration](/eas-update/debug).
+Once the update is built and uploaded to EAS and the command completes, force close and reopen your app up to two times to download and view the update. By default, `expo-updates` checks for updates every time the app is loaded. However, you can also implement a custom strategy with the [Updates API](/versions/latest/sdk/updates) and [app config](/versions/latest/config/app/#updates). If your app is not updating as expected, [validate your configuration](/eas-update/debug).
 
 </Step>
 


### PR DESCRIPTION
# Why

GPT implies that EAS Update doesnt give the user fined grained control via an API, which is not true (asked over multiple prompts). This signals to me that there is outdated information in our community and our pitch should aim to clarify these, in addition to talking about the value propositions of the product. We need to do a better job of linking our API/config in our docs so folks know they can create a custom update strategy. 

# How

Talk about the available API in FAQ, and getting started guides

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
