### PR TITLE
[go] Fix DevMenu window bounds on macOS

### DIFF
--- a/ios/Client/Menu/EXDevMenuViewController.m
+++ b/ios/Client/Menu/EXDevMenuViewController.m
@@ -145,7 +145,6 @@
     _hasCalledJSLoadedNotification = NO;
 
     _reactRootView = [[RCTRootView alloc] initWithBridge:mainBridge moduleName:@"HomeMenu" initialProperties:[self _getInitialPropsForVisibleApp]];
-    _reactRootView.frame = self.view.bounds;
 
     // By default react root view has white background,
     // however devmenu's bottom sheet looks better with partially visible experience.

--- a/ios/Client/Menu/EXDevMenuWindow.m
+++ b/ios/Client/Menu/EXDevMenuWindow.m
@@ -21,7 +21,6 @@
     // https://github.com/facebook/react-native/blob/0.64-stable/React/CoreModules/RCTLogBoxView.mm#L38
     self.windowLevel = UIWindowLevelStatusBar;
     self.backgroundColor = [UIColor clearColor];
-    self.bounds = [[UIScreen mainScreen] bounds];
     self.hidden = YES;
   }
   return self;


### PR DESCRIPTION
# Why

Partially fixes ENG-9201

# How

By not manually setting `bounds` to `[[UIScreen mainScreen] bounds]` the DevMenu automatically resizes when resizing the Expo Go window on macOS

# Test Plan

Run Expo Go on iOS and macOS
 
<table>
    <tr><th>iOS</th><th>macOS</th></tr>
    <tr>
    <td>
        <video src="https://github.com/expo/expo/assets/11707729/065d746f-7def-4f9e-ad39-e5cc3e0e1c8c"/>
   </td>
   <td>
   <video src="https://github.com/expo/expo/assets/11707729/b3f1e6e7-42e3-4def-89f5-78941e6f49ad"   />  
    </td>
</tr> 
</table> 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
