### PR TITLE
[docs] Home: shuffle "Learn More" tiles colors

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -119,21 +119,21 @@ const Home = () => {
               xl={6}
               lg={6}
               css={css({
-                backgroundColor: palette.purple3,
-                borderColor: palette.purple7,
+                backgroundColor: palette.orange3,
+                borderColor: palette.orange7,
               })}>
               <SnackImage />
-              <RawH3 css={css({ color: palette.purple11 })}>Try Expo in your browser</RawH3>
-              <P css={css({ color: palette.purple11, ...typography.fontSizes[14] })}>
+              <RawH3 css={css({ color: palette.orange11 })}>Try Expo in your browser</RawH3>
+              <P css={css({ color: palette.orange11, ...typography.fontSizes[14] })}>
                 Expo’s Snack lets you try Expo
                 <br />
                 with zero local setup.
               </P>
               <HomeButton
-                className="bg-palette-purple11 border-palette-purple11 text-palette-purple3 hocus:bg-palette-purple11 hocus:opacity-80"
+                className="bg-palette-orange11 border-palette-orange11 text-palette-orange3 hocus:bg-palette-orange11 hocus:opacity-80"
                 href="https://snack.expo.dev/"
                 target="_blank"
-                rightSlot={<ArrowUpRightIcon className="text-palette-purple3 icon-md" />}>
+                rightSlot={<ArrowUpRightIcon className="text-palette-orange3 icon-md" />}>
                 Create a Snack
               </HomeButton>
             </GridCell>
@@ -183,20 +183,20 @@ const Home = () => {
               xl={6}
               lg={6}
               css={css({
-                backgroundColor: palette.gray3,
-                borderColor: palette.gray8,
+                backgroundColor: palette.purple3,
+                borderColor: palette.purple7,
               })}>
-              <div className="absolute bottom-6 right-6 p-5 bg-palette-gray12 rounded-full">
+              <div className="absolute bottom-6 right-6 p-5 bg-palette-purple9 rounded-full">
                 <DiscordIcon className="icon-2xl text-palette-white" />
               </div>
-              <RawH3 css={css({ color: palette.gray12 })}>Chat with the community</RawH3>
-              <P css={{ color: palette.gray12, ...typography.fontSizes[14] }}>
+              <RawH3 css={css({ color: palette.purple11 })}>Chat with the community</RawH3>
+              <P css={{ color: palette.purple11, ...typography.fontSizes[14] }}>
                 Join over 15,000 other developers
                 <br />
                 on the Expo Community Discord.
               </P>
               <HomeButton
-                className="bg-palette-gray12 border-palette-gray11 text-palette-gray2 hocus:bg-palette-gray11 hocus:opacity-80"
+                className="bg-palette-purple11 border-palette-purple11 text-palette-purple2 hocus:bg-palette-purple11 hocus:opacity-80"
                 href="https://chat.expo.dev"
                 rightSlot={<ArrowUpRightIcon className="text-palette-gray2 icon-md" />}>
                 Go to Discord

--- a/docs/ui/components/Home/resources/SnackImage.tsx
+++ b/docs/ui/components/Home/resources/SnackImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { palette } from '@expo/styleguide-base';
 
 export const SnackImage = () => (
   <svg
@@ -12,59 +12,43 @@ export const SnackImage = () => (
     viewBox="0 0 80 81"
     fill="none"
     xmlns="http://www.w3.org/2000/svg">
-    <g filter="url(#f0cd9fa4924e22267af4fdde31d18ea1)">
+    <g filter="url(#inset-shadow)">
       <circle
         cx="68.2409"
         cy="15.9358"
         r="11.6439"
-        css={{ fill: 'var(--purple7)', '.dark-theme &': { fill: 'var(--purple11)' } }}
+        css={{ fill: 'var(--orange7)', '.dark-theme &': { fill: 'var(--orange11)' } }}
       />
     </g>
     <g>
       <path
         d="M34.9717 40.887V80.8089L0.0400391 60.8479V20.926L34.9717 40.887Z"
-        css={{ fill: 'var(--purple8)', '.dark-theme &': { fill: 'var(--purple8)' } }}
+        css={{ fill: 'var(--orange8)', '.dark-theme &': { fill: 'var(--orange8)' } }}
       />
       <path
         d="M51.607 32.5704V10.946L34.9729 20.9265V40.8875L51.607 32.5704Z"
-        css={{ fill: 'var(--purple11)', '.dark-theme &': { fill: 'var(--purple6)' } }}
+        css={{ fill: 'var(--orange11)', '.dark-theme &': { fill: 'var(--orange6)' } }}
       />
       <path
         d="M68.2403 40.8871L51.6062 32.5701L36.6355 40.8871L51.6062 49.2042L68.2403 40.8871Z"
-        fill="var(--purple8)"
+        fill="var(--orange8)"
       />
       <path
         d="M34.9729 40.8871V80.809L68.2412 60.848V40.8871L51.607 49.2042V30.9066L34.9729 40.8871Z"
-        css={{ fill: 'var(--purple11)', '.dark-theme &': { fill: 'var(--purple6)' } }}
+        css={{ fill: 'var(--orange11)', '.dark-theme &': { fill: 'var(--orange6)' } }}
       />
       <path
         d="M34.9723 0.964966L0.0406494 20.9259L34.9723 40.8869L51.6064 30.9064L34.9723 20.9259L51.6064 10.9454L34.9723 0.964966Z"
-        css={{ fill: 'var(--purple7)', '.dark-theme &': { fill: 'var(--purple11)' } }}
+        css={{ fill: 'var(--orange7)', '.dark-theme &': { fill: 'var(--orange11)' } }}
       />
     </g>
-    <defs>
-      <filter
-        id="f0cd9fa4924e22267af4fdde31d18ea1"
-        x="56.597"
-        y="1.57089"
-        width="23.2878"
-        height="26.0087"
-        filterUnits="userSpaceOnUse"
-        colorInterpolationFilters="sRGB">
-        <feFlood floodOpacity="0" result="BackgroundImageFix" />
-        <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-        <feColorMatrix
-          in="SourceAlpha"
-          type="matrix"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
-          result="hardAlpha"
-        />
-        <feOffset dy="-2.72098" />
-        <feGaussianBlur stdDeviation="2.72098" />
-        <feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1" />
-        <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" />
-        <feBlend mode="normal" in2="shape" result="effect1_innerShadow_39:1494" />
-      </filter>
-    </defs>
+    <filter id="inset-shadow">
+      <feOffset dx="1" dy="-3" />
+      <feGaussianBlur stdDeviation="2.5" result="offset-blur" />
+      <feComposite operator="out" in="SourceGraphic" in2="offset-blur" result="inverse" />
+      <feFlood floodColor={palette.light.orange11} floodOpacity=".8" result="color" />
+      <feComposite operator="in" in="color" in2="inverse" result="shadow" />
+      <feComposite operator="over" in="shadow" in2="SourceGraphic" />
+    </filter>
   </svg>
 );


### PR DESCRIPTION
# Why

Gray tile doesn't look that good, let's shuffle the tile themes so we can use another color form the palette instead it.

# How

Switch Snack tile to orange palette, switch new Discord tile to use purple one.

Additionally, I have simplified the inner shadow effect used on the Snack illustration.

# Test Plan

The changes have been verified by running docs website locally. Lint checks and tests are passing.

# Preview

<img width="1198" alt="Screenshot 2023-07-05 at 12 57 07" src="https://github.com/expo/expo/assets/719641/45f4d552-6372-49e5-8533-cb089471ec94">

<img width="1198" alt="Screenshot 2023-07-05 at 13 04 03" src="https://github.com/expo/expo/assets/719641/f1dba41d-9457-4bac-bd6e-f8e7ccc983f9">
