### PR TITLE
[expo-apple-auth] Fix internal links in TSDoc

### DIFF
--- a/packages/expo-apple-authentication/src/AppleAuthentication.ts
+++ b/packages/expo-apple-authentication/src/AppleAuthentication.ts
@@ -99,7 +99,7 @@ export async function refreshAsync(
  *
  * It is not recommended to use this method to sign out the user as it works counterintuitively.
  * Instead of using this method it is recommended to simply clear all the user's data collected
- * from using [`signInAsync`](./#signinasync) or [`refreshAsync`](./#refreshasync) methods.
+ * from using [`signInAsync`](#signinasync) or [`refreshAsync`](#refreshasync) methods.
  *
  * @param options An [`AppleAuthenticationSignOutOptions`](#appleauthenticationsignoutoptions) object
  * @returns A promise that fulfills with an [`AppleAuthenticationCredential`](#appleauthenticationcredential)


### PR DESCRIPTION
# Why

The links to `refreshAsync` and `signinAsync` were broken, and were redirecting to a 404 error page.

# How

The routes were incorrect, so I just fixed those.

# Test Plan

NA

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).