### PR TITLE
[docs] Add EAS Insights to the EAS introduction page

### DIFF
--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -6,7 +6,13 @@ description: Learn about Expo Application Services (EAS) for Expo and React Nati
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasSubmitIcon, EasMetadataIcon, LayersTwo02Icon } from '@expo/styleguide-icons';
+import {
+  BuildIcon,
+  EasSubmitIcon,
+  EasMetadataIcon,
+  LayersTwo02Icon,
+  DataIcon,
+} from '@expo/styleguide-icons';
 
 Expo Application Services (EAS) are deeply integrated cloud services for Expo and React Native apps, from the team behind Expo.
 
@@ -14,28 +20,35 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 
 <BoxLink
   title="EAS Build"
-  description="Compile and sign Android/iOS apps with custom native code in the cloud. Learn more."
+  description="Compile and sign Android/iOS apps with custom native code in the cloud."
   href="/build/introduction"
   Icon={BuildIcon}
 />
 
 <BoxLink
   title="EAS Submit"
-  description="Upload your app to the Google Play Store or Apple App Store from the cloud with one CLI command. Learn more."
+  description="Upload your app to the Google Play Store or Apple App Store from the cloud with one CLI command."
   href="/submit/introduction"
   Icon={EasSubmitIcon}
 />
 
 <BoxLink
   title="EAS Update"
-  description="Address small bugs and push quick fixes directly to end-users. Learn more."
+  description="Address small bugs and push quick fixes directly to end-users."
   href="/eas-update/introduction"
   Icon={LayersTwo02Icon}
 />
 
 <BoxLink
   title="EAS Metadata (In Beta)"
-  description="Upload all app store information required to get your app published. Learn more."
+  description="Upload all app store information required to get your app published."
   href="/eas/metadata/"
   Icon={EasMetadataIcon}
+/>
+
+<BoxLink
+  title="EAS Insights (In Preview)"
+  description="View analytics about a project's performance, usage, and reach."
+  href="/eas-insights/introduction/"
+  Icon={DataIcon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We recently published an introductory doc for EAS Insights but it is not listed on the main https://docs.expo.dev/eas/ page.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding a `BoxLink` for the EAS Insights.

<img width="1161" alt="CleanShot 2023-07-11 at 00 31 32@2x" src="https://github.com/expo/expo/assets/10234615/3e16a722-9be4-46ad-8864-3b3c44c3825e">


# Test Plan

Run docs locally and visit: https://docs.expo.dev/eas/

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
