### PR TITLE
changed link so its no longer broken

### DIFF
--- a/docs/pages/router/reference/faq.mdx
+++ b/docs/pages/router/reference/faq.mdx
@@ -17,7 +17,7 @@ export const unstable_settings = {
 
 Historically, React Native has been non prescriptive about how apps should be built, this is similar to using React without a modern web framework. Expo Router is an opinionated framework for React Native, similar to how Remix and Next.js are opinionated frameworks for web-only React.
 
-Expo Router is designed to bring the best architectural patterns to everyone, to ensure React Native is leveraged to its fullest. For example, Expo Router's [Async Routes](/router/static-rendering/async-routes) feature enables lazy bundling for everyone. Previously, lazy bundling was only used at Meta to build the Facebook app.
+Expo Router is designed to bring the best architectural patterns to everyone, to ensure React Native is leveraged to its fullest. For example, Expo Router's [Async Routes](/router/reference/async-routes) feature enables lazy bundling for everyone. Previously, lazy bundling was only used at Meta to build the Facebook app.
 
 ## Can I use Expo Router in my React Native app?
 


### PR DESCRIPTION
# Why

The previous link led to this page which gave me a 404: https://docs.expo.dev/router/static-rendering/async-routes/

# How

I exchanged the link with a working one

# Test Plan

I tested it running it locally on my machin, calling http://localhost:3002/router/reference/faq/ and clicking on the link to verify it works :-)

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
