### PR TITLE
[docs] Update upgrading-expo-sdk-walkthrough.mdx

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -8,6 +8,10 @@ description: Learn how to incrementally upgrade the Expo SDK version in your pro
 Expo maintains ~6 months of backward compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo Go app.
 However, you will still be able to publish updates via `eas update`, and build using `eas build`. Deprecations **will not** affect standalone apps you have in production.
 
+## SDK 49
+
+[Blog Post](https://blog.expo.dev/expo-sdk-49-c6d398cdf740)
+
 ## SDK 48
 
 [Blog Post](https://blog.expo.dev/expo-sdk-48-ccb8302e231)
@@ -16,7 +20,7 @@ However, you will still be able to publish updates via `eas update`, and build u
 
 [Blog Post](https://blog.expo.dev/expo-sdk-47-a0f6f5c038af)
 
-## SDK 46
+## SDK 46 [DEPRECATED]
 
 [Blog Post](https://blog.expo.dev/expo-sdk-46-c2a1655f63f7)
 


### PR DESCRIPTION
[docs] Upgrade expo SDK walkthrough docs to the latest version

# Why

The docs need to upgrade

# How

The latest blog post about upgrading Expo was been added to the docs and Expo SDK 46 based on "~6 months of backward compatibility" was DEPRECATED

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
