### PR TITLE
Fix DocumentPicker copy to cache on iOS

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `copyToCacheDirectory` on iOS.
+- Fix `copyToCacheDirectory` on iOS. ([#23102](https://github.com/expo/expo/pull/23102) by [@aleqsio](https://github.com/aleqsio))
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ## 11.4.0 — 2023-05-08

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `copyToCacheDirectory` on iOS.
 - Fixed Android build warnings for Gradle version 8. ([#22537](https://github.com/expo/expo/pull/22537), [#22609](https://github.com/expo/expo/pull/22609) by [@kudo](https://github.com/kudo))
 
 ## 11.4.0 — 2023-05-08

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -121,11 +121,12 @@ public class DocumentPickerModule: Module, PickingResultHandler {
     }
 
     if copy {
-      let directory = URL(fileURLWithPath: fileSystem.cachesDirectory).appendingPathComponent("DocumentPicker", isDirectory: true).path
+      let cacheDirURL = URL(fileURLWithPath: fileSystem.cachesDirectory)
+      let directory = cacheDirURL.appendingPathComponent("DocumentPicker", isDirectory: true).path
       let fileExtension = "." + documentUrl.pathExtension
       let path = fileSystem.generatePath(inDirectory: directory, withExtension: fileExtension)
       newUrl = URL(fileURLWithPath: path)
-      
+
       try FileManager.default.copyItem(at: documentUrl, to: newUrl)
     }
 

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -110,7 +110,6 @@ public class DocumentPickerModule: Module, PickingResultHandler {
   }
 
   private func readDocumentDetails(documentUrl: URL, copy: Bool) throws -> DocumentInfo {
-    let pathExtension = documentUrl.pathExtension
     var newUrl = documentUrl
 
     guard let fileSystem = self.appContext?.fileSystem else {
@@ -122,13 +121,15 @@ public class DocumentPickerModule: Module, PickingResultHandler {
     }
 
     if copy {
-      let directory = fileSystem.cachesDirectory.appending("DocumentPicker")
-      let path = fileSystem.generatePath(inDirectory: directory, withExtension: pathExtension)
+      let directory = URL(fileURLWithPath: fileSystem.cachesDirectory).appendingPathComponent("DocumentPicker", isDirectory: true).path
+      let fileExtension = "." + documentUrl.pathExtension
+      let path = fileSystem.generatePath(inDirectory: directory, withExtension: fileExtension)
       newUrl = URL(fileURLWithPath: path)
+      
       try FileManager.default.copyItem(at: documentUrl, to: newUrl)
     }
 
-    let mimeType = self.getMimeType(from: pathExtension)
+    let mimeType = self.getMimeType(from: documentUrl.pathExtension)
 
     return DocumentInfo(
       uri: newUrl.absoluteString,


### PR DESCRIPTION
# Why

Current implementation incorrectly appended paths and resulted in

```
Error: File '...' isn't readable.
```

because of path

```
...%2540aleqsio%252FreadableDocumentPicker/287DF057-2173-4655-BC8D-06F634700C00...
```

instead of path

```
...%2540aleqsio%252Freadable/DocumentPicker/287DF057-2173-4655-BC8D-06F634700C00...
```

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
