### PR TITLE
[docs] Fix info about Vercel deployment

### DIFF
--- a/docs/pages/distribution/publishing-websites.mdx
+++ b/docs/pages/distribution/publishing-websites.mdx
@@ -172,7 +172,20 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
 <Terminal cmd={['$ npm install -g vercel@latest']} />
 
 </Step>
+
 <Step label="2">
+  Compile the Expo website.
+  <Tabs>
+    <Tab label="Expo Router">
+      <Terminal cmd={['# Compiles to ./dist', '$ npx expo export -p web']} />
+    </Tab>
+    <Tab label="webpack">
+      <Terminal cmd={['# Compiles to ./web-build', '$ npx expo export:web']} />
+    </Tab>
+  </Tabs>
+</Step>
+
+<Step label="3">
   Configure redirects for single-page applications.
   <Tabs>
     <Tab label="Expo Router">
@@ -194,37 +207,27 @@ Install the [Vercel CLI](https://vercel.com/docs/cli).
       If you modify this file, you will need to rebuild your project with `npx expo export -p web` to have it safely copied into the **dist** directory.
     </Tab>
     <Tab label="webpack">
-      If your app implements any navigation, you must configure Vercel to redirect requests to the single **web-build/index.html** file. This can be done in Vercel by creating a **`./public/vercel.json` file and redirecting all requests to `/index.html`.**
+      If your app implements any navigation, you must configure Vercel to redirect requests to the single **web-build/index.html** file.
 
-      Navigate inside the **web-build** directory and run the following command to create **\_redirects** file with rule:
+      Create a **web** directory at the root of your project. Inside this directory, create a **vercel.json** file with the following rule:
 
       ```json web/vercel.json
       {
         "version": 2,
-        "routes": [
+        "rewrites": [
           {
-            "src": "/(.*)",
-            "dest": "/"
+            "source": "/(.*)",
+            "destination": "/"
           }
         ]
       }
       ```
-      If you modify this file, you will need to rebuild your project with `npx expo export:web` to have it safely copied into the **web-build** directory.
 
+      Now, rebuild your project by running `npx expo export:web` command to copy the contents of the **web** directory into the **web-build** directory.
+
+      > Anytime you modify this file, rebuild your project with `npx expo export:web`. This safely copies the changes into the **web-build** directory.
     </Tab>
 
-  </Tabs>
-</Step>
-
-<Step label="3">
-  Compile the Expo website.
-  <Tabs>
-    <Tab label="Expo Router">
-      <Terminal cmd={['# Compiles to ./dist', '$ npx expo export -p web']} />
-    </Tab>
-    <Tab label="webpack">
-      <Terminal cmd={['# Compiles to ./web-build', '$ npx expo export:web']} />
-    </Tab>
   </Tabs>
 </Step>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1688936800389809)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By interchanging step 2 and 3 to generate output directory first before adding redirects (not all cases will require redirects)

<img width="911" alt="CleanShot 2023-07-11 at 17 15 47@2x" src="https://github.com/expo/expo/assets/10234615/c134b923-45ca-4b13-a255-1c7ecc0c3aa7">

- By updating redirect steps for webpack in step 3. Removed outdated info and updated the steps to provide clear instructions

<img width="830" alt="CleanShot 2023-07-11 at 17 16 04@2x" src="https://github.com/expo/expo/assets/10234615/a99b1093-7f33-4715-94c5-f6d191e06488">




# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/distribution/publishing-websites/#vercel

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
