### PR TITLE
[expo-document-picker][ios] Fix type prop support in v13

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `type` on `DocumentPickerOptions` on iOS. ([#23497](https://github.com/expo/expo/pull/23497) by [@aleqsio](https://github.com/aleqsio))
+
 ### 💡 Others
 
 ## 11.5.3 - 2023-07-10

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -156,15 +156,61 @@ public class DocumentPickerModule: Module, PickingResultHandler {
     }
   }
 
+  @available(iOS 14.0, *)
+  private func toUTType(mimeType: String) -> UTType? {
+    switch mimeType {
+      case "*/*":
+        return UTType.item
+      case "image/*":
+        return UTType.image
+      case "video/*":
+        return UTType.video
+      case "audio/*":
+        return UTType.audio
+      case "text/*":
+        return UTType.text
+      default:
+        return UTType(mimeType: mimeType)
+    }
+  }
+
+  private func toUTI(mimeType: String) -> String {
+    var uti: CFString
+
+    switch mimeType {
+      case "*/*":
+        uti = kUTTypeItem
+      case "image/*":
+        uti = kUTTypeImage
+      case "video/*":
+        uti = kUTTypeVideo
+      case "audio/*":
+        uti = kUTTypeAudio
+      case "text/*":
+        uti = kUTTypeText
+      default:
+        if let ref = UTTypeCreatePreferredIdentifierForTag(
+          kUTTagClassMIMEType,
+          mimeType as CFString,
+          nil
+        )?.takeRetainedValue() {
+          uti = ref
+        } else {
+          uti = kUTTypeItem
+        }
+    }
+    return uti as String
+  }
+
   private func createDocumentPicker(with options: DocumentPickerOptions) -> UIDocumentPickerViewController {
     if #available(iOS 14.0, *) {
-      let utTypes = options.type.compactMap { $0.toUTType() }
+      let utTypes = options.type.compactMap { toUTType(mimeType: $0) }
       return UIDocumentPickerViewController(
         forOpeningContentTypes: utTypes,
         asCopy: true
       )
     } else {
-      let utiTypes = options.type.map { $0.toUTI() }
+      let utiTypes = options.type.map { toUTI(mimeType: $0) }
       return UIDocumentPickerViewController(
         documentTypes: utiTypes,
         in: .import

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -160,17 +160,17 @@ public class DocumentPickerModule: Module, PickingResultHandler {
   private func toUTType(mimeType: String) -> UTType? {
     switch mimeType {
       case "*/*":
-        return UTType.item
+      return UTType.item
       case "image/*":
-        return UTType.image
+      return UTType.image
       case "video/*":
-        return UTType.video
+      return UTType.video
       case "audio/*":
-        return UTType.audio
+      return UTType.audio
       case "text/*":
-        return UTType.text
+      return UTType.text
       default:
-        return UTType(mimeType: mimeType)
+      return UTType(mimeType: mimeType)
     }
   }
 
@@ -179,25 +179,25 @@ public class DocumentPickerModule: Module, PickingResultHandler {
 
     switch mimeType {
       case "*/*":
-        uti = kUTTypeItem
+      uti = kUTTypeItem
       case "image/*":
-        uti = kUTTypeImage
+      uti = kUTTypeImage
       case "video/*":
-        uti = kUTTypeVideo
+      uti = kUTTypeVideo
       case "audio/*":
-        uti = kUTTypeAudio
+      uti = kUTTypeAudio
       case "text/*":
-        uti = kUTTypeText
+      uti = kUTTypeText
       default:
-        if let ref = UTTypeCreatePreferredIdentifierForTag(
-          kUTTagClassMIMEType,
-          mimeType as CFString,
-          nil
-        )?.takeRetainedValue() {
-          uti = ref
-        } else {
-          uti = kUTTypeItem
-        }
+      if let ref = UTTypeCreatePreferredIdentifierForTag(
+        kUTTagClassMIMEType,
+        mimeType as CFString,
+        nil
+      )?.takeRetainedValue() {
+        uti = ref
+      } else {
+        uti = kUTTypeItem
+      }
     }
     return uti as String
   }

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -159,17 +159,17 @@ public class DocumentPickerModule: Module, PickingResultHandler {
   @available(iOS 14.0, *)
   private func toUTType(mimeType: String) -> UTType? {
     switch mimeType {
-      case "*/*":
+    case "*/*":
       return UTType.item
-      case "image/*":
+    case "image/*":
       return UTType.image
-      case "video/*":
+    case "video/*":
       return UTType.video
-      case "audio/*":
+    case "audio/*":
       return UTType.audio
-      case "text/*":
+    case "text/*":
       return UTType.text
-      default:
+    default:
       return UTType(mimeType: mimeType)
     }
   }
@@ -178,17 +178,17 @@ public class DocumentPickerModule: Module, PickingResultHandler {
     var uti: CFString
 
     switch mimeType {
-      case "*/*":
+    case "*/*":
       uti = kUTTypeItem
-      case "image/*":
+    case "image/*":
       uti = kUTTypeImage
-      case "video/*":
+    case "video/*":
       uti = kUTTypeVideo
-      case "audio/*":
+    case "audio/*":
       uti = kUTTypeAudio
-      case "text/*":
+    case "text/*":
       uti = kUTTypeText
-      default:
+    default:
       if let ref = UTTypeCreatePreferredIdentifierForTag(
         kUTTagClassMIMEType,
         mimeType as CFString,

--- a/packages/expo-document-picker/ios/DocumentPickerOptions.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerOptions.swift
@@ -6,63 +6,8 @@ struct DocumentPickerOptions: Record {
   var copyToCacheDirectory: Bool
 
   @Field
-  var type: [MimeType]
+  var type: [String]
 
   @Field
   var multiple: Bool
-}
-
-internal enum MimeType: String, Enumerable {
-  case item = "*/*"
-  case image = "image/*"
-  case video = "video/*"
-  case audio = "audio/*"
-  case text = "text/*"
-
-  @available(iOS 14.0, *)
-  func toUTType() -> UTType? {
-    switch self {
-    case .item:
-      return UTType.item
-    case .image:
-      return UTType.image
-    case .video:
-      return UTType.video
-    case .audio:
-      return UTType.audio
-    case .text:
-      return UTType.text
-    default:
-      return UTType(mimeType: self.rawValue)
-    }
-  }
-
-  func toUTI() -> String {
-    var uti: CFString
-
-    switch self {
-    case .item:
-      uti = kUTTypeItem
-    case .image:
-      uti = kUTTypeImage
-    case .video:
-      uti = kUTTypeVideo
-    case .audio:
-      uti = kUTTypeAudio
-    case .text:
-      uti = kUTTypeText
-    default:
-      if let ref = UTTypeCreatePreferredIdentifierForTag(
-        kUTTagClassMIMEType,
-        self.rawValue as CFString,
-        nil
-      )?.takeRetainedValue() {
-        uti = ref
-      } else {
-        uti = kUTTypeItem
-      }
-    }
-
-    return uti as String
-  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "*": ["ts-declarations/*", "node_modules/*"]
+      "*": [
+        "ts-declarations/*",
+        "node_modules/*"
+      ]
     }
-  }
+  },
+  "extends": "expo/tsconfig.base"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,7 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "*": [
-        "ts-declarations/*",
-        "node_modules/*"
-      ]
+      "*": ["ts-declarations/*", "node_modules/*"]
     }
-  },
-  "extends": "expo/tsconfig.base"
+  }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/22351

# How

Mimetypes are supposed to be arbitrary, so we can't represent them using a swift enum. Instead, we can reuse the logic but change the Swift type to a String.

# Test Plan

Tested this in BareExpo.
Before the change I got an error as described in the issue.
After the change I can live the type prop empty and get all files, or set any mimetype and get correct filtering.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
