### PR TITLE
[location][android] Downgrade play-services-location to 20.0.0

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Downgrade play-services-location to 20.0.0 to support react-native-maps. ([#23501](https://github.com/expo/expo/pull/23501) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 16.0.0 — 2023-06-21

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -82,7 +82,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  api 'com.google.android.gms:play-services-location:21.0.1'
+  api 'com.google.android.gms:play-services-location:20.0.0'
 
   api('io.nlopez.smartlocation:library:3.3.3') {
     transitive = false

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.java
@@ -119,15 +119,16 @@ public class LocationHelpers {
     return heading;
   }
 
-  public static LocationRequest.Builder prepareLocationRequest(Map<String, Object> options) {
+  public static LocationRequest prepareLocationRequest(Map<String, Object> options) {
     LocationParams locationParams = LocationHelpers.mapOptionsToLocationParams(options);
     int accuracy = LocationHelpers.getAccuracyFromOptions(options);
 
-    return new LocationRequest.Builder(locationParams.getInterval())
-      .setMinUpdateIntervalMillis(locationParams.getInterval())
-      .setMaxUpdateDelayMillis(locationParams.getInterval())
-      .setMinUpdateDistanceMeters(locationParams.getDistance())
-      .setPriority(mapAccuracyToPriority(accuracy));
+    return new LocationRequest()
+        .setFastestInterval(locationParams.getInterval())
+        .setInterval(locationParams.getInterval())
+        .setMaxWaitTime(locationParams.getInterval())
+        .setSmallestDisplacement(locationParams.getDistance())
+        .setPriority(mapAccuracyToPriority(accuracy));
   }
 
   public static LocationParams mapOptionsToLocationParams(Map<String, Object> options) {
@@ -146,14 +147,14 @@ public class LocationHelpers {
     return locationParamsBuilder.build();
   }
 
-  static void requestSingleLocation(final LocationModule locationModule, final LocationRequest.Builder locationRequest, final Promise promise) {
+  static void requestSingleLocation(final LocationModule locationModule, final LocationRequest locationRequest, final Promise promise) {
     // we want just one update
-    locationRequest.setMaxUpdates(1);
+    locationRequest.setNumUpdates(1);
 
-    locationModule.requestLocationUpdates(locationRequest.build(), null, new LocationRequestCallbacks() {
+    locationModule.requestLocationUpdates(locationRequest, null, new LocationRequestCallbacks() {
       @Override
       public void onLocationChanged(Location location) {
-          promise.resolve(LocationHelpers.locationToBundle(location, Bundle.class));
+        promise.resolve(LocationHelpers.locationToBundle(location, Bundle.class));
       }
 
       @Override

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.java
@@ -275,7 +275,7 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
   @ExpoMethod
   public void getCurrentPositionAsync(final Map<String, Object> options, final Promise promise) {
     // Read options
-    final LocationRequest.Builder builder = LocationHelpers.prepareLocationRequest(options);
+    final LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(options);
     boolean showUserSettingsDialog = !options.containsKey(SHOW_USER_SETTINGS_DIALOG_KEY) || (boolean) options.get(SHOW_USER_SETTINGS_DIALOG_KEY);
 
     // Check for permissions
@@ -285,12 +285,12 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
     }
 
     if (LocationHelpers.hasNetworkProviderEnabled(mContext) || !showUserSettingsDialog) {
-      LocationHelpers.requestSingleLocation(this, builder, promise);
+      LocationHelpers.requestSingleLocation(this, locationRequest, promise);
     } else {
       // Pending requests can ask the user to turn on improved accuracy mode in user's settings.
-      addPendingLocationRequest(builder.build(), resultCode -> {
+      addPendingLocationRequest(locationRequest, resultCode -> {
         if (resultCode == Activity.RESULT_OK) {
-          LocationHelpers.requestSingleLocation(LocationModule.this, builder, promise);
+          LocationHelpers.requestSingleLocation(LocationModule.this, locationRequest, promise);
         } else {
           promise.reject(new LocationSettingsUnsatisfiedException());
         }
@@ -336,16 +336,16 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
       return;
     }
 
-    final LocationRequest.Builder locationRequest = LocationHelpers.prepareLocationRequest(options);
+    final LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(options);
     boolean showUserSettingsDialog = !options.containsKey(SHOW_USER_SETTINGS_DIALOG_KEY) || (boolean) options.get(SHOW_USER_SETTINGS_DIALOG_KEY);
 
     if (LocationHelpers.hasNetworkProviderEnabled(mContext) || !showUserSettingsDialog) {
-      LocationHelpers.requestContinuousUpdates(this, locationRequest.build(), watchId, promise);
+      LocationHelpers.requestContinuousUpdates(this, locationRequest, watchId, promise);
     } else {
       // Pending requests can ask the user to turn on improved accuracy mode in user's settings.
-      addPendingLocationRequest(locationRequest.build(), resultCode -> {
+      addPendingLocationRequest(locationRequest, resultCode -> {
         if (resultCode == Activity.RESULT_OK) {
-          LocationHelpers.requestContinuousUpdates(LocationModule.this, locationRequest.build(), watchId, promise);
+          LocationHelpers.requestContinuousUpdates(LocationModule.this, locationRequest, watchId, promise);
         } else {
           promise.reject(new LocationSettingsUnsatisfiedException());
         }
@@ -443,9 +443,9 @@ public class LocationModule extends ExportedModule implements LifecycleEventList
       return;
     }
 
-    LocationRequest.Builder locationRequest = LocationHelpers.prepareLocationRequest(new HashMap<>());
+    LocationRequest locationRequest = LocationHelpers.prepareLocationRequest(new HashMap<>());
 
-    addPendingLocationRequest(locationRequest.build(), resultCode -> {
+    addPendingLocationRequest(locationRequest, resultCode -> {
       if (resultCode == Activity.RESULT_OK) {
         promise.resolve(null);
       } else {

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.java
@@ -181,7 +181,7 @@ public class LocationTaskConsumer extends TaskConsumer implements TaskConsumerIn
       return;
     }
 
-    mLocationRequest = LocationHelpers.prepareLocationRequest(mTask.getOptions()).build();
+    mLocationRequest = LocationHelpers.prepareLocationRequest(mTask.getOptions());
     mPendingIntent = preparePendingIntent();
 
     try {


### PR DESCRIPTION
# Why

The latest version of `react-native-maps` (v1.7.1) is not yet compatible with `play-services-location:21.0.0`. This incompatibility causes apps to crash when utilizing `expo-location` along with `react-native-maps`, especially when the `showUserLocation` prop is enabled.

Closes ENG-9289
Fixes https://github.com/expo/expo/issues/23396

# How

This PR downgrades `play-services-location` to v20.0.0, the same used by Expo Go. As a side effect, we need to revert  https://github.com/expo/expo/commit/3436d44c0008c2b8049b7611f13ef75818d591b1 as things like `LocationRequest.Builder` were only introduced on v21 ([Release Notes](https://developers.google.com/android/guides/releases?hl=en#october_13_2022))



# Test Plan

Run bare-expo on Android and test `expo-location` and `react-native-maps` through the "Background Location" screen

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
