### PR TITLE
[iOS] Specify Obj-C names for React delegate handlers for versioning

### DIFF
--- a/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ABI49_0_0EXReactDelegateWrapper+Private.h
+++ b/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ABI49_0_0EXReactDelegateWrapper+Private.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ABI49_0_0EXReactDelegateWrapper(Private)
 
-- (instancetype)initWithExpoReactDelegate:(ExpoReactDelegate *)expoReactDelegate;
+- (instancetype)initWithExpoReactDelegate:(ABI49_0_0EXReactDelegate *)expoReactDelegate;
 
 @end
 

--- a/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ABI49_0_0EXReactDelegateWrapper.m
+++ b/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ABI49_0_0EXReactDelegateWrapper.m
@@ -7,13 +7,13 @@
 
 @interface ABI49_0_0EXReactDelegateWrapper()
 
-@property (nonatomic, weak) ExpoReactDelegate *expoReactDelegate;
+@property (nonatomic, weak) ABI49_0_0EXReactDelegate *expoReactDelegate;
 
 @end
 
 @implementation ABI49_0_0EXReactDelegateWrapper
 
-- (instancetype)initWithExpoReactDelegate:(ExpoReactDelegate *)expoReactDelegate
+- (instancetype)initWithExpoReactDelegate:(ABI49_0_0EXReactDelegate *)expoReactDelegate
 {
   if (self = [super init]) {
     _expoReactDelegate = expoReactDelegate;

--- a/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -3,7 +3,7 @@
 /**
  An extensible react instance creation delegate. This class will loop through each `ExpoReactDelegateHandler` to determine the winner to create the instance.
  */
-@objc
+@objc(ABI49_0_0EXReactDelegate)
 public class ExpoReactDelegate: NSObject {
   private let handlers: [ExpoReactDelegateHandler]
 

--- a/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ExpoReactDelegateHandler.swift
+++ b/ios/versioned/sdk49/ExpoModulesCore/ios/ReactDelegates/ExpoReactDelegateHandler.swift
@@ -5,7 +5,7 @@ import ABI49_0_0React
 /**
  The handler for `ExpoReactDelegate`. A module can implement a handler to process react instance creation.
  */
-@objc
+@objc(ABI49_0_0EXReactDelegateHandler)
 open class ExpoReactDelegateHandler: NSObject {
   public override required init() {}
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Changed Objective-C names for `ExpoReactDelegate` and `ExpoReactDelegateHandler` to fix issues with versioning in Expo Go. ([#23229](https://github.com/expo/expo/pull/23229) by [@tsapeta](https://github.com/tsapeta))
+
 ## 1.5.3 — 2023-06-24
 
 ### 🎉 New features

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper+Private.h
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper+Private.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface EXReactDelegateWrapper(Private)
 
-- (instancetype)initWithExpoReactDelegate:(ExpoReactDelegate *)expoReactDelegate;
+- (instancetype)initWithExpoReactDelegate:(EXReactDelegate *)expoReactDelegate;
 
 @end
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.m
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactDelegateWrapper.m
@@ -7,13 +7,13 @@
 
 @interface EXReactDelegateWrapper()
 
-@property (nonatomic, weak) ExpoReactDelegate *expoReactDelegate;
+@property (nonatomic, weak) EXReactDelegate *expoReactDelegate;
 
 @end
 
 @implementation EXReactDelegateWrapper
 
-- (instancetype)initWithExpoReactDelegate:(ExpoReactDelegate *)expoReactDelegate
+- (instancetype)initWithExpoReactDelegate:(EXReactDelegate *)expoReactDelegate
 {
   if (self = [super init]) {
     _expoReactDelegate = expoReactDelegate;

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegate.swift
@@ -3,7 +3,7 @@
 /**
  An extensible react instance creation delegate. This class will loop through each `ExpoReactDelegateHandler` to determine the winner to create the instance.
  */
-@objc
+@objc(EXReactDelegate)
 public class ExpoReactDelegate: NSObject {
   private let handlers: [ExpoReactDelegateHandler]
 

--- a/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
+++ b/packages/expo-modules-core/ios/ReactDelegates/ExpoReactDelegateHandler.swift
@@ -5,7 +5,7 @@ import React
 /**
  The handler for `ExpoReactDelegate`. A module can implement a handler to process react instance creation.
  */
-@objc
+@objc(EXReactDelegateHandler)
 open class ExpoReactDelegateHandler: NSObject {
   public override required init() {}
 


### PR DESCRIPTION
# Why

With #23228 and #23227, it becomes possible that versioned pod will depend on its unversioned version. This causes conflicts in `ExpoReactDelegate` and `ExpoReactDelegateHandler` classes as their versioned equivalents are exported under the same (Obj-C) name in the autogenerated Swift headers.

# How

Rename `ExpoReactDelegate` to `EXReactDelegate` and `ExpoReactDelegateHandler` to `EXReactDelegateHandler` for Objective-C, so they can be properly prefixed by the versioning script and solve these conflicts.

# Test Plan

Thanks to this change, the code from #23228 can compile without errors