### PR TITLE
[ios][secure-store] Check for plist key if auth is required

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Added a check for the `NSFaceIDUsageDescription` key in the `set` function. ([#23275](https://github.com/expo/expo/pull/23275) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 12.3.0 — 2023-06-13
 
 ### 🐛 Bug fixes

--- a/packages/expo-secure-store/ios/SecureStoreExceptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreExceptions.swift
@@ -6,6 +6,12 @@ internal class InvalidKeyException: Exception {
   }
 }
 
+internal class MissingPlistKeyException: Exception {
+  override var reason: String {
+    "You must set `NSFaceIDUsageDescription` in your info.plist. This is not available in Expo go"
+  }
+}
+
 internal class KeyChainException: GenericException<OSStatus> {
   override var reason: String {
     switch param {

--- a/packages/expo-secure-store/ios/SecureStoreExceptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreExceptions.swift
@@ -8,7 +8,7 @@ internal class InvalidKeyException: Exception {
 
 internal class MissingPlistKeyException: Exception {
   override var reason: String {
-    "You must set `NSFaceIDUsageDescription` in your info.plist. This is not available in Expo go"
+    "You must set `NSFaceIDUsageDescription` in your Info.plist file to use the `requireAuthentication` option"
   }
 }
 

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -39,7 +39,7 @@ public final class SecureStoreModule: Module {
     }
 
     AsyncFunction("deleteValueWithKeyAsync") { (key: String, options: SecureStoreOptions) in
-      var searchDictionary = query(with: key, options: options)
+      let searchDictionary = query(with: key, options: options)
       SecItemDelete(searchDictionary as CFDictionary)
     }
   }
@@ -55,6 +55,9 @@ public final class SecureStoreModule: Module {
     if !options.requireAuthentication {
       query[kSecAttrAccessible as String] = accessibility
     } else {
+      guard let _ = Bundle.main.infoDictionary?["NSFaceIDUsageDescription"] as? String else {
+        throw MissingPlistKeyException()
+      }
       let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, SecAccessControlCreateFlags.biometryCurrentSet, nil)
       query[kSecAttrAccessControl as String] = accessOptions
     }
@@ -108,7 +111,6 @@ public final class SecureStoreModule: Module {
       guard let item = item as? Data else {
         return nil
       }
-
       return item
     case errSecItemNotFound:
       return nil
@@ -119,7 +121,7 @@ public final class SecureStoreModule: Module {
 
   private func query(with key: String, options: SecureStoreOptions) -> [String: Any] {
     let service = options.keychainService ?? "app"
-    let encodedKey = key.data(using: .utf8)
+    let encodedKey = Data(key.utf8)
 
     return [
       kSecClass as String: kSecClassGenericPassword,


### PR DESCRIPTION
# Why
Mainly to fix an issue where expo go will crash because it does not have the `NSFaceIDUsageDescription` set. Doesn't fully fix the problem. I'm going to look into if there is any way we can check if the key requires auth before trying to read it.

# How
Added a check in the `set` function.

# Test Plan
Test suite all passes