### PR TITLE
[screen-orientation][ios] Fix initial orientation being set to portrait

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] When config plugin is not configured the initial orientation is now based on values in `Info.plist` instead of being set to portrait.
+
 ### 💡 Others
 
 - [iOS] Refactor the singleton class to work properly in versioned code in Expo Go. ([#23228](https://github.com/expo/expo/pull/23228) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] When config plugin is not configured the initial orientation is now based on values in `Info.plist` instead of being set to portrait.
+- [iOS] When config plugin is not configured the initial orientation is now based on values in `Info.plist` instead of being set to portrait. ([#23456](https://github.com/expo/expo/pull/23456) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
@@ -73,6 +73,23 @@ internal func plistStringToInterfaceOrientationMask(_ maskName: String) -> UIInt
   }
 }
 
+extension UIInterfaceOrientationMask.Element {
+  internal init?(fromOrientationString orientationString: String) {
+    switch orientationString {
+    case "UIInterfaceOrientationPortrait":
+      self = .portrait
+    case "UIInterfaceOrientationPortraitUpsideDown":
+      self = .portraitUpsideDown
+    case "UIInterfaceOrientationLandscapeRight":
+      self = .landscapeRight
+    case "UIInterfaceOrientationLandscapeLeft":
+      self = .landscapeLeft
+    default:
+      return nil
+    }
+  }
+}
+
 extension UIInterfaceOrientation {
   internal func toInterfaceOrientationMask() -> UIInterfaceOrientationMask {
     return UIInterfaceOrientationMask(rawValue: 1 << self.rawValue)

--- a/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
@@ -73,20 +73,18 @@ internal func plistStringToInterfaceOrientationMask(_ maskName: String) -> UIInt
   }
 }
 
-extension UIInterfaceOrientationMask.Element {
-  internal init?(fromOrientationString orientationString: String) {
-    switch orientationString {
-    case "UIInterfaceOrientationPortrait":
-      self = .portrait
-    case "UIInterfaceOrientationPortraitUpsideDown":
-      self = .portraitUpsideDown
-    case "UIInterfaceOrientationLandscapeRight":
-      self = .landscapeRight
-    case "UIInterfaceOrientationLandscapeLeft":
-      self = .landscapeLeft
-    default:
-      return nil
-    }
+internal func orientationStringToInterfaceOrientationMask(_ orientationString: String) -> UIInterfaceOrientationMask? {
+  switch orientationString {
+  case "UIInterfaceOrientationPortrait":
+    return .portrait
+  case "UIInterfaceOrientationPortraitUpsideDown":
+    return .portraitUpsideDown
+  case "UIInterfaceOrientationLandscapeRight":
+    return .landscapeRight
+  case "UIInterfaceOrientationLandscapeLeft":
+    return .landscapeLeft
+  default:
+    return nil
   }
 }
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -8,7 +8,7 @@ class ScreenOrientationViewController: UIViewController {
   let screenOrientationRegistry = ScreenOrientationRegistry.shared
   private var defaultOrientationMask: UIInterfaceOrientationMask
 
-  init(defaultOrientationMask: UIInterfaceOrientationMask = .portrait) {
+  init(defaultOrientationMask: UIInterfaceOrientationMask = doesDeviceHaveNotch ? .allButUpsideDown : .all) {
     self.defaultOrientationMask = defaultOrientationMask
     super.init(nibName: nil, bundle: nil)
   }
@@ -24,13 +24,13 @@ class ScreenOrientationViewController: UIViewController {
     }
 
     guard let mask = plistStringToInterfaceOrientationMask(orientationString) else {
-      log.warn("Orientation lock string '\(orientationString)' provided in Info.plist does not correspond to a valid orientation mask. Application will default to portrait orientation lock.")
+      log.warn("Orientation lock string '\(orientationString)' provided in Info.plist does not correspond to a valid orientation mask. Application will default to orientation mask set in \(supportedOrientationsKey).")
       self.init(defaultOrientationMask: supportedInterfaceOrientations)
       return
     }
 
     guard mask.isSupportedByDevice() else {
-      log.warn("Orientation lock string '\(orientationString)' provided in Info.plist is not supported by the device. Application will default to portrait orientation lock.")
+      log.warn("Orientation lock string '\(orientationString)' provided in Info.plist is not supported by the device. Application will default to orientation lock set in \(supportedOrientationsKey).")
       self.init(defaultOrientationMask: supportedInterfaceOrientations)
       return
     }


### PR DESCRIPTION
# Why

Fixes ENG-9217
`screen-orientation` would lock to .portrait by default if there was no config plugin configuration present in `Info.plist`.

# How

Made screen orientation check for values set in `UISupportedInterfaceOrientations` and use them as the default orientation lock. If initial orientation is configured with a config plugin it will be used instead of the values set in Info.plist.

# Test Plan

Tested on iOS 16 and iPadOS 16 simulators in Bare Expo and Expo Go
