### PR TITLE
[go] disable expo-network-addons autolinking

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -47,7 +47,8 @@ useExpoModules([
         'expo-dev-menu',
         'expo-dev-launcher',
         'expo-dev-client',
-        'expo-maps'
+        'expo-maps',
+        'expo-network-addons',
     ]
 ])
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -37,6 +37,7 @@ abstract_target 'Expo Go' do
       'expo-dev-launcher',
       'expo-dev-client',
       'expo-maps',
+      'expo-network-addons',
       'expo-insights',
       'expo-face-detector',
     ],


### PR DESCRIPTION
# Why

currently the only feature in expo-network-addons is brotli compression for all okhttp requests. since we can literally control all okhttp requests in expo-go, we don't this expo-network-addons in the meantime. 
this may also resolve the crash issue: https://console.firebase.google.com/project/exponent-5dd6d/crashlytics/app/android:host.exp.exponent/issues/abcfcc9f22425a76b2d1170fe6463b16

# How

remove expo-network-addons from autolinking in expo-go

# Test Plan

smoke test in expo-go

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
