### PR TITLE
[dev-launcher] fix network inspector CDP events missing occasionally

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed network inspector losing events when the dev-server listening on port other than 8081. ([#23122](https://github.com/expo/expo/pull/23122) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 2.4.3 — 2023-06-27

--- a/packages/expo-dev-launcher/ios/DevLauncherNetworkInterceptor.swift
+++ b/packages/expo-dev-launcher/ios/DevLauncherNetworkInterceptor.swift
@@ -60,7 +60,10 @@ extension RCTInspectorDevServerHelper {
       A0: bundleURL
     ) as? RCTInspectorPackagerConnection
 
-    DevLauncherNetworkInterceptor.inspectorPackagerConn = inspectorPackagerConn
+    // Exclude the connections for dev-client bundles
+    if !bundleURL.absoluteString.starts(with: Bundle.main.bundleURL.absoluteString) {
+      DevLauncherNetworkInterceptor.inspectorPackagerConn = inspectorPackagerConn
+    }
     return inspectorPackagerConn
   }
 }


### PR DESCRIPTION
# Why

fix the issue that devtools does not receive cdp events from dev-client sometimes.

# How

this issue happen when the dev server port listening on port other than 8081. the swizzled `connect` method will be called for EXDevMenu.bundle and EXDevLauncher.bundle. react-native will convert the address to port 8081. we should exclude the dev-client's bundle loading.

# Test Plan

- ci passed
- `npx expo start -p 8082` with network inspector test

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
