### PR TITLE
[docs] Fix link in Custom native code in Expo Go

### DIFF
--- a/docs/pages/bare/using-expo-client.mdx
+++ b/docs/pages/bare/using-expo-client.mdx
@@ -144,6 +144,6 @@ This method is the least reliable because there are several reasons that a `requ
 
 ## Deprecated `.expo` extensions
 
-The `.expo.[js/json/ts/tsx]` extensions to provide Expo Go specific fallbacks are removed in favor of optional imports syntax. For more information, see [Migration off the expo file extension](https://github.com/expo/fyi/blob/main/expo-extension-migration.mdx#after).
+The `.expo.[js/json/ts/tsx]` extensions to provide Expo Go specific fallbacks are removed in favor of optional imports syntax. For more information, see [Migration off the expo file extension](https://expo.fyi/expo-extension-migration.md#after).
 
 [expo-go]: https://expo.dev/expo-go


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix https://github.com/expo/expo/issues/23327

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By updating the link

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/bare/using-expo-client/#deprecated-expo-extensions. Then click on the migration link.

<img width="1203" alt="CleanShot 2023-07-06 at 18 24 50@2x" src="https://github.com/expo/expo/assets/10234615/4adf215c-ca8a-4e86-8cb8-cfa01317367a">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
