### PR TITLE
[docs] specify explicit SDK version in router install docs

### DIFF
--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -19,7 +19,7 @@ Find the steps below to create a new project with Expo Router library or add it 
 
 We recommend creating a new Expo app using `create-expo-app`. This will create a minimal project with the Expo Router library already installed. To create a project, run the command:
 
-<Terminal cmd={['$ npx create-expo-app@latest --template tabs']} />
+<Terminal cmd={['$ npx create-expo-app@latest --template tabs@49']} />
 
 </Step>
 


### PR DESCRIPTION
# Why

Because the templates are still on SDK 48 because of upstream issues, it might make sense to be explicit in using the SDK 49 version of the templates for now.

This can be reverted when the debugging issues are fixed.

# How

Added template version to installation instructions.

# Test Plan

Ran command locally to verify it's correctness.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
