### PR TITLE
[go] fix android crash when returning back to home

### DIFF
--- a/dev-home-config.json
+++ b/dev-home-config.json
@@ -1,3 +1,3 @@
 {
-  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-fbf0fab239b09466785895c43f7325b0fa1124a1"
+  "url": "exp://exp.host/@expo-home-dev/expo-home-dev-cd76aafe111aa92239b015fd4af5e987c564749d"
 }

--- a/home/menu/DevMenuBottomSheet.tsx
+++ b/home/menu/DevMenuBottomSheet.tsx
@@ -58,7 +58,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
     const closeSubscription = DevMenu.listenForCloseRequests(() => {
       bottomSheetRef.current?.collapse();
       return new Promise((resolve) => {
-        resolve(true);
+        resolve();
       });
     });
     return () => {


### PR DESCRIPTION
# Why

fixes #23393
close ENG-9266

# How

the resolved promise result did matter on android because on native side, we will [convert the result to ReadableMap](https://github.com/expo/expo/blob/1d68edad21eea82cc9e30f5fbc0c2add9fdd9c06/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt#L156). if we passing true, we will receive a java exception where boolean cannot convert to ReadableMap.

this is a regression from #22219

# Test Plan

test "go home" on expo-go

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
