### PR TITLE
fix(cli): avoid creating dev client urls containing `_` in protocol

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Improve file formatting when `EXPO_USE_METRO_WORKSPACE_ROOT` is used. ([#23910](https://github.com/expo/expo/pull/23910) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `EXPO_SKIP_MANIFEST_VALIDATION_TOKEN` usage. ([#23890](https://github.com/expo/expo/pull/23890) by [@EvanBacon](https://github.com/EvanBacon))
+- Prohibit dev client URLs containing `_` in protocol. ([#23519](https://github.com/expo/expo/pull/23519) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -53,7 +53,9 @@ export class UrlCreator {
     if (
       !protocol ||
       // Prohibit the use of http(s) in dev client URIs since they'll never be valid.
-      ['http', 'https'].includes(protocol.toLowerCase())
+      ['http', 'https'].includes(protocol.toLowerCase()) ||
+      // Prohibit the use of `_` characters in the protocol, Node will throw an error when parsing these URLs
+      protocol.includes('_')
     ) {
       return null;
     }

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -47,6 +47,11 @@ describe('constructDevClientUrl', () => {
     expect(createDefaultCreator().constructDevClientUrl({ scheme: 'http' })).toEqual(null);
     expect(createDefaultCreator().constructDevClientUrl({ scheme: 'https' })).toEqual(null);
   });
+  it(`returns null when protocol contains "_" characters`, () => {
+    expect(
+      createDefaultCreator().constructDevClientUrl({ scheme: 'dev.expo.invalid_node_protocol' })
+    ).toEqual(null);
+  });
   it(`creates default`, () => {
     expect(createDefaultCreator().constructDevClientUrl({ scheme: 'bacon' })).toMatchInlineSnapshot(
       `"bacon://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A8081"`


### PR DESCRIPTION
# Why

Fixes #23440

Unfortunately, due to Node's limitation in URL, we can't use `_` in protocols. Even when we do fix it, we run into URL parsing issues in Expo Router (that's also using Node's URL). Instead, this change makes protocols containing `_` fully invalid as any dev client URL.

# How

- Prohibited dev client URLs with `_` characters in the protocol
- This will trigger the [`_resolveAlternativeLaunchUrl`](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/start/platforms/android/AndroidPlatformManager.ts#L48-L53) on Android and create `com.example.some_package/.MainActivity` instead


# Test Plan

- `$ yarn create expo ./fix-23440 --template tabs@49`
- `$ cd ./fix-23440`
- Update `app.json` with `expo.android.package = "com.example.protocol_underscore"`
- `$ yarn expo run:android`
- Should fall back to `com.example.protocol_underscore/.MainActivity` URL and open the app properly

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
