### PR TITLE
[docs][notifications] ack FCM legacy key deprecation

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -258,11 +258,9 @@ For Expo to send push notifications from our servers and use your credentials, y
 
 4. In your [Expo account's](https://expo.dev/) dashboard, select your project, and click on **Credentials** in the navigation menu. Then, click on your **Application Identifier** that follows the pattern:`com.company.app`.
 
-   > For Legacy Application Identifiers, run `expo push:android:upload --api-key your-token-here`, replacing `your-token-here` with the string you just copied. We'll store your token securely on our servers, where it will only be accessed when you send a push notification.
-
 5. Under **Service Credentials** > **FCM Server Key**, click **Add a FCM Server Key** > **Google Cloud Messaging Token** and add the **Server key** from **step 3**.
 
-   > **warning** Having Service Credentials in both Legacy and non-legacy Application Identifiers can prevent push notifications from working on Android devices. If you have a Legacy Application Identifier, you should remove all of its Service Credentials.
+> Expo notifications only supports the **Cloud Messaging API (Legacy)** key at this time. This key is deprecated by Firebase, but will continue to work until 6/30/2024. We will provide information on migrating to the new v1 key in the future.
 
 ### iOS
 

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -260,7 +260,7 @@ For Expo to send push notifications from our servers and use your credentials, y
 
 5. Under **Service Credentials** > **FCM Server Key**, click **Add a FCM Server Key** > **Google Cloud Messaging Token** and add the **Server key** from **step 3**.
 
-> Expo notifications only supports the **Cloud Messaging API (Legacy)** key at this time. This key is deprecated by Firebase, but will continue to work until 6/30/2024. We will provide information on migrating to the new v1 key in the future.
+> Expo Notifications only supports the **Cloud Messaging API (Legacy)** key at this time. This key is deprecated by Firebase. However, it will continue to work until June 30, 2024. We will provide information on migrating to the new v1 key in the future.
 
 ### iOS
 


### PR DESCRIPTION
# Why
Folks are asking about this a lot. We should acknowledge the key is deprecated and that there's a deadline, so users know we're aware of it and that we will communicate more about it in the future. Google's messaging here is prompting some to actually try to input the v1 key into Expo's app credentials, which doesn't work.

<img width="912" alt="image" src="https://github.com/expo/expo/assets/8053974/9808e992-0765-4d80-92ce-ac0537da9432">

Also, removed the "legacy application identifier" notes, since that leads to a lot of "legacy" talk, referring to two totally different things, in a rather tight space. I don't recall "legacy application identifier" terminology being used in many other places, and I think that all is pretty far in the rear-view mirror, so maybe not needed? If we do keep something about it, I think it should be just advice to use `expo push:android:clear`. I don't think there's a reason to update credentials in the global CLI at this point.
 
# How

Updated docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
