### PR TITLE
[docs] Fix Apple's request push address for custom push notification

### DIFF
--- a/docs/pages/push-notifications/sending-notifications-custom.mdx
+++ b/docs/pages/push-notifications/sending-notifications-custom.mdx
@@ -89,7 +89,7 @@ const authorizationToken = jwt.sign(
 
 ### HTTP/2 connection
 
-After getting the `authorizationToken`, you can open up an HTTP/2 connection to Apple's servers. In development, send requests to `api.development.push.apple.com`. In production, send requests to `api.push.apple.com`.
+After getting the `authorizationToken`, you can open up an HTTP/2 connection to Apple's servers. In development, send requests to `api.sandbox.push.apple.com`. In production, send requests to `api.push.apple.com`.
 
 Here's how to construct the request:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context in [slack](https://exponent-internal.slack.com/archives/C03H8T98KNH/p1687379111857129?thread_ts=1687347316.536459&cid=C03H8T98KNH)

Originally, this issue and a proposed fix were raised in #21165

# How

By changing the `api.development.push.apple.com` to `api.sandbox.push.apple.com`.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! Please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally using `yarn run dev` and visit: https://docs.expo.dev/push-notifications/sending-notifications-custom/#http2-connection

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
