### PR TITLE
[docs] mark certain UI elements labels as non-crawlable

### DIFF
--- a/docs/ui/components/CommandMenu/CommandMenuTrigger.tsx
+++ b/docs/ui/components/CommandMenu/CommandMenuTrigger.tsx
@@ -35,7 +35,9 @@ export const CommandMenuTrigger = ({ setOpen }: Props) => {
   return (
     <Button theme="secondary" css={buttonStyle} onClick={() => setOpen(true)}>
       <SearchSmIcon />
-      <CALLOUT css={labelStyle}>Search</CALLOUT>
+      <CALLOUT css={labelStyle} crawlable={false}>
+        Search
+      </CALLOUT>
       {isMac !== null && (
         <div css={[keysWrapperStyle, hideOnMobileStyle]}>
           <KBD>{isMac ? '⌘' : 'Ctrl'}</KBD> <KBD>K</KBD>

--- a/docs/ui/components/PageTitle/PageTitle.tsx
+++ b/docs/ui/components/PageTitle/PageTitle.tsx
@@ -28,7 +28,9 @@ export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props)
             css={linkStyle}
             title={`View source code of ${packageName} on GitHub`}>
             <GithubIcon className="text-icon-secondary" />
-            <CALLOUT theme="secondary">GitHub</CALLOUT>
+            <CALLOUT crawlable={false} theme="secondary">
+              GitHub
+            </CALLOUT>
           </A>
         )}
         <A
@@ -38,7 +40,9 @@ export const PageTitle = ({ title, packageName, iconUrl, sourceCodeUrl }: Props)
           css={linkStyle}
           title="View package in npm Registry">
           <BuildIcon className="text-icon-secondary" />
-          <CALLOUT theme="secondary">npm</CALLOUT>
+          <CALLOUT crawlable={false} theme="secondary">
+            npm
+          </CALLOUT>
         </A>
       </span>
     )}

--- a/docs/ui/components/Sidebar/SidebarTitle.tsx
+++ b/docs/ui/components/Sidebar/SidebarTitle.tsx
@@ -8,7 +8,9 @@ type SidebarTitleProps = PropsWithChildren;
 
 export const SidebarTitle = ({ children }: SidebarTitleProps) => (
   <div css={STYLES_TITLE}>
-    <CALLOUT weight="medium">{children}</CALLOUT>
+    <CALLOUT weight="medium" crawlable={false}>
+      {children}
+    </CALLOUT>
   </div>
 );
 


### PR DESCRIPTION
# Why

Those labels appears as a content of some Algolia records, when they should not.

# How

Mark some UI elements labels as non-crawlable to prevent attaching their content to certain records extracted by crawler.

# Test Plan

Made sure locally, that those tag no longer include `data-text="true"` attr.

