### PR TITLE
[docs] correct internal links hrefs and behaviour

### DIFF
--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -26,7 +26,7 @@ It may be useful to create an Organization when:
 - Expenses need to be isolated.
 - Granting different levels of access by assigning a role to each member of the organization.
 - Structuring projects for different contexts. For example, when working for different clients, a new organization may be created for each client.
-- Sharing an [EAS Subscription](https://docs.expo.dev/eas/).
+- Sharing an [EAS Subscription](/eas/).
 
 ### Creating new Organizations
 

--- a/docs/pages/eas-update/codepush.mdx
+++ b/docs/pages/eas-update/codepush.mdx
@@ -93,7 +93,7 @@ You can check whether you are logged in by running `eas whoami`.
 <Step label="7">
 ## Configure project, deploy builds and publish updates
 
-We have finished all the steps tailored for a CodePush-enabled bare React Native project. To proceed with the configuration of your project, please begin with Step 4 in [the main guide](https://docs.expo.dev/eas-update/getting-started/#create-a-build-for-the-project) and follow it through to completion.
+We have finished all the steps tailored for a CodePush-enabled bare React Native project. To proceed with the configuration of your project, please begin with Step 4 in [the main guide](/eas-update/getting-started/#create-a-build-for-the-project) and follow it through to completion.
 
 > You may need to edit some of the code `eas update:configure` generates depending on how you build and run your project. See [Updating bare app](/bare/updating-your-app) for more details about the native changes.
 

--- a/docs/pages/eas-update/deployment-patterns.mdx
+++ b/docs/pages/eas-update/deployment-patterns.mdx
@@ -136,7 +136,7 @@ This flow is for projects that need to build and update their Android and iOS ap
 
 This flow is an example of a flow for managing versioned releases.
 
-> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](https://docs.expo.dev/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, and `"nativeVersion"`). You will need to [manually specify](https://docs.expo.dev/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
+> **warning** This flow requires a bit more bookkeeping and does not support automatic [runtime version policies](/eas-update/runtime-versions/#setting-runtimeversion) (`"sdkVersion"`, `"appVersion"`, and `"nativeVersion"`). You will need to [manually specify](/eas-update/runtime-versions/#custom-runtimeversion) your runtimes' versions with this flow.
 
 Here are the parts of the deployment process above that make up this flow:
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -67,7 +67,6 @@ Metro doesn't come with monorepo support by default (yet). That's why we need to
 We can configure this by [creating a **metro.config.js**](/guides/customizing-metro/#customizing) with the following content:
 
 ```js metro.config.js
-// Learn more https://docs.expo.dev/guides/monorepos
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 
@@ -102,7 +101,6 @@ When using monorepos, your app dependencies splits up into different directories
 As your monorepo increases in size, watching all files within the monorepo becomes slower. You can speed things up by only watching the packages your app uses. Typically, these are the ones that are installed with an asterisk (\*) in your **package.json**. For example:
 
 ```js
-// Learn more https://docs.expo.dev/guides/monorepos
 const { getDefaultConfig } = require('expo/metro-config');
 const path = require('path');
 

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -40,7 +40,6 @@ To enable Search Engine Optimization (SEO) on the web you must statically render
   If you have a **metro.config.js** file in your project, ensure it extends **expo/metro-config** as shown below:
 
 ```js metro.config.js
-// Learn more: https://docs.expo.dev/guides/customizing-metro/
 const { getDefaultConfig } = require('expo/metro-config');
 
 /** @type {import('expo/metro-config').MetroConfig} */
@@ -50,6 +49,8 @@ const config = getDefaultConfig(__dirname, {
 
 module.exports = config;
 ```
+
+  You can also [learn more](/guides/customizing-metro/) about customizing Metro.
 
 </Step>
 
@@ -193,7 +194,7 @@ export default function Root({ children }: { children: React.ReactNode }) {
         <meta charSet="utf-8" />
         <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
 
-        {/* 
+        {/*
           This viewport disables scaling which makes the mobile website act more like a native app.
           However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
             <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
@@ -202,8 +203,8 @@ export default function Root({ children }: { children: React.ReactNode }) {
           name="viewport"
           content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
         />
-        {/* 
-          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native. 
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
           However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
         */}
         <ScrollViewStyleReset />

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -394,13 +394,13 @@ The second button with the label "Use this photo" resembles the actual button fr
 ## Enhance the reusable button component
 
 The "Choose a photo" button requires different styling than the "Use this photo" button, so we will add a new button theme prop that will allow us to apply a `primary` theme.
-This button also has an icon before the label. We will use an icon from the <A href="/guides/icons/#expovector-icons" openInNewTab>`@expo/vector-icons`</A> library that includes icons from popular icon sets.
+This button also has an icon before the label. We will use an icon from the <A href="/guides/icons/#expovector-icons">`@expo/vector-icons`</A> library that includes icons from popular icon sets.
 
 Stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal. Then, install the `@expo/vector-icons` library:
 
 <Terminal cmd={['$ npx expo install @expo/vector-icons']} />
 
-The <A href="/more/expo-cli/#installation" openInNewTab>`npx expo install`</A> command will install the library and add it to the project's dependencies in **package.json**.
+The <A href="/more/expo-cli/#installation">`npx expo install`</A> command will install the library and add it to the project's dependencies in **package.json**.
 
 After installing the library, restart the development server by running the `npx expo start` command.
 

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -17,7 +17,7 @@ Before considering the app fully launchable, we have to configure the status bar
 
 ## Configure the status bar
 
-The <A href="/versions/latest/sdk/status-bar/" openInNewTab>`expo-status-bar`</A> library comes pre-installed in every project created using `create-expo-app`.
+The <A href="/versions/latest/sdk/status-bar/">`expo-status-bar`</A> library comes pre-installed in every project created using `create-expo-app`.
 This library provides a `<StatusBar>` component that allows configuring the app's status bar to change the text color, background color, make it translucent, and so on.
 
 The `<StatusBar>` component is already imported in the **App.js**:
@@ -54,7 +54,7 @@ To make the status bar light, change the `style` value to `light`.
 
 A splash screen is a screen that is visible before the contents of the app has had a chance to load. It hides once the app is ready for use and the content is ready to be displayed.
 
-The splash screen is configured by defining a path to the `"splash.image"` property in the <A href="/workflow/configuration/" openInNewTab>**app.json** file</A>.
+The splash screen is configured by defining a path to the `"splash.image"` property in the <A href="/workflow/configuration/">**app.json** file</A>.
 It has a current value of `"./assets/splash.png"` path. This is already done by default when a new Expo project is created.
 
 We already have **splash.png** in the **assets** directory. It looks as shown below:

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -10,7 +10,7 @@ import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
 
-React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal) that presents content above the rest of your app. In general, modals are used to draw a user's attention toward critical information or guide them to take action. For example, in the <A href="/tutorial/build-a-screen/#step-7-enhance-the-reusable-button-component" openInNewTab>second chapter</A>,
+React Native provides a [`<Modal>` component](https://reactnative.dev/docs/modal) that presents content above the rest of your app. In general, modals are used to draw a user's attention toward critical information or guide them to take action. For example, in the [second chapter](/tutorial/build-a-screen/#step-7-enhance-the-reusable-button-component),
 we used `alert()` to display a placeholder when a button is pressed. That's how a modal component displays an overlay.
 
 In this chapter, we'll create a modal that shows an emoji picker list.

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -24,7 +24,7 @@ This tutorial also assumes that you have a basic knowledge of JavaScript and Rea
 
 ## Initialize a new Expo app
 
-We will use <A href="/more/glossary-of-terms/#create-expo-app" openInNewTab>`create-expo-app`</A> to initialize a new Expo app. It is a command line tool that allows to create a new React Native project with the `expo` package installed.
+We will use <A href="/more/glossary-of-terms/#create-expo-app">`create-expo-app`</A> to initialize a new Expo app. It is a command line tool that allows to create a new React Native project with the `expo` package installed.
 
 It will create a new project directory and install all the necessary dependencies to get the project up and running locally. Run the following command in your terminal:
 
@@ -74,11 +74,11 @@ To run the project on the web, we need to install the following dependencies tha
 
 ## Run the app on mobile and web
 
-In the project directory, run the following command to start a <A href="/more/glossary-of-terms/#development-server" openInNewTab>development server</A> from the terminal:
+In the project directory, run the following command to start a <A href="/more/glossary-of-terms/#development-server">development server</A> from the terminal:
 
 <Terminal cmd={['$ npx expo start']} />
 
-Once the development server is running, the easiest way to launch the app is on a physical device with Expo Go. For more information, see <A href="/get-started/create-a-project/#open-the-app-on-your-device" openInNewTab>Open app on a device</A>.
+Once the development server is running, the easiest way to launch the app is on a physical device with Expo Go. For more information, see <A href="/get-started/create-a-project/#open-the-app-on-your-device">Open app on a device</A>.
 
 To see the web app in action, press <kbd>w</kbd> in the terminal. It will open the web app in the default web browser.
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -12,7 +12,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons';
 React Native provides built-in components that are standard building blocks used by every application, such as `<View>`, `<Text>`, and `<Pressable>`.
 We want to build a feature that isn't possible with these core components and API: selecting an image from the device's media library. For that, we will need a library.
 
-To achieve this, we'll use an Expo SDK library called <A href="/versions/latest/sdk/imagepicker" openInNewTab>`expo-image-picker`</A>.
+To achieve this, we'll use an Expo SDK library called <A href="/versions/latest/sdk/imagepicker">`expo-image-picker`</A>.
 
 > `expo-image-picker` provides access to the system's UI to select images and videos from the phone's library or take a photo with the camera.
 
@@ -72,7 +72,7 @@ export default function App() {
 Let's learn what the above code does.
 
 - The `launchImageLibraryAsync()` receives an object in which different options are specified.
-  This object is an <A href="/versions/latest/sdk/imagepicker/#imagepickeroptions" openInNewTab>`ImagePickerOptions` object</A>.
+  This object is an <A href="/versions/latest/sdk/imagepicker/#imagepickeroptions">`ImagePickerOptions` object</A>.
   We can pass the object to specify different options when invoking the method.
 - When `allowsEditing` is set to `true`, the user can crop the image during the selection process on Android and iOS but not on the web.
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -11,7 +11,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 In this chapter, we will learn how to take a screenshot using a third-party library and save it on the device's media library.
 We'll use the following libraries [`react-native-view-shot`](https://github.com/gre/react-native-view-shot) that allows taking a screenshot,
-and <A href="/versions/latest/sdk/media-library/" openInNewTab>`expo-media-library`</A> that allows accessing a device's media library to save an image.
+and <A href="/versions/latest/sdk/media-library/">`expo-media-library`</A> that allows accessing a device's media library to save an image.
 
 > So far, we have been using some third-party libraries such as `react-native-gesture-handler`, `react-native-reanimated`, and now `react-native-view-shot`.
 > We can find hundreds of other third-party libraries on [React Native Directory](https://reactnative.directory/).
@@ -122,7 +122,7 @@ Now we can capture a screenshot of the view by calling the `captureRef()` method
 We can read more about available options in [the library's documentation](https://github.com/gre/react-native-view-shot#capturerefview-options-lower-level-imperative-api).
 
 The `captureRef()` method returns a promise that fulfills with the URI of the captured screenshot.
-We will pass this URI as a parameter to <A href="/versions/latest/sdk/media-library/#medialibrarysavetolibraryasynclocaluri" openInNewTab>`MediaLibrary.saveToLibraryAsync()`</A>,
+We will pass this URI as a parameter to <A href="/versions/latest/sdk/media-library/#medialibrarysavetolibraryasynclocaluri">`MediaLibrary.saveToLibraryAsync()`</A>,
 which will save the screenshot to the device's media library.
 
 Update the `onSaveImageAsync()` function with the following code:

--- a/docs/pages/ui-programming/implementing-a-checkbox.mdx
+++ b/docs/pages/ui-programming/implementing-a-checkbox.mdx
@@ -5,7 +5,7 @@ description: Learn how to implement a fully customizable checkbox in your Expo p
 
 import { SnackInline } from '~/ui/components/Snippet';
 
-The [`expo-checkbox`](https://docs.expo.dev/versions/latest/sdk/checkbox/) package provides a quick implementation of a checkbox that you can directly use in your project. However, to have full customization, and control over the look and feel of the checkbox, this page goes in-depth on how to implement the component from scratch.
+The [`expo-checkbox`](/versions/latest/sdk/checkbox/) package provides a quick implementation of a checkbox that you can directly use in your project. However, to have full customization, and control over the look and feel of the checkbox, this page goes in-depth on how to implement the component from scratch.
 
 ## Understanding the checkbox
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -18,7 +18,7 @@ If you are migrating an older project to SDK 49 or above, then you should ignore
 .env*.local
 ```
 
-> Dotenv files are Expo CLI-specific as of SDK 49. EAS CLI uses a different mechanism for environment variables until it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](https://docs.expo.dev/build-reference/variables/).
+> Dotenv files are Expo CLI-specific as of SDK 49. EAS CLI uses a different mechanism for environment variables until it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](/build-reference/variables/).
 
 ### Disabling dotenv files
 

--- a/docs/pages/versions/v49.0.0/config/metro.mdx
+++ b/docs/pages/versions/v49.0.0/config/metro.mdx
@@ -18,7 +18,7 @@ If you are migrating an older project to SDK 49 or above, then you should ignore
 .env*.local
 ```
 
-> Dotenv files are Expo CLI-specific as of SDK 49. EAS CLI uses a different mechanism for environment variables until it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](https://docs.expo.dev/build-reference/variables/).
+> Dotenv files are Expo CLI-specific as of SDK 49. EAS CLI uses a different mechanism for environment variables until it invokes Expo CLI for compiling and bundling. Learn more about [environment variables in EAS](/build-reference/variables/).
 
 ### Disabling dotenv files
 


### PR DESCRIPTION
# Why

During working on latest changes I have spotted that there are few internal link using full docs path, and few one which open in new tab, let's fix them.

# How

Correct internal URL hrefs to make sure they do not include full docs patch which break forces full re-render on navigation and caused issues while working on app on different environments. Additionally, I have removed the `openInNewTab` prop from few internal links, since this is an unexpected behavior, and it's better to align with general pattern and let user decide how to open an internal link.

# Test Plan

The changes have been reviewed by running docs app locally. Lint checks are passing.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
