### PR TITLE
[expo-updates][iOS] Correctly handle roll backs in JS module methods

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
-- [Android] Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356) by [@wschurman](https://github.com/wschurman))
+- Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -125,4 +125,104 @@ internal final class RemoteAppLoader: AppLoader {
       }
     }
   }
+
+  static func processSuccessLoaderResult(
+    config: UpdatesConfig,
+    database: UpdatesDatabase,
+    selectionPolicy: SelectionPolicy,
+    launchedUpdate: Update?,
+    directory: URL,
+    loaderTaskQueue: DispatchQueue,
+    updateResponse: UpdateResponse?,
+    priorError: Error?,
+    onComplete: @escaping (_ updateToLaunch: Update?, _ error: Error?, _ didRollBackToEmbedded: Bool) -> Void
+  ) {
+    let updateBeingLaunched = updateResponse?.manifestUpdateResponsePart?.updateManifest
+
+    if let rollBackDirective = updateResponse?.directiveUpdateResponsePart?.updateDirective as? RollBackToEmbeddedUpdateDirective {
+      self.processRollBackToEmbeddedDirective(
+        config: config,
+        database: database,
+        selectionPolicy: selectionPolicy,
+        launchedUpdate: launchedUpdate,
+        directory: directory,
+        loaderTaskQueue: loaderTaskQueue,
+        rollBackDirective: rollBackDirective,
+        manifestFilters: updateResponse?.responseHeaderData?.manifestFilters,
+        priorError: priorError,
+        onComplete: onComplete
+      )
+    } else {
+      onComplete(updateBeingLaunched, priorError, false)
+    }
+  }
+
+  /**
+   * If directive is to roll-back to the embedded update and there is an embedded update,
+   * we need to update embedded update in the DB with the newer commitTime from the message so that
+   * the selection policy will choose it. That way future updates can continue to be applied
+   * over this roll back, but older ones won't.
+   * The embedded update is guaranteed to be in the DB from the earlier [EmbeddedAppLoader] call in this task.
+   */
+  private static func processRollBackToEmbeddedDirective(
+    config: UpdatesConfig,
+    database: UpdatesDatabase,
+    selectionPolicy: SelectionPolicy,
+    launchedUpdate: Update?,
+    directory: URL,
+    loaderTaskQueue: DispatchQueue,
+    rollBackDirective: RollBackToEmbeddedUpdateDirective,
+    manifestFilters: [String: Any]?,
+    priorError: Error?,
+    onComplete: @escaping (_ updateToLaunch: Update?, _ error: Error?, _ didRollBackToEmbedded: Bool) -> Void
+  ) {
+    if !config.hasEmbeddedUpdate {
+      onComplete(nil, priorError, false)
+      return
+    }
+
+    guard let embeddedManifest = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database) else {
+      onComplete(nil, priorError, false)
+      return
+    }
+
+    if !selectionPolicy.shouldLoadRollBackToEmbeddedDirective(
+      rollBackDirective,
+      withEmbeddedUpdate: embeddedManifest,
+      launchedUpdate: launchedUpdate,
+      filters: manifestFilters
+    ) {
+      onComplete(nil, priorError, false)
+      return
+    }
+
+    // update the embedded update commit time in the in-memory embedded update since it is a singleton
+    embeddedManifest.commitTime = rollBackDirective.commitTime
+
+    EmbeddedAppLoader(
+      config: config,
+      database: database,
+      directory: directory,
+      launchedUpdate: nil,
+      completionQueue: loaderTaskQueue
+    ).loadUpdateResponseFromEmbeddedManifest(
+      withCallback: { _ in
+        return true
+      }, asset: { _, _, _, _ in
+      }, success: { updateResponse in
+        do {
+          let update = updateResponse?.manifestUpdateResponsePart?.updateManifest
+          // do this synchronously as it is needed to launch, and we're already on a background dispatch queue so no UI will be blocked
+          try database.databaseQueue.sync {
+            try database.setUpdateCommitTime(rollBackDirective.commitTime, onUpdate: update!)
+          }
+          onComplete(update, priorError, true)
+        } catch {
+          onComplete(nil, error, false)
+        }
+      }, error: { embeddedLoaderError in
+        onComplete(nil, embeddedLoaderError, false)
+      }
+    )
+  }
 }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -1,7 +1,6 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 // swiftlint:disable closure_body_length
-// swiftlint:disable force_unwrapping
 // swiftlint:disable function_parameter_count
 
 import Foundation
@@ -216,7 +215,9 @@ internal final class RemoteAppLoader: AppLoader {
           let update = updateResponse?.manifestUpdateResponsePart?.updateManifest
           // do this synchronously as it is needed to launch, and we're already on a background dispatch queue so no UI will be blocked
           try database.databaseQueue.sync {
+            // swiftlint:disable force_unwrapping
             try database.setUpdateCommitTime(rollBackDirective.commitTime, onUpdate: update!)
+            // swiftlint:enable force_unwrapping
           }
           onComplete(update, priorError, true)
         } catch {
@@ -229,5 +230,4 @@ internal final class RemoteAppLoader: AppLoader {
   }
 }
 
-// swiftlint:enable force_unwrapping
 // swiftlint:enable function_parameter_count

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -228,3 +228,6 @@ internal final class RemoteAppLoader: AppLoader {
     )
   }
 }
+
+// swiftlint:enable force_unwrapping
+// swiftlint:enable function_parameter_count

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -1,6 +1,8 @@
 //  Copyright © 2019 650 Industries. All rights reserved.
 
 // swiftlint:disable closure_body_length
+// swiftlint:disable force_unwrapping
+// swiftlint:disable function_parameter_count
 
 import Foundation
 


### PR DESCRIPTION
# Why

iOS Equivalent of https://github.com/expo/expo/pull/23356.

Closes ENG-9161.

# How

Same approach.

# Test Plan

Same test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
