### PR TITLE
test(cli): Update E2E tests to expect hbc bundles

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Update E2E tests to expect `.hbc` bundles instead of `.js` bundles. ([#23241](https://github.com/expo/expo/pull/23241) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.10.4 — 2023-06-28
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/e2e/__tests__/export-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-test.ts
@@ -116,7 +116,7 @@ describe('server', () => {
                 path: 'assets/3858f62230ac3c915f300c664312c63f',
               },
             ],
-            bundle: expect.stringMatching(/bundles\/android-.*\.js/),
+            bundle: expect.stringMatching(/bundles\/android-.*\.hbc/),
           },
           ios: {
             assets: [
@@ -133,7 +133,7 @@ describe('server', () => {
                 path: 'assets/2f334f6c7ca5b2a504bdf8acdee104f3',
               },
             ],
-            bundle: expect.stringMatching(/bundles\/ios-.*\.js/),
+            bundle: expect.stringMatching(/bundles\/ios-.*\.hbc/),
           },
           web: {
             assets: [
@@ -210,9 +210,9 @@ describe('server', () => {
         'assets/assets/icon@2x.png',
 
         'assets/fb960eb5e4eb49ec8786c7f6c4a57ce2',
-        expect.stringMatching(/bundles\/android-[\w\d]+\.js/),
+        expect.stringMatching(/bundles\/android-[\w\d]+\.hbc/),
         expect.stringMatching(/bundles\/android-[\w\d]+\.map/),
-        expect.stringMatching(/bundles\/ios-[\w\d]+\.js/),
+        expect.stringMatching(/bundles\/ios-[\w\d]+\.hbc/),
         expect.stringMatching(/bundles\/ios-[\w\d]+\.map/),
         expect.stringMatching(/bundles\/web-[\w\d]+\.js/),
         expect.stringMatching(/bundles\/web-[\w\d]+\.map/),


### PR DESCRIPTION
# Why


`CLI / Test` actions are failing on main because E2E tests are expecting `.js` bundles instead of `.hbc`
 

# How

Update E2E tests to expect `.hbc` bundles instead of `.js`

# Test Plan

Ensure CI is green 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
