### PR TITLE
android permission dialog issue in Android Q and T in Expo Image Picker library

### DIFF
--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <!-- Required for picking images from camera roll -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -1,9 +1,12 @@
 package expo.modules.imagepicker
 
 import android.Manifest
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.OperationCanceledException
 import expo.modules.core.errors.ModuleNotFoundException
 import expo.modules.imagepicker.contracts.CameraContract
@@ -171,10 +174,16 @@ class ImagePickerModule : Module() {
   // region Utils
 
   private fun getMediaLibraryPermissions(writeOnly: Boolean): Array<String> =
-    if (writeOnly) {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      listOfNotNull(
+        READ_MEDIA_IMAGES,
+        READ_MEDIA_VIDEO
+      ).toTypedArray()
     } else {
-      arrayOf(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
+      listOfNotNull(
+        Manifest.permission.WRITE_EXTERNAL_STORAGE,
+        Manifest.permission.READ_EXTERNAL_STORAGE.takeIf { !writeOnly }
+      ).toTypedArray()
     }
 
   private fun ensureTargetActivityIsAvailable(options: ImagePickerOptions) {
@@ -189,7 +198,13 @@ class ImagePickerModule : Module() {
 
     permissions.askForPermissions(
       { permissionsResponse ->
-        if (
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+          if (permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED) {
+            continuation.resume(Unit)
+          } else {
+            continuation.resumeWithException(UserRejectedPermissionsException())
+          }
+        } else if (
           permissionsResponse[Manifest.permission.WRITE_EXTERNAL_STORAGE]?.status == PermissionsStatus.GRANTED &&
           permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED
         ) {
@@ -198,7 +213,8 @@ class ImagePickerModule : Module() {
           continuation.resumeWithException(UserRejectedPermissionsException())
         }
       },
-      Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA
+      Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU },
+      Manifest.permission.CAMERA
     )
   }
 


### PR DESCRIPTION
# Why

 permission dialog were not opening in Android T and Q because of `READ_MEDIA_IMAGES` `READ_MEDIA_VIDEO` manifiest permissions.  
Environments:- 

```
    "expo": "47.0.0",
    "expo-application": "~5.0.1",
    "expo-build-properties": "~0.4.1",
    "expo-cached-image": "47.0.0",
    "expo-image-picker": "~14.0.2"
     "react": "18.1.0",
    "react-dom": "18.1.0",
    "react-native": "0.70.8",
```




# How

I  did modification in one kotlin files and AndroidManifest.xml

`expo-image-picker/android/src/main/AndroidManifest.xml`
`expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt`

# Test Plan

I did try this code in production and debug builds codes are working fine in lower version of sdk and latest android versions.


