### PR TITLE
[ios][file-system] Remove unused options parameter

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed hard crash on iOS when calling readDirectoryAsync.
+
 ### 💡 Others
 
 ## 15.4.0 — 2023-06-13

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed hard crash on iOS when calling readDirectoryAsync.
+- Fixed hard crash on iOS when calling readDirectoryAsync. ([#23106](https://github.com/expo/expo/pull/23106) by [@aleqsio](https://github.com/aleqsio))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
+++ b/packages/expo-file-system/ios/EXFileSystem/EXFileSystem.m
@@ -501,7 +501,6 @@ EX_EXPORT_METHOD_AS(makeDirectoryAsync,
 
 EX_EXPORT_METHOD_AS(readDirectoryAsync,
                     readDirectoryAsyncWithURI:(NSString *)uriString
-                    withOptions:(NSDictionary *)options
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
# Why

[This line](https://github.com/expo/expo/pull/22728/files#diff-e097476902c24a2c6bd7347e1a3ea7ff74f568ffa66a94b994b6452207c62c9bL204) by @alanjhughes (btw awesome job on the migration <3, it's such a complex module!) removed a weird empty options object in two function calls on the JS side, but we still need to remove that param from the native Swift side, otherwise it causes our `reject` to be null

# How

Removed it since it's not set from JS, this fixes tests and the API.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
