### PR TITLE
[docs] Add a note regarding the BlurView on Android

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -1,6 +1,6 @@
 ---
 title: BlurView
-description: A React component that renders a native blur view on iOS and falls back to a semi-transparent view on Android.
+description: A React component that blurs everything underneath the view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-blur'
 packageName: 'expo-blur'
 iconUrl: '/static/images/packages/expo-blur.png'
@@ -10,13 +10,17 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
-A React component that blurs everything underneath the view. On iOS, it renders a native blur view. On Android, it falls back to a semi-transparent view. Common usage of this is for navigation bars, tab bars, and modals.
+A React component that blurs everything underneath the view. Common usage of this is for navigation bars, tab bars, and modals.
+
+> **info** `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
 
 <PlatformsSection emulator android ios simulator web />
 
-> `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
-> On Android `BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
+#### Known issues&ensp;<PlatformTags platforms={['android']} />
+
+`BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
 
 ## Installation
 

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -15,6 +15,9 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection emulator android ios simulator web />
 
+> BlurView on Android is computationally expensive, so it is recommended not to render more than a few BlurView components at once.
+> On Android BlurView may render incorrectly during screen transitions made by `react-native-screens`.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -15,8 +15,8 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection emulator android ios simulator web />
 
-> BlurView on Android is computationally expensive, so it is recommended not to render more than a few BlurView components at once.
-> On Android BlurView may render incorrectly during screen transitions made by `react-native-screens`.
+> `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
+> On Android `BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -1,6 +1,6 @@
 ---
 title: BlurView
-description: A React component that renders a native blur view on iOS and falls back to a semi-transparent view on Android.
+description: A React component that blurs everything underneath the view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-blur'
 packageName: 'expo-blur'
 iconUrl: '/static/images/packages/expo-blur.png'
@@ -10,13 +10,17 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
-A React component that blurs everything underneath the view. On iOS, it renders a native blur view. On Android, it falls back to a semi-transparent view. Common usage of this is for navigation bars, tab bars, and modals.
+A React component that blurs everything underneath the view. Common usage of this is for navigation bars, tab bars, and modals.
+
+> **info** `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
 
 <PlatformsSection emulator android ios simulator web />
 
-> `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
-> On Android `BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
+#### Known issues&ensp;<PlatformTags platforms={['android']} />
+
+`BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
 
 ## Installation
 

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -15,6 +15,9 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection emulator android ios simulator web />
 
+> BlurView on Android is computationally expensive, so it is recommended not to render more than a few BlurView components at once.
+> On Android BlurView may render incorrectly during screen transitions made by `react-native-screens`.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -15,8 +15,8 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 <PlatformsSection emulator android ios simulator web />
 
-> BlurView on Android is computationally expensive, so it is recommended not to render more than a few BlurView components at once.
-> On Android BlurView may render incorrectly during screen transitions made by `react-native-screens`.
+> `BlurView` on Android is computationally expensive, so it is recommended not to render more than a few `BlurView` components at once.
+> On Android `BlurView` may render incorrectly during screen transitions made by `react-native-screens`.
 
 ## Installation
 


### PR DESCRIPTION
# Why

During the SDK 49 Beta it has been reported that the BlurView renders incorrectly and causes performance issues during screen transitions on Android https://github.com/expo/expo/issues/23239.  
This is caused by `react-native-screens` switching to a hardware accelerated layout during screen transitions. This makes the native `BlurView` library we are using  to fail at creating a Bitmap capture of the view underneath which causes flickering and performance issues.

# How

For now it's not really possible to fix this issue quickly. We would most likely have to modify the code of the native `BlurView` library to make it work correctly or find a different library (disabling hardware acceleration in `RNScreens` is a bad idea). It might be a good idea to notify the users of the limitations on Android in the docs
