### PR TITLE
[expo-updates][ios] Allow nil scopeKey for bare/embedded updates

### DIFF
--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/AppLoader.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/AppLoader/AppLoader.swift
@@ -151,9 +151,11 @@ public class AppLoader: NSObject {
       // but different scope keys, we should try to launch something rather than show a cryptic
       // error to the user.
       if let existingUpdate = existingUpdate,
-        existingUpdate.scopeKey != updateManifest.scopeKey {
+        let existingUpdateScopeKey = existingUpdate.scopeKey,
+        let updateManifestScopeKey = updateManifest.scopeKey,
+        existingUpdateScopeKey != updateManifestScopeKey {
         do {
-          try self.database.setScopeKey(updateManifest.scopeKey, onUpdate: existingUpdate)
+          try self.database.setScopeKey(updateManifestScopeKey, onUpdate: existingUpdate)
         } catch {
           self.finish(withError: error)
           return

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Database/UpdatesDatabase.swift
@@ -99,7 +99,7 @@ public final class UpdatesDatabase: NSObject {
       sql: sql,
       withArgs: [
         update.updateId,
-        update.scopeKey,
+        update.scopeKey.require("Update must have scopeKey to be stored in database"),
         update.commitTime,
         update.runtimeVersion,
         update.manifest.rawManifestJSON(),

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
@@ -25,8 +25,13 @@ public final class ReaperSelectionPolicyFilterAware: NSObject, ReaperSelectionPo
     var nextNewestUpdateMatchingFilters: Update?
 
     for update in updates {
+      guard let launchedUpdateScopeKey = launchedUpdate.scopeKey,
+        let updateScopeKey = update.scopeKey else {
+        continue
+      }
+
       // ignore any updates whose scopeKey doesn't match that of the launched update
-      if launchedUpdate.scopeKey != update.scopeKey {
+      if launchedUpdateScopeKey != updateScopeKey {
         continue
       }
 

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/BareUpdate.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/BareUpdate.swift
@@ -51,7 +51,7 @@ internal final class BareUpdate: Update {
       config: config,
       database: database,
       updateId: uuid,
-      scopeKey: config.scopeKey.require("Must supply scopeKey in configuration"),
+      scopeKey: config.scopeKey,
       commitTime: Date(timeIntervalSince1970: Double(commitTime) / 1000),
       runtimeVersion: UpdatesUtils.getRuntimeVersion(withConfig: config),
       keep: true,

--- a/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/Update.swift
+++ b/ios/versioned/sdk49/EXUpdates/EXUpdates/Update/Update.swift
@@ -81,7 +81,7 @@ public enum UpdateError: Int, Error {
 @objcMembers
 public class Update: NSObject {
   public let updateId: UUID
-  public let scopeKey: String
+  public let scopeKey: String?
   public var commitTime: Date
   public let runtimeVersion: String
   public let keep: Bool
@@ -103,7 +103,7 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase?,
     updateId: UUID,
-    scopeKey: String,
+    scopeKey: String?,
     commitTime: Date,
     runtimeVersion: String,
     keep: Bool,

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
+- [ios] Allow nil scopeKey for bare/embedded updates. ([#23385](https://github.com/expo/expo/pull/23385) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -151,9 +151,11 @@ public class AppLoader: NSObject {
       // but different scope keys, we should try to launch something rather than show a cryptic
       // error to the user.
       if let existingUpdate = existingUpdate,
-        existingUpdate.scopeKey != updateManifest.scopeKey {
+        let existingUpdateScopeKey = existingUpdate.scopeKey,
+        let updateManifestScopeKey = updateManifest.scopeKey,
+        existingUpdateScopeKey != updateManifestScopeKey {
         do {
-          try self.database.setScopeKey(updateManifest.scopeKey, onUpdate: existingUpdate)
+          try self.database.setScopeKey(updateManifestScopeKey, onUpdate: existingUpdate)
         } catch {
           self.finish(withError: error)
           return

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -99,7 +99,7 @@ public final class UpdatesDatabase: NSObject {
       sql: sql,
       withArgs: [
         update.updateId,
-        update.scopeKey,
+        update.scopeKey.require("Update must have scopeKey to be stored in database"),
         update.commitTime,
         update.runtimeVersion,
         update.manifest.rawManifestJSON(),

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
@@ -25,8 +25,13 @@ public final class ReaperSelectionPolicyFilterAware: NSObject, ReaperSelectionPo
     var nextNewestUpdateMatchingFilters: Update?
 
     for update in updates {
+      guard let launchedUpdateScopeKey = launchedUpdate.scopeKey,
+        let updateScopeKey = update.scopeKey else {
+        continue
+      }
+
       // ignore any updates whose scopeKey doesn't match that of the launched update
-      if launchedUpdate.scopeKey != update.scopeKey {
+      if launchedUpdateScopeKey != updateScopeKey {
         continue
       }
 

--- a/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/BareUpdate.swift
@@ -51,7 +51,7 @@ internal final class BareUpdate: Update {
       config: config,
       database: database,
       updateId: uuid,
-      scopeKey: config.scopeKey.require("Must supply scopeKey in configuration"),
+      scopeKey: config.scopeKey,
       commitTime: Date(timeIntervalSince1970: Double(commitTime) / 1000),
       runtimeVersion: UpdatesUtils.getRuntimeVersion(withConfig: config),
       keep: true,

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -81,7 +81,7 @@ public enum UpdateError: Int, Error {
 @objcMembers
 public class Update: NSObject {
   public let updateId: UUID
-  public let scopeKey: String
+  public let scopeKey: String?
   public var commitTime: Date
   public let runtimeVersion: String
   public let keep: Bool
@@ -103,7 +103,7 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase?,
     updateId: UUID,
-    scopeKey: String,
+    scopeKey: String?,
     commitTime: Date,
     runtimeVersion: String,
     keep: Bool,


### PR DESCRIPTION
# Why

Blame: https://github.com/expo/expo/commit/0b66f7ddca830fc07b994e1371b091b24abb88ab

The objective-c code was written in a way that suggested that this field should never be nil, so that constraint was added in as part of the swift conversion. But, there exists one case where it is nil, which is when expo-updates is not enabled: https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/AppController.swift#L213

In all other cases the scopeKey must be non-null since it is relied upon for logic and as a key in the database. But for this case we implicitly don't use the database, and therefore the scope key is not required.

Fixes https://github.com/expo/expo/issues/23382.
Closes ENG-9257.

# How

The fix is to not require scope key until it is read so that for the case that implicitly doesn't require it, it doesn't break upon initialization. This is more fragile as now each callsite must decide what to do in the nil case.

# Test Plan

```
npx create-expo-app@latest --template blank@sdk-49 testblankupdates2
npx expo install expo-updates
npx expo prebuild
<open in xcode, set to release, build>
<see reported crash>
<apply this PR patch>
<build>
<no longer see crash>
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
