### PR TITLE
[go] fix crashlytics gradle plugin build error

### DIFF
--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --ignore-missing --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'hhvm' 'mono-complete' 
+        sudo apt-get remove -y --ignore-missing --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
         echo 'Disk space after cleanup'

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --no-upgrade --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
         echo 'Disk space after cleanup'

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,8 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*'
+        sudo apt-get remove -y --ignore-missing --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'hhvm' 'mono-complete' 
         sudo apt-get autoremove -y
+        sudo rm -rf /usr/share/dotnet
         echo 'Disk space after cleanup'
         df -aH

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -1,5 +1,5 @@
 name: 'Cleanup GitHub Linux Runner Disk Space'
-description: 'Cleanup unused preinstalled packages on the GitHub Ubuntu runners"
+description: 'Cleanup unused preinstalled packages on the GitHub Ubuntu runners'
 
 runs:
   using: 'composite'

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' ''^dotnet-.*' '^php.*-.*'
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*'
         sudo apt-get autoremove -y
         echo 'Disk space after cleanup'
         df -aH

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -9,7 +9,7 @@ runs:
       run: |
         echo 'Disk space before cleanup'
         df -aH
-        sudo apt-get remove -y --ignore-missing --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
+        sudo apt-get remove -y --no-upgrade --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
         echo 'Disk space after cleanup'

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -1,0 +1,15 @@
+name: 'Cleanup GitHub Linux Runner Disk Space'
+description: 'Cleanup unused preinstalled packages on the GitHub Ubuntu runners"
+
+runs:
+  using: 'composite'
+  steps:
+    - name: '🧹 Cleanup preinstalled packages'
+      shell: bash
+      run: |
+        echo 'Disk space before cleanup'
+        df -aH
+        sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' ''^dotnet-.*' '^php.*-.*'
+        sudo apt-get autoremove -y
+        echo 'Disk space after cleanup'
+        df -aH

--- a/.github/actions/cleanup-linux-disk-space/action.yml
+++ b/.github/actions/cleanup-linux-disk-space/action.yml
@@ -12,5 +12,10 @@ runs:
         sudo apt-get remove -y --purge '^mysql-.*' '^mongodb-.*' '^postgresql-.*' '^aspnetcore-*' '^dotnet-.*' '^php.*-.*' 'mono-complete' 
         sudo apt-get autoremove -y
         sudo rm -rf /usr/share/dotnet
+        echo 'Showing Android SDKs'
+        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --list
+        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall 'ndk;24.0.8215888' 'ndk;25.2.9519653'
+        echo 'Removing all Docker images'
+        docker rmi -f $(docker images -aq)
         echo 'Disk space after cleanup'
         df -aH

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -45,15 +45,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '11'
-      - name: 💎 Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -69,6 +69,10 @@ android {
   buildTypes {
     debug {
       debuggable true
+      firebaseCrashlytics {
+        nativeSymbolUploadEnabled false
+        mappingFileUploadEnabled false
+      }
     }
     release {
       minifyEnabled true
@@ -77,8 +81,10 @@ android {
       if (!System.getenv("ANDROID_UNSIGNED")) {
         signingConfig signingConfigs.release
       }
+      def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
       firebaseCrashlytics {
-        nativeSymbolUploadEnabled true
+        nativeSymbolUploadEnabled shouldUploadCrashlytics
+        mappingFileUploadEnabled shouldUploadCrashlytics
       }
     }
   }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ buildscript {
   dependencies {
     classpath "com.android.tools.build:gradle:${gradlePluginVersion}"
     classpath 'com.google.gms:google-services:4.3.5'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.6'
     classpath "de.undercouch:gradle-download-task:$gradleDownloadTaskVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 


### PR DESCRIPTION
# Why

building error for `./gradlew :app:assembleVersionedRelease`

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':app:mergeVersionedReleaseNativeLibs' (type 'MergeNativeLibsTask').
  - Gradle detected a problem with the following location: '/Users/kudo/01_Work/Repos/expo/expo/android/app/build/intermediates/merged_native_libs/versionedRelease/out'.

    Reason: Task ':app:injectCrashlyticsBuildIdsVersionedRelease' uses this output of task ':app:mergeVersionedReleaseNativeLibs' without declaring an explicit or implicit dependency. This can lead to incorrect
results being produced, depending on what order the tasks are executed.

    Possible solutions:
      1. Declare task ':app:mergeVersionedReleaseNativeLibs' as an input of ':app:injectCrashlyticsBuildIdsVersionedRelease'.
      2. Declare an explicit dependency on ':app:mergeVersionedReleaseNativeLibs' from ':app:injectCrashlyticsBuildIdsVersionedRelease' using Task#dependsOn.
      3. Declare an explicit dependency on ':app:mergeVersionedReleaseNativeLibs' from ':app:injectCrashlyticsBuildIdsVersionedRelease' using Task#mustRunAfter.

    Please refer to https://docs.gradle.org/8.0.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

# How

- upgrade crashlytics gradle plugin. this issue probably relate to this: https://github.com/firebase/firebase-android-sdk/issues/4682
- since this pr touches `android/build.gradle`, it will trigger ci for building versioned expo-go and suffered from the error of "no space left" on github ci. i've tried to address the problem by some changes:
  - only upload crashlytics on eas build
  - add a composite github action to cleanup github linux runner disk space

# Test Plan

- ci passed
- `./gradlew :app:assembleVersionedRelease`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
