### PR TITLE
fix(expo): use node resolution when invoking `@expo/cli` from `expo`

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Use node module resolution when invoking `@expo/cli` from `expo`.
+- Use node module resolution when invoking `@expo/cli` from `expo`. ([#23220](https://github.com/expo/expo/pull/23220) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use node module resolution when invoking `@expo/cli` from `expo`.
+
 ### 💡 Others
 
 ## 49.0.0-beta.0 — 2023-06-28

--- a/packages/expo/bin/cli
+++ b/packages/expo/bin/cli
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node
 
-# Forward all arguments to the local CLI (@expo/cli).
-npm exec --no-install -- expo-internal "$@"
+// Execute the CLI using node module resultion, instead of creating a new process.
+// This avoids resolving issues with pnpm and yarn 2+ package managers.
+require('@expo/cli');

--- a/packages/expo/bin/cli
+++ b/packages/expo/bin/cli
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-// Execute the CLI using node module resultion, instead of creating a new process.
+// Execute the CLI using node module resolution, instead of creating a new process.
 // This avoids resolving issues with pnpm and yarn 2+ package managers.
 require('@expo/cli');


### PR DESCRIPTION
# Why

Fixes #23194

We've had reports of package managers being unable to resolve the `@expo/cli` when executing from the `expo` package.

- https://github.com/expo/expo/issues/23193
- https://github.com/expo/expo/issues/23194
- https://github.com/expo/expo/issues/23252

I've had a similar experience with pnpm and yarn v1 and workspaces with `"noHoist": ["**"]`. This should fix some parts of that.

<details><summary>vscode-expo fixtures issue I ran into</summary>

<img width="754" alt="image" src="https://github.com/expo/expo/assets/1203991/92324113-5a1a-44ae-a573-ba2582c5d2e9">

</details>

> **Note**
> I've tested this in: https://github.com/byCedric/being-productive-can-have-many-reasons/blob/main/ISSUES.md (a repository with fixes required for pnpm). You can clone that repository, and try it yourself. Make sure you always install with `pnpm install`, because the patches are only set for pnpm.

# How

Instead of creating a new process, either through `spawnAsync` or `npm exec`, we just execute the `@expo/cli` in the process of the `expo` bin.

By letting Node resolve this, it should avoid issues with complex patterns such as [isolated modules](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md) too.

# Test Plan

- `$ yarn create expo ./test-bin -t tabs@beta`
- `$ cd ./test-bin`
- `$ rm -rf node_modules yarn.lock`
- _Any of these commands should work:_
  - `$ yarn install && yarn expo --help` (yarn v1)
  - `$ npm install && npx expo --help` (any npm version)
  - `$ pnpm install && pnpm expo --help` (any pnpm version)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
