### PR TITLE
[docs] Fix typo in tabs.mdx

### DIFF
--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -6,7 +6,7 @@ description: Learn how to use the Tabs layout in Expo Router.
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
 
-The `Stack` layout in Expo Router wraps the [Bottom Tabs](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation.
+The `Tabs` layout in Expo Router wraps the [Bottom Tabs](https://reactnavigation.org/docs/bottom-tab-navigator) from React Navigation.
 
 Expo Router adds `href` screen option which can only be used with screen options that are an object (for example, `screenOptions={{ href: "/path" }}`) and cannot be used simultaneously with `tabBarButton`.
 


### PR DESCRIPTION
Fixed a typo (it's a Tabs page not a Stack one ;))
