### PR TITLE
[docs] SidebarCollapsible: mark label as non-crawlable

### DIFF
--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -87,7 +87,7 @@ export function SidebarCollapsible(props: Props) {
             css={!isOpen && chevronClosedStyle}
           />
         </div>
-        <CALLOUT>{info.name}</CALLOUT>
+        <CALLOUT crawlable={false}>{info.name}</CALLOUT>
       </ButtonBase>
       {isOpen && (
         <div aria-hidden={!isOpen ? 'true' : 'false'} css={childrenContainerStyle}>


### PR DESCRIPTION
# Why

Follow up to #23199

# How

Spotted one more case when search crawler extracted currently unwanted content in the record, so let's mark the problematic labels as non-crawlable.

# Test Plan

Made sure locally, that collapsible labels do not include `[data-text="true"]` anymore.
