### PR TITLE
chore: update react-native-web to 0.19.6

### DIFF
--- a/apps/fabric-tester/package.json
+++ b/apps/fabric-tester/package.json
@@ -22,7 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.0",
-    "react-native-web": "~0.18.10"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -152,7 +152,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-view-shot": "3.7.0",
-    "react-native-web": "~0.18.10",
+    "react-native-web": "~0.19.6",
     "react-native-webview": "13.2.2",
     "react-navigation": "^4.4.0",
     "regl": "^1.3.0",

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -3,6 +3,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
 import { Text } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import RedirectScreen from '../screens/RedirectScreen';
 import SearchScreen from '../screens/SearchScreen';
@@ -33,16 +34,18 @@ export const linking: LinkingOptions<object> = {
 
 export default function RootNavigation() {
   return (
-    <NavigationContainer linking={linking} fallback={<Text>Loading…</Text>}>
-      <Switch.Navigator screenOptions={{ presentation: 'modal', headerShown: false }}>
-        <Switch.Screen name="main" component={MainTabNavigator} />
-        <Switch.Screen name="redirect" component={RedirectScreen} />
-        <Switch.Screen
-          name="searchNavigator"
-          component={SearchScreen}
-          options={{ cardStyle: { backgroundColor: 'transparent' } }}
-        />
-      </Switch.Navigator>
-    </NavigationContainer>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer linking={linking} fallback={<Text>Loading…</Text>}>
+        <Switch.Navigator screenOptions={{ presentation: 'modal', headerShown: false }}>
+          <Switch.Screen name="main" component={MainTabNavigator} />
+          <Switch.Screen name="redirect" component={RedirectScreen} />
+          <Switch.Screen
+            name="searchNavigator"
+            component={SearchScreen}
+            options={{ cardStyle: { backgroundColor: 'transparent' } }}
+          />
+        </Switch.Navigator>
+      </NavigationContainer>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.android.tsx
+++ b/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.android.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { DrawerLayoutAndroid, Text, View, Platform } from 'react-native';
+
+import TitleSwitch from '../components/TitledSwitch';
+
+export default function DrawerLayoutAndroidScreen() {
+  const [isRight, setRight] = React.useState(false);
+
+  const renderNavigationView = () => (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#fff',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Text>DrawerLayoutAndroid</Text>
+    </View>
+  );
+
+  return Platform.OS === 'android' ? (
+    <DrawerLayoutAndroid
+      drawerWidth={300}
+      drawerPosition={isRight ? 'right' : 'left'}
+      renderNavigationView={renderNavigationView}>
+      <View style={{ flex: 1, padding: 16 }}>
+        <TitleSwitch title="Is Right" value={isRight} setValue={setRight} />
+        <Text>Pull from the {isRight ? 'right' : 'left'}</Text>
+      </View>
+    </DrawerLayoutAndroid>
+  ) : (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#fff',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Text>Only available on Android</Text>
+    </View>
+  );
+}
+
+DrawerLayoutAndroidScreen.navigationOptions = {
+  title: 'DrawerLayoutAndroid',
+};

--- a/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.tsx
+++ b/apps/native-component-list/src/screens/DrawerLayoutAndroidScreen.tsx
@@ -1,34 +1,7 @@
-import * as React from 'react';
-import { DrawerLayoutAndroid, Text, View, Platform } from 'react-native';
-
-import TitleSwitch from '../components/TitledSwitch';
+import { Text, View } from 'react-native';
 
 export default function DrawerLayoutAndroidScreen() {
-  const [isRight, setRight] = React.useState(false);
-
-  const renderNavigationView = () => (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: '#fff',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }}>
-      <Text>DrawerLayoutAndroid</Text>
-    </View>
-  );
-
-  return Platform.OS === 'android' ? (
-    <DrawerLayoutAndroid
-      drawerWidth={300}
-      drawerPosition={isRight ? 'right' : 'left'}
-      renderNavigationView={renderNavigationView}>
-      <View style={{ flex: 1, padding: 16 }}>
-        <TitleSwitch title="Is Right" value={isRight} setValue={setRight} />
-        <Text>Pull from the {isRight ? 'right' : 'left'}</Text>
-      </View>
-    </DrawerLayoutAndroid>
-  ) : (
+  return (
     <View
       style={{
         flex: 1,

--- a/apps/native-component-list/src/screens/IntentLauncherScreen.android.tsx
+++ b/apps/native-component-list/src/screens/IntentLauncherScreen.android.tsx
@@ -1,0 +1,72 @@
+import { startActivityAsync, ActivityAction } from 'expo-intent-launcher';
+import React from 'react';
+import { Platform, ScrollView, Text, ToastAndroid, View } from 'react-native';
+
+import Button from '../components/Button';
+
+export default class IntentLauncherScreen extends React.Component {
+  static navigationOptions = {
+    title: 'IntentLauncher',
+  };
+
+  renderSettingsLink(title: string, activityAction: ActivityAction, intentParams = {}) {
+    return (
+      <View>
+        <Button
+          onPress={async () => {
+            try {
+              const result = await startActivityAsync(activityAction, intentParams);
+              ToastAndroid.show(`Activity finished: ${JSON.stringify(result)}`, ToastAndroid.SHORT);
+            } catch (e) {
+              ToastAndroid.show(`An error occurred: ${e.message}`, ToastAndroid.SHORT);
+            }
+          }}
+          title={title}
+          style={{ marginBottom: 10 }}
+        />
+      </View>
+    );
+  }
+
+  render() {
+    if (Platform.OS !== 'android') {
+      return (
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+          <Text>IntentLauncherAndroid is only available on Android.</Text>
+        </View>
+      );
+    }
+
+    return (
+      <ScrollView style={{ padding: 10 }}>
+        {this.renderSettingsLink('Location Settings', ActivityAction.LOCATION_SOURCE_SETTINGS)}
+
+        {this.renderSettingsLink('Wireless Settings', ActivityAction.WIRELESS_SETTINGS)}
+
+        {this.renderSettingsLink(
+          'Application Details for Expo Go',
+          ActivityAction.APPLICATION_DETAILS_SETTINGS,
+          {
+            data: 'package:host.exp.exponent',
+          }
+        )}
+
+        {this.renderSettingsLink(
+          'Application Details for Play Store',
+          ActivityAction.APPLICATION_DETAILS_SETTINGS,
+          {
+            data: 'package:com.android.vending',
+          }
+        )}
+
+        {this.renderSettingsLink(
+          'Application Details for not existing package',
+          ActivityAction.APPLICATION_DETAILS_SETTINGS,
+          {
+            data: 'package:package.name.that.doesnt.exist',
+          }
+        )}
+      </ScrollView>
+    );
+  }
+}

--- a/apps/native-component-list/src/screens/IntentLauncherScreen.tsx
+++ b/apps/native-component-list/src/screens/IntentLauncherScreen.tsx
@@ -1,72 +1,13 @@
-import { startActivityAsync, ActivityAction } from 'expo-intent-launcher';
-import React from 'react';
-import { Platform, ScrollView, Text, ToastAndroid, View } from 'react-native';
+import { Text, View } from 'react-native';
 
-import Button from '../components/Button';
-
-export default class IntentLauncherScreen extends React.Component {
-  static navigationOptions = {
-    title: 'IntentLauncher',
-  };
-
-  renderSettingsLink(title: string, activityAction: ActivityAction, intentParams = {}) {
-    return (
-      <View>
-        <Button
-          onPress={async () => {
-            try {
-              const result = await startActivityAsync(activityAction, intentParams);
-              ToastAndroid.show(`Activity finished: ${JSON.stringify(result)}`, ToastAndroid.SHORT);
-            } catch (e) {
-              ToastAndroid.show(`An error occurred: ${e.message}`, ToastAndroid.SHORT);
-            }
-          }}
-          title={title}
-          style={{ marginBottom: 10 }}
-        />
-      </View>
-    );
-  }
-
-  render() {
-    if (Platform.OS !== 'android') {
-      return (
-        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-          <Text>IntentLauncherAndroid is only available on Android.</Text>
-        </View>
-      );
-    }
-
-    return (
-      <ScrollView style={{ padding: 10 }}>
-        {this.renderSettingsLink('Location Settings', ActivityAction.LOCATION_SOURCE_SETTINGS)}
-
-        {this.renderSettingsLink('Wireless Settings', ActivityAction.WIRELESS_SETTINGS)}
-
-        {this.renderSettingsLink(
-          'Application Details for Expo Go',
-          ActivityAction.APPLICATION_DETAILS_SETTINGS,
-          {
-            data: 'package:host.exp.exponent',
-          }
-        )}
-
-        {this.renderSettingsLink(
-          'Application Details for Play Store',
-          ActivityAction.APPLICATION_DETAILS_SETTINGS,
-          {
-            data: 'package:com.android.vending',
-          }
-        )}
-
-        {this.renderSettingsLink(
-          'Application Details for not existing package',
-          ActivityAction.APPLICATION_DETAILS_SETTINGS,
-          {
-            data: 'package:package.name.that.doesnt.exist',
-          }
-        )}
-      </ScrollView>
-    );
-  }
+export default function IntentLauncherScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>IntentLauncherAndroid is only available on Android.</Text>
+    </View>
+  );
 }
+
+IntentLauncherScreen.navigationOptions = {
+  title: 'IntentLauncher',
+};

--- a/packages/@expo/cli/e2e/fixtures/with-assets/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-assets/package.json
@@ -2,11 +2,11 @@
   "private": true,
   "main": "node_modules/expo/AppEntry.js",
   "dependencies": {
-     "expo": "~47.0.13",
+    "expo": "~47.0.13",
     "react": "18.1.0",
     "react-native": "0.70.5",
     "react-dom": "18.1.0",
-    "react-native-web": "~0.18.7"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9"

--- a/packages/@expo/cli/e2e/fixtures/with-router/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-router/package.json
@@ -13,7 +13,7 @@
     "react-native-gesture-handler": "~2.9.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
-    "react-native-web": "~0.18.7"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3"

--- a/packages/@expo/cli/e2e/fixtures/with-web/package.json
+++ b/packages/@expo/cli/e2e/fixtures/with-web/package.json
@@ -6,7 +6,7 @@
     "react": "18.1.0",
     "react-native": "0.70.5",
     "react-dom": "18.1.0",
-    "react-native-web": "~0.18.7"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -84,7 +84,7 @@
   "react": "18.2.0",
   "react-dom": "18.2.0",
   "react-native": "0.72.0",
-  "react-native-web": "~0.18.10",
+  "react-native-web": "~0.19.6",
   "react-native-gesture-handler": "~2.12.0",
   "react-native-get-random-values": "~1.8.0",
   "react-native-maps": "1.7.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -29,7 +29,7 @@
     "react-native": "0.72.0",
     "react-native-safe-area-context": "4.6.3",
     "react-native-screens": "~3.22.0",
-    "react-native-web": "~0.18.10"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,7 +3370,7 @@
   resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.72.1.tgz#905343ef0c51256f128256330fccbdb35b922291"
   integrity sha512-cRPZh2rBswFnGt5X5EUEPs0r+pAsXxYsifv/fgy9ZLQokuT52bPH+9xjDR+7TafRua5CttGW83wP4TntRcWNDA==
 
-"@react-native/normalize-color@^2.0.0":
+"@react-native/normalize-color@^2.0.0", "@react-native/normalize-color@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@react-native/normalize-color/-/normalize-color-2.1.0.tgz#939b87a9849e81687d3640c5efa2a486ac266f91"
   integrity sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==
@@ -7282,14 +7282,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-class@^15.7.0:
-  version "15.7.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
-  integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
-  dependencies:
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -12865,7 +12857,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -13070,6 +13062,11 @@ memoize-one@^5.0.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
+memoize-one@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
+  integrity sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==
 
 memoizee@^0.4.15:
   version "0.4.15"
@@ -14022,11 +14019,6 @@ nopt@1.0.10:
   integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
   dependencies:
     abbrev "1"
-
-normalize-css-color@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
-  integrity sha1-Apkel8zOxmI/5XOvu/Deah8+n40=
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
@@ -15973,18 +15965,19 @@ react-native-view-shot@3.7.0:
   dependencies:
     html2canvas "^1.4.1"
 
-react-native-web@~0.18.10:
-  version "0.18.12"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.18.12.tgz#d4bb3a783ece2514ba0508d7805b09c0a98f5a8e"
-  integrity sha512-fboP7yqobJ8InSr4fP+bQ3scOtSQtUoPcR+HWasH8b/fk/RO+mWcJs/8n+lewy9WTZc2D68ha7VwRDviUshEWA==
+react-native-web@~0.19.6:
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.19.6.tgz#d9bb880b28b30725c09e7efdb70f2c07df0a6ab2"
+  integrity sha512-lk0X4y4DhZxc2e7Wdc1NkvJVObZZOLAz9l7S5a5awLI5SsZoF5L0WZhiU/+qWu5cpV0wMkME9qx7CvegmO4snw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    create-react-class "^15.7.0"
+    "@react-native/normalize-color" "^2.1.0"
     fbjs "^3.0.4"
     inline-style-prefixer "^6.0.1"
-    normalize-css-color "^1.0.2"
+    memoize-one "^6.0.0"
+    nullthrows "^1.1.1"
     postcss-value-parser "^4.2.0"
-    styleq "^0.1.2"
+    styleq "^0.1.3"
 
 react-native-webview@13.2.2:
   version "13.2.2"
@@ -17718,10 +17711,10 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-styleq@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/styleq/-/styleq-0.1.2.tgz#052b46af5ca4f920b1bdae2735ffb1e3970f53cd"
-  integrity sha512-EBNuMVSxpssuFcJq/c4zmZ4tpCyX9E27hz5xPJhw4URjRHcYXPHh8rDHY/tJsw5gtP0+tIL3IBYeQVIYjdZFhg==
+styleq@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/styleq/-/styleq-0.1.3.tgz#8efb2892debd51ce7b31dc09c227ad920decab71"
+  integrity sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==
 
 sucrase@^3.20.0:
   version "3.20.3"


### PR DESCRIPTION
# Why

bump react-native-web to 0.19.6 for sdk 49

# How

- since [the issue](https://github.com/necolas/react-native-web/issues/2523) is fixed by react-native-web@0.19.6. it's a good time to bump the version.
- [ncl] fix some broken imports
- [ncl] fix gesture-handler error 

# Test Plan

- smoke testing ncl on web
- ci passed

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
