### PR TITLE
[ci] Stop caching yarn cache

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -73,10 +73,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: 🔍️ Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
     - name: ♻️ Restore workspace node modules
       if: inputs.yarn-workspace == 'true'
       uses: actions/cache@v3
@@ -85,7 +81,6 @@ runs:
         # See "workspaces" → "packages" in the root package.json for the source of truth of
         # which node_modules are affected by the root yarn.lock
         path: |
-          ${{ steps.yarn-cache-dir-path.outputs.dir }}
           node_modules
           apps/*/node_modules
           apps/*/__generated__/AppEntry.js


### PR DESCRIPTION
# Why

Caching Yarn's cache is slowing down cache restoration because it takes too much space.

# How

Removed `yarn cache dir` path from the composite action.

# Test Plan

I dispatched this workflow: https://github.com/expo/expo/actions/runs/5438832355/jobs/9890312651
Size of the `macOS-workspace-modules-*` cache went down from about 2 GB to about 410 MB