### PR TITLE
[docs] Update permissions.mdx

### DIFF
--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -84,7 +84,7 @@ Many of these properties are also directly configurable using the [config plugin
 ```
 
 - Changes to the **Info.plist** cannot be updated over-the-air, they will only be deployed when you submit a new native binary, eg: with [`eas build`](/build/introduction).
-- Apple's official [permission message recommendations](https://developer.apple.com/design/human-interface-guidelines/ios/app-architecture/requesting-permission/).
+- Apple's official [permission message recommendations](https://developer.apple.com/design/human-interface-guidelines/privacy).
 - [All available **Info.plist** properties](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html).
 
 <ConfigReactNative>

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -84,7 +84,7 @@ Many of these properties are also directly configurable using the [config plugin
 ```
 
 - Changes to the **Info.plist** cannot be updated over-the-air, they will only be deployed when you submit a new native binary, eg: with [`eas build`](/build/introduction).
-- Apple's official [permission message recommendations](https://developer.apple.com/design/human-interface-guidelines/privacy).
+- Apple's official [permission message recommendations](https://developer.apple.com/design/human-interface-guidelines/privacy#Requesting-permission).
 - [All available **Info.plist** properties](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html).
 
 <ConfigReactNative>


### PR DESCRIPTION
# Why

https://docs.expo.dev/guides/permissions/ - The link to "Apple's official permission message recommendations." is not available anymore. This is the new resource: https://developer.apple.com/design/human-interface-guidelines/privacy