### PR TITLE
fix(cli): only warn users when using non-recommended versions of important dependencies

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fixed JavaScript inspector broken when using Metro web with SSG. ([#23197](https://github.com/expo/expo/pull/23197) by [@kudo](https://github.com/kudo))
-- Fixed prebuild dependency versions warning to only show when versions do not intersect.
+- Fixed prebuild dependency versions warning to only show when versions do not intersect. ([#23232](https://github.com/expo/expo/pull/23232) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - Fixed JavaScript inspector broken when using Metro web with SSG. ([#23197](https://github.com/expo/expo/pull/23197) by [@kudo](https://github.com/kudo))
+- Fixed prebuild dependency versions warning to only show when versions do not intersect.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -275,7 +275,7 @@ export function createFileHash(contents: string): string {
 function versionRangesIntersect(rangeA: string | SemverRange, rangeB: string | SemverRange) {
   try {
     return semverIntersects(rangeA, rangeB);
-  } finally {
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
# Why

<img width="937" alt="image" src="https://github.com/expo/expo/assets/1203991/0352e5db-dc19-46d4-a348-cb84b3b624c2">

This warning was over-eagerly displayed to users during the SDK 49 beta. This change fixes that behavior to only warn when the used versions and recommended versions do not intersect.

# How

- Turned out it was `finally` always returning `false`, replaced with `catch`

# Test Plan

- `$ yarn create expo ./test-prebuild-version-warning -t tabs@beta`
- `$ cd ./test-prebuild-version-warning`
- `$ yarn expo prebuild`
- Should not warn in its current state 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
