### PR TITLE
fix: [expo-image] - don't reset image source with recylingKey on first render

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed an issue where recyclingKey would reset the image source on mount. ([#23187](https://github.com/expo/expo/pull/23187) by [@hirbod](https://github.com/hirbod))
+- Fixed an issue where recyclingKey would reset the image source on mount. ([#23187](https://github.com/expo/expo/pull/23187) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed an issue where recyclingKey would reset the image source on mount.
+- [iOS] Fixed an issue where recyclingKey would reset the image source on mount. ([#23187](https://github.com/expo/expo/pull/23187) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed an issue where recyclingKey would reset the image source on mount.
+
 ### 💡 Others
 
 ## 1.3.0 — 2023-06-13

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -151,8 +151,8 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
   var recyclingKey: String? = null
     set(value) {
-      clearViewBeforeChangingSource = value != null && value != field
-      field = value
+        clearViewBeforeChangingSource = field != null && value != null && value != field
+        field = value
     }
 
   internal var allowDownscaling: Boolean = true

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -151,8 +151,8 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
   var recyclingKey: String? = null
     set(value) {
-        clearViewBeforeChangingSource = field != null && value != null && value != field
-        field = value
+      clearViewBeforeChangingSource = field != null && value != null && value != field
+      field = value
     }
 
   internal var allowDownscaling: Boolean = true

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -43,14 +43,12 @@ public final class ImageView: ExpoView {
 
   var recyclingKey: String? {
     didSet {
-      guard oldValue != nil else {
-        return
-      }
-      if recyclingKey != oldValue {
-        sdImageView.image = nil
+      if oldValue != nil && recyclingKey != oldValue {
+          sdImageView.image = nil
       }
     }
   }
+
 
   // MARK: - Events
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -1,7 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-import SDWebImage
 import ExpoModulesCore
+import SDWebImage
 import VisionKit
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
@@ -21,8 +21,8 @@ public final class ImageView: ExpoView {
   )
 
   var loadingOptions: SDWebImageOptions = [
-    .retryFailed, // Don't blacklist URLs that failed downloading
-    .handleCookies // Handle cookies stored in the shared `HTTPCookieStore`
+    .retryFailed,  // Don't blacklist URLs that failed downloading
+    .handleCookies,  // Handle cookies stored in the shared `HTTPCookieStore`
   ]
 
   var sources: [ImageSource]?
@@ -43,6 +43,9 @@ public final class ImageView: ExpoView {
 
   var recyclingKey: String? {
     didSet {
+      guard oldValue != nil else {
+        return
+      }
       if recyclingKey != oldValue {
         sdImageView.image = nil
       }
@@ -117,7 +120,8 @@ public final class ImageView: ExpoView {
 
     // Modify URL request to add headers.
     if let headers = source.headers {
-      context[SDWebImageContextOption.downloadRequestModifier] = SDWebImageDownloaderRequestModifier(headers: headers)
+      context[SDWebImageContextOption.downloadRequestModifier] =
+        SDWebImageDownloaderRequestModifier(headers: headers)
     }
 
     context[.cacheKeyFilter] = createCacheKeyFilter(source.cacheKey)
@@ -171,7 +175,7 @@ public final class ImageView: ExpoView {
     onProgress([
       "loaded": isPhotoLibraryAsset ? nil : receivedSize,
       "total": isPhotoLibraryAsset ? nil : expectedSize,
-      "progress": Double(receivedSize) / Double(expectedSize)
+      "progress": Double(receivedSize) / Double(expectedSize),
     ])
   }
 
@@ -199,8 +203,8 @@ public final class ImageView: ExpoView {
           "url": imageUrl?.absoluteString,
           "width": image.size.width,
           "height": image.size.height,
-          "mediaType": imageFormatToMediaType(image.sd_imageFormat)
-        ]
+          "mediaType": imageFormatToMediaType(image.sd_imageFormat),
+        ],
       ])
 
       let scale = window?.screen.scale ?? UIScreen.main.scale
@@ -249,7 +253,8 @@ public final class ImageView: ExpoView {
    Same as `bestSource`, but for placeholders.
    */
   var bestPlaceholder: ImageSource? {
-    return getBestSource(from: placeholderSources, forSize: bounds.size, scale: screenScale) ?? placeholderSources.first
+    return getBestSource(from: placeholderSources, forSize: bounds.size, scale: screenScale)
+      ?? placeholderSources.first
   }
 
   /**
@@ -280,7 +285,8 @@ public final class ImageView: ExpoView {
     // Some loaders (e.g. blurhash) need access to the source.
     context[ImageView.contextSourceKey] = placeholder
 
-    imageManager.loadImage(with: placeholder.uri, context: context, progress: nil) { [weak self] placeholder, _, _, _, finished, _ in
+    imageManager.loadImage(with: placeholder.uri, context: context, progress: nil) {
+      [weak self] placeholder, _, _, _, finished, _ in
       guard let self = self, let placeholder = placeholder, finished else {
         return
       }
@@ -305,7 +311,7 @@ public final class ImageView: ExpoView {
   private func createTransformPipeline() -> SDImagePipelineTransformer {
     let transformers: [SDImageTransformer] = [
       SDImageBlurTransformer(radius: blurRadius),
-      SDImageTintTransformer(color: imageTintColor)
+      SDImageTintTransformer(color: imageTintColor),
     ]
     return SDImagePipelineTransformer(transformers: transformers)
   }
@@ -398,7 +404,9 @@ public final class ImageView: ExpoView {
 
   var enableLiveTextInteraction: Bool = false {
     didSet {
-      guard #available(iOS 16.0, *), oldValue != enableLiveTextInteraction, ImageAnalyzer.isSupported else {
+      guard #available(iOS 16.0, *), oldValue != enableLiveTextInteraction,
+        ImageAnalyzer.isSupported
+      else {
         return
       }
       if enableLiveTextInteraction {
@@ -416,7 +424,9 @@ public final class ImageView: ExpoView {
     }
 
     Task {
-      guard let imageAnalyzer = Self.imageAnalyzer, let imageAnalysisInteraction = findImageAnalysisInteraction() else {
+      guard let imageAnalyzer = Self.imageAnalyzer,
+        let imageAnalysisInteraction = findImageAnalysisInteraction()
+      else {
         return
       }
       let configuration = ImageAnalyzer.Configuration([.text, .machineReadableCode])

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -44,11 +44,10 @@ public final class ImageView: ExpoView {
   var recyclingKey: String? {
     didSet {
       if oldValue != nil && recyclingKey != oldValue {
-          sdImageView.image = nil
+        sdImageView.image = nil
       }
     }
   }
-
 
   // MARK: - Events
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -1,7 +1,7 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
-import ExpoModulesCore
 import SDWebImage
+import ExpoModulesCore
 import VisionKit
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
@@ -21,8 +21,8 @@ public final class ImageView: ExpoView {
   )
 
   var loadingOptions: SDWebImageOptions = [
-    .retryFailed,  // Don't blacklist URLs that failed downloading
-    .handleCookies,  // Handle cookies stored in the shared `HTTPCookieStore`
+    .retryFailed, // Don't blacklist URLs that failed downloading
+    .handleCookies // Handle cookies stored in the shared `HTTPCookieStore`
   ]
 
   var sources: [ImageSource]?
@@ -120,8 +120,7 @@ public final class ImageView: ExpoView {
 
     // Modify URL request to add headers.
     if let headers = source.headers {
-      context[SDWebImageContextOption.downloadRequestModifier] =
-        SDWebImageDownloaderRequestModifier(headers: headers)
+      context[SDWebImageContextOption.downloadRequestModifier] = SDWebImageDownloaderRequestModifier(headers: headers)
     }
 
     context[.cacheKeyFilter] = createCacheKeyFilter(source.cacheKey)
@@ -175,7 +174,7 @@ public final class ImageView: ExpoView {
     onProgress([
       "loaded": isPhotoLibraryAsset ? nil : receivedSize,
       "total": isPhotoLibraryAsset ? nil : expectedSize,
-      "progress": Double(receivedSize) / Double(expectedSize),
+      "progress": Double(receivedSize) / Double(expectedSize)
     ])
   }
 
@@ -203,8 +202,8 @@ public final class ImageView: ExpoView {
           "url": imageUrl?.absoluteString,
           "width": image.size.width,
           "height": image.size.height,
-          "mediaType": imageFormatToMediaType(image.sd_imageFormat),
-        ],
+          "mediaType": imageFormatToMediaType(image.sd_imageFormat)
+        ]
       ])
 
       let scale = window?.screen.scale ?? UIScreen.main.scale
@@ -253,8 +252,7 @@ public final class ImageView: ExpoView {
    Same as `bestSource`, but for placeholders.
    */
   var bestPlaceholder: ImageSource? {
-    return getBestSource(from: placeholderSources, forSize: bounds.size, scale: screenScale)
-      ?? placeholderSources.first
+    return getBestSource(from: placeholderSources, forSize: bounds.size, scale: screenScale) ?? placeholderSources.first
   }
 
   /**
@@ -285,8 +283,7 @@ public final class ImageView: ExpoView {
     // Some loaders (e.g. blurhash) need access to the source.
     context[ImageView.contextSourceKey] = placeholder
 
-    imageManager.loadImage(with: placeholder.uri, context: context, progress: nil) {
-      [weak self] placeholder, _, _, _, finished, _ in
+    imageManager.loadImage(with: placeholder.uri, context: context, progress: nil) { [weak self] placeholder, _, _, _, finished, _ in
       guard let self = self, let placeholder = placeholder, finished else {
         return
       }
@@ -311,7 +308,7 @@ public final class ImageView: ExpoView {
   private func createTransformPipeline() -> SDImagePipelineTransformer {
     let transformers: [SDImageTransformer] = [
       SDImageBlurTransformer(radius: blurRadius),
-      SDImageTintTransformer(color: imageTintColor),
+      SDImageTintTransformer(color: imageTintColor)
     ]
     return SDImagePipelineTransformer(transformers: transformers)
   }
@@ -404,9 +401,7 @@ public final class ImageView: ExpoView {
 
   var enableLiveTextInteraction: Bool = false {
     didSet {
-      guard #available(iOS 16.0, *), oldValue != enableLiveTextInteraction,
-        ImageAnalyzer.isSupported
-      else {
+      guard #available(iOS 16.0, *), oldValue != enableLiveTextInteraction, ImageAnalyzer.isSupported else {
         return
       }
       if enableLiveTextInteraction {
@@ -424,9 +419,7 @@ public final class ImageView: ExpoView {
     }
 
     Task {
-      guard let imageAnalyzer = Self.imageAnalyzer,
-        let imageAnalysisInteraction = findImageAnalysisInteraction()
-      else {
+      guard let imageAnalyzer = Self.imageAnalyzer, let imageAnalysisInteraction = findImageAnalysisInteraction() else {
         return
       }
       let configuration = ImageAnalyzer.Configuration([.text, .machineReadableCode])


### PR DESCRIPTION
# Why

The recyclingKey observer triggers during the first render, inadvertently setting the image source to nil. However, it shouldn't be performing this action at this stage.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Since oldValue is nil at the point of mounting, I've added a nil/null check

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- iPhone 13 Pro Max (Device)
- iPhone 14 Pro Max (Simulator)
 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
