### PR TITLE
[home][iOS] Fix SafeAreaView height after opening web browser

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-58ffe862b2830d56253b51ff4e0518ca970267c8"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-fbf0fab239b09466785895c43f7325b0fa1124a1"
 }

--- a/home/screens/HomeScreen/index.tsx
+++ b/home/screens/HomeScreen/index.tsx
@@ -1,7 +1,7 @@
 import { StackScreenProps } from '@react-navigation/stack';
-import { useCurrentTheme, useExpoTheme } from 'expo-dev-client-components';
+import { View, useCurrentTheme, useExpoTheme } from 'expo-dev-client-components';
 import * as React from 'react';
-import { SafeAreaView } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { HomeScreenDataQuery } from '../../graphql/types';
 import { HomeStackRoutes } from '../../navigation/Navigation.types';
@@ -49,9 +49,10 @@ export function HomeScreen(props: NavigationProps) {
   const themeType = useCurrentTheme();
   const { accountName } = useAccountName();
   const { homeScreenData } = useInitialData();
+  const insets = useSafeAreaInsets();
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: theme.background.default }}>
+    <View style={{ flex: 1, backgroundColor: theme.background.default, paddingTop: insets.top }}>
       <HomeScreenView
         theme={themeType}
         {...props}
@@ -63,6 +64,6 @@ export function HomeScreen(props: NavigationProps) {
         isAuthenticated={isAuthenticated}
         initialData={homeScreenData}
       />
-    </SafeAreaView>
+    </View>
   );
 }


### PR DESCRIPTION
# Why

Closes ENG-9124

Originally we switched to using the react-native `SafeAreaView` in order to fix a brief layout flash when launching the app on iOS (https://github.com/expo/expo/pull/21310), but this introduced another issue when opening 2 nested modals. 

# How

This PR replaces the SafeAreaView used on the Expo Go home screen to use the `useSafeAreaInsets` hook from `react-native-safe-area-context`. The main reason for using the `useSafeAreaInsets` hook directly instead of the SafeAreaView component from `react-native-safe-area-context` is that as stated on the ([React Navigation Docs](https://reactnavigation.org/docs/handling-safe-area/)) using SafeAreaView may cause a jumpy behavior.
  

# Test Plan

Run Expo Go Versioned 



 <video src="https://github.com/expo/expo/assets/11707729/c3dd9eb9-5e0e-4944-87d6-eacb453f9817" />
 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
