### PR TITLE
[iOS][image] Fix `tintColor` prop not working for some SVGs

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -84,6 +84,13 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Tinting',
+    route: 'image/tinting',
+    getComponent() {
+      return optionalRequire(() => require('./ImageTintingScreen'));
+    },
+  },
+  {
     name: 'Hash Placeholders',
     route: 'image/hash-placeholders',
     getComponent() {

--- a/apps/native-component-list/src/screens/Image/ImageTintingScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageTintingScreen.tsx
@@ -1,0 +1,83 @@
+import { Image, ImageSource } from 'expo-image';
+import React from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+
+import MonoText from '../../components/MonoText';
+import { Colors } from '../../constants';
+
+const EXAMPLES = [
+  {
+    description: 'tintColor={null}',
+    tintColor: null,
+  },
+  {
+    description: 'tintColor="red"',
+    tintColor: 'red',
+  },
+  {
+    description: 'tintColor={Colors.tintColor}',
+    tintColor: Colors.tintColor,
+  },
+  {
+    description: 'tintColor="#0002"',
+    tintColor: '#0002',
+  },
+];
+
+const IMAGES: ImageSource[] = [
+  require('../../../assets/images/expo.svg'),
+  'https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg',
+  'https://img.icons8.com/?size=512&id=121173&format=png',
+];
+
+export default function ImageTintingScreen() {
+  return (
+    <ScrollView style={styles.container}>
+      {EXAMPLES.map((example, index) => {
+        return (
+          <View style={styles.example} key={index}>
+            <MonoText>{example.description}</MonoText>
+            <View style={styles.group}>
+              {IMAGES.map((image, imageIndex) => {
+                return (
+                  <Image
+                    style={styles.image}
+                    source={image}
+                    contentFit="contain"
+                    tintColor={example.tintColor}
+                    key={imageIndex}
+                  />
+                );
+              })}
+            </View>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  example: {
+    alignItems: 'flex-start',
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    borderTopColor: Colors.border,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  group: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: 20,
+  },
+  image: {
+    width: 100,
+    height: 100,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    marginVertical: 10,
+  },
+});

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `tintColor` prop not working for SVGs. ([#23418](https://github.com/expo/expo/pull/23418) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 1.3.1 - 2023-06-29

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -54,7 +54,7 @@ public final class ImageModule: Module {
       }
 
       Prop("tintColor") { (view, tintColor: UIColor?) in
-        view.imageTintColor = tintColor ?? .clear
+        view.imageTintColor = tintColor
       }
 
       Prop("priority") { (view, priority: ImagePriority?) in


### PR DESCRIPTION
# Why

`tintColor` prop was not working for some SVGs (including Expo logo 😮)

# How

It turned out that the tint transformer doesn't trigger for vector and animated images. To solve this, I removed the transformer completely and used the `tintColor` attribute directly on the image view.

Then it turned out that it still doesn't work for some SVGs (not all, but it includes Expo logo, which is just a simple path).

I noticed that the SVG coder has an option to render to a bitmap instead of a vector... and that did the trick! Maybe this isn't ideal, but I don't think we have any other way and in the not-too-distant future we'll switch to SVGNative coder which always renders to a bitmap anyway.

# Test Plan

Added a new screen to NCL to demonstrate `tintColor` prop.

<img width="428" alt="Screenshot 2023-07-10 at 00 07 03" src="https://github.com/expo/expo/assets/1714764/20080fbb-ac11-4050-a6a5-f3d4088c085d">
