### PR TITLE
[docs] Guides: Update using-firebase.mdx with SDK 9 specific instructions

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -94,7 +94,7 @@ You do not have to install other plugins or configurations to use Firebase JS SD
 
 Firebase version 9 provides a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
 
-> Using Firebase Authentication with SDK `v9.x.x` or below? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
+> Using Firebase Authentication with version 9 or below? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
 
 </Step>
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -94,7 +94,7 @@ You do not have to install other plugins or configurations to use Firebase JS SD
 
 Firebase version 9 provides a modular API. You can directly import any service you want to use from the `firebase` package. For example, if you want to use an authentication service in your project, you can import the `auth` module from the `firebase/auth` package.
 
-> Using Firebase Authentication? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
+> Using Firebase Authentication with SDK `v9.x.x` or below? See [the guide for setting up persistence to keep users logged in between reloads](https://expo.fyi/firebase-js-auth-setup).
 
 </Step>
 


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
With the recent release of Firebase JS SDK 10, some breaking API changes were made, specifically React Native Persistence is now built into the library and supported out of the box, making the callout in this doc and the page it links to no longer applicable. In the series of discussions linked below, I have attempted to make it clear that this is only applicable to Firebase JS SDK versions below 10. Any feedback and review would be much appreciated.

# How
<!--
How did you build this feature or fix this bug and why?
-->
- [Firebase JS SDK 10 release notes](https://firebase.google.com/support/release-notes/js#version_1000_-_july_6_2023)
- expo/fyi#122
- expo/fyi#123
- firebase/firebase-js-sdk#7425

# Test Plan
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Look at docs:
 - https://docs.expo.dev/guides/using-firebase/#initialize-the-sdk-in-your-project
 - https://expo.fyi/firebase-js-auth-setup

# Checklist
<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
