### PR TITLE
[go] Fix hermes inspector crash from vscode-expo

### DIFF
--- a/ios/versioned-react-native/ABI47_0_0/ReactNative/ReactCommon/hermes/inspector/ABI47_0_0Inspector.h
+++ b/ios/versioned-react-native/ABI47_0_0/ReactNative/ReactCommon/hermes/inspector/ABI47_0_0Inspector.h
@@ -372,6 +372,10 @@ folly::Optional<UserCallbackException> runUserCallback(C &cb, A &&...arg) {
     cb(std::forward<A>(arg)...);
   } catch (const std::exception &e) {
     return UserCallbackException(e);
+  } catch (const std::runtime_error &e) {
+    // NOTE(kudo): Adding this to catch Hermes inspector exceptions after SDK 49.
+    // I still not figure out why the std::runtime_error is not catched by the std::exception above.
+    return UserCallbackException(e);
   }
 
   return {};

--- a/ios/versioned-react-native/ABI48_0_0/ReactNative/ReactCommon/hermes/inspector/ABI48_0_0Inspector.h
+++ b/ios/versioned-react-native/ABI48_0_0/ReactNative/ReactCommon/hermes/inspector/ABI48_0_0Inspector.h
@@ -372,6 +372,10 @@ folly::Optional<UserCallbackException> runUserCallback(C &cb, A &&...arg) {
     cb(std::forward<A>(arg)...);
   } catch (const std::exception &e) {
     return UserCallbackException(e);
+  } catch (const std::runtime_error &e) {
+    // NOTE(kudo): Adding this to catch Hermes inspector exceptions after SDK 49.
+    // I still not figure out why the std::runtime_error is not catched by the std::exception above.
+    return UserCallbackException(e);
   }
 
   return {};

--- a/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/hermes/inspector/ABI49_0_0Inspector.h
+++ b/ios/versioned-react-native/ABI49_0_0/ReactNative/ReactCommon/hermes/inspector/ABI49_0_0Inspector.h
@@ -372,6 +372,10 @@ std::optional<UserCallbackException> runUserCallback(C &cb, A &&...arg) {
     cb(std::forward<A>(arg)...);
   } catch (const std::exception &e) {
     return UserCallbackException(e);
+  } catch (const std::runtime_error &e) {
+    // NOTE(kudo): Adding this to catch Hermes inspector exceptions after SDK 49.
+    // I still not figure out why the std::runtime_error is not catched by the std::exception above.
+    return UserCallbackException(e);
   }
 
   return {};


### PR DESCRIPTION
# Why

when vscode-expo sending the `Runtime.callFunctionOn` event, it will crash ios expo go.
close ENG-9172

# How

compared this on top of expo-go and expo-dev-client, both reaching the line `throw std::runtime_error("unknown object id " + objId);`. only expo-go will crash the app because the exception is not caught. this happens on the new expo-go, even the older sdks (that's why this pr includes to backporting changes).
as the comment said, i still not figure out why the `std::runtime_error` is not caught by the `std::exception`. but the trick works 🙈

# Test Plan

ios expo go + sdk49 + vscode-expo debugging

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
