### PR TITLE
[docs] Format docs in Expo account section 

### DIFF
--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -1,5 +1,6 @@
 ---
-title: Account Types
+title: Account types
+description: Learn about the different types of Expo accounts and how to use them.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
@@ -10,7 +11,7 @@ An Expo account is a container that holds Expo projects and allows for different
 
 When you [sign up for an account](https://expo.dev/signup) with Expo, a Personal Account is automatically created for you. This account is a good place to work on your personal projects.
 
-> **warning** You must not share authentication credentials for your Personal Account with anyone for any reason.
+> **warning** Do not share authentication credentials for your Personal Account with anyone for any reason.
 
 ## Organizations
 
@@ -28,7 +29,7 @@ It may be useful to create an Organization when:
 - Structuring projects for different contexts. For example, when working for different clients, a new organization may be created for each client.
 - Sharing an [EAS Subscription](/eas/).
 
-### Creating new Organizations
+### Create new organizations
 
 If you are logged in to your Personal Account, you can create a new Organization from the dashboard:
 
@@ -51,7 +52,7 @@ If you are logged in to your Personal Account, you can create a new Organization
 
 After creating a new Organization, you are redirected to the new dashboard page for the organization. To associate a new project with the Organization, you have to add the [Owner key](/versions/latest/config/app/#owner) under the `"expo"` key to your project's **app.json**.
 
-### Converting Personal Accounts into Organizations
+### Convert Personal Accounts into Organizations
 
 You can convert your Personal Account into an Organization when you want to share access to projects with other members and assign each member a role-based privilege.
 
@@ -77,7 +78,7 @@ The example below is Step 3 in the conversion process on a Personal Account with
 
 After completing the conversion process, you will no longer be able to log in as your old user. To continue using Expo services, log into [expo.dev](https://expo.dev/) with the user you selected or created during the conversion process. Then, select the organization from the top left dropdown to access the organization.
 
-### Inviting members
+### Invite members
 
 Other Expo users can be invited to join your Organization. To invite a new member:
 
@@ -98,7 +99,7 @@ When inviting a new member, keep in mind:
 - Members with an Owner role can grant members and invitees any role.
 - Members with an Admin role can only give members and invitees up to and including Admin role (every role but Owner).
 
-### Renaming an Account
+### Rename an Account
 
 Accounts can be renamed a limited number of times. Only Owners can rename accounts. To rename an account, visit [the account settings](https://expo.dev/accounts/[account]/settings) and follow the steps under [Rename Account](https://expo.dev/accounts/[account]/settings#rename-account).
 
@@ -112,7 +113,7 @@ Accounts can be renamed a limited number of times. Only Owners can rename accoun
 
 After renaming an account, new publishes to projects within the account must be on Expo SDK 43 or above.
 
-### Transferring projects between Accounts
+### Transfer projects between Accounts
 
 Projects can be transferred a limited number of times. A user must be an Owner or Admin on both source and destination accounts to transfer projects between them. Visit [the project settings page](https://expo.dev/accounts/[account]/projects/[project]/settings) and follow the steps under Transfer project.
 

--- a/docs/pages/accounts/account-types.mdx
+++ b/docs/pages/accounts/account-types.mdx
@@ -29,7 +29,7 @@ It may be useful to create an Organization when:
 - Structuring projects for different contexts. For example, when working for different clients, a new organization may be created for each client.
 - Sharing an [EAS Subscription](/eas/).
 
-### Create new organizations
+### Create new Organizations
 
 If you are logged in to your Personal Account, you can create a new Organization from the dashboard:
 

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -1,8 +1,9 @@
 ---
 title: Programmatic Access
+description: Learn about types of access tokens and how to use them.
 ---
 
-When setting up CI or writing a script to help manage your projects, we recommend avoiding using your username and password to authenticate. With these credentials, anyone would be able to log in and use your account.
+When setting up CI or writing a script to help manage your projects, we recommend avoiding using your username and password to authenticate. With these credentials, anyone will be able to log in and use your account.
 
 Instead of providing credentials, you can generate tokens that will allow you to manage each integration point separately. Anyone who has access to these tokens will be able to perform actions against your account. Please treat them with the same care as a user password. In case something is leaked, you can revoke these tokens to block access.
 
@@ -10,11 +11,11 @@ Instead of providing credentials, you can generate tokens that will allow you to
 
 You can create Personal Access Tokens from the [Access Tokens page](https://expo.dev/settings/access-tokens) on your dashboard. Anyone with this token can perform actions on your behalf. That applies to all content on your Personal Account, as well as any Personal Accounts or Organizations that you have been granted access to.
 
-## Bot Users & Access Tokens
+## Bot Users and Access Tokens
 
 Accounts can create Bot Users to take actions on resources owned by the Account. Bot Users can be assigned [a role](/accounts/working-together) to limit the actions they are authorized to perform. Bot users cannot sign in to any Expo products, cannot own any projects themselves, and can only authenticate via an access token.
 
-## Using Access Tokens
+## Access Tokens usage
 
 You can use any tokens you have created to perform actions with the Expo CLI (other than signing in and out). To use tokens, you need to define an environment variable, like `EXPO_TOKEN="token"`, before running commands.
 
@@ -26,6 +27,6 @@ Common situations where access tokens are useful:
 - Renew a token to keep it as secure as possible; no need to reset your password and sign out of all sessions
 - Give someone (or a script) one-time access to your project with limited permissions
 
-## Revoking Access Tokens
+## Revoke Access Tokens
 
 In case a token was accidentally leaked, you can revoke it without changing your username and password. When you revoke the access token, you block all access to your account using this token. To do this, go to the [Access Token page](https://expo.dev/settings/access-tokens) on your dashboard and delete the token you want to revoke.

--- a/docs/pages/accounts/programmatic-access.mdx
+++ b/docs/pages/accounts/programmatic-access.mdx
@@ -1,5 +1,5 @@
 ---
-title: Programmatic Access
+title: Programmatic access
 description: Learn about types of access tokens and how to use them.
 ---
 

--- a/docs/pages/accounts/two-factor.mdx
+++ b/docs/pages/accounts/two-factor.mdx
@@ -1,18 +1,19 @@
 ---
 title: Two-Factor Authentication
+description: Learn about how you leverage two-factor authentication (2FA) to secure your Expo account.
 ---
 
 Two-factor authentication provides an extra layer of security when logging in to expo.dev, the Expo Go app, and command line tools. With two-factor authentication enabled, you will need to provide a short-lived code in addition to your username and password to access your account.
 
-## Enabling Two-Factor Authentication (2FA)
+## Enable two-factor authentication (2FA)
 
 You can enable two-factor authentication from your [personal account settings](https://expo.dev/settings#two-factor-auth).
 
-## Two-Factor Authentication Methods
+## Two-factor authentication methods
 
 You can receive 2FA codes through an authenticator app.
 
-### Authenticator Apps
+### Authenticator apps
 
 Expo accepts any authenticator app that supports Time-based One-time Passwords (TOTP) including:
 
@@ -24,13 +25,13 @@ Expo accepts any authenticator app that supports Time-based One-time Passwords (
 
 Expo will provide a QR code to scan with your authenticator app during setup. The app will provide a confirmation code to enter on Expo. Enter the code to finish activating 2FA via your authenticator app.
 
-### SMS Messages
+### SMS messages
 
 > **warning** **Deprecated:** SMS is no longer supported for newly-added two-factor authentication methods. Existing SMS two-factor authentication methods will continue to work, though we suggest switching to an authenticator app as it provides better security.
 
 Provide a mobile phone number to receive a short-lived token via SMS. Codes received via SMS will be valid for at least 10 minutes, so you may receive the same code multiple times within this window. If you set an SMS device as your default 2FA method, you will be sent a verification code automatically whenever you take an action that requires a 2FA code.
 
-### Recovery Codes
+### Recovery codes
 
 When you set up two-factor authentication for your account, you'll receive a set of recovery codes. These codes can be used instead of a one-time password if you lose access to your authenticator app or SMS device. Keep in mind that each recovery code is only valid for one use.
 
@@ -38,7 +39,7 @@ If you selected the option to download your recovery codes at the time they were
 
 > Store your recovery codes in a secure and memorable place to ensure you, and only you can access your account!
 
-## Changing Your Two-Factor Settings
+## Change your two-Factor settings
 
 You can make changes to your two-factor settings from your [personal account settings](https://expo.dev/settings). You can:
 
@@ -49,16 +50,16 @@ You can make changes to your two-factor settings from your [personal account set
 
 You will need to provide a one-time password to make any changes to your 2FA settings.
 
-## Recovering Your Account
+## Recover your account
 
-### Recovery Codes
+### Recovery codes
 
 When you set up your account to use 2FA, Expo provides you with a list of recovery codes. In the event you lose your device(s), a recovery code may be used in place of a one-time password. Each of these codes may only be used once. You may regenerate your recovery codes, which will invalidate any existing codes, from your [personal account settings](https://expo.dev/settings/).
 
-### Secondary 2FA Methods
+### Secondary 2FA methods
 
 By setting up multiple authentication methods associated with different physical devices, you can ensure you will not lose access to your account in the event a device is reset or lost.
 
-### Manual Recovery
+### Manual recovery
 
 If you cannot access your account through any of the supplied methods, you may email Expo support from the email associated with your account. Unfortunately, we cannot guarantee we will be able to restore your access to your account in this scenario.

--- a/docs/pages/accounts/two-factor.mdx
+++ b/docs/pages/accounts/two-factor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Two-Factor Authentication
+title: Two-factor authentication
 description: Learn about how you leverage two-factor authentication (2FA) to secure your Expo account.
 ---
 

--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -1,26 +1,27 @@
 ---
 title: Work Together
+description: Learn how to work with other developers on Expo projects.
 ---
 
 You can grant other users access to the projects belonging to your Personal Account or Organizations. The type of access depends on the granted role.
 
-## Adding Members
+## Add members
 
 You can invite new members to your Personal Account, or any account you administrate, from the [Members page](https://expo.dev/settings/members) in your dashboard. You can only add users with Expo accounts as members; you can direct them to [https://expo.dev/signup](https://expo.dev/signup) if they don't have an account yet. You may have up to 100 members and pending invitations combined for a single account.
 
 > When adding new developers to your projects, who are publishing updates or create new builds, make sure to add the [`owner`](../versions/latest/config/app.mdx#owner) property to your project's app config.
 
-## Managing Access
+## Manage access
 
 Access for members is managed through a role-based system. Users can have the _owner_, _admin_, _developer_, or _viewer_ role within Personal Accounts.
 
-| Role          | Description                                                                                                                                           |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Owner**     | Can take any action on an account or any projects, including deleting them. (Note: the Owner role is not available on your Personal Account)          |
-| **Admin**     | Can control most settings on your account, including signing up for paid services, change permissions of other users, and manage programmatic access. |
-| **Developer** | Can create new projects, make new builds, release updates, and manage credentials.                                                                    |
-| **Viewer**    | Can only view your projects through Expo Go, but can't modify your projects in any way.                                                               |
+| Role          | Description                                                                                                                                               |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Owner**     | Can take any action on an account or any projects, including deleting them. (Note: the Owner role is not available on your Personal Account)              |
+| **Admin**     | Can control most settings on your account, including signing up for paid services, changing permissions of other users, and managing programmatic access. |
+| **Developer** | Can create new projects, make new builds, release updates, and manage credentials.                                                                        |
+| **Viewer**    | Can only view your projects through Expo Go, but can't modify your projects in any way.                                                                   |
 
-## Removing members
+## Remove members
 
 To remove members, go to the [Members](https://expo.dev/settings/members) page and revoke access.

--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -1,5 +1,5 @@
 ---
-title: Work Together
+title: Work together
 description: Learn how to work with other developers on Expo projects.
 ---
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -45,7 +45,7 @@ If you haven't done this yet, please refer to the [Creating your first build](se
 
 Next, we need to ensure that we can authenticate ourselves on CI as the owner of the app. This is possible by storing a personal access token in the `EXPO_TOKEN` environment variable in the CI settings.
 
-See [the guide for personal access tokens](/accounts/programmatic-access.mdx#personal-account-personal-access-tokens) to learn how to create access tokens.
+See [personal access tokens](/accounts/programmatic-access/#personal-access-tokens) to learn how to create access tokens.
 
 ### Trigger new builds
 

--- a/docs/pages/distribution/app-transfers.mdx
+++ b/docs/pages/distribution/app-transfers.mdx
@@ -11,7 +11,7 @@ There are two different representations of your app to consider when handing ove
 <BoxLink
   title="EAS project transfers"
   description="Transfer an EAS project to a different Expo account."
-  href="/accounts/account-types/#transferring-projects-between-accounts"
+  href="/accounts/account-types/#transfer-projects-between-accounts"
 />
 
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

While working on Guides organization, I found pages under Expo account section do not exactly follow sentence case usage for [section headings from our writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#headings).

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Use sentence case for section headings
- Fix inaccurate usage of verb at different places
- Use short form instead of gerunds for section headings and page titles

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/accounts/account-types/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
