### PR TITLE
[tools] Allow for package-specific transforms in versioning script

### DIFF
--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -1,6 +1,6 @@
 import { Podspec } from '../../../CocoaPods';
 import { FileTransforms } from '../../../Transforms.types';
-import { VersioningModuleConfig } from '../../types';
+import { VersioningModuleConfig } from '../types';
 
 const objcFilesPattern = '*.{h,m,mm,cpp}';
 const swiftFilesPattern = '*.swift';
@@ -153,7 +153,7 @@ export function getCommonExpoModulesTransforms(prefix: string): FileTransforms {
   };
 }
 
-export function getVersioningModuleConfig(
+export function getVersioningExpoModuleConfig(
   prefix: string,
   moduleName: string
 ): VersioningModuleConfig {
@@ -186,12 +186,7 @@ export function getVersioningModuleConfig(
       },
       mutatePodspec(podspec: Podspec) {
         // Versioned screen orientation must depend on unversioned copy to use unversioned singleton object.
-        const unversionedName = podspec.name.replace(prefix, '');
-
-        if (!podspec.dependencies) {
-          podspec.dependencies = {};
-        }
-        podspec.dependencies[unversionedName] = [];
+        addDependency(podspec, podspec.name.replace(prefix, ''));
       },
     },
   };
@@ -202,4 +197,11 @@ function removeScriptPhasesAndResourceBundles(podspec: Podspec): void {
   // For expo-updates and expo-constants in Expo Go, we don't need app.config and app.manifest in versioned code.
   delete podspec['script_phases'];
   delete podspec['resource_bundles'];
+}
+
+function addDependency(podspec: Podspec, dependencyName: string) {
+  if (!podspec.dependencies) {
+    podspec.dependencies = {};
+  }
+  podspec.dependencies[dependencyName] = [];
 }

--- a/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
+++ b/tools/src/versioning/ios/transforms/expoModulesTransforms.ts
@@ -153,7 +153,10 @@ export function getCommonExpoModulesTransforms(prefix: string): FileTransforms {
   };
 }
 
-export function getVersioningModuleConfig(prefix: string, moduleName: string): VersioningModuleConfig {
+export function getVersioningModuleConfig(
+  prefix: string,
+  moduleName: string
+): VersioningModuleConfig {
   const config: Record<string, VersioningModuleConfig> = {
     'expo-constants': {
       mutatePodspec: removeScriptPhasesAndResourceBundles,
@@ -176,10 +179,10 @@ export function getVersioningModuleConfig(prefix: string, moduleName: string): V
               '',
               'typealias ScreenOrientationRegistry = ExpoScreenOrientation.ScreenOrientationRegistry',
               'typealias ScreenOrientationController = ExpoScreenOrientation.ScreenOrientationController',
-              ''
+              '',
             ].join('\n'),
           },
-        ]
+        ],
       },
       mutatePodspec(podspec: Podspec) {
         // Versioned screen orientation must depend on unversioned copy to use unversioned singleton object.
@@ -190,7 +193,7 @@ export function getVersioningModuleConfig(prefix: string, moduleName: string): V
         }
         podspec.dependencies[unversionedName] = [];
       },
-    }
+    },
   };
   return config[moduleName] ?? {};
 }

--- a/tools/src/versioning/ios/types.ts
+++ b/tools/src/versioning/ios/types.ts
@@ -1,5 +1,5 @@
-import { Podspec } from '../CocoaPods';
-import { FileTransforms } from '../Transforms.types';
+import { Podspec } from '../../CocoaPods';
+import { FileTransforms } from '../../Transforms.types';
 
 export type VersioningModuleConfig = {
   transforms?: FileTransforms;

--- a/tools/src/versioning/ios/versionExpoModules.ts
+++ b/tools/src/versioning/ios/versionExpoModules.ts
@@ -9,11 +9,11 @@ import logger from '../../Logger';
 import { Package } from '../../Packages';
 import { FileTransforms, copyFileWithTransformsAsync } from '../../Transforms';
 import { arrayize, searchFilesAsync } from '../../Utils';
-import { VersioningModuleConfig } from '../types';
 import {
   getCommonExpoModulesTransforms,
-  getVersioningModuleConfig,
+  getVersioningExpoModuleConfig,
 } from './transforms/expoModulesTransforms';
+import { VersioningModuleConfig } from './types';
 import { getVersionPrefix, getVersionedDirectory } from './utils';
 
 // Label of the console's timer used during versioning
@@ -53,7 +53,7 @@ export async function versionExpoModulesAsync(
       await fs.remove(targetDirectory);
     }
 
-    const moduleConfig = getVersioningModuleConfig(prefix, pkg.packageName);
+    const moduleConfig = getVersioningExpoModuleConfig(prefix, pkg.packageName);
 
     // Create a podspec in JSON format so we don't have to keep `package.json`s
     const podspec = await generateVersionedPodspecAsync(

--- a/tools/src/versioning/ios/versionExpoModules.ts
+++ b/tools/src/versioning/ios/versionExpoModules.ts
@@ -9,9 +9,12 @@ import logger from '../../Logger';
 import { Package } from '../../Packages';
 import { FileTransforms, copyFileWithTransformsAsync } from '../../Transforms';
 import { arrayize, searchFilesAsync } from '../../Utils';
-import { getCommonExpoModulesTransforms, getVersioningModuleConfig } from './transforms/expoModulesTransforms';
-import { getVersionPrefix, getVersionedDirectory } from './utils';
 import { VersioningModuleConfig } from '../types';
+import {
+  getCommonExpoModulesTransforms,
+  getVersioningModuleConfig,
+} from './transforms/expoModulesTransforms';
+import { getVersionPrefix, getVersionedDirectory } from './utils';
 
 // Label of the console's timer used during versioning
 const TIMER_LABEL = 'Versioning expo modules finished in';
@@ -53,7 +56,12 @@ export async function versionExpoModulesAsync(
     const moduleConfig = getVersioningModuleConfig(prefix, pkg.packageName);
 
     // Create a podspec in JSON format so we don't have to keep `package.json`s
-    const podspec = await generateVersionedPodspecAsync(pkg, prefix, targetDirectory, moduleConfig.mutatePodspec);
+    const podspec = await generateVersionedPodspecAsync(
+      pkg,
+      prefix,
+      targetDirectory,
+      moduleConfig.mutatePodspec
+    );
 
     // Find files within the package based on source_files in the podspec, except the podspec itself.
     // Podspecs depend on the corresponding `package.json`,
@@ -97,7 +105,7 @@ async function generateVersionedPodspecAsync(
   pkg: Package,
   prefix: string,
   targetDirectory: string,
-  mutator?: VersioningModuleConfig['mutatePodspec'],
+  mutator?: VersioningModuleConfig['mutatePodspec']
 ): Promise<Podspec> {
   const podspec = await pkg.getPodspecAsync();
 

--- a/tools/src/versioning/types.ts
+++ b/tools/src/versioning/types.ts
@@ -1,0 +1,7 @@
+import { Podspec } from '../CocoaPods';
+import { FileTransforms } from '../Transforms.types';
+
+export type VersioningModuleConfig = {
+  transforms?: FileTransforms;
+  mutatePodspec?: (podspec: Podspec) => void;
+};


### PR DESCRIPTION
# Why

Package-specific transforms and podspec mutations are necessary for some packages. For example:
- `expo-constants` and `expo-updates` need to remove build phase and resource bundle from the podspec
- `expo-screen-orientation` needs to clear out `ScreenOrientationRegistry` class

# How

In addition to the common transformation rules that are applied to all modules, we can now specify package-specific rules and provide podspec mutators (similarly to what we have in the vendoring script).

# Test Plan

I tried these three commands and all seem to version these modules correctly:
- `et add-sdk -p ios -s 49.0.0 -x expo-screen-orientation`
- `et add-sdk -p ios -s 49.0.0 -x expo-updates`
- `et add-sdk -p ios -s 49.0.0 -x expo-constants`
