### PR TITLE
fix: Expo Router generating types for invalid route files

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added improved error message for static metro when a package is missing. ([#23499](https://github.com/expo/expo/pull/23499) by [@EvanBacon](https://github.com/EvanBacon))
 - Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix Expo Router generating types for invalid route files. ([#23421](https://github.com/expo/expo/pull/23421) by [@marklawlor](https://github.com/marklawlor))
+  > > > > > > > be224b97a6 (update CHANGELOG)
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -155,7 +155,9 @@ describe(getTypedRoutesUtils, () => {
         for (const staticRoute of expectedRoutes.static) {
           expect(actualRoutes).toContain(staticRoute);
         }
-      } else {
+      }
+
+      if ('dynamic' in expectedRoutes) {
         const actualRoutes = dynamicRoutes.get(filePathToRoute(filepath));
 
         expect(actualRoutes?.size).toEqual(expectedRoutes.dynamic.length);

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -70,8 +70,26 @@ describe(`${CAPTURE_GROUP_REGEX}`, () => {
 });
 
 describe(getTypedRoutesUtils, () => {
-  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath } =
+  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath, isRouteFile } =
     getTypedRoutesUtils('/user/project/app');
+
+  describe(isRouteFile, () => {
+    const filepaths = [
+      ['/user/project/app/file.tsx', true],
+      ['/user/project/app/folder/index.tsx', true],
+      ['/user/project/other/file.tsx', false],
+      ['/user/project/other/app/file.tsx', false],
+      ['/user/project/other/app/_layout.tsx', false],
+      ['/user/project/app/_layout.tsx', false],
+      ['/user/project/app/+html.tsx', false],
+      ['/user/project/app/folder/+html.tsx', false],
+      ['/user/project/app/folder/_layout.tsx', false],
+    ] as const;
+
+    it.each(filepaths)('is within the app root: %s', (filepath, expected) => {
+      expect(isRouteFile(filepath)).toEqual(expected);
+    });
+  });
 
   describe(filePathToRoute, () => {
     describe('unix paths', () => {

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -35,7 +35,7 @@ export async function setupTypedRoutes({
 }: SetupTypedRoutesOptions) {
   const appRoot = path.join(projectRoot, routerDirectory);
 
-  const { filePathToRoute, staticRoutes, dynamicRoutes, addFilePath } =
+  const { filePathToRoute, staticRoutes, dynamicRoutes, addFilePath, isRouteFile } =
     getTypedRoutesUtils(appRoot);
 
   if (metro) {
@@ -46,7 +46,12 @@ export async function setupTypedRoutes({
       metro,
       eventTypes: ['add', 'delete', 'change'],
       async callback({ filePath, type }) {
+        if (!isRouteFile(filePath)) {
+          return;
+        }
+
         let shouldRegenerate = false;
+
         if (type === 'delete') {
           const route = filePathToRoute(filePath);
           staticRoutes.delete(route);
@@ -153,11 +158,18 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
       .replace(/\.[jt]sx?$/, '');
   };
 
-  const addFilePath = (filePath: string): boolean => {
-    if (filePath.match(/_layout\.[tj]sx?$/)) {
+  const isRouteFile = (filePath: string) => {
+    // Layout and filenames starting with `+` are not routes
+    if (filePath.match(/_layout\.[tj]sx?$/) || filePath.match(/\/\+/)) {
       return false;
     }
 
+    // Route files must be nested with in the appRoot
+    const relative = path.relative(appRoot, filePath);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+  };
+
+  const addFilePath = (filePath: string): boolean => {
     const route = filePathToRoute(filePath);
 
     // We have already processed this file
@@ -220,6 +232,7 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
     dynamicRoutes,
     filePathToRoute,
     addFilePath,
+    isRouteFile,
   };
 }
 


### PR DESCRIPTION
# Why

https://github.com/expo/router/issues/736

Additionally, I noticed that `+html` files were not handled correctly.

# How

We return early inside the Metro watcher if the file is not a route file

# Test Plan

Reproduction steps in linked issue

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
