### PR TITLE
fix: dev client crash

### DIFF
--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -1008,11 +1008,13 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
   ) {
     let task = session.dataTask(with: request) { data, response, error in
       guard let response = response else {
-        // error is non-nil when data and response are both nil
-        // swiftlint:disable:next force_unwrapping
-        let error = error!
-        self.logger.error(message: error.localizedDescription, code: .unknown)
-        errorBlock(error)
+        let fallbackMessage = "downloadData: both response and error are empty"
+        self.logger.error(message: error?.localizedDescription ?? fallbackMessage, code: .unknown)
+        errorBlock(error ?? NSError(
+          domain: ErrorDomain,
+          code: FileDownloaderErrorCode.InvalidResponseError.rawValue,
+          userInfo: [NSLocalizedDescriptionKey: fallbackMessage]
+        ))
         return
       }
 


### PR DESCRIPTION
# Why

This fixes a crash that I'm seeing locally when developing with a device. I'm not sure I can share a repro but I can reproduce it consistently, here's a screenshot: 

<img width="1021" alt="Screenshot 2023-07-12 at 16 17 22" src="https://github.com/expo/expo/assets/1566403/dcabc647-2c8d-4065-94cf-1ecff5ea8777">


maybe related to not being able to log in, the sign in button spins forever. I'm running ios 16 beta 4.

https://github.com/expo/expo/assets/1566403/9fb60445-4222-46a2-8732-eb456c978153



this does avoid the hard crash but I'm not sure if it's an actual solution to the problem I'm having.

# How

I'm just avoiding the force-unwrap.

# Test Plan

tested locally: instead of a hard crash, I get an error. Not what I want but better than before

<details>
  <summary>screenshot after</summary>
  ![IMG_01EFE8E3091E-1](https://github.com/expo/expo/assets/1566403/bef4377b-30ec-435b-8aa5-ce681ee0ea94)


</details>



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
