### PR TITLE
[docs] Fix Platform Compatibility preview for BarCodeScanner

### DIFF
--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android ios web />
+<PlatformsSection android ios />
 
 #### Limitations
 

--- a/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/unversioned/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android ios web />
 
 #### Limitations
 

--- a/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
@@ -13,7 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android ios web />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/bar-code-scanner.mdx
@@ -13,7 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 **`expo-barcode-scanner`** provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android ios web />
+<PlatformsSection android ios />
 
 > **Note:** Only one active BarCodeScanner preview is supported currently. When using navigation, the best practice is to unmount any previously rendered BarCodeScanner component so the following screens can use `<BarCodeScanner />` without issues.
 

--- a/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
@@ -14,7 +14,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android ios web />
 
 #### Limitations
 

--- a/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/bar-code-scanner.mdx
@@ -14,7 +14,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android ios web />
+<PlatformsSection android ios />
 
 #### Limitations
 

--- a/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android ios web />
+<PlatformsSection android ios />
 
 #### Limitations
 

--- a/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android ios web />
 
 #### Limitations
 

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android ios web />
+<PlatformsSection android ios />
 
 #### Limitations
 

--- a/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/bar-code-scanner.mdx
@@ -20,7 +20,7 @@ import { AndroidPermissions, IOSPermissions } from '~/components/plugins/permiss
 
 `expo-barcode-scanner` provides a React component that renders a viewfinder for the device's camera (either front or back) and will scan bar codes that show up in the frame.
 
-<PlatformsSection android emulator ios simulator />
+<PlatformsSection android ios web />
 
 #### Limitations
 


### PR DESCRIPTION
# Why

Align `<PlatformsSection android ios web />` from `expo-camera`

- https://docs.expo.dev/versions/latest/sdk/camera/
- https://docs.expo.dev/versions/latest/sdk/bar-code-scanner/

# How

--

# Test Plan

Checked with iOS simulator. I believe it's the same for Android.

![image](https://github.com/expo/expo/assets/360936/b935574f-904c-436b-916c-baee1cb5dd2e)

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
