### PR TITLE
[expo-updates][cli] Drop `fs-extra` in favor of `fs`

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 - [ios] Allow nil scopeKey for bare/embedded updates. ([#23385](https://github.com/expo/expo/pull/23385) by [@wschurman](https://github.com/wschurman))
 - [CLI] Add missing chalk dependency for the `expo-updates` cli. ([#23429](https://github.com/expo/expo/pull/23429) by [@byCedric](https://github.com/byCedric))
+- [CLI] Drop `fs-extra` in favor of `fs`.
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 - [ios] Allow nil scopeKey for bare/embedded updates. ([#23385](https://github.com/expo/expo/pull/23385) by [@wschurman](https://github.com/wschurman))
 - [CLI] Add missing chalk dependency for the `expo-updates` cli. ([#23429](https://github.com/expo/expo/pull/23429) by [@byCedric](https://github.com/byCedric))
-- [CLI] Drop `fs-extra` in favor of `fs`.
+- [CLI] Drop `fs-extra` in favor of `fs`. ([#23431](https://github.com/expo/expo/pull/23431) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-updates/cli/generateCodeSigningAsync.ts
+++ b/packages/expo-updates/cli/generateCodeSigningAsync.ts
@@ -6,9 +6,9 @@ import {
 } from '@expo/code-signing-certificates';
 import assert from 'assert';
 import { promises as fs } from 'fs';
-import { ensureDir } from 'fs-extra';
 import path from 'path';
 
+import { ensureDirAsync } from './utils/dir';
 import { log } from './utils/log';
 
 type Options = {
@@ -26,7 +26,7 @@ export async function generateCodeSigningAsync(
 
   const certificateOutputDir = path.resolve(projectRoot, certificateOutput);
   const keyOutputDir = path.resolve(projectRoot, keyOutput);
-  await Promise.all([ensureDir(certificateOutputDir), ensureDir(keyOutputDir)]);
+  await Promise.all([ensureDirAsync(certificateOutputDir), ensureDirAsync(keyOutputDir)]);
 
   const [certificateOutputDirContents, keyOutputDirContents] = await Promise.all([
     fs.readdir(certificateOutputDir),

--- a/packages/expo-updates/cli/utils/dir.ts
+++ b/packages/expo-updates/cli/utils/dir.ts
@@ -1,0 +1,5 @@
+import { promises as fs } from 'fs';
+
+export function ensureDirAsync(path: string) {
+  return fs.mkdir(path, { recursive: true });
+}

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -58,7 +58,6 @@
     "expo-module-scripts": "^3.0.0",
     "express": "^4.17.2",
     "form-data": "^4.0.0",
-    "fs-extra": "^9.1.0",
     "memfs": "^3.2.0",
     "xstate": "^4.37.2"
   },


### PR DESCRIPTION
# Why

`fs-extra` is used in the `expo-updates` CLI, but `fs-extra` was only added as `devDependency` to the **package.json**. This could cause issues in [isolated modules](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md), or when `expo-updates` is installed without other dependencies installing `fs-extra`.

# How

- Dropped `fs-extra`'s `ensureDir` in favor of `fs.promises.mkdir(..., { recursive: true });`

# Test Plan

Minor change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
