### PR TITLE
[core] fix incorrect conversion of valid url

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix the `View cannot be cast to ViewGroup` exception on Android. ([#23264](https://github.com/expo/expo/pull/23264) by [@lukmccall](https://github.com/lukmccall))
+- Fix url converions that failed despite receiving a string that contained a valid URL. ([#23331](https://github.com/expo/expo/pull/23331) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix the `View cannot be cast to ViewGroup` exception on Android. ([#23264](https://github.com/expo/expo/pull/23264) by [@lukmccall](https://github.com/lukmccall))
-- Fix url converions that failed despite receiving a string that contained a valid URL. ([#23331](https://github.com/expo/expo/pull/23331) by [@alanhughes](https://github.com/alanjhughes))
+- [iOS] Fix conversion to `URL` type that failed despite receiving a string that contained a valid URL. ([#23331](https://github.com/expo/expo/pull/23331) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -19,8 +19,7 @@ extension URL: Convertible {
 
     // URLComponents parses and constructs URLs according to RFC 3986.
     // For some unusual urls URL(string:) will fail incorrectly
-    let components = URLComponents(string: value)
-    if let components, let url = components.url {
+    if let components = URLComponents(string: value), let url = components.url {
       // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
       return url.scheme != nil ? url : URL(fileURLWithPath: value)
     }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -17,8 +17,10 @@ extension URL: Convertible {
       throw Conversions.ConvertingException<URL>(value)
     }
 
-    // Try to construct the URL object from the string as it came in.
-    if let url = URL(string: value) {
+    // URLComponents parses and constructs URLs according to RFC 3986.
+    // For some unusual urls URL(string:) will fail incorrectly
+    let components = URLComponents(string: value)
+    if let components, let url = components.url {
       // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
       return url.scheme != nil ? url : URL(fileURLWithPath: value)
     }

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -17,11 +17,8 @@ extension URL: Convertible {
       throw Conversions.ConvertingException<URL>(value)
     }
 
-    // URLComponents parses and constructs URLs according to RFC 3986.
-    // For some unusual urls URL(string:) will fail incorrectly
-    if let components = URLComponents(string: value), let url = components.url {
-      // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
-      return url.scheme != nil ? url : URL(fileURLWithPath: value)
+    if let url = convertToUrl(string: value) {
+      return url
     }
 
     // File path doesn't need to be percent-encoded.
@@ -30,8 +27,8 @@ extension URL: Convertible {
     }
 
     // If we get here, the string is not the file url and may require percent-encoding characters that are not URL-safe according to RFC 3986.
-    if let encodedValue = percentEncodeUrlString(value), let url = URL(string: encodedValue) {
-      return url.scheme != nil ? url : URL(fileURLWithPath: value)
+    if let encodedValue = percentEncodeUrlString(value), let url = convertToUrl(string: encodedValue) {
+      return url
     }
 
     // If it still fails to create the URL object, the string possibly contains characters that must be explicitly percent-encoded beforehand.

--- a/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
+++ b/packages/expo-modules-core/ios/Swift/Arguments/Convertibles.swift
@@ -17,6 +17,7 @@ extension URL: Convertible {
       throw Conversions.ConvertingException<URL>(value)
     }
 
+    // First we try to create a URL without extra encoding, as it came.
     if let url = convertToUrl(string: value) {
       return url
     }

--- a/packages/expo-modules-core/ios/Swift/Utilities.swift
+++ b/packages/expo-modules-core/ios/Swift/Utilities.swift
@@ -58,3 +58,13 @@ internal func isFileUrlPath(_ path: String) -> Bool {
   }
   return URL(string: encodedPath)?.scheme == nil
 }
+
+internal func convertToUrl(string value: String) -> URL? {
+  // URLComponents parses and constructs URLs according to RFC 3986.
+  // For some unusual urls URL(string:) will fail incorrectly
+  guard let url = URLComponents(string: value)?.url ?? URL(string: value) else {
+    return nil
+  }
+  // If it has no scheme, we assume it was the file path which needs to be recreated to be recognized as the file url.
+  return url.scheme != nil ? url : URL(fileURLWithPath: value)
+}

--- a/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/ConvertiblesSpec.swift
@@ -71,13 +71,6 @@ class ConvertiblesSpec: ExpoSpec {
         }
       }
 
-      it("throws when url contains percent alone") {
-        // The percent character alone must be percent-encoded to `%25` beforehand, otherwise it should throw an exception.
-        let urlString = "https://expo.dev/?param=%"
-
-        expect({ try URL.convert(from: urlString, appContext: appContext) }).to(throwError(errorType: UrlContainsInvalidCharactersException.self))
-      }
-
       it("converts from url containing the anchor") {
         // The hash is not allowed in the query (requires percent-encoding),
         // but we want it to be recognized as the beginning of the fragment,


### PR DESCRIPTION
# Why
Closes #23282 
Some unusual but valid URLs will fail to be created with `URL(string:)` 
example: https://matrix.to/#/#sh.itjust.works:matrix.org
When this happens the URL is assumed to be a file which then crashes the app once it's passed to the browser

# How
Create the URL with URLComponents which ensures it is [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) compliant. 

# Test Plan
Tested with multiple variations of URL and the one causing the issue. All work correctly.
