### PR TITLE
[expo-updates] Add E2E tests to check `expoConfig` values

### DIFF
--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -6,6 +6,7 @@ import {
   runUpdate,
   useUpdatesState,
 } from '@expo/use-updates';
+import Constants from 'expo-constants';
 import { NativeModulesProxy } from 'expo-modules-core';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
@@ -21,8 +22,11 @@ function TestValue(props: { testID: string; value: string }) {
   return (
     <View>
       <View style={{ flexDirection: 'row' }}>
-        <Text>{props.testID}</Text>
-        <Text testID={props.testID}>{props.value}</Text>
+        <Text style={styles.labelText}>{props.testID}</Text>
+        <Text style={styles.labelText}>&nbsp;</Text>
+        <Text style={styles.labelText} testID={props.testID}>
+          {props.value}
+        </Text>
       </View>
       <Text>---</Text>
     </View>
@@ -171,6 +175,13 @@ export default function App() {
         </Text>
       </ScrollView>
 
+      <Text>expoConfig</Text>
+      <ScrollView style={styles.logEntriesContainer}>
+        <Text testID="expoConfig" style={styles.logEntriesText}>
+          {JSON.stringify(Constants.expoConfig)}
+        </Text>
+      </ScrollView>
+
       {active ? <ActivityIndicator testID="activity" size="small" color="#0000ff" /> : null}
       <View style={{ flexDirection: 'row' }}>
         <View>
@@ -210,7 +221,6 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: 8,
   },
   button: {
     alignItems: 'center',
@@ -224,6 +234,10 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     color: 'white',
+    fontSize: 6,
+  },
+  labelText: {
+    fontSize: 6,
   },
   logEntriesContainer: {
     margin: 10,

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -175,9 +175,16 @@ export default function App() {
         </Text>
       </ScrollView>
 
-      <Text>expoConfig</Text>
+      <Text>Updates expoConfig</Text>
       <ScrollView style={styles.logEntriesContainer}>
-        <Text testID="expoConfig" style={styles.logEntriesText}>
+        <Text testID="updates.expoConfig" style={styles.logEntriesText}>
+          {JSON.stringify(Updates.manifest.extra?.expoConfig || {})}
+        </Text>
+      </ScrollView>
+
+      <Text>Constants expoConfig</Text>
+      <ScrollView style={styles.logEntriesContainer}>
+        <Text testID="constants.expoConfig" style={styles.logEntriesText}>
           {JSON.stringify(Constants.expoConfig)}
         </Text>
       </ScrollView>

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -555,8 +555,10 @@ describe('JS API tests', () => {
     console.warn(`latestManifestId = ${latestManifestId}`);
     console.warn(`downloadedManifestId = ${downloadedManifestId}`);
 
-    const expoConfigEmbeddedString = await testElementValueAsync('expoConfig');
-    console.warn(`expoConfigEmbedded = ${expoConfigEmbeddedString}`);
+    const updatesExpoConfigEmbeddedString = await testElementValueAsync('updates.expoConfig');
+    const constantsExpoConfigEmbeddedString = await testElementValueAsync('constants.expoConfig');
+    console.warn(`updatesExpoConfigEmbedded = ${updatesExpoConfigEmbeddedString}`);
+    console.warn(`constantsExpoConfigEmbedded = ${constantsExpoConfigEmbeddedString}`);
 
     // Now serve a manifest
     Server.start(Update.serverPort, protocolVersion);
@@ -618,8 +620,10 @@ describe('JS API tests', () => {
     console.warn(`latestManifestId4 = ${latestManifestId4}`);
     console.warn(`downloadedManifestId4 = ${downloadedManifestId4}`);
 
-    const expoConfigUpdateString = await testElementValueAsync('expoConfig');
-    console.warn(`expoConfigUpdateString = ${expoConfigUpdateString}`);
+    const updatesExpoConfigUpdateString = await testElementValueAsync('updates.expoConfig');
+    const constantsExpoConfigUpdateString = await testElementValueAsync('constants.expoConfig');
+    console.warn(`updatesExpoConfigUpdate = ${updatesExpoConfigUpdateString}`);
+    console.warn(`constantsExpoConfigUpdate = ${constantsExpoConfigUpdateString}`);
 
     // Now serve a rollback
     const rollbackDirective = Update.getRollbackDirective(new Date());
@@ -667,16 +671,14 @@ describe('JS API tests', () => {
     console.warn(`latestManifestId6 = ${latestManifestId6}`);
     console.warn(`downloadedManifestId6 = ${downloadedManifestId6}`);
 
-    const expoConfigRollbackString = await testElementValueAsync('expoConfig');
-    console.warn(`expoConfigRollbackString = ${expoConfigRollbackString}`);
+    const updatesExpoConfigRollbackString = await testElementValueAsync('updates.expoConfig');
+    const constantsExpoConfigRollbackString = await testElementValueAsync('constants.expoConfig');
+    console.warn(`updatesExpoConfigRollback = ${updatesExpoConfigRollbackString}`);
+    console.warn(`constantsExpoConfigRollback = ${constantsExpoConfigRollbackString}`);
 
     // Unpack expo config values and check them
-    const expoConfigEmbedded = JSON.parse(expoConfigEmbeddedString);
-    jestExpect(expoConfigEmbedded).not.toBeNull();
-    // const expoConfigUpdate = JSON.parse(expoConfigUpdateString);
-    // const expoConfigRollback = JSON.parse(expoConfigRollbackString);
-    // expect(expoConfigUpdate).toEqual(expoConfigEmbedded);
-    // expect(expoConfigRollback).toEqual(expoConfigEmbedded);
+    const updatesExpoConfigEmbedded = JSON.parse(updatesExpoConfigEmbeddedString);
+    jestExpect(updatesExpoConfigEmbedded).not.toBeNull();
 
     // Verify correct behavior
     // On launch

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -124,7 +124,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-1-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -168,7 +169,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-1-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -229,7 +231,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-2-key',
       bundleFilename,
-      assets
+      assets,
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -306,7 +309,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-2-key',
       bundleFilename,
-      assets
+      assets,
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -345,7 +349,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-old-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -384,7 +389,8 @@ describe('Basic tests', () => {
       hash,
       'test-update-3-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
 
     Server.start(Update.serverPort, protocolVersion);
@@ -468,7 +474,8 @@ describe('JS API tests', () => {
       hash,
       'test-update-1-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
     await device.installApp();
     await device.launchApp({
@@ -522,8 +529,11 @@ describe('JS API tests', () => {
       hash,
       'test-update-1-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
+
+    console.warn(`signed manifest = ${JSON.stringify(manifest, null, 2)}`);
 
     // Launch app
     await device.installApp();
@@ -544,6 +554,9 @@ describe('JS API tests', () => {
     console.warn(`isRollback = ${isRollback}`);
     console.warn(`latestManifestId = ${latestManifestId}`);
     console.warn(`downloadedManifestId = ${downloadedManifestId}`);
+
+    const expoConfigEmbeddedString = await testElementValueAsync('expoConfig');
+    console.warn(`expoConfigEmbedded = ${expoConfigEmbeddedString}`);
 
     // Now serve a manifest
     Server.start(Update.serverPort, protocolVersion);
@@ -605,6 +618,9 @@ describe('JS API tests', () => {
     console.warn(`latestManifestId4 = ${latestManifestId4}`);
     console.warn(`downloadedManifestId4 = ${downloadedManifestId4}`);
 
+    const expoConfigUpdateString = await testElementValueAsync('expoConfig');
+    console.warn(`expoConfigUpdateString = ${expoConfigUpdateString}`);
+
     // Now serve a rollback
     const rollbackDirective = Update.getRollbackDirective(new Date());
     await Server.serveSignedDirective(rollbackDirective, projectRoot);
@@ -623,7 +639,6 @@ describe('JS API tests', () => {
     console.warn(`isRollback5 = ${isRollback5}`);
     console.warn(`latestManifestId5 = ${latestManifestId5}`);
     console.warn(`downloadedManifestId5 = ${downloadedManifestId5}`);
-
     {
       const logEntries: any[] = await readLogEntriesAsync();
       console.warn(
@@ -634,6 +649,34 @@ describe('JS API tests', () => {
       );
       await clearLogEntriesAsync();
     }
+
+    // Terminate and relaunch app, we should be running the original bundle again, and back to the default state
+    await device.terminateApp();
+    await device.launchApp();
+    await waitForAppToBecomeVisible();
+
+    const isUpdatePending6 = await testElementValueAsync('state.isUpdatePending');
+    const isUpdateAvailable6 = await testElementValueAsync('state.isUpdateAvailable');
+    const latestManifestId6 = await testElementValueAsync('state.latestManifest.id');
+    const downloadedManifestId6 = await testElementValueAsync('state.downloadedManifest.id');
+    const isRollback6 = await testElementValueAsync('state.isRollback');
+
+    console.warn(`isUpdatePending6 = ${isUpdatePending6}`);
+    console.warn(`isUpdateAvailable6 = ${isUpdateAvailable6}`);
+    console.warn(`isRollback6 = ${isRollback6}`);
+    console.warn(`latestManifestId6 = ${latestManifestId6}`);
+    console.warn(`downloadedManifestId6 = ${downloadedManifestId6}`);
+
+    const expoConfigRollbackString = await testElementValueAsync('expoConfig');
+    console.warn(`expoConfigRollbackString = ${expoConfigRollbackString}`);
+
+    // Unpack expo config values and check them
+    const expoConfigEmbedded = JSON.parse(expoConfigEmbeddedString);
+    jestExpect(expoConfigEmbedded).not.toBeNull();
+    // const expoConfigUpdate = JSON.parse(expoConfigUpdateString);
+    // const expoConfigRollback = JSON.parse(expoConfigRollbackString);
+    // expect(expoConfigUpdate).toEqual(expoConfigEmbedded);
+    // expect(expoConfigRollback).toEqual(expoConfigEmbedded);
 
     // Verify correct behavior
     // On launch
@@ -683,7 +726,8 @@ describe('JS API tests', () => {
       hash,
       'test-update-1-key',
       bundleFilename,
-      []
+      [],
+      projectRoot
     );
     // Launch app
     await device.installApp();
@@ -930,7 +974,8 @@ describe('Asset deletion recovery tests', () => {
       bundleHash,
       'test-assets-bundle',
       bundleFilename,
-      assets
+      assets,
+      projectRoot
     );
 
     // Install the app and launch it so that it downloads the new update we're hosting

--- a/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/e2e/tests/utils/update.ts
@@ -94,8 +94,10 @@ function getUpdateManifestForBundleFilename(
   hash: string,
   key: string,
   bundleFilename: string,
-  assets: any[]
+  assets: any[],
+  projectRoot: string
 ) {
+  const appJson = require(`${projectRoot}/app.json`);
   return {
     id: crypto.randomUUID(),
     createdAt: date.toISOString(),
@@ -108,7 +110,9 @@ function getUpdateManifestForBundleFilename(
     },
     assets,
     metadata: {},
-    extra: {},
+    extra: {
+      expoConfig: appJson.expo,
+    },
   };
 }
 


### PR DESCRIPTION
# Why

Add test coverage for `Constants.expoConfig`, and separately for `Updates.manifest.extra.expoConfig`. This will allow greater safety when making changes to these APIs in the future.
# How

- Add code in the E2E server utils to attach the config object to the test manifests.
- Add code to read these values in the E2E test app, and test code to read and log them.
- TBD: add `expect` calls to check for the correct values.

# Test Plan

E2E should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
