### PR TITLE
[barcode-scanner][html-elements] Update jest snapshots

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update snapshots. ([#23238](https://github.com/expo/expo/pull/23238) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 12.5.2 — 2023-06-28
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.node
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.node
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
   dir={null}
 >
   <div
-    className="css-text-1rynq56"
+    className="css-text-146c3p1"
     dir="auto"
   >
     BarCodeScanner Component not supported on the web

--- a/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.web
+++ b/packages/expo-barcode-scanner/src/__tests__/__snapshots__/BarCodeScanner-test.tsx.snap.web
@@ -6,7 +6,7 @@ exports[`renders correctly 1`] = `
   dir={null}
 >
   <div
-    className="css-text-1rynq56"
+    className="css-text-146c3p1"
     dir="auto"
   >
     BarCodeScanner Component not supported on the web

--- a/packages/html-elements/CHANGELOG.md
+++ b/packages/html-elements/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Update snapshots. ([#23238](https://github.com/expo/expo/pull/23238) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.5.0 — 2023-06-21
 
 _This version does not introduce any user-facing changes._

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Anchor-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Anchor-test.tsx.snap.web
@@ -2,7 +2,7 @@
 
 exports[`renders A 1`] = `
 <a
-  className="css-text-1rynq56"
+  className="css-text-146c3p1"
   dir="auto"
   href="#"
   role="link"

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Headings-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Headings-test.tsx.snap.web
@@ -3,7 +3,7 @@
 exports[`renders H1 1`] = `
 <h1
   aria-level={1}
-  className="css-text-1rynq56 r-fontSize-6e8ixz r-fontWeight-vw2c0b r-marginVertical-100r6m0"
+  className="css-text-146c3p1 r-fontSize-6e8ixz r-fontWeight-vw2c0b r-marginBlock-19oforl"
   dir="auto"
   role="heading"
 />
@@ -12,7 +12,7 @@ exports[`renders H1 1`] = `
 exports[`renders H2 1`] = `
 <h2
   aria-level={2}
-  className="css-text-1rynq56 r-fontSize-1lijs1h r-fontWeight-vw2c0b r-marginVertical-1fcj2ci"
+  className="css-text-146c3p1 r-fontSize-1lijs1h r-fontWeight-vw2c0b r-marginBlock-1u31v3z"
   dir="auto"
   role="heading"
 />
@@ -21,7 +21,7 @@ exports[`renders H2 1`] = `
 exports[`renders H3 1`] = `
 <h3
   aria-level={3}
-  className="css-text-1rynq56 r-fontSize-tg2c11 r-fontWeight-vw2c0b r-marginVertical-gdo61v"
+  className="css-text-146c3p1 r-fontSize-tg2c11 r-fontWeight-vw2c0b r-marginBlock-11nzuo4"
   dir="auto"
   role="heading"
 />
@@ -30,7 +30,7 @@ exports[`renders H3 1`] = `
 exports[`renders H4 1`] = `
 <h4
   aria-level={4}
-  className="css-text-1rynq56 r-fontSize-bzi31h r-fontWeight-vw2c0b r-marginVertical-1e3jtjs"
+  className="css-text-146c3p1 r-fontSize-bzi31h r-fontWeight-vw2c0b r-marginBlock-1hga0el"
   dir="auto"
   role="heading"
 />
@@ -39,7 +39,7 @@ exports[`renders H4 1`] = `
 exports[`renders H5 1`] = `
 <h5
   aria-level={5}
-  className="css-text-1rynq56 r-fontSize-n230yh r-fontWeight-vw2c0b r-marginVertical-10805p1"
+  className="css-text-146c3p1 r-fontSize-n230yh r-fontWeight-vw2c0b r-marginBlock-1946khe"
   dir="auto"
   role="heading"
 />
@@ -48,7 +48,7 @@ exports[`renders H5 1`] = `
 exports[`renders H6 1`] = `
 <h6
   aria-level={6}
-  className="css-text-1rynq56 r-fontSize-ydqdv4 r-fontWeight-vw2c0b r-marginVertical-1esx64j"
+  className="css-text-146c3p1 r-fontSize-ydqdv4 r-fontWeight-vw2c0b r-marginBlock-1jm7qrm"
   dir="auto"
   role="heading"
 />

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Lists-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Lists-test.tsx.snap.web
@@ -7,7 +7,7 @@ exports[`renders UL nested in LI 1`] = `
   role="listitem"
 >
   <li
-    className="css-text-1rynq56"
+    className="css-text-146c3p1"
     dir="auto"
     role="listitem"
   >
@@ -19,7 +19,7 @@ exports[`renders UL nested in LI 1`] = `
     role="list"
   >
     <li
-      className="css-text-1rynq56"
+      className="css-text-146c3p1"
       dir="auto"
       role="listitem"
     >

--- a/packages/html-elements/src/elements/__tests__/__snapshots__/Text-test.tsx.snap.web
+++ b/packages/html-elements/src/elements/__tests__/__snapshots__/Text-test.tsx.snap.web
@@ -2,7 +2,7 @@
 
 exports[`renders B 1`] = `
 <div
-  className="css-text-1rynq56 r-fontWeight-vw2c0b"
+  className="css-text-146c3p1 r-fontWeight-vw2c0b"
   dir="auto"
 >
   demo
@@ -11,28 +11,28 @@ exports[`renders B 1`] = `
 
 exports[`renders BR 1`] = `
 <div
-  className="css-text-1rynq56 r-height-10rkof1 r-width-1h2t8mc"
+  className="css-text-146c3p1 r-height-10rkof1 r-width-1h2t8mc"
   dir="auto"
 />
 `;
 
 exports[`renders BlockQuote 1`] = `
 <div
-  className="css-view-175oi2r r-marginVertical-gdo61v"
+  className="css-view-175oi2r r-marginBlock-11nzuo4"
   dir={null}
 />
 `;
 
 exports[`renders Code 1`] = `
 <div
-  className="css-text-1rynq56 r-fontFamily-1pm8pkb r-fontWeight-majxgm"
+  className="css-text-146c3p1 r-fontFamily-1pm8pkb r-fontWeight-majxgm"
   dir="auto"
 />
 `;
 
 exports[`renders Del 1`] = `
 <div
-  className="css-text-1rynq56 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
+  className="css-text-146c3p1 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
   dir="auto"
 >
   demo
@@ -41,7 +41,7 @@ exports[`renders Del 1`] = `
 
 exports[`renders EM 1`] = `
 <div
-  className="css-text-1rynq56 r-fontStyle-36ujnk"
+  className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
 >
   demo
@@ -50,7 +50,7 @@ exports[`renders EM 1`] = `
 
 exports[`renders I 1`] = `
 <div
-  className="css-text-1rynq56 r-fontStyle-36ujnk"
+  className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
 >
   demo
@@ -59,14 +59,14 @@ exports[`renders I 1`] = `
 
 exports[`renders Mark 1`] = `
 <div
-  className="css-text-1rynq56 r-backgroundColor-98uye2 r-color-cqee49"
+  className="css-text-146c3p1 r-backgroundColor-98uye2 r-color-cqee49"
   dir="auto"
 />
 `;
 
 exports[`renders P 1`] = `
 <div
-  className="css-text-1rynq56 r-marginVertical-gdo61v"
+  className="css-text-146c3p1 r-marginBlock-11nzuo4"
   dir="auto"
 >
   demo
@@ -75,7 +75,7 @@ exports[`renders P 1`] = `
 
 exports[`renders Pre 1`] = `
 <div
-  className="css-text-1rynq56 r-fontFamily-1pm8pkb r-fontWeight-majxgm r-marginVertical-gdo61v"
+  className="css-text-146c3p1 r-fontFamily-1pm8pkb r-fontWeight-majxgm r-marginBlock-11nzuo4"
   dir="auto"
 >
   
@@ -88,7 +88,7 @@ exports[`renders Pre 1`] = `
 
 exports[`renders Q 1`] = `
 <div
-  className="css-text-1rynq56 r-fontStyle-36ujnk"
+  className="css-text-146c3p1 r-fontStyle-36ujnk"
   dir="auto"
 >
   "
@@ -99,7 +99,7 @@ exports[`renders Q 1`] = `
 
 exports[`renders S 1`] = `
 <div
-  className="css-text-1rynq56 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
+  className="css-text-146c3p1 r-textDecorationLine-142tt33 r-textDecorationStyle-1a2p6p6"
   dir="auto"
 >
   demo
@@ -108,7 +108,7 @@ exports[`renders S 1`] = `
 
 exports[`renders Span 1`] = `
 <div
-  className="css-text-1rynq56"
+  className="css-text-146c3p1"
   dir="auto"
 >
   demo
@@ -117,7 +117,7 @@ exports[`renders Span 1`] = `
 
 exports[`renders Strong 1`] = `
 <div
-  className="css-text-1rynq56 r-fontWeight-vw2c0b"
+  className="css-text-146c3p1 r-fontWeight-vw2c0b"
   dir="auto"
 >
   demo
@@ -126,7 +126,7 @@ exports[`renders Strong 1`] = `
 
 exports[`renders Time 1`] = `
 <div
-  className="css-text-1rynq56"
+  className="css-text-146c3p1"
   dir="auto"
 >
   May 15

--- a/packages/html-elements/src/primitives/__tests__/__snapshots__/createDevView.test.tsx.snap.web
+++ b/packages/html-elements/src/primitives/__tests__/__snapshots__/createDevView.test.tsx.snap.web
@@ -6,12 +6,12 @@ exports[`warns about unwrapped strings 1`] = `
   dir={null}
 >
   <div
-    className="css-text-1rynq56 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-backgroundColor-1kfbv51 r-color-jwli3a"
+    className="css-text-146c3p1 r-bottom-1p0dtai r-left-1d2f490 r-position-u8s1d r-right-zchlnj r-top-ipm5af r-backgroundColor-1kfbv51 r-color-jwli3a"
     dir="auto"
   >
     Unwrapped text: "
     <span
-      className="css-textHasAncestor-1qaijid"
+      className="css-textHasAncestor-1jxf684"
       dir={null}
       style={
         {


### PR DESCRIPTION
# Why

`SDK/check-packages` actions are failing because `barcode-scanner` and `html-elements` snapshots are not up to date, that's because updating `react-native-web` to `0.19.6` ended up changing some className hashes. 

# How

Run `yarn test --update-snapshot` inside *packages/barcode-scanner* and *packages/html-elements*

# Test Plan

Ensure CI is green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
