### PR TITLE
[docs] Fix typos

### DIFF
--- a/docs/pages/eas-update/runtime-versions.mdx
+++ b/docs/pages/eas-update/runtime-versions.mdx
@@ -71,7 +71,7 @@ For a project that has the following in its app config:
 }
 ```
 
-The `"appVersion"` policy will set the runtime version to the projects current `"version"` property. The runtime version for the iOS and Android builds and any updates would be in this case `"1.0.0"`.
+The `"appVersion"` policy will set the runtime version to the project's current `"version"` property. The runtime version for the iOS and Android builds and any updates would be in this case `"1.0.0"`.
 
 This policy is great for projects that contain custom native code and that update the `"version"` field after every public release. To submit an app, the app stores require an updated native version number for each submitted build, which makes this policy convenient if you want to be sure that every version installed on user devices has a different runtime version.
 
@@ -91,7 +91,7 @@ We provide the `"nativeVersion"` runtime version policy for projects that have c
 }
 ```
 
-The `"nativeVersion"` policy will set the runtime version to the projects current `"version"` and `"buildNumber"` (iOS) or `"versionCode"` (Android) properties. For a project that has the following in its app config:
+The `"nativeVersion"` policy will set the runtime version to the project's current `"version"` and `"buildNumber"` (iOS) or `"versionCode"` (Android) properties. For a project that has the following in its app config:
 
 ```json
 {


### PR DESCRIPTION
# Why

Fixed a couple of small typos

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
