### PR TITLE
[core][go] fix network inspector crash on android expo go

### DIFF
--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt
@@ -2,9 +2,12 @@
 
 package abi49_0_0.expo.modules.kotlin.devtools
 
+import android.util.Log
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
+
+private const val TAG = "ExpoNetworkInspector"
 
 // Currently keeps the delegate fixed for ExpoRequestCdpInterceptor and be thread-safe
 internal val delegate: ExpoNetworkInspectOkHttpInterceptorsDelegate = ExpoRequestCdpInterceptor
@@ -16,19 +19,22 @@ internal val delegate: ExpoNetworkInspectOkHttpInterceptorsDelegate = ExpoReques
 class ExpoNetworkInspectOkHttpNetworkInterceptor : Interceptor {
   override fun intercept(chain: Interceptor.Chain): Response {
     val request = chain.request()
-    val redirectResponse = request.tag(RedirectResponse::class.java)
-    val requestId = redirectResponse?.requestId ?: request.hashCode().toString()
-    delegate.willSendRequest(requestId, request, redirectResponse?.priorResponse)
-
     val response = chain.proceed(request)
+    try {
+      val redirectResponse = request.tag(RedirectResponse::class.java)
+      val requestId = redirectResponse?.requestId ?: request.hashCode().toString()
+      delegate.willSendRequest(requestId, request, redirectResponse?.priorResponse)
 
-    if (response.isRedirect) {
-      response.request.tag(RedirectResponse::class.java)?.let {
-        it.requestId = requestId
-        it.priorResponse = response
+      if (response.isRedirect) {
+        response.request.tag(RedirectResponse::class.java)?.let {
+          it.requestId = requestId
+          it.priorResponse = response
+        }
+      } else {
+        delegate.didReceiveResponse(requestId, request, response)
       }
-    } else {
-      delegate.didReceiveResponse(requestId, request, response)
+    } catch (e: Exception) {
+      Log.e(TAG, "Failed to send network request CDP event", e)
     }
     return response
   }

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix the `View cannot be cast to ViewGroup` exception on Android. ([#23264](https://github.com/expo/expo/pull/23264) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix conversion to `URL` type that failed despite receiving a string that contained a valid URL. ([#23331](https://github.com/expo/expo/pull/23331) by [@alanhughes](https://github.com/alanjhughes))
+- Improved the OkHttp network inspector stability on Android. ([#23350](https://github.com/expo/expo/pull/23350) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

another try to fix the top crash from the network inspector crash: 

```
Fatal Exception: java.lang.IllegalStateException: network interceptor or.c0@2ba75f9 must call proceed() exactly once
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:99)
       at host.exp.exponent.kernel.KernelNetworkInterceptor.okhttpNetworkInterceptorProxy$lambda$1(KernelNetworkInterceptor.kt:42)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at host.exp.exponent.kernel.KernelNetworkInterceptor.okhttpAppInterceptorProxy$lambda$0(KernelNetworkInterceptor.kt:37)
       at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
       at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
       at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:923)
```

# How

my hypothesis is that the [network inspector may crash from some special requests](https://github.com/expo/expo/blob/d71c82f553e3fbb3d6ce7621536aaf191b7577a9/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoNetworkInspectOkHttpInterceptors.kt#L18-L32). the expo-go's `RNObject.call` will return null when receiving `InvocationTargetException`. the KernelNetworkInterceptor will call `chain.proceed()` again and cause the exception.

unfortunately, RNObject does not rethrow exceptions but only return null. this pr only has to catch and log the exception.

# Test Plan

still not find a way to reproduce the crash, just make sure the code change does not break any existing functionalities.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
