### PR TITLE
[core][Android] Fix the `View cannot be cast to ViewGroup` exception

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the `View cannot be cast to ViewGroup` exception on Android.
+
 ### 💡 Others
 
 - Changed Objective-C names for `ExpoReactDelegate` and `ExpoReactDelegateHandler` to fix issues with versioning in Expo Go. ([#23229](https://github.com/expo/expo/pull/23229) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix the `View cannot be cast to ViewGroup` exception on Android.
+- Fix the `View cannot be cast to ViewGroup` exception on Android. ([#23264](https://github.com/expo/expo/pull/23264) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ErrorViewGroup.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ErrorViewGroup.kt
@@ -1,0 +1,11 @@
+package expo.modules.kotlin.views
+
+import android.content.Context
+import android.view.ViewGroup
+
+/**
+ * A NOOP view group, which is used when an error occurs.
+ */
+class ErrorViewGroup(context: Context) : ViewGroup(context) {
+  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) = Unit
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import expo.modules.core.ViewManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
+import expo.modules.core.ViewManager
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
@@ -334,7 +335,12 @@ class ViewDefinitionBuilder<T : View>(
         UnexpectedException(e)
       }
     )
-    return View(context)
+
+    return if (ViewGroup::class.java.isAssignableFrom(viewClass.java)) {
+      ErrorViewGroup(context)
+    } else {
+      View(context)
+    }
   }
 
   private fun getPrimaryConstructor(): KFunction<T>? {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/22710
Closes https://github.com/expo/expo/issues/23011

# How

In case of an error, we have to create an empty view. However, we can't always create a plain View, sometimes (right now mostly) we have to return a view group instead. So, I've created a no-op implementation of the view group abstract class and returned it, when an error occurs. 

# Test Plan

- bare-expo ✅