### PR TITLE
[docs] Add Navigation to Home overview

### DIFF
--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -9,7 +9,9 @@ Expo is an [open-source framework](https://github.com/expo/expo/) for apps that 
 
 - **Develop**: Developing an app requires writing code in JavaScript/TypeScript. When you create a new project, Expo provides a standard [project structure](/develop/project-structure) which you can customize as per your needs. It also provides [development builds](/develop/development-builds/introduction) that help your team to iterate quickly to achieve web-like iteration speeds and safely.
 
-{/* TODO: (@aman) Add a section for Navigation, Review later when they are ready. */}
+- **Navigation**: Developing an app that requires navigation involves creating different screens, linking them to URLs, switching between screens, and displaying UI elements related to navigation on specific platforms. [Expo Router](/routing/introduction/) simplifies this process by converting each file in the app directory into a route and offering automatic deep linking.
+
+{/* TODO: (@aman) Add a section for Review later when its are ready. */}
 
 - **Deploy**: Deploying your app requires you to publish your app to the Play Store and App Store. Expo provides a [build service](/deploy/build-project/) that helps you to build your app for Android and iOS. It also provides ways to automate [uploading and submitting your app binaries](/deploy/submit-to-app-stores) to the app stores, and fixing small bugs and [pushing quick fixes](/deploy/instant-updates) a snap in between app store submissions.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Adding "Navigation" in was part of the Home organization spec. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding info about Navigation in the Home > Overview doc

<img width="1104" alt="CleanShot 2023-07-11 at 22 16 45@2x" src="https://github.com/expo/expo/assets/10234615/78340a5b-bf37-4b18-a74f-790e44670414">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/overview/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
