### PR TITLE
[templates] add default kotlin version

### DIFF
--- a/templates/expo-template-bare-minimum/android/build.gradle
+++ b/templates/expo-template-bare-minimum/android/build.gradle
@@ -6,9 +6,7 @@ buildscript {
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '21')
         compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '33')
         targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '33')
-        if (findProperty('android.kotlinVersion')) {
-            kotlinVersion = findProperty('android.kotlinVersion')
-        }
+        kotlinVersion = findProperty('android.kotlinVersion') ?: '1.8.10'
         frescoVersion = findProperty('expo.frescoVersion') ?: '2.5.0'
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.


### PR DESCRIPTION
# Why

we noticed some regression of 3rd party modules with older kotlin versions which is incompatible with gradle 8 now. e.g. https://github.com/Shopify/flash-list/issues/862. i looks like we should include the default kotlin version without user to have expo-build-properties as a workaround.

# How

add the default `kotlinVersion '1.8.10'` if gradle.properties or expo-build-properties does not overwrite it.

# Test Plan

smoke test by changing the same line on a sdk 49 bare project