### PR TITLE
[docs] Sidebar: add icons for EAS Insights and Router sections

### DIFF
--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -1,3 +1,4 @@
+import { RouterLogo } from '@expo/styleguide';
 import {
   Cube01Icon,
   CpuChip01Icon,
@@ -9,6 +10,7 @@ import {
   Bell03Icon,
   PlanEnterpriseIcon,
   PaletteIcon,
+  DataIcon,
 } from '@expo/styleguide-icons';
 
 import { SidebarNodeProps } from './Sidebar';
@@ -72,8 +74,12 @@ function getIconElement(iconName?: string) {
       return LayersTwo02Icon;
     case 'EAS Metadata':
       return EasMetadataIcon;
+    case 'EAS Insights':
+      return DataIcon;
     case 'Expo Modules API':
       return CpuChip01Icon;
+    case 'Expo Router':
+      return RouterLogo;
     case 'Push notifications':
       return Bell03Icon;
     case 'UI programming':


### PR DESCRIPTION
# Why

We have added two, new sections after the initial version of sidebar icons PR, let's fill the gaps.

# How

Add icons to EAS Insights and Router sections in Guides sidebar.

# Test Plan

The changes have been verified locally.

# Preview

<img width="279" alt="Screenshot 2023-07-12 at 18 43 59" src="https://github.com/expo/expo/assets/719641/dbbbc3ac-35c4-44b6-b878-236d4ba231aa">
<img width="279" alt="Screenshot 2023-07-12 at 18 43 45" src="https://github.com/expo/expo/assets/719641/ed6aa540-5623-47ae-a134-365cc4308b13">

