### PR TITLE
[docs] Fix internal links in Expo Router docs

### DIFF
--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -31,7 +31,7 @@ export default function Layout() {
 
 Now deep linking directly to `/other` or reloading the page will continue to show the back arrow.
 
-When using [array syntax](/router/routing/groups/#arrays) `(foo,bar)` you can specify the name of a group in the `unstable_settings` object to target a particular segment.
+When using [array syntax](/router/advanced/shared-routes/#arrays) `(foo,bar)` you can specify the name of a group in the `unstable_settings` object to target a particular segment.
 
 ```js other.js
 export const unstable_settings = {

--- a/docs/pages/router/reference/async-routes.mdx
+++ b/docs/pages/router/reference/async-routes.mdx
@@ -22,7 +22,7 @@ All Routes are wrapped inside a suspense boundary and are loaded asynchronously.
 
 {/* The [Suspense fallback](https://react.dev/reference/react/Suspense#displaying-a-fallback-while-content-is-loading) or loading state **cannot be customized** at this time. We plan to add support in the future via a **route+loading.js** file. */}
 
-Loading errors are handled in the parent route, via the [`ErrorBoundary`](/router/routing/errors) export.
+Loading errors are handled in the parent route, via the [`ErrorBoundary`](/routing/error-handling/#errorboundary) export.
 
 Async routes cannot be statically filtered during development, so all files will be treated as routes even if they don't export a default component. After the component is bundled and loaded, then any invalid route will use a fallback warning screen. This behavior is development-only and will not be present in production.
 

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -12,7 +12,7 @@ Consider the following project:
 
 <FileTree files={['app/_layout.js', 'app/index.js', 'app/(auth)/sign-in.js']} />
 
-First, we'll setup a [React Context provider](https://reactjs.org/docs/context.html) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](/guides/authentication/).
+First, we'll setup a [React Context provider](https://react.dev/reference/react/createContext) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](/guides/authentication/).
 
 ```js context/auth.js
 import { router, useSegments } from 'expo-router';

--- a/docs/pages/router/reference/faq.mdx
+++ b/docs/pages/router/reference/faq.mdx
@@ -5,7 +5,7 @@ sidebar_title: FAQ
 
 ## Missing back button
 
-If you set up a modal or another screen that is expected to have a back button, then you'll need to add [`unstable_settings`](https://expo.github.io/router/docs/features/routing/#layout-settings) to the route's layout to ensure the initial route is configured. Initial routes are somewhat unique to mobile apps and therefore fit awkwardly in the system &mdash; improvements pending.
+If you set up a modal or another screen that is expected to have a back button, then you'll need to add [`unstable_settings`](/router/advanced/router-settings/) to the route's layout to ensure the initial route is configured. Initial routes are somewhat unique to mobile apps and therefore fit awkwardly in the system &mdash; improvements pending.
 
 ```jsx app/_layout.tsx
 export const unstable_settings = {

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -50,7 +50,7 @@ const config = getDefaultConfig(__dirname, {
 module.exports = config;
 ```
 
-  You can also [learn more](/guides/customizing-metro/) about customizing Metro.
+You can also [learn more](/guides/customizing-metro/) about customizing Metro.
 
 </Step>
 
@@ -231,7 +231,7 @@ The exports from `expo-router/html` are related to the Root HTML component.
 
 ## Meta Tags
 
-You can add meta tags to your pages with the [`<Head />`](/docs/features/head) module from `expo-router`:
+You can add meta tags to your pages with the `<Head />` module from `expo-router`:
 
 ```js app/about.tsx
 import Head from 'expo-router/head';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some internal links refer to old links before migration.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes internal links and updates one external link to new React docs in various docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit docs in which links are updated in this PR and click those links manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
