### PR TITLE
[docs] Add description for all pages under SDK 49 in Reference

### DIFF
--- a/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/accelerometer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Accelerometer
+description: A library that provides access to the device's accelerometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
@@ -7,11 +8,11 @@ iconUrl: '/static/images/packages/expo-sensors.png'
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-`Accelerometer` from **`expo-sensors`** provides access to the device accelerometer sensor(s) and associated listeners to respond to changes in acceleration in three-dimensional space, meaning any movement or vibration.
+`Accelerometer` from `expo-sensors` provides access to the device accelerometer sensor(s) and associated listeners to respond to changes in acceleration in three-dimensional space, meaning any movement or vibration.
 
 <PlatformsSection android emulator ios web />
 
@@ -40,9 +41,7 @@ export default function App() {
   const _fast = () => Accelerometer.setUpdateInterval(16);
 
   const _subscribe = () => {
-    setSubscription(
-      Accelerometer.addListener(setData)
-    );
+    setSubscription(Accelerometer.addListener(setData));
   };
 
   const _unsubscribe = () => {

--- a/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: AppleAuthentication
+description: A library that provides Sign in with Apple capability for iOS 13 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-apple-authentication'
 packageName: 'expo-apple-authentication'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/application.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/application.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application
+description: A universal library that provides information native application's ID, app name and build version at runtime.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-application'
 packageName: 'expo-application'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/asset.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/asset.mdx
@@ -1,5 +1,6 @@
 ---
 title: Asset
+description: A universal library that allows downloading assets and using them with other libraries.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-asset'
 packageName: 'expo-asset'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/async-storage.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/async-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: AsyncStorage
+description: A library that provides an asynchronous, unencrypted, persistent, key-value storage API.
 sourceCodeUrl: 'https://github.com/react-native-async-storage/async-storage'
 packageName: '@react-native-async-storage/async-storage'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/audio.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/audio.mdx
@@ -1,5 +1,6 @@
 ---
 title: Audio
+description: A library that provides an API to implement audio playback and recording in apps.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'
@@ -7,13 +8,13 @@ iconUrl: '/static/images/packages/expo-av.png'
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 import APISection from '~/components/plugins/APISection';
 import { PlatformTags } from '~/ui/components/Tag';
 
-**`expo-av`** allows you to implement audio playback and recording in your app.
+`Audio` from `expo-av` allows you to implement audio playback and recording in your app.
 
-Note that audio automatically stops if headphones / bluetooth audio devices are disconnected.
+Note that audio automatically stops if headphones/bluetooth audio devices are disconnected.
 
 Try the [playlist example app](https://expo.dev/@documentation/playlist-example) (source code is [on GitHub](https://github.com/expo/playlist-example)) to see an example usage of the media playback API, and the [recording example app](https://expo.dev/@documentation/record) (source code is [on GitHub](https://github.com/expo/audio-recording-example)) to see an example usage of the recording API.
 
@@ -120,9 +121,11 @@ export default function App() {
     console.log('Stopping recording..');
     setRecording(undefined);
     /* @info */ await recording.stopAndUnloadAsync(); /* @end */
-    /* @info iOS may reroute audio playback to the phone earpiece when recording is allowed, so disable once finished. */ await Audio.setAudioModeAsync({
-      allowsRecordingIOS: false,
-    }); /* @end */
+    /* @info iOS may reroute audio playback to the phone earpiece when recording is allowed, so disable once finished. */ await Audio.setAudioModeAsync(
+      {
+        allowsRecordingIOS: false,
+      }
+    ); /* @end */
     /* @info */ const uri = recording.getURI(); /* @end */
     console.log('Recording stopped and stored at', uri);
   }

--- a/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/auth-session.mdx
@@ -1,5 +1,6 @@
 ---
 title: AuthSession
+description: A universal library that provides an API to handle browser-based authentication.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-auth-session'
 packageName: 'expo-auth-session'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/av.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/av.mdx
@@ -1,5 +1,6 @@
 ---
 title: AV
+description: A universal library that provides separate APIs for Audio and Video playback.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'

--- a/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/background-fetch.mdx
@@ -1,5 +1,6 @@
 ---
 title: BackgroundFetch
+description: A universal library that provides API for performing background fetch tasks.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-background-fetch'
 packageName: 'expo-background-fetch'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -1,5 +1,6 @@
 ---
 title: BarCodeScanner
+description: A library that allows scanning a variety of supported barcodes. It is available both as a standalone library and as an extension for Expo Camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-barcode-scanner'
 packageName: 'expo-barcode-scanner'
 iconUrl: '/static/images/packages/expo-barcode-scanner.png'

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -4,7 +4,6 @@ description: A library that allows scanning a variety of supported barcodes. It 
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-barcode-scanner'
 packageName: 'expo-barcode-scanner'
 iconUrl: '/static/images/packages/expo-barcode-scanner.png'
-description: 'Allows scanning variety of supported barcodes both as standalone module and as extension for expo-camera.'
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v49.0.0/sdk/barometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/barometer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Barometer
+description: A library that provides access to device's barometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v49.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/battery.mdx
@@ -1,5 +1,6 @@
 ---
 title: Battery
+description: A library that provides battery information for the physical device, as well as corresponding event listeners.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-battery'
 packageName: 'expo-battery'
 iconUrl: '/static/images/packages/expo-battery.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-battery.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-battery`** provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
@@ -23,9 +24,9 @@ import { SnackInline} from '~/ui/components/Snippet';
 <SnackInline label='Basic Battery Usage' dependencies={['expo-battery']}>
 
 ```jsx
-import { useEffect, useState, useCallback } from "react";
-import * as Battery from "expo-battery";
-import { StyleSheet, Text, View } from "react-native";
+import { useEffect, useState, useCallback } from 'react';
+import * as Battery from 'expo-battery';
+import { StyleSheet, Text, View } from 'react-native';
 
 export default function App() {
   const [batteryLevel, setBatteryLevel] = useState(null);
@@ -34,11 +35,11 @@ export default function App() {
   const _subscribe = async () => {
     const batteryLevel = await Battery.getBatteryLevelAsync();
     setBatteryLevel(batteryLevel);
-    
+
     setSubscription(
       Battery.addBatteryLevelListener(({ batteryLevel }) => {
         setBatteryLevel(batteryLevel);
-        console.log("batteryLevel changed!", batteryLevel);
+        console.log('batteryLevel changed!', batteryLevel);
       })
     );
   };

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: BlurView
+description: A React component that renders a native blur view on iOS and falls back to a semi-transparent view on Android.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-blur'
 packageName: 'expo-blur'
 iconUrl: '/static/images/packages/expo-blur.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-blur.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 A React component that blurs everything underneath the view. On iOS, it renders a native blur view. On Android, it falls back to a semi-transparent view. Common usage of this is for navigation bars, tab bars, and modals.
 

--- a/docs/pages/versions/v49.0.0/sdk/brightness.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/brightness.mdx
@@ -1,5 +1,6 @@
 ---
 title: Brightness
+description: A library that provides access to an API for getting and setting the screen brightness.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-brightness'
 packageName: 'expo-brightness'
 iconUrl: '/static/images/packages/expo-brightness.png'

--- a/docs/pages/versions/v49.0.0/sdk/build-properties.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/build-properties.mdx
@@ -1,5 +1,6 @@
 ---
 title: BuildProperties
+description: A config plugin that allows customizing native build properties during prebuild.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-build-properties'
 packageName: 'expo-build-properties'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/calendar.mdx
@@ -1,5 +1,6 @@
 ---
 title: Calendar
+description: A library that provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-calendar'
 packageName: 'expo-calendar'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/camera.mdx
@@ -1,5 +1,6 @@
 ---
 title: Camera
+description: A React component that renders a preview for the device's front or back camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-camera'
 packageName: 'expo-camera'
 iconUrl: '/static/images/packages/expo-camera.png'

--- a/docs/pages/versions/v49.0.0/sdk/captureRef.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/captureRef.mdx
@@ -1,5 +1,6 @@
 ---
 title: captureRef
+description: A library that allows you to capture a React Native view and save it as an image.
 sourceCodeUrl: 'https://github.com/gre/react-native-view-shot'
 packageName: 'react-native-view-shot'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/cellular.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/cellular.mdx
@@ -1,5 +1,6 @@
 ---
 title: Cellular
+description: An API that provides information about the user's cellular service provider.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-cellular'
 packageName: 'expo-cellular'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/checkbox.mdx
@@ -1,5 +1,6 @@
 ---
 title: Checkbox
+description: A universal React component that provides basic checkbox functionality.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-checkbox'
 packageName: 'expo-checkbox'
 ---
@@ -7,7 +8,7 @@ packageName: 'expo-checkbox'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-checkbox`** provides a basic `boolean` input element for all platforms. If you are looking for a more flexible checkbox component, please see the [guide to implementing your own checkbox](/ui-programming/implementing-a-checkbox.mdx).
 

--- a/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/clipboard.mdx
@@ -1,5 +1,6 @@
 ---
 title: Clipboard
+description: A universal library that allows getting and setting Clipboard content.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-clipboard'
 packageName: 'expo-clipboard'
 ---
@@ -7,7 +8,7 @@ packageName: 'expo-clipboard'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-clipboard`** provides an interface for getting and setting Clipboard content on Android, iOS, and Web.
 

--- a/docs/pages/versions/v49.0.0/sdk/constants.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/constants.mdx
@@ -1,5 +1,6 @@
 ---
 title: Constants
+description: An API that provides system information that remains constant throughout the lifetime of your app's installation.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-constants'
 packageName: 'expo-constants'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/contacts.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/contacts.mdx
@@ -1,5 +1,6 @@
 ---
 title: Contacts
+description: A library that provides access to the phone's system contacts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-contacts'
 packageName: 'expo-contacts'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/crypto.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/crypto.mdx
@@ -1,5 +1,6 @@
 ---
 title: Crypto
+description: A universal library for crypto operations.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-crypto'
 packageName: 'expo-crypto'
 iconUrl: '/static/images/packages/expo-crypto.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-crypto.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-crypto` enables you to hash data in an equivalent manner to the Node.js core `crypto` API.
 

--- a/docs/pages/versions/v49.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/date-time-picker.mdx
@@ -1,5 +1,6 @@
 ---
 title: DateTimePicker
+description: A component that provides access to the system UI for date and time selection.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-datetimepicker'
 packageName: '@react-native-community/datetimepicker'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/device.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/device.mdx
@@ -1,5 +1,6 @@
 ---
 title: Device
+description: A universal library provides access to system information about the physical device.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-device'
 packageName: 'expo-device'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/devicemotion.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/devicemotion.mdx
@@ -1,5 +1,6 @@
 ---
 title: DeviceMotion
+description: A library that provides access to a device's motion and orientation sensors.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v49.0.0/sdk/document-picker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/document-picker.mdx
@@ -1,5 +1,6 @@
 ---
 title: DocumentPicker
+description: A library that provides access to the system's UI for selecting documents from the available providers on the user's device.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-document-picker'
 packageName: 'expo-document-picker'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/facedetector.mdx
@@ -1,5 +1,6 @@
 ---
 title: FaceDetector
+description: A library that uses Google Mobile Vision to detect faces on images.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-face-detector'
 packageName: 'expo-face-detector'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/filesystem.mdx
@@ -1,5 +1,6 @@
 ---
 title: FileSystem
+description: A library that provides access to the local file system on the device.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-file-system'
 packageName: 'expo-file-system'
 iconUrl: '/static/images/packages/expo-file-system.png'

--- a/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/flash-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: FlashList
+description: A React Native component that provides a fast and performant way to render lists.
 sourceCodeUrl: 'https://github.com/shopify/flash-list'
 packageName: '@shopify/flash-list'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/font.mdx
@@ -1,5 +1,6 @@
 ---
 title: Font
+description: A library that allows loading fonts at runtime and using them in React Native components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-font'
 packageName: 'expo-font'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gesture-handler.mdx
@@ -1,5 +1,6 @@
 ---
 title: GestureHandler
+description: A library that provides an API for handling complex gestures.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-gesture-handler'
 packageName: 'react-native-gesture-handler'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/gl-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gl-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: GLView
+description: A library that provides GLView that acts as an OpenGL ES render target and provides GLContext. Useful for rendering 2D and 3D graphics.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-gl'
 packageName: 'expo-gl'
 iconUrl: '/static/images/packages/expo-gl.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-gl.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-gl`** provides a `View` that acts as an OpenGL ES render target, useful for rendering 2D and 3D graphics. On mounting, an OpenGL ES context is created. Its drawing buffer is presented as the contents of the `View` every frame.
 

--- a/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/gyroscope.mdx
@@ -1,5 +1,6 @@
 ---
 title: Gyroscope
+description: A library that provides access to the device's gyroscope sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-sensors.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `Gyroscope` from **`expo-sensors`** provides access to the device's gyroscope sensor to respond to changes in rotation in three-dimensional space.
 

--- a/docs/pages/versions/v49.0.0/sdk/haptics.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/haptics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Haptics
+description: A library that provides access to the system's vibration effects on Android and the haptics engine on iOS.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-haptics'
 packageName: 'expo-haptics'
 iconUrl: '/static/images/packages/expo-haptics.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-haptics.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-haptics`** provides haptic (touch) feedback for
 

--- a/docs/pages/versions/v49.0.0/sdk/image.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/image.mdx
@@ -1,5 +1,6 @@
 ---
 title: Image
+description: A cross-platform and performant React component that loads and renders images.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-image'
 packageName: 'expo-image'
 iconUrl: '/static/images/packages/expo-image.png'
@@ -27,17 +28,17 @@ import { YesIcon, NoIcon, PendingIcon } from '~/ui/components/DocIcons';
 
 #### Supported image formats
 
-|   Format   |   Android   |     iOS     |                                 Web                                 |
-| :--------: | :---------: | :---------: | :-----------------------------------------------------------------: |
-|    WebP    | <YesIcon /> | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
-| PNG / APNG | <YesIcon /> | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
-|    AVIF    | <YesIcon /> (No support for animated AVIFs)| <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
-|    HEIC    | <YesIcon /> | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
-|    JPEG    | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
-|    GIF     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
-|    SVG     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
-|    ICO     | <YesIcon /> | <YesIcon /> |                             <YesIcon />                             |
-|    ICNS    | <NoIcon />  | <YesIcon /> |                             <NoIcon />                              |
+|   Format   |                   Android                   |     iOS     |                                 Web                                 |
+| :--------: | :-----------------------------------------: | :---------: | :-----------------------------------------------------------------: |
+|    WebP    |                 <YesIcon />                 | <YesIcon /> |        <YesIcon /> [~96% adoption](https://caniuse.com/webp)        |
+| PNG / APNG |                 <YesIcon />                 | <YesIcon /> | <YesIcon /> / <YesIcon /> [~96% adoption](https://caniuse.com/apng) |
+|    AVIF    | <YesIcon /> (No support for animated AVIFs) | <YesIcon /> |      <PendingIcon /> [~79% adoption](https://caniuse.com/avif)      |
+|    HEIC    |                 <YesIcon />                 | <YesIcon /> |       <NoIcon /> [not adopted yet](https://caniuse.com/heif)        |
+|    JPEG    |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
+|    GIF     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
+|    SVG     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
+|    ICO     |                 <YesIcon />                 | <YesIcon /> |                             <YesIcon />                             |
+|    ICNS    |                 <NoIcon />                  | <YesIcon /> |                             <NoIcon />                              |
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagemanipulator.mdx
@@ -1,5 +1,6 @@
 ---
 title: ImageManipulator
+description: A library that provides an API for image manipulation on the local file system.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-image-manipulator'
 packageName: 'expo-image-manipulator'
 iconUrl: '/static/images/packages/expo-image-manipulator.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-image-manipulator.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-image-manipulator`** provides an API to modify images stored on the local file system.
 

--- a/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/imagepicker.mdx
@@ -1,5 +1,6 @@
 ---
 title: ImagePicker
+description: A library that provides access to the system's UI for selecting images and videos from the phone's library or taking a photo with the camera.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-image-picker'
 packageName: 'expo-image-picker'
 iconUrl: '/static/images/packages/expo-image-picker.png'

--- a/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
@@ -1,5 +1,6 @@
 ---
 title: InAppPurchases
+description: A library for accepting in-app purchases.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-in-app-purchases'
 packageName: 'expo-in-app-purchases'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/intent-launcher.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/intent-launcher.mdx
@@ -1,5 +1,6 @@
 ---
 title: IntentLauncher
+description: A library that provides an API to launch Android intents.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-intent-launcher'
 packageName: 'expo-intent-launcher'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/keep-awake.mdx
@@ -1,5 +1,6 @@
 ---
 title: KeepAwake
+description: A React component that prevents the screen from sleeping when rendered.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-keep-awake'
 packageName: 'expo-keep-awake'
 ---
@@ -7,17 +8,11 @@ packageName: 'expo-keep-awake'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-keep-awake`** provides a React hook that prevents the screen from sleeping and a pair of functions to enable this behavior imperatively.
 
-<PlatformsSection
-  android
-  emulator
-  ios
-  simulator
-  web
-/>
+<PlatformsSection android emulator ios simulator web />
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/light-sensor.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/light-sensor.mdx
@@ -1,5 +1,6 @@
 ---
 title: LightSensor
+description: A library that provides access to the device's light sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/linear-gradient.mdx
@@ -1,5 +1,6 @@
 ---
 title: LinearGradient
+description: A universal React component that renders a gradient view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-linear-gradient'
 packageName: 'expo-linear-gradient'
 iconUrl: '/static/images/packages/expo-linear-gradient.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-linear-gradient.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-linear-gradient`** provides a native React view that transitions between multiple colors in a linear direction.
 

--- a/docs/pages/versions/v49.0.0/sdk/linking.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/linking.mdx
@@ -1,5 +1,6 @@
 ---
 title: Linking
+description: An API that provides methods to create and open deep links universally.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-linking'
 packageName: 'expo-linking'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/local-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/local-authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: LocalAuthentication
+description: A library that provides functionality for implementing the Fingerprint API (Android) or FaceID and TouchID (iOS) to authenticate the user with a face or fingerprint scan.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-local-authentication'
 packageName: 'expo-local-authentication'
 iconUrl: '/static/images/packages/expo-local-authentication.png'

--- a/docs/pages/versions/v49.0.0/sdk/localization.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/localization.mdx
@@ -1,5 +1,6 @@
 ---
 title: Localization
+description: A library that provides an interface for native user localization information.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-localization'
 packageName: 'expo-localization'
 iconUrl: '/static/images/packages/expo-localization.png'

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -1,5 +1,6 @@
 ---
 title: Location
+description: A library that provides access to reading geolocation information, polling current location or subscribing location update events from the device.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-location'
 packageName: 'expo-location'
 ---
@@ -72,8 +73,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
     {
       name: 'isIosBackgroundLocationEnabled',
       platform: 'ios',
-      description:
-        'A boolean to enable `location` in the `UIBackgroundModes` in **Info.plist**.',
+      description: 'A boolean to enable `location` in the `UIBackgroundModes` in **Info.plist**.',
       default: 'false',
     },
     {

--- a/docs/pages/versions/v49.0.0/sdk/lottie.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/lottie.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lottie
+description: A library that allows rendering After Effects animations.
 sourceCodeUrl: 'https://github.com/lottie-react-native/lottie-react-native'
 packageName: 'lottie-react-native'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/magnetometer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Magnetometer
+description: A library that provides access to the device's magnetometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'
@@ -8,7 +9,7 @@ iconUrl: '/static/images/packages/expo-sensors.png'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 `Magnetometer` from **`expo-sensors`** provides access to the device magnetometer sensor(s) to respond to and measure the changes in the magnetic field measured in microtesla (`μT`).
 

--- a/docs/pages/versions/v49.0.0/sdk/mail-composer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/mail-composer.mdx
@@ -1,5 +1,6 @@
 ---
 title: MailComposer
+description: A library that provides functionality to compose and send emails with the system's specific UI.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-mail-composer'
 packageName: 'expo-mail-composer'
 iconUrl: '/static/images/packages/expo-mail-composer.png'

--- a/docs/pages/versions/v49.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/map-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: MapView
+description: A library that provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 sourceCodeUrl: 'https://github.com/react-native-maps/react-native-maps'
 packageName: 'react-native-maps'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/masked-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: MaskedView
+description: A library that provides a masked view.
 sourceCodeUrl: 'https://github.com/react-native-masked-view/masked-view'
 packageName: '@react-native-masked-view/masked-view'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/media-library.mdx
@@ -1,5 +1,6 @@
 ---
 title: MediaLibrary
+description: A library that provides access to the device's media library.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-media-library'
 packageName: 'expo-media-library'
 iconUrl: '/static/images/packages/expo-media-library.png'

--- a/docs/pages/versions/v49.0.0/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/navigation-bar.mdx
@@ -1,5 +1,6 @@
 ---
 title: NavigationBar
+description: A library that provides access to various interactions with the native navigation bar on Android.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-navigation-bar'
 packageName: 'expo-navigation-bar'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/netinfo.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/netinfo.mdx
@@ -1,5 +1,6 @@
 ---
 title: NetInfo
+description: A cross-platform API that provides access to network information.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-netinfo'
 packageName: '@react-native-community/netinfo'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/network.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/network.mdx
@@ -1,5 +1,6 @@
 ---
 title: Network
+description: A library that provides access to the device's network such as its IP address, MAC address, and airplane mode status.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-network'
 packageName: 'expo-network'
 iconUrl: '/static/images/packages/expo-network.png'

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -1,5 +1,6 @@
 ---
 title: Notifications
+description: A library that provides an API to fetch push notification tokens and to present, schedule, receive and respond to notifications.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-notifications'
 packageName: 'expo-notifications'
 iconUrl: '/static/images/packages/expo-notifications.png'

--- a/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/pedometer.mdx
@@ -1,5 +1,6 @@
 ---
 title: Pedometer
+description: A library that provides access to the device's pedometer sensor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v49.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/picker.mdx
@@ -1,5 +1,6 @@
 ---
 title: Picker
+description: A cross-platform component that provides access to the system UI for picking between several options.
 sourceCodeUrl: 'https://github.com/react-native-picker/picker'
 packageName: '@react-native-picker/picker'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/print.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/print.mdx
@@ -1,5 +1,6 @@
 ---
 title: Print
+description: A library that provides printing functionality for Android and iOS (AirPrint).
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-print'
 packageName: 'expo-print'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/random.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/random.mdx
@@ -1,5 +1,6 @@
 ---
 title: Random
+description: A universal library for generating random bytes.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-random'
 packageName: 'expo-random'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -1,5 +1,6 @@
 ---
 title: Reanimated
+description: A library that provides an API that greatly simplifies the process of creating smooth, powerful, and maintainable animations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-reanimated'
 packageName: 'react-native-reanimated'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/register-root-component.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/register-root-component.mdx
@@ -1,5 +1,6 @@
 ---
 title: registerRootComponent
+description: A universal component that allows setting the initial React component to render natively in the app's root React Native view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo/src/launch'
 packageName: 'expo'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
@@ -1,5 +1,6 @@
 ---
 title: SafeAreaContext
+description: A library with a flexible API for accessing the device's safe area inset information.
 sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/screen-capture.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/screen-capture.mdx
@@ -1,5 +1,6 @@
 ---
 title: ScreenCapture
+description: A library that allows you to protect screens in your app from being captured or recorded.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-screen-capture'
 packageName: 'expo-screen-capture'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/screen-orientation.mdx
@@ -1,5 +1,6 @@
 ---
 title: ScreenOrientation
+description: A universal library for managing a device's screen orientation.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-screen-orientation'
 packageName: 'expo-screen-orientation'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/screens.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/screens.mdx
@@ -1,5 +1,6 @@
 ---
 title: Screens
+description: A library that provides native primitives to represent screens instead of plain React Native View components for better operating system behavior and screen optimizations.
 sourceCodeUrl: 'https://github.com/software-mansion/react-native-screens'
 packageName: 'react-native-screens'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/securestore.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/securestore.mdx
@@ -1,5 +1,6 @@
 ---
 title: SecureStore
+description: A library that provides a way to encrypt and securely store key-value pairs locally on the device.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-secure-store'
 packageName: 'expo-secure-store'
 iconUrl: '/static/images/packages/expo-secure-store.png'

--- a/docs/pages/versions/v49.0.0/sdk/segmented-control.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/segmented-control.mdx
@@ -1,5 +1,6 @@
 ---
 title: SegmentedControl
+description: A React Native library that provides a component to render UISegmentedControl from iOS.
 sourceCodeUrl: 'https://github.com/react-native-community/segmented-control'
 packageName: '@react-native-segmented-control/segmented-control'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/sensors.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sensors.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sensors
+description: A library that provides access to a device's accelerometer, barometer, motion, gyroscope, magnetometer, and pedometer.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sensors'
 packageName: 'expo-sensors'
 iconUrl: '/static/images/packages/expo-sensors.png'

--- a/docs/pages/versions/v49.0.0/sdk/sharing.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sharing.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sharing
+description: A library that provides implementing sharing files.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sharing'
 packageName: 'expo-sharing'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/skia.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/skia.mdx
@@ -1,5 +1,6 @@
 ---
 title: Skia
+description: A React Native library for creating graphics using Skia.
 sourceCodeUrl: 'https://github.com/shopify/react-native-skia'
 packageName: '@shopify/react-native-skia'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/slider.mdx
@@ -1,5 +1,6 @@
 ---
 title: Slider
+description: A React Native component library that provides access to the system UI for a slider control.
 sourceCodeUrl: 'https://github.com/callstack/react-native-slider'
 packageName: '@react-native-community/slider'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/sms.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sms.mdx
@@ -1,5 +1,6 @@
 ---
 title: SMS
+description: A library that provides access to the system's UI/app for sending SMS messages.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sms'
 packageName: 'expo-sms'
 iconUrl: '/static/images/packages/expo-sms.png'

--- a/docs/pages/versions/v49.0.0/sdk/speech.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/speech.mdx
@@ -1,5 +1,6 @@
 ---
 title: Speech
+description: A library that provides access to text-to-speech functionality.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-speech'
 packageName: 'expo-speech'
 ---
@@ -7,7 +8,7 @@ packageName: 'expo-speech'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-speech`** provides an API that allows you to utilize Text-to-speech functionality in your app.
 

--- a/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/splash-screen.mdx
@@ -1,5 +1,6 @@
 ---
 title: SplashScreen
+description: A library that provides access to controlling the visibility behavior of native splash screen.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-splash-screen'
 packageName: 'expo-splash-screen'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/sqlite.mdx
@@ -1,5 +1,6 @@
 ---
 title: SQLite
+description: A library that provides access to a database that can be queried through a WebSQL-like API.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-sqlite'
 packageName: 'expo-sqlite'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/status-bar.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/status-bar.mdx
@@ -1,6 +1,7 @@
 ---
 id: statusbar
 title: StatusBar
+description: A library that provides the same interface as the React Native StatusBar API, but with slightly different defaults to work great in Expo environments.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-status-bar'
 packageName: 'expo-status-bar'
 ---
@@ -8,7 +9,7 @@ packageName: 'expo-status-bar'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-status-bar`** gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 

--- a/docs/pages/versions/v49.0.0/sdk/storereview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/storereview.mdx
@@ -1,5 +1,6 @@
 ---
 title: StoreReview
+description: A library that provides access to native APIs for in-app reviews.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-store-review'
 packageName: 'expo-store-review'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/stripe.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stripe
+description: A library that provides access to native APIs for integrating Stripe payments.
 sourceCodeUrl: 'https://github.com/stripe/stripe-react-native'
 packageName: '@stripe/stripe-react-native'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/svg.mdx
@@ -1,5 +1,6 @@
 ---
 title: Svg
+description: A library that allows using SVGs in your app.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-svg'
 packageName: 'react-native-svg'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/system-ui.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/system-ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: SystemUI
+description: A library that allows interacting with system UI elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-system-ui'
 packageName: 'expo-system-ui'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/task-manager.mdx
@@ -1,5 +1,6 @@
 ---
 title: TaskManager
+description: A library that provides support for tasks that can run in the background.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-task-manager'
 packageName: 'expo-task-manager'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/tracking-transparency.mdx
@@ -1,5 +1,6 @@
 ---
 title: TrackingTransparency
+description: A library for requesting permission to track the users on devices using iOS 14 and higher.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-tracking-transparency'
 packageName: 'expo-tracking-transparency'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/updates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Updates
+description: A library that allows programmatically controlling and responding to new updates made available to your app.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-updates'
 packageName: 'expo-updates'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video-thumbnails.mdx
@@ -1,5 +1,6 @@
 ---
 title: VideoThumbnails
+description: A library that allows you to generate an image to serve as a thumbnail from a video file.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-video-thumbnails'
 packageName: 'expo-video-thumbnails'
 ---
@@ -7,7 +8,7 @@ packageName: 'expo-video-thumbnails'
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-video-thumbnails`** allows you to generate an image to serve as a thumbnail from a video file.
 

--- a/docs/pages/versions/v49.0.0/sdk/video.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/video.mdx
@@ -1,5 +1,6 @@
 ---
 title: Video
+description: A library that provides an API to implement video playback and recording in apps.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-av'
 packageName: 'expo-av'
 iconUrl: '/static/images/packages/expo-av.png'

--- a/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/view-pager.mdx
@@ -1,5 +1,6 @@
 ---
 title: ViewPager
+description: A component library that provides a carousel-like view to swipe through pages of content.
 sourceCodeUrl: 'https://github.com/callstack/react-native-pager-view'
 packageName: 'react-native-pager-view'
 ---

--- a/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webbrowser.mdx
@@ -1,5 +1,6 @@
 ---
 title: WebBrowser
+description: A library that provides access to the system's web browser and supports handling redirects.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-web-browser'
 packageName: 'expo-web-browser'
 iconUrl: '/static/images/packages/expo-web-browser.png'

--- a/docs/pages/versions/v49.0.0/sdk/webview.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/webview.mdx
@@ -1,12 +1,13 @@
 ---
 title: WebView
+description: A library that provides a WebView component.
 sourceCodeUrl: 'https://github.com/react-native-community/react-native-webview'
 packageName: 'react-native-webview'
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
-import { SnackInline} from '~/ui/components/Snippet';
+import { SnackInline } from '~/ui/components/Snippet';
 
 **`react-native-webview`** provides a `WebView` component that renders web content in a native view.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up PR for #22974 


# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding descriptions for docs under SDK 49.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally and visiting a doc in Reference > Expo SDK. For example: http://localhost:3002/versions/v49.0.0/sdk/bar-code-scanner/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
