### PR TITLE
[expo-updates][Android] Correctly handle roll backs in JS module methods

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
+- [Android] Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -263,7 +263,7 @@ class UpdatesModule(
           }
 
           is CheckForUpdateAsyncResult.UpdateAvailable -> {
-            putBoolean("isRollBackToEmbedded", true)
+            putBoolean("isRollBackToEmbedded", false)
             putBoolean("isAvailable", true)
             putString("manifestString", checkForUpdateAsyncResult.updateManifest.manifest.toString())
           }
@@ -295,10 +295,11 @@ class UpdatesModule(
       updatesServiceLocal.stateMachine?.processEvent(UpdatesStateEvent.Download())
       AsyncTask.execute {
         val databaseHolder = updatesServiceLocal.databaseHolder
+        val database = databaseHolder.database
         RemoteLoader(
           context,
           updatesServiceLocal.configuration,
-          databaseHolder.database,
+          database,
           updatesServiceLocal.fileDownloader,
           updatesServiceLocal.directory,
           updatesServiceLocal.launchedUpdate
@@ -348,7 +349,7 @@ class UpdatesModule(
                 RemoteLoader.processSuccessLoaderResult(
                   context,
                   updatesServiceLocal.configuration,
-                  databaseHolder.database,
+                  database,
                   updatesServiceLocal.selectionPolicy,
                   updatesServiceLocal.directory,
                   updatesServiceLocal.launchedUpdate,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -27,7 +27,6 @@ import expo.modules.updates.manifest.UpdateManifest
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
 import expo.modules.updates.UpdatesConfiguration
-import org.json.JSONObject
 /* ktlint-enable no-unused-imports */
 
 /**

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -21,10 +21,13 @@ import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import java.util.Date
+import expo.modules.updates.manifest.EmbeddedManifest
+import expo.modules.updates.manifest.UpdateManifest
 
 // these unused imports must stay because of versioning
 /* ktlint-disable no-unused-imports */
 import expo.modules.updates.UpdatesConfiguration
+import org.json.JSONObject
 /* ktlint-enable no-unused-imports */
 
 /**
@@ -169,42 +172,46 @@ class UpdatesModule(
               val updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective
               val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
 
-              val updateInfo = Bundle()
+              val launchedUpdate = updatesServiceLocal.launchedUpdate
+
               if (updateDirective != null) {
                 if (updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-                  updateInfo.putBoolean("isRollBackToEmbedded", true)
-                  updateInfo.putBoolean("isAvailable", false)
-                  promise.resolve(updateInfo)
-                  updatesServiceLocal.stateMachine?.processEvent(
-                    UpdatesStateEvent.CheckCompleteWithRollback()
-                  )
+                  if (!updatesServiceLocal.configuration.hasEmbeddedUpdate) {
+                    promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.NoUpdateAvailable(), updatesServiceLocal)
+                    return
+                  }
+
+                  val embeddedUpdate = EmbeddedManifest.get(context, updatesServiceLocal.configuration)!!.updateEntity
+                  if (embeddedUpdate == null) {
+                    promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.NoUpdateAvailable(), updatesServiceLocal)
+                    return
+                  }
+
+                  if (!updatesServiceLocal.selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+                      updateDirective,
+                      embeddedUpdate,
+                      launchedUpdate,
+                      updateResponse.responseHeaderData?.manifestFilters
+                    )
+                  ) {
+                    promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.NoUpdateAvailable(), updatesServiceLocal)
+                    return
+                  }
+
+                  promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.RollBackToEmbedded(), updatesServiceLocal)
                   return
                 }
               }
 
               if (updateManifest == null) {
-                updateInfo.putBoolean("isRollBackToEmbedded", false)
-                updateInfo.putBoolean("isAvailable", false)
-                promise.resolve(updateInfo)
-                updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckCompleteUnavailable()
-                )
+                promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.NoUpdateAvailable(), updatesServiceLocal)
                 return
               }
 
-              val launchedUpdate = updatesServiceLocal.launchedUpdate
               if (launchedUpdate == null) {
                 // this shouldn't ever happen, but if we don't have anything to compare
                 // the new manifest to, let the user know an update is available
-                updateInfo.putBoolean("isRollBackToEmbedded", false)
-                updateInfo.putBoolean("isAvailable", true)
-                updateInfo.putString("manifestString", updateManifest.manifest.toString())
-                promise.resolve(updateInfo)
-                updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckCompleteWithUpdate(
-                    updateManifest.manifest.getRawJson()
-                  )
-                )
+                promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.UpdateAvailable(updateManifest), updatesServiceLocal)
                 return
               }
 
@@ -214,22 +221,9 @@ class UpdatesModule(
                   updateResponse.responseHeaderData?.manifestFilters
                 )
               ) {
-                updateInfo.putBoolean("isRollBackToEmbedded", false)
-                updateInfo.putBoolean("isAvailable", true)
-                updateInfo.putString("manifestString", updateManifest.manifest.toString())
-                promise.resolve(updateInfo)
-                updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckCompleteWithUpdate(
-                    updateManifest.manifest.getRawJson()
-                  )
-                )
+                promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.UpdateAvailable(updateManifest), updatesServiceLocal)
               } else {
-                updateInfo.putBoolean("isRollBackToEmbedded", false)
-                updateInfo.putBoolean("isAvailable", false)
-                promise.resolve(updateInfo)
-                updatesServiceLocal.stateMachine?.processEvent(
-                  UpdatesStateEvent.CheckCompleteUnavailable()
-                )
+                promise.resolveWithCheckForUpdateAsyncResult(CheckForUpdateAsyncResult.NoUpdateAvailable(), updatesServiceLocal)
               }
             }
           }
@@ -241,6 +235,51 @@ class UpdatesModule(
         "The updates module controller has not been properly initialized. If you're using a development client, you cannot check for updates. Otherwise, make sure you have called the native method UpdatesController.initialize()."
       )
     }
+  }
+
+  private sealed class CheckForUpdateAsyncResult(private val status: Status) {
+    private enum class Status {
+      NO_UPDATE_AVAILABLE,
+      UPDATE_AVAILABLE,
+      ROLL_BACK_TO_EMBEDDED
+    }
+
+    class NoUpdateAvailable : CheckForUpdateAsyncResult(Status.NO_UPDATE_AVAILABLE)
+    class UpdateAvailable(val updateManifest: UpdateManifest) : CheckForUpdateAsyncResult(Status.UPDATE_AVAILABLE)
+    class RollBackToEmbedded : CheckForUpdateAsyncResult(Status.ROLL_BACK_TO_EMBEDDED)
+  }
+
+  private fun Promise.resolveWithCheckForUpdateAsyncResult(checkForUpdateAsyncResult: CheckForUpdateAsyncResult, updatesServiceLocal: UpdatesInterface) {
+    resolve(
+      Bundle().apply {
+        when (checkForUpdateAsyncResult) {
+          is CheckForUpdateAsyncResult.NoUpdateAvailable -> {
+            putBoolean("isRollBackToEmbedded", false)
+            putBoolean("isAvailable", false)
+          }
+
+          is CheckForUpdateAsyncResult.RollBackToEmbedded -> {
+            putBoolean("isRollBackToEmbedded", true)
+            putBoolean("isAvailable", false)
+          }
+
+          is CheckForUpdateAsyncResult.UpdateAvailable -> {
+            putBoolean("isRollBackToEmbedded", true)
+            putBoolean("isAvailable", true)
+            putString("manifestString", checkForUpdateAsyncResult.updateManifest.manifest.toString())
+          }
+        }
+      }
+    )
+    updatesServiceLocal.stateMachine?.processEvent(
+      when (checkForUpdateAsyncResult) {
+        is CheckForUpdateAsyncResult.NoUpdateAvailable -> UpdatesStateEvent.CheckCompleteUnavailable()
+        is CheckForUpdateAsyncResult.RollBackToEmbedded -> UpdatesStateEvent.CheckCompleteWithRollback()
+        is CheckForUpdateAsyncResult.UpdateAvailable -> UpdatesStateEvent.CheckCompleteWithUpdate(
+          checkForUpdateAsyncResult.updateManifest.manifest.getRawJson()
+        )
+      }
+    )
   }
 
   @ExpoMethod
@@ -294,7 +333,8 @@ class UpdatesModule(
                   )
                 }
 
-                val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
+                val updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest
+                  ?: return Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = false)
 
                 return Loader.OnUpdateResponseLoadedResult(
                   shouldDownloadManifestIfPresentInResponse = updatesServiceLocal.selectionPolicy.shouldLoadNewUpdate(
@@ -306,44 +346,59 @@ class UpdatesModule(
               }
 
               override fun onSuccess(loaderResult: Loader.LoaderResult) {
-                databaseHolder.releaseDatabase()
-                val updateInfo = Bundle()
+                RemoteLoader.processSuccessLoaderResult(
+                  context,
+                  updatesServiceLocal.configuration,
+                  databaseHolder.database,
+                  updatesServiceLocal.selectionPolicy,
+                  updatesServiceLocal.directory,
+                  updatesServiceLocal.launchedUpdate,
+                  loaderResult
+                ) { availableUpdate, didRollBackToEmbedded ->
+                  databaseHolder.releaseDatabase()
 
-                if (loaderResult.updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
-                  updateInfo.putBoolean("isRollBackToEmbedded", true)
-                  updateInfo.putBoolean("isNew", false)
-
-                  updatesServiceLocal.stateMachine?.processEvent(
-                    UpdatesStateEvent.DownloadCompleteWithRollback()
-                  )
-                } else {
-                  updateInfo.putBoolean("isRollBackToEmbedded", false)
-
-                  if (loaderResult.updateEntity == null) {
-                    updateInfo.putBoolean("isNew", false)
+                  if (didRollBackToEmbedded) {
+                    promise.resolve(
+                      Bundle().apply {
+                        putBoolean("isRollBackToEmbedded", true)
+                        putBoolean("isNew", false)
+                      }
+                    )
                     updatesServiceLocal.stateMachine?.processEvent(
-                      UpdatesStateEvent.DownloadComplete()
+                      UpdatesStateEvent.DownloadCompleteWithRollback()
                     )
                   } else {
-                    updatesServiceLocal.resetSelectionPolicy()
-                    updateInfo.putBoolean("isNew", true)
+                    if (availableUpdate == null) {
+                      promise.resolve(
+                        Bundle().apply {
+                          putBoolean("isRollBackToEmbedded", false)
+                          putBoolean("isNew", false)
+                        }
+                      )
+                      updatesServiceLocal.stateMachine?.processEvent(
+                        UpdatesStateEvent.DownloadComplete()
+                      )
+                    } else {
+                      updatesServiceLocal.resetSelectionPolicy()
 
-                    // We need the explicit casting here because when in versioned expo-updates,
-                    // the UpdateEntity and UpdatesModule are in different package namespace,
-                    // Kotlin cannot do the smart casting for that case.
-                    val updateEntity = loaderResult.updateEntity as UpdateEntity
+                      // We need the explicit casting here because when in versioned expo-updates,
+                      // the UpdateEntity and UpdatesModule are in different package namespace,
+                      // Kotlin cannot do the smart casting for that case.
+                      val updateEntity = loaderResult.updateEntity as UpdateEntity
 
-                    updateInfo.putString(
-                      "manifestString",
-                      updateEntity.manifest.toString()
-                    )
-                    updatesServiceLocal.stateMachine?.processEvent(
-                      UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest!!)
-                    )
+                      promise.resolve(
+                        Bundle().apply {
+                          putBoolean("isRollBackToEmbedded", false)
+                          putBoolean("isNew", true)
+                          putString("manifestString", updateEntity.manifest.toString())
+                        }
+                      )
+                      updatesServiceLocal.stateMachine?.processEvent(
+                        UpdatesStateEvent.DownloadCompleteWithUpdate(updateEntity.manifest!!)
+                      )
+                    }
                   }
                 }
-
-                promise.resolve(updateInfo)
               }
             }
           )

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -1,12 +1,16 @@
 package expo.modules.updates.loader
 
 import android.content.Context
+import android.util.Log
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.FileDownloader.AssetDownloadCallback
 import expo.modules.updates.loader.FileDownloader.RemoteUpdateDownloadCallback
+import expo.modules.updates.manifest.EmbeddedManifest
+import expo.modules.updates.manifest.ManifestMetadata
+import expo.modules.updates.selectionpolicy.SelectionPolicy
 import java.io.File
 
 /**
@@ -61,5 +65,93 @@ class RemoteLoader internal constructor(
 
   companion object {
     private val TAG = RemoteLoader::class.java.simpleName
+
+    fun processSuccessLoaderResult(
+      context: Context,
+      configuration: UpdatesConfiguration,
+      database: UpdatesDatabase,
+      selectionPolicy: SelectionPolicy,
+      directory: File?,
+      launchedUpdate: UpdateEntity?,
+      loaderResult: LoaderResult,
+      onComplete: (availableUpdate: UpdateEntity?, didRollBackToEmbedded: Boolean) -> Unit
+    ) {
+      val updateEntity = loaderResult.updateEntity
+      val updateDirective = loaderResult.updateDirective
+
+      if (updateDirective != null && updateDirective is UpdateDirective.RollBackToEmbeddedUpdateDirective) {
+        processRollBackToEmbeddedDirective(context, configuration, database, selectionPolicy, directory, launchedUpdate, updateDirective) { didRollBackToEmbedded ->
+          onComplete(null, didRollBackToEmbedded)
+        }
+      } else {
+        onComplete(updateEntity, false)
+      }
+    }
+
+    /**
+     * If directive is to roll-back to the embedded update and there is an embedded update,
+     * we need to update embedded update in the DB with the newer commitTime from the directive
+     * so that the selection policy will choose it. That way future updates can continue to be applied
+     * over this roll back, but older ones won't.
+     */
+    private fun processRollBackToEmbeddedDirective(
+      context: Context,
+      configuration: UpdatesConfiguration,
+      database: UpdatesDatabase,
+      selectionPolicy: SelectionPolicy,
+      directory: File?,
+      launchedUpdate: UpdateEntity?,
+      updateDirective: UpdateDirective.RollBackToEmbeddedUpdateDirective,
+      onComplete: (didRollBackToEmbedded: Boolean) -> Unit
+    ) {
+      if (!configuration.hasEmbeddedUpdate) {
+        onComplete(false)
+        return
+      }
+
+      val embeddedUpdate = EmbeddedManifest.get(context, configuration)!!.updateEntity
+      if (embeddedUpdate == null) {
+        onComplete(false)
+        return
+      }
+
+      val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
+      if (!selectionPolicy.shouldLoadRollBackToEmbeddedDirective(updateDirective, embeddedUpdate, launchedUpdate, manifestFilters)) {
+        onComplete(false)
+        return
+      }
+
+      // update the embedded update commit time in the in-memory embedded update since it is a singleton
+      embeddedUpdate.commitTime = updateDirective.commitTime
+
+      // update the embedded update commit time in the database (requires loading and then updating)
+      EmbeddedLoader(context, configuration, database, directory).start(object : LoaderCallback {
+        /**
+         * This should never happen since we check for the embedded update above
+         */
+        override fun onFailure(e: Exception) {
+          Log.e(TAG, "Embedded update erroneously null when applying roll back to embedded directive", e)
+          onComplete(false)
+        }
+
+        override fun onSuccess(loaderResult: Loader.LoaderResult) {
+          val embeddedUpdateToLoad = loaderResult.updateEntity
+          database.updateDao().setUpdateCommitTime(embeddedUpdateToLoad!!, updateDirective.commitTime)
+          onComplete(true)
+        }
+
+        override fun onAssetLoaded(
+          asset: AssetEntity,
+          successfulAssetCount: Int,
+          failedAssetCount: Int,
+          totalAssetCount: Int
+        ) {
+        }
+
+        override fun onUpdateResponseLoaded(updateResponse: UpdateResponse): OnUpdateResponseLoadedResult {
+          return OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+        }
+      })
+    }
   }
 }


### PR DESCRIPTION
# Why

This fixes the behavior of roll back to embedded update in the JS module methods `checkForUpdateAsync` and `fetchUpdateAsync`.

Previously these didn't take into account selection policy or 

# How

For `checkForUpdateAsync`: add logic to check against selection policy to know whether a roll back is apply-able
For `fetchUpdateAsync`: Factor out logic that applies the roll back (sets the commit time of the embedded update in the DB to that of the roll back directive). Call it from both the LoaderTask (previous location of the logic) and this method which also applies the update.

# Test Plan

Create a test app that prints the result of `checkForUpdateAsync` and `fetchUpdateAsync`. Ensure that when a roll back is committed after a embedded update, the roll back applies and the two methods return the correct result. Ensure that when an embedded update is newer but the old roll back is still the latest update that RemoteLoader downloads, both methods return the correct result.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
