### PR TITLE
[cli][inspector-proxy] fix devtools websocket connection on windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed opening browser on Windows when debugging or opening Metro web. ([#23287](https://github.com/expo/expo/pull/23287) by [@byCedric](https://github.com/byCedric))
+- Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/proxy.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/inspector-proxy/__tests__/proxy.test.ts
@@ -234,6 +234,46 @@ it('keeps debugger connection alive when device reconnects', async () => {
   }
 });
 
+describe('ExpoInspectorProxy.normalizeServerAddress', () => {
+  it('should return address in `{address}:{port}` format - IPv4', () => {
+    expect(
+      ExpoProxy.normalizeServerAddress({ address: '1.2.3.4', family: 'IPv4', port: 8081 })
+    ).toBe('1.2.3.4:8081');
+  });
+
+  it('should return address in `[{address}]:{port}` format - IPv6', () => {
+    expect(
+      ExpoProxy.normalizeServerAddress({
+        address: '2001:1:2:3:4:5:6:7',
+        family: 'IPv6',
+        port: 8082,
+      })
+    ).toBe('[2001:1:2:3:4:5:6:7]:8082');
+  });
+
+  it('should return default loopback `localhost:{port}` address when IPv4 server address is 0.0.0.0', () => {
+    expect(
+      ExpoProxy.normalizeServerAddress({ address: '0.0.0.0', family: 'IPv4', port: 8081 })
+    ).toBe('localhost:8081');
+  });
+
+  it('should return default loopback `[::1]:{port}` address when IPv6 server address is `::`', () => {
+    expect(ExpoProxy.normalizeServerAddress({ address: '::', family: 'IPv6', port: 8082 })).toBe(
+      '[::1]:8082'
+    );
+  });
+
+  it('should throw error when given an invalid address', () => {
+    expect(() => {
+      ExpoProxy.normalizeServerAddress(null);
+    }).toThrow();
+
+    expect(() => {
+      ExpoProxy.normalizeServerAddress('string is not a valid address');
+    }).toThrow();
+  });
+});
+
 function createTestProxy() {
   class ExpoDevice {
     constructor(


### PR DESCRIPTION
# Why

fixes #23332
close ENG-9233

# How

windows does not support `0.0.0.0` or `[::]` as loopback address. in these case, we should fallback to `localhost` or `[::1]`.

# Test Plan

test devtools on windows

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
