### PR TITLE
[docs] Fix internal links

### DIFF
--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -37,5 +37,5 @@ Debugging errors is one of the most frustrating but satisfying parts of developm
 <BoxLink
   title="Debugging"
   description="Learn about different techniques available to debug runtime issues in your Expo project."
-  href="/debugging/runtime-issue"
+  href="/debugging/runtime-issues"
 />

--- a/docs/pages/debugging/index.js
+++ b/docs/pages/debugging/index.js
@@ -1,3 +1,3 @@
 import redirect from '~/common/redirect';
 
-export default redirect('/debugging/runtime-issue/');
+export default redirect('/debugging/runtime-issues/');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, at two places we refer outdated link for Debugging > Runtime issues guide.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix the link to `/debugging/runtime-issues/`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit: https://docs.expo.dev/debugging/errors-and-warnings/ & then click the BoxLink in the Next step.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
