### PR TITLE
[cli] fix js inspector is broken when using web SSG

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed JavaScript inspector broken when using Metro web with SSG. ([#23197](https://github.com/expo/expo/pull/23197) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.10.4 — 2023-06-28

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -3,14 +3,16 @@
 //
 // Forks https://github.com/facebook/metro/blob/b80d9a0f638ee9fb82ff69cd3c8d9f4309ca1da2/packages/metro/src/index.flow.js#L57
 // and adds the ability to access the bundler instance.
+import assert from 'assert';
 import http from 'http';
 import https from 'https';
 import { RunServerOptions, Server } from 'metro';
 import { ConfigT } from 'metro-config';
-import { InspectorProxy } from 'metro-inspector-proxy';
+import type { InspectorProxy } from 'metro-inspector-proxy';
 import { parse } from 'url';
 
 import { env } from '../../../utils/env';
+import type { ConnectAppType } from '../middleware/server.types';
 import { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { createInspectorProxy, ExpoInspectorProxy } from './inspector-proxy';
 import {
@@ -40,8 +42,6 @@ export const runServer = async (
 
   const createWebsocketServer = importMetroCreateWebsocketServerFromProject(projectRoot);
 
-  const { InspectorProxy } = importMetroInspectorProxyFromProject(projectRoot);
-
   const MetroHmrServer = importMetroHmrServerFromProject(projectRoot);
 
   // await earlyPortCheck(host, config.server.port);
@@ -55,10 +55,6 @@ export const runServer = async (
   //       "Metro's https development server.",
   //   );
   // }
-  // Lazy require
-  const connect = require('connect');
-
-  const serverApp = connect();
 
   const { middleware, end, metroServer } = await Metro.createConnectMiddleware(config, {
     hasReducedPerformance,
@@ -66,12 +62,14 @@ export const runServer = async (
     watch,
   });
 
-  serverApp.use(middleware);
+  assert(typeof (middleware as any).use === 'function');
+  const serverApp = middleware as ConnectAppType;
 
   let inspectorProxy: InspectorProxy | ExpoInspectorProxy | null = null;
   if (config.server.runInspectorProxy && !env.EXPO_NO_INSPECTOR_PROXY) {
     inspectorProxy = createInspectorProxy(metroBundler, config.projectRoot);
   } else if (config.server.runInspectorProxy) {
+    const { InspectorProxy } = importMetroInspectorProxyFromProject(projectRoot);
     inspectorProxy = new InspectorProxy(config.projectRoot);
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/HistoryFallbackMiddleware.ts
@@ -1,35 +1,6 @@
 import { parsePlatformHeader } from './resolvePlatform';
 import { ServerNext, ServerRequest, ServerResponse } from './server.types';
 
-const debug = require('debug')('expo:start:server:metro:historyFallback') as typeof console.log;
-
-const WS_DEVICE_URL = '/inspector/device';
-const WS_DEBUGGER_URL = '/inspector/debug';
-const PAGES_LIST_JSON_URL = '/json';
-const PAGES_LIST_JSON_URL_2 = '/json/list';
-const PAGES_LIST_JSON_VERSION_URL = '/json/version';
-
-export function isInspectorProxyRequest(req: ServerRequest) {
-  const ua = req.headers['user-agent'];
-  const url = req.url;
-
-  // This check is very fragile but it enables websites to use any of the
-  // endpoints below without triggering the inspector proxy.
-  if (!url || (ua && !ua.includes('node-fetch'))) {
-    // This optimizes for the inspector working over the endpoint being available on web.
-    // Web is less fragile.
-    return false;
-  }
-
-  return [
-    WS_DEVICE_URL,
-    WS_DEBUGGER_URL,
-    PAGES_LIST_JSON_URL,
-    PAGES_LIST_JSON_URL_2,
-    PAGES_LIST_JSON_VERSION_URL,
-  ].includes(url);
-}
-
 /**
  * Create a web-only middleware which redirects to the index middleware without losing the path component.
  * This is useful for things like React Navigation which need to render the index.html and then direct the user in-memory.
@@ -47,10 +18,6 @@ export class HistoryFallbackMiddleware {
       const platform = parsePlatformHeader(req);
 
       if (!platform || platform === 'web') {
-        if (isInspectorProxyRequest(req)) {
-          debug('Inspector proxy request:', req.url, 'UA:', req.headers['user-agent']);
-          return next();
-        }
         // Redirect unknown to the manifest handler while preserving the path.
         // This implements the HTML5 history fallback API.
         return this.indexMiddleware(req, res, next);

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/HistoryFallbackMiddleware-test.ts
@@ -1,65 +1,7 @@
-import { HistoryFallbackMiddleware, isInspectorProxyRequest } from '../HistoryFallbackMiddleware';
+import { HistoryFallbackMiddleware } from '../HistoryFallbackMiddleware';
 import { ServerRequest } from '../server.types';
 
 const asRequest = (req: Partial<ServerRequest>) => req as ServerRequest;
-
-describe(isInspectorProxyRequest, () => {
-  it(`return true for no UA + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/inspector/debug',
-          headers: {},
-        })
-      )
-    ).toBe(true);
-  });
-  it(`return true for node-fetch user-agent + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/json/list',
-          headers: {
-            'user-agent': 'node-fetch',
-          },
-        })
-      )
-    ).toBe(true);
-  });
-  it(`return false for browser user-agent + known inspector endpoint`, () => {
-    expect(
-      isInspectorProxyRequest(
-        asRequest({
-          url: '/json/list',
-          headers: {
-            'user-agent':
-              'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36',
-          },
-        })
-      )
-    ).toBe(false);
-  });
-});
-
-it(`skips requests to the Metro inspector proxy`, () => {
-  const indexMiddleware = jest.fn();
-  const middleware = new HistoryFallbackMiddleware(indexMiddleware).getHandler();
-
-  const next = jest.fn();
-  middleware(
-    asRequest({
-      url: '/json/list',
-      headers: {
-        'user-agent': 'node-fetch',
-      },
-    }),
-    {} as any,
-    next
-  );
-  // Redirects to middleware with URL intact.
-  expect(indexMiddleware).toBeCalledTimes(0);
-  expect(next).toBeCalledTimes(1);
-});
 
 it(`redirects to provided middleware on web with query parameter`, () => {
   const indexMiddleware = jest.fn();

--- a/packages/@expo/cli/src/start/server/middleware/server.types.ts
+++ b/packages/@expo/cli/src/start/server/middleware/server.types.ts
@@ -9,3 +9,8 @@ export type ServerRequest = express.Request | http.IncomingMessage;
 export type ServerResponse = express.Response | http.ServerResponse;
 /** Next function */
 export type ServerNext = (err?: Error) => void;
+
+/** The `connect()` app that is a http.RequestListener and having the `use()` function for middlewares. */
+export interface ConnectAppType extends http.RequestListener {
+  use: Function;
+}


### PR DESCRIPTION
# Why

when web SSG is enabled, pressing `j` to open js inspector is broken:
```
Opening JavaScript inspector in the browser...
Web Bundling complete 4499ms
Web Bundling complete 4524ms
FetchError: invalid json response body at http://192.168.50.38:8081/json/list reason: Unexpected token < in JSON at position 0
FetchError: invalid json response body at http://192.168.50.38:8081/json/list reason: Unexpected token < in JSON at position 0
```

# How

originally we have #21068 fix for the HistoryFallbackMiddleware. the new middleware for SSG unfortunately does not have the fix.
i feel like the root cause is coming from middleware disorder. digging the code in deep, i found we've chained the `connect` app. the `middleware` returned from `Metro.createConnectMiddleware` is actually a connect app, because rn-cli will set the `enhanceMiddleware` and it creates the `connect` app under the hood.

this pr tries to reuse the connect app. without the connect app chaining, those web middlewares will be placed after the inspector proxy middleware.

also removed the #21068 hack for HistoryFallbackMiddleware in this pr.

###  Code References
- https://github.com/expo/expo/blob/c1f7b418dd89d3b5a3614424bb3bdea54731b7fa/packages/%40expo/cli/src/start/server/metro/runServer-fork.ts#L63-L67
- https://github.com/facebook/metro/blob/649864dfe053a6c96785b3cdbd4061b451b068c1/packages/metro/src/index.flow.js#L213-L219
- https://github.com/react-native-community/cli/blob/0d118e3e3fdd99a5b056884f68a82440794bf6fc/packages/cli-plugin-metro/src/commands/start/runServer.ts#L88-L96
- https://github.com/react-native-community/cli/blob/0d118e3e3fdd99a5b056884f68a82440794bf6fc/packages/cli-plugin-metro/src/commands/start/runServer.ts#L74-L96
- https://github.com/react-native-community/cli/blob/0d118e3e3fdd99a5b056884f68a82440794bf6fc/packages/cli-server-api/src/index.ts#L47

# Test Plan

```
$ yarn create expo -t tabs@sdk-49 sdk49tabs
$ cd sdk49tabs
$ npx expo start
# press `j`
```

after the fix, i've checked:
1. press `j`
2. check `http://localhost:8081/json/list` returns an array
3. check `http://localhost:8081/helloweb` returns a html content
4. disable SSG (the `"output": "static"` in **app.json**), check `http://localhost:8081/helloweb` returns a html content 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
