### PR TITLE
[expo-constants][Android] Fix Task ':expo-constants:packageDebugAssets' uses this output of task ':expo-constants:copyReleaseExpoConfig' without declaring an explicit or implicit dependency

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix task ':expo-constants:packageDebugAssets' uses this output of task ':expo-constants:copyReleaseExpoConfig' without declaring an explicit or implicit dependency when running `gradlew test` on Android.
+- Fix task ':expo-constants:packageDebugAssets' uses this output of task ':expo-constants:copyReleaseExpoConfig' without declaring an explicit or implicit dependency when running `gradlew test` on Android. ([#23511](https://github.com/expo/expo/pull/23511) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix task ':expo-constants:packageDebugAssets' uses this output of task ':expo-constants:copyReleaseExpoConfig' without declaring an explicit or implicit dependency when running `gradlew test` on Android.
+
 ### 💡 Others
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))

--- a/packages/expo-constants/scripts/get-app-config-android.gradle
+++ b/packages/expo-constants/scripts/get-app-config-android.gradle
@@ -1,4 +1,4 @@
-// Gradle script for generating serialized public app config (from app.config.js/ts or app.json) and bundling it into the APK 
+// Gradle script for generating serialized public app config (from app.config.js/ts or app.json) and bundling it into the APK
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
@@ -47,20 +47,24 @@ afterEvaluate {
       description = "expo-constants: Copy generated app.config into ${targetName}."
 
       from(assetsDir)
-      into("${projectDir}/src/main/assets")
+      into("${projectDir}/src/${targetPath}/assets")
       include('app.config')
 
-      dependsOn("create${targetName}ExpoConfig")
+      dependsOn(currentBundleTask)
     }
 
     def currentCleanupAppConfigTask = tasks.register("cleanup${targetName}ExpoConfig", Delete) {
       description = "expo-constants: Cleanup generated app.config from ${targetName}."
 
+      // In the past, the `app.config` file was placed in the `main` directory.
+      // However, this is no longer the case. To ensure a smooth transition,
+      // we’re also cleaning the `app.config` from the old location.
       delete files("${projectDir}/src/main/assets/app.config")
+      delete files("${projectDir}/src/${targetPath}/assets/app.config")
       dependsOn(packageTaskName)
     }
 
-    // In summary, these tasks try to create `src/main/assets/app.config` in building time for gradle to merge the asset.
+    // In summary, these tasks try to create `src/${targetPath}/assets/app.config` in building time for gradle to merge the asset.
     // And cleanup the generated app.config after building time.
     tasks.findByPath(packageTaskName).dependsOn(currentCopyAppConfigTask)
     tasks.findByPath("process${targetName}JavaRes").dependsOn(currentCleanupAppConfigTask)


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/23457.

# How

During the Gradle test, a dependency between two tasks was discovered: `expo-constants:packageDebugAssets` and `expo-constants:copyReleaseExpoConfig`. This occurred because both the `Release` and `Debug` variants utilize an `app.config` file located in the `main` directory. It's not an ideal scenario. That way I decided to generate the config file in the `src/${targetPath}/assets` instead. This change should not affect the structure or outcome of the generated `APK`.

# Test Plan

- new project ✅
- bare-expo ✅
- manually confirm that the `app.config` is inside of the generated apk ✅
![Screenshot 2023-07-13 at 12 09 52](https://github.com/expo/expo/assets/9578601/cdd8c50b-3062-42b3-9a44-372c473cc365)

