### PR TITLE
[tools] Remove ethon override

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,3 @@ gem "fastlane", "~> 2.205.2"
 gem "cocoapods", "~> 1.12.1"
 
 gem "xcpretty", "~> 0.3.0" # used by bare-expo (build-detox-ios.sh)
-
-# ethon is manually updated to avoid segmentation fault crashes on the M1. See https://github.com/CocoaPods/CocoaPods/issues/10446
-gem 'ethon', '>=0.13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,7 +275,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.12.1)
-  ethon (>= 0.13.0)
   fastlane (~> 2.205.2)
   xcpretty (~> 0.3.0)
 


### PR DESCRIPTION
Why
---
Commit 40530249b2d64942a1076e151e96c6d634e5de10 manually specified a newer version of the "ethon" gem to fix CocoaPods for Apple silicon. That was in 2021. We now require CocoaPods 1.12.1 which was released in 2023 and I was able to run `pod install` on Apple silicon without any crashes.

How
---
Removed the ethon gem override.

Test Plan
---
Installed the gems with `bundler install` and ran `et pod-install` with an M2 CPU.
