### PR TITLE
Bump @shopify/flash-list from v1.4.3 to v1.5.0

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -55,7 +55,7 @@
     "@react-navigation/material-bottom-tabs": "~6.2.4 ",
     "@react-navigation/native": "~6.0.13",
     "@react-navigation/stack": "~6.3.2",
-    "@shopify/flash-list": "1.4.3",
+    "@shopify/flash-list": "1.5.0",
     "@shopify/react-native-skia": "0.1.196",
     "date-format": "^2.0.0",
     "deep-object-diff": "^1.1.9",


### PR DESCRIPTION
Update @shopify/flash-list for React Native .72 compatibility
