### PR TITLE
[media-library][Android] Fix `the bind value at index 1 is null` exception

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `the bind value at index 1 is null` exception thrown by `ExpoMediaLibrary.migrateAlbumIfNeededAsync` on Android.
+- Fix `the bind value at index 1 is null` exception thrown by `ExpoMediaLibrary.migrateAlbumIfNeededAsync` on Android. ([#23515](https://github.com/expo/expo/pull/23515) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `the bind value at index 1 is null` exception thrown by `ExpoMediaLibrary.migrateAlbumIfNeededAsync` on Android.
+
 ### 💡 Others
 
 ## 15.4.0 — 2023-06-21

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/MediaLibraryModule.kt
@@ -218,10 +218,18 @@ class MediaLibraryModule : Module() {
         return@AsyncFunction
       }
 
+      val assetsIds = getAssetsInAlbums(context, albumId)
+        .filter { it.isNotEmpty() }
+        .toTypedArray()
+      // The album is empty, nothing to migrate
+      if (assetsIds.isEmpty()) {
+        return@AsyncFunction
+      }
+
       val assets = MediaLibraryUtils.getAssetsById(
         context,
         null,
-        *getAssetsInAlbums(context, albumId).toTypedArray()
+        *assetsIds
       )
 
       val albumsMap = assets


### PR DESCRIPTION
# Why

Closes https://github.com/expo/expo/issues/21937.

# How

When `migrateAlbumIfNeededAsync` was invoked on an empty album, the `the bind value at index 1 is null` was thrown. Ensures that the album has some assets to migrate. 

# Test Plan

- bare-expo ✅