### PR TITLE
[expo-updates][Android] EX_UPDATES_ANDROID_DELAY_LOAD_APP settable from environment

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 💡 Others
 
 - Native getter for state machine context. ([#23428](https://github.com/expo/expo/pull/23428) by [@douglowder](https://github.com/douglowder))
+- [Android] EX_UPDATES_ANDROID_DELAY_LOAD_APP settable by env. ([#23479](https://github.com/expo/expo/pull/23479) by [@douglowder](https://github.com/douglowder))
 
 ## 0.18.9 - 2023-07-10
 

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -6,7 +6,32 @@ apply plugin: 'maven-publish'
 group = 'host.exp.exponent'
 version = '0.18.5'
 
-def ex_updates_native_debug = System.getenv("EX_UPDATES_NATIVE_DEBUG") == "1" ? "true" : "false"
+// Utility method to derive boolean values from the environment or from Java properties,
+// and return them as strings to be used in BuildConfig fields
+def get_bool_string_value_from_prop_or_env(String name, Boolean defaultValue) {
+  def env_value = System.getenv(name)
+  def prop_value = findProperty(name)
+  def value = defaultValue.toString()
+  // If present, property value in gradle.properties overrides default
+  if (prop_value != null) {
+    value = boolish(prop_value).toString()
+    System.out.println("expo-updates: Value of ${name} was overridden by property, new value = ${value}")
+  }
+  // If present, env value overrides default and gradle.properties
+  if (env_value != null) {
+    value = boolish(env_value).toString()
+    System.out.println("expo-updates: Value of ${name} was overridden by environment, new value = ${value}")
+  }
+  return value
+}
+
+// If true, app will use bundled manifest and updates will be enabled, even for
+// debug builds. (default false)
+def ex_updates_native_debug = get_bool_string_value_from_prop_or_env("EX_UPDATES_NATIVE_DEBUG", false)
+
+// If true, code will run that delays app loading until updates is initialized, to prevent ANR issues.
+// (default true)
+def ex_updates_android_delay_load_app = get_bool_string_value_from_prop_or_env("EX_UPDATES_ANDROID_DELAY_LOAD_APP", true)
 
 buildscript {
   def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
@@ -75,7 +100,7 @@ android {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
     buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
-    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", boolish(findProperty("EX_UPDATES_ANDROID_DELAY_LOAD_APP") ?: true).toString())
+    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", ex_updates_android_delay_load_app)
 
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -8,30 +8,30 @@ version = '0.18.5'
 
 // Utility method to derive boolean values from the environment or from Java properties,
 // and return them as strings to be used in BuildConfig fields
-def get_bool_string_value_from_prop_or_env(String name, Boolean defaultValue) {
+def getBoolStringFromPropOrEnv(String name, Boolean defaultValue) {
   def env_value = System.getenv(name)
   def prop_value = findProperty(name)
   def value = defaultValue.toString()
   // If present, property value in gradle.properties overrides default
   if (prop_value != null) {
     value = boolish(prop_value).toString()
-    System.out.println("expo-updates: Value of ${name} was overridden by property, new value = ${value}")
+    println("expo-updates: Value of ${name} was overridden by property, new value = ${value}")
   }
   // If present, env value overrides default and gradle.properties
   if (env_value != null) {
     value = boolish(env_value).toString()
-    System.out.println("expo-updates: Value of ${name} was overridden by environment, new value = ${value}")
+    println("expo-updates: Value of ${name} was overridden by environment, new value = ${value}")
   }
   return value
 }
 
 // If true, app will use bundled manifest and updates will be enabled, even for
 // debug builds. (default false)
-def ex_updates_native_debug = get_bool_string_value_from_prop_or_env("EX_UPDATES_NATIVE_DEBUG", false)
+def exUpdatesNativeDebug = getBoolStringFromPropOrEnv("EX_UPDATES_NATIVE_DEBUG", false)
 
 // If true, code will run that delays app loading until updates is initialized, to prevent ANR issues.
 // (default true)
-def ex_updates_android_delay_load_app = get_bool_string_value_from_prop_or_env("EX_UPDATES_ANDROID_DELAY_LOAD_APP", true)
+def exUpdatesAndroidDelayLoadApp = getBoolStringFromPropOrEnv("EX_UPDATES_ANDROID_DELAY_LOAD_APP", true)
 
 buildscript {
   def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
@@ -99,8 +99,8 @@ android {
     consumerProguardFiles("proguard-rules.pro")
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-    buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", ex_updates_native_debug)
-    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", ex_updates_android_delay_load_app)
+    buildConfigField("boolean", "EX_UPDATES_NATIVE_DEBUG", exUpdatesNativeDebug)
+    buildConfigField("boolean", "EX_UPDATES_ANDROID_DELAY_LOAD_APP", exUpdatesAndroidDelayLoadApp)
 
     // uncomment below to export the database schema when making changes
     /* javaCompileOptions {


### PR DESCRIPTION
# Why

SDK 49 includes a change on Android that delays app startup until `expo-updates` is initialized, in a way that prevents possible ANR (app not responsive) crashes (#20273).

As this change may need to be turned off (e.g. for issue #23363), a Java property `EX_UPDATES_ANDROID_DELAY_LOAD_APP` was provided that could be set to `false` in `gradle.properties`. However, in managed apps built by EAS Build, the Android directory does not exist in the source project, so this change is difficult to make.

# How

Solution: modify `expo-updates` `build.gradle` so that an environment variable can be passed in to set this property in EAS builds, as in this example:

```json
{
  "build": {
    "preview": {
      "env": {
        "EX_UPDATES_ANDROID_DELAY_LOAD_APP": "false"
      },
      "distribution": "internal",
      "android": {
        "withoutCredentials": true
      },
      "ios": {
        "simulator": true
      },
      "channel": "preview"
    },
    "production": {
      "channel": "production"
    }
  }
}
```

Added a common method to correctly derive a similar boolean value for another property needed by native code (`EX_UPDATES_NATIVE_DEBUG`).

# Test Plan

- Tested on desktop to verify that the properties are picked up as expected
- Added logging to note when these properties are changed so that those will be available in Android build logs
- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
