### PR TITLE
[expo-json-utils][ios] Prefix category methods to reduce likelihood of conflicts

### DIFF
--- a/packages/expo-json-utils/CHANGELOG.md
+++ b/packages/expo-json-utils/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [ios] Prefix category methods to reduce likelihood of conflicts. ([#23441](https://github.com/expo/expo/pull/23441) by [@wschurman](https://github.com/wschurman))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.h
+++ b/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.h
@@ -6,14 +6,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDictionary<__covariant KeyType, __covariant ObjectType> (EXJSONUtils)
 
-- (NSString *)stringForKey:(KeyType)key;
-- (nullable NSString *)nullableStringForKey:(KeyType)key;
-- (NSNumber *)numberForKey:(KeyType)key;
-- (nullable NSNumber *)nullableNumberForKey:(KeyType)key;
-- (NSArray *)arrayForKey:(KeyType)key;
-- (nullable NSArray *)nullableArrayForKey:(KeyType)key;
-- (NSDictionary *)dictionaryForKey:(KeyType)key;
-- (nullable NSDictionary *)nullableDictionaryForKey:(KeyType)key;
+- (NSString *)expo_stringForKey:(KeyType)key;
+- (nullable NSString *)expo_nullableStringForKey:(KeyType)key;
+- (NSNumber *)expo_numberForKey:(KeyType)key;
+- (nullable NSNumber *)expo_nullableNumberForKey:(KeyType)key;
+- (NSArray *)expo_arrayForKey:(KeyType)key;
+- (nullable NSArray *)expo_nullableArrayForKey:(KeyType)key;
+- (NSDictionary *)expo_dictionaryForKey:(KeyType)key;
+- (nullable NSDictionary *)expo_nullableDictionaryForKey:(KeyType)key;
 
 @end
 

--- a/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.m
+++ b/packages/expo-json-utils/ios/EXJSONUtils/NSDictionary+EXJSONUtils.m
@@ -19,35 +19,35 @@
 
 @implementation NSDictionary (EXJSONUtils)
 
-- (NSString *)stringForKey:(id)key {
+- (NSString *)expo_stringForKey:(id)key {
   return EXGetNonNullManifestValue(NSString, key);
 }
 
-- (nullable NSString *)nullableStringForKey:(id)key {
+- (nullable NSString *)expo_nullableStringForKey:(id)key {
   return EXGetNullableManifestValue(NSString, key);
 }
 
-- (NSNumber *)numberForKey:(id)key {
+- (NSNumber *)expo_numberForKey:(id)key {
   return EXGetNonNullManifestValue(NSNumber, key);
 }
 
-- (nullable NSNumber *)nullableNumberForKey:(id)key {
+- (nullable NSNumber *)expo_nullableNumberForKey:(id)key {
   return EXGetNullableManifestValue(NSNumber, key);
 }
 
-- (NSArray *)arrayForKey:(id)key {
+- (NSArray *)expo_arrayForKey:(id)key {
   return EXGetNonNullManifestValue(NSArray, key);
 }
 
-- (nullable NSArray *)nullableArrayForKey:(id)key {
+- (nullable NSArray *)expo_nullableArrayForKey:(id)key {
   return EXGetNullableManifestValue(NSArray, key);
 }
 
-- (NSDictionary *)dictionaryForKey:(id)key {
+- (NSDictionary *)expo_dictionaryForKey:(id)key {
   return EXGetNonNullManifestValue(NSDictionary, key);
 }
 
-- (nullable NSDictionary *)nullableDictionaryForKey:(id)key {
+- (nullable NSDictionary *)expo_nullableDictionaryForKey:(id)key {
   return EXGetNullableManifestValue(NSDictionary, key);
 }
 

--- a/packages/expo-json-utils/ios/Tests/NSDictionary+EXJSONUtilsTest.m
+++ b/packages/expo-json-utils/ios/Tests/NSDictionary+EXJSONUtilsTest.m
@@ -22,51 +22,51 @@
 }
 
 - (void)test_stringForKey {
-  XCTAssertEqual([self.testData stringForKey:@"string"], @"hello");
-  XCTAssertThrows([self.testData stringForKey:@"number"]);
-  XCTAssertThrows([self.testData stringForKey:@"nonexistent"]);
+  XCTAssertEqual([self.testData expo_stringForKey:@"string"], @"hello");
+  XCTAssertThrows([self.testData expo_stringForKey:@"number"]);
+  XCTAssertThrows([self.testData expo_stringForKey:@"nonexistent"]);
 }
 
 - (void)test_nullableStringForKey {
-  XCTAssertEqual([self.testData nullableStringForKey:@"string"], @"hello");
-  XCTAssertNil([self.testData nullableStringForKey:@"nonexistent"]);
-  XCTAssertThrows([self.testData nullableStringForKey:@"number"]);
+  XCTAssertEqual([self.testData expo_nullableStringForKey:@"string"], @"hello");
+  XCTAssertNil([self.testData expo_nullableStringForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData expo_nullableStringForKey:@"number"]);
 }
 
 - (void)test_numberForKey {
-  XCTAssertEqual([self.testData numberForKey:@"number"], @2);
-  XCTAssertThrows([self.testData numberForKey:@"string"]);
-  XCTAssertThrows([self.testData numberForKey:@"nonexistent"]);
+  XCTAssertEqual([self.testData expo_numberForKey:@"number"], @2);
+  XCTAssertThrows([self.testData expo_numberForKey:@"string"]);
+  XCTAssertThrows([self.testData expo_numberForKey:@"nonexistent"]);
 }
 
 - (void)test_nullableNumberForKey {
-  XCTAssertEqual([self.testData nullableNumberForKey:@"number"], @2);
-  XCTAssertNil([self.testData nullableNumberForKey:@"nonexistent"]);
-  XCTAssertThrows([self.testData nullableNumberForKey:@"string"]);
+  XCTAssertEqual([self.testData expo_nullableNumberForKey:@"number"], @2);
+  XCTAssertNil([self.testData expo_nullableNumberForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData expo_nullableNumberForKey:@"string"]);
 }
 
 - (void)test_dictionaryForKey {
-  XCTAssertEqual([self.testData dictionaryForKey:@"dictionary"], @{});
-  XCTAssertThrows([self.testData dictionaryForKey:@"string"]);
-  XCTAssertThrows([self.testData dictionaryForKey:@"nonexistent"]);
+  XCTAssertEqual([self.testData expo_dictionaryForKey:@"dictionary"], @{});
+  XCTAssertThrows([self.testData expo_dictionaryForKey:@"string"]);
+  XCTAssertThrows([self.testData expo_dictionaryForKey:@"nonexistent"]);
 }
 
 - (void)test_nullableDictionaryForKey {
-  XCTAssertEqual([self.testData nullableDictionaryForKey:@"dictionary"], @{});
-  XCTAssertNil([self.testData nullableDictionaryForKey:@"nonexistent"]);
-  XCTAssertThrows([self.testData nullableDictionaryForKey:@"string"]);
+  XCTAssertEqual([self.testData expo_nullableDictionaryForKey:@"dictionary"], @{});
+  XCTAssertNil([self.testData expo_nullableDictionaryForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData expo_nullableDictionaryForKey:@"string"]);
 }
 
 - (void)arrayForKey {
-  XCTAssertEqual([self.testData arrayForKey:@"array"], @[]);
-  XCTAssertThrows([self.testData arrayForKey:@"string"]);
-  XCTAssertThrows([self.testData arrayForKey:@"nonexistent"]);
+  XCTAssertEqual([self.testData expo_arrayForKey:@"array"], @[]);
+  XCTAssertThrows([self.testData expo_arrayForKey:@"string"]);
+  XCTAssertThrows([self.testData expo_arrayForKey:@"nonexistent"]);
 }
 
 - (void)test_nullableArrayForKey {
-  XCTAssertEqual([self.testData nullableArrayForKey:@"array"], @[]);
-  XCTAssertNil([self.testData nullableArrayForKey:@"nonexistent"]);
-  XCTAssertThrows([self.testData nullableArrayForKey:@"string"]);
+  XCTAssertEqual([self.testData expo_nullableArrayForKey:@"array"], @[]);
+  XCTAssertNil([self.testData expo_nullableArrayForKey:@"nonexistent"]);
+  XCTAssertThrows([self.testData expo_nullableArrayForKey:@"string"]);
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/21674. While these aren't used in first-party code any more, they may still be relied upon in others' code.

Closes ENG-9226.

# How

The fix is to prefix (namespace) the category methods.

# Test Plan

Build

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
