### PR TITLE
inserted missing slash so link is no longer broken

### DIFF
--- a/docs/pages/routing/layouts.mdx
+++ b/docs/pages/routing/layouts.mdx
@@ -83,7 +83,7 @@ Groups are also good for organizing sections of the app. In the following exampl
 
 ## Native layouts
 
-One of the best advantages to React Native is being able to use native UI components. Expo Router provides a few drop-in native layouts that you can use to easily achieve familiar native behavior. To change between truly-native layouts on certain platforms and custom layouts on others, see [Platform-specific modules](router/advanced/platform-specific-modules).
+One of the best advantages to React Native is being able to use native UI components. Expo Router provides a few drop-in native layouts that you can use to easily achieve familiar native behavior. To change between truly-native layouts on certain platforms and custom layouts on others, see [Platform-specific modules](/router/advanced/platform-specific-modules).
 
 ```js app/home/_layout.js
 import { Stack } from 'expo-router';


### PR DESCRIPTION
# Why

The old link led to a 404 page: https://docs.expo.dev/routing/router/advanced/platform-specific-modules/

# How

I inserted the missing slash so the internal link is now working

# Test Plan

I built it locally and tested the documentation via http://localhost:3002/routing/layouts/

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
