### PR TITLE
[docs] Authentication doc: update BoxLink components and intro paragraph

### DIFF
--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -7,7 +7,7 @@ hideTOC: true
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
 
-Expo can be used to login to many popular providers on iOS, Android, and web. [`expo-auth-session`](/versions/latest/sdk/auth-session/) package allows [browser-based authentication](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work) (using OAuth or OpenID Connect) to your project for Android, iOS, and the web. You can also implement authentication using native SDKs for third-party providers with [development builds](/develop/development-builds/create-a-build).
+Expo can be used to login to many popular providers on iOS, Android, and web. [`expo-auth-session`](/versions/latest/sdk/auth-session/) package allows [browser-based authentication](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work) (using OAuth or OpenID Connect) to your project for Android, iOS, and the web. You can also implement authentication using native libraries for third-party providers with [development builds](/develop/development-builds/create-a-build).
 
 <BoxLink
   title="AuthSession API"

--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -5,35 +5,55 @@ hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { CODE } from '~/ui/components/Text';
 
-Expo can be used to login to many popular providers on iOS, Android, and web. [`expo-auth-session`](/versions/latest/sdk/auth-session/) package allows [browser-based authentication](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work) (using OAuth or OpenID Connect) to your project for Android, iOS, and the web. This guide provides steps on configuring and using the API with Google and a [development build](/develop/development-builds/create-a-build).
+Expo can be used to login to many popular providers on iOS, Android, and web. [`expo-auth-session`](/versions/latest/sdk/auth-session/) package allows [browser-based authentication](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work) (using OAuth or OpenID Connect) to your project for Android, iOS, and the web. You can also implement authentication using native SDKs for third-party providers with [development builds](/develop/development-builds/create-a-build).
 
 <BoxLink
   title="AuthSession API"
-  description="expo-auth-session is the easiest way to add web browser-based authentication (for example, browser-based OAuth flows) to your app."
+  description={
+    <>
+      <CODE>expo-auth-session</CODE> is the easiest way to add web browser-based authentication (for
+      example, browser-based OAuth flows) to your app.
+    </>
+  }
   href="/versions/latest/sdk/auth-session"
 />
 
 <BoxLink
-  title="Authentication with Google and AuthSession API"
-  description="A guide on setting up and using Google authentication with expo-auth-session in your Expo app."
+  title="Google authentication"
+  description={
+    <>
+      A guide on using <CODE>@react-native-google-signin/google-signin</CODE> library to integrate
+      Google authentication in your Expo project.
+    </>
+  }
   href="/guides/google-authentication"
 />
 
 <BoxLink
-  title="Authentication with Facebook and AuthSession API"
-  description="A guide on setting up and using Facebook authentication with AuthSession API in your Expo app."
+  title="Facebook authentication"
+  description={
+    <>
+      A guide on using <CODE>react-native-fbsdk-next</CODE> library to integrate Facebook
+      authentication in your Expo project.
+    </>
+  }
   href="/guides/facebook-authentication"
 />
 
 <BoxLink
   title="Apple Authentication"
-  description="expo-apple-authentication provides Apple authentication for iOS 13+."
+  description={
+    <>
+      <CODE>expo-apple-authentication</CODE> provides Apple authentication for iOS 13 and higher.
+    </>
+  }
   href="/versions/latest/sdk/apple-authentication"
 />
 
 <BoxLink
-  title="Other authentication guides"
-  description="A collection of implementing web-based authentication in your Expo app using AuthSession API and other OAuth providers. "
+  title="Other authentication examples"
+  description="A collection of examples for implementing web-based authentication in your Expo app using AuthSession API and other OAuth providers. "
   href="/guides/authentication"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Since we've updated Google and Facebook guides, Authentication doc in Home > Develop had outdated info.

# How

<!--
How did you build this feature or fix this bug and why?
-->
- Update the description of BoxLinks for Google and Facebook auth guides
- Update the intro paragraph to mention native SDKs can be used with Development builds
- Use `CODE` component to add code syntax highlight for libraries in `BoxLink` component
- Remove outdated and misinformation in the intro paragraph

**Preview**

<img width="1122" alt="CleanShot 2023-06-27 at 13 17 56@2x" src="https://github.com/expo/expo/assets/10234615/a400d93a-aa0a-4534-80b7-814c134ed98e">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/authentication/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
