### PR TITLE
Update `plugins` key type to accurately reflect valid type

### DIFF
--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -234,7 +234,7 @@ export interface ExpoConfig {
   /**
    * Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.dev/guides/config-plugins/).
    */
-  plugins?: (string | [] | [string] | [string, any])[];
+  plugins?: (string | [string, any])[];
   splash?: Splash;
   /**
    * Specifies the JavaScript engine for apps. Supported only on EAS Build. Defaults to `hermes`. Valid values: `hermes`, `jsc`.


### PR DESCRIPTION
# Why

`plugins: [['expo-image-picker']]` results in a fatal crash: https://github.com/expo/expo/issues/23549.

I looked at the type of `ExpoConfig` and noticed `[string]` as a valid plugin configuration. This seems to be false. Or well, it's not working for `expo-image-picker`. Are there other plugins for which this _is_ valid?

I also noticed `[]` as a valid plugin configuration. Why? `plugins: [[], [], []]` is a valid type but makes no sense I feel?

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
