### PR TITLE
Update layouts.mdx

### DIFF
--- a/docs/pages/routing/layouts.mdx
+++ b/docs/pages/routing/layouts.mdx
@@ -124,7 +124,7 @@ Learn more about the built-in layouts:
   title="Modals"
   Icon={BookOpen02Icon}
   description="Implement native modals which float over the current context."
-  href="/router/advanced/modal"
+  href="/router/advanced/modals"
 />
 
 ## Advanced


### PR DESCRIPTION
fixed a broken link

# Why

Clicking on "modals" in the expo-router documentation leads to this page: https://docs.expo.dev/router/advanced/modal/ (404 page)

# How

Inserted the right link which ends with "modals" (not "modal")

# Test Plan

click on the new link and confirm its working

# Checklist


- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
