### PR TITLE
[eas-expo-go] upload crashlytics native symbols for expo-go on s3

### DIFF
--- a/apps/eas-expo-go/scripts/eas-build-on-success.sh
+++ b/apps/eas-expo-go/scripts/eas-build-on-success.sh
@@ -49,6 +49,10 @@ if [[ "$EAS_BUILD_PROFILE" == "release-client" ]]; then
 fi
 
 if [[ "$EAS_BUILD_PROFILE" == "publish-client" ]]; then
+  if [[ "$EAS_BUILD_PLATFORM" == "android" ]]; then
+    upload_crashlytics_symbols "VersionedRelease"
+  fi
+
   SLUG="publish-client"
   COMMIT_HASH="$(git rev-parse HEAD)"
   COMMIT_AUTHOR="$(git log --pretty=format:"%an - %ae" | head -n 1)"


### PR DESCRIPTION
# Why

since the builds between release-client and publish-client are different, we should upload the crashlytics native symbols separately.

# How

upload crashlytics native symbols on publish-client android variant

# Test Plan

let's see whether it works for the publish-client job next time