### PR TITLE
[docs] Deprecate Google and Facebook auth providers in SDK 49

### DIFF
--- a/docs/pages/versions/unversioned/sdk/auth-session.mdx
+++ b/docs/pages/versions/unversioned/sdk/auth-session.mdx
@@ -91,13 +91,20 @@ AuthSession has built-in support for some popular providers to make usage as eas
 
 ## Google
 
-```tsx
+> **warning** **Deprecated:** This provider is deprecated and will be removed in a future SDK version. See [Google authentication](/guides/google-authentication/) instead.
+
+```jsx
 import * as Google from 'expo-auth-session/providers/google';
 ```
 
 - See the guide for more info on usage: [Google Authentication](/guides/authentication.mdx#google).
 - Provides an extra `loginHint` parameter. If the user's email address is known ahead of time, it can be supplied to be the default option.
-- Enforces minimum scopes to `['openid', 'https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']` for optimal usage with services like Firebase and Auth0.
+- Enforces minimum scopes to the following APIs for optimal usage with services like Firebase and Auth0.
+
+  ```
+  ['openid', 'https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']
+  ```
+
 - By default, the authorization `code` will be automatically exchanged for an access token. This can be overridden with `shouldAutoExchangeCode`.
 - Defaults to using the bundle ID and package name for the native URI redirect instead of the reverse client ID.
 - Disables PKCE for implicit and id-token based auth responses.
@@ -124,7 +131,9 @@ A [`DiscoveryDocument`](#discoverydocument) object containing the discovery URLs
 
 ## Facebook
 
-```tsx
+> **warning** **Deprecated:** This provider is deprecated and will be removed in a future SDK version. See [Facebook authentication](/guides/facebook-authentication/) instead.
+
+```jsx
 import * as Facebook from 'expo-auth-session/providers/facebook';
 ```
 

--- a/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
@@ -91,13 +91,20 @@ AuthSession has built-in support for some popular providers to make usage as eas
 
 ## Google
 
-```tsx
+> **warning** **Deprecated:** This provider is deprecated and will be removed in a future SDK version. See [Google authentication](/guides/google-authentication/) instead.
+
+```jsx
 import * as Google from 'expo-auth-session/providers/google';
 ```
 
 - See the guide for more info on usage: [Google Authentication](/guides/authentication.mdx#google).
 - Provides an extra `loginHint` parameter. If the user's email address is known ahead of time, it can be supplied to be the default option.
-- Enforces minimum scopes to `['openid', 'https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']` for optimal usage with services like Firebase and Auth0.
+- Enforces minimum scopes to the following APIs for optimal usage with services like Firebase and Auth0.
+
+  ```
+  ['openid', 'https://www.googleapis.com/auth/userinfo.profile', 'https://www.googleapis.com/auth/userinfo.email']
+  ```
+
 - By default, the authorization `code` will be automatically exchanged for an access token. This can be overridden with `shouldAutoExchangeCode`.
 - Defaults to using the bundle ID and package name for the native URI redirect instead of the reverse client ID.
 - Disables PKCE for implicit and id-token based auth responses.
@@ -124,7 +131,9 @@ A [`DiscoveryDocument`](#discoverydocument) object containing the discovery URLs
 
 ## Facebook
 
-```tsx
+> **warning** **Deprecated:** This provider is deprecated and will be removed in a future SDK version. See [Facebook authentication](/guides/facebook-authentication/) instead.
+
+```jsx
 import * as Facebook from 'expo-auth-session/providers/facebook';
 ```
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-8772

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a deprecation callout for Google & Facebook auth providers and add link to the new guides for these providers.
Changes applied to `unversioned` and SDK 49 (beta) docs.

**Preview**

<img width="877" alt="CleanShot 2023-06-27 at 16 47 18@2x" src="https://github.com/expo/expo/assets/10234615/027c70cc-975d-4fc3-982d-634b031944eb">

<img width="897" alt="CleanShot 2023-06-27 at 16 47 08@2x" src="https://github.com/expo/expo/assets/10234615/f11af4f4-14ef-4a6e-a101-f10c129a1740">


Also, improve the code snippet in list for Google auth provider where scopes are mentioned.

<img width="900" alt="CleanShot 2023-06-27 at 16 47 13@2x" src="https://github.com/expo/expo/assets/10234615/77ed255a-1b57-4caf-ae41-15471cad43b1">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test changes, run docs locally and visit:
- http://localhost:3002/versions/unversioned/sdk/auth-session/#google
- http://localhost:3002/versions/unversioned/sdk/auth-session/#facebook

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
