### PR TITLE
fix: [Android][expo-camera] - Recording video with {mute: true} option without audio permission throws exception 

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolved an issue on Android where recording a video, even with the mute: true option, would still result in an audio permission exception. Furthermore, the mute flag was incorrectly referred to as muteValue, causing it to be consistently ignored
+
 ### 💡 Others
 
 ## 13.4.0 — 2023-06-13

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolved an issue on Android where recording a video, even with the mute: true option, would still result in an audio permission exception. Furthermore, the mute flag was incorrectly referred to as muteValue, causing it to be consistently ignored
+- Resolved an issue on Android where recording a video, even with the mute: true option, would still result in an audio permission exception. Furthermore, the mute flag was incorrectly referred to as muteValue, causing it to be consistently ignored ([#23145](https://github.com/expo/expo/pull/23145) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -83,7 +83,7 @@ class CameraViewModule : Module() {
     }.runOnQueue(Queues.MAIN)
 
     AsyncFunction("record") { options: RecordingOptions, viewTag: Int, promise: Promise ->
-      if (!permissionsManager.hasGrantedPermissions(Manifest.permission.RECORD_AUDIO)) {
+      if (!options.mute && !permissionsManager.hasGrantedPermissions(Manifest.permission.RECORD_AUDIO)) {
         throw Exceptions.MissingPermissions(Manifest.permission.RECORD_AUDIO)
       }
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -165,7 +165,7 @@ class ExpoCameraView(
       val path = FileSystemUtils.generateOutputPath(cacheDirectory, "Camera", ".mp4")
       val profile = getCamcorderProfile(cameraView.cameraId, options.quality)
       options.videoBitrate?.let { profile.videoBitRate = it }
-      if (cameraView.record(path, options.maxDuration * 1000, options.maxFileSize, !options.muteValue, profile)) {
+      if (cameraView.record(path, options.maxDuration * 1000, options.maxFileSize, !options.mute, profile)) {
         videoRecordedPromise = promise
       } else {
         promise.reject("E_RECORDING_FAILED", "Starting video recording failed. Another recording might be in progress.", null)

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
@@ -19,6 +19,6 @@ class RecordingOptions : Record {
   @Field val maxDuration: Int = -1
   @Field val maxFileSize: Int = -1
   @Field val quality: Int = CamcorderProfile.QUALITY_HIGH
-  @Field val muteValue: Boolean = false
+  @Field val mute: Boolean = false
   @Field val videoBitrate: Int? = null
 }


### PR DESCRIPTION
# Why

Recording a video with the `{ mute: true }` option throws an exception when audio permission is not granted. Furthermore, the option was incorrectly implemented (referred to as `muteValue` instead of `mute`), so it never functioned as intended.

Fixes #23127

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Corrected the option and implemented a check to avoid throwing an exception when the `mute: false` flag is present, allowing it to function without audio permission.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested on Android 12+ (real device) and inside an Emulator with emulated video and mic.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
