### PR TITLE
fix(cli): generate correct route types on Windows

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed opening browser on Windows when debugging or opening Metro web. ([#23287](https://github.com/expo/expo/pull/23287) by [@byCedric](https://github.com/byCedric))
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
+- Fixed route types generation on Windows not working.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed opening browser on Windows when debugging or opening Metro web. ([#23287](https://github.com/expo/expo/pull/23287) by [@byCedric](https://github.com/byCedric))
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
-- Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto))
+- Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fixed opening browser on Windows when debugging or opening Metro web. ([#23287](https://github.com/expo/expo/pull/23287) by [@byCedric](https://github.com/byCedric))
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
-- Fixed route types generation on Windows not working.
+- Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -70,18 +70,39 @@ describe(`${CAPTURE_GROUP_REGEX}`, () => {
 });
 
 describe(getTypedRoutesUtils, () => {
-  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath } = getTypedRoutesUtils('/app');
+  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath } =
+    getTypedRoutesUtils('/user/project/app');
 
   describe(filePathToRoute, () => {
-    const filepaths = [
-      ['/app/file.tsx', '/file'],
-      ['/app/file2.jsx', '/file2'],
-      ['/app/folder/index.tsx', '/folder/'],
-      ['/app/folder/(group)/[param].tsx', '/folder/(group)/[param]'],
-    ];
+    describe('unix paths', () => {
+      const filepaths = [
+        ['/user/project/app/file.tsx', '/file'],
+        ['/user/project/app/file2.jsx', '/file2'],
+        ['/user/project/app/folder/index.tsx', '/folder/'],
+        ['/user/project/app/folder/(group)/[param].tsx', '/folder/(group)/[param]'],
+      ];
 
-    it.each(filepaths)('normalizes a filepath: %s', (filepath, route) => {
-      expect(filePathToRoute(filepath)).toEqual(route);
+      it.each(filepaths)('normalizes a filepath: %s', (filepath, route) => {
+        expect(filePathToRoute(filepath)).toEqual(route);
+      });
+    });
+
+    describe('windows paths', () => {
+      const windowsUtils = getTypedRoutesUtils('C:\\user\\project with space\\app', '\\');
+
+      const filepaths = [
+        ['C:\\user\\project with space\\app\\file.tsx', '/file'],
+        ['C:\\user\\project with space\\app\\file2.jsx', '/file2'],
+        ['C:\\user\\project with space\\app\\folder\\index.tsx', '/folder/'],
+        [
+          'C:\\user\\project with space\\app\\folder\\(group)\\[param].tsx',
+          '/folder/(group)/[param]',
+        ],
+      ];
+
+      it.each(filepaths)('normalizes a windows filepath: %s', (filepath, route) => {
+        expect(windowsUtils.filePathToRoute(filepath)).toEqual(route);
+      });
     });
   });
 
@@ -99,11 +120,11 @@ describe(getTypedRoutesUtils, () => {
     });
 
     const filepaths = [
-      ['/app/file.tsx', true, { static: ['/file'] }],
-      ['/app/(group)/page.tsx', true, { static: ['/(group)/page', '/page'] }],
-      ['/app/folder/[slug].tsx', true, { dynamic: ['/folder/${SingleRoutePart<T>}'] }],
+      ['/user/project/app/file.tsx', true, { static: ['/file'] }],
+      ['/user/project/app/(group)/page.tsx', true, { static: ['/(group)/page', '/page'] }],
+      ['/user/project/app/folder/[slug].tsx', true, { dynamic: ['/folder/${SingleRoutePart<T>}'] }],
       [
-        '/app/(a,b,c)/(d,e)/page.tsx',
+        '/user/project/app/(a,b,c)/(d,e)/page.tsx',
         true,
         {
           static: [
@@ -124,7 +145,6 @@ describe(getTypedRoutesUtils, () => {
 
     it.each(filepaths)('normalizes a filepath: %s', (filepath, expectedResult, expectedRoutes) => {
       const result = addFilePath(filepath);
-
       expect(result).toEqual(expectedResult);
 
       if ('static' in expectedRoutes) {

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -119,7 +119,7 @@ export function getTemplateString(
  *
  * These are extracted for easier testing
  */
-export function getTypedRoutesUtils(appRoot: string) {
+export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.sep) {
   /*
    * staticRoutes are a map where the key if the route without groups and the value
    *   is another set of all group versions of the route. e.g,
@@ -140,12 +140,14 @@ export function getTypedRoutesUtils(appRoot: string) {
    */
   const dynamicRoutes = new Map<string, Set<string>>();
 
-  const filePathToRoute = (filePath: string) => {
-    const normalizedAppRoot = appRoot.replaceAll(path.sep, '/').replaceAll(' ', '_');
-    // Normalize the path so it's easier to convert to URLs, as done in the walk function
-    const normalizedFilePath = filePath.replaceAll(path.sep, '/').replaceAll(' ', '_');
+  function normalizedFilePath(filePath: string) {
+    return filePath.replaceAll(filePathSeperator, '/').replaceAll(' ', '_');
+  }
 
-    return normalizedFilePath
+  const normalizedAppRoot = normalizedFilePath(appRoot);
+
+  const filePathToRoute = (filePath: string) => {
+    return normalizedFilePath(filePath)
       .replace(normalizedAppRoot, '')
       .replace(/index.[jt]sx?/, '')
       .replace(/\.[jt]sx?$/, '');

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -141,8 +141,10 @@ export function getTypedRoutesUtils(appRoot: string) {
   const dynamicRoutes = new Map<string, Set<string>>();
 
   const filePathToRoute = (filePath: string) => {
+    const normalizedAppRoot = appRoot.replaceAll(path.sep, '/').replaceAll(' ', '_');
+
     return filePath
-      .replace(appRoot, '')
+      .replace(normalizedAppRoot, '')
       .replace(/index.[jt]sx?/, '')
       .replace(/\.[jt]sx?$/, '');
   };

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -142,8 +142,10 @@ export function getTypedRoutesUtils(appRoot: string) {
 
   const filePathToRoute = (filePath: string) => {
     const normalizedAppRoot = appRoot.replaceAll(path.sep, '/').replaceAll(' ', '_');
+    // Normalize the path so it's easier to convert to URLs, as done in the walk function
+    const normalizedFilePath = filePath.replaceAll(path.sep, '/').replaceAll(' ', '_');
 
-    return filePath
+    return normalizedFilePath
       .replace(normalizedAppRoot, '')
       .replace(/index.[jt]sx?/, '')
       .replace(/\.[jt]sx?$/, '');


### PR DESCRIPTION
# Why

- CLI was generating wrong route types in windows
- Fixes [issue in expo/router](https://github.com/expo/router/issues/719)
- Watcher not adding/deleting route type in some cases, e.g. route name with space

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Normalized appRoot to use POSIX separator in windows, allowing to remove appRoot from path
- Normalized file path from watcher to match route generated

# Test Plan
Needs to be tested on Windows:

1. Build the cli: ```yarn build``` 
2. Create an alias to the cli: ```alias nexpo="/path/to/expo/packages/@expo/cli/build/bin/cli"```
3. Run expo on new project and check generated types on ```.expo\types\router.d.ts```

> Not sure it's the best way to test this, First PR to expo open to feedback

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
