### PR TITLE
Detox helper with testID

### DIFF
--- a/packages/expo-dev-menu/app/components/Main.tsx
+++ b/packages/expo-dev-menu/app/components/Main.tsx
@@ -114,7 +114,7 @@ export function Main({ registeredCallbacks = [], isDevice }: MainProps) {
             <Spacer.Horizontal />
 
             <View width="large" style={{ alignSelf: 'flex-start' }}>
-              <Button.FadeOnPressContainer onPress={hideMenu} bg="ghost" rounded="full">
+              <Button.FadeOnPressContainer onPress={hideMenu} bg="ghost" rounded="full" testID="fade-on-press-container">
                 <View padding="micro">
                   <XIcon />
                 </View>


### PR DESCRIPTION
Allows detox to bypass this screen by setting testID on XIcon button.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
