### PR TITLE
[screen-orienetation][ios] Stop emitting events when no listeners are registered

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
-- [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
 - [iOS] Refactor the singleton class to work properly in versioned code in Expo Go. ([#23228](https://github.com/expo/expo/pull/23228) by [@tsapeta](https://github.com/tsapeta))
 
 ## 6.0.1 — 2023-06-23

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [iOS] Fix event emitter sending events with no registered listeners.
 - [iOS] Refactor the singleton class to work properly in versioned code in Expo Go. ([#23228](https://github.com/expo/expo/pull/23228) by [@tsapeta](https://github.com/tsapeta))
 
 ## 6.0.1 — 2023-06-23

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Fix event emitter sending events with no registered listeners.
+- [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
 - [iOS] Refactor the singleton class to work properly in versioned code in Expo Go. ([#23228](https://github.com/expo/expo/pull/23228) by [@tsapeta](https://github.com/tsapeta))
 
 ## 6.0.1 — 2023-06-23

--- a/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationModule.swift
@@ -4,7 +4,7 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
   static let didUpdateDimensionsEvent = "expoDidUpdateDimensions"
 
   let screenOrientationRegistry = ScreenOrientationRegistry.shared
-  var eventEmitter: EXEventEmitterService?
+  var shouldEmitEvents = false
 
   public func definition() -> ModuleDefinition {
     Name("ExpoScreenOrientation")
@@ -82,12 +82,20 @@ public class ScreenOrientationModule: Module, ScreenOrientationController {
     OnDestroy {
       screenOrientationRegistry.unregisterController(self)
     }
+
+    OnStartObserving {
+      shouldEmitEvents = true
+    }
+
+    OnStopObserving {
+      shouldEmitEvents = false
+    }
   }
 
   // MARK: - ScreenOrientationController
 
   public func screenOrientationDidChange(_ orientation: UIInterfaceOrientation) {
-    guard let currentTraitCollection = screenOrientationRegistry.currentTraitCollection else {
+    guard let currentTraitCollection = screenOrientationRegistry.currentTraitCollection, shouldEmitEvents else {
       return
     }
 


### PR DESCRIPTION
# Why

Fixes ENG-9216 - "Sending `expoDidUpdateDimensions` with no listeners registered." when rotation occurs and no listener is added to ScreenOrientation

# How

Added a check to make sure that there are listeners before sending the event. Also removed the `eventEmitter` variable which is a leftover from migrating to new modules API.

# Test Plan

Tested in Bare Expo on iOS 16 simulator