### PR TITLE
[docs] mention useClassicUpdates

### DIFF
--- a/docs/pages/archive/expo-cli.mdx
+++ b/docs/pages/archive/expo-cli.mdx
@@ -340,7 +340,7 @@ Alias: `expo update`
 
 ### Publish
 
-> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](versions/latest/config/app/#useclassicupdates) in your app config.
+> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](/versions/latest/config/app/#useclassicupdates) in your app config.
 
 <Collapsible summary={<><h4>expo publish</h4>Deploy a project to Expo hosting</>}>
 

--- a/docs/pages/archive/expo-cli.mdx
+++ b/docs/pages/archive/expo-cli.mdx
@@ -340,6 +340,8 @@ Alias: `expo update`
 
 ### Publish
 
+> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](versions/latest/config/app/#useclassicupdates) in your app config.
+
 <Collapsible summary={<><h4>expo publish</h4>Deploy a project to Expo hosting</>}>
 
 Alias: `expo p`

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -8,6 +8,8 @@ import { Step } from '~/ui/components/Step';
 
 EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
+> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](versions/latest/config/app/#useclassicupdates) in your app config.
+
 ## Prerequisites
 
 EAS Update requires the following versions or greater:

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -6,9 +6,9 @@ description: A guide to help migrate from Classic Updates to EAS Update.
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
-
 > SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](/versions/latest/config/app/#useclassicupdates) in your app config.
+
+EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
 ## Prerequisites
 

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -8,7 +8,7 @@ import { Step } from '~/ui/components/Step';
 
 EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
-> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](versions/latest/config/app/#useclassicupdates) in your app config.
+> SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](/versions/latest/config/app/#useclassicupdates) in your app config.
 
 ## Prerequisites
 


### PR DESCRIPTION
# Why

Mention `useClassicupdates` in the docs so people know what to do if they want to continue using classic updates


# Test Plan

- [ ] manually testsed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
