### PR TITLE
[docs] Fix: auth context

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -22,47 +22,47 @@ const AuthContext = React.createContext(null);
 
 // This hook can be used to access the user info.
 export function useAuth() {
-	return React.useContext(AuthContext);
+  return React.useContext(AuthContext);
 }
 
 // This hook will protect the route access based on user authentication.
 function useProtectedRoute(user) {
-	const segments = useSegments();
-	const router = useRouter();
+  const segments = useSegments();
+  const router = useRouter();
 
-	React.useEffect(() => {
-		const inAuthGroup = segments[0] === "(auth)";
+  React.useEffect(() => {
+    const inAuthGroup = segments[0] === "(auth)";
 
-		if (
-			// If the user is not signed in and the initial segment is not anything in the auth group.
-			!user &&
-			!inAuthGroup
-		) {
-			// Redirect to the sign-in page.
-			router.replace("/sign-in");
-		} else if (user && inAuthGroup) {
-			// Redirect away from the sign-in page.
-			router.replace("/");
-		}
-	}, [user, segments]);
+    if (
+      // If the user is not signed in and the initial segment is not anything in the auth group.
+      !user &&
+      !inAuthGroup
+    ) {
+      // Redirect to the sign-in page.
+      router.replace("/sign-in");
+    } else if (user && inAuthGroup) {
+      // Redirect away from the sign-in page.
+      router.replace("/");
+    }
+  }, [user, segments]);
 }
 
 export function Provider(props) {
-	const [user, setAuth] = React.useState(null);
+  const [user, setAuth] = React.useState(null);
 
-	useProtectedRoute(user);
+  useProtectedRoute(user);
 
-	return (
-		<AuthContext.Provider
-			value={{
-				signIn: () => setAuth({}),
-				signOut: () => setAuth(null),
-				user,
-			}}
-		>
-			{props.children}
-		</AuthContext.Provider>
-	);
+  return (
+    <AuthContext.Provider
+      value={{
+        signIn: () => setAuth({}),
+        signOut: () => setAuth(null),
+        user,
+      }}
+    >
+      {props.children}
+    </AuthContext.Provider>
+  );
 }
 ```
 

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -15,52 +15,54 @@ Consider the following project:
 First, we'll setup a [React Context provider](https://reactjs.org/docs/context.html) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](/guides/authentication/).
 
 ```js context/auth.js
-import { router, useSegments } from 'expo-router';
-import React from 'react';
+import { useRouter, useSegments } from "expo-router";
+import React from "react";
 
 const AuthContext = React.createContext(null);
 
 // This hook can be used to access the user info.
 export function useAuth() {
-  return React.useContext(AuthContext);
+	return React.useContext(AuthContext);
 }
 
 // This hook will protect the route access based on user authentication.
 function useProtectedRoute(user) {
-  const segments = useSegments();
+	const segments = useSegments();
+	const router = useRouter();
 
-  React.useEffect(() => {
-    const inAuthGroup = segments[0] === '(auth)';
+	React.useEffect(() => {
+		const inAuthGroup = segments[0] === "(auth)";
 
-    if (
-      // If the user is not signed in and the initial segment is not anything in the auth group.
-      !user &&
-      !inAuthGroup
-    ) {
-      // Redirect to the sign-in page.
-      router.replace('/sign-in');
-    } else if (user && inAuthGroup) {
-      // Redirect away from the sign-in page.
-      router.replace('/');
-    }
-  }, [user, segments]);
+		if (
+			// If the user is not signed in and the initial segment is not anything in the auth group.
+			!user &&
+			!inAuthGroup
+		) {
+			// Redirect to the sign-in page.
+			router.replace("/sign-in");
+		} else if (user && inAuthGroup) {
+			// Redirect away from the sign-in page.
+			router.replace("/");
+		}
+	}, [user, segments]);
 }
 
 export function Provider(props) {
-  const [user, setAuth] = React.useState(null);
+	const [user, setAuth] = React.useState(null);
 
-  useProtectedRoute(user);
+	useProtectedRoute(user);
 
-  return (
-    <AuthContext.Provider
-      value={{
-        signIn: () => setAuth({}),
-        signOut: () => setAuth(null),
-        user,
-      }}>
-      {props.children}
-    </AuthContext.Provider>
-  );
+	return (
+		<AuthContext.Provider
+			value={{
+				signIn: () => setAuth({}),
+				signOut: () => setAuth(null),
+				user,
+			}}
+		>
+			{props.children}
+		</AuthContext.Provider>
+	);
 }
 ```
 


### PR DESCRIPTION
# Why
With the code provided in the documentation, there was an error on calling the method "replace" because it was imported router instead of creating a const named router with the "useRouter" hook.

# How

I did this change using the last version of the expo-router doc (now removed from the official website) that I was using in another project

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
