### PR TITLE
[expo-updates][ios][49-only] Make manifest nil for embedded bare updates

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
+++ b/ios/Exponent/Kernel/AppLoader/EXExpoGoLauncherSelectionPolicyFilterAware.swift
@@ -21,7 +21,8 @@ public final class EXExpoGoLauncherSelectionPolicyFilterAware: NSObject, Launche
   public func launchableUpdate(fromUpdates updates: [Update], filters: [String: Any]?) -> Update? {
     var runnableUpdate: Update?
     for update in updates {
-      guard let updateSDKVersion = update.manifest.expoGoSDKVersion() else {
+      guard let manifest = update.manifest,
+        let updateSDKVersion = manifest.expoGoSDKVersion() else {
         continue
       }
 

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppController.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppController.swift
@@ -463,10 +463,10 @@ public class AppController: NSObject, AppLoaderTaskDelegate, ErrorRecoveryDelega
         updateId: update.loggingId(),
         assetId: nil
       )
-      stateMachine?.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+      stateMachine?.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
       // Send UpdateEvents to JS
       sendLegacyUpdateEventToBridge(AppController.UpdateAvailableEventName, body: [
-        "manifest": update.manifest.rawManifestJSON()
+        "manifest": update.manifest!.rawManifestJSON()
       ])
     case .noUpdateAvailable:
       remoteLoadStatus = .Idle

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -381,7 +381,7 @@ public final class AppLoaderTask: NSObject {
         self.isUpToDate = false
         if let delegate = self.delegate {
           self.delegateQueue.async {
-            delegate.didFinishCheckingForRemoteUpdate(["manifest": update.manifest.rawManifestJSON()])
+            delegate.didFinishCheckingForRemoteUpdate(["manifest": update.manifest?.rawManifestJSON()])
             delegate.appLoaderTask(self, didStartLoadingUpdate: update)
           }
         }

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
@@ -9,7 +9,6 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable type_body_length
 // swiftlint:disable legacy_objc_type
-// swiftlint:disable force_unwrapping
 
 import Foundation
 import ABI49_0_0EASClient
@@ -949,7 +948,10 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
             return
           }
 
+          // swiftlint:disable force_unwrapping
           let manifestForProjectInformation = update.manifest!
+          // swiftlint:enable force_unwrapping
+          
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
@@ -9,6 +9,7 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable type_body_length
 // swiftlint:disable legacy_objc_type
+// swiftlint:disable force_unwrapping
 
 import Foundation
 import ABI49_0_0EASClient

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
@@ -948,7 +948,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
             return
           }
 
-          let manifestForProjectInformation = update.manifest
+          let manifestForProjectInformation = update.manifest!
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
@@ -951,7 +951,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
           // swiftlint:disable force_unwrapping
           let manifestForProjectInformation = update.manifest!
           // swiftlint:enable force_unwrapping
-          
+
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
@@ -102,7 +102,7 @@ public final class UpdatesDatabase: NSObject {
         update.scopeKey,
         update.commitTime,
         update.runtimeVersion,
-        update.manifest.rawManifestJSON(),
+        update.manifest?.rawManifestJSON(),
         update.status.rawValue,
         update.lastAccessed,
         update.successfulLaunchCount,

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/DevLauncherController.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/DevLauncherController.swift
@@ -100,7 +100,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
         return false
       }
 
-      return manifestBlock(update.manifest.rawManifestJSON())
+      return manifestBlock(update.manifest!.rawManifestJSON())
     } asset: { _, successfulAssetCount, failedAssetCount, totalAssetCount in
       progressBlock(UInt(successfulAssetCount), UInt(failedAssetCount), UInt(totalAssetCount))
     } success: { updateResponse in
@@ -234,7 +234,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
 
       controller.isStarted = true
       controller.launcher = launcher
-      successBlock(launcher.launchedUpdate?.manifest.rawManifestJSON())
+      successBlock(launcher.launchedUpdate?.manifest?.rawManifestJSON())
       controller.runReaper()
     }
   }

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/SelectionPolicy/SelectionPolicies.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/SelectionPolicy/SelectionPolicies.swift
@@ -10,8 +10,8 @@ public final class SelectionPolicies: NSObject {
       return true
     }
 
-    let metadata = update.manifest.rawManifestJSON()["metadata"]
-    guard let metadata = metadata as? [String: AnyObject] else {
+    guard let manifest = update.manifest,
+      let metadata = manifest.rawManifestJSON()["metadata"] as? [String: AnyObject] else {
       return true
     }
 

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/BareUpdate.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/BareUpdate.swift
@@ -47,7 +47,7 @@ internal final class BareUpdate: Update {
     }
 
     let update = Update.init(
-      manifest: manifest,
+      manifest: nil, // https://github.com/expo/expo/pull/12818 changed this to be nil
       config: config,
       database: database,
       updateId: uuid,

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/Update.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/Update.swift
@@ -88,7 +88,7 @@ public class Update: NSObject {
   public let isDevelopmentMode: Bool
   private let assetsFromManifest: [UpdateAsset]?
 
-  public let manifest: Manifest
+  public let manifest: Manifest?
 
   public var status: UpdateStatus
   public var lastAccessed: Date
@@ -99,7 +99,7 @@ public class Update: NSObject {
   private let database: UpdatesDatabase?
 
   public init(
-    manifest: Manifest,
+    manifest: Manifest?,
     config: UpdatesConfig,
     database: UpdatesDatabase?,
     updateId: UUID,

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/UpdatesModule.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/UpdatesModule.swift
@@ -54,7 +54,7 @@ public final class UpdatesModule: Module {
         "isEmbeddedLaunch": updatesService.isEmbeddedLaunch,
         "isUsingEmbeddedAssets": updatesService.isUsingEmbeddedAssets,
         "updateId": launchedUpdate.updateId.uuidString,
-        "manifest": launchedUpdate.manifest.rawManifestJSON(),
+        "manifest": launchedUpdate.manifest?.rawManifestJSON() ?? [:],
         "localAssets": updatesService.assetFilesMap ?? [:],
         "isEmergencyLaunch": updatesService.isEmergencyLaunch,
         "isMissingRuntimeVersion": isMissingRuntimeVersion,

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/UpdatesUtils.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/UpdatesUtils.swift
@@ -107,10 +107,10 @@ public final class UpdatesUtils: NSObject {
           filters: updateResponse.responseHeaderData?.manifestFilters
         ) {
           let body = [
-            "manifest": update.manifest.rawManifestJSON()
+            "manifest": update.manifest!.rawManifestJSON()
           ]
           block(body)
-          sendStateEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+          sendStateEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
         } else {
           block([:])
             sendStateEvent(UpdatesStateEventCheckComplete())
@@ -192,10 +192,10 @@ public final class UpdatesUtils: NSObject {
             let body = [
               "isNew": true,
               "isRollBackToEmbedded": false,
-              "manifest": update.manifest.rawManifestJSON()
+              "manifest": update.manifest!.rawManifestJSON()
             ] as [String: Any]
             block(body)
-            sendStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+            sendStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
             return
           } else {
             let body = [

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -463,10 +463,10 @@ public class AppController: NSObject, AppLoaderTaskDelegate, ErrorRecoveryDelega
         updateId: update.loggingId(),
         assetId: nil
       )
-      stateMachine?.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+      stateMachine?.processEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
       // Send UpdateEvents to JS
       sendLegacyUpdateEventToBridge(AppController.UpdateAvailableEventName, body: [
-        "manifest": update.manifest.rawManifestJSON()
+        "manifest": update.manifest!.rawManifestJSON()
       ])
     case .noUpdateAvailable:
       remoteLoadStatus = .Idle

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -381,7 +381,7 @@ public final class AppLoaderTask: NSObject {
         self.isUpToDate = false
         if let delegate = self.delegate {
           self.delegateQueue.async {
-            delegate.didFinishCheckingForRemoteUpdate(["manifest": update.manifest.rawManifestJSON()])
+            delegate.didFinishCheckingForRemoteUpdate(["manifest": update.manifest?.rawManifestJSON()])
             delegate.appLoaderTask(self, didStartLoadingUpdate: update)
           }
         }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -9,6 +9,7 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable type_body_length
 // swiftlint:disable legacy_objc_type
+// swiftlint:disable force_unwrapping
 
 import Foundation
 import EASClient

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -9,7 +9,6 @@
 // swiftlint:disable identifier_name
 // swiftlint:disable type_body_length
 // swiftlint:disable legacy_objc_type
-// swiftlint:disable force_unwrapping
 
 import Foundation
 import EASClient
@@ -949,7 +948,10 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
             return
           }
 
+          // swiftlint:disable force_unwrapping
           let manifestForProjectInformation = update.manifest!
+          // swiftlint:enable force_unwrapping
+          
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -948,7 +948,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
             return
           }
 
-          let manifestForProjectInformation = update.manifest
+          let manifestForProjectInformation = update.manifest!
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -951,7 +951,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
           // swiftlint:disable force_unwrapping
           let manifestForProjectInformation = update.manifest!
           // swiftlint:enable force_unwrapping
-          
+
           if expoProjectInformation.projectId != manifestForProjectInformation.easProjectId() ||
             expoProjectInformation.scopeKey != manifestForProjectInformation.scopeKey() {
             let message = "Invalid certificate for manifest project ID or scope key"

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -102,7 +102,7 @@ public final class UpdatesDatabase: NSObject {
         update.scopeKey,
         update.commitTime,
         update.runtimeVersion,
-        update.manifest.rawManifestJSON(),
+        update.manifest?.rawManifestJSON(),
         update.status.rawValue,
         update.lastAccessed,
         update.successfulLaunchCount,

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -100,7 +100,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
         return false
       }
 
-      return manifestBlock(update.manifest.rawManifestJSON())
+      return manifestBlock(update.manifest!.rawManifestJSON())
     } asset: { _, successfulAssetCount, failedAssetCount, totalAssetCount in
       progressBlock(UInt(successfulAssetCount), UInt(failedAssetCount), UInt(totalAssetCount))
     } success: { updateResponse in
@@ -234,7 +234,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
 
       controller.isStarted = true
       controller.launcher = launcher
-      successBlock(launcher.launchedUpdate?.manifest.rawManifestJSON())
+      successBlock(launcher.launchedUpdate?.manifest?.rawManifestJSON())
       controller.runReaper()
     }
   }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
@@ -10,8 +10,8 @@ public final class SelectionPolicies: NSObject {
       return true
     }
 
-    let metadata = update.manifest.rawManifestJSON()["metadata"]
-    guard let metadata = metadata as? [String: AnyObject] else {
+    guard let manifest = update.manifest,
+          let metadata = manifest.rawManifestJSON()["metadata"] as? [String: AnyObject] else {
       return true
     }
 

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
@@ -11,7 +11,7 @@ public final class SelectionPolicies: NSObject {
     }
 
     guard let manifest = update.manifest,
-          let metadata = manifest.rawManifestJSON()["metadata"] as? [String: AnyObject] else {
+      let metadata = manifest.rawManifestJSON()["metadata"] as? [String: AnyObject] else {
       return true
     }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
@@ -47,7 +47,7 @@ internal final class BareUpdate: Update {
     }
 
     let update = Update.init(
-      manifest: manifest,
+      manifest: nil, // https://github.com/expo/expo/pull/12818 changed this to be nil
       config: config,
       database: database,
       updateId: uuid,

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -88,7 +88,7 @@ public class Update: NSObject {
   public let isDevelopmentMode: Bool
   private let assetsFromManifest: [UpdateAsset]?
 
-  public let manifest: Manifest
+  public let manifest: Manifest?
 
   public var status: UpdateStatus
   public var lastAccessed: Date
@@ -99,7 +99,7 @@ public class Update: NSObject {
   private let database: UpdatesDatabase?
 
   public init(
-    manifest: Manifest,
+    manifest: Manifest?,
     config: UpdatesConfig,
     database: UpdatesDatabase?,
     updateId: UUID,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -54,7 +54,7 @@ public final class UpdatesModule: Module {
         "isEmbeddedLaunch": updatesService.isEmbeddedLaunch,
         "isUsingEmbeddedAssets": updatesService.isUsingEmbeddedAssets,
         "updateId": launchedUpdate.updateId.uuidString,
-        "manifest": launchedUpdate.manifest.rawManifestJSON(),
+        "manifest": launchedUpdate.manifest?.rawManifestJSON() ?? [:],
         "localAssets": updatesService.assetFilesMap ?? [:],
         "isEmergencyLaunch": updatesService.isEmergencyLaunch,
         "isMissingRuntimeVersion": isMissingRuntimeVersion,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -107,10 +107,10 @@ public final class UpdatesUtils: NSObject {
           filters: updateResponse.responseHeaderData?.manifestFilters
         ) {
           let body = [
-            "manifest": update.manifest.rawManifestJSON()
+            "manifest": update.manifest!.rawManifestJSON()
           ]
           block(body)
-          sendStateEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+          sendStateEvent(UpdatesStateEventCheckCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
         } else {
           block([:])
             sendStateEvent(UpdatesStateEventCheckComplete())
@@ -192,10 +192,10 @@ public final class UpdatesUtils: NSObject {
             let body = [
               "isNew": true,
               "isRollBackToEmbedded": false,
-              "manifest": update.manifest.rawManifestJSON()
+              "manifest": update.manifest!.rawManifestJSON()
             ] as [String: Any]
             block(body)
-            sendStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest.rawManifestJSON()))
+            sendStateEvent(UpdatesStateEventDownloadCompleteWithUpdate(manifest: update.manifest!.rawManifestJSON()))
             return
           } else {
             let body = [

--- a/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderManifestParsingSpec.swift
@@ -42,7 +42,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         expect(errorOccurred).to(beNil())
         expect(resultUpdateResponse?.manifestUpdateResponsePart).notTo(beNil())
-        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest.isVerified()) == false
+        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest?.isVerified()) == false
       }
       
       it("multipart body") {
@@ -80,7 +80,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(errorOccurred).to(beNil())
         expect(resultUpdateResponse).notTo(beNil())
         expect(resultUpdateResponse?.manifestUpdateResponsePart).notTo(beNil())
-        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest.isVerified()) == false
+        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest?.isVerified()) == false
         
         expect(resultUpdateResponse?.directiveUpdateResponsePart).notTo(beNil())
         expect(resultUpdateResponse?.directiveUpdateResponsePart?.updateDirective is NoUpdateAvailableUpdateDirective) == true
@@ -357,7 +357,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         expect(errorOccurred).to(beNil())
         expect(resultUpdateResponse?.manifestUpdateResponsePart).notTo(beNil())
-        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest.isVerified()) == true
+        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest?.isVerified()) == true
       }
       
       it("multipart body signed") {
@@ -402,7 +402,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         expect(resultUpdateResponse).notTo(beNil())
         expect(resultUpdateResponse).notTo(beNil())
         expect(resultUpdateResponse?.manifestUpdateResponsePart).notTo(beNil())
-        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest.isVerified()) == true
+        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest?.isVerified()) == true
         
         expect(resultUpdateResponse?.directiveUpdateResponsePart).notTo(beNil())
         expect(resultUpdateResponse?.directiveUpdateResponsePart?.updateDirective is NoUpdateAvailableUpdateDirective) == true
@@ -484,7 +484,7 @@ class FileDownloaderManifestParsingSpec : ExpoSpec {
         
         expect(errorOccurred).to(beNil())
         expect(resultUpdateResponse).notTo(beNil())
-        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest.isVerified()) == true
+        expect(resultUpdateResponse?.manifestUpdateResponsePart?.updateManifest.manifest?.isVerified()) == true
         
         expect(resultUpdateResponse?.directiveUpdateResponsePart).notTo(beNil())
         expect(resultUpdateResponse?.directiveUpdateResponsePart?.updateDirective is NoUpdateAvailableUpdateDirective) == true


### PR DESCRIPTION
# Why

Ref ENG-9068.

The history here is as follows:
- https://github.com/expo/expo/pull/12818 made bare manifests explicitly not store their manifests in the DB. Unfortunately a lot of code existed and more was added that read the manifest assuming it was non-null, but objective-c doesn't have strong nullability typing so a lot of the callsites just sort-of worked, and behavior became assumed.
- One piece of code implicitly relied upon this being nil though: when running in an embedded app. Reading https://github.com/expo/expo/pull/12818, it sounds like this was intended.
- https://github.com/expo/expo/pull/21320 added types (converted to swift), and fixed what looked like a bug: a bunch of callsites assuming a non-null property but the property being nullable, so it was made non-nullable. This caused the `Updates.manifest` constant to be defined for embedded updates, which broke the assumption in `expo-constants`.

# How

The safest thing to do in the release branch is to revert this back to be nullable. This matches the behavior on android. That's what this PR does. It's unclear at a lot of callsites what the behavior should be if it is null (crash vs not crash). In the past, a lot of these callsites would have crashed so I tried my best to emulate them.

Then, on `main`, I'll keep the current non-nil type and instead make android non-null as well. Then, @douglowder and I will figure out how to correct make `expo-constants` work. Some options:
- Just make `Updates.manifest` constant nil when running embedded update. (keep the non-nil type in most code but export nil over the bridge).
- In `expo-constants` do some logic to handle embedded cases.

# Test Plan

Cherry-pick manually into https://github.com/brentvatne/try-expoconfig, verify that it fixes the issue.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
