### PR TITLE
feature(cli): add `expo run` command to select platform to run

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add first-class Xcode IDE hints for Metro bundling errors during production iOS builds from Xcode. ([#25410](https://github.com/expo/expo/pull/25410) by [@EvanBacon](https://github.com/EvanBacon))
 - Added support for React Native 0.73.0. ([#24971](https://github.com/expo/expo/pull/24971), [#25453](https://github.com/expo/expo/pull/25453) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Re-implement debugging tools with new React Native JS Inspector. ([#25649](https://github.com/expo/expo/pull/25649) by [@byCedric](https://github.com/byCedric))
+- Add `expo run` command to select platform to run. ([#23514](https://github.com/expo/expo/pull/23514) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -91,6 +91,9 @@ if (!isSubcommand && args['--help']) {
     // workaround until we can use `expo export` for all production bundling.
     // https://github.com/expo/expo/pull/21396/files#r1121025873
     'export:embed': exportEmbed_unused,
+    // Other ignored commands, these are intentially not listed in the `--help` output
+    run: _run,
+    // All other commands
     ...others
   } = commands;
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -18,6 +18,7 @@ export type Command = (argv?: string[]) => void;
 const commands: { [command: string]: () => Promise<Command> } = {
   // Add a new command here
   // NOTE(EvanBacon): Ensure every bundler-related command sets `NODE_ENV` as expected for the command.
+  run: () => import('../src/run').then((i) => i.expoRun),
   'run:ios': () => import('../src/run/ios/index.js').then((i) => i.expoRunIos),
   'run:android': () => import('../src/run/android/index.js').then((i) => i.expoRunAndroid),
   start: () => import('../src/start/index.js').then((i) => i.expoStart),

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -18,7 +18,7 @@ export type Command = (argv?: string[]) => void;
 const commands: { [command: string]: () => Promise<Command> } = {
   // Add a new command here
   // NOTE(EvanBacon): Ensure every bundler-related command sets `NODE_ENV` as expected for the command.
-  run: () => import('../src/run').then((i) => i.expoRun),
+  run: () => import('../src/run/index.js').then((i) => i.expoRun),
   'run:ios': () => import('../src/run/ios/index.js').then((i) => i.expoRunIos),
   'run:android': () => import('../src/run/android/index.js').then((i) => i.expoRunAndroid),
   start: () => import('../src/start/index.js').then((i) => i.expoStart),

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -55,7 +55,7 @@ it('runs `npx expo run --help`', async () => {
 it('runs `npx expo run android --help`', async () => {
   const results = await execute('run', 'android', '--help');
   expect(results.stdout).toMatchInlineSnapshot(`
-    "› Using expo run android --help
+    "› Using expo run:android --help
 
       Description
         Run the native Android app locally
@@ -63,7 +63,7 @@ it('runs `npx expo run android --help`', async () => {
       Usage
         $ npx expo run:android <dir>
 
-      Options
+      Options 
         --no-build-cache       Clear the native build cache
         --no-install           Skip installing dependencies
         --no-bundler           Skip starting the bundler
@@ -78,7 +78,7 @@ it('runs `npx expo run android --help`', async () => {
 it('runs `npx expo run ios --help`', async () => {
   const results = await execute('run', 'ios', '--help');
   expect(results.stdout).toMatchInlineSnapshot(`
-    "› Using expo run ios --help
+    "› Using expo run:ios --help
 
       Info
         Run the iOS app binary locally

--- a/packages/@expo/cli/e2e/__tests__/run-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/run-test.ts
@@ -1,0 +1,103 @@
+import fs from 'fs/promises';
+
+import { execute, getLoadedModulesAsync, projectRoot } from './utils';
+
+const originalForceColor = process.env.FORCE_COLOR;
+const originalCI = process.env.CI;
+
+beforeAll(async () => {
+  await fs.mkdir(projectRoot, { recursive: true });
+  process.env.FORCE_COLOR = '0';
+  process.env.CI = '1';
+});
+
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
+  process.env.CI = originalCI;
+});
+
+it('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(`require('../../build/src/run').expoRun`);
+  expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
+    '../node_modules/arg/index.js',
+    '../node_modules/chalk/source/index.js',
+    '../node_modules/chalk/source/util.js',
+    '../node_modules/getenv/index.js',
+    '../node_modules/has-flag/index.js',
+    '../node_modules/supports-color/index.js',
+    '@expo/cli/build/src/log.js',
+    '@expo/cli/build/src/run/hints.js',
+    '@expo/cli/build/src/run/index.js',
+    '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/env.js',
+    '@expo/cli/build/src/utils/errors.js',
+    '@expo/cli/build/src/utils/interactive.js',
+  ]);
+});
+
+it('runs `npx expo run --help`', async () => {
+  const results = await execute('run', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "
+      Info
+        Run the native app locally
+
+      Usage
+        $ npx expo run <android|ios>
+
+      Options
+        $ npx expo run <android|ios> --help  Output usage information
+    "
+  `);
+});
+
+it('runs `npx expo run android --help`', async () => {
+  const results = await execute('run', 'android', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "› Using expo run android --help
+
+      Description
+        Run the native Android app locally
+
+      Usage
+        $ npx expo run:android <dir>
+
+      Options
+        --no-build-cache       Clear the native build cache
+        --no-install           Skip installing dependencies
+        --no-bundler           Skip starting the bundler
+        --variant <name>       Build variant. Default: debug
+        -d, --device [device]  Device name to run the app on
+        -p, --port <port>      Port to start the dev server on. Default: 8081
+        -h, --help             Output usage information
+    "
+  `);
+});
+
+it('runs `npx expo run ios --help`', async () => {
+  const results = await execute('run', 'ios', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "› Using expo run ios --help
+
+      Info
+        Run the iOS app binary locally
+
+      Usage
+        $ npx expo run:ios
+
+      Options
+        --no-build-cache                 Clear the native derived data before building
+        --no-install                     Skip installing dependencies
+        --no-bundler                     Skip starting the Metro bundler
+        --scheme [scheme]                Scheme to build
+        --configuration <configuration>  Xcode configuration to use. Debug or Release. Default: Debug
+        -d, --device [device]            Device name or UDID to build the app on
+        -p, --port <port>                Port to start the Metro bundler on. Default: 8081
+        -h, --help                       Usage info
+
+      Build for production (unsigned) with the Release configuration:
+        $ npx expo run:ios --configuration Release
+    "
+  `);
+});

--- a/packages/@expo/cli/src/run/hints.ts
+++ b/packages/@expo/cli/src/run/hints.ts
@@ -8,6 +8,10 @@ export function logDeviceArgument(id: string) {
   Log.log(chalk.dim`› Using --device ${id}`);
 }
 
+export function logPlatformRunCommand(platform: string, argv: string[] = []) {
+  Log.log(chalk.dim(`› Using expo run:${platform} ${argv.join(' ')}`));
+}
+
 export function logProjectLogsLocation() {
   Log.log(
     chalk`\n› Logs for your project will appear below.${

--- a/packages/@expo/cli/src/run/hints.ts
+++ b/packages/@expo/cli/src/run/hints.ts
@@ -9,7 +9,7 @@ export function logDeviceArgument(id: string) {
 }
 
 export function logPlatformRunCommand(platform: string, argv: string[] = []) {
-  Log.log(chalk.dim(`› Using expo run ${platform} ${argv.join(' ')}`));
+  Log.log(chalk.dim(`› Using expo run:${platform} ${argv.join(' ')}`));
 }
 
 export function logProjectLogsLocation() {

--- a/packages/@expo/cli/src/run/hints.ts
+++ b/packages/@expo/cli/src/run/hints.ts
@@ -9,7 +9,7 @@ export function logDeviceArgument(id: string) {
 }
 
 export function logPlatformRunCommand(platform: string, argv: string[] = []) {
-  Log.log(chalk.dim(`› Using expo run:${platform} ${argv.join(' ')}`));
+  Log.log(chalk.dim(`› Using expo run ${platform} ${argv.join(' ')}`));
 }
 
 export function logProjectLogsLocation() {

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -6,6 +6,7 @@ import { Log } from '../log';
 import { assertWithOptionsArgs } from '../utils/args';
 import { CommandError } from '../utils/errors';
 import { selectAsync } from '../utils/prompts';
+import { logPlatformRunCommand } from './hints';
 
 export const expoRun: Command = async (argv) => {
   const args = assertWithOptionsArgs(
@@ -50,6 +51,8 @@ export const expoRun: Command = async (argv) => {
     { title: 'Android', value: 'android' },
     { title: 'iOS', value: 'ios' },
   ]);
+
+  logPlatformRunCommand(platform, argv);
 
   switch (platform) {
     case 'android': {

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -27,18 +27,19 @@ export const expoRun: Command = async (argv) => {
   if (args['--help']) {
     Log.exit(
       chalk`
-  {bold Description}
+  {bold Info}
     Run the native app locally
 
   {bold Usage}
-    $ npx expo run:android <dir>
-    $ npx expo run:ios <dir>
+    {dim $} npx expo run:android <dir>
+    {dim $} npx expo run:ios <dir>
 
   {bold Options}
-    $ npx expo run:android --help    Output Android usage information
-    $ npx expo run:ios --help        Output iOS usage information
     -p, --platform <android|ios>     Run the native app on this platform
     -h, --help                       Output usage information
+
+    {dim $} npx expo run:android --help    Output Android usage information
+    {dim $} npx expo run:ios --help        Output iOS usage information
 `,
       0
     );

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -42,7 +42,7 @@ export const expoRun: Command = async (argv) => {
     }
 
     if (!platform) {
-      const { selectAsync } = await import('../utils/prompts');
+      const { selectAsync } = await import('../utils/prompts.js');
       platform = await selectAsync('Select the platform to run', [
         { title: 'Android', value: 'android' },
         { title: 'iOS', value: 'ios' },
@@ -53,12 +53,12 @@ export const expoRun: Command = async (argv) => {
 
     switch (platform) {
       case 'android': {
-        const { expoRunAndroid } = await import('./android');
+        const { expoRunAndroid } = await import('./android/index.js');
         return expoRunAndroid(argsWithoutPlatform);
       }
 
       case 'ios': {
-        const { expoRunIos } = await import('./ios');
+        const { expoRunIos } = await import('./ios/index.js');
         return expoRunIos(argsWithoutPlatform);
       }
 

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+import { Log } from '../log';
+import { assertWithOptionsArgs } from '../utils/args';
+import { CommandError } from '../utils/errors';
+import { selectAsync } from '../utils/prompts';
+
+export const expoRun: Command = async (argv) => {
+  const args = assertWithOptionsArgs(
+    {
+      // Types
+      '--help': Boolean,
+      // Aliases
+      '-h': '--help',
+      // All other flags are handled by `expoRunAndroid` or `expoRunIos`
+    },
+    {
+      argv,
+      permissive: true,
+    }
+  );
+
+  if (args['--help']) {
+    Log.exit(
+      chalk`
+  {bold Description}
+    Run the native app locally
+
+  {bold Usage}
+    $ npx expo run:android <dir>
+    $ npx expo run:ios <dir>
+
+  {bold Options}
+    --no-build-cache                 Clear the native build cache
+    --no-install                     Skip installing dependencies
+    --no-bundler                     Skip starting the bundler
+    --configuration <configuration>  {underline iOS} Xcode configuration to use. Debug or Release. {dim Default: Debug}
+    --variant <name>                 {underline Android} build variant to use. {dim Default: debug}
+    -d, --device [device]            Device name to run the app on
+    -p, --port <port>                Port to start the dev server on. {dim Default: 8081}
+    -h, --help                       Output usage information
+`,
+      0
+    );
+  }
+
+  const platform = await selectAsync('Platform to run your app on', [
+    { title: 'Android', value: 'android' },
+    { title: 'iOS', value: 'ios' },
+  ]);
+
+  switch (platform) {
+    case 'android': {
+      const { expoRunAndroid } = await import('./android');
+      return expoRunAndroid(argv);
+    }
+
+    case 'ios': {
+      const { expoRunIos } = await import('./ios');
+      return expoRunIos(argv);
+    }
+
+    default:
+      throw new CommandError('UNSUPPORTED_PLATFORM', `Unsupported platform: ${platform}`);
+  }
+};

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -2,8 +2,7 @@
 import chalk from 'chalk';
 
 import { Command } from '../../bin/cli';
-import { Log } from '../log';
-import { assertWithOptionsArgs } from '../utils/args';
+import { assertWithOptionsArgs, printHelp } from '../utils/args';
 import { CommandError, logCmdError } from '../utils/errors';
 import { selectAsync } from '../utils/prompts';
 import { logPlatformRunCommand } from './hints';
@@ -24,20 +23,10 @@ export const expoRun: Command = async (argv) => {
   );
 
   if (args['--help']) {
-    Log.exit(
-      chalk`
-  {bold Info}
-    Run the native app locally
-
-  {bold Usage}
-    {dim $} npx expo run android <dir>
-    {dim $} npx expo run ios <dir>
-
-  {bold Options}
-    {dim $} npx expo run android --help    Output Android usage information
-    {dim $} npx expo run ios --help        Output iOS usage information
-`,
-      0
+    printHelp(
+      'Run the native app locally',
+      `npx expo run <android|ios>`,
+      chalk`{dim $} npx expo run <android|ios> --help  Output usage information`
     );
   }
 

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -13,13 +13,12 @@ export const expoRun: Command = async (argv) => {
     {
       // Types
       '--help': Boolean,
-      '--platform': String,
       // Aliases
       '-h': '--help',
-      // All other flags are handled by `expoRunAndroid` or `expoRunIos`
     },
     {
       argv,
+      // Allow additional flags for both android and ios commands
       permissive: true,
     }
   );
@@ -31,32 +30,26 @@ export const expoRun: Command = async (argv) => {
     Run the native app locally
 
   {bold Usage}
-    {dim $} npx expo run:android <dir>
-    {dim $} npx expo run:ios <dir>
+    {dim $} npx expo run android <dir>
+    {dim $} npx expo run ios <dir>
 
   {bold Options}
-    -p, --platform <android|ios>     Run the native app on this platform
-    -h, --help                       Output usage information
-
-    {dim $} npx expo run:android --help    Output Android usage information
-    {dim $} npx expo run:ios --help        Output iOS usage information
+    {dim $} npx expo run android --help    Output Android usage information
+    {dim $} npx expo run ios --help        Output iOS usage information
 `,
       0
     );
   }
 
   try {
-    const platform =
-      args['--platform'] ??
-      (await selectAsync('Select the platform to run', [
+    let [platform, ...argsWithoutPlatform] = args._ ?? [];
+
+    if (!platform) {
+      platform = await selectAsync('Select the platform to run', [
         { title: 'Android', value: 'android' },
         { title: 'iOS', value: 'ios' },
-      ]));
-
-    // Filter `--platform=android|ios` or `--platform android|ios` from the args for `run:android|ios`
-    const argsWithoutPlatform = Object.values(args._).filter(
-      (flag) => !flag.startsWith('--platform') || ['android', 'ios'].includes(flag)
-    );
+      ]);
+    }
 
     logPlatformRunCommand(platform, argsWithoutPlatform);
 

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -13,6 +13,7 @@ export const expoRun: Command = async (argv) => {
     {
       // Types
       '--help': Boolean,
+      '--platform': String,
       // Aliases
       '-h': '--help',
       // All other flags are handled by `expoRunAndroid` or `expoRunIos`
@@ -34,23 +35,21 @@ export const expoRun: Command = async (argv) => {
     $ npx expo run:ios <dir>
 
   {bold Options}
-    --no-build-cache                 Clear the native build cache
-    --no-install                     Skip installing dependencies
-    --no-bundler                     Skip starting the bundler
-    --configuration <configuration>  {underline iOS} Xcode configuration to use. Debug or Release. {dim Default: Debug}
-    --variant <name>                 {underline Android} build variant to use. {dim Default: debug}
-    -d, --device [device]            Device name to run the app on
-    -p, --port <port>                Port to start the dev server on. {dim Default: 8081}
+    $ npx expo run:android --help    Output Android usage information
+    $ npx expo run:ios --help        Output iOS usage information
+    -p, --platform <android|ios>     Run the native app on this platform
     -h, --help                       Output usage information
 `,
       0
     );
   }
 
-  const platform = await selectAsync('Select the platform to run', [
-    { title: 'Android', value: 'android' },
-    { title: 'iOS', value: 'ios' },
-  ]);
+  const platform =
+    args['--platform'] ??
+    (await selectAsync('Select the platform to run', [
+      { title: 'Android', value: 'android' },
+      { title: 'iOS', value: 'ios' },
+    ]));
 
   logPlatformRunCommand(platform, argv);
 

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
 
+import { logPlatformRunCommand } from './hints';
 import { Command } from '../../bin/cli';
 import { assertWithOptionsArgs, printHelp } from '../utils/args';
 import { CommandError, logCmdError } from '../utils/errors';
-import { selectAsync } from '../utils/prompts';
-import { logPlatformRunCommand } from './hints';
 
 export const expoRun: Command = async (argv) => {
   const args = assertWithOptionsArgs(
@@ -22,18 +21,23 @@ export const expoRun: Command = async (argv) => {
     }
   );
 
-  if (args['--help']) {
-    printHelp(
-      'Run the native app locally',
-      `npx expo run <android|ios>`,
-      chalk`{dim $} npx expo run <android|ios> --help  Output usage information`
-    );
-  }
-
   try {
-    let [platform, ...argsWithoutPlatform] = args._ ?? [];
+    let [platform] = args._ ?? [];
+
+    // Remove the platform from raw arguments, when provided
+    const argsWithoutPlatform = !platform ? argv : argv?.splice(1);
+
+    // Do not capture `--help` when platform is provided
+    if (!platform && args['--help']) {
+      printHelp(
+        'Run the native app locally',
+        `npx expo run <android|ios>`,
+        chalk`{dim $} npx expo run <android|ios> --help  Output usage information`
+      );
+    }
 
     if (!platform) {
+      const { selectAsync } = await import('../utils/prompts');
       platform = await selectAsync('Select the platform to run', [
         { title: 'Android', value: 'android' },
         { title: 'iOS', value: 'ios' },

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -52,17 +52,22 @@ export const expoRun: Command = async (argv) => {
         { title: 'iOS', value: 'ios' },
       ]));
 
-    logPlatformRunCommand(platform, argv);
+    // Filter `--platform=android|ios` or `--platform android|ios` from the args for `run:android|ios`
+    const argsWithoutPlatform = Object.values(args._).filter(
+      (flag) => !flag.startsWith('--platform') || ['android', 'ios'].includes(flag)
+    );
+
+    logPlatformRunCommand(platform, argsWithoutPlatform);
 
     switch (platform) {
       case 'android': {
         const { expoRunAndroid } = await import('./android');
-        return expoRunAndroid(argv);
+        return expoRunAndroid(argsWithoutPlatform);
       }
 
       case 'ios': {
         const { expoRunIos } = await import('./ios');
-        return expoRunIos(argv);
+        return expoRunIos(argsWithoutPlatform);
       }
 
       default:

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -24,6 +24,11 @@ export const expoRun: Command = async (argv) => {
   try {
     let [platform] = args._ ?? [];
 
+    // Workaround, filter `--flag` as platform
+    if (platform?.startsWith('-')) {
+      platform = '';
+    }
+
     // Remove the platform from raw arguments, when provided
     const argsWithoutPlatform = !platform ? argv : argv?.splice(1);
 

--- a/packages/@expo/cli/src/run/index.ts
+++ b/packages/@expo/cli/src/run/index.ts
@@ -46,7 +46,7 @@ export const expoRun: Command = async (argv) => {
     );
   }
 
-  const platform = await selectAsync('Platform to run your app on', [
+  const platform = await selectAsync('Select the platform to run', [
     { title: 'Android', value: 'android' },
     { title: 'iOS', value: 'ios' },
   ]);


### PR DESCRIPTION
# Why

Fixes ENG-8456

# How

This `expo run` command is identical to the `eas build:run` command, where users are presented with a selection of each platform.

- Added `src/run/index.ts` command
- Combined all flags in the help information, with platform-specific flags underlined

<details><summary><code>$ expo run --help</code></summary>

<img width="477" alt="image" src="https://github.com/expo/expo/assets/1203991/77e11ab7-0021-4a3b-b1fa-72476c1ef53c">

</details>

<details><summary><code>$ expo run --device</code> <i>(android)</i></summary>

<img width="304" alt="image" src="https://github.com/expo/expo/assets/1203991/62eba933-39e4-489a-abe6-88685e4e7978">


</details>

<details><summary><code>$ expo run --device</code> <i>(ios)</i></summary>

<img width="356" alt="image" src="https://github.com/expo/expo/assets/1203991/e1dae145-cc4a-4d5b-afa8-fd22d38a7f01">

</details>

<details><summary><code>$ expo run android --help</code></summary>

<img width="539" alt="image" src="https://github.com/expo/expo/assets/1203991/54e9e3fd-ea77-4030-8cff-d42cf97e8ac4">

</details>

<details><summary><code>$ expo run ios --help</code></summary>

<img width="690" alt="image" src="https://github.com/expo/expo/assets/1203991/3feea85f-852f-4443-9d95-a5a8ec3c2cf5">

</details>


# Test Plan

See above commands, all flags should be propagated and handled by the original `expo run:android|ios` commands, except `--help`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
