### PR TITLE
[templates] enable network inspector by default

### DIFF
--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -52,5 +52,9 @@ expo.webp.enabled=true
 # Disabled by default because iOS doesn't support animated webp
 expo.webp.animated=false
 
+# Enable network inspector
+EX_DEV_CLIENT_NETWORK_INSPECTOR=true
+
 # Remove this workaround when upgrading to react-native@0.72.1
 kotlin.jvm.target.validation.mode=warning
+

--- a/templates/expo-template-bare-minimum/android/gradle.properties
+++ b/templates/expo-template-bare-minimum/android/gradle.properties
@@ -57,4 +57,3 @@ EX_DEV_CLIENT_NETWORK_INSPECTOR=true
 
 # Remove this workaround when upgrading to react-native@0.72.1
 kotlin.jvm.target.validation.mode=warning
-

--- a/templates/expo-template-bare-minimum/ios/Podfile.properties.json
+++ b/templates/expo-template-bare-minimum/ios/Podfile.properties.json
@@ -1,3 +1,4 @@
 {
-  "expo.jsEngine": "hermes"
+  "expo.jsEngine": "hermes",
+  "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true"
 }


### PR DESCRIPTION
# Why

found that network inspector doesn't enable on sdk 49 project without expo-build-properties

# How

we should add the default properties even expo-build-properties is not installed

# Test Plan

tested on a new sdk49 blank project

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
