### PR TITLE
[docs] Update docs for Expo Modules API

### DIFF
--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -295,7 +295,9 @@ View(TextView::class) {
 
 </CodeBlocksTable>
 
-> Support for rendering SwiftUI views is planned. For now, you can use [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) and add its content view to your UIKit view.
+> **Info** Support for rendering SwiftUI views is planned. For now, you can use [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) and add its content view to your UIKit view.
+
+> **Info** View functions are available as of SDK 49.
 
 </APIBox>
 <APIBox header="Prop">
@@ -667,7 +669,7 @@ The implementation for three Either types is currently provided out of the box, 
 - `EitherOfThree<FirstType, SecondType, ThirdType>` — A container for one of three types.
 - `EitherOfFour<FirstType, SecondType, ThirdType, FourthType>` — A container for one of four types.
 
-> Either types are available as of SDK 47.
+> **Info** Either types are available as of SDK 47.
 
 </APIBox>
 <APIBox header="JavaScript values">
@@ -712,6 +714,8 @@ Function("mutateMe") { jsObject: JavaScriptObject ->
 ```
 
 </CodeBlocksTable>
+
+> **Info** JavaScript types are available as of SDK 49.
 
 </APIBox>
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -259,40 +259,6 @@ MyModule.foo = 'foobar';
 ```
 
 </APIBox>
-<APIBox header="ViewManager">
-
-> **warning** **Deprecated**: To better integrate with [React Native's new architecture (Fabric)](https://reactnative.dev/architecture/fabric-renderer) and its recycling mechanism, as of SDK 47 the `ViewManager` component is deprecated in favor of [`View`](#view) with a view class passed as the first argument. This component will be removed in SDK 48.
-
-Enables the module to be used as a view manager. The view manager definition is built from the definition components used in the closure passed to `ViewManager`. Definition components that are accepted as part of the view manager definition: [`View`](#view), [`Prop`](#prop).
-
-<CodeBlocksTable>
-
-```swift
-ViewManager {
-  View {
-    MyNativeView()
-  }
-
-  Prop("isHidden") { (view: UIView, hidden: Bool) in
-    view.isHidden = hidden
-  }
-}
-```
-
-```kotlin
-ViewManager {
-  View { context ->
-    MyNativeView(context)
-  }
-
-  Prop("isHidden") { view: View, hidden: Bool ->
-    view.isVisible = !hidden
-  }
-}
-```
-
-</CodeBlocksTable>
-</APIBox>
 <APIBox header="View">
 
 Enables the module to be used as a native view. Definition components that are accepted as part of the view definition: [`Prop`](#prop), [`Events`](#events), [`GroupView`](#groupview).

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -261,7 +261,10 @@ MyModule.foo = 'foobar';
 </APIBox>
 <APIBox header="View">
 
-Enables the module to be used as a native view. Definition components that are accepted as part of the view definition: [`Prop`](#prop), [`Events`](#events), [`GroupView`](#groupview).
+Enables the module to be used as a native view. Definition components that are accepted as part of the view definition: [`Prop`](#prop), [`Events`](#events), [`GroupView`](#groupview) and [`AsyncFunction`](#asyncfunction).
+
+[`AsyncFunction`](#asyncfunction) in the view definition is added to the React ref of the React component representing the native view.
+Such async functions automatically receive an instance of the native view as the first argument and run on the UI thread by default.
 
 #### Arguments
 
@@ -273,12 +276,20 @@ Enables the module to be used as a native view. Definition components that are a
 ```swift
 View(UITextView.self) {
   Prop("text") { ... }
+
+  AsyncFunction("focus") { (view: UITextView) in
+    view.becomeFirstResponder()
+  }
 }
 ```
 
 ```kotlin
 View(TextView::class) {
   Prop("text") { ... }
+
+  AsyncFunction("focus") { view: TextView ->
+    view.requestFocus()
+  }
 }
 ```
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -670,6 +670,50 @@ The implementation for three Either types is currently provided out of the box, 
 > Either types are available as of SDK 47.
 
 </APIBox>
+<APIBox header="JavaScript values">
+
+It's also possible to use a `JavaScriptValue` type which is a holder for any value that can be represented in JavaScript.
+This type is useful when you want to mutate the given argument or when you want to omit type validations and conversions.
+Note that using JavaScript-specific types is restricted to synchronous functions as all reads and writes in the JavaScript runtime must happen on the JavaScript thread.
+Any access to these values from different threads will result in a crash.
+
+In addition to the raw value, `JavaScriptObject` type can be used to allow only object types and `JavaScriptFunction<ReturnType>` for callbacks.
+
+<CodeBlocksTable>
+
+```swift
+Function("mutateMe") { (value: JavaScriptValue) in
+  if value.isObject() {
+    let jsObject = value.getObject()
+    jsObject.setProperty("expo", value: "modules")
+  }
+}
+
+// or
+
+Function("mutateMe") { (jsObject: JavaScriptObject) in
+  jsObject.setProperty("expo", value: "modules")
+}
+```
+
+```kotlin
+Function("mutateMe") { value: JavaScriptValue ->
+  if (value.isObject()) {
+    val jsObject = value.getObject()
+    jsObject.setProperty("expo", "modules")
+  }
+}
+
+// or
+
+Function("mutateMe") { jsObject: JavaScriptObject ->
+  jsObject.setProperty("expo", "modules")
+}
+```
+
+</CodeBlocksTable>
+
+</APIBox>
 
 ## Native Classes
 

--- a/docs/pages/modules/module-api.mdx
+++ b/docs/pages/modules/module-api.mdx
@@ -679,7 +679,7 @@ This type is useful when you want to mutate the given argument or when you want 
 Note that using JavaScript-specific types is restricted to synchronous functions as all reads and writes in the JavaScript runtime must happen on the JavaScript thread.
 Any access to these values from different threads will result in a crash.
 
-In addition to the raw value, `JavaScriptObject` type can be used to allow only object types and `JavaScriptFunction<ReturnType>` for callbacks.
+In addition to the raw value, the `JavaScriptObject` type can be used to allow only object types and `JavaScriptFunction<ReturnType>` for callbacks.
 
 <CodeBlocksTable>
 


### PR DESCRIPTION
# Why

Update Expo Modules API docs for SDK 49

# How

- Removed deprecated `ViewManager` component
- Added docs for view functions
- Added docs for JavaScript values
- Added and unified notes about feature availability

I think it might be a good idea to also add a simple guide on how to use the view functions, but I'll make a separate PR for that.

# Test Plan

![Screenshot 2023-07-04 at 16 26 27](https://github.com/expo/expo/assets/1714764/b97b41b4-955f-44f5-9a80-fd297e518ee9)
![Screenshot 2023-07-04 at 16 26 48](https://github.com/expo/expo/assets/1714764/2c664caf-5958-4a30-a4e6-f0d21953570a)
