### PR TITLE
[go] fix network inspector crash on android

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelNetworkInterceptor.kt
@@ -33,12 +33,12 @@ object KernelNetworkInterceptor {
   }
 
   val okhttpAppInterceptorProxy = Interceptor { chain ->
-    versionedAppInterceptorObject?.call("intercept", chain) as? Response
+    versionedAppInterceptorObject?.callWithThrowable("intercept", chain) as? Response
       ?: chain.proceed(chain.request())
   }
 
   val okhttpNetworkInterceptorProxy = Interceptor { chain ->
-    versionedNetworkInterceptorObject?.call("intercept", chain) as? Response
+    versionedNetworkInterceptorObject?.callWithThrowable("intercept", chain) as? Response
       ?: chain.proceed(chain.request())
   }
 


### PR DESCRIPTION
# Why

another fix for android expo go for network inspector

```
Fatal Exception: java.lang.IllegalStateException: network interceptor or.c0@2ba75f9 must call proceed() exactly once
```

# How

looks like #23350 does not fix the root cause, i can finally reproduce the problem and getting the backtrace:

```
             System.err  W  java.lang.reflect.InvocationTargetException
                         W      at java.lang.reflect.Method.invoke(Native Method)
                         W      at host.exp.exponent.RNObject.callWithReceiver(RNObject.kt:116)
                         W      at host.exp.exponent.RNObject.call(RNObject.kt:89)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor.okhttpNetworkInterceptorProxy$lambda$1(KernelNetworkInterceptor.kt:44)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor.$r8$lambda$ubbJXMbZzPmoWZtkgyWXf4wRJ60(Unknown Source:0)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor$$ExternalSyntheticLambda1.intercept(Unknown Source:0)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:95)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor.okhttpAppInterceptorProxy$lambda$0(KernelNetworkInterceptor.kt:39)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor.$r8$lambda$GE6sFpCGfmbK4YyhnwI1mRdeJvY(Unknown Source:0)
                         W      at host.exp.exponent.kernel.KernelNetworkInterceptor$$ExternalSyntheticLambda0.intercept(Unknown Source:0)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:201)
                         W      at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:517)
                         W      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
                         W      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
                         W      at java.lang.Thread.run(Thread.java:1012)
                         W  Caused by: java.io.IOException: unexpected end of stream on http://192.168.50.38/...
                         W      at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:202)
                         W      at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:106)
                         W      at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:79)
                         W      at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:109)
                         W      at expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor.intercept(ExpoNetworkInspectOkHttpInterceptors.kt:22)
                         W      ... 24 more
                         W  Caused by: java.io.EOFException: \n not found: limit=0 content=…
                         W      at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:332)
                         W      at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)
                         W      at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:178)
                         W      ... 28 more
```

okhttp internally will catch the IOException and cancel the request. however, calling through the `RNObject` with reflection, we will catch the `InvocationTargetException` and suppress the exception.

to make okhttp interceptor works expectedly, we should throw out the IOException, so this pr introduces a `RNObject.callWithThrowable` to throw out the exceptions.

# Test Plan

it seems easier to reproduce this problem from clean state:

```sh
$ adb shell pm clear host.exp.exponent
$ adb shell am start -n host.exp.exponent/.experience.HomeActivity
# on sdk49 blank project, press `a` to launch app in android expo-go
```

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
