### PR TITLE
[blur][Android] Add BlurModule to ExperiencePackagePicker

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -7,6 +7,7 @@ import expo.modules.backgroundfetch.BackgroundFetchPackage
 import expo.modules.barcodescanner.BarCodeScannerModule
 import expo.modules.barcodescanner.BarCodeScannerPackage
 import expo.modules.battery.BatteryPackage
+import expo.modules.blur.BlurModule
 import expo.modules.brightness.BrightnessModule
 import expo.modules.calendar.CalendarPackage
 import expo.modules.camera.CameraViewModule
@@ -113,6 +114,7 @@ object ExperiencePackagePicker : ModulesProvider {
 
   override fun getModulesList(): List<Class<out Module>> = listOf(
     BarCodeScannerModule::class.java,
+    BlurModule::class.java,
     CameraViewModule::class.java,
     CellularModule::class.java,
     ClipboardModule::class.java,

--- a/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/android/versioned-abis/expoview-abi49_0_0/src/main/java/abi49_0_0/host/exp/exponent/ExperiencePackagePicker.kt
@@ -7,6 +7,7 @@ import abi49_0_0.expo.modules.backgroundfetch.BackgroundFetchPackage
 import abi49_0_0.expo.modules.barcodescanner.BarCodeScannerModule
 import abi49_0_0.expo.modules.barcodescanner.BarCodeScannerPackage
 import abi49_0_0.expo.modules.battery.BatteryPackage
+import abi49_0_0.expo.modules.blur.BlurModule
 import abi49_0_0.expo.modules.brightness.BrightnessModule
 import abi49_0_0.expo.modules.calendar.CalendarPackage
 import abi49_0_0.expo.modules.camera.CameraViewModule
@@ -113,6 +114,7 @@ object ExperiencePackagePicker : ModulesProvider {
 
   override fun getModulesList(): List<Class<out Module>> = listOf(
     BarCodeScannerModule::class.java,
+    BlurModule::class.java,
     CameraViewModule::class.java,
     CellularModule::class.java,
     ClipboardModule::class.java,


### PR DESCRIPTION
# Why

There was no BlurModule in the ExperiencePackagePicker, because of this `BlurView` doesn't work in Expo Go.

# How

Added BlurModule to the getModulesList() in ExperiencePackagePicker

# Test Plan

Tested on versioned and unversioned expo go builds

