### PR TITLE
[expo-manifests][ios] Expose getMetadata method to match android

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Expose getMetadata method to match android. ([#23445](https://github.com/expo/expo/pull/23445) by [@wschurman](https://github.com/wschurman))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-manifests/ios/EXManifests/Manifest.swift
+++ b/packages/expo-manifests/ios/EXManifests/Manifest.swift
@@ -150,6 +150,10 @@ public class Manifest: NSObject {
     return expoClientConfigRootObject()?.optionalValue(forKey: "revisionId")
   }
 
+  public func getMetadata() -> [String: Any]? {
+    return rawManifestJSONInternal.optionalValue(forKey: "metadata")
+  }
+
   public func slug() -> String? {
     return expoClientConfigRootObject()?.optionalValue(forKey: "slug")
   }

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/SelectionPolicies.swift
@@ -10,8 +10,7 @@ public final class SelectionPolicies: NSObject {
       return true
     }
 
-    let metadata = update.manifest.rawManifestJSON()["metadata"]
-    guard let metadata = metadata as? [String: AnyObject] else {
+    guard let metadata = update.manifest.getMetadata() else {
       return true
     }
 


### PR DESCRIPTION
# Why

Closes ENG-9113.

This PR brings this up-to-date with the android implementation, which already has this method.

# How

Add method, use method.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
