### PR TITLE
[docs] Update broken link in Expo Router installation docs

### DIFF
--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -117,7 +117,7 @@ The above command will install versions of these libraries that are compatible w
 
 ### Modify project configuration
 
-Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#web-support-how) in your app config (**app.json** or **app.config.js**):
+Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) in your app config (**app.json** or **app.config.js**):
 
 ```diff
 {


### PR DESCRIPTION
# Why

The anchor for the Metro Web link didn't exist (anymore).

# How

Updated the anchor as per @EvanBacon's recommendation.

# Test Plan

Run docs, click link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
