### PR TITLE
[expo-updates] Fix expo-extra-params header

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Support discriminated unions for JS API method result types. ([#23173](https://github.com/expo/expo/pull/23173) by [@wschurman](https://github.com/wschurman))
+- Fix expo-extra-params header. ([#23206](https://github.com/expo/expo/pull/23206) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/FileDownloaderTest.kt
@@ -160,6 +160,7 @@ class FileDownloaderTest {
   fun testGetExtraHeaders() {
     mockkObject(ManifestMetadata)
     every { ManifestMetadata.getServerDefinedHeaders(any(), any()) } returns null
+    every { ManifestMetadata.getExtraParams(any(), any()) } returns mapOf("hello" to "world", "what" to "123")
 
     val launchedUpdateUUIDString = "7c1d2bd0-f88b-454d-998c-7fa92a924dbf"
     val launchedUpdate = UpdateEntity(UUID.fromString(launchedUpdateUUIDString), Date(), "1.0", "test")
@@ -170,6 +171,7 @@ class FileDownloaderTest {
 
     Assert.assertEquals(launchedUpdateUUIDString, extraHeaders.get("Expo-Current-Update-ID"))
     Assert.assertEquals(embeddedUpdateUUIDString, extraHeaders.get("Expo-Embedded-Update-ID"))
+    Assert.assertEquals("hello=\"world\", what=\"123\"", extraHeaders.get("Expo-Extra-Params"))
 
     // cleanup
     unmockkObject(ManifestMetadata)
@@ -183,6 +185,7 @@ class FileDownloaderTest {
     val extraHeaders = FileDownloader.getExtraHeadersForRemoteUpdateRequest(mockk(), mockk(), null, null)
     Assert.assertFalse(extraHeaders.has("Expo-Current-Update-ID"))
     Assert.assertFalse(extraHeaders.has("Expo-Embedded-Update-ID"))
+    Assert.assertFalse(extraHeaders.has("Expo-Extra-Params"))
 
     // cleanup
     unmockkObject(ManifestMetadata)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -834,7 +834,7 @@ open class FileDownloader(context: Context, private val client: OkHttpClient) {
         ManifestMetadata.getServerDefinedHeaders(database, configuration) ?: JSONObject()
 
       ManifestMetadata.getExtraParams(database, configuration)?.let {
-        extraHeaders.put("Expo-Extra-Params", Dictionary.valueOf(it.mapValues { elem -> StringItem.valueOf(elem.value) }))
+        extraHeaders.put("Expo-Extra-Params", Dictionary.valueOf(it.mapValues { elem -> StringItem.valueOf(elem.value) }).serialize())
       }
 
       launchedUpdate?.let {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
@@ -74,7 +74,7 @@ object ManifestMetadata {
 
       // ensure that this can be serialized to a structured-header dictionary
       // this will throw for invalid values
-      Dictionary.valueOf(extraParamsToWrite.mapValues { elem -> StringItem.valueOf(elem.value) })
+      Dictionary.valueOf(extraParamsToWrite.mapValues { elem -> StringItem.valueOf(elem.value) }).serialize()
 
       JSONObject(extraParamsToWrite).toString()
     }

--- a/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
+++ b/packages/expo-updates/ios/Tests/FileDownloaderSpec.swift
@@ -142,6 +142,9 @@ class FileDownloaderSpec : ExpoSpec {
         )
         
         db.databaseQueue.sync {
+          try! db.setExtraParam(key: "hello", value: "world", withScopeKey: config.scopeKey!)
+          try! db.setExtraParam(key: "what", value: "123", withScopeKey: config.scopeKey!)
+
           let extraHeaders = FileDownloader.extraHeadersForRemoteUpdateRequest(
             withDatabase: db,
             config: config,
@@ -150,6 +153,8 @@ class FileDownloaderSpec : ExpoSpec {
           )
           expect(extraHeaders["Expo-Current-Update-ID"] as? String) == launchedUpdateUUIDString
           expect(extraHeaders["Expo-Embedded-Update-ID"] as? String) == embeddedUpdateUUIDString
+          expect(extraHeaders["Expo-Extra-Params"] as? String).to(contain("what=\"123\""))
+          expect(extraHeaders["Expo-Extra-Params"] as? String).to(contain("hello=\"world\""))
         }
       }
       
@@ -167,6 +172,7 @@ class FileDownloaderSpec : ExpoSpec {
           )
           expect(extraHeaders["Expo-Current-Update-ID"]).to(beNil())
           expect(extraHeaders["Expo-Embedded-Update-ID"]).to(beNil())
+          expect(extraHeaders["Expo-Extra-Params"]).to(beNil())
         }
       }
     }


### PR DESCRIPTION
# Why

Closes ENG-8073.

While QA'ing this feature, I noticed that the serialization here was incorrect on Android. This PR fixes it and adds new tests for it.

# Test Plan

Run new test.

Manual test:
```
yarn create expo-app --template blank@beta extrabranchparams
eas init
npx expo install expo-updates
eas update:configure
eas build:configure
npx expo prebuild
npx expo run:ios --configuration Release
```
With the following in App.tsx:
```
export default function App() {
  const [extraParams, setExtraParams] = useState<string>('');

  const onPressSet = async () => {
    await Updates.setExtraParamAsync('hello', 'world');
    console.log('done');
  };

  const onPressGet = async () => {
    console.log('get');
    const value = await Updates.getExtraParamsAsync();
    setExtraParams(JSON.stringify(value));
    console.log(value);
  };

  const onPressWat = async () => {
    console.log('wat');
    const value = await Updates.checkForUpdateAsync();
    setExtraParams(JSON.stringify(value));
    console.log(value);
  };

  return (
    <View style={styles.container}>
      <Text>Open up App.js to start working on your app! {extraParams}</Text>
      <Button onPress={onPressSet} title='SET' />
      <Button onPress={onPressGet} title='GET' />
      <Button onPress={onPressWat} title='WAT' />
      <StatusBar style="auto" />
    </View>
  );
}
```

Then, use proxyman to inspect headers of requests to ensure that before the `SET` button is pushed it doesn't contain the new header and afterward it does contain the new header.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
