### PR TITLE
[cli] Use node server default port selection for SSO login server

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add support for SSO users. ([#22945](https://github.com/expo/expo/pull/22945) by [@lzkb](https://github.com/lzkb))
+- Use node server default port selection for SSO login server. ([#23505](https://github.com/expo/expo/pull/23505) by [@wschurman](https://github.com/wschurman))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -1,5 +1,4 @@
 import { env } from '../utils/env';
-import { getFreePortAsync } from '../utils/port';
 
 /** Get the URL for the expo.dev API. */
 export function getExpoApiBaseUrl(): string {
@@ -21,9 +20,4 @@ export function getExpoWebsiteBaseUrl(): string {
   } else {
     return `https://expo.dev`;
   }
-}
-
-export async function getSsoLocalServerPortAsync(): Promise<number> {
-  const startPort = env.EXPO_SSO_LOCAL_SERVER_PORT;
-  return await getFreePortAsync(startPort);
 }

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -6,7 +6,7 @@ import * as Log from '../../log';
 import * as Analytics from '../../utils/analytics/rudderstackClient';
 import { getDevelopmentCodeSigningDirectory } from '../../utils/codesigning';
 import { env } from '../../utils/env';
-import { getExpoWebsiteBaseUrl, getSsoLocalServerPortAsync } from '../endpoint';
+import { getExpoWebsiteBaseUrl } from '../endpoint';
 import { graphqlClient } from '../graphql/client';
 import { UserQuery } from '../graphql/queries/UserQuery';
 import { fetchAsync } from '../rest/client';
@@ -77,11 +77,9 @@ export async function loginAsync(json: {
 }
 
 export async function ssoLoginAsync(): Promise<void> {
-  const config = {
+  const sessionSecret = await getSessionUsingBrowserAuthFlowAsync({
     expoWebsiteUrl: getExpoWebsiteBaseUrl(),
-    serverPort: await getSsoLocalServerPortAsync(),
-  };
-  const sessionSecret = await getSessionUsingBrowserAuthFlowAsync(config);
+  });
   const userData = await fetchUserAsync({ sessionSecret });
 
   await UserSettings.setSessionAsync({

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -151,11 +151,6 @@ class Env {
   get EXPO_NO_METRO_LAZY() {
     return boolish('EXPO_NO_METRO_LAZY', false);
   }
-
-  /** The start value for the port that the local server used for SSO login listens on. */
-  get EXPO_SSO_LOCAL_SERVER_PORT() {
-    return int('EXPO_SSO_LOCAL_SERVER_PORT', 19200);
-  }
 }
 
 export const env = new Env();


### PR DESCRIPTION
# Why

As suggested in https://github.com/expo/eas-cli/pull/1875#discussion_r1229587098, we can just use the default port selection mechanism for starting a listener server for the SSO auth redirect.

Closes ENG-8950.

# How

Change code to use default port selection.

# Test Plan

```
nexpo login --sso
```

(see it logs in)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
