### PR TITLE
fix(cli): avoid capturing inspector proxy requests when using SSG

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 🐛 Bug fixes
 
 - Avoid changing required dependency versions when prebuilding. ([#23146](https://github.com/expo/expo/pull/23146) by [@byCedric](https://github.com/byCedric))
+- Avoid capturing inspector proxy requests when using SSG.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### 🐛 Bug fixes
 
 - Avoid changing required dependency versions when prebuilding. ([#23146](https://github.com/expo/expo/pull/23146) by [@byCedric](https://github.com/byCedric))
-- Avoid capturing inspector proxy requests when using SSG.
+- Avoid capturing inspector proxy requests when using SSG. ([#23192](https://github.com/expo/expo/pull/23192) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -356,9 +356,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       // This MUST run last since it's the fallback.
       if (!useWebSSG) {
         middleware.use(
-          withoutInspectorRequests(
-            new HistoryFallbackMiddleware(manifestMiddleware.getHandler().internal).getHandler()
-          )
+          new HistoryFallbackMiddleware(manifestMiddleware.getHandler().internal).getHandler()
         );
       }
     }

--- a/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
@@ -1,3 +1,4 @@
+import { withoutInspectorRequests } from './InspectorMiddleware';
 import { parsePlatformHeader } from './resolvePlatform';
 import { ServerMiddleware } from './server.types';
 
@@ -8,8 +9,8 @@ import { ServerMiddleware } from './server.types';
 export class HistoryFallbackMiddleware {
   constructor(private indexMiddleware: ServerMiddleware) {}
 
-  getHandler(): ServerMiddleware {
-    return async (req, res, next) => {
+  getHandler() {
+    return withoutInspectorRequests(async (req, res, next) => {
       const platform = parsePlatformHeader(req);
 
       if (!platform || platform === 'web') {
@@ -19,6 +20,6 @@ export class HistoryFallbackMiddleware {
       }
 
       return next();
-    };
+    });
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
@@ -1,59 +1,21 @@
 import { parsePlatformHeader } from './resolvePlatform';
-import { ServerNext, ServerRequest, ServerResponse } from './server.types';
-
-const debug = require('debug')('expo:start:server:metro:historyFallback') as typeof console.log;
-
-const WS_DEVICE_URL = '/inspector/device';
-const WS_DEBUGGER_URL = '/inspector/debug';
-const PAGES_LIST_JSON_URL = '/json';
-const PAGES_LIST_JSON_URL_2 = '/json/list';
-const PAGES_LIST_JSON_VERSION_URL = '/json/version';
-
-export function isInspectorProxyRequest(req: ServerRequest) {
-  const ua = req.headers['user-agent'];
-  const url = req.url;
-
-  // This check is very fragile but it enables websites to use any of the
-  // endpoints below without triggering the inspector proxy.
-  if (!url || (ua && !ua.includes('node-fetch'))) {
-    // This optimizes for the inspector working over the endpoint being available on web.
-    // Web is less fragile.
-    return false;
-  }
-
-  return [
-    WS_DEVICE_URL,
-    WS_DEBUGGER_URL,
-    PAGES_LIST_JSON_URL,
-    PAGES_LIST_JSON_URL_2,
-    PAGES_LIST_JSON_VERSION_URL,
-  ].includes(url);
-}
+import { ServerMiddleware } from './server.types';
 
 /**
  * Create a web-only middleware which redirects to the index middleware without losing the path component.
  * This is useful for things like React Navigation which need to render the index.html and then direct the user in-memory.
  */
 export class HistoryFallbackMiddleware {
-  constructor(
-    private indexMiddleware: (
-      req: ServerRequest,
-      res: ServerResponse,
-      next: ServerNext
-    ) => Promise<void>
-  ) {}
-  getHandler() {
-    return (req: ServerRequest, res: ServerResponse, next: any) => {
+  constructor(private indexMiddleware: ServerMiddleware) {}
+
+  getHandler(): ServerMiddleware {
+    return async (req, res, next) => {
       const platform = parsePlatformHeader(req);
 
       if (!platform || platform === 'web') {
-        if (isInspectorProxyRequest(req)) {
-          debug('Inspector proxy request:', req.url, 'UA:', req.headers['user-agent']);
-          return next();
-        }
         // Redirect unknown to the manifest handler while preserving the path.
         // This implements the HTML5 history fallback API.
-        return this.indexMiddleware(req, res, next);
+        return await this.indexMiddleware(req, res, next);
       }
 
       return next();

--- a/packages/@expo/cli/src/start/server/middleware/InspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InspectorMiddleware.ts
@@ -1,0 +1,51 @@
+import { parsePlatformHeader } from './resolvePlatform';
+import { ServerMiddleware, ServerRequest } from './server.types';
+
+const debug = require('debug')('expo:start:server:metro:inspectorMiddleware') as typeof console.log;
+
+const WS_DEVICE_URL = '/inspector/device';
+const WS_DEBUGGER_URL = '/inspector/debug';
+const PAGES_LIST_JSON_URL = '/json';
+const PAGES_LIST_JSON_URL_2 = '/json/list';
+const PAGES_LIST_JSON_VERSION_URL = '/json/version';
+
+function isInspectorRequest(req: ServerRequest) {
+  const ua = req.headers['user-agent'];
+  const url = req.url;
+
+  // This check is very fragile but it enables websites to use any of the
+  // endpoints below without triggering the inspector proxy.
+  if (!url || (ua && !ua.includes('node-fetch'))) {
+    // This optimizes for the inspector working over the endpoint being available on web.
+    // Web is less fragile.
+    return false;
+  }
+
+  return [
+    WS_DEVICE_URL,
+    WS_DEBUGGER_URL,
+    PAGES_LIST_JSON_URL,
+    PAGES_LIST_JSON_URL_2,
+    PAGES_LIST_JSON_VERSION_URL,
+  ].includes(url);
+}
+
+function isWebRequest(req: ServerRequest) {
+  const platform = parsePlatformHeader(req);
+  return !platform || platform === 'web';
+}
+
+/**
+ * Wrap any middleware in a check to avoid capturing inspector proxy requests.
+ * When such a request is detected, the middleware will not be called.
+ */
+export function withoutInspectorRequests(middleware: ServerMiddleware): ServerMiddleware {
+  return async (req, res, next) => {
+    if (isWebRequest(req) && isInspectorRequest(req)) {
+      debug('Inspector request:', req.url, 'UA:', req.headers['user-agent']);
+      return next();
+    }
+
+    return await middleware(req, res, next);
+  };
+}

--- a/packages/@expo/cli/src/start/server/middleware/InspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InspectorMiddleware.ts
@@ -9,7 +9,8 @@ const PAGES_LIST_JSON_URL = '/json';
 const PAGES_LIST_JSON_URL_2 = '/json/list';
 const PAGES_LIST_JSON_VERSION_URL = '/json/version';
 
-function isInspectorRequest(req: ServerRequest) {
+/** Exposed for testing */
+export function isInspectorRequest(req: ServerRequest) {
   const ua = req.headers['user-agent'];
   const url = req.url;
 
@@ -30,7 +31,8 @@ function isInspectorRequest(req: ServerRequest) {
   ].includes(url);
 }
 
-function isWebRequest(req: ServerRequest) {
+/** Exposed for testing */
+export function isWebRequest(req: ServerRequest) {
   const platform = parsePlatformHeader(req);
   return !platform || platform === 'web';
 }

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
@@ -1,45 +1,7 @@
-import { HistoryFallbackMiddleware, isInspectorProxyRequest } from '../HistoryFallbackMiddleware';
+import { HistoryFallbackMiddleware } from '../HistoryFallbackMiddleware';
 import { ServerRequest } from '../server.types';
 
 const asRequest = (req: Partial<ServerRequest>) => req as ServerRequest;
-
-describe(isInspectorProxyRequest, () => {
-  it(`return true for no UA + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/inspector/debug',
-          headers: {},
-        })
-      )
-    ).toBe(true);
-  });
-  it(`return true for node-fetch user-agent + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/json/list',
-          headers: {
-            'user-agent': 'node-fetch',
-          },
-        })
-      )
-    ).toBe(true);
-  });
-  it(`return false for browser user-agent + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/json/list',
-          headers: {
-            'user-agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
-          },
-        })
-      )
-    ).toBe(false);
-  });
-});
 
 it(`skips requests to the Metro inspector proxy`, () => {
   const indexMiddleware = jest.fn();

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InspectorMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InspectorMiddleware.test.ts
@@ -1,0 +1,118 @@
+import { isInspectorRequest, isWebRequest, withoutInspectorRequests } from '../InspectorMiddleware';
+import { ServerRequest } from '../server.types';
+
+const asRequest = (req: Partial<ServerRequest>) => req as ServerRequest;
+
+describe(isInspectorRequest, () => {
+  it('returns true for no UA + known inspector endpoint', () => {
+    const request = asRequest({
+      url: '/inspector/debug',
+      headers: {},
+    });
+
+    expect(isInspectorRequest(request)).toBe(true);
+  });
+
+  it('returns true for node-fetch user-agent + known inspector endpoint', () => {
+    const request = asRequest({
+      url: '/json/list',
+      headers: {
+        'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+      },
+    });
+
+    expect(isInspectorRequest(request)).toBe(true);
+  });
+
+  it('returns false for browser user-agent + known inspector endpoint', () => {
+    const request = asRequest({
+      url: '/json/list',
+      headers: {
+        'user-agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
+      },
+    });
+
+    expect(isInspectorRequest(request)).toBe(false);
+  });
+});
+
+describe(isWebRequest, () => {
+  it('returns false for android platform request', () => {
+    const request = asRequest({
+      url: '/some/page',
+      headers: {
+        'expo-platform': 'android',
+      },
+    });
+
+    expect(isWebRequest(request)).toBe(false);
+  });
+
+  it('returns false for ios platform request', () => {
+    const request = asRequest({
+      url: '/some/page',
+      headers: {
+        'expo-platform': 'ios',
+      },
+    });
+
+    expect(isWebRequest(request)).toBe(false);
+  });
+
+  it('returns true for web platform request', () => {
+    const request = asRequest({
+      url: '/some/page',
+      headers: {
+        'expo-platform': 'web',
+      },
+    });
+
+    expect(isWebRequest(request)).toBe(true);
+  });
+
+  it('returns true when platform is not specified', () => {
+    const request = asRequest({
+      url: '/some/page',
+      headers: {},
+    });
+
+    expect(isWebRequest(request)).toBe(true);
+  });
+});
+
+describe(withoutInspectorRequests, () => {
+  it('disables middleware for inspector requests', () => {
+    const middleware = jest.fn();
+    const next = jest.fn();
+
+    const handler = withoutInspectorRequests(middleware);
+    const request = asRequest({
+      url: '/json/list',
+      headers: {
+        'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+      },
+    });
+
+    handler(request, {} as any, next);
+
+    expect(middleware).toBeCalledTimes(0);
+    expect(next).toBeCalledTimes(1);
+  });
+
+  it('enables middleware for non-inspector requests', () => {
+    const middleware = jest.fn();
+    const next = jest.fn();
+
+    const handler = withoutInspectorRequests(middleware);
+    const request = asRequest({
+      url: '/some/page',
+      headers: {},
+    });
+
+    handler(request, {} as any, next);
+
+    expect(middleware).toBeCalledTimes(1);
+    expect(next).toBeCalledTimes(0);
+  });
+});

--- a/packages/@expo/cli/src/start/server/middleware/server.types.ts
+++ b/packages/@expo/cli/src/start/server/middleware/server.types.ts
@@ -9,3 +9,9 @@ export type ServerRequest = express.Request | http.IncomingMessage;
 export type ServerResponse = express.Response | http.ServerResponse;
 /** Next function */
 export type ServerNext = (err?: Error) => void;
+/** Middleware */
+export type ServerMiddleware = (
+  req: ServerRequest,
+  res: ServerResponse,
+  next: ServerNext
+) => Promise<void>;


### PR DESCRIPTION
# Why

In the old `HistoryFallbackMiddleware`, we had code that avoids mixing up normal web requests with inspector proxy requests. Meaning that if tools such as vscode-expo connects to `/json/list`, it should not be handled by that HTML generating middleware.

Unfortunately, when adding SSG support, this was not ported over and caused requests from vscode-expo to be handled as normal web request.

# How

This changes the following:
  - Pull out inspector related request checks into `InspectorMiddleware`
  - Export a middleware wrapping function that checks for inspector requests, and disables the middleware if that's the case
  - Reimplemented this for both `HistoryFallbackMiddleware` as well as the current SSG implementation

# Test Plan

- `$ yarn create expo ./sdk-49-tabs -t tabs@beta`
- `$ yarn start`
- Open vscode, using the vscode expo plugin
- Run `Expo: Debug app` command
- Should be able to connect without issues

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
