### PR TITLE
drop unused cli env vars

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,13 +7,6 @@ export EXPO_ROOT_DIR=`pwd`
 # ANDROID_HOME should be replaced with ANDROID_SDK_ROOT as soon as RN stops using it for its buildscripts
 export ANDROID_HOME="${ANDROID_SDK_ROOT:=$ANDROID_SDK}"
 
-# Enable experimental dev server in expo-cli
-export EXPO_USE_DEV_SERVER=true
-
-# Enable experimental JS version of simctl for opening iOS simulators `expo start -i`
-# and listing simulators `expo run:ios -d` and `shift+i` in `expo start`.
-export EXPO_USE_CORE_SIM=1
-
 # Force all Expo modules to be compiled from source
 export EXPO_USE_SOURCE=1
 


### PR DESCRIPTION
# Why

These are no longer used in versioned CLI and shouldn't be used in any of the global CLI tests.