### PR TITLE
[docs] Importing useRouter from hook to avoid error

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -15,7 +15,7 @@ Consider the following project:
 First, we'll setup a [React Context provider](https://react.dev/reference/react/createContext) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](/guides/authentication/).
 
 ```js context/auth.js
-import { router, useSegments } from 'expo-router';
+import { useRouter, useSegments } from 'expo-router';
 import React from 'react';
 
 const AuthContext = React.createContext(null);
@@ -28,6 +28,7 @@ export function useAuth() {
 // This hook will protect the route access based on user authentication.
 function useProtectedRoute(user) {
   const segments = useSegments();
+  const router = useRouter();
 
   React.useEffect(() => {
     const inAuthGroup = segments[0] === '(auth)';


### PR DESCRIPTION
# Why
Fix on the documentation to provide stop the example code from throwing an error.
# How
By importing the `router` directly from `expo-router` the user gets the error:
`Module '"expo-router"' has no exported member 'router'.`
# Test Plan
It was testing by implementing that provider/context code to see if the error is still appearing. No further testing necessary.
# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
