### PR TITLE
[camera] Fix crash when onBarCodeScanned or onFacesDetected callback is removed

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix crash when onBarCodeScanned or onFacesDetected callback is removed. ([#23223](https://github.com/expo/expo/pull/23223) by [@thespacemanatee](https://github.com/thespacemanatee))
+
 ### 💡 Others
 
 ## 13.4.1 — 2023-06-28

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/CameraViewModule.kt
@@ -238,12 +238,12 @@ class CameraViewModule : Module() {
         view.cameraView.setUsingCamera2Api(useCamera2Api)
       }
 
-      Prop("barCodeScannerEnabled") { view: ExpoCameraView, barCodeScannerEnabled: Boolean ->
-        view.setShouldScanBarCodes(barCodeScannerEnabled)
+      Prop("barCodeScannerEnabled") { view: ExpoCameraView, barCodeScannerEnabled: Boolean? ->
+        view.setShouldScanBarCodes(barCodeScannerEnabled ?: false)
       }
 
-      Prop("faceDetectorEnabled") { view: ExpoCameraView, faceDetectorEnabled: Boolean ->
-        view.setShouldDetectFaces(faceDetectorEnabled)
+      Prop("faceDetectorEnabled") { view: ExpoCameraView, faceDetectorEnabled: Boolean? ->
+        view.setShouldDetectFaces(faceDetectorEnabled ?: false)
       }
 
       Prop("faceDetectorSettings") { view: ExpoCameraView, settings: Map<String, Any>? ->

--- a/packages/expo-camera/ios/EXCamera/CameraViewModule.swift
+++ b/packages/expo-camera/ios/EXCamera/CameraViewModule.swift
@@ -126,15 +126,15 @@ public final class CameraViewModule: Module {
         view.updatePictureSize()
       }
 
-      Prop("faceDetectorEnabled") { (view, detectFaces: Bool) in
+      Prop("faceDetectorEnabled") { (view, detectFaces: Bool?) in
         if view.isDetectingFaces != detectFaces {
-          view.isDetectingFaces = detectFaces
+          view.isDetectingFaces = detectFaces ?? false
         }
       }
 
-      Prop("barCodeScannerEnabled") { (view, scanBarCodes: Bool) in
+      Prop("barCodeScannerEnabled") { (view, scanBarCodes: Bool?) in
         if view.isScanningBarCodes != scanBarCodes {
-          view.isScanningBarCodes = scanBarCodes
+          view.isScanningBarCodes = scanBarCodes ?? false
         }
       }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

A fatal crash occurs when the `onBarCodeScanned` callback is provided, and then removed in a subsequent re-render. My best guess is that when `onBarCodeScanned` is initially provided, `barCodeScannerEnabled` is set to `true`, and in a subsequent re-render where `onBarCodeScanned` is removed, the existing `barCodeScannerEnabled` on the component's `this.props` is not recognised by `ensureNativeProps` function and is set to `undefined`. This will crash on the native side because it expects a non-nullable `Boolean`.

Besides, it makes sense that the camera should not be scanning when the callbacks are `undefined` to save resources.

![Screenshot 2023-06-30 at 6 24 00 PM](https://github.com/expo/expo/assets/6837599/1fa52dc9-9b7b-4291-a5a9-158760a8b0c6)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Handle nullable values native-side.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I've tested this change on my own expo project, where I implemented the changes as a patch.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
