### PR TITLE
[docs] Update broken link in EAS Update environnement variable

### DIFF
--- a/docs/pages/eas-update/environment-variables.mdx
+++ b/docs/pages/eas-update/environment-variables.mdx
@@ -72,7 +72,7 @@ export default Config;
 ```
 Now you can set `EXPO_PUBLIC_API_URL` and `EXPO_PUBLIC_ENABLE_HIDDEN_FEATURES` in an uncommitted **.env.local** file, and they will be used instead of the default when running `npx expo start`.
 
-This can also be used for EAS Updates run from your [development build](/develop/development-builds/introduction/). For example, you can point updates created for [PR previews](eas-update/github-actions/#publish-previews-on-pull-requests) to a specific API server by committing an **.env** file with `EXPO_PUBLIC_API_URL` set.
+This can also be used for EAS Updates run from your [development build](/develop/development-builds/introduction/). For example, you can point updates created for [PR previews](/eas-update/github-actions/#publish-previews-on-pull-requests) to a specific API server by committing an **.env** file with `EXPO_PUBLIC_API_URL` set.
 
 ## Using variables in app.config.js
 [Expo environment variables](/guides/environment-variables) are only available in SDK 49 or higher. In previous versions, it was common to set variables to be used in updates in **app.config.js** under the `expo.extra` property:


### PR DESCRIPTION

# Why

The modified link currently leads to  https://docs.expo.dev/eas-update/eas-update/github-actions/#publish-previews-on-pull-requests which gives a 404 error because `/eas-update` is repeated in the link. But at the code level there is not this repetition, so I think that the fact that the link is not preceded by the `/` is the cause of this and redirects by adding the path of the current page which causes the issue.

# How

Just add `/` at the beginning of the link to fix it

# Checklist



- [x] Conforms with the [Documentation Writing Style Guide]
