### PR TITLE
[go] fix network inspector stability on android

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
@@ -4,8 +4,7 @@ package host.exp.exponent
 import android.util.Log
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.common.JavascriptException
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor
+import host.exp.exponent.kernel.KernelNetworkInterceptor
 import host.exp.exponent.network.ExponentNetwork
 import host.exp.expoview.Exponent
 import okhttp3.CookieJar
@@ -174,8 +173,8 @@ object ReactNativeStaticHelpers {
       .writeTimeout(0, TimeUnit.MILLISECONDS)
       .cookieJar(cookieJar as CookieJar)
       .cache(exponentNetwork!!.cache)
-      .addInterceptor(ExpoNetworkInspectOkHttpAppInterceptor())
-      .addNetworkInterceptor(ExpoNetworkInspectOkHttpNetworkInterceptor())
+      .addInterceptor(KernelNetworkInterceptor.okhttpAppInterceptorProxy)
+      .addNetworkInterceptor(KernelNetworkInterceptor.okhttpNetworkInterceptorProxy)
     return client.build()
   }
 }

--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -71,9 +71,6 @@ abstract class ReactNativeActivity :
     RNObject("com.facebook.react.ReactInstanceManager")
   protected var isCrashed = false
 
-  protected val networkInterceptor =
-    RNObject("host.exp.exponent.ExpoNetworkInterceptor")
-
   protected var manifestUrl: String? = null
   var experienceKey: ExperienceKey? = null
   protected var sdkVersion: String? = null
@@ -290,7 +287,7 @@ abstract class ReactNativeActivity :
   override fun onPause() {
     super.onPause()
     if (reactInstanceManager.isNotNull && !isCrashed) {
-      networkInterceptor.call("onPause")
+      KernelNetworkInterceptor.onPause()
       reactInstanceManager.onHostPause()
       // TODO: use onHostPause(activity)
     }
@@ -300,7 +297,7 @@ abstract class ReactNativeActivity :
     super.onResume()
     if (reactInstanceManager.isNotNull && !isCrashed) {
       reactInstanceManager.onHostResume(this, this)
-      networkInterceptor.call("onResume", reactInstanceManager.get())
+      KernelNetworkInterceptor.onResume(reactInstanceManager.get())
     }
   }
 
@@ -492,7 +489,7 @@ abstract class ReactNativeActivity :
       initialProps(bundle)
     )
 
-    networkInterceptor.loadVersion(sdkVersion).construct().call("start", manifest, mReactInstanceManager.get())
+    KernelNetworkInterceptor.start(manifest!!, mReactInstanceManager.get())
 
     // Requesting layout to make sure {@link ReactRootView} attached to {@link ReactInstanceManager}
     // Otherwise, {@link ReactRootView} will hang in {@link waitForReactRootViewToHaveChildrenAndRunCallback}.

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
@@ -1,0 +1,54 @@
+package host.exp.exponent.kernel
+
+import expo.modules.manifests.core.Manifest
+import host.exp.exponent.RNObject
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * A singleton network interceptor proxy to forward okhttp requests to the versioned handlers.
+ */
+object KernelNetworkInterceptor {
+  private var sdkVersion: String = RNObject.UNVERSIONED
+  private var versionedAppInterceptorObject: RNObject? = null
+  private var versionedNetworkInterceptorObject: RNObject? = null
+  private var expoNetworkInterceptor: RNObject? = null
+
+  fun start(manifest: Manifest, reactInstanceManager: Any?) {
+    sdkVersion = manifest.getExpoGoSDKVersion() ?: throw IllegalArgumentException("Invalid SDK version")
+    val sdkMajorVersion = sdkVersion.split(".")[0].toIntOrNull() ?: Int.MAX_VALUE
+    if (sdkMajorVersion < 49) {
+      return
+    }
+    versionedAppInterceptorObject = RNObject("expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor")
+      .loadVersion(sdkVersion)
+      .construct()
+    versionedNetworkInterceptorObject = RNObject("expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor")
+      .loadVersion(sdkVersion)
+      .construct()
+    expoNetworkInterceptor = RNObject("host.exp.exponent.ExpoNetworkInterceptor")
+      .loadVersion(sdkVersion)
+      .construct()
+    expoNetworkInterceptor?.call("start", manifest, reactInstanceManager)
+  }
+
+  val okhttpAppInterceptorProxy = Interceptor { chain ->
+    versionedAppInterceptorObject?.call("intercept", chain) as? Response
+      ?: chain.proceed(chain.request())
+  }
+
+  val okhttpNetworkInterceptorProxy = Interceptor { chain ->
+    versionedNetworkInterceptorObject?.call("intercept", chain) as? Response
+      ?: chain.proceed(chain.request())
+  }
+
+  fun onResume(reactInstanceManager: Any?) {
+    expoNetworkInterceptor?.call("onResume", reactInstanceManager)
+  }
+
+  fun onPause() {
+    expoNetworkInterceptor?.call("onPause")
+    versionedNetworkInterceptorObject = null
+    versionedAppInterceptorObject = null
+  }
+}

--- a/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -20,14 +20,13 @@ import com.raizlabs.android.dbflow.config.FlowConfig
 import com.raizlabs.android.dbflow.config.FlowManager
 import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.SingletonModule
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.*
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.kernel.ExponentUrls
 import host.exp.exponent.kernel.KernelConstants
+import host.exp.exponent.kernel.KernelNetworkInterceptor
 import host.exp.exponent.network.ExpoResponse
 import host.exp.exponent.network.ExponentHttpClient.SafeCallback
 import host.exp.exponent.network.ExponentNetwork
@@ -416,8 +415,8 @@ class Exponent private constructor(val context: Context, val application: Applic
         .connectTimeout(HttpUrlConnectionNetworkFetcher.HTTP_DEFAULT_TIMEOUT.toLong(), TimeUnit.MILLISECONDS)
         .readTimeout(0, TimeUnit.MILLISECONDS)
         .writeTimeout(0, TimeUnit.MILLISECONDS)
-        .addInterceptor(ExpoNetworkInspectOkHttpAppInterceptor())
-        .addNetworkInterceptor(ExpoNetworkInspectOkHttpNetworkInterceptor())
+        .addInterceptor(KernelNetworkInterceptor.okhttpAppInterceptorProxy)
+        .addNetworkInterceptor(KernelNetworkInterceptor.okhttpNetworkInterceptorProxy)
         .build()
       val imagePipelineConfig = OkHttpImagePipelineConfigFactory.newBuilder(context, okHttpClient).build()
       Fresco.initialize(context, imagePipelineConfig)

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExpoNetworkInterceptor.kt
@@ -27,7 +27,7 @@ class ExpoNetworkInterceptor : Closeable, ExpoRequestCdpInterceptor.Delegate {
   }
 
   fun onResume(reactInstanceManager: ReactInstanceManager) {
-    if (!isStarted) {
+    if (!isStarted || !reactInstanceManager.devSupportManager.devSupportEnabled) {
       return
     }
     this.reactInstanceManager = reactInstanceManager

--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/host/exp/exponent/ExpoNetworkInterceptor.kt
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/host/exp/exponent/ExpoNetworkInterceptor.kt
@@ -27,7 +27,7 @@ class ExpoNetworkInterceptor : Closeable, ExpoRequestCdpInterceptor.Delegate {
   }
 
   fun onResume(reactInstanceManager: ReactInstanceManager) {
-    if (!isStarted) {
+    if (!isStarted || !reactInstanceManager.devSupportManager.devSupportEnabled) {
       return
     }
     this.reactInstanceManager = reactInstanceManager


### PR DESCRIPTION
# Why

fix some stability issues for network inspector on android expo go
close ENG-9111

# How

- disable network inspector when devSupportEnabled=false. this case happens when loading bundles without dev support, e.g. published updates.
- original network inspector is broken on versioned expo go. because we add the okhttp interceptors from unversioned classes, but on **ReactNativeActivity** we use the versioned classes to set the delegate.

# Test Plan

use versioned release expo go to test
- ✅ sdk 49 project with network inspector
- ✅ sdk 49 published project with network requests -> should not crash
- ✅ sdk 48 project with network requests -> should not crash

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
