### PR TITLE
[go] update @shopify/react-native-skia to 0.1.196

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - Updated `@react-native-picker/picker` from `2.4.8` to `2.4.10`. ([#22919](https://github.com/expo/expo/pull/22919) by [@keith-kurak](https://github.com/keith-kurak))
 - Updated `@react-native-segmented-control/segmented-control` from `2.4.0` to `2.4.1`. ([#22911](https://github.com/expo/expo/pull/22911) by [@keith-kurak](https://github.com/keith-kurak))
 - Updated `@shopify/flash-list` from `1.4.0` to `1.4.3`. ([#22893](https://github.com/expo/expo/pull/22893) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Updated `@shopify/react-native-skia` from `0.1.172` to `0.1.195`. ([#23036](https://github.com/expo/expo/pull/23036) by [@kudo](https://github.com/kudo))
+- Updated `@shopify/react-native-skia` from `0.1.172` to `0.1.196`. ([#22900](https://github.com/expo/expo/pull/22900), [#23036](https://github.com/expo/expo/pull/23036), [#23157](https://github.com/expo/expo/pull/23157) by [@kudo](https://github.com/kudo))
 - Updated `lottie-react-native` from `5.1.4` to `5.1.6`. ([#22868](https://github.com/expo/expo/pull/22868) by [@alanjhughes](https://github.com/alanjhughes))
 - Updated `react-native-gesture-handler` from `2.10.1` to `2.12.0`. ([#22621](https://github.com/expo/expo/pull/22906) by [@aleqsio](https://github.com/aleqsio))
 - Updated `react-native-maps` from `1.3.2` to `1.7.1`. ([#22908](https://github.com/expo/expo/pull/22908) by [@aleqsio](https://github.com/aleqsio))

--- a/android/vendored/sdk49/@shopify/react-native-skia/android/build.gradle
+++ b/android/vendored/sdk49/@shopify/react-native-skia/android/build.gradle
@@ -137,6 +137,12 @@ android {
         abortOnError false
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
@@ -232,6 +238,17 @@ dependencies {
     }
 }
 
+afterEvaluate { project ->
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
+        }
+    }
+}
+
 task extractAARHeaders {
     doLast {
         configurations.extractHeaders.files.each {
@@ -267,7 +284,6 @@ if (ENABLE_PREFAB) {
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
         include "**/*.h"
-        duplicatesStrategy = 'include'
         eachFile {
             String path = it.path
 

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
@@ -3,17 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include <ReactCommon/TurboModuleUtils.h>
 #include <jsi/jsi.h>
 
-#include "SkBase64.h"
-
+#include "JsiPromises.h"
 #include "JsiSkData.h"
+#include "SkBase64.h"
 
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 class JsiSkDataFactory : public JsiSkHostObject {
 public:
@@ -21,11 +19,11 @@ public:
     auto jsiLocalUri = arguments[0].asString(runtime);
     auto localUri = jsiLocalUri.utf8(runtime);
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
         [context = std::move(context), localUri = std::move(localUri)](
             jsi::Runtime &runtime,
-            std::shared_ptr<react::Promise> promise) -> void {
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run in a
           // separate thread
           context->performStreamOperation(

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
@@ -5,6 +5,7 @@
 
 #include <jsi/jsi.h>
 
+#include "JsiPromises.h"
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
 #include "JsiSkImage.h"
@@ -41,11 +42,11 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTag) {
     auto viewTag = arguments[0].asNumber();
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
-        [context = std::move(context),
-         viewTag](jsi::Runtime &runtime,
-                  std::shared_ptr<react::Promise> promise) -> void {
+        [context = std::move(context), viewTag](
+            jsi::Runtime &runtime,
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
@@ -1,0 +1,39 @@
+#include "JsiPromises.h"
+
+namespace RNJsi {
+
+JsiPromises::Promise::Promise(jsi::Runtime &rt, jsi::Function resolve,
+                              jsi::Function reject)
+    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+
+void JsiPromises::Promise::resolve(const jsi::Value &result) {
+  resolve_.call(runtime_, result);
+}
+
+void JsiPromises::Promise::reject(const std::string &message) {
+  jsi::Object error(runtime_);
+  error.setProperty(runtime_, "message",
+                    jsi::String::createFromUtf8(runtime_, message));
+  reject_.call(runtime_, error);
+}
+
+jsi::Value
+JsiPromises::createPromiseAsJSIValue(jsi::Runtime &rt,
+                                     PromiseSetupFunctionType &&func) {
+  jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
+  jsi::Function fn = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "fn"), 2,
+      [func = std::move(func)](jsi::Runtime &rt2, const jsi::Value &thisVal,
+                               const jsi::Value *args, size_t count) {
+        jsi::Function resolve = args[0].getObject(rt2).getFunction(rt2);
+        jsi::Function reject = args[1].getObject(rt2).getFunction(rt2);
+        auto wrapper = std::make_shared<Promise>(rt2, std::move(resolve),
+                                                 std::move(reject));
+        func(rt2, wrapper);
+        return jsi::Value::undefined();
+      });
+
+  return JSPromise.callAsConstructor(rt, fn);
+}
+
+} // namespace RNJsi

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <jsi/jsi.h>
+
+#include "SkBase64.h"
+
+namespace RNJsi {
+namespace jsi = facebook::jsi;
+
+/**
+ These classes are taken from ReactCommon TurboModuleUtils. It is no longer (RN
+ 0.72) possible to include and uses TurboModulesUtils without a lot of trouble
+ when use_frameworks are true in POD file. Instead we're now just including the
+ implementations ourselves.
+ */
+
+class LongLivedObject {
+public:
+  void allowRelease();
+
+protected:
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
+};
+
+class JsiPromises {
+public:
+  struct Promise : public LongLivedObject {
+    Promise(jsi::Runtime &rt, jsi::Function resolve, jsi::Function reject);
+
+    void resolve(const jsi::Value &result);
+    void reject(const std::string &error);
+
+    jsi::Runtime &runtime_;
+    jsi::Function resolve_;
+    jsi::Function reject_;
+  };
+
+  using PromiseSetupFunctionType =
+      std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
+
+  static jsi::Value createPromiseAsJSIValue(jsi::Runtime &rt,
+                                            PromiseSetupFunctionType &&func);
+};
+
+} // namespace RNJsi

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
@@ -55,10 +55,9 @@ public:
   void setPicture(std::shared_ptr<jsi::HostObject> picture) {
     if (picture == nullptr) {
       _picture = nullptr;
-      return;
+    } else {
+      _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     }
-
-    _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     _requestRedraw();
   }
 
@@ -107,7 +106,6 @@ public:
           // Clear picture
           std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
               ->setPicture(nullptr);
-          requestRedraw();
           continue;
         } else if (prop.second.getType() !=
                    RNJsi::JsiWrapperValueType::HostObject) {
@@ -119,9 +117,6 @@ public:
         // Save picture
         std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
             ->setPicture(prop.second.getAsHostObject());
-
-        // Request redraw
-        requestRedraw();
       }
     }
   }

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/codec/SkEncodedImageFormat.h" // IWYU pragma: export

--- a/android/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
+++ b/android/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/encode/SkICC.h" // IWYU pragma: export

--- a/android/vendored/unversioned/@shopify/react-native-skia/android/CMakeLists.txt
+++ b/android/vendored/unversioned/@shopify/react-native-skia/android/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(
         "${PROJECT_SOURCE_DIR}/../cpp/jsi/JsiValue.cpp"
         "${PROJECT_SOURCE_DIR}/../cpp/jsi/RuntimeLifecycleMonitor.cpp"
         "${PROJECT_SOURCE_DIR}/../cpp/jsi/RuntimeAwareCache.cpp"        
+        "${PROJECT_SOURCE_DIR}/../cpp/jsi/JsiPromises.cpp"
 
         "${PROJECT_SOURCE_DIR}/../cpp/rnskia/RNSkManager.cpp"
         "${PROJECT_SOURCE_DIR}/../cpp/rnskia/RNSkJsView.cpp"

--- a/android/vendored/unversioned/@shopify/react-native-skia/android/build.gradle
+++ b/android/vendored/unversioned/@shopify/react-native-skia/android/build.gradle
@@ -137,6 +137,12 @@ android {
         abortOnError false
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+
     externalNativeBuild {
         cmake {
             path file('CMakeLists.txt')
@@ -222,6 +228,17 @@ dependencies {
     }
 }
 
+afterEvaluate { project ->
+    android.libraryVariants.all { variant ->
+        def name = variant.name.capitalize()
+        def javaCompileTask = variant.javaCompileProvider.get()
+
+        task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
+            from javaCompileTask.destinationDir
+        }
+    }
+}
+
 task extractAARHeaders {
     doLast {
         configurations.extractHeaders.files.each {
@@ -257,7 +274,6 @@ if (ENABLE_PREFAB) {
         into "${project.buildDir}/headers/rnskia/"
         includeEmptyDirs = false
         include "**/*.h"
-        duplicatesStrategy = 'include'
         eachFile {
             String path = it.path
 

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
@@ -3,17 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include <ReactCommon/TurboModuleUtils.h>
 #include <jsi/jsi.h>
 
-#include "SkBase64.h"
-
+#include "JsiPromises.h"
 #include "JsiSkData.h"
+#include "SkBase64.h"
 
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 class JsiSkDataFactory : public JsiSkHostObject {
 public:
@@ -21,11 +19,11 @@ public:
     auto jsiLocalUri = arguments[0].asString(runtime);
     auto localUri = jsiLocalUri.utf8(runtime);
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
         [context = std::move(context), localUri = std::move(localUri)](
             jsi::Runtime &runtime,
-            std::shared_ptr<react::Promise> promise) -> void {
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run in a
           // separate thread
           context->performStreamOperation(

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
@@ -5,6 +5,7 @@
 
 #include <jsi/jsi.h>
 
+#include "JsiPromises.h"
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
 #include "JsiSkImage.h"
@@ -41,11 +42,11 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTag) {
     auto viewTag = arguments[0].asNumber();
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
-        [context = std::move(context),
-         viewTag](jsi::Runtime &runtime,
-                  std::shared_ptr<react::Promise> promise) -> void {
+        [context = std::move(context), viewTag](
+            jsi::Runtime &runtime,
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
@@ -1,0 +1,39 @@
+#include "JsiPromises.h"
+
+namespace RNJsi {
+
+JsiPromises::Promise::Promise(jsi::Runtime &rt, jsi::Function resolve,
+                              jsi::Function reject)
+    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+
+void JsiPromises::Promise::resolve(const jsi::Value &result) {
+  resolve_.call(runtime_, result);
+}
+
+void JsiPromises::Promise::reject(const std::string &message) {
+  jsi::Object error(runtime_);
+  error.setProperty(runtime_, "message",
+                    jsi::String::createFromUtf8(runtime_, message));
+  reject_.call(runtime_, error);
+}
+
+jsi::Value
+JsiPromises::createPromiseAsJSIValue(jsi::Runtime &rt,
+                                     PromiseSetupFunctionType &&func) {
+  jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
+  jsi::Function fn = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "fn"), 2,
+      [func = std::move(func)](jsi::Runtime &rt2, const jsi::Value &thisVal,
+                               const jsi::Value *args, size_t count) {
+        jsi::Function resolve = args[0].getObject(rt2).getFunction(rt2);
+        jsi::Function reject = args[1].getObject(rt2).getFunction(rt2);
+        auto wrapper = std::make_shared<Promise>(rt2, std::move(resolve),
+                                                 std::move(reject));
+        func(rt2, wrapper);
+        return jsi::Value::undefined();
+      });
+
+  return JSPromise.callAsConstructor(rt, fn);
+}
+
+} // namespace RNJsi

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <jsi/jsi.h>
+
+#include "SkBase64.h"
+
+namespace RNJsi {
+namespace jsi = facebook::jsi;
+
+/**
+ These classes are taken from ReactCommon TurboModuleUtils. It is no longer (RN
+ 0.72) possible to include and uses TurboModulesUtils without a lot of trouble
+ when use_frameworks are true in POD file. Instead we're now just including the
+ implementations ourselves.
+ */
+
+class LongLivedObject {
+public:
+  void allowRelease();
+
+protected:
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
+};
+
+class JsiPromises {
+public:
+  struct Promise : public LongLivedObject {
+    Promise(jsi::Runtime &rt, jsi::Function resolve, jsi::Function reject);
+
+    void resolve(const jsi::Value &result);
+    void reject(const std::string &error);
+
+    jsi::Runtime &runtime_;
+    jsi::Function resolve_;
+    jsi::Function reject_;
+  };
+
+  using PromiseSetupFunctionType =
+      std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
+
+  static jsi::Value createPromiseAsJSIValue(jsi::Runtime &rt,
+                                            PromiseSetupFunctionType &&func);
+};
+
+} // namespace RNJsi

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
@@ -55,10 +55,9 @@ public:
   void setPicture(std::shared_ptr<jsi::HostObject> picture) {
     if (picture == nullptr) {
       _picture = nullptr;
-      return;
+    } else {
+      _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     }
-
-    _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     _requestRedraw();
   }
 
@@ -107,7 +106,6 @@ public:
           // Clear picture
           std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
               ->setPicture(nullptr);
-          requestRedraw();
           continue;
         } else if (prop.second.getType() !=
                    RNJsi::JsiWrapperValueType::HostObject) {
@@ -119,9 +117,6 @@ public:
         // Save picture
         std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
             ->setPicture(prop.second.getAsHostObject());
-
-        // Request redraw
-        requestRedraw();
       }
     }
   }

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/codec/SkEncodedImageFormat.h" // IWYU pragma: export

--- a/android/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
+++ b/android/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/encode/SkICC.h" // IWYU pragma: export

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -56,7 +56,7 @@
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
     "@shopify/flash-list": "1.4.3",
-    "@shopify/react-native-skia": "0.1.195",
+    "@shopify/react-native-skia": "0.1.196",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",
     "expo": "~49.0.0-alpha.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1974,7 +1974,7 @@ PODS:
     - RCT-Folly
   - ABI49_0_0react-native-segmented-control (2.4.1):
     - ABI49_0_0React-Core
-  - ABI49_0_0react-native-skia (0.1.195):
+  - ABI49_0_0react-native-skia (0.1.196):
     - ABI49_0_0React
     - ABI49_0_0React-callinvoker
     - ABI49_0_0React-Core
@@ -4853,7 +4853,7 @@ SPEC CHECKSUMS:
   ABI49_0_0react-native-pager-view: 3085538cedbfd658da66107d636e09a6fa713574
   ABI49_0_0react-native-safe-area-context: 485f2482d15324f6570466b190bf4d8034ebb314
   ABI49_0_0react-native-segmented-control: af3039721178c2e16ba6ad97a519c3381bdd3436
-  ABI49_0_0react-native-skia: 5328891d4643494f8843a350be24b105e5c6faea
+  ABI49_0_0react-native-skia: d73265f61bc43159ccd6c1f85b2e90a8486814b0
   ABI49_0_0react-native-slider: f3d7912b17549c80ede3b9bc576446a63f4ce9bf
   ABI49_0_0react-native-webview: b1f4262ca5ded7143d619044d8fa589c3781cbe4
   ABI49_0_0React-NativeModulesApple: da1d30c9519eab1755b6d05fd692c5d697e197a0

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2870,7 +2870,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - react-native-segmented-control (2.4.1):
     - React-Core
-  - react-native-skia (0.1.195):
+  - react-native-skia (0.1.196):
     - React
     - React-callinvoker
     - React-Core
@@ -5011,7 +5011,7 @@ SPEC CHECKSUMS:
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 36cc67648134e89465663b8172336a19eeda493d
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
-  react-native-skia: a1bb816972960f3506c1339738eac794814fbac0
+  react-native-skia: 4753a9e236c5dfc73cfb98dccfff3496f12fd877
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-webview: b8ec89966713985111a14d6e4bf98d8b54bced0d
   React-NativeModulesApple: 038cd625999ff352fc13d11fd335ea7509794599

--- a/ios/vendored/sdk49/@shopify/react-native-skia/ABI49_0_0react-native-skia.podspec.json
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/ABI49_0_0react-native-skia.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "ABI49_0_0react-native-skia",
-  "version": "0.1.195",
+  "version": "0.1.196",
   "summary": "High-performance ABI49_0_0React Native Graphics using Skia",
   "description": "@shopify/react-native-skia",
   "homepage": "https://github.com/shopify/react-native-skia",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/react-native-skia/react-native-skia.git",
-    "tag": "0.1.195"
+    "tag": "0.1.196"
   },
   "requires_arc": true,
   "pod_target_xcconfig": {

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
@@ -3,17 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include <ABI49_0_0ReactCommon/ABI49_0_0TurboModuleUtils.h>
 #include <ABI49_0_0jsi/ABI49_0_0jsi.h>
 
-#include "SkBase64.h"
-
+#include "JsiPromises.h"
 #include "JsiSkData.h"
+#include "SkBase64.h"
 
 namespace ABI49_0_0RNSkia {
 
 namespace jsi = ABI49_0_0facebook::jsi;
-namespace ABI49_0_0React = ABI49_0_0facebook::ABI49_0_0React;
 
 class JsiSkDataFactory : public JsiSkHostObject {
 public:
@@ -21,11 +19,11 @@ public:
     auto jsiLocalUri = arguments[0].asString(runtime);
     auto localUri = jsiLocalUri.utf8(runtime);
     auto context = getContext();
-    return ABI49_0_0React::createPromiseAsJSIValue(
+    return ABI49_0_0RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
         [context = std::move(context), localUri = std::move(localUri)](
             jsi::Runtime &runtime,
-            std::shared_ptr<ABI49_0_0React::Promise> promise) -> void {
+            std::shared_ptr<ABI49_0_0RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run in a
           // separate thread
           context->performStreamOperation(

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
@@ -5,6 +5,7 @@
 
 #include <ABI49_0_0jsi/ABI49_0_0jsi.h>
 
+#include "JsiPromises.h"
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
 #include "JsiSkImage.h"
@@ -41,11 +42,11 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTag) {
     auto viewTag = arguments[0].asNumber();
     auto context = getContext();
-    return ABI49_0_0React::createPromiseAsJSIValue(
+    return ABI49_0_0RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
-        [context = std::move(context),
-         viewTag](jsi::Runtime &runtime,
-                  std::shared_ptr<ABI49_0_0React::Promise> promise) -> void {
+        [context = std::move(context), viewTag](
+            jsi::Runtime &runtime,
+            std::shared_ptr<ABI49_0_0RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
@@ -1,0 +1,39 @@
+#include "JsiPromises.h"
+
+namespace ABI49_0_0RNJsi {
+
+JsiPromises::Promise::Promise(jsi::Runtime &rt, jsi::Function resolve,
+                              jsi::Function reject)
+    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+
+void JsiPromises::Promise::resolve(const jsi::Value &result) {
+  resolve_.call(runtime_, result);
+}
+
+void JsiPromises::Promise::reject(const std::string &message) {
+  jsi::Object error(runtime_);
+  error.setProperty(runtime_, "message",
+                    jsi::String::createFromUtf8(runtime_, message));
+  reject_.call(runtime_, error);
+}
+
+jsi::Value
+JsiPromises::createPromiseAsJSIValue(jsi::Runtime &rt,
+                                     PromiseSetupFunctionType &&func) {
+  jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
+  jsi::Function fn = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "fn"), 2,
+      [func = std::move(func)](jsi::Runtime &rt2, const jsi::Value &thisVal,
+                               const jsi::Value *args, size_t count) {
+        jsi::Function resolve = args[0].getObject(rt2).getFunction(rt2);
+        jsi::Function reject = args[1].getObject(rt2).getFunction(rt2);
+        auto wrapper = std::make_shared<Promise>(rt2, std::move(resolve),
+                                                 std::move(reject));
+        func(rt2, wrapper);
+        return jsi::Value::undefined();
+      });
+
+  return JSPromise.callAsConstructor(rt, fn);
+}
+
+} // namespace ABI49_0_0RNJsi

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <ABI49_0_0jsi/ABI49_0_0jsi.h>
+
+#include "SkBase64.h"
+
+namespace ABI49_0_0RNJsi {
+namespace jsi = ABI49_0_0facebook::jsi;
+
+/**
+ These classes are taken from ABI49_0_0ReactCommon TurboModuleUtils. It is no longer (RN
+ 0.72) possible to include and uses TurboModulesUtils without a lot of trouble
+ when use_frameworks are true in POD file. Instead we're now just including the
+ implementations ourselves.
+ */
+
+class LongLivedObject {
+public:
+  void allowRelease();
+
+protected:
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
+};
+
+class JsiPromises {
+public:
+  struct Promise : public LongLivedObject {
+    Promise(jsi::Runtime &rt, jsi::Function resolve, jsi::Function reject);
+
+    void resolve(const jsi::Value &result);
+    void reject(const std::string &error);
+
+    jsi::Runtime &runtime_;
+    jsi::Function resolve_;
+    jsi::Function reject_;
+  };
+
+  using PromiseSetupFunctionType =
+      std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
+
+  static jsi::Value createPromiseAsJSIValue(jsi::Runtime &rt,
+                                            PromiseSetupFunctionType &&func);
+};
+
+} // namespace ABI49_0_0RNJsi

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/rnskia/ABI49_0_0RNSkPictureView.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/rnskia/ABI49_0_0RNSkPictureView.h
@@ -55,10 +55,9 @@ public:
   void setPicture(std::shared_ptr<jsi::HostObject> picture) {
     if (picture == nullptr) {
       _picture = nullptr;
-      return;
+    } else {
+      _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     }
-
-    _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     _requestRedraw();
   }
 
@@ -107,7 +106,6 @@ public:
           // Clear picture
           std::static_pointer_cast<ABI49_0_0RNSkPictureRenderer>(getRenderer())
               ->setPicture(nullptr);
-          requestRedraw();
           continue;
         } else if (prop.second.getType() !=
                    ABI49_0_0RNJsi::JsiWrapperValueType::HostObject) {
@@ -119,9 +117,6 @@ public:
         // Save picture
         std::static_pointer_cast<ABI49_0_0RNSkPictureRenderer>(getRenderer())
             ->setPicture(prop.second.getAsHostObject());
-
-        // Request redraw
-        requestRedraw();
       }
     }
   }

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/codec/SkEncodedImageFormat.h" // IWYU pragma: export

--- a/ios/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
+++ b/ios/vendored/sdk49/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/encode/SkICC.h" // IWYU pragma: export

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkDataFactory.h
@@ -3,17 +3,15 @@
 #include <memory>
 #include <utility>
 
-#include <ReactCommon/TurboModuleUtils.h>
 #include <jsi/jsi.h>
 
-#include "SkBase64.h"
-
+#include "JsiPromises.h"
 #include "JsiSkData.h"
+#include "SkBase64.h"
 
 namespace RNSkia {
 
 namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 class JsiSkDataFactory : public JsiSkHostObject {
 public:
@@ -21,11 +19,11 @@ public:
     auto jsiLocalUri = arguments[0].asString(runtime);
     auto localUri = jsiLocalUri.utf8(runtime);
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
         [context = std::move(context), localUri = std::move(localUri)](
             jsi::Runtime &runtime,
-            std::shared_ptr<react::Promise> promise) -> void {
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run in a
           // separate thread
           context->performStreamOperation(

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/api/JsiSkImageFactory.h
@@ -5,6 +5,7 @@
 
 #include <jsi/jsi.h>
 
+#include "JsiPromises.h"
 #include "JsiSkData.h"
 #include "JsiSkHostObjects.h"
 #include "JsiSkImage.h"
@@ -41,11 +42,11 @@ public:
   JSI_HOST_FUNCTION(MakeImageFromViewTag) {
     auto viewTag = arguments[0].asNumber();
     auto context = getContext();
-    return react::createPromiseAsJSIValue(
+    return RNJsi::JsiPromises::createPromiseAsJSIValue(
         runtime,
-        [context = std::move(context),
-         viewTag](jsi::Runtime &runtime,
-                  std::shared_ptr<react::Promise> promise) -> void {
+        [context = std::move(context), viewTag](
+            jsi::Runtime &runtime,
+            std::shared_ptr<RNJsi::JsiPromises::Promise> promise) -> void {
           // Create a stream operation - this will be run on the main thread
           context->makeViewScreenshot(
               viewTag, [&runtime, context = std::move(context),

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.cpp
@@ -1,0 +1,39 @@
+#include "JsiPromises.h"
+
+namespace RNJsi {
+
+JsiPromises::Promise::Promise(jsi::Runtime &rt, jsi::Function resolve,
+                              jsi::Function reject)
+    : runtime_(rt), resolve_(std::move(resolve)), reject_(std::move(reject)) {}
+
+void JsiPromises::Promise::resolve(const jsi::Value &result) {
+  resolve_.call(runtime_, result);
+}
+
+void JsiPromises::Promise::reject(const std::string &message) {
+  jsi::Object error(runtime_);
+  error.setProperty(runtime_, "message",
+                    jsi::String::createFromUtf8(runtime_, message));
+  reject_.call(runtime_, error);
+}
+
+jsi::Value
+JsiPromises::createPromiseAsJSIValue(jsi::Runtime &rt,
+                                     PromiseSetupFunctionType &&func) {
+  jsi::Function JSPromise = rt.global().getPropertyAsFunction(rt, "Promise");
+  jsi::Function fn = jsi::Function::createFromHostFunction(
+      rt, jsi::PropNameID::forAscii(rt, "fn"), 2,
+      [func = std::move(func)](jsi::Runtime &rt2, const jsi::Value &thisVal,
+                               const jsi::Value *args, size_t count) {
+        jsi::Function resolve = args[0].getObject(rt2).getFunction(rt2);
+        jsi::Function reject = args[1].getObject(rt2).getFunction(rt2);
+        auto wrapper = std::make_shared<Promise>(rt2, std::move(resolve),
+                                                 std::move(reject));
+        func(rt2, wrapper);
+        return jsi::Value::undefined();
+      });
+
+  return JSPromise.callAsConstructor(rt, fn);
+}
+
+} // namespace RNJsi

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/jsi/JsiPromises.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <jsi/jsi.h>
+
+#include "SkBase64.h"
+
+namespace RNJsi {
+namespace jsi = facebook::jsi;
+
+/**
+ These classes are taken from ReactCommon TurboModuleUtils. It is no longer (RN
+ 0.72) possible to include and uses TurboModulesUtils without a lot of trouble
+ when use_frameworks are true in POD file. Instead we're now just including the
+ implementations ourselves.
+ */
+
+class LongLivedObject {
+public:
+  void allowRelease();
+
+protected:
+  LongLivedObject() = default;
+  virtual ~LongLivedObject() = default;
+};
+
+class JsiPromises {
+public:
+  struct Promise : public LongLivedObject {
+    Promise(jsi::Runtime &rt, jsi::Function resolve, jsi::Function reject);
+
+    void resolve(const jsi::Value &result);
+    void reject(const std::string &error);
+
+    jsi::Runtime &runtime_;
+    jsi::Function resolve_;
+    jsi::Function reject_;
+  };
+
+  using PromiseSetupFunctionType =
+      std::function<void(jsi::Runtime &rt, std::shared_ptr<Promise>)>;
+
+  static jsi::Value createPromiseAsJSIValue(jsi::Runtime &rt,
+                                            PromiseSetupFunctionType &&func);
+};
+
+} // namespace RNJsi

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/rnskia/RNSkPictureView.h
@@ -55,10 +55,9 @@ public:
   void setPicture(std::shared_ptr<jsi::HostObject> picture) {
     if (picture == nullptr) {
       _picture = nullptr;
-      return;
+    } else {
+      _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     }
-
-    _picture = std::dynamic_pointer_cast<JsiSkPicture>(picture);
     _requestRedraw();
   }
 
@@ -107,7 +106,6 @@ public:
           // Clear picture
           std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
               ->setPicture(nullptr);
-          requestRedraw();
           continue;
         } else if (prop.second.getType() !=
                    RNJsi::JsiWrapperValueType::HostObject) {
@@ -119,9 +117,6 @@ public:
         // Save picture
         std::static_pointer_cast<RNSkPictureRenderer>(getRenderer())
             ->setPicture(prop.second.getAsHostObject());
-
-        // Request redraw
-        requestRedraw();
       }
     }
   }

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkEncodedImageFormat.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/codec/SkEncodedImageFormat.h" // IWYU pragma: export

--- a/ios/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/cpp/skia/include/core/SkICC.h
@@ -1,9 +1,0 @@
-/*
- * Copyright 2023 Google LLC
- *
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
-
-// TODO(kjlubick) remove this shim after clients have been moved to the new location
-#include "include/encode/SkICC.h" // IWYU pragma: export

--- a/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
+++ b/ios/vendored/unversioned/@shopify/react-native-skia/react-native-skia.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-skia",
-  "version": "0.1.195",
+  "version": "0.1.196",
   "summary": "High-performance React Native Graphics using Skia",
   "description": "@shopify/react-native-skia",
   "homepage": "https://github.com/shopify/react-native-skia",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/shopify/react-native-skia/react-native-skia.git",
-    "tag": "0.1.195"
+    "tag": "0.1.196"
   },
   "requires_arc": true,
   "pod_target_xcconfig": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.2.0",
   "unimodules-image-loader-interface": "~6.1.0",
-  "@shopify/react-native-skia": "0.1.195",
+  "@shopify/react-native-skia": "0.1.196",
   "@shopify/flash-list": "1.4.3",
   "@sentry/react-native": "5.5.0"
 }

--- a/tools/src/vendoring/config/react-native-skia.patch
+++ b/tools/src/vendoring/config/react-native-skia.patch
@@ -1,6 +1,6 @@
 --- android/CMakeLists.txt
 +++ android/CMakeLists.txt
-@@ -47,20 +47,20 @@
+@@ -47,21 +47,21 @@ add_library(
          "${PROJECT_SOURCE_DIR}/cpp/rnskia-android/RNSkOpenGLCanvasProvider.cpp"
          "${PROJECT_SOURCE_DIR}/cpp/rnskia-android/SkiaOpenGLRenderer.cpp"
  
@@ -8,10 +8,12 @@
 -        "${PROJECT_SOURCE_DIR}/cpp/jsi/JsiValue.cpp"
 -        "${PROJECT_SOURCE_DIR}/cpp/jsi/RuntimeLifecycleMonitor.cpp"
 -        "${PROJECT_SOURCE_DIR}/cpp/jsi/RuntimeAwareCache.cpp"        
+-        "${PROJECT_SOURCE_DIR}/cpp/jsi/JsiPromises.cpp"
 +        "${PROJECT_SOURCE_DIR}/../cpp/jsi/JsiHostObject.cpp"
 +        "${PROJECT_SOURCE_DIR}/../cpp/jsi/JsiValue.cpp"
 +        "${PROJECT_SOURCE_DIR}/../cpp/jsi/RuntimeLifecycleMonitor.cpp"
 +        "${PROJECT_SOURCE_DIR}/../cpp/jsi/RuntimeAwareCache.cpp"        
++        "${PROJECT_SOURCE_DIR}/../cpp/jsi/JsiPromises.cpp"
  
 -        "${PROJECT_SOURCE_DIR}/cpp/rnskia/RNSkManager.cpp"
 -        "${PROJECT_SOURCE_DIR}/cpp/rnskia/RNSkJsView.cpp"
@@ -32,7 +34,7 @@
  
  )
  
-@@ -74,33 +74,33 @@
+@@ -75,33 +75,33 @@ target_include_directories(
          "${NODE_MODULES_DIR}/react-native/ReactCommon/react/nativemodule/core"
          "${NODE_MODULES_DIR}/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/jni"
  
@@ -51,9 +53,7 @@
          #cpp/skia/modules/skparagraph/include/
 -        cpp/skia/include/
 -        cpp/skia
-+        ${PROJECT_SOURCE_DIR}/../cpp/skia/include/
-+        ${PROJECT_SOURCE_DIR}/../cpp/skia
- 
+-
 -        cpp/api
 -        cpp/jsi
 -        cpp/jni/include
@@ -65,6 +65,9 @@
 -        cpp/rnskia/dom/nodes
 -        cpp/rnskia/dom/props
 -        cpp/utils
++        ${PROJECT_SOURCE_DIR}/../cpp/skia/include/
++        ${PROJECT_SOURCE_DIR}/../cpp/skia
++
 +        ${PROJECT_SOURCE_DIR}/../cpp/api
 +        ${PROJECT_SOURCE_DIR}/../cpp/jsi
 +        ${PROJECT_SOURCE_DIR}/cpp/jni/include
@@ -88,7 +91,7 @@
  set_property(TARGET skia PROPERTY IMPORTED_LOCATION "${SKIA_LIBS_PATH}/libskia.a")
 --- android/build.gradle
 +++ android/build.gradle
-@@ -48,7 +48,7 @@
+@@ -48,7 +48,7 @@ static def findNodeModules(baseDir) {
    throw new GradleException("React-Native-Skia: Failed to find node_modules/ path!")
  }
  
@@ -97,7 +100,7 @@
  logger.warn("react-native-skia: node_modules/ found at: ${nodeModules}")
  
  def sourceBuild = false
-@@ -56,9 +56,9 @@
+@@ -56,9 +56,9 @@ def defaultDir
  
  if (rootProject.ext.has('reactNativeAndroidRoot')) {
    defaultDir = rootProject.ext.get('reactNativeAndroidRoot')
@@ -109,31 +112,3 @@
  } else {
    defaultDir = file("$nodeModules/react-native")
  }
-@@ -222,27 +222,6 @@
-     }
- }
- 
--afterEvaluate { project ->
--    task androidSourcesJar(type: Jar) {
--        classifier = 'sources'
--        from android.sourceSets.main.java.srcDirs
--        include '**/*.java'
--    }
--
--    android.libraryVariants.all { variant ->
--        def name = variant.name.capitalize()
--        def javaCompileTask = variant.javaCompileProvider.get()
--
--        task "jar${name}"(type: Jar, dependsOn: javaCompileTask) {
--            from javaCompileTask.destinationDir
--        }
--    }
--
--    artifacts {
--        archives androidSourcesJar
--    }
--}
--
- task extractAARHeaders {
-     doLast {
-         configurations.extractHeaders.files.each {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,10 +3539,10 @@
     recyclerlistview "4.2.0"
     tslib "2.4.0"
 
-"@shopify/react-native-skia@0.1.195":
-  version "0.1.195"
-  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.195.tgz#b911bccf651967356a9ac2203318be4b3b2fb709"
-  integrity sha512-uVehYdr2jInBnpZ70f28MzlAIPcjnrv9nK7pLitbLkQUkq4RGfO/SkUvpK52uQGIf1wK3fgJYhDfaJK4fOBE/g==
+"@shopify/react-native-skia@0.1.196":
+  version "0.1.196"
+  resolved "https://registry.yarnpkg.com/@shopify/react-native-skia/-/react-native-skia-0.1.196.tgz#f58be7cffd22d4e86f285b6d85c336188b3a61c7"
+  integrity sha512-MwL+X9XzwPdyp5juOel6pNkd7DoRfPSbjqlkOTs5C83HCdceZOO0x6DMK9uiZv/mVxQwOnexfNh5h06185qiow==
   dependencies:
     canvaskit-wasm "0.38.0"
     react-reconciler "^0.27.0"


### PR DESCRIPTION
# Why

0.1.196 is the first version compatible with react-native 0.72, we need this version for sdk 49

# How

- `et uvm -m @shopify/react-native-skia -c 0.1.196`
- re-add sdk49 versioned code for skia

# Test Plan

- ✅ unversioned expo-go + unversioned ncl skia test case
- ✅ sdk49 versioned expo-go + sdk49 ncl skia test case
- ✅ ios expo go (2.29.1, the current testflight version, which is @shopify/react-native-skia@0.1.195) + sdk49 ncl skia test case (@shopify/react-native-skia@0.1.196). this test makes sure 0.1.196 doesn't have breaking changes and compatible with 0.1.195, so that we don't have to submit a new expo-go build.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
