### PR TITLE
Update sending-notifications.mdx

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -179,7 +179,7 @@ curl -H "Content-Type: application/json" -X POST "https://exp.host/--/api/v2/pus
   "ids": [
     "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
     "YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY",
-    "ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ",
+    "ZZZZZZZZ-ZZZZ-ZZZZ-ZZZZ-ZZZZZZZZZZZZ"
   ]
 }'
 ```


### PR DESCRIPTION
Remove trailing comma in code example, leading to `NotFound` instead of expected results.

# Why

Causes an issue with a difficult-to-debug error message.

# How

Just a small change in the example. Found out by trial and error.

# Test Plan

> curl -H "Content-Type: application/json" -X POST "https://exp.host/--/api/v2/push/getReceipts" -d '{
  "ids": [
    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
  ]
}'
Not Found

> curl -H "Content-Type: application/json" -X POST "https://exp.host/--/api/v2/push/getReceipts" -d '{
  "ids": [
    "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
  ]
}'
{"data":{"XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX":{"status":"ok"}}}

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
