### PR TITLE
[docs] Video: do not autoplay external videos

### DIFF
--- a/docs/components/plugins/Video.tsx
+++ b/docs/components/plugins/Video.tsx
@@ -40,7 +40,7 @@ const Video = ({ controls, spaceAfter, url, file, loop = true }: VideoProps) => 
               height={PLAYER_HEIGHT}
               style={playerStyle}
               muted
-              playing={isVisible}
+              playing={isVisible && !!file}
               controls={typeof controls === 'undefined' ? forceShowControls : controls}
               playsinline
               loop={loop}


### PR DESCRIPTION
# Why

Refs https://exponent-internal.slack.com/archives/C5ERY0TAR/p1686963182874339?thread_ts=1686955174.662689&cid=C5ERY0TAR

# How

Disable autoplay of external embedded videos.

# Test Plan

Changes have been tested locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
