### PR TITLE
[expo-image-picker] Bump cropper version to fix eas build

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+- Fix manifest merger build fail on Android. ([#23191](https://github.com/expo/expo/pull/23191) by [@alexandrius](https://github.com/alexandrius))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -85,7 +85,7 @@ dependencies {
   implementation "androidx.activity:activity-ktx:1.7.1"
   implementation "androidx.appcompat:appcompat:1.4.2"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
-  implementation "com.github.CanHub:Android-Image-Cropper:4.3.0"
+  implementation "com.github.CanHub:Android-Image-Cropper:4.3.1"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.3"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"


### PR DESCRIPTION
# Why
Android Image Cropper lib manifest includes multiple `<activity/>` elements in the manifest. They actually removed those in the [next version](https://github.com/CanHub/Android-Image-Cropper/compare/4.3.0...4.3.1). The activity elements included style tag - causing app build fail on SDK49-Beta:

```
[stderr] 
/home/expo/workingdir/build/android/app/src/debug/AndroidManifest.xml:41:13-49 Error:
[stderr] 
	Attribute activity#androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity@theme value=(@android:style/Theme) from [com.github.CanHub:Android-Image-Cropper:4.3.0] AndroidManifest.xml:41:13-49
[stderr] 
	is also present at [androidx.test:core:1.5.0] AndroidManifest.xml:30:13-56 value=(@style/WhiteBackgroundTheme).
[stderr] 
	Suggestion: add 'tools:replace="android:theme"' to <activity> element at AndroidManifest.xml:38:9-45:20 to override.
[stderr] 
/home/expo/workingdir/build/android/app/src/debug/AndroidManifest.xml:49:13-49 Error:
[stderr] 
	Attribute activity#androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity@theme value=(@android:style/Theme) from [com.github.CanHub:Android-Image-Cropper:4.3.0] AndroidManifest.xml:49:13-49
[stderr] 
	is also present at [androidx.test:core:1.5.0] AndroidManifest.xml:38:13-56 value=(@style/WhiteBackgroundTheme).
[stderr] 
	Suggestion: add 'tools:replace="android:theme"' to <activity> element at AndroidManifest.xml:46:9-53:20 to override.
[stderr] 
/home/expo/workingdir/build/android/app/src/debug/AndroidManifest.xml:57:13-56 Error:
[stderr] 
	Attribute activity#androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity@theme value=(@android:style/Theme.Dialog) from [com.github.CanHub:Android-Image-Cropper:4.3.0] AndroidManifest.xml:57:13-56
[stderr] 
	is also present at [androidx.test:core:1.5.0] AndroidManifest.xml:46:13-62 value=(@style/WhiteBackgroundDialogTheme).
[stderr] 
	Suggestion: add 'tools:replace="android:theme"' to <activity> element at AndroidManifest.xml:54:9-61:20 to override.
```


# How
Changed 4.3.0 to 4.3.1

# Test Plan

- Install the library in an empty project
- Build the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
