### PR TITLE
[config-plugins][prebuild-config][jest-expo] fix unit tests

### DIFF
--- a/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Updates-test.ts.snap
+++ b/packages/@expo/config-plugins/src/android/__tests__/__snapshots__/Updates-test.ts.snap
@@ -91,6 +91,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
+
+        buildConfigField("boolean", "REACT_NATIVE_UNSTABLE_USE_RUNTIME_SCHEDULER_ALWAYS", (findProperty("reactNative.unstable_useRuntimeSchedulerAlways") ?: true).toString())
     }
     signingConfigs {
         debug {

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -803,6 +803,18 @@ exports[`built-in plugins introspects mods 1`] = `
           },
           {
             "type": "comment",
+            "value": "Enable network inspector",
+          },
+          {
+            "key": "EX_DEV_CLIENT_NETWORK_INSPECTOR",
+            "type": "property",
+            "value": "true",
+          },
+          {
+            "type": "empty",
+          },
+          {
+            "type": "comment",
             "value": "Remove this workaround when upgrading to react-native@0.72.1",
           },
           {
@@ -1299,6 +1311,7 @@ exports[`built-in plugins introspects mods 1`] = `
           },
         },
         "podfileProperties": {
+          "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
           "expo.jsEngine": "hermes",
         },
         "splashScreenStoryboard": {

--- a/packages/jest-expo/src/preset/expoModules.js
+++ b/packages/jest-expo/src/preset/expoModules.js
@@ -282,6 +282,7 @@ module.exports = {
             key: 'isRootedExperimentalAsync',
           },
         ],
+        ExpoDevMenu: [],
         ExpoDocumentPicker: [
           { name: 'getDocumentAsync', argumentsCount: 1, key: 'getDocumentAsync' },
         ],


### PR DESCRIPTION
# Why

fix broken unit tests due to template changes and jest-expo changes

# How

- [config-plugins][prebuild-config] update test snapshot
- [jest-expo] add back the jest mock to fix expo-dev-client unit test

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
