### PR TITLE
[android][image-picker] Fix backported photo picker crashing with null intent

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix backported photo picker crashing with null intent. ([#23224](https://github.com/expo/expo/pull/23224) by [@thespacemanatee](https://github.com/thespacemanatee))
+
 ### 💡 Others
 
 ## 14.3.0 — 2023-06-13

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:tools="http://schemas.android.com/tools"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Required for picking images from camera directly -->
     <uses-permission android:name="android.permission.CAMERA"/>
 
@@ -10,22 +9,10 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
     <application>
-      <!-- Trigger Google Play services to install the backported photo picker module. -->
-      <service android:name="com.google.android.gms.metadata.ModuleDependencies"
-        android:enabled="false"
-        android:exported="false"
-        tools:ignore="MissingClass">
-        <intent-filter>
-            <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
-        </intent-filter>
-        <meta-data android:name="photopicker_activity:0:required" android:value="" />
-      </service>
-
-
       <activity
         android:name="com.canhub.cropper.CropImageActivity"
         android:theme="@style/Base.Theme.AppCompat"/>
-      <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
+        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
         <provider
             android:name=".fileprovider.ImagePickerFileProvider"
             android:authorities="${applicationId}.ImagePickerFileProvider"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Resolves #23020

Support both the new photo picker and the old document picker flow.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove the block in `AndroidManifest.xml` that automatically downloads the backported photo picker on older devices
- Restore the old `Intent` creation code
- Add a `isPhotoPickerAvailable` check that returns the appropriate `Intent`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested on `bare-expo` to be working, and on my company's project.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
