### PR TITLE
[home] Fix Home header not updating after signing out

### DIFF
--- a/home/screens/HomeScreen/HomeScreenView.tsx
+++ b/home/screens/HomeScreen/HomeScreenView.tsx
@@ -197,6 +197,7 @@ export class HomeScreenView extends React.Component<Props, State> {
       // eslint-disable-next-line
       this.setState(({ projects }) => ({
         projects: projects.filter((p) => p.source === 'snack'),
+        data: undefined,
       }));
 
       this._stopPollingForProjects();


### PR DESCRIPTION
# Why

Closes ENG-9122

Seems that this bug has been happening for quite a long time, I tested the latest Expo Go version from Google play, and this wrong behavior was already present 

# How

Resets HomeScreenView data state when the user logs out 

# Test Plan

Run Expo Go locally 

https://github.com/expo/expo/assets/11707729/69683080-f6a8-4fa7-a243-05a4c3609ae0



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
