### PR TITLE
[cli] remove --dev-client prebuild side effect

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Removed prebuild side effect that adding `--dev-client` to the npm start script. ([#23121](https://github.com/expo/expo/pull/23121) by [@kudo](https://github.com/kudo))
+
 ## 0.10.3 — 2023-06-27
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -145,7 +145,7 @@ it(
     expect(pkg.scripts).toStrictEqual({
       android: 'expo run:android',
       ios: 'expo run:ios',
-      start: 'expo start --dev-client',
+      start: 'expo start',
     });
 
     // If this changes then everything else probably changed as well.

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -145,7 +145,6 @@ it(
     expect(pkg.scripts).toStrictEqual({
       android: 'expo run:android',
       ios: 'expo run:ios',
-      start: 'expo start',
     });
 
     // If this changes then everything else probably changed as well.

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -256,9 +256,6 @@ function updatePkgScripts({ pkg }: { pkg: PackageJSONConfig }) {
   if (!pkg.scripts) {
     pkg.scripts = {};
   }
-  if (!pkg.scripts.start?.includes('--dev-client')) {
-    pkg.scripts.start = 'expo start --dev-client';
-  }
   if (!pkg.scripts.android?.includes('run')) {
     pkg.scripts.android = 'expo run:android';
   }


### PR DESCRIPTION
# Why

the `--dev-client` is deprecated in sdk 49

# How

remove the side effect of adding `--dev-client` when prebuild

# Test Plan

ci pass

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
