### PR TITLE
[docs] Add info about .expo folder in Expo CLI doc

### DIFF
--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -65,7 +65,9 @@ The following changes are optional but recommended.
 
 **.gitignore**
 
-You can add `.expo/` to your `.gitignore` to prevent generated values from Expo CLI from being committed. You can also add `ios/` and `android/` to the `.gitignore` if you want to ensure they aren't committed between prebuilds.
+You can add **.expo** to your **.gitignore** to prevent generated values from Expo CLI from being committed. These [values are unique to your project](/more/expo-cli/#expo-directory) on your local computer.
+
+You can also add **android** and **ios** to the **.gitignore** if you want to ensure they aren't committed between prebuilds.
 
 **app.json**
 

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -135,6 +135,15 @@ Offline will prevent the CLI from making network requests. If you don't use the 
 
 Expo CLI makes network requests to sign manifests with your user credentials to ensure sensitive information is sandboxed in reusable runtimes like Expo Go.
 
+### .expo directory
+
+When the you start the development server in a project for the first time, a **.expo** directory is created at the root of that project. It contains two files:
+
+- **devices.json**: Contains information about devices that have opened this project recently.
+- **settings.json**: Contains information about server configuration that is used to serve the project's manifest.
+
+Both of these files have information that is specific to your local computer. This is the reason why **.expo** directory is included in the **.gitignore** file, by default, when a new project is created. It is not meant to be shared with other developers.
+
 ## Building
 
 A React Native app consists of two parts: a native runtime ([compiling](#compiling)), and static files like JavaScript bundles and assets ([exporting](#exporting)). Expo CLI provides commands for performing both tasks.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-6156

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a new section about **.expo** directory in the Develop section of Expo CLI doc.

**Preview**
<img width="1208" alt="CleanShot 2023-06-26 at 16 31 24@2x" src="https://github.com/expo/expo/assets/10234615/f804715f-822f-4d66-b67a-ad0d402a3bb9">

- Add a link from Adopting prebuild doc to **.expo** directory section.

**Preview**

<img width="916" alt="CleanShot 2023-06-26 at 16 32 40@2x" src="https://github.com/expo/expo/assets/10234615/06e709ae-2319-44c8-9016-ce1a5b575a6c">

- Apply writing style guideline about bold filenames in Adopting prebuild guide for the above section


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting: http://localhost:3002/more/expo-cli/#expo-directory

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
