### PR TITLE
[expo-updates][android] Bare update manifest non-nullability parity

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoGoLauncherSelectionPolicyFilterAware.kt
@@ -18,7 +18,7 @@ class ExpoGoLauncherSelectionPolicyFilterAware(private val sdkVersions: List<Str
   ): UpdateEntity? {
     var updateToLaunch: UpdateEntity? = null
     for (update in updates) {
-      val manifest = Manifest.fromManifestJson(update.manifest!!)
+      val manifest = Manifest.fromManifestJson(update.manifest)
       if (!sdkVersions.contains(manifest.getExpoGoSDKVersion()) || !SelectionPolicies.matchesFilters(
           update,
           filters

--- a/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -228,7 +228,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
         }
 
         override fun onCachedUpdateLoaded(update: UpdateEntity): Boolean {
-          val manifest = Manifest.fromManifestJson(update.manifest!!)
+          val manifest = Manifest.fromManifestJson(update.manifest)
           setShouldShowAppLoaderStatus(manifest)
           if (manifest.isUsingDeveloperTool()) {
             return false
@@ -271,7 +271,7 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
           this@ExpoUpdatesAppLoader.launcher = launcher
           this@ExpoUpdatesAppLoader.isUpToDate = isUpToDate
           try {
-            val manifestJson = processManifestJson(launcher.launchedUpdate!!.manifest!!)
+            val manifestJson = processManifestJson(launcher.launchedUpdate!!.manifest)
             val manifest = Manifest.fromManifestJson(manifestJson)
             callback.onManifestCompleted(manifest)
 

--- a/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi47_0_0/src/main/java/abi47_0_0/expo/modules/updates/UpdatesModule.kt
@@ -71,8 +71,7 @@ class UpdatesModule(
         if (launchedUpdate != null) {
           constants["updateId"] = launchedUpdate.id.toString()
           constants["commitTime"] = launchedUpdate.commitTime.time
-          constants["manifestString"] =
-            if (launchedUpdate.manifest != null) launchedUpdate.manifest.toString() else "{}"
+          constants["manifestString"] = launchedUpdate.manifest.toString()
         }
         val localAssetFiles = updatesServiceLocal.localAssetFiles
         if (localAssetFiles != null) {

--- a/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi48_0_0/src/main/java/abi48_0_0/expo/modules/updates/UpdatesModule.kt
@@ -72,8 +72,7 @@ class UpdatesModule(
         if (launchedUpdate != null) {
           constants["updateId"] = launchedUpdate.id.toString()
           constants["commitTime"] = launchedUpdate.commitTime.time
-          constants["manifestString"] =
-            if (launchedUpdate.manifest != null) launchedUpdate.manifest.toString() else "{}"
+          constants["manifestString"] = launchedUpdate.manifest.toString()
         }
         val localAssetFiles = updatesServiceLocal.localAssetFiles
         if (localAssetFiles != null) {

--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updates/UpdatesModule.kt
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/updates/UpdatesModule.kt
@@ -76,8 +76,7 @@ class UpdatesModule(
         if (launchedUpdate != null) {
           constants["updateId"] = launchedUpdate.id.toString()
           constants["commitTime"] = launchedUpdate.commitTime.time
-          constants["manifestString"] =
-            if (launchedUpdate.manifest != null) launchedUpdate.manifest.toString() else "{}"
+          constants["manifestString"] = launchedUpdate.manifest.toString()
         }
         val localAssetFiles = updatesServiceLocal.localAssetFiles
         if (localAssetFiles != null) {
@@ -338,7 +337,7 @@ class UpdatesModule(
                       updateEntity.manifest.toString()
                     )
                     updatesServiceLocal.stateMachine?.processEvent(
-                      UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest!!)
+                      UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest)
                     )
                   }
                 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed the `node` execution on Windows. ([#23983](https://github.com/expo/expo/pull/23983) by [@kudo](https://github.com/kudo))
+- Bare update manifest non-nullability parity. ([#23166](https://github.com/expo/expo/pull/23166) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/BuildDataTest.kt
@@ -8,6 +8,7 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.entity.UpdateEntity
 import io.mockk.spyk
 import io.mockk.verify
+import org.json.JSONObject
 import org.junit.Assert.*
 
 import org.junit.After
@@ -57,7 +58,7 @@ class BuildDataTest {
     val date = Date()
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId)
+    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId, JSONObject("{}"))
     db.updateDao().insertUpdate(testUpdate)
 
     spyBuildData = spyk(BuildData)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/DatabaseIntegrityCheckTest.kt
@@ -9,6 +9,7 @@ import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.db.entity.AssetEntity
 import io.mockk.every
 import io.mockk.spyk
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -39,10 +40,10 @@ class DatabaseIntegrityCheckTest {
     // from the database entirely.
     val scopeKey = "testScopeKey"
 
-    val embeddedUpdate1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), "1.0", scopeKey)
+    val embeddedUpdate1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), "1.0", scopeKey, JSONObject("{}"))
     embeddedUpdate1.status = UpdateStatus.EMBEDDED
 
-    val embeddedUpdate2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), "1.0", scopeKey)
+    val embeddedUpdate2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), "1.0", scopeKey, JSONObject("{}"))
     embeddedUpdate2.status = UpdateStatus.EMBEDDED
 
     db.updateDao().insertUpdate(embeddedUpdate1)
@@ -67,7 +68,7 @@ class DatabaseIntegrityCheckTest {
 
     val scopeKey = "testScopeKey"
 
-    val update1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", scopeKey)
+    val update1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", scopeKey, JSONObject("{}"))
     update1.status = UpdateStatus.READY
 
     db.updateDao().insertUpdate(update1)
@@ -97,7 +98,7 @@ class DatabaseIntegrityCheckTest {
 
     val scopeKey = "testScopeKey"
 
-    val update1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", scopeKey)
+    val update1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", scopeKey, JSONObject("{}"))
     update1.status = UpdateStatus.READY
 
     db.updateDao().insertUpdate(update1)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
@@ -9,6 +9,7 @@ import expo.modules.updates.db.dao.UpdateDao
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateAssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -41,7 +42,8 @@ class UpdatesDatabaseTest {
     val date = Date()
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId)
+    val manifest = JSONObject("{}")
+    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId, manifest)
 
     updateDao.insertUpdate(testUpdate)
 
@@ -51,6 +53,7 @@ class UpdatesDatabaseTest {
     Assert.assertEquals(date, byId.commitTime)
     Assert.assertEquals(runtimeVersion, byId.runtimeVersion)
     Assert.assertEquals(projectId, byId.scopeKey)
+    Assert.assertEquals(manifest.toString(), byId.manifest.toString())
 
     updateDao.deleteUpdates(listOf(testUpdate))
     Assert.assertEquals(0, updateDao.loadAllUpdates().size.toLong())
@@ -62,7 +65,7 @@ class UpdatesDatabaseTest {
     val date = Date()
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId)
+    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId, JSONObject("{}"))
 
     updateDao.insertUpdate(testUpdate)
 
@@ -79,7 +82,7 @@ class UpdatesDatabaseTest {
     val date = Date()
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId)
+    val testUpdate = UpdateEntity(uuid, date, runtimeVersion, projectId, JSONObject("{}"))
 
     updateDao.insertUpdate(testUpdate)
     Assert.assertEquals(0, updateDao.loadLaunchableUpdatesForScope(projectId).size.toLong())
@@ -95,20 +98,20 @@ class UpdatesDatabaseTest {
   fun testDeleteUnusedAssets() {
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val update1 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId)
+    val update1 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId, JSONObject("{}"))
     val asset1 = AssetEntity("asset1", "png")
     val commonAsset = AssetEntity("commonAsset", "png")
 
     updateDao.insertUpdate(update1)
     assetDao.insertAssets(listOf(asset1, commonAsset), update1)
 
-    val update2 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId)
+    val update2 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId, JSONObject("{}"))
     val asset2 = AssetEntity("asset2", "png")
     updateDao.insertUpdate(update2)
     assetDao.insertAssets(listOf(asset2), update2)
     assetDao.addExistingAssetToUpdate(update2, commonAsset, false)
 
-    val update3 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId)
+    val update3 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId, JSONObject("{}"))
     val asset3 = AssetEntity("asset3", "png")
     updateDao.insertUpdate(update3)
     assetDao.insertAssets(listOf(asset3), update3)
@@ -146,8 +149,8 @@ class UpdatesDatabaseTest {
   fun testDeleteUnusedAssets_DuplicateFilenames() {
     val runtimeVersion = "1.0"
     val projectId = "https://exp.host/@esamelson/test-project"
-    val update1 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId)
-    val update2 = UpdateEntity(UUID.randomUUID(), Date(Date().time + 1), runtimeVersion, projectId)
+    val update1 = UpdateEntity(UUID.randomUUID(), Date(), runtimeVersion, projectId, JSONObject("{}"))
+    val update2 = UpdateEntity(UUID.randomUUID(), Date(Date().time + 1), runtimeVersion, projectId, JSONObject("{}"))
     updateDao.insertUpdate(update1)
     updateDao.insertUpdate(update2)
     updateDao.markUpdateFinished(update1)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -17,6 +17,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -59,7 +60,7 @@ class DatabaseLauncherTest {
 
   @Test
   fun testGetUpdateIds_DBWithOneUpdate() {
-    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
     testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate.status = UpdateStatus.READY
     db.updateDao().insertUpdate(testUpdate)
@@ -80,12 +81,12 @@ class DatabaseLauncherTest {
 
   @Test
   fun testGetUpdateIds_DBWithOneReadyUpdate() {
-    val testUpdate1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    val testUpdate1 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
     testUpdate1.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate1.status = UpdateStatus.READY
     db.updateDao().insertUpdate(testUpdate1)
 
-    val testUpdate2 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    val testUpdate2 = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
     testUpdate2.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     testUpdate2.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(testUpdate2)
@@ -106,7 +107,7 @@ class DatabaseLauncherTest {
 
   @Test
   fun testLaunch_MarkUpdateAccessed() {
-    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey")
+    val testUpdate = UpdateEntity(UUID.randomUUID(), Date(), "1.0", "scopeKey", JSONObject("{}"))
     testUpdate.lastAccessed = Date(Date().time - DateUtils.DAY_IN_MILLIS) // yesterday
     db.updateDao().insertUpdate(testUpdate)
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -240,7 +240,8 @@ class EmbeddedLoaderTest {
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
       manifest.updateEntity!!.runtimeVersion,
-      manifest.updateEntity!!.scopeKey
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
@@ -263,7 +264,8 @@ class EmbeddedLoaderTest {
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
       manifest.updateEntity!!.runtimeVersion,
-      manifest.updateEntity!!.scopeKey
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest
     )
     update.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(update)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -163,9 +163,9 @@ class FileDownloaderTest {
     every { ManifestMetadata.getExtraParams(any(), any()) } returns mapOf("hello" to "world", "what" to "123")
 
     val launchedUpdateUUIDString = "7c1d2bd0-f88b-454d-998c-7fa92a924dbf"
-    val launchedUpdate = UpdateEntity(UUID.fromString(launchedUpdateUUIDString), Date(), "1.0", "test")
+    val launchedUpdate = UpdateEntity(UUID.fromString(launchedUpdateUUIDString), Date(), "1.0", "test", JSONObject("{}"))
     val embeddedUpdateUUIDString = "9433b1ed-4006-46b8-8aa7-fdc7eeb203fd"
-    val embeddedUpdate = UpdateEntity(UUID.fromString(embeddedUpdateUUIDString), Date(), "1.0", "test")
+    val embeddedUpdate = UpdateEntity(UUID.fromString(embeddedUpdateUUIDString), Date(), "1.0", "test", JSONObject("{}"))
 
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(mockk(), mockk(), launchedUpdate, embeddedUpdate)
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -184,7 +184,8 @@ class RemoteLoaderTest {
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
       manifest.updateEntity!!.runtimeVersion,
-      manifest.updateEntity!!.scopeKey
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
@@ -205,7 +206,8 @@ class RemoteLoaderTest {
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
       manifest.updateEntity!!.runtimeVersion,
-      manifest.updateEntity!!.scopeKey
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest
     )
     update.status = UpdateStatus.PENDING
     db.updateDao().insertUpdate(update)
@@ -230,7 +232,8 @@ class RemoteLoaderTest {
       manifest.updateEntity!!.id,
       manifest.updateEntity!!.commitTime,
       manifest.updateEntity!!.runtimeVersion,
-      "differentScopeKey"
+      "differentScopeKey",
+      manifest.updateEntity!!.manifest
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClientTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyDevelopmentClientTest.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.selectionpolicy
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import expo.modules.updates.db.entity.UpdateEntity
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,11 +13,11 @@ class ReaperSelectionPolicyDevelopmentClientTest {
   private val runtimeVersion = "1.0"
 
   // test updates with different scopes to ensure this policy ignores scopes
-  private val update1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), runtimeVersion, "scope1")
-  private val update2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), runtimeVersion, "scope2")
-  private val update3 = UpdateEntity(UUID.randomUUID(), Date(1608667857776L), runtimeVersion, "scope3")
-  private val update4 = UpdateEntity(UUID.randomUUID(), Date(1608667857777L), runtimeVersion, "scope4")
-  private val update5 = UpdateEntity(UUID.randomUUID(), Date(1608667857778L), runtimeVersion, "scope5")
+  private val update1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), runtimeVersion, "scope1", JSONObject("{}"))
+  private val update2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), runtimeVersion, "scope2", JSONObject("{}"))
+  private val update3 = UpdateEntity(UUID.randomUUID(), Date(1608667857776L), runtimeVersion, "scope3", JSONObject("{}"))
+  private val update4 = UpdateEntity(UUID.randomUUID(), Date(1608667857777L), runtimeVersion, "scope4", JSONObject("{}"))
+  private val update5 = UpdateEntity(UUID.randomUUID(), Date(1608667857778L), runtimeVersion, "scope5", JSONObject("{}"))
 
   // for readability/writability, test with a policy that keeps only 3 updates;
   // the actual functionality is independent of the number

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAwareTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/selectionpolicy/ReaperSelectionPolicyFilterAwareTest.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.selectionpolicy
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import expo.modules.updates.db.entity.UpdateEntity
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,11 +12,11 @@ import java.util.*
 class ReaperSelectionPolicyFilterAwareTest {
   private val runtimeVersion = "1.0"
   private val scopeKey = "dummyScope"
-  private val update1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), runtimeVersion, scopeKey)
-  private val update2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), runtimeVersion, scopeKey)
-  private val update3 = UpdateEntity(UUID.randomUUID(), Date(1608667857776L), runtimeVersion, scopeKey)
-  private val update4 = UpdateEntity(UUID.randomUUID(), Date(1608667857777L), runtimeVersion, scopeKey)
-  private val update5 = UpdateEntity(UUID.randomUUID(), Date(1608667857778L), runtimeVersion, scopeKey)
+  private val update1 = UpdateEntity(UUID.randomUUID(), Date(1608667857774L), runtimeVersion, scopeKey, JSONObject("{}"))
+  private val update2 = UpdateEntity(UUID.randomUUID(), Date(1608667857775L), runtimeVersion, scopeKey, JSONObject("{}"))
+  private val update3 = UpdateEntity(UUID.randomUUID(), Date(1608667857776L), runtimeVersion, scopeKey, JSONObject("{}"))
+  private val update4 = UpdateEntity(UUID.randomUUID(), Date(1608667857777L), runtimeVersion, scopeKey, JSONObject("{}"))
+  private val update5 = UpdateEntity(UUID.randomUUID(), Date(1608667857778L), runtimeVersion, scopeKey, JSONObject("{}"))
   private val selectionPolicy: ReaperSelectionPolicy = ReaperSelectionPolicyFilterAware()
 
   @Test
@@ -65,7 +66,7 @@ class ReaperSelectionPolicyFilterAwareTest {
   @Test
   fun testSelectUpdatesToDelete_differentScopeKey() {
     val update4DifferentScope =
-      UpdateEntity(update4.id, update4.commitTime, update4.runtimeVersion, "differentScopeKey")
+      UpdateEntity(update4.id, update4.commitTime, update4.runtimeVersion, "differentScopeKey", JSONObject("{}"))
     val updatesToDelete = selectionPolicy.selectUpdatesToDelete(
       listOf(update1, update2, update3, update4DifferentScope),
       update4DifferentScope,

--- a/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/12.json
+++ b/packages/expo-updates/android/src/androidTest/schemas/expo.modules.updates.db.UpdatesDatabase/12.json
@@ -1,0 +1,344 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "472340246d291854f67ce4b51e48fb0b",
+    "entities": [
+      {
+        "tableName": "updates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` BLOB NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `scope_key` TEXT NOT NULL, `manifest` TEXT NOT NULL, `launch_asset_id` INTEGER, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commitTime",
+            "columnName": "commit_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtimeVersion",
+            "columnName": "runtime_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manifest",
+            "columnName": "manifest",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchAssetId",
+            "columnName": "launch_asset_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "keep",
+            "columnName": "keep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastAccessed",
+            "columnName": "last_accessed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "successfulLaunchCount",
+            "columnName": "successful_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "failedLaunchCount",
+            "columnName": "failed_launch_count",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_launch_asset_id",
+            "unique": false,
+            "columnNames": [
+              "launch_asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_launch_asset_id` ON `${TABLE_NAME}` (`launch_asset_id`)"
+          },
+          {
+            "name": "index_updates_scope_key_commit_time",
+            "unique": true,
+            "columnNames": [
+              "scope_key",
+              "commit_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_updates_scope_key_commit_time` ON `${TABLE_NAME}` (`scope_key`, `commit_time`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "launch_asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "updates_assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`update_id` BLOB NOT NULL, `asset_id` INTEGER NOT NULL, PRIMARY KEY(`update_id`, `asset_id`), FOREIGN KEY(`update_id`) REFERENCES `updates`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "updateId",
+            "columnName": "update_id",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assetId",
+            "columnName": "asset_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "update_id",
+            "asset_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_updates_assets_asset_id",
+            "unique": false,
+            "columnNames": [
+              "asset_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_updates_assets_asset_id` ON `${TABLE_NAME}` (`asset_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "updates",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "update_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "assets",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "asset_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "assets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT, `type` TEXT, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `url` TEXT, `headers` TEXT, `extra_request_headers` TEXT, `metadata` TEXT, `download_time` INTEGER, `relative_path` TEXT, `hash` BLOB, `hash_type` INTEGER NOT NULL, `expected_hash` TEXT, `marked_for_deletion` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "headers",
+            "columnName": "headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "extraRequestHeaders",
+            "columnName": "extra_request_headers",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadTime",
+            "columnName": "download_time",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relativePath",
+            "columnName": "relative_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "hashType",
+            "columnName": "hash_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expectedHash",
+            "columnName": "expected_hash",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "markedForDeletion",
+            "columnName": "marked_for_deletion",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_assets_key",
+            "unique": true,
+            "columnNames": [
+              "key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_assets_key` ON `${TABLE_NAME}` (`key`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "json_data",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`key` TEXT NOT NULL, `value` TEXT NOT NULL, `last_updated` INTEGER NOT NULL, `scope_key` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdated",
+            "columnName": "last_updated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scopeKey",
+            "columnName": "scope_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_json_data_scope_key",
+            "unique": false,
+            "columnNames": [
+              "scope_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_json_data_scope_key` ON `${TABLE_NAME}` (`scope_key`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '472340246d291854f67ce4b51e48fb0b')"
+    ]
+  }
+}

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -375,7 +375,7 @@ class UpdatesController private constructor(
               params.putString("manifestString", update.manifest.toString())
               sendLegacyUpdateEventToJS(UPDATE_AVAILABLE_EVENT, params)
               stateMachine.processEvent(
-                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest!!)
+                UpdatesStateEvent.DownloadCompleteWithUpdate(update.manifest)
               )
             }
             RemoteUpdateStatus.NO_UPDATE_AVAILABLE -> {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -154,7 +154,7 @@ class UpdatesDevLauncherController : UpdatesInterface {
           controller.setLauncher(launcher)
           callback.onSuccess(object : UpdatesInterface.Update {
             override fun getManifest(): JSONObject {
-              return launcher.launchedUpdate!!.manifest!!
+              return launcher.launchedUpdate!!.manifest
             }
 
             override fun getLaunchAssetPath(): String {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -80,8 +80,7 @@ class UpdatesModule(
         if (launchedUpdate != null) {
           constants["updateId"] = launchedUpdate.id.toString()
           constants["commitTime"] = launchedUpdate.commitTime.time
-          constants["manifestString"] =
-            if (launchedUpdate.manifest != null) launchedUpdate.manifest.toString() else "{}"
+          constants["manifestString"] = launchedUpdate.manifest.toString()
         }
         val localAssetFiles = updatesServiceLocal.localAssetFiles
         if (localAssetFiles != null) {
@@ -418,7 +417,7 @@ class UpdatesModule(
                         }
                       )
                       updatesServiceLocal.stateMachine?.processEvent(
-                        UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest!!)
+                        UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest)
                       )
                     }
                   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
@@ -44,7 +44,7 @@ import java.util.*
 @Database(
   entities = [UpdateEntity::class, UpdateAssetEntity::class, AssetEntity::class, JSONDataEntity::class],
   exportSchema = false,
-  version = 11
+  version = 12
 )
 @TypeConverters(Converters::class)
 abstract class UpdatesDatabase : RoomDatabase() {
@@ -69,6 +69,7 @@ abstract class UpdatesDatabase : RoomDatabase() {
           .addMigrations(MIGRATION_8_9)
           .addMigrations(MIGRATION_9_10)
           .addMigrations(MIGRATION_10_11)
+          .addMigrations(MIGRATION_11_12)
           .fallbackToDestructiveMigration()
           .allowMainThreadQueries()
           .build()
@@ -196,6 +197,26 @@ abstract class UpdatesDatabase : RoomDatabase() {
       override fun migrate(database: SupportSQLiteDatabase) {
         database.runInTransaction {
           execSQL("UPDATE `assets` SET `expected_hash` = NULL")
+        }
+      }
+    }
+
+    /**
+     * Change the `updates.manifest` column to be non-null
+     */
+    val MIGRATION_11_12: Migration = object : Migration(11, 12) {
+      override fun migrate(database: SupportSQLiteDatabase) {
+        database.runInTransactionWithForeignKeysOff {
+          execSQL("CREATE TABLE `new_updates` (`id` BLOB NOT NULL, `scope_key` TEXT NOT NULL, `commit_time` INTEGER NOT NULL, `runtime_version` TEXT NOT NULL, `launch_asset_id` INTEGER, `manifest` TEXT NOT NULL, `status` INTEGER NOT NULL, `keep` INTEGER NOT NULL, `last_accessed` INTEGER NOT NULL, `successful_launch_count` INTEGER NOT NULL DEFAULT 0, `failed_launch_count` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`), FOREIGN KEY(`launch_asset_id`) REFERENCES `assets`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+
+          execSQL(
+            "INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, `successful_launch_count`, `failed_launch_count`)" +
+              " SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, `successful_launch_count`, `failed_launch_count` FROM `updates` WHERE `manifest` IS NOT NULL"
+          )
+          execSQL("DROP TABLE `updates`")
+          execSQL("ALTER TABLE `new_updates` RENAME TO `updates`")
+          execSQL("CREATE INDEX `index_updates_launch_asset_id` ON `updates` (`launch_asset_id`)")
+          execSQL("CREATE UNIQUE INDEX `index_updates_scope_key_commit_time` ON `updates` (`scope_key`, `commit_time`)")
         }
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/entity/UpdateEntity.kt
@@ -36,13 +36,11 @@ class UpdateEntity(
   @field:ColumnInfo(typeAffinity = ColumnInfo.BLOB) @field:PrimaryKey var id: UUID,
   @field:ColumnInfo(name = "commit_time") var commitTime: Date,
   @field:ColumnInfo(name = "runtime_version") var runtimeVersion: String,
-  @field:ColumnInfo(name = "scope_key") var scopeKey: String
+  @field:ColumnInfo(name = "scope_key") var scopeKey: String,
+  @field:ColumnInfo(name = "manifest") var manifest: JSONObject,
 ) {
   @ColumnInfo(name = "launch_asset_id")
   var launchAssetId: Long? = null
-
-  @ColumnInfo(name = "manifest")
-  var manifest: JSONObject? = null
 
   var status = UpdateStatus.PENDING
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
@@ -28,7 +28,7 @@ class BareUpdateManifest private constructor(
   private val mAssets: JSONArray?
 ) : UpdateManifest {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
+    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@BareUpdateManifest.manifest.getRawJson()).apply {
       status = UpdateStatus.EMBEDDED
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
@@ -34,8 +34,7 @@ class LegacyUpdateManifest private constructor(
   private val mAssets: JSONArray?
 ) : UpdateManifest {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
-      manifest = this@LegacyUpdateManifest.manifest.getRawJson()
+    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@LegacyUpdateManifest.manifest.getRawJson()).apply {
       if (isDevelopmentMode) {
         status = UpdateStatus.DEVELOPMENT
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -31,9 +31,7 @@ class NewUpdateManifest private constructor(
   private val mExtensions: JSONObject?
 ) : UpdateManifest {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey).apply {
-      manifest = this@NewUpdateManifest.manifest.getRawJson()
-    }
+    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@NewUpdateManifest.manifest.getRawJson())
   }
 
   private val assetHeaders: Map<String, JSONObject> by lazy {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt
@@ -13,13 +13,12 @@ object SelectionPolicies {
   val TAG = SelectionPolicies::class.java.simpleName
 
   fun matchesFilters(update: UpdateEntity, manifestFilters: JSONObject?): Boolean {
-    val rawManifest = update.manifest
-    if (manifestFilters == null || rawManifest == null) {
+    if (manifestFilters == null) {
       // empty matches all
       return true
     }
 
-    val manifest = Manifest.fromManifestJson(rawManifest)
+    val manifest = Manifest.fromManifestJson(update.manifest)
     val metadata = manifest.getMetadata() ?: return true // empty matches all
 
     try {


### PR DESCRIPTION
# Why

This is the second part of ENG-9068, summarized in https://github.com/expo/expo/pull/23147.

This brings android to the same state that iOS is currently in main (though still need to make the column non-nullable on iOS).

# How

Make the column non-nullable. Make all callsites non-nullable.

# Test Plan

Run all tests, build and run expo go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
