### PR TITLE
fix(cli): Set `preferNativePlatform` to `false` for all web requests.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added improved error message for static metro when a package is missing. ([#23499](https://github.com/expo/expo/pull/23499) by [@EvanBacon](https://github.com/EvanBacon))
-- Set `preferNativePlatform` to `false` for all web requests.
+- Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added improved error message for static metro when a package is missing. ([#23499](https://github.com/expo/expo/pull/23499) by [@EvanBacon](https://github.com/EvanBacon))
+- Set `preferNativePlatform` to `false` for all web requests.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroResolvers.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroResolvers.test.ts
@@ -70,4 +70,28 @@ describe(withMetroResolvers, () => {
     // Never called
     expect(originalResolveRequest).not.toBeCalled();
   });
+  it(`disables native extensions for all web resolvers regardless of if web is enabled`, () => {
+    const customResolver1 = jest.fn(() => {
+      return {} as any;
+    });
+
+    const originalResolveRequest = jest.fn();
+    const modified = withMetroResolvers(
+      asMetroConfig({
+        // @ts-expect-error
+        resolver: {
+          resolveRequest: originalResolveRequest,
+        },
+      }),
+      '/',
+      [customResolver1]
+    );
+
+    // @ts-expect-error: invalid types on resolveRequest
+    modified.resolver.resolveRequest!({}, 'react-native', 'web');
+
+    // Resolves
+    expect(customResolver1).toBeCalledTimes(1);
+    expect(customResolver1).toBeCalledWith({ preferNativePlatform: false }, 'react-native', 'web');
+  });
 });


### PR DESCRIPTION
# Why

- Currently we fallback on the default or user-defined resolver if the expo resolver fails. Now we'll skip the default if the expo resolver asserts.
- If the user-defined resolver is called, it will now have `preferNativePlatform` disabled. This ensures we never attempt to resolve a web file with `.native` extensions.

# Test Plan

- Unit tests