### PR TITLE
[docs] Home: add talks section

### DIFF
--- a/docs/common/utilities.ts
+++ b/docs/common/utilities.ts
@@ -72,3 +72,10 @@ export const stripVersionFromPath = (path?: string) => {
 export const pathStartsWith = (name: string, path: string) => {
   return path.startsWith(`/${name}`);
 };
+
+export const chunkArray = (array: any[], chunkSize: number) => {
+  return array.reduce((acc, _, i) => {
+    if (i % chunkSize === 0) acc.push(array.slice(i, i + chunkSize));
+    return acc;
+  }, []);
+};

--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -2,6 +2,12 @@
 title: Additional resources
 ---
 
+import { Row } from 'react-grid-system';
+
+import { chunkArray } from '~/common/utilities';
+import TALKS from '~/public/static/talks';
+import { TalkGridCell, CellContainer } from '~/ui/components/Home';
+
 The following resources are useful for learning about Expo tooling and services.
 
 ## Expo Blog
@@ -42,7 +48,11 @@ The following resources are useful for learning about Expo tooling and services.
 
 ## Talks
 
-- [App.js Conf - Expo keynote (2022)](https://youtu.be/ObeaMae0hug)
-- [React Advanced - Expo overview (2021)](https://www.youtube.com/watch?v=YjJ0NG9MFkg)
-- [React Europe - Expo Snack](https://www.youtube.com/watch?v=U0vnAW4UNXE)
-- [React Europe - Building li.st for Android with Expo and React Native](https://www.youtube.com/watch?v=cI9bDvDEsYE)
+
+<CellContainer>
+  {chunkArray(TALKS, 4).map(talks => (
+    <Row>
+      {talks.map(talk => <TalkGridCell {...talk} />)}
+    </Row>
+  ))}
+</CellContainer>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { theme, typography } from '@expo/styleguide';
+import { Button, theme, typography } from '@expo/styleguide';
 import { spacing, breakpoints, borderRadius } from '@expo/styleguide-base';
 import {
   ArrowUpRightIcon,
@@ -11,11 +11,13 @@ import {
   TwitterIcon,
 } from '@expo/styleguide-icons';
 import type { PropsWithChildren } from 'react';
-import { Container, Row, ScreenClassProvider } from 'react-grid-system';
+import { Row, ScreenClassProvider } from 'react-grid-system';
 
 import DocumentationPage from '~/components/DocumentationPage';
+import TALKS from '~/public/static/talks';
 import { AppJSBanner } from '~/ui/components/AppJSBanner';
 import {
+  CellContainer,
   APIGridCell,
   CommunityGridCell,
   GridCell,
@@ -38,13 +40,6 @@ import {
 } from '~/ui/components/Home/resources';
 import { Terminal } from '~/ui/components/Snippet';
 import { H1, RawH2, RawH3, P } from '~/ui/components/Text';
-
-export const CellContainer = ({ children }: PropsWithChildren<object>) => (
-  // https://github.com/sealninja/react-grid-system/issues/175
-  <Container fluid style={{ paddingLeft: -15, paddingRight: -15, marginBottom: spacing[6] }}>
-    {children}
-  </Container>
-);
 
 const Description = ({ children }: PropsWithChildren<object>) => (
   <P css={css({ marginTop: spacing[1], marginBottom: spacing[3], color: theme.text.secondary })}>
@@ -238,32 +233,22 @@ const Home = () => {
             <APIGridCell title="View all APIs" link="/versions/latest/" icon={<APIListIcon />} />
           </Row>
         </CellContainer>
-        <RawH3>Watch the latest talks</RawH3>
-        <Description>
-          Explore our team's presentations. Stay informed and gain expertise.
-        </Description>
+        <div className="flex items-center gap-2">
+          <div>
+            <RawH3>Watch the latest talks</RawH3>
+            <Description>
+              Explore our team's presentations. Stay informed and gain expertise.
+            </Description>
+          </div>
+          <Button theme="secondary" className="ml-auto" rightSlot={<ArrowRightIcon />} href="/additional-resources/#talks">
+            See more talks
+          </Button>
+        </div>
         <CellContainer>
           <Row>
-            <TalkGridCell
-              title="Keynote: community & workflows"
-              description="Charlie Cheever & James Ide"
-              videoId="xHMu4oT6-SQ"
-            />
-            <TalkGridCell
-              title="EAS: Iterate with confidence"
-              description="Jon Samp"
-              videoId="LTui_5dqXyM"
-            />
-            <TalkGridCell
-              title="Expo Router: Write Once, Route Everywhere"
-              description="Evan Bacon"
-              videoId="608r8etX_cg"
-            />
-            <TalkGridCell
-              title="Debugging should be easier"
-              description="Cedric van Putten"
-              videoId="sRLunWEzwHI"
-            />
+            {TALKS.filter(talk => talk.home).map(talk => (
+              <TalkGridCell {...talk} />
+            ))}
           </Row>
         </CellContainer>
         <RawH3>Join the community</RawH3>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -15,7 +15,13 @@ import { Container, Row, ScreenClassProvider } from 'react-grid-system';
 
 import DocumentationPage from '~/components/DocumentationPage';
 import { AppJSBanner } from '~/ui/components/AppJSBanner';
-import { APIGridCell, CommunityGridCell, GridCell, HomeButton } from '~/ui/components/Home';
+import {
+  APIGridCell,
+  CommunityGridCell,
+  GridCell,
+  HomeButton,
+  TalkGridCell,
+} from '~/ui/components/Home';
 import {
   APICameraIcon,
   APIListIcon,
@@ -232,6 +238,34 @@ const Home = () => {
             <APIGridCell title="View all APIs" link="/versions/latest/" icon={<APIListIcon />} />
           </Row>
         </CellContainer>
+        <RawH3>Watch the latest talks</RawH3>
+        <Description>
+          Explore our team's presentations. Stay informed and gain expertise.
+        </Description>
+        <CellContainer>
+          <Row>
+            <TalkGridCell
+              title="Keynote: community & workflows"
+              description="Charlie Cheever & James Ide"
+              videoId="xHMu4oT6-SQ"
+            />
+            <TalkGridCell
+              title="EAS: Iterate with confidence"
+              description="Jon Samp"
+              videoId="LTui_5dqXyM"
+            />
+            <TalkGridCell
+              title="Expo Router: Write Once, Route Everywhere"
+              description="Evan Bacon"
+              videoId="608r8etX_cg"
+            />
+            <TalkGridCell
+              title="Debugging should be easier"
+              description="Cedric van Putten"
+              videoId="sRLunWEzwHI"
+            />
+          </Row>
+        </CellContainer>
         <RawH3>Join the community</RawH3>
         <JoinTheCommunity />
       </DocumentationPage>
@@ -289,11 +323,11 @@ export function JoinTheCommunity() {
 }
 
 const docsTitleStyle = css({
-  marginTop: 0,
+  marginTop: spacing[2],
   marginBottom: spacing[2],
   paddingBottom: 0,
   borderBottomWidth: 0,
-  fontWeight: '900',
+  fontWeight: '800',
 });
 
 const baseGradientStyle = css({

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -235,7 +235,7 @@ const Home = () => {
         </CellContainer>
         <div className="flex items-center gap-2">
           <div>
-            <RawH3>Watch the latest talks</RawH3>
+            <RawH3>Watch our latest talks</RawH3>
             <Description>
               Explore our team's presentations. Stay informed and gain expertise.
             </Description>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -240,7 +240,11 @@ const Home = () => {
               Explore our team's presentations. Stay informed and gain expertise.
             </Description>
           </div>
-          <Button theme="secondary" className="ml-auto" rightSlot={<ArrowRightIcon />} href="/additional-resources/#talks">
+          <Button
+            theme="secondary"
+            className="ml-auto"
+            rightSlot={<ArrowRightIcon />}
+            href="/additional-resources/#talks">
             See more talks
           </Button>
         </div>

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -1,0 +1,86 @@
+export default [
+  {
+    title: "Keynote: community & workflows",
+    event: 'App.js Conf 2023',
+    description: "Charlie Cheever & James Ide",
+    videoId: "xHMu4oT6-SQ",
+    home: true,
+  },
+  {
+    title: "EAS: Iterate with confidence",
+    event: 'App.js Conf 2023',
+    description: "Jon Samp",
+    videoId: "LTui_5dqXyM",
+    home: true,
+  },
+  {
+    title: "Expo Router: Write Once, Route Everywhere",
+    event: 'App.js Conf 2023',
+    description: "Evan Bacon",
+    videoId: "608r8etX_cg",
+    home: true,
+  },
+  {
+    title: "Debugging should be easier",
+    event: 'App.js Conf 2023',
+    description: "Cedric van Putten",
+    videoId: "sRLunWEzwHI",
+    home: true,
+  },
+  {
+    title: 'React Native on Linux with the New Architecture',
+    event: 'App.js Conf 2023',
+    description: 'Kudo Chien',
+    videoId: 'Ca4SNa6kL_M',
+  },
+  {
+    title: 'Not your grandparents’ Expo',
+    event: 'Chain React 2023',
+    description: 'Keith Kurak',
+    videoId: 'YufZFVL-BJc',
+  },
+  {
+    title: 'Expo keynote',
+    event: 'App.js Conf 2022',
+    description: 'Charlie Cheever, Evan Bacon, Tomasz Sapeta',
+    videoId: 'ObeaMae0hug',
+  },
+  {
+    title: 'The Hidden Features from V8 to Boost React Native',
+    event: 'App.js Conf 2022',
+    description: 'Kudo Chien',
+    videoId: '6e0b2O6NRz4',
+  },
+  {
+    title: 'Publish Updates with Expo and React Native',
+    event: 'App.js Conf 2022',
+    description: 'Quinlan Jung',
+    videoId: 'd0wzwVp8dug',
+  },
+  {
+    title: 'Limitless App Development',
+    event: 'React Advanced 2021',
+    description: 'Evan Bacon',
+    videoId: 'YjJ0NG9MFkg',
+  },
+  {
+    title: 'Expo Snack',
+    event: 'ReactEurope 2017',
+    description: 'Brent Vatne',
+    videoId: 'U0vnAW4UNXE',
+  },
+  {
+    title: 'Building li.st for Android',
+    event: 'ReactEurope 2016',
+    description: 'Brent Vatne',
+    videoId: 'cI9bDvDEsYE',
+  }
+] as Talk[];
+
+export type Talk = {
+  title: string;
+  event: string;
+  description: string;
+  videoId: string;
+  home?:boolean
+}

--- a/docs/public/static/talks.ts
+++ b/docs/public/static/talks.ts
@@ -63,18 +63,6 @@ export default [
     description: 'Evan Bacon',
     videoId: 'YjJ0NG9MFkg',
   },
-  {
-    title: 'Expo Snack',
-    event: 'ReactEurope 2017',
-    description: 'Brent Vatne',
-    videoId: 'U0vnAW4UNXE',
-  },
-  {
-    title: 'Building li.st for Android',
-    event: 'ReactEurope 2016',
-    description: 'Brent Vatne',
-    videoId: 'cI9bDvDEsYE',
-  }
 ] as Talk[];
 
 export type Talk = {

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -3,9 +3,16 @@ import { shadows, theme, typography } from '@expo/styleguide';
 import { borderRadius, breakpoints, palette, spacing } from '@expo/styleguide-base';
 import { ArrowRightIcon, ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { PropsWithChildren } from 'react';
-import { Col, ColProps } from 'react-grid-system';
+import { Container, Col, ColProps } from 'react-grid-system';
 
 import { A, CALLOUT, LABEL, P } from '~/ui/components/Text';
+
+export const CellContainer = ({ children }: PropsWithChildren<object>) => (
+  // https://github.com/sealninja/react-grid-system/issues/175
+  <Container fluid style={{ paddingLeft: -15, paddingRight: -15, marginBottom: spacing[6] }}>
+    {children}
+  </Container>
+);
 
 const CustomCol = ({ children, sm, md, lg, xl, xxl }: PropsWithChildren<ColProps>) => (
   <>
@@ -61,12 +68,14 @@ export const APIGridCell = ({
 
 type TalkGridCellProps = ColProps & {
   title?: string;
+  event?: string;
   description?: string;
   videoId?: string;
 };
 
 export const TalkGridCell = ({
   title,
+  event,
   description,
   videoId,
   className,
@@ -82,11 +91,12 @@ export const TalkGridCell = ({
       css={[cellStyle, cellAPIStyle, cellHoverStyle]}
       className={className}
       isStyled>
-      <img src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`} alt="Thumbnail" />
-      <div css={cellTitleWrapperStyle}>
+      <img src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`} alt="Thumbnail" className="border-b border-b-default" />
+      <div css={cellTitleWrapperStyle} className="gap-1">
         <div>
           <LABEL className="block !leading-normal !mb-1">{title}</LABEL>
           <CALLOUT theme="secondary">{description}</CALLOUT>
+          <CALLOUT theme="secondary">{event}</CALLOUT>
         </div>
         <ArrowUpRightIcon className="text-icon-secondary shrink-0" />
       </div>

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -5,7 +5,7 @@ import { ArrowRightIcon, ArrowUpRightIcon } from '@expo/styleguide-icons';
 import { PropsWithChildren } from 'react';
 import { Col, ColProps } from 'react-grid-system';
 
-import { A, P } from '~/ui/components/Text';
+import { A, CALLOUT, LABEL, P } from '~/ui/components/Text';
 
 const CustomCol = ({ children, sm, md, lg, xl, xxl }: PropsWithChildren<ColProps>) => (
   <>
@@ -51,9 +51,44 @@ export const APIGridCell = ({
   <CustomCol css={cellWrapperStyle} md={md} sm={sm} lg={lg} xl={xl}>
     <A href={link} css={[cellStyle, cellAPIStyle, cellHoverStyle]} className={className} isStyled>
       <div css={cellIconWrapperStyle}>{icon}</div>
-      <div css={cellTitleWrapperStyle}>
+      <LABEL css={cellTitleWrapperStyle}>
         {title}
         <ArrowRightIcon className="text-icon-secondary" />
+      </LABEL>
+    </A>
+  </CustomCol>
+);
+
+type TalkGridCellProps = ColProps & {
+  title?: string;
+  description?: string;
+  videoId?: string;
+};
+
+export const TalkGridCell = ({
+  title,
+  description,
+  videoId,
+  className,
+  sm = 6,
+  md = 6,
+  lg = 6,
+  xl = 3,
+}: TalkGridCellProps) => (
+  <CustomCol css={cellWrapperStyle} md={md} sm={sm} lg={lg} xl={xl}>
+    <A
+      openInNewTab
+      href={`https://www.youtube.com/watch?v=${videoId}`}
+      css={[cellStyle, cellAPIStyle, cellHoverStyle]}
+      className={className}
+      isStyled>
+      <img src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`} alt="Thumbnail" />
+      <div css={cellTitleWrapperStyle}>
+        <div>
+          <LABEL className="block !leading-normal !mb-1">{title}</LABEL>
+          <CALLOUT theme="secondary">{description}</CALLOUT>
+        </div>
+        <ArrowUpRightIcon className="text-icon-secondary shrink-0" />
       </div>
     </A>
   </CustomCol>
@@ -161,20 +196,18 @@ const cellAPIStyle = css({
 
 const cellIconWrapperStyle = css({
   display: 'flex',
-  minHeight: 136,
+  minHeight: 142,
   justifyContent: 'space-around',
   alignItems: 'center',
 });
 
 const cellTitleWrapperStyle = css({
-  ...typography.fontSizes[15],
   display: 'flex',
   justifyContent: 'space-between',
   backgroundColor: theme.background.default,
   padding: spacing[4],
   textDecoration: 'none',
-  fontWeight: 500,
-  lineHeight: '30px',
+  minHeight: 30,
   color: theme.text.default,
   alignItems: 'center',
 });

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -91,7 +91,11 @@ export const TalkGridCell = ({
       css={[cellStyle, cellAPIStyle, cellHoverStyle]}
       className={className}
       isStyled>
-      <img src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`} alt="Thumbnail" className="border-b border-b-default" />
+      <img
+        src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`}
+        alt="Thumbnail"
+        className="border-b border-b-default"
+      />
       <div css={cellTitleWrapperStyle} className="gap-1">
         <div>
           <LABEL className="block !leading-normal !mb-1">{title}</LABEL>


### PR DESCRIPTION
# Why

Since this year App.js Conf talks have been published as a separate videos, let's add few of them under new Talks section on the docs homepage. 

Fixes ENG-9104 and fixes ENG-9001.

# How

This PR adds the "Watch the latest talks" section to the homepage, which includes tiles build from YouTube thumbnail and talk data. They are linking to given video on YouTube platform.

# Test Plan

The changes have been tested locally. Lint check and tests are passing.

# Preview

### Home

<img width="1296" alt="Screenshot 2023-06-27 at 14 01 07" src="https://github.com/expo/expo/assets/719641/3aa49f18-f817-4acd-9612-5e1607767740">

### Additional Resources

<img width="1296" alt="Screenshot 2023-06-27 at 14 17 11" src="https://github.com/expo/expo/assets/719641/1459d236-1199-4539-a127-a036610380a1">
