### PR TITLE
[docs] Format Use TypeScript guide

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -63,6 +63,8 @@ Rename files to convert them to TypeScript. For example, rename **App.js** to **
 
 <Terminal cmd={['$ mv App.js App.tsx']} />
 
+> **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`. **For SDK 47 and below**, the command also prompts you to install `@types/react-native` as an additional dependency.
+
 For npm, add the following `script` to the **package.json**:
 
 {/* prettier-ignore */}
@@ -76,8 +78,6 @@ For npm, add the following `script` to the **package.json**:
 ```
 
 You can now run `npm tsc` or `yarn tsc` to type-check the project.
-
-> **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`. **For SDK 47 and below**, the command also prompts you to install `@types/react-native` as an additional dependency.
 
 ## Base configuration
 

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -4,51 +4,62 @@ description: An in-depth guide on configuring an Expo project with TypeScript.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
-
-> Example project: [with-typescript](https://github.com/expo/examples/tree/master/with-typescript)
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon } from '@expo/styleguide-icons';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
 
 Expo has first-class support for [TypeScript](https://www.typescriptlang.org/). The JavaScript interface of the Expo SDK is completely written in TypeScript.
 
-To get started, create a **tsconfig.json** in your project root:
+<BoxLink
+  title="with-typescript"
+  description="See the example project on GitHub."
+  href="https://github.com/expo/examples/tree/master/with-typescript"
+  Icon={GithubIcon}
+/>
 
-<Terminal cmd={['$ touch tsconfig.json']} />
+<TabsGroup>
 
-For SDK 48 and above, running `npx expo start` will prompt you to install the required dependencies, such as `typescript` and `@types/react`, and automatically configure your **tsconfig.json**. For SDK 47 and below, the command will also prompt to install `@types/react-native` as an additional dependency.
+## Get started
 
-Rename files to convert them to TypeScript. For example, you would rename **App.js** to **App.tsx**. Use the **.tsx** extension if the file includes React components (JSX). If the file did not include any JSX, you can use the **.ts** file extension.
+### Quick start with a template
+
+The easiest way to get started is to initialize your new project using a TypeScript template:
+
+<Terminal cmd={['$ npx create-expo-app -t expo-template-blank-typescript']} />
+
+Then, to type-check the project, run the following command:
+
+<Tabs>
+<Tab label="npx">
+
+<Terminal cmd={['$ npx tsc']} />
+
+</Tab>
+
+<Tab label="yarn">
+
+<Terminal cmd={['$ yarn tsc']} />
+
+</Tab>
+</Tabs>
+
+When you create new source files in your project you should use the **.ts** extension or the **.tsx** if the file includes React components.
+
+### In an existing project
+
+Rename files to convert them to TypeScript. For example, rename **App.js** to **App.tsx**. Use the **.tsx** extension if the file includes React components (JSX). If the file does not include any JSX, you can use the **.ts** file extension.
 
 <Terminal cmd={['$ mv App.js App.tsx']} />
 
-You can now run `yarn tsc` or `npx tsc` to typecheck the project.
+You can now run `npx tsc` or `yarn tsc` to type-check the project.
+
+> **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`. **For SDK 47 and below**, the command also prompts you to install `@types/react-native` as an additional dependency.
 
 ## Base configuration
 
 > You can disable the TypeScript setup in Expo CLI with the environment variable `EXPO_NO_TYPESCRIPT_SETUP=1`
 
-A project's **tsconfig.json** should extend the `expo/tsconfig.base` by default. This sets the following default [compiler options][tsc-compileroptions] (which can be overwritten in your project's **tsconfig.json**):
-
-- `"allowJs"`: `true`
-  - Allow JavaScript files to be compiled. If you project requires more strictness, you can disable this.
-- `"esModuleInterop"`: `true`
-  - Improve Babel ecosystem compatibility. This also sets `allowSyntheticDefaultImports` to `true`, allowing default imports from modules with no default export.
-- [`"jsx"`][tsc-jsx]: `"react-native"`
-  - Preserve JSX, and converts the `jsx` extension to `js`. This is optimized for bundlers that transform the JSX internally (like Metro).
-- `"lib"`: `["DOM", "ESNext"]`
-  - Allow using the latest [ECMAScript proposed features and libraries](https://github.com/tc39/proposals).
-- [`"moduleResolution"`][tsc-moduleresolution]: `"node"`
-  - Emulate how Metro and webpack resolve modules.
-- `"noEmit"`: `true`
-  - Only use the TypeScript compiler (TSC) to check the code. The Metro bundler is responsible for compiling TypeScript to JavaScript.
-- `"resolveJsonModule"`: `true`
-  - Enables importing **.json** files. Metro's default behavior is to allow importing json files as JS objects.
-- `"skipLibCheck"`: `true`
-  - Skip type checking of all declaration files (`*.d.ts`).
-- `"target"`: `"ESNext"`
-  - Compile to the latest version of ECMAScript.
-
-[tsc-jsx]: https://www.typescriptlang.org/docs/handbook/jsx.html
-[tsc-compileroptions]: https://www.typescriptlang.org/docs/handbook/compiler-options.html
-[tsc-moduleresolution]: https://www.typescriptlang.org/docs/handbook/module-resolution.html
+A project's **tsconfig.json** should extend the `expo/tsconfig.base` by default. This sets the following default [compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) (which can be overwritten in your project's **tsconfig.json**):
 
 ## Project configuration
 
@@ -61,26 +72,15 @@ Expo CLI will automatically modify your **tsconfig.json** to the preferred defau
 }
 ```
 
-The default configuration is forgiving and makes it easier to adopt TypeScript. If you'd like to opt-in to more strict type checking, you can add `"strict": true` to the `compilerOptions`. We recommend enabling this to minimize the chance of introducing runtime errors.
+The default configuration for TypeScript is user-friendly and encourages adoption. However, if you prefer strict type checking, you can enable it by adding `"strict": true` to the `compilerOptions`. We recommend enabling this to minimize the chance of introducing runtime errors.
 
-Certain language features may require additional configuration, for example if you'd like to use decorators you will need to add the `experimentalDecorators` option. For more information on the available properties see the [TypeScript compiler options documentation](https://www.typescriptlang.org/docs/handbook/compiler-options.html) documentation.
+Some language features may require additional configuration. For example, if want to use decorators you'll need to add the `experimentalDecorators` option. For more information on the available properties see the [TypeScript compiler options](https://www.typescriptlang.org/docs/handbook/compiler-options.html) documentation.
 
-## Starting from scratch: using a TypeScript template
-
-<Terminal
-  cmd={['$ npx create-expo-app -t expo-template-blank-typescript']}
-  cmdCopy="npx create-expo-app -t expo-template-blank-typescript"
-/>
-
-The easiest way to get started is to initialize your new project using a TypeScript template, then run `yarn tsc` or `npx tsc` to "typecheck" the project.
-
-When you create new source files in your project you should use the **.ts** extension or the **.tsx** if the file includes React components.
-
-## Path Aliases
+## Path aliases
 
 > Available in SDK 49 and higher.
 
-SDK 49 projects will need to enable this feature in the project's **app.json**:
+In SDK 49 projects, you'll need to enable path aliases in the project's [app config](/workflow/configuration/):
 
 ```json app.json
 {
@@ -100,7 +100,7 @@ For example, if you have a file at **src/components/Button.tsx** and wish to imp
 import Button from '@/components/Button';
 ```
 
-Then simply add the alias **@/** in the project's **tsconfig.json** and set it to the **src** directory:
+Then simply add the alias **@/\*** in the project's **tsconfig.json** and set it to the **src** directory:
 
 ```json tsconfig.json
 {
@@ -113,17 +113,19 @@ Then simply add the alias **@/** in the project's **tsconfig.json** and set it t
 }
 ```
 
-- Expo CLI must be restarted to update path aliases when you change the **tsconfig.json**. You don't need to clear the Metro cache when the aliases change.
-- **jsconfig.json** can be used instead of **tsconfig.json** if you are not using TypeScript.
-- Path aliases add additional resolution time when defined.
-- Path aliases are Metro-only (including Metro web) and not supported by `@expo/webpack-config`.
-- This feature requires additional setup in bare projects. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+Consider the following when using path aliases:
 
-## Absolute Imports
+- Restart Expo CLI after changing **tsconfig.json** to update path aliases. You don't need to clear the Metro cache when the aliases change.
+- If not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
+- Path aliases add additional resolution time when defined.
+- Path aliases are only supported by Metro (including Metro web) and not by `@expo/webpack-config`.
+- Bare projects require additional setup for this feature. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+
+## Absolute imports
 
 > Available in SDK 49 and higher.
 
-SDK 49 projects will need to enable this feature in the project's **app.json**:
+In SDK 49 projects, you'll need to enable absolute imports in the project's [app config](/workflow/configuration/):
 
 ```json app.json
 {
@@ -135,16 +137,14 @@ SDK 49 projects will need to enable this feature in the project's **app.json**:
 }
 ```
 
-Absolute imports from the project root directory are enabled automatically when the project contains a **tsconfig.json** or **jsconfig.json** file.
-
-This enables imports like:
+Absolute imports from the project root directory are enabled automatically when the project contains a **tsconfig.json** or **jsconfig.json** file. For example:
 
 ```tsx
 import Button from 'src/components/Button';
 // Imports `<project root>/src/components/Button`
 ```
 
-The base directory can be modified in the **tsconfig.json** (or **jsconfig.json**) using the [`baseUrl`][baseurl] option:
+You can modify the base directory in the tsconfig.json (or jsconfig.json) using the [baseUrl](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) option"
 
 ```json tsconfig.json
 {
@@ -154,24 +154,36 @@ The base directory can be modified in the **tsconfig.json** (or **jsconfig.json*
 }
 ```
 
-- [`compilerOptions.baseUrl`][baseurl] is automatically set to `.` when the `tsconfig.json` or **jsconfig.json** files exist.
-- Node modules take precedence over absolute imports, so you cannot overwrite a node module import with an absolute import.
-- Expo CLI must be restarted to update [`compilerOptions.baseUrl`][baseurl] when you change the **tsconfig.json**.
-- **jsconfig.json** can be used instead of **tsconfig.json** if you are not using TypeScript.
-- Absolute imports are Metro-only (including Metro web) and not supported by `@expo/webpack-config`.
-- This feature requires additional setup in bare projects. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
+Consider the following when using absolute imports:
 
-[baseurl]: https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url
+- [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) is automatically set to `.` when the `tsconfig.json` or **jsconfig.json** file exists.
+- Absolute imports in Node modules cannot be overwritten by absolute imports, as they take precedence.
+- Restarting Expo CLI is necessary to update [`compilerOptions.baseUrl`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) after modifying **the tsconfig.json**.
+- If not using TypeScript, **jsconfig.json** can serve as an alternative to **tsconfig.json**.
+- Absolute imports are only supported by Metro (including Metro web) and not by `@expo/webpack-config`.
+- Bare projects require additional setup for this feature. See the [versioned Metro setup guide](/versions/latest/config/metro#bare-workflow-setup) for more information.
 
 ## TypeScript for config files
 
-You may find that you want to use TypeScript for the config files in your project, like the **webpack.config.js**, **metro.config.js**, or **app.config.js**. These will require a little extra setup. You can utilize the [`ts-node` require hook](https://github.com/TypeStrong/ts-node#programmatic) to _import_ TypeScript files into your JS config file, meaning any import can be TypeScript, but the root file will still need to be JavaScript.
+If you want to use TypeScript for configuration files such as **webpack.config.js**, **metro.config.js**, or **app.config.js**, additional setup is needed. You can utilize the [`ts-node` require hook](https://github.com/TypeStrong/ts-node#programmatic) to import TypeScript files within your JS config file, allowing TypeScript imports while keeping the root file as JavaScript.
+
+<Tabs>
+<Tab label="npm">
+
+<Terminal cmd={['$ npm install ts-node typescript --save-dev']} />
+
+</Tab>
+
+<Tab label="yarn">
 
 <Terminal cmd={['$ yarn add -D ts-node typescript']} />
 
+</Tab>
+</Tabs>
+
 ### webpack.config.js
 
-> You may need to install the `@expo/webpack-config` package.
+> Install the `@expo/webpack-config` package.
 
 ```js webpack.config.js
 require('ts-node/register');
@@ -206,7 +218,7 @@ module.exports = config;
 
 ### app.config.js
 
-Technically **app.config.ts** is supported by default, but it doesn't support external TypeScript modules, or **tsconfig.json** customization. You can use the following approach to get a more comprehensive TypeScript setup.
+**app.config.ts** is supported by default. However, it doesn't support external TypeScript modules, or **tsconfig.json** customization. You can use the following approach to get a more comprehensive TypeScript setup:
 
 ```js app.config.js
 require('ts-node/register');
@@ -227,14 +239,10 @@ const config: ExpoConfig = {
 export default config;
 ```
 
-## Learning how to use TypeScript
+## Learn how to use TypeScript
 
 A good place to start learning TypeScript is the official [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html).
 
-### TypeScript and React components
+**For TypeScript and React components,** we recommend referring to the [React TypeScript CheatSheet](https://github.com/typescript-cheatsheets/react) to learn how to type your React components in a variety of common situations.
 
-We recommend reading over and referring to the [React TypeScript CheatSheet](https://github.com/typescript-cheatsheets/react) to learn how to type your React components in a variety of common situations.
-
-### Advanced types
-
-If you would like to go deeper and learn how to create more expressive and powerful types, we recommend the [Advanced Static Types in TypeScript course](https://egghead.io/courses/advanced-static-types-in-typescript) (this requires an egghead.io subscription).
+</TabsGroup>

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -27,12 +27,24 @@ The easiest way to get started is to initialize your new project using a TypeScr
 
 <Terminal cmd={['$ npx create-expo-app -t expo-template-blank-typescript']} />
 
+For npm, add the following `script` to the **package.json**:
+
+{/* prettier-ignore */}
+```json package.json
+{
+  "scripts": {
+    "tsc": "tsc"
+    /* @hide ... */ /* @end */
+  }
+}
+```
+
 Then, to type-check the project, run the following command:
 
 <Tabs>
-<Tab label="npx">
+<Tab label="npm">
 
-<Terminal cmd={['$ npx tsc']} />
+<Terminal cmd={['$ npm tsc']} />
 
 </Tab>
 
@@ -51,7 +63,19 @@ Rename files to convert them to TypeScript. For example, rename **App.js** to **
 
 <Terminal cmd={['$ mv App.js App.tsx']} />
 
-You can now run `npx tsc` or `yarn tsc` to type-check the project.
+For npm, add the following `script` to the **package.json**:
+
+{/* prettier-ignore */}
+```json package.json
+{
+  "scripts": {
+    "tsc": "tsc"
+    /* @hide ... */ /* @end */
+  }
+}
+```
+
+You can now run `npm tsc` or `yarn tsc` to type-check the project.
 
 > **For SDK 48 and higher**, running `npx expo start` prompts you to install the required dependencies, such as `typescript` and `@types/react`. **For SDK 47 and below**, the command also prompts you to install `@types/react-native` as an additional dependency.
 
@@ -144,7 +168,7 @@ import Button from 'src/components/Button';
 // Imports `<project root>/src/components/Button`
 ```
 
-You can modify the base directory in the tsconfig.json (or jsconfig.json) using the [baseUrl](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) option"
+You can modify the base directory in the tsconfig.json (or jsconfig.json) using the [baseUrl](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url) option:
 
 ```json tsconfig.json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The guide is not up to date and received some feedback from @jonsamp.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update get started section to distinguish between starting with a template and starting with an existing project 
- Convert compiler list options to a table, 
- Remove paid course link since it is two years old and there is no verification if it is up to date
- Use Tabs and TabsGroup to switch between npx/npm and yarn for installation command
- Remove info about creating tsconfig file
- Use BoxLink for example link
- Improve verbiage for bullet points
- Use short form verbs for section headings instead of gerunds

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/typescript

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
