### PR TITLE
[docs] Update Home navigation

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -50,7 +50,7 @@ const generalDirectories = fs
 // --- Navigation ---
 
 const home = [
-  makePage('overview.mdx'),
+  makeSection('', [makePage('overview.mdx')]),
   makeSection('Get started', [
     makePage('get-started/installation.mdx'),
     makePage('get-started/expo-go.mdx'),


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After changing `makeSection(...)` to `makePage(...)` to display Home > Overview doc, it gets hidden.

<img width="278" alt="CleanShot 2023-07-12 at 21 42 01@2x" src="https://github.com/expo/expo/assets/10234615/13487b32-57a9-4b71-9aca-232177de891e">


# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR reverts that change back.

<img width="277" alt="CleanShot 2023-07-12 at 21 42 11@2x" src="https://github.com/expo/expo/assets/10234615/c48d78e9-1945-4f84-8bfc-4fdee14749c7">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
