### PR TITLE
[docs] Update Google Analytics measurement ID

### DIFF
--- a/docs/providers/Analytics.tsx
+++ b/docs/providers/Analytics.tsx
@@ -4,7 +4,7 @@ import Script from 'next/script';
 import React, { PropsWithChildren, useEffect } from 'react';
 
 /** The global analytics measurement ID */
-const MEASUREMENT_ID = 'UA-107832480-3';
+const MEASUREMENT_ID = 'G-YKNPYCMLWY';
 
 type AnalyticsProps = PropsWithChildren<object>;
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update to use Google Analytics 4 measurement ID instead of GA3.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the value of `MEASUREMENT_ID`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- In docs repo, run `yarn export`
- `cd out`
- `npx serve`
- Open Developer menu in Chrome
- Under elements find the `googletagmanager` script to verify the new measurement id

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
