### PR TITLE
[cli] Add styling to SSO auth redirect completion page

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add support for SSO users. ([#22945](https://github.com/expo/expo/pull/22945) by [@lzkb](https://github.com/lzkb))
 - Use node server default port selection for SSO login server. ([#23505](https://github.com/expo/expo/pull/23505) by [@wschurman](https://github.com/wschurman))
+- Add styling to SSO auth redirect completion page. ([#23477](https://github.com/expo/expo/pull/23477) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -6,6 +6,36 @@ import querystring from 'querystring';
 
 import * as Log from '../../log';
 
+const successBody = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Expo SSO Login</title>
+  <meta charset="utf-8">
+  <style type="text/css">
+    html {
+      margin: 0;
+      padding: 0
+    }
+
+    body {
+      background-color: #fff;
+      font-family: Tahoma,Verdana;
+      font-size: 16px;
+      color: #000;
+      max-width: 100%;
+      box-sizing: border-box;
+      padding: .5rem;
+      margin: 1em;
+      overflow-wrap: break-word
+    }
+  </style>
+</head>
+<body>
+  SSO login complete. You may now close this tab and return to the command prompt.
+</body>
+</html>`;
+
 export async function getSessionUsingBrowserAuthFlowAsync({
   expoWebsiteUrl,
 }: {
@@ -41,8 +71,8 @@ export async function getSessionUsingBrowserAuthFlowAsync({
               throw new Error('Request missing session_secret search parameter.');
             }
             resolve(sessionSecret);
-            response.writeHead(200, { 'Content-Type': 'text/plain' });
-            response.write(`Website login has completed. You can now close this tab.`);
+            response.writeHead(200, { 'Content-Type': 'text/html' });
+            response.write(successBody);
             response.end();
           } catch (error) {
             reject(error);


### PR DESCRIPTION
# Why

Just to make this slightly more readable. Would be cool if we could auto-close it but most browsers don't allow `window.close` JS to be executed without interaction.

# How

Add styling.

# Test Plan

Login with SSO, see:

<img width="694" alt="Screenshot 2023-07-11 at 4 28 17 PM" src="https://github.com/expo/expo/assets/189568/e2339d36-740f-4d5f-a080-e4808895eae0">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
