### PR TITLE
[expo-updates][ios] Fix response header casing bug

### DIFF
--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/FileDownloader.swift
@@ -357,12 +357,11 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
     successBlock: @escaping RemoteUpdateDownloadSuccessBlock,
     errorBlock: @escaping RemoteUpdateDownloadErrorBlock
   ) {
-    let headerDictionary = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
-      serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
-      manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
-      manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
+      protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+      serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+      manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+      manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
     )
 
     if httpResponse.statusCode == 204 || data == nil {
@@ -388,7 +387,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       return
     }
 
-    let contentType = headerDictionary.stringValueForCaseInsensitiveKey("content-type") ?? ""
+    let contentType = httpResponse.value(forHTTPHeaderField: "content-type") ?? ""
 
     if contentType.lowercased().hasPrefix("multipart/") {
       guard let contentTypeParameters = ABI49_0_0EXUpdatesParameterParser().parseParameterString(
@@ -417,15 +416,15 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       return
     } else {
       let responseHeaderData = ResponseHeaderData(
-        protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
-        serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
-        manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
-        manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
+        protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+        serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+        manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+        manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
       )
 
       let manifestResponseInfo = ResponsePartInfo(
         responseHeaderData: responseHeaderData,
-        responsePartHeaderData: ResponsePartHeaderData(signature: headerDictionary.optionalValue(forKey: "expo-signature")),
+        responsePartHeaderData: ResponsePartHeaderData(signature: httpResponse.value(forHTTPHeaderField: "expo-signature")),
         body: data
       )
 
@@ -540,12 +539,11 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       String(data: it, encoding: .utf8)
     }
 
-    let responseHeaders = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersionRaw: responseHeaders.optionalValue(forKey: "expo-protocol-version"),
-      serverDefinedHeadersRaw: responseHeaders.optionalValue(forKey: "expo-server-defined-headers"),
-      manifestFiltersRaw: responseHeaders.optionalValue(forKey: "expo-manifest-filters"),
-      manifestSignature: responseHeaders.optionalValue(forKey: "expo-manifest-signature")
+      protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+      serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+      manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+      manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
     )
 
     let manifestResponseInfo = manifestPartHeadersAndData.let { it in

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Support discriminated unions for JS API method result types. ([#23173](https://github.com/expo/expo/pull/23173) by [@wschurman](https://github.com/wschurman))
 - Fix expo-extra-params header. ([#23206](https://github.com/expo/expo/pull/23206) by [@wschurman](https://github.com/wschurman))
+- [iOS] Fix response header casing bug. ([#23234](https://github.com/expo/expo/pull/23234) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -357,12 +357,11 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
     successBlock: @escaping RemoteUpdateDownloadSuccessBlock,
     errorBlock: @escaping RemoteUpdateDownloadErrorBlock
   ) {
-    let headerDictionary = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
-      serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
-      manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
-      manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
+      protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+      serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+      manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+      manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
     )
 
     if httpResponse.statusCode == 204 || data == nil {
@@ -388,7 +387,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       return
     }
 
-    let contentType = headerDictionary.stringValueForCaseInsensitiveKey("content-type") ?? ""
+    let contentType = httpResponse.value(forHTTPHeaderField: "content-type") ?? ""
 
     if contentType.lowercased().hasPrefix("multipart/") {
       guard let contentTypeParameters = EXUpdatesParameterParser().parseParameterString(
@@ -417,15 +416,15 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       return
     } else {
       let responseHeaderData = ResponseHeaderData(
-        protocolVersionRaw: headerDictionary.optionalValue(forKey: "expo-protocol-version"),
-        serverDefinedHeadersRaw: headerDictionary.optionalValue(forKey: "expo-server-defined-headers"),
-        manifestFiltersRaw: headerDictionary.optionalValue(forKey: "expo-manifest-filters"),
-        manifestSignature: headerDictionary.optionalValue(forKey: "expo-manifest-signature")
+        protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+        serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+        manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+        manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
       )
 
       let manifestResponseInfo = ResponsePartInfo(
         responseHeaderData: responseHeaderData,
-        responsePartHeaderData: ResponsePartHeaderData(signature: headerDictionary.optionalValue(forKey: "expo-signature")),
+        responsePartHeaderData: ResponsePartHeaderData(signature: httpResponse.value(forHTTPHeaderField: "expo-signature")),
         body: data
       )
 
@@ -540,12 +539,11 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       String(data: it, encoding: .utf8)
     }
 
-    let responseHeaders = httpResponse.allHeaderFields as! [String: Any]
     let responseHeaderData = ResponseHeaderData(
-      protocolVersionRaw: responseHeaders.optionalValue(forKey: "expo-protocol-version"),
-      serverDefinedHeadersRaw: responseHeaders.optionalValue(forKey: "expo-server-defined-headers"),
-      manifestFiltersRaw: responseHeaders.optionalValue(forKey: "expo-manifest-filters"),
-      manifestSignature: responseHeaders.optionalValue(forKey: "expo-manifest-signature")
+      protocolVersionRaw: httpResponse.value(forHTTPHeaderField: "expo-protocol-version"),
+      serverDefinedHeadersRaw: httpResponse.value(forHTTPHeaderField: "expo-server-defined-headers"),
+      manifestFiltersRaw: httpResponse.value(forHTTPHeaderField: "expo-manifest-filters"),
+      manifestSignature: httpResponse.value(forHTTPHeaderField: "expo-manifest-signature")
     )
 
     let manifestResponseInfo = manifestPartHeadersAndData.let { it in


### PR DESCRIPTION
# Why

This fixes a bug that manifested due to the switch to modern manifests being the default served for local development in the CLI.

There's a bit of history here:
- [This comment](https://github.com/expo/expo/blob/59bdcb4db0356fd61f47c3cf0bcad3b7fa14ea02/packages/expo-updates/ios/EXUpdates/AppLoader/EXUpdatesFileDownloader.m#L196) was added to indicate that that these should be case insensitive. But it wasn't strictly needed since we assumed all modern servers used lower-case header field keys.
- Apparently the local server when served through a tunnel doesn't use lower-case header field keys. Still need to investigate if and why this differs from non-tunneled headers.
- Previously these upper case header field keys didn't matter: legacy manifests are the "default" no matter what headers are sent and the manifest happened to be a legacy manifest. So it just worked.
- But, we changed the local server to serve new modern manifests by default in SDK 49, so now these header fields being upper case do matter, and the bug manifested.

Closes ENG-9086.

It seems that ngrok capitalizes the headers, this causing this bug only when ngrok is used: (curl the tunneled endpoint followed by the tunnel)
```
$ curl -I http://localhost:8081/
HTTP/1.1 200 OK
expo-protocol-version: 0
expo-sfv-version: 0
cache-control: private, max-age=0
content-type: text/plain
Date: Fri, 30 Jun 2023 16:29:23 GMT
Connection: keep-alive
Keep-Alive: timeout=5

$ curl -I http://ley4inc.wschurman.8081.exp.direct
HTTP/1.1 200 OK
Cache-Control: private, max-age=0
Content-Type: text/plain
Date: Fri, 30 Jun 2023 16:29:35 GMT
Expo-Protocol-Version: 0
Expo-Sfv-Version: 0
Ngrok-Trace-Id: 28f3fb3f2b6815b1cc6a5de714ed463d
```

This seems to be a [previously-found issue with ngrok](https://github.com/inconshreveable/ngrok/issues/519), and while they technically aren't incorrect since HTTP 1.1 defines header field names to be case-insensitive, a tunnel should probably not modify things.

This doesn't happen on android because android `Headers` already uses case insensitive header accessors: https://github.com/square/okhttp/blob/7c92ed0879477eddb2fce6b4066d151525d5687f/okhttp/src/commonMain/kotlin/okhttp3/internal/-HeadersCommon.kt#L68

# How

This was found by breakpointing at the point of crash and then tracing up the parsing code, only to see that the headers were present but they looked like "Expo-Protocol-Version", ...

Since we dropped support for iOS 12 in this release, we can use the case-insensitive header accessor, `value:forHTTPHeaderField:`. Therefore, use it everywhere.

# Test Plan

Build and run expo go in sim.

```
npx create-expo-app repro-crash --template blank@sdk-49
cd repro-crash
npx expo start --tunnel // requires that @expo/ngrok is installed globally
# press i to launch, or scan qr code
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
