### PR TITLE
[expo-updates] Fix unmatched selection policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix unmatched selection policy. ([#23535](https://github.com/expo/expo/pull/23535) by [@chochihim](https://github.com/chochihim))
+
 ### 💡 Others
 
 ## 49.0.0 — 2023-06-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix unmatched selection policy. ([#23535](https://github.com/expo/expo/pull/23535) by [@chochihim](https://github.com/chochihim))
-
 ### 💡 Others
 
 ## 49.0.0 — 2023-06-27

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Fix rollback embedded update logic. ([#23244](https://github.com/expo/expo/pull/23244) by [@wschurman](https://github.com/wschurman))
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
+- [iOS] Fix unmatched selection policy. ([#23535](https://github.com/expo/expo/pull/23535) by [@chochihim](https://github.com/chochihim))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -167,6 +167,10 @@ public class AppController: NSObject, AppLoaderTaskDelegate, AppLoaderTaskSwiftD
       .raise()
     }
 
+    defaultSelectionPolicy = SelectionPolicyFactory.filterAwarePolicy(
+      withRuntimeVersion: UpdatesUtils.getRuntimeVersion(withConfig: config)
+    )
+
     resetSelectionPolicyToDefault()
   }
 


### PR DESCRIPTION
# Why

If one sets `runtimeVersion` via `setConfiguration` at run time, we also need to reset the default selection policy so that it matches the desired `runtimeVersion`.

