### PR TITLE
[core] fix network inspector does not preview response body without content-length header

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix the `View cannot be cast to ViewGroup` exception on Android. ([#23264](https://github.com/expo/expo/pull/23264) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fix conversion to `URL` type that failed despite receiving a string that contained a valid URL. ([#23331](https://github.com/expo/expo/pull/23331) by [@alanhughes](https://github.com/alanjhughes))
 - Improved the OkHttp network inspector stability on Android. ([#23350](https://github.com/expo/expo/pull/23350) by [@kudo](https://github.com/kudo))
+- Fixed the Network Inspector cannot preview response body for response without the `Content-Length` header. ([#23405](https://github.com/expo/expo/pull/23405) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptor.kt
@@ -54,14 +54,13 @@ object ExpoRequestCdpInterceptor : ExpoNetworkInspectOkHttpInterceptorsDelegate 
     val params = ResponseReceivedParams(now, requestId, request, response)
     dispatchEvent(Event("Network.responseReceived", params))
 
-    val params2 = LoadingFinishedParams(now, requestId, request, response)
-    dispatchEvent(Event("Network.loadingFinished", params2))
-
-    val contentLength = response.body?.contentLength() ?: 0
-    if (contentLength >= 0 && contentLength <= ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE) {
-      val params3 = ExpoReceivedResponseBodyParams(now, requestId, request, response)
-      dispatchEvent(Event("Expo(Network.receivedResponseBody)", params3))
+    if (response.peekBody(ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE + 1).contentLength() <= ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE) {
+      val params2 = ExpoReceivedResponseBodyParams(now, requestId, request, response)
+      dispatchEvent(Event("Expo(Network.receivedResponseBody)", params2))
     }
+
+    val params3 = LoadingFinishedParams(now, requestId, request, response)
+    dispatchEvent(Event("Network.loadingFinished", params3))
   }
 
   //endregion ExpoNetworkInspectOkHttpInterceptorsDelegate implementations

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/cdp/CdpNetworkTypes.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/devtools/cdp/CdpNetworkTypes.kt
@@ -205,10 +205,10 @@ data class LoadingFinishedParams(
   val timestamp: MonotonicTime,
   val encodedDataLength: Long,
 ) : JsonSerializable {
-  constructor(now: BigDecimal, requestId: RequestId, request: okhttp3.Request, repsonse: okhttp3.Response) : this(
+  constructor(now: BigDecimal, requestId: RequestId, request: okhttp3.Request, response: okhttp3.Response) : this(
     requestId = requestId,
     timestamp = now,
-    encodedDataLength = repsonse.body?.contentLength() ?: 0,
+    encodedDataLength = response.body?.contentLength() ?: 0,
   )
 
   override fun toJSONObject(): JSONObject {
@@ -230,8 +230,6 @@ data class ExpoReceivedResponseBodyParams(
     body = "",
     base64Encoded = false,
   ) {
-    val contentLength = response.body?.contentLength() ?: 0
-    check(contentLength >= 0 && contentLength <= ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE)
     val rawBody = response.peekBody(ExpoNetworkInspectOkHttpNetworkInterceptor.MAX_BODY_SIZE)
     val contentType = rawBody.contentType()
     val isText = contentType?.type == "text" || (contentType?.type == "application" && contentType.subtype == "json")

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptorTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/devtools/ExpoRequestCdpInterceptorTest.kt
@@ -62,22 +62,24 @@ class ExpoRequestCdpInterceptorTest {
     Truth.assertThat(params.getString("requestId")).isEqualTo(requestId)
     Truth.assertThat(response.getInt("status")).isEqualTo(200)
     Truth.assertThat(response.getJSONObject("headers").length()).isGreaterThan(0)
-
-    // Network.loadingFinished
-    json = JSONObject(mockDelegate.events[3])
-    method = json.getString("method")
-    params = json.getJSONObject("params")
-    Truth.assertThat(method).isEqualTo("Network.loadingFinished")
-    Truth.assertThat(params.getString("requestId")).isEqualTo(requestId)
+    Truth.assertThat(response.getLong("encodedDataLength")).isGreaterThan(0)
 
     // Expo(Network.receivedResponseBody)
-    json = JSONObject(mockDelegate.events[4])
+    json = JSONObject(mockDelegate.events[3])
     method = json.getString("method")
     params = json.getJSONObject("params")
     Truth.assertThat(method).isEqualTo("Expo(Network.receivedResponseBody)")
     Truth.assertThat(params.getString("requestId")).isEqualTo(requestId)
     Truth.assertThat(params.getString("body")).isNotEmpty()
     Truth.assertThat(params.getBoolean("base64Encoded")).isFalse()
+
+    // Network.loadingFinished
+    json = JSONObject(mockDelegate.events[4])
+    method = json.getString("method")
+    params = json.getJSONObject("params")
+    Truth.assertThat(method).isEqualTo("Network.loadingFinished")
+    Truth.assertThat(params.getString("requestId")).isEqualTo(requestId)
+    Truth.assertThat(params.getLong("encodedDataLength")).isGreaterThan(0)
   }
 
   @Test
@@ -122,16 +124,16 @@ class ExpoRequestCdpInterceptorTest {
     Truth.assertThat(response.getString("mimeType")).isEqualTo("image/png")
     Truth.assertThat(response.getJSONObject("headers").length()).isGreaterThan(0)
 
-    // Network.loadingFinished
-
     // Expo(Network.receivedResponseBody)
-    json = JSONObject(mockDelegate.events[6])
+    json = JSONObject(mockDelegate.events[5])
     method = json.getString("method")
     params = json.getJSONObject("params")
     Truth.assertThat(method).isEqualTo("Expo(Network.receivedResponseBody)")
     Truth.assertThat(params.getString("requestId")).isEqualTo(requestId)
     Truth.assertThat(params.getString("body")).isNotEmpty()
     Truth.assertThat(params.getBoolean("base64Encoded")).isTrue()
+
+    // Network.loadingFinished
   }
 
   @Test
@@ -151,5 +153,23 @@ class ExpoRequestCdpInterceptorTest {
     Truth.assertThat(response.getInt("status")).isEqualTo(200)
     Truth.assertThat(response.getString("mimeType")).isEqualTo("image/png")
     Truth.assertThat(params.getString("type")).isEqualTo("Image")
+  }
+
+  @Test
+  fun `skip 'receivedResponseBody' when response size exceeding 1MB limit`() {
+    client.newCall(Request.Builder().url("https://raw.githubusercontent.com/expo/expo/main/apps/native-component-list/assets/videos/ace.mp4").build()).execute()
+    Truth.assertThat(mockDelegate.events.size).isEqualTo(4)
+
+    var json = JSONObject(mockDelegate.events[0])
+    Truth.assertThat(json.getString("method")).isEqualTo("Network.requestWillBeSent")
+
+    json = JSONObject(mockDelegate.events[1])
+    Truth.assertThat(json.getString("method")).isEqualTo("Network.requestWillBeSentExtraInfo")
+
+    json = JSONObject(mockDelegate.events[2])
+    Truth.assertThat(json.getString("method")).isEqualTo("Network.responseReceived")
+
+    json = JSONObject(mockDelegate.events[3])
+    Truth.assertThat(json.getString("method")).isEqualTo("Network.loadingFinished")
   }
 }

--- a/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/CdpNetworkTypes.swift
@@ -62,7 +62,7 @@ struct CdpNetwork {
     let mimeType: String
     let encodedDataLength: Int64
 
-    init(_ response: HTTPURLResponse) {
+    init(_ response: HTTPURLResponse, encodedDataLength: Int64) {
       self.url = response.url?.absoluteString ?? ""
       self.status = response.statusCode
       self.statusText = ""
@@ -73,7 +73,7 @@ struct CdpNetwork {
       }
       self.headers = headers
       self.mimeType = response.value(forHTTPHeaderField: "Content-Type") ?? ""
-      self.encodedDataLength = response.expectedContentLength
+      self.encodedDataLength = encodedDataLength
     }
   }
 
@@ -94,13 +94,13 @@ struct CdpNetwork {
     var referrerPolicy = "no-referrer"
     let type: ResourceType
 
-    init(now: TimeInterval, requestId: RequestId, request: URLRequest, redirectResponse: HTTPURLResponse?) {
+    init(now: TimeInterval, requestId: RequestId, request: URLRequest, encodedDataLength: Int64, redirectResponse: HTTPURLResponse?) {
       self.requestId = requestId
       self.request = Request(request)
       self.timestamp = now
       self.wallTime = now
       if let redirectResponse = redirectResponse {
-        self.redirectResponse = Response(redirectResponse)
+        self.redirectResponse = Response(redirectResponse, encodedDataLength: encodedDataLength)
       } else {
         self.redirectResponse = nil
       }
@@ -129,10 +129,10 @@ struct CdpNetwork {
     let response: Response
     var hasExtraInfo = false
 
-    init(now: TimeInterval, requestId: RequestId, request: URLRequest, response: HTTPURLResponse) {
+    init(now: TimeInterval, requestId: RequestId, request: URLRequest, response: HTTPURLResponse, encodedDataLength: Int64) {
       self.requestId = requestId
       self.timestamp = now
-      self.response = Response(response)
+      self.response = Response(response, encodedDataLength: encodedDataLength)
       self.type = ResourceType.fromMimeType(self.response.mimeType)
     }
   }
@@ -142,10 +142,10 @@ struct CdpNetwork {
     let timestamp: MonotonicTime
     let encodedDataLength: Int64
 
-    init(now: TimeInterval, requestId: RequestId, request: URLRequest, response: HTTPURLResponse) {
+    init(now: TimeInterval, requestId: RequestId, encodedDataLength: Int64) {
       self.requestId = requestId
       self.timestamp = now
-      self.encodedDataLength = response.expectedContentLength
+      self.encodedDataLength = encodedDataLength
     }
   }
 

--- a/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
@@ -34,30 +34,32 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
 
   // MARK: ExpoRequestInterceptorProtocolDelegate implementations
 
-  func willSendRequest(requestId: String, request: URLRequest, redirectResponse: HTTPURLResponse?) {
+  func willSendRequest(requestId: String, task: URLSessionTask, request: URLRequest, redirectResponse: HTTPURLResponse?) {
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.RequestWillBeSentParams(now: now, requestId: requestId, request: request, redirectResponse: redirectResponse)
+    let params = CdpNetwork.RequestWillBeSentParams(now: now, requestId: requestId, request: request, encodedDataLength: task.countOfBytesReceived, redirectResponse: redirectResponse)
     dispatchEvent(CdpNetwork.Event(method: "Network.requestWillBeSent", params: params))
 
     let params2 = CdpNetwork.RequestWillBeSentExtraInfoParams(now: now, requestId: requestId, request: request)
     dispatchEvent(CdpNetwork.Event(method: "Network.requestWillBeSentExtraInfo", params: params2))
   }
 
-  func didReceiveResponse(requestId: String, request: URLRequest, response: HTTPURLResponse) {
+  func didReceiveResponse(requestId: String, task: URLSessionTask, responseBody: Data, isText: Bool, responseBodyExceedsLimit: Bool) {
+    guard let request = task.currentRequest, let response = task.response as? HTTPURLResponse else {
+      return
+    }
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.ResponseReceivedParams(now: now, requestId: requestId, request: request, response: response)
+    let params = CdpNetwork.ResponseReceivedParams(now: now, requestId: requestId, request: request, response: response, encodedDataLength: task.countOfBytesReceived)
     dispatchEvent(CdpNetwork.Event(method: "Network.responseReceived", params: params))
 
-    let params2 = CdpNetwork.LoadingFinishedParams(now: now, requestId: requestId, request: request, response: response)
-    dispatchEvent(CdpNetwork.Event(method: "Network.loadingFinished", params: params2))
-  }
+    if !responseBodyExceedsLimit {
+      let params2 = CdpNetwork.ExpoReceivedResponseBodyParams(now: now, requestId: requestId, responseBody: responseBody, isText: isText)
+      dispatchEvent(CdpNetwork.Event(method: "Expo(Network.receivedResponseBody)", params: params2))
+    }
 
-  func didReceiveResponseBody(requestId: String, responseBody: Data, isText: Bool) {
-    let now = Date().timeIntervalSince1970
-    let params = CdpNetwork.ExpoReceivedResponseBodyParams(now: now, requestId: requestId, responseBody: responseBody, isText: isText)
-    dispatchEvent(CdpNetwork.Event(method: "Expo(Network.receivedResponseBody)", params: params))
+    let params3 = CdpNetwork.LoadingFinishedParams(now: now, requestId: requestId, encodedDataLength: task.countOfBytesReceived)
+    dispatchEvent(CdpNetwork.Event(method: "Network.loadingFinished", params: params3))
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
@@ -37,7 +37,8 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
   func willSendRequest(requestId: String, task: URLSessionTask, request: URLRequest, redirectResponse: HTTPURLResponse?) {
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.RequestWillBeSentParams(now: now, requestId: requestId, request: request, encodedDataLength: task.countOfBytesReceived, redirectResponse: redirectResponse)
+    let params = CdpNetwork.RequestWillBeSentParams(now: now, requestId: requestId, request: request,
+                                                    encodedDataLength: task.countOfBytesReceived, redirectResponse: redirectResponse)
     dispatchEvent(CdpNetwork.Event(method: "Network.requestWillBeSent", params: params))
 
     let params2 = CdpNetwork.RequestWillBeSentExtraInfoParams(now: now, requestId: requestId, request: request)
@@ -50,7 +51,8 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
     }
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.ResponseReceivedParams(now: now, requestId: requestId, request: request, response: response, encodedDataLength: task.countOfBytesReceived)
+    let params = CdpNetwork.ResponseReceivedParams(now: now, requestId: requestId, request: request,
+                                                   response: response, encodedDataLength: task.countOfBytesReceived)
     dispatchEvent(CdpNetwork.Event(method: "Network.responseReceived", params: params))
 
     if !responseBodyExceedsLimit {

--- a/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestCdpInterceptor.swift
@@ -37,8 +37,12 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
   func willSendRequest(requestId: String, task: URLSessionTask, request: URLRequest, redirectResponse: HTTPURLResponse?) {
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.RequestWillBeSentParams(now: now, requestId: requestId, request: request,
-                                                    encodedDataLength: task.countOfBytesReceived, redirectResponse: redirectResponse)
+    let params = CdpNetwork.RequestWillBeSentParams(
+      now: now,
+      requestId: requestId,
+      request: request,
+      encodedDataLength: task.countOfBytesReceived,
+      redirectResponse: redirectResponse)
     dispatchEvent(CdpNetwork.Event(method: "Network.requestWillBeSent", params: params))
 
     let params2 = CdpNetwork.RequestWillBeSentExtraInfoParams(now: now, requestId: requestId, request: request)
@@ -51,8 +55,12 @@ public final class ExpoRequestCdpInterceptor: NSObject, ExpoRequestInterceptorPr
     }
     let now = Date().timeIntervalSince1970
 
-    let params = CdpNetwork.ResponseReceivedParams(now: now, requestId: requestId, request: request,
-                                                   response: response, encodedDataLength: task.countOfBytesReceived)
+    let params = CdpNetwork.ResponseReceivedParams(
+      now: now,
+      requestId: requestId,
+      request: request,
+      response: response,
+      encodedDataLength: task.countOfBytesReceived)
     dispatchEvent(CdpNetwork.Event(method: "Network.responseReceived", params: params))
 
     if !responseBodyExceedsLimit {

--- a/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -97,7 +97,6 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
           forKey: Self.REQUEST_ID,
           in: currentRequest
         ) as? String {
-
         let contentType = response.value(forHTTPHeaderField: "Content-Type")
         let isText = (contentType?.starts(with: "text/") ?? false) || contentType == "application/json"
         Self.delegate.didReceiveResponse(

--- a/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestInterceptorProtocol.swift
+++ b/packages/expo-modules-core/ios/Swift/DevTools/ExpoRequestInterceptorProtocol.swift
@@ -16,8 +16,7 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
   )
   private var dataTask_: URLSessionDataTask?
   private let responseBody = NSMutableData()
-  private var responseIsText = false
-  private var responseContentLength: Int64 = 0
+  private var responseBodyExceedsLimit = false
 
   static let MAX_BODY_SIZE = 1_048_576
 
@@ -55,12 +54,14 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
       forKey: Self.REQUEST_ID,
       in: mutableRequest
     )
+    let dataTask = urlSession.dataTask(with: mutableRequest as URLRequest)
     Self.delegate.willSendRequest(
       requestId: requestId,
+      task: dataTask,
       request: mutableRequest as URLRequest,
       redirectResponse: nil
     )
-    dataTask_ = urlSession.dataTask(with: mutableRequest as URLRequest)
+    dataTask_ = dataTask
   }
 
   public override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -81,47 +82,26 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
     client?.urlProtocol(self, didLoad: data)
     if responseBody.length + data.count <= Self.MAX_BODY_SIZE {
       responseBody.append(data)
+    } else {
+      responseBodyExceedsLimit = true
     }
-  }
-
-  public func urlSession(
-    _: URLSession,
-    dataTask: URLSessionDataTask,
-    didReceive response: URLResponse,
-    completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
-  ) {
-    if let resp = response as? HTTPURLResponse,
-      let currentRequest = dataTask.currentRequest,
-      let requestId = URLProtocol.property(
-        forKey: Self.REQUEST_ID,
-        in: currentRequest
-      ) as? String {
-      Self.delegate.didReceiveResponse(
-        requestId: requestId,
-        request: currentRequest,
-        response: resp
-      )
-
-      let contentType = resp.value(forHTTPHeaderField: "Content-Type")
-      responseIsText = (contentType?.starts(with: "text/") ?? false) || contentType == "application/json"
-      responseContentLength = resp.expectedContentLength
-    }
-    completionHandler(.allow)
-    client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .allowed)
   }
 
   public func urlSession(_: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     if let error = error {
       client?.urlProtocol(self, didFailWithError: error)
     } else {
-      if responseContentLength > 0 && responseContentLength <= Self.MAX_BODY_SIZE,
-        let currentRequest = task.currentRequest,
+      if let currentRequest = task.currentRequest,
+        let response = task.response as? HTTPURLResponse,
         let requestId = URLProtocol.property(
           forKey: Self.REQUEST_ID,
           in: currentRequest
         ) as? String {
-        Self.delegate.didReceiveResponseBody(
-          requestId: requestId, responseBody: responseBody as Data, isText: responseIsText)
+
+        let contentType = response.value(forHTTPHeaderField: "Content-Type")
+        let isText = (contentType?.starts(with: "text/") ?? false) || contentType == "application/json"
+        Self.delegate.didReceiveResponse(
+          requestId: requestId, task: task, responseBody: responseBody as Data, isText: isText, responseBodyExceedsLimit: responseBodyExceedsLimit)
       }
       client?.urlProtocolDidFinishLoading(self)
     }
@@ -129,7 +109,7 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
 
   public func urlSession(
     _: URLSession,
-    task _: URLSessionTask,
+    task: URLSessionTask,
     willPerformHTTPRedirection response: HTTPURLResponse,
     newRequest request: URLRequest,
     completionHandler: @escaping (URLRequest?) -> Void
@@ -137,6 +117,7 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
     if let requestId = URLProtocol.property(forKey: Self.REQUEST_ID, in: request) as? String {
       Self.delegate.willSendRequest(
         requestId: requestId,
+        task: task,
         request: request,
         redirectResponse: response
       )
@@ -173,11 +154,8 @@ public final class ExpoRequestInterceptorProtocol: URLProtocol, URLSessionDataDe
 @objc(EXRequestInterceptorProtocolDelegate)
 protocol ExpoRequestInterceptorProtocolDelegate {
   @objc
-  func willSendRequest(requestId: String, request: URLRequest, redirectResponse: HTTPURLResponse?)
+  func willSendRequest(requestId: String, task: URLSessionTask, request: URLRequest, redirectResponse: HTTPURLResponse?)
 
   @objc
-  func didReceiveResponse(requestId: String, request: URLRequest, response: HTTPURLResponse)
-
-  @objc
-  func didReceiveResponseBody(requestId: String, responseBody: Data, isText: Bool)
+  func didReceiveResponse(requestId: String, task: URLSessionTask, responseBody: Data, isText: Bool, responseBodyExceedsLimit: Bool)
 }


### PR DESCRIPTION
# Why

some responses do not  have the `Content-Length` header,  and we thought the content-length is zero and not sent the `Network.receivedResponseBody` CDP event.
fixes #23383
close ENG-9261

# How

- sending the `Network.receivedResponseBody` even `Content-Length` is unknown. we only care about our `responseBody` exceeds our 1MB buffer or not.
- moving `Network.loadingFinished` after `Network.receivedResponseBody`. that should be correct order
- [ios only] the `encodedDataLength` should be real bytes transferred on the network without decoding. that pr fixes the semantic correctly. unfortunately,  on android okhttp, they don't have an easy way to get the real bytes, so on android we still use the `Content-Length` and may sometimes get `encodedDataLength=-1`

# Test Plan

- test network inspector preview for `fetch("https://api.publicapis.org/entries")`
- unit test passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
