### PR TITLE
[expo-updates][cli] Add missing chalk dependency to `expo-updates` cli

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 - [ios] Allow nil scopeKey for bare/embedded updates. ([#23385](https://github.com/expo/expo/pull/23385) by [@wschurman](https://github.com/wschurman))
-- [CLI] Add missing chalk dependency for the `expo-updates` cli.
+- [CLI] Add missing chalk dependency for the `expo-updates` cli. ([#23429](https://github.com/expo/expo/pull/23429) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 - [ios] Allow nil scopeKey for bare/embedded updates. ([#23385](https://github.com/expo/expo/pull/23385) by [@wschurman](https://github.com/wschurman))
+- [CLI] Add missing chalk dependency for the `expo-updates` cli.
 
 ### 💡 Others
 

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -43,6 +43,7 @@
     "@expo/config": "~8.1.0",
     "@expo/config-plugins": "~7.2.0",
     "arg": "4.1.0",
+    "chalk": "^4.1.2",
     "expo-eas-client": "~0.6.0",
     "expo-manifests": "~0.7.0",
     "expo-structured-headers": "~3.3.0",


### PR DESCRIPTION
# Why

`chalk` is used in the `expo-updates` CLI, but `chalk` was not added to the **package.json**. This could cause issues in [isolated modules](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md), or when `expo-updates` is installed without other dependencies installing `chalk`.

# How

- Added currently used `chalk@^4.1.2` as `dependency` to **package.json**.

<img width="281" alt="image" src="https://github.com/expo/expo/assets/1203991/5c3a114c-efdb-45c2-9b50-f5340cabc8c7">


# Test Plan

Minor change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
