### PR TITLE
[docs] Move reset Google Play upload key to a collapsible

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -5,6 +5,9 @@ description: Learn about what app credentials Android and iOS require.
 
 import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
 
 Expo automates the process of signing your app for Android and iOS, but in both cases, you can choose to provide your overrides. [EAS Build](/build/introduction) can generate signed or unsigned applications, but to distribute your application through the stores, it **must** be a signed application.
 
@@ -25,32 +28,52 @@ See [here](https://developer.android.com/studio/publish/app-signing) to find mor
 
 When you [upload your first release to Google Play](https://expo.fyi/first-android-submission) you will see a notice about "App signing by Google Play" and "Google is protecting your app signing key". This is the default behavior and requires no action on your behalf except to press "Continue".
 
-> If you lose your upload keystore (or it's compromised), you must ask the Google Support Team to reset your upload key.
-
 If you currently manage your app signing key and want Google to manage it for you, see [Use app signing by Google Play](https://support.google.com/googleplay/android-developer/answer/9842756).
 
-#### Resetting your Google App Signing credentials 
+<Collapsible summary="Lost your keystore? Learn how to reset your upload key on Google Play">
 
-If you need to sync your expo keystore with Google, follow these steps:
+To sync your Expo keystore with Google, follow these steps:
 
-1. Run `eas credentials` 
-2. Select `Android` for the platform and the profile whose credentials you wish to download. 
-3. Select `credentials.json: Upload/Download credentials between EAS servers and your local json` 
-4. Select ` Download credentials from EAS to credentials.json`
+<Step label="1">
+### Download Credentials
 
-Your application's keystore should be kept private. **Under no circumstances should you check it in to your repository.** Debug keystores are the only exception because we don't use them for uploading apps to the Google Play Store.
+In a terminal window:
 
-Once you've downloaded your credentials and the keystore, you must export it to the `pem` format so that you can submit it to Google. To do so:
+1. Run `eas credentials`
+2. Select `Android` for the platform and the profile whose credentials you wish to download.
+3. Select the option `credentials.json: Upload/Download credentials between EAS servers and your local json`
+4. Select `Download credentials from EAS to credentials.json`
 
-1. Find the key alias in your `credentials.json` file under the `keyAlias` key.
-2. Use `keytool` to export the certificate
-~~~
-keytool -export -rfc -alias {alias_from_step_1} -file {certificate_for_google.pem} -keystore {./path/to/keystore.jks}
-~~~
+Your application's keystore should be kept private. **Under no circumstances should you check it into your repository.** Debug keystores are the only exception because we don't use them for uploading apps to the Google Play Store.
 
-Then, contact Google Support and request they change your key using [this support form](https://support.google.com/googleplay/android-developer/contact/key), attaching the `pem` file exported from the keystore.
+</Step>
 
-Once Google updates this on your account, builds created through `eas build` will be correctly signed as expected by the Google Play Store. Note that Google will set the validity start date of the new upload certificate to 72 hours in the future so you will have to wait before your first submission after performing this process.
+<Step label="2">
+### Export keystore to `pem` format
+
+Once you've downloaded your credentials and the keystore, export it to the `pem` format so that you can submit it to Google:
+
+1. Find the key alias in your **credentials.json** file under the `keyAlias` key.
+2. Use `keytool` to export the certificate:
+
+<Terminal
+  cmd={[
+    '$keytool -export -rfc -alias alias_from_step_1 -file certificate_for_google.pem -keystore ./path/to/keystore.jks',
+  ]}
+/>
+
+</Step>
+
+<Step label="3">
+### Contact Google support
+
+Contact Google Support and request them to change your key using [this support form](https://support.google.com/googleplay/android-developer/contact/key). While filling out the form, attach the `pem` file exported from the keystore.
+
+Once Google updates this on your account, builds created through `eas build` will be correctly signed as expected by the Google Play Store. Note that Google will set the validity start date of the new upload certificate to 72 hours in the future so you'll have to wait before your first submission after performing this process.
+
+</Step>
+
+</Collapsible>
 
 ## iOS
 
@@ -71,7 +94,7 @@ This certificate will be used for all of your apps. If this certificate expires,
 
 Apple Push Notification Keys (often abbreviated as APN keys) allow the associated apps to send and receive push notifications.
 
-You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts. 
+You can have a maximum of 2 APN keys associated with your Apple Developer account, and a single key can be used with any number of apps. If you revoke an APN key, all apps that rely on that key will no longer be able to send or receive push notifications until you upload a new key to replace it. Uploading a new APN key **will not** change your users' [Expo Push Tokens](/versions/latest/sdk/notifications#notificationsgetexpopushtokenasync). Push notification keys do not expire. You can clear the APN key Expo currently has stored for your app by running `eas credentials` and following the prompts.
 
 > APN keys created by Expo can be downloaded on the [Expo website](https://expo.dev/accounts/[account]/settings/credentials).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for #21143

# How

<!--
How did you build this feature or fix this bug and why?
-->

Based on Brent's suggestion, this PR
- moves the section about resetting app signing credentials for Android to a Collapsible
- Use Step to breakdown and format steps, and Terminal to display the command
- Update overall verbiage
- Remove note about "lose your upload keystore..."

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="941" alt="CleanShot 2023-07-04 at 20 33 37@2x" src="https://github.com/expo/expo/assets/10234615/4d7714ea-2bf5-49db-aa00-eaf9a342a378">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
