### PR TITLE
add note about Expo Go and Analytics

### DIFF
--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -4,7 +4,6 @@ description: An overview of analytics services available in the Expo and React N
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { FOOTNOTE } from '~/ui/components/Text';
 
 An analytics service allows you to track how users interact with your app. With this data, you can take a measured approach when improving your app.
 
@@ -44,12 +43,6 @@ The following list provides common analytics providers that are available in the
 
 <BoxLink
   title="Aptabase"
-  description={
-    <>
-      Learn how to integrate Aptabase Analytics in your project.
-      <br />
-      <FOOTNOTE tag="span" theme="success">Works with Expo Go</FOOTNOTE>
-    </>
-  }
+  description="Learn how to integrate Aptabase Analytics in your project. Works with Expo Go."
   href="https://aptabase.com/for-react-native"
 />

--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -4,12 +4,13 @@ description: An overview of analytics services available in the Expo and React N
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { FOOTNOTE } from '~/ui/components/Text';
 
 An analytics service allows you to track how users interact with your app. With this data, you can take a measured approach when improving your app.
 
 The following list provides common analytics providers that are available in the Expo and React Native ecosystem.
 
-> Each analytics SDK requires configuring custom native code. Native code is not configurable when using Expo Go. However, you can create a [development build](/develop/development-builds/introduction/), which will allow you to use any of the services below.
+> Most analytics SDK requires configuring custom native code. Native code is not configurable when using Expo Go. However, you can create a [development build](/develop/development-builds/introduction/), which will allow you to use any of the services below.
 
 <BoxLink
   title="Google Firebase Analytics"
@@ -43,6 +44,12 @@ The following list provides common analytics providers that are available in the
 
 <BoxLink
   title="Aptabase"
-  description="Learn how to integrate Aptabase Analytics in your project."
+  description={
+    <>
+      Learn how to integrate Aptabase Analytics in your project.
+      <br />
+      <FOOTNOTE tag="span" theme="success">Works with Expo Go</FOOTNOTE>
+    </>
+  }
   href="https://aptabase.com/for-react-native"
 />


### PR DESCRIPTION
# Why

This is a follow up from https://github.com/expo/expo/pull/23263 to clarify that Aptabase works with Expo Go. This addition was a suggestion from one of our users as this can be useful during the decision making process.

# How

- Changed "each" to "most" which I think is more accurate
- Reused existing components and docs styleguide to highlight compatibility with Expo Go. 

Let me know what you think!

<img width="851" alt="Screenshot 2023-07-13 at 07 44 03" src="https://github.com/expo/expo/assets/94755/66a8b04d-cce5-4905-8f2d-3e588c34dfd2">
