### PR TITLE
[expo-updates] Fix update parsing when getting manifest from dev server through tunnel

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -135,6 +135,16 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase
   ) throws -> Update {
+    // Sanity check for remotely getting a manifest through a tunnel
+    // from a dev-server, where manifest is modern but no protocol header
+    if withManifest["releaseId"] == nil {
+      return NewUpdate.update(
+        withNewManifest: NewManifest(rawManifestJSON: withManifest),
+        extensions: extensions,
+        config: config,
+        database: database
+      )
+    }
     let protocolVersion = responseHeaderData.protocolVersion
     switch protocolVersion {
     case nil:
@@ -166,13 +176,12 @@ public class Update: NSObject {
         config: config,
         database: database
       )
-    } else {
-      return BareUpdate.update(
-        withBareManifest: BareManifest(rawManifestJSON: withEmbeddedManifest),
-        config: config,
-        database: database
-      )
     }
+    return BareUpdate.update(
+      withBareManifest: BareManifest(rawManifestJSON: withEmbeddedManifest),
+      config: config,
+      database: database
+    )
   }
 
   /**

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -135,24 +135,25 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase
   ) throws -> Update {
-    // Sanity check for remotely getting a manifest through a tunnel
-    // from a dev-server, where manifest is modern but no protocol header
-    if withManifest["releaseId"] == nil {
-      return NewUpdate.update(
-        withNewManifest: NewManifest(rawManifestJSON: withManifest),
-        extensions: extensions,
-        config: config,
-        database: database
-      )
-    }
     let protocolVersion = responseHeaderData.protocolVersion
     switch protocolVersion {
     case nil:
-      return LegacyUpdate.update(
-        withLegacyManifest: LegacyManifest(rawManifestJSON: withManifest),
-        config: config,
-        database: database
-      )
+      // Sanity check for the correct type of manifest
+      switch withManifest["releaseId"] {
+      case nil:
+        return NewUpdate.update(
+          withNewManifest: NewManifest(rawManifestJSON: withManifest),
+          extensions: extensions,
+          config: config,
+          database: database
+        )
+      default:
+        return LegacyUpdate.update(
+          withLegacyManifest: LegacyManifest(rawManifestJSON: withManifest),
+          config: config,
+          database: database
+        )
+      }
     case 0, 1:
       return NewUpdate.update(
         withNewManifest: NewManifest(rawManifestJSON: withManifest),


### PR DESCRIPTION
# Why

When Expo Go gets an app from a dev server through a tunnel, the app bundle is processed as an update. The manifest provided by the dev server is a modern manifest, but no protocol version header is supplied, so the code attempts to create a legacy update, leading to a crash.

# How

Ideally, Expo Go should be able to recognize that the tunnel URL is actually a dev server URL and not an update URL. However, fixing `Update.swift` to process the manifest correctly is an ok fix for now, and allows Expo Go to acquire and run the app from the tunnel URL.

# Test Plan

These repro steps should not cause a crash:

```bash
npx create-expo-app repro-crash --template blank@sdk-49
cd repro-crash
npx expo start --tunnel # requires that @expo/ngrok is installed globally
# press i to launch, or scan qr code
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
