### PR TITLE
[docs] Update tables in Reference index

### DIFF
--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -56,11 +56,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0           | 0.71                 | 0.18.12                  |
+| 49.0.0           | 0.72                 | 0.19.6                   |
+| 48.0.0           | 0.71                 | 0.18.10                  |
 | 47.0.0           | 0.70                 | 0.18.9                   |
 | 46.0.0           | 0.69                 | 0.18.7                   |
-| 45.0.0           | 0.68                 | 0.17.7                   |
-| 44.0.0           | 0.64                 | 0.17.1                   |
 
 ### Support for other React Native versions
 
@@ -72,8 +71,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 49.0.0           | 5+              | 33                  | 13+         |
 | 48.0.0           | 5+              | 33                  | 13+         |
 | 47.0.0           | 5+              | 31                  | 13+         |
 | 46.0.0           | 5+              | 31                  | 12.4+       |
-| 45.0.0           | 5+              | 31                  | 12+         |
-| 44.0.0           | 5+              | 30                  | 12+         |

--- a/docs/pages/versions/unversioned/index.mdx
+++ b/docs/pages/versions/unversioned/index.mdx
@@ -38,8 +38,8 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
   href="/bare/installing-expo-modules"
   description={
     <>
-      Projects that were created with <CODE>npx react-native init</CODE> require
-      additional setup to use the Expo SDK.
+      Projects that were created with <CODE>npx react-native init</CODE> require additional setup to
+      use the Expo SDK.
     </>
   }
 />
@@ -72,6 +72,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 48.0.0           | 5+              | 33                  | 13+         |
 | 47.0.0           | 5+              | 31                  | 13+         |
 | 46.0.0           | 5+              | 31                  | 12.4+       |
 | 45.0.0           | 5+              | 31                  | 12+         |

--- a/docs/pages/versions/v48.0.0/index.mdx
+++ b/docs/pages/versions/v48.0.0/index.mdx
@@ -38,8 +38,8 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
   href="/bare/installing-expo-modules"
   description={
     <>
-      Projects that were created with <CODE>npx react-native init</CODE> require
-      additional setup to use the Expo SDK.
+      Projects that were created with <CODE>npx react-native init</CODE> require additional setup to
+      use the Expo SDK.
     </>
   }
 />
@@ -56,7 +56,7 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0           | 0.71                 | 0.18.12                  |
+| 48.0.0           | 0.71                 | 0.18.10                  |
 | 47.0.0           | 0.70                 | 0.18.9                   |
 | 46.0.0           | 0.69                 | 0.18.7                   |
 | 45.0.0           | 0.68                 | 0.17.7                   |

--- a/docs/pages/versions/v49.0.0/index.mdx
+++ b/docs/pages/versions/v49.0.0/index.mdx
@@ -56,11 +56,10 @@ Every quarter there is a new Expo SDK release that typically updates to the late
 
 | Expo SDK version | React Native version | React Native Web version |
 | ---------------- | -------------------- | ------------------------ |
-| 48.0.0           | 0.71                 | 0.18.12                  |
+| 49.0.0           | 0.72                 | 0.19.6                   |
+| 48.0.0           | 0.71                 | 0.18.10                  |
 | 47.0.0           | 0.70                 | 0.18.9                   |
 | 46.0.0           | 0.69                 | 0.18.7                   |
-| 45.0.0           | 0.68                 | 0.17.7                   |
-| 44.0.0           | 0.64                 | 0.17.1                   |
 
 ### Support for other React Native versions
 
@@ -72,8 +71,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 49.0.0           | 5+              | 33                  | 13+         |
 | 48.0.0           | 5+              | 33                  | 13+         |
 | 47.0.0           | 5+              | 31                  | 13+         |
 | 46.0.0           | 5+              | 31                  | 12.4+       |
-| 45.0.0           | 5+              | 31                  | 12+         |
-| 44.0.0           | 5+              | 30                  | 12+         |

--- a/docs/pages/versions/v49.0.0/index.mdx
+++ b/docs/pages/versions/v49.0.0/index.mdx
@@ -38,8 +38,8 @@ The easiest way to create a bare React Native app with support for the Expo SDK 
   href="/bare/installing-expo-modules"
   description={
     <>
-      Projects that were created with <CODE>npx react-native init</CODE> require
-      additional setup to use the Expo SDK.
+      Projects that were created with <CODE>npx react-native init</CODE> require additional setup to
+      use the Expo SDK.
     </>
   }
 />
@@ -72,6 +72,7 @@ Each version of Expo SDK supports a minimum OS version of Android and iOS. For A
 
 | Expo SDK version | Android version | `compileSdkVersion` | iOS version |
 | ---------------- | --------------- | ------------------- | ----------- |
+| 48.0.0           | 5+              | 33                  | 13+         |
 | 47.0.0           | 5+              | 31                  | 13+         |
 | 46.0.0           | 5+              | 31                  | 12.4+       |
 | 45.0.0           | 5+              | 31                  | 12+         |


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

SDK 49 Reference tables are not up to date.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update SDK support version & Android/iOS version tables for SDK 48 in `unversioned`.
- Update tables for SDK 49 and backport changes from the previous point.

<img width="1172" alt="CleanShot 2023-07-10 at 20 08 01@2x" src="https://github.com/expo/expo/assets/10234615/62ffc2de-de5d-4992-b5cf-87f5785aef84">

<img width="1137" alt="CleanShot 2023-07-10 at 20 07 56@2x" src="https://github.com/expo/expo/assets/10234615/398e9f70-0c3b-4b29-8cda-e3d36f961a43">

- Fix React Native Web version in SDK 48 (Expo CLI installs `0.18.10` and previously, we mentioned it was `0.18.12`.
<img width="1138" alt="CleanShot 2023-07-10 at 20 08 17@2x" src="https://github.com/expo/expo/assets/10234615/37604270-33fc-4032-9c4c-f2a96af7acf5">

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
