### PR TITLE
refactor(cli): avoid changing required dependency versions when prebuilding

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Avoid changing required dependency versions when prebuilding.
+
 ### 💡 Others
 
 - Removed prebuild side effect that adding `--dev-client` to the npm start script. ([#23121](https://github.com/expo/expo/pull/23121) by [@kudo](https://github.com/kudo))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Avoid changing required dependency versions when prebuilding.
+- Avoid changing required dependency versions when prebuilding. ([#23146](https://github.com/expo/expo/pull/23146) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -137,11 +137,16 @@ describe(updatePkgDependencies, () => {
     expect(pkg.dependencies).toStrictEqual({
       ...requiredPackages,
       'react-native': 'version-from-project', // add-only package, do not overwrite
-      expo: 'version-from-template',
+      expo: 'version-from-project',
     });
     expect(Log.warn).toBeCalledWith(
       expect.stringContaining(
-        `instead of recommended ${chalk.bold('react-native@version-from-template-required-1')}`
+        `instead of recommended ${[
+          `expo@version-from-template`,
+          `react-native@version-from-template-required-1`,
+        ]
+          .map((dep) => chalk.bold(dep))
+          .join(', ')}`
       )
     );
   });


### PR DESCRIPTION
# Why

In the past, we've had issues with bugfixes and minor bumps causing issues in user projects, without user knowledge of these bumps.

# How

Instead of overwriting, the user is prompted with a warning that they arent using the recommended versions. This can be resolved with `expo install --fix` before prebuilding.

# Test Plan

- `$ yarn create expo ./test`
- Downgrade (patch or minor) any of these packages:
  - `expo`, `expo-splash-screen`, `react`, or `react-native`
- `$ yarn expo prebuild`
- This command should warn you that you are not using the recommended versions. It should NOT change these versions.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
