### PR TITLE
[expo-updates][Android] Fix rollback embedded update logic

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 ## 0.18.7 - 2023-06-30

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -34,9 +34,6 @@ abstract class UpdateDao {
   @Query("UPDATE updates SET status = :status WHERE id = :id;")
   abstract fun _markUpdateWithStatus(status: UpdateStatus, id: UUID)
 
-  @Update
-  abstract fun _updateUpdate(update: UpdateEntity)
-
   @Query(
     "UPDATE updates SET status = :status WHERE id IN (" +
       "SELECT DISTINCT update_id FROM updates_assets WHERE asset_id IN (:missingAssetIds));"
@@ -78,13 +75,19 @@ abstract class UpdateDao {
 
   fun setUpdateScopeKey(update: UpdateEntity, newScopeKey: String) {
     update.scopeKey = newScopeKey
-    _updateUpdate(update)
+    _setUpdateScopeKeyInternal(update.id, newScopeKey)
   }
+
+  @Query("UPDATE updates SET scope_key = :newScopeKey WHERE id = :id;")
+  abstract fun _setUpdateScopeKeyInternal(id: UUID, newScopeKey: String)
 
   fun setUpdateCommitTime(update: UpdateEntity, commitTime: Date) {
     update.commitTime = commitTime
-    _updateUpdate(update)
+    _setUpdateCommitTime(update.id, commitTime)
   }
+
+  @Query("UPDATE updates SET commit_time = :commitTime WHERE id = :id;")
+  abstract fun _setUpdateCommitTime(id: UUID, commitTime: Date)
 
   @Transaction
   open fun markUpdateFinished(update: UpdateEntity, hasSkippedEmbeddedAssets: Boolean) {
@@ -103,19 +106,29 @@ abstract class UpdateDao {
   }
 
   fun markUpdateAccessed(update: UpdateEntity) {
-    update.lastAccessed = Date()
-    _updateUpdate(update)
+    val newLastAccessed = Date()
+    update.lastAccessed = newLastAccessed
+    _markUpdateAccessed(update.id, newLastAccessed)
   }
+
+  @Query("UPDATE updates SET last_accessed = :lastAccessed WHERE id = :id;")
+  abstract fun _markUpdateAccessed(id: UUID, lastAccessed: Date)
 
   fun incrementSuccessfulLaunchCount(update: UpdateEntity) {
     update.successfulLaunchCount++
-    _updateUpdate(update)
+    _incrementSuccessfulLaunchCount(update.id)
   }
+
+  @Query("UPDATE updates SET successful_launch_count = successful_launch_count + 1 WHERE id = :id;")
+  abstract fun _incrementSuccessfulLaunchCount(id: UUID)
 
   fun incrementFailedLaunchCount(update: UpdateEntity) {
     update.failedLaunchCount++
-    _updateUpdate(update)
+    _incrementFailedLaunchCount(update.id)
   }
+
+  @Query("UPDATE updates SET failed_launch_count = failed_launch_count + 1 WHERE id = :id;")
+  abstract fun _incrementFailedLaunchCount(id: UUID)
 
   fun markUpdatesWithMissingAssets(missingAssets: List<AssetEntity>) {
     val missingAssetIds = mutableListOf<Long>()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -400,11 +400,8 @@ class LoaderTask(
               return
             }
 
-            val launcher = DatabaseLauncher(configuration, directory, fileDownloader, selectionPolicy)
-            val launchableUpdate = launcher.getLaunchableUpdate(database, context)
             val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
-
-            if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(updateDirective, embeddedUpdate, launchableUpdate, manifestFilters)) {
+            if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(updateDirective, embeddedUpdate, candidateLauncher?.launchedUpdate, manifestFilters)) {
               launchUpdate(null)
               return
             }


### PR DESCRIPTION
# Why

This fixes two bugs:
1. Clobbering of update changes due to full replacement of object in DB. this occurs for write after read race conditions not being synchronized. (read A, read B, change field 1 in A, write A, change field 2 in B, write B, write A is clobbered)
2. Not comparing a received roll back directive to the update about to be launched, and instead always comparing it to the one on disk. This meant that the following case behaved oddly:

```
build (embedded update time T = 0)
publish update (T = 1)
publish rollback (T = 2)
<app reports a new rollback>
restart
<app still reports a new rollback since embedded update commit time update was either clobbered due to bug 1 or comparing T = 0 since it used the embedded update on disk in selection policy compare>
```

# How

1. Make all database updates single column instead of updating the whole row.
2. Make the android implementation consistent with the iOS implementation.

# Test Plan

```
yarn create expo-app --template blank@beta rollbackcheck
eas init
npx expo install expo-updates
eas update:configure
eas build:configure
npx expo prebuild
eas build # to create runtime and channel objects
eas update --branch production --message "wat"
eas update:roll-back-to-embedded --branch production
```

Then, in android studio, enable "Wait for debugger" for app. Build and run, attach debugger, ensure the database is consistent at all times by inspecting the room db in android studio. Ensure rollbacks work.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
