### PR TITLE
fix: incorrect type generation for Expo Router useLocalSearchParams

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed opening browser on Windows when debugging or opening Metro web. ([#23287](https://github.com/expo/expo/pull/23287) by [@byCedric](https://github.com/byCedric))
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
+- Fixed useLocalSearchParams type generation. ([#23422](https://github.com/expo/expo/pull/23422) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -177,12 +177,11 @@ export declare const Link: LinkComponent;
  ************/
 export declare function useRouter(): Router;
 export declare function useLocalSearchParams<
-  T extends DynamicRouteTemplate | StaticRoutes | RelativePathString
->(): SearchParams<T>;
+  T extends AllRoutes | SearchParams<DynamicRouteTemplate>
+>(): T extends AllRoutes ? SearchParams<T> : T;
 export declare function useSearchParams<
   T extends AllRoutes | SearchParams<DynamicRouteTemplate>
 >(): T extends AllRoutes ? SearchParams<T> : T;
-
 export declare function useGlobalSearchParams<
   T extends AllRoutes | SearchParams<DynamicRouteTemplate>
 >(): T extends AllRoutes ? SearchParams<T> : T;

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/route.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/route.test.ts
@@ -1,6 +1,12 @@
 import { expectType, expectError } from 'tsd-lite';
 
-import { useGlobalSearchParams, useSegments, useRouter, useSearchParams } from './fixtures/basic';
+import {
+  useGlobalSearchParams,
+  useSegments,
+  useRouter,
+  useSearchParams,
+  useLocalSearchParams,
+} from './fixtures/basic';
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
 const router = useRouter();
@@ -141,6 +147,13 @@ describe('router.push()', () => {
 describe('useSearchParams', () => {
   expectType<Record<'color', string>>(useSearchParams<'/colors/[color]'>());
   expectType<Record<'color', string>>(useSearchParams<Record<'color', string>>());
+  expectError(useSearchParams<'/invalid'>());
+  expectError(useSearchParams<Record<'custom', string>>());
+});
+
+describe('useLocalSearchParams', () => {
+  expectType<Record<'color', string>>(useLocalSearchParams<'/colors/[color]'>());
+  expectType<Record<'color', string>>(useLocalSearchParams<Record<'color', string>>());
   expectError(useSearchParams<'/invalid'>());
   expectError(useSearchParams<Record<'custom', string>>());
 });

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -448,12 +448,11 @@ declare module "expo-router" {
    ************/
   export function useRouter(): Router;
   export function useLocalSearchParams<
-    T extends DynamicRouteTemplate | StaticRoutes | RelativePathString
-  >(): SearchParams<T>;
+    T extends AllRoutes | SearchParams<DynamicRouteTemplate>
+  >(): T extends AllRoutes ? SearchParams<T> : T;
   export function useSearchParams<
     T extends AllRoutes | SearchParams<DynamicRouteTemplate>
   >(): T extends AllRoutes ? SearchParams<T> : T;
-
   export function useGlobalSearchParams<
     T extends AllRoutes | SearchParams<DynamicRouteTemplate>
   >(): T extends AllRoutes ? SearchParams<T> : T;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/23269

# How

Fix incorrect generic on `useLocalSearchParams`

# Test Plan

Production in linked issue

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
