### PR TITLE
Correct typo in JSDoc comment

### DIFF
--- a/packages/expo-sensors/src/Magnetometer.ts
+++ b/packages/expo-sensors/src/Magnetometer.ts
@@ -37,7 +37,7 @@ export class MagnetometerSensor extends DeviceSensor<MagnetometerMeasurement> {
 
   /**
    * Subscribe for updates to the magnetometer.
-   * @param listener A callback that is invoked when a barometer update is available. When invoked, the listener is provided with a single argument that is `MagnetometerMeasurement`.
+   * @param listener A callback that is invoked when a magnetometer update is available. When invoked, the listener is provided with a single argument that is `MagnetometerMeasurement`.
    * @return A subscription that you can call `remove()` on when you would like to unsubscribe the listener.
    */
   addListener(listener: Listener<MagnetometerMeasurement>): Subscription {


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

Typo in JSDoc comment results in confusing documentation ([Magnetometer](https://docs.expo.dev/versions/latest/sdk/magnetometer/)):

Expected:
`A callback that is invoked when a magnetometer update is available. When invoked, the listener is provided with a single argument that is MagnetometerMeasurement`

Actual:
`A callback that is invoked when a barometer update is available. When invoked, the listener is provided with a single argument that is MagnetometerMeasurement`

# Checklist
- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide.