### PR TITLE
[expo] add expo-insights to bundledNativeModules for Expo 49 compatibility

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -46,6 +46,7 @@
   "expo-image-picker": "~14.3.0",
   "expo-in-app-purchases": "~14.3.0",
   "expo-intent-launcher": "~10.7.0",
+  "expo-insights": "~0.2.0",
   "expo-keep-awake": "~12.3.0",
   "expo-linear-gradient": "~12.3.0",
   "expo-linking": "~5.0.2",


### PR DESCRIPTION
# Why
If you install `expo-insights` into an SDK 49 app or update an app with Insights in it, insights will install `0.1.0` and you'll get an [Android build error](https://expo.dev/accounts/keith-kurak/projects/just-kana/builds/571bfeb3-0784-4fc3-9afa-2f6a737c5061):
```Could not set unknown property 'classifier' for task ':expo-insights:androidSourcesJar' of type org.gradle.api.tasks.bundling.Jar.``` I believe this has something to do with the Gradle 8 updates.

`expo-insights` `0.2.0` is currently published to `next` in NPM and that works, so this would presumably fix itself once 49 is out of beta, but seems like a good idea to put it in **bundledNativeModules** in case future SDK updates affect compatibility, even though it's not included in Expo Go.

# How

Added it.

# Test Plan
- [x] Successfully built a blank SDK 49 app with `expo-insights` `0.2.0`.
