### PR TITLE
[expo-updates][ios] Make updates.manifest column non-nullable

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
@@ -1,0 +1,51 @@
+//  Copyright © 2021 650 Industries. All rights reserved.
+
+// swiftlint:disable line_length
+
+import Foundation
+import SQLite3
+
+internal final class UpdatesDatabaseMigration9To10: UpdatesDatabaseMigration {
+  private(set) var filename: String = "expo-v9.db"
+
+  func runMigration(onDatabase db: OpaquePointer) throws {
+    try db.withTransaction { trx in
+      try trx.safeExecOrRollback(sql: """
+        DELETE FROM "updates" WHERE "manifest" IS NULL
+      """)
+    }
+
+    try db.withForeignKeysOff {
+      try db.withTransaction { trx in
+        try trx.safeExecOrRollback(sql: """
+          CREATE TABLE "new_updates" (
+            "id"  BLOB UNIQUE,
+            "scope_key"  TEXT NOT NULL,
+            "commit_time"  INTEGER NOT NULL,
+            "runtime_version"  TEXT NOT NULL,
+            "launch_asset_id" INTEGER,
+            "manifest"  TEXT NOT NULL,
+            "status"  INTEGER NOT NULL,
+            "keep"  INTEGER NOT NULL,
+            "last_accessed"  INTEGER NOT NULL,
+            "successful_launch_count"  INTEGER NOT NULL DEFAULT 0,
+            "failed_launch_count"  INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY("id"),
+            FOREIGN KEY("launch_asset_id") REFERENCES "assets"("id") ON DELETE CASCADE
+          )
+        """)
+
+        try trx.safeExecOrRollback(sql: "INSERT INTO `new_updates` (`id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, `successful_launch_count`, `failed_launch_count`) SELECT `id`, `scope_key`, `commit_time`, `runtime_version`, `launch_asset_id`, `manifest`, `status`, `keep`, `last_accessed`, `successful_launch_count`, `failed_launch_count` FROM `updates` WHERE `manifest` IS NOT NULL")
+
+        try trx.safeExecOrRollback(sql: "DROP TABLE `updates`")
+        try trx.safeExecOrRollback(sql: "ALTER TABLE `new_updates` RENAME TO `updates`")
+        try trx.safeExecOrRollback(sql: """
+          CREATE UNIQUE INDEX "index_updates_scope_key_commit_time" ON "updates" ("scope_key", "commit_time")
+        """)
+        try trx.safeExecOrRollback(sql: """
+          CREATE INDEX "index_updates_launch_asset_id" ON "updates" ("launch_asset_id")
+        """)
+      }
+    }
+  }
+}

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigrationRegistry.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigrationRegistry.swift
@@ -10,7 +10,8 @@ internal final class UpdatesDatabaseMigrationRegistry {
       UpdatesDatabaseMigration5To6(),
       UpdatesDatabaseMigration6To7(),
       UpdatesDatabaseMigration7To8(),
-      UpdatesDatabaseMigration8To9()
+      UpdatesDatabaseMigration8To9(),
+      UpdatesDatabaseMigration9To10()
     ]
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -591,19 +591,15 @@ public final class UpdatesDatabase: NSObject {
   }
 
   private func update(withRow row: [String: Any?], config: UpdatesConfig) -> Update {
-    let rowManifest = row["manifest"]
-    var manifest: [String: Any]?
-    if let rowManifest = rowManifest as? String {
-      manifest = (try? JSONSerialization.jsonObject(with: rowManifest.data(using: .utf8)!) as? [String: Any]).require("Update manifest should be a valid JSON object")
-    }
-
+    let rowManifest: String = row.requiredValue(forKey: "manifest")
+    let manifest = (try? JSONSerialization.jsonObject(with: rowManifest.data(using: .utf8)!) as? [String: Any]).require("Update manifest should be a valid JSON object")
     let keep: NSNumber = row.requiredValue(forKey: "keep")
     let status: NSNumber = row.requiredValue(forKey: "status")
     let successfulLaunchCount: NSNumber = row.requiredValue(forKey: "successful_launch_count")
     let failedLaunchCount: NSNumber = row.requiredValue(forKey: "failed_launch_count")
 
     let update = Update(
-      manifest: ManifestFactory.manifest(forManifestJSON: manifest ?? [:]),
+      manifest: ManifestFactory.manifest(forManifestJSON: manifest),
       config: config,
       database: self,
       updateId: row.requiredValue(forKey: "id"),

--- a/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
+++ b/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
@@ -233,6 +233,55 @@ let UpdatesDatabaseV8Schema = """
   CREATE INDEX "index_json_data_scope_key" ON "json_data" ("scope_key");
 """
 
+let UpdatesDatabaseV9Schema = """
+  CREATE TABLE "updates" (
+    "id"  BLOB UNIQUE,
+    "scope_key"  TEXT NOT NULL,
+    "commit_time"  INTEGER NOT NULL,
+    "runtime_version"  TEXT NOT NULL,
+    "launch_asset_id" INTEGER,
+    "manifest"  TEXT,
+    "status"  INTEGER NOT NULL,
+    "keep"  INTEGER NOT NULL,
+    "last_accessed"  INTEGER NOT NULL,
+    "successful_launch_count"  INTEGER NOT NULL DEFAULT 0,
+    "failed_launch_count"  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY("id"),
+    FOREIGN KEY("launch_asset_id") REFERENCES "assets"("id") ON DELETE CASCADE
+  );
+  CREATE TABLE "assets" (
+    "id"  INTEGER PRIMARY KEY AUTOINCREMENT,
+    "url"  TEXT,
+    "key"  TEXT UNIQUE,
+    "headers"  TEXT,
+    "expected_hash"  TEXT,
+    "extra_request_headers"  TEXT,
+    "type"  TEXT NOT NULL,
+    "metadata"  TEXT,
+    "download_time"  INTEGER NOT NULL,
+    "relative_path"  TEXT NOT NULL,
+    "hash"  BLOB NOT NULL,
+    "hash_type"  INTEGER NOT NULL,
+    "marked_for_deletion"  INTEGER NOT NULL
+  );
+  CREATE TABLE "updates_assets" (
+    "update_id"  BLOB NOT NULL,
+    "asset_id" INTEGER NOT NULL,
+    FOREIGN KEY("update_id") REFERENCES "updates"("id") ON DELETE CASCADE,
+    FOREIGN KEY("asset_id") REFERENCES "assets"("id") ON DELETE CASCADE
+  );
+  CREATE TABLE "json_data" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "last_updated" INTEGER NOT NULL,
+    "scope_key" TEXT NOT NULL
+  );
+  CREATE UNIQUE INDEX "index_updates_scope_key_commit_time" ON "updates" ("scope_key", "commit_time");
+  CREATE INDEX "index_updates_launch_asset_id" ON "updates" ("launch_asset_id");
+  CREATE INDEX "index_json_data_scope_key" ON "json_data" ("scope_key");
+"""
+
 class UpdatesDatabaseInitializationSpec : ExpoSpec {
   override func spec() {
     var testDatabaseDir: URL!
@@ -313,8 +362,10 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         // verify data integrity
         let updatesSql1 = "SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'"
         expect(try! UpdatesDatabaseUtils.execute(sql:updatesSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
+
+        // expect the second update to have been deleted since it didn't have a manifest
         let updatesSql2 = "SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980'"
-        expect(try! UpdatesDatabaseUtils.execute(sql:updatesSql2, withArgs:nil, onDatabase:migratedDb).count) == 1
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesSql2, withArgs:nil, onDatabase:migratedDb).count) == 0
 
         let assetsSql1 = "SELECT * FROM `assets` WHERE `id` = 2"
         expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
@@ -327,14 +378,16 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
         let updatesAssetsSql2 = "SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3"
         expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql2, withArgs:nil, onDatabase:migratedDb).count) == 1
+
+        // this asset should be deleted by foreign key constraint since its update had a null manifest and was deleted
         let updatesAssetsSql3 = "SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4"
-        expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql3, withArgs:nil, onDatabase:migratedDb).count) == 1
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql3, withArgs:nil, onDatabase:migratedDb).count) == 0
 
         // make sure multiple migrations are running
         let lastAccessedSql = "SELECT DISTINCT `last_accessed` FROM `updates` WHERE `last_accessed` IS NOT NULL"
         expect(try! UpdatesDatabaseUtils.execute(sql:lastAccessedSql, withArgs:nil, onDatabase:migratedDb).count) == 1
         let successfulLaunchCountSql = "SELECT * FROM `updates` WHERE `successful_launch_count` = 1"
-        expect(try! UpdatesDatabaseUtils.execute(sql:successfulLaunchCountSql, withArgs:nil, onDatabase:migratedDb).count) == 2
+        expect(try! UpdatesDatabaseUtils.execute(sql:successfulLaunchCountSql, withArgs:nil, onDatabase:migratedDb).count) == 1
       }
 
       it("migrates 4 to 5") {
@@ -709,6 +762,70 @@ class UpdatesDatabaseInitializationSpec : ExpoSpec {
         expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql2, withArgs:nil, onDatabase:migratedDb).count) == 1
         let assetsSql3 = "SELECT * FROM `assets` WHERE `id` = 4 AND `url` IS NULL AND `key` IS NULL AND `headers` IS NULL AND `type` = 'js' AND `metadata` IS NULL AND `download_time` = 1614137406588 AND `relative_path` = 'bundle-1614137401950' AND `hash` = '6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952' AND `hash_type` = 0 AND `marked_for_deletion` = 0 AND `extra_request_headers` IS NULL AND `expected_hash` IS NULL"
         expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql3, withArgs:nil, onDatabase:migratedDb).count) == 1
+      }
+
+      it("migrates 9 to 10") {
+        let db = try! UpdatesDatabaseInitialization.initializeDatabase(
+          withSchema: UpdatesDatabaseV9Schema,
+          filename: "expo-v9.db",
+          inDirectory: testDatabaseDir,
+          shouldMigrate: false,
+          migrations: []
+        )
+
+        // insert test data
+        let insertAssetsSql = """
+          INSERT INTO "assets" ("id","url","key","headers","type","metadata","download_time","relative_path","hash","hash_type","marked_for_deletion") VALUES
+            (2,'https://url.to/b56cf690e0afa93bd4dc7756d01edd3e','b56cf690e0afa93bd4dc7756d01edd3e.png',NULL,'image/png',NULL,1614137309295,'b56cf690e0afa93bd4dc7756d01edd3e.png','c4fdfc2ec388025067a0f755bda7731a0a868a2be79c84509f4de4e40d23161b',0,0),
+            (3,'https://url.to/bundle-1614137308871','bundle-1614137308871',NULL,'application/javascript',NULL,1614137309513,'bundle-1614137308871','e4d658861e85e301fb89bcfc49c42738ebcc0f9d5c979e037556435f44a27aa2',0,0),
+            (4,NULL,NULL,NULL,'js',NULL,1614137406588,'bundle-1614137401950','6ff4ee75b48a21c7a9ed98015ff6bfd0a47b94cd087c5e2258262e65af239952',0,0);
+        """
+        let insertUpdatesSql = """
+          INSERT INTO "updates" ("id","scope_key","commit_time","runtime_version","launch_asset_id","manifest","status","keep", "last_accessed") VALUES
+            (X'8C263F9DE3FF48888496E3244C788661','http://192.168.4.44:3000',1614137308871,'40.0.0',3,'{\\"metadata\\":{\\"updateGroup\\":\\"34993d39-57e6-46cf-8fa2-eba836f40828\\",\\"branchName\\":\\"rollout\\"}}',1,1,1619647642456),
+            (X'594100ea066e4804b5c7c907c773f980','http://192.168.4.44:3000',1614137401950,'40.0.0',4,NULL,1,1,1619647642457);
+        """
+        let insertUpdatesAssetsSql = """
+          INSERT INTO "updates_assets" ("update_id","asset_id") VALUES
+            (X'8C263F9DE3FF48888496E3244C788661',2),
+            (X'8C263F9DE3FF48888496E3244C788661',3),
+            (X'594100ea066e4804b5c7c907c773f980',4);
+        """
+        _ = try! UpdatesDatabaseUtils.execute(sql:insertAssetsSql, withArgs:nil, onDatabase:db)
+        _ = try! UpdatesDatabaseUtils.execute(sql:insertUpdatesSql, withArgs:nil, onDatabase:db)
+        _ = try! UpdatesDatabaseUtils.execute(sql:insertUpdatesAssetsSql, withArgs:nil, onDatabase:db)
+
+        sqlite3_close(db)
+
+        // initialize a new database object the normal way and run migrations
+        let migratedDb = try! UpdatesDatabaseInitialization.initializeDatabaseWithLatestSchema(
+          inDirectory: testDatabaseDir,
+          migrations: [UpdatesDatabaseMigration9To10()]
+        )
+
+        // verify data integrity
+        let updatesSql1 = "SELECT * FROM `updates` WHERE `id` = X'8C263F9DE3FF48888496E3244C788661'"
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
+
+        // expect the second update to have been deleted since it didn't have a manifest
+        let updatesSql2 = "SELECT * FROM `updates` WHERE `id` = X'594100ea066e4804b5c7c907c773f980'"
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesSql2, withArgs:nil, onDatabase:migratedDb).count) == 0
+
+        let assetsSql1 = "SELECT * FROM `assets` WHERE `id` = 2"
+        expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
+        let assetsSql2 = "SELECT * FROM `assets` WHERE `id` = 3"
+        expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql2, withArgs:nil, onDatabase:migratedDb).count) == 1
+        let assetsSql3 = "SELECT * FROM `assets` WHERE `id` = 4"
+        expect(try! UpdatesDatabaseUtils.execute(sql:assetsSql3, withArgs:nil, onDatabase:migratedDb).count) == 1
+
+        let updatesAssetsSql1 = "SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 2"
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql1, withArgs:nil, onDatabase:migratedDb).count) == 1
+        let updatesAssetsSql2 = "SELECT * FROM `updates_assets` WHERE `update_id` = X'8C263F9DE3FF48888496E3244C788661' AND `asset_id` = 3"
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql2, withArgs:nil, onDatabase:migratedDb).count) == 1
+
+        // this asset should be deleted by foreign key constraint since its update had a null manifest and was deleted
+        let updatesAssetsSql3 = "SELECT * FROM `updates_assets` WHERE `update_id` = X'594100ea066e4804b5c7c907c773f980' AND `asset_id` = 4"
+        expect(try! UpdatesDatabaseUtils.execute(sql:updatesAssetsSql3, withArgs:nil, onDatabase:migratedDb).count) == 0
       }
     }
   }


### PR DESCRIPTION
# Why

iOS counterpart to https://github.com/expo/expo/pull/23166.

This just makes the updates.manifest column non-nullable.

# How

Follow db migration guide.

# Test Plan

Run all tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
