### PR TITLE
chore(docs): integrate config plugins doc

### DIFF
--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -423,19 +423,7 @@ A config plugin in a node module (without an **app.plugin.js**) will use the `ma
 
 This is different to how Node modules work because **app.plugin.js** won't be resolved by default in a directory. You'll have to manually specify `./my-config-plugin/app.plugin.js` to use it, otherwise **index.js** in the directory will be used.
 
-<FileTree
-  files={[
-    'app.config.js',
-    ['my-config-plugin/index.js', 'Node module or monorepo package'],
-    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
-    [
-      'node_modules/expo-splash-screen/build/index.js',
-      <>
-        <YesIcon /> Node resolves a folder's <code>index.js</code> file as the main file
-      </>,
-    ],
-  ]}
-/>
+<FileTree files={['app.config.js', ['my-config-plugin/index.js', 'Config Plugin']]} />
 
 ### Module internals
 

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -374,9 +374,7 @@ If an **app.plugin.js** file is present in the root of a Node module's folder, i
   files={[
     ['app.config.js', <code>import "expo-splash-screen"</code>],
     ['node_modules/expo-splash-screen', 'Node module'],
-
-    'node_modules/expo-splash-screen/package.json',
-
+    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
     [
       'node_modules/expo-splash-screen/app.plugin.js',
       <>
@@ -389,8 +387,7 @@ If an **app.plugin.js** file is present in the root of a Node module's folder, i
         <NoIcon /> Skipped in favor of <code>app.plugin.js</code>
       </>,
     ],
-
-]}
+  ]}
 />
 
 ```js node_modules/expo-splash-screen/app.plugin.js

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -27,29 +27,39 @@ Say you wanted to create a plugin that added custom values to **Info.plist** in 
 
 ```js my-plugin.js
 const withMySDK = (config, { apiKey }) => {
-  // Ensure the objects exist
+  /* @info Ensure the objects exist */
   if (!config.ios) {
+    /* @end */
     config.ios = {};
   }
   if (!config.ios.infoPlist) {
     config.ios.infoPlist = {};
   }
 
-  // Append the apiKey
+  /* @info Append the API Key */
   config.ios.infoPlist['MY_CUSTOM_NATIVE_IOS_API_KEY'] = apiKey;
+  /* @end */
 
   return config;
 };
 
-// 💡 Usage:
+module.exports.withMySDK = withMySDK;
+```
 
-/// Create a config
+To use the plugin, import it and wrap the config:
+
+```js app.config.js
+const { withMySDK } = require('./my-plugin');
+
+/* @info Create a config */
 const config = {
+  /* @end */
   name: 'my app',
 };
 
-/// Use the plugin
-export default withMySDK(config, { apiKey: 'X-XXX-XXX' });
+/* @info Apply the plugin */
+module.exports = withMySDK(config, { apiKey: 'X-XXX-XXX' });
+/* @end */
 ```
 
 ## Import a plugin
@@ -68,7 +78,7 @@ Consider the following example that changes the config name:
 <FileTree
   files={[
     ['app.config.js', 'Expo config'],
-    ['ios-index.json', 'Custom Config Plugin file'],
+    ['my-plugin.js', 'Custom Config Plugin file'],
   ]}
 />
 
@@ -92,7 +102,7 @@ It evaluates to the following JSON config:
 
 ```json Evaluated config JSON
 {
-  "name": "custom-my-app",
+  "name": /* @info */ "custom-my-app" /* @end */,
   "plugins": [["./my-plugin", "custom"]]
 }
 ```
@@ -264,18 +274,22 @@ A mod plugin gets passed a `config` object with additional properties `modResult
 
 Say you wanted to write a mod to update the Xcode Project's "product name":
 
-```js my-config-plugin.js
+```ts my-config-plugin.ts
 import { ConfigPlugin, withXcodeProject } from 'expo/config-plugins';
 
 const withCustomProductName: ConfigPlugin = (config, customName) => {
-  return withXcodeProject(config, async config => {
-    // config = { modResults, modRequest, ...expoConfig }
+  return withXcodeProject(
+    config,
+    async (
+      /* @info <b>{ modResults, modRequest }</b> */ config
+      /* @end */
+    ) => {
+      const xcodeProject = config.modResults;
+      xcodeProject.productName = customName;
 
-    const xcodeProject = config.modResults;
-    xcodeProject.productName = customName;
-
-    return config;
-  });
+      return config;
+    }
+  );
 };
 
 // 💡 Usage:
@@ -310,8 +324,9 @@ export const withIcons = config => {
   return withDangerousMod(config, [
     'ios',
     async config => {
-      // No modifications are made to the config
+      /* @info No modifications are made to the config */
       await setIconsAsync(config, config.modRequest.projectRoot);
+      /* @end */
       return config;
     },
   ]);
@@ -424,6 +439,8 @@ This is different to how Node modules work because **app.plugin.js** won't be re
 
 ### Module internals
 
+> **error** Avoid importing module internals.
+
 If a file inside a Node module is specified, then the module's root **app.plugin.js** resolution will be skipped. This is referred to as "reaching inside a package" and is considered **bad form**.
 We support this to make testing, and plugin authoring easier, but we don't expect library authors to expose their plugins like this as a public API.
 
@@ -466,8 +483,9 @@ const config = {
         /* props */
       },
     ],
-    // Without props
+    /* @info Without props */
     withCustom,
+    /* @end */
   ],
 };
 ```

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -347,11 +347,19 @@ The strings passed to the `plugins` array can be resolved in a few different way
 
 You can quickly create a plugin in your project and use it in your config.
 
-- <YesIcon /> `'./my-config-plugin'`
+<FileTree
+  files={[
+    ['app.config.js', <code>import "./my-config-plugin"</code>],
+    [
+      'my-config-plugin.js',
+      <>
+        <YesIcon /> Imported from config
+      </>,
+    ],
+  ]}
+/>
 
-- <NoIcon /> `'./my-config-plugin.js'`
-
-<FileTree files={['app.config.js', 'my-config-plugin.js']} />
+In this example, the config plugin file contains a bare minimum function:
 
 ```js my-config-plugin.js
 module.exports = config => config;
@@ -362,14 +370,10 @@ module.exports = config => config;
 Sometimes you want your package to export React components and also support a plugin. To do this, multiple entry points need to be used because the transpilation (Babel preset) may be different.
 If an **app.plugin.js** file is present in the root of a Node module's folder, it'll be used instead of the package's `main` file.
 
-- <YesIcon /> `'expo-splash-screen'`
-
-- <NoIcon /> `'expo-splash-screen/app.plugin.js'`
-
 <FileTree
   files={[
-    'app.config.js',
-    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
+    ['app.config.js', <code>import "expo-splash-screen"</code>],
+    ['node_modules/expo-splash-screen', 'Node module'],
 
     'node_modules/expo-splash-screen/package.json',
 
@@ -397,14 +401,11 @@ module.exports = config => config;
 
 A config plugin in a node module (without an **app.plugin.js**) will use the `main` file defined in the **package.json**.
 
-- <YesIcon /> `'expo-splash-screen'`
-
-- <NoIcon /> `'expo-splash-screen/build/index'`
-
 <FileTree
   files={[
-    'app.config.js',
-    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
+    ['app.config.js', <code>import "expo-splash-screen"</code>],
+
+    ['node_modules/expo-splash-screen', 'Node module'],
     ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
     [
       'node_modules/expo-splash-screen/build/index.js',
@@ -412,39 +413,47 @@ A config plugin in a node module (without an **app.plugin.js**) will use the `ma
         <YesIcon /> Node resolve to this file
       </>,
     ],
-  ]}
+
+]}
 />
 
 ### Project folder
 
-- <YesIcon /> `'./my-config-plugin'`
+This is different to how Config Plugins in Node modules work because **app.plugin.js** won't be resolved by default in a directory. You'll have to manually specify `./my-config-plugin/app.plugin.js` to use it, otherwise **index.js** in the directory will be used.
 
-- <NoIcon /> `'./my-config-plugin.js'`
-
-This is different to how Node modules work because **app.plugin.js** won't be resolved by default in a directory. You'll have to manually specify `./my-config-plugin/app.plugin.js` to use it, otherwise **index.js** in the directory will be used.
-
-<FileTree files={['app.config.js', ['my-config-plugin/index.js', 'Config Plugin']]} />
+<FileTree
+  files={[
+    ['app.config.js', <code>import "./my-config-plugin"</code>],
+    [
+      'my-config-plugin/index.js',
+      <>
+        <YesIcon /> Config Plugin
+      </>,
+    ],
+    [
+      'my-config-plugin/app.plugin.js',
+      <>
+        <NoIcon /> Skipped outside of a node module
+      </>,
+    ],
+  ]}
+/>
 
 ### Module internals
 
 > **error** Avoid importing module internals.
 
-If a file inside a Node module is specified, then the module's root **app.plugin.js** resolution will be skipped. This is referred to as "reaching inside a package" and is considered **bad form**.
+If a file inside a Node module is directly imported, then the module's root **app.plugin.js** resolution will be skipped. This is referred to as "reaching inside a package" and is considered **bad form**.
 We support this to make testing, and plugin authoring easier, but we don't expect library authors to expose their plugins like this as a public API.
-
-- <NoIcon /> `'expo-splash-screen/build/index.js'`
-
-- <NoIcon /> `'expo-splash-screen/build'`
 
 <FileTree
   files={[
-    'app.config.js',
-    ['my-config-plugin/index.js', 'Node module or monorepo package'],
+    ['app.config.js', <code>import "expo-splash-screen/build/index.js"</code>],
     ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
     [
       'node_modules/expo-splash-screen/app.plugin.js',
       <>
-        <NoIcon /> Ignored because the reference reaches into the package internals
+        <NoIcon /> Ignored due to direct import
       </>,
     ],
     [
@@ -458,7 +467,7 @@ We support this to make testing, and plugin authoring easier, but we don't expec
 
 ### Raw functions
 
-You can also just pass in a config plugin.
+Expo config objects also support passing functions as-is to the `plugins` array. This is useful for testing, or if you want to use a plugin without creating a file.
 
 ```js app.config.js
 const withCustom = (config, props) => config;
@@ -490,7 +499,7 @@ Here is what the serialized config would look like:
 
 ## Why app.plugin.js for plugins
 
-Config resolution searches for a **app.plugin.js** first when a Node module name is provided.
+Config resolution searches for a file named **app.plugin.js** first when a Node module ID is provided as a plugin.
 This is because Node environments are often different to iOS, Android, or web JS environments and therefore require different transpilation presets (ex: `module.exports` instead of `import/export`).
 
 Because of this reasoning, the root of a Node module is searched instead of right next to the **index.js**.

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -6,6 +6,7 @@ description: Learn about what are plugins and mods when creating a config plugin
 import { YesIcon, NoIcon, WarningIcon } from '~/ui/components/DocIcons';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { FileTree } from '~/ui/components/FileTree';
 
 Plugins are **synchronous** functions that accept an [`ExpoConfig`](/versions/latest/config/app/) and return a modified [`ExpoConfig`](/versions/latest/config/app/).
 
@@ -64,10 +65,12 @@ You may want to create a plugin in a different file, here's how:
 
 Consider the following example that changes the config name:
 
-```
-╭── app.config.js ➡️ App config
-╰── my-plugin.js ➡️ Our custom plugin file
-```
+<FileTree
+  files={[
+    ['app.config.js', 'Expo config'],
+    ['ios-index.json', 'Custom Config Plugin file'],
+  ]}
+/>
 
 ```js my-plugin.js
 module.exports = function withPrefixedName(config, prefix) {
@@ -333,9 +336,10 @@ You can quickly create a plugin in your project and use it in your config.
 
 - <NoIcon /> `'./my-config-plugin.js'`
 
-```
-╭── app.config.js ➡️ app config
-╰── my-config-plugin.js ➡️ ✅ `module.exports = (config) => config`
+<FileTree files={['app.config.js', 'my-config-plugin.js']} />
+
+```js my-config-plugin.js
+module.exports = config => config;
 ```
 
 ### app.plugin.js
@@ -346,6 +350,56 @@ If an **app.plugin.js** file is present in the root of a Node module's folder, i
 - <YesIcon /> `'expo-splash-screen'`
 
 - <NoIcon /> `'expo-splash-screen/app.plugin.js'`
+
+By default, the `main` file is used as the entry point for the config plugin.
+
+<FileTree
+  files={[
+    'app.config.js',
+    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
+
+    ['node_modules/expo-splash-screen/package.json',
+    <>
+    Specifies <code>"main": "./build/index.js"</code>
+    </>],
+    [
+      'node_modules/expo-splash-screen/build/index.js',
+      <>
+        <YesIcon /> Default file in <code>main</code>
+      </>,
+    ],
+
+]}
+/>
+
+If a package has a `app.plugin.js` in the root, then it will take priority over the `main` file.
+
+<FileTree
+  files={[
+    'app.config.js',
+    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
+
+    'node_modules/expo-splash-screen/package.json',
+
+    [
+      'node_modules/expo-splash-screen/app.plugin.js',
+      <>
+        <YesIcon /> Entry file for custom plugins
+      </>,
+    ],
+    [
+      'node_modules/expo-splash-screen/build/index.js',
+      <>
+        <NoIcon /> Skipped in favor of <code>app.plugin.js</code>
+      </>,
+    ],
+
+]}
+/>
+
+```js node_modules/expo-splash-screen/app.plugin.js
+module.exports = config => config;
+```
 
 ```
 ╭── app.config.js ➡️ App config

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -351,29 +351,6 @@ If an **app.plugin.js** file is present in the root of a Node module's folder, i
 
 - <NoIcon /> `'expo-splash-screen/app.plugin.js'`
 
-By default, the `main` file is used as the entry point for the config plugin.
-
-<FileTree
-  files={[
-    'app.config.js',
-    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
-
-    ['node_modules/expo-splash-screen/package.json',
-    <>
-    Specifies <code>"main": "./build/index.js"</code>
-    </>],
-    [
-      'node_modules/expo-splash-screen/build/index.js',
-      <>
-        <YesIcon /> Default file in <code>main</code>
-      </>,
-    ],
-
-]}
-/>
-
-If a package has a `app.plugin.js` in the root, then it will take priority over the `main` file.
-
 <FileTree
   files={[
     'app.config.js',
@@ -401,14 +378,6 @@ If a package has a `app.plugin.js` in the root, then it will take priority over 
 module.exports = config => config;
 ```
 
-```
-╭── app.config.js ➡️ App config
-╰── node_modules/expo-splash-screen/ ➡️ Module installed from NPM (works with Yarn workspaces as well).
-    ├── package.json ➡️ The `main` file will be used if **app.plugin.js** doesn't exist.
-    ├── app.plugin.js ➡️ ✅ `module.exports = (config) => config` -- must export a function.
-    ╰── build/index.js ➡️ ❌ Ignored because **app.plugin.js** exists. This could be used with `expo-splash-screen/build/index.js`
-```
-
 ### Node module default file
 
 A config plugin in a node module (without an **app.plugin.js**) will use the `main` file defined in the **package.json**.
@@ -417,12 +386,19 @@ A config plugin in a node module (without an **app.plugin.js**) will use the `ma
 
 - <NoIcon /> `'expo-splash-screen/build/index'`
 
-```
-╭── app.config.js ➡️ App config
-╰── node_modules/expo-splash-screen/ ➡️ Module installed from NPM (works with Yarn workspaces as well).
-    ├── package.json ➡️ The `main` file points to **build/index.js**
-    ╰── build/index.js ➡️  ✅ Node resolves to this module.
-```
+<FileTree
+  files={[
+    'app.config.js',
+    ['node_modules/expo-splash-screen', 'Node module or monorepo package'],
+    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
+    [
+      'node_modules/expo-splash-screen/build/index.js',
+      <>
+        <YesIcon /> Node resolve to this file
+      </>,
+    ],
+  ]}
+/>
 
 ### Project folder
 
@@ -432,11 +408,19 @@ A config plugin in a node module (without an **app.plugin.js**) will use the `ma
 
 This is different to how Node modules work because **app.plugin.js** won't be resolved by default in a directory. You'll have to manually specify `./my-config-plugin/app.plugin.js` to use it, otherwise **index.js** in the directory will be used.
 
-```
-╭── app.config.js ➡️ App config
-╰── my-config-plugin/ ➡️ Folder containing plugin code
-    ╰── index.js ➡️ ✅ By default, Node resolves a folder's index.js file as the main file.
-```
+<FileTree
+  files={[
+    'app.config.js',
+    ['my-config-plugin/index.js', 'Node module or monorepo package'],
+    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
+    [
+      'node_modules/expo-splash-screen/build/index.js',
+      <>
+        <YesIcon /> Node resolves a folder's <code>index.js</code> file as the main file
+      </>,
+    ],
+  ]}
+/>
 
 ### Module internals
 
@@ -447,13 +431,25 @@ We support this to make testing, and plugin authoring easier, but we don't expec
 
 - <NoIcon /> `'expo-splash-screen/build'`
 
-```
-╭── app.config.js ➡️ App config
-╰── node_modules/expo-splash-screen/ ➡️ Module installed from npm (works with Yarn workspaces as well).
-    ├── package.json ➡️ The `main` file will be used if **app.plugin.js** doesn't exist.
-    ├── app.plugin.js ➡️ ❌ Ignored because the reference reaches into the package internals.
-    ╰── build/index.js ➡️ ✅ `module.exports = (config) => config`
-```
+<FileTree
+  files={[
+    'app.config.js',
+    ['my-config-plugin/index.js', 'Node module or monorepo package'],
+    ['node_modules/expo-splash-screen/package.json', <code>"main": "./build/index.js"</code>],
+    [
+      'node_modules/expo-splash-screen/app.plugin.js',
+      <>
+        <NoIcon /> Ignored because the reference reaches into the package internals
+      </>,
+    ],
+    [
+      'node_modules/expo-splash-screen/build/index.js',
+      <>
+        <YesIcon /> <code>expo-splash-screen/build/index.js</code>
+      </>,
+    ],
+  ]}
+/>
 
 ### Raw functions
 

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -75,7 +75,7 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
       </div>
     ) : (
       <div className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
-        {' '.repeat(Math.max(level - 1, 0))}
+        {' '.repeat(Math.max(level, 0))}
         <FileIcon className="text-icon-tertiary mr-2 min-w-[20px]" />
         <TextWithNote name={name} note={note} className="text-default" />
       </div>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -14,7 +14,7 @@ type FileObject = {
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
     <div
-      className="text-xs border border-default rounded-md bg-default mb-4 p-2 pr-4 pb-4"
+      className="text-xs border border-default rounded-md bg-default mb-4 p-2 pr-4 pb-4 whitespace-nowrap overflow-x-auto"
       {...rest}>
       {renderStructure(generateStructure(files))}
     </div>
@@ -68,7 +68,7 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
       <div key={name + '_' + index} className="mt-1 pt-1 pl-2 rounded-sm flex flex-col">
         <div className="flex items-center">
           {' '.repeat(level)}
-          <FolderIcon className="text-icon-tertiary mr-2 opacity-60" />
+          <FolderIcon className="text-icon-tertiary mr-2 opacity-60 min-w-[20px]" />
           <TextWithNote name={name} note={note} className="text-secondary" />
         </div>
         {renderStructure(files, level + 1)}
@@ -76,7 +76,7 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
     ) : (
       <div className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
         {' '.repeat(Math.max(level - 1, 0))}
-        <FileIcon className="text-icon-tertiary mr-2" />
+        <FileIcon className="text-icon-tertiary mr-2 min-w-[20px]" />
         <TextWithNote name={name} note={note} className="text-default" />
       </div>
     );
@@ -100,7 +100,7 @@ function TextWithNote({
       {note && (
         <>
           {/* divider pushing  */}
-          <span className="flex-1 border-b border-default opacity-60 mx-3" />
+          <span className="flex-1 border-b border-default opacity-60 mx-2 md:mx-3 min-w-[2rem]" />
           {/* Optional note */}
           <code className="text-default">{note}</code>
         </>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -62,10 +62,10 @@ function generateStructure(files: (string | [string, string])[]): FileObject[] {
 }
 
 function renderStructure(structure: FileObject[], level = 0): ReactNode {
-  return structure.map(({ name, note, files }) => {
+  return structure.map(({ name, note, files }, index) => {
     const FileIcon = getIconForFile(name);
     return files.length ? (
-      <div className="mt-1 pt-1 pl-2 rounded-sm flex flex-col">
+      <div key={name + '_' + index} className="mt-1 pt-1 pl-2 rounded-sm flex flex-col">
         <div className="flex items-center">
           {' '.repeat(level)}
           <FolderIcon className="text-icon-tertiary mr-2 opacity-60" />

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -2,49 +2,111 @@ import { FileCode01Icon, LayoutAlt01Icon, FolderIcon } from '@expo/styleguide-ic
 import { HTMLAttributes, ReactNode } from 'react';
 
 type FileTreeProps = HTMLAttributes<HTMLDivElement> & {
-  files?: string[];
+  files?: (string | [string, string])[];
 };
 
 type FileObject = {
-  [key: string]: FileObject;
+  name: string;
+  note?: string;
+  files: FileObject[];
 };
 
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
-    <div className="text-xs border border-default rounded-md bg-default mb-4 p-2 pb-4" {...rest}>
+    <div
+      className="text-xs border border-default rounded-md bg-default mb-4 p-2 pr-4 pb-4"
+      {...rest}>
       {renderStructure(generateStructure(files))}
     </div>
   );
 }
 
-function generateStructure(files: string[]): FileObject {
-  const structure = {};
-  files.forEach(path =>
-    path.split('/').reduce((acc: FileObject, key) => acc[key] ?? (acc[key] = {}), structure)
-  );
+/**
+ * Given an array of file paths, generate a tree structure.
+ * @param files
+ * @returns
+ */
+function generateStructure(files: (string | [string, string])[]): FileObject[] {
+  const structure: FileObject[] = [];
+
+  function modifyPath(path: string, note?: string) {
+    const parts = path.split('/');
+    let currentLevel = structure;
+    parts.forEach((part, index) => {
+      const existingPath = currentLevel.find(item => item.name === part);
+      if (existingPath) {
+        currentLevel = existingPath.files;
+      } else {
+        const newPart: FileObject = {
+          name: part,
+          files: [],
+        };
+        if (note && index === parts.length - 1) {
+          newPart.note = note;
+        }
+        currentLevel.push(newPart);
+        currentLevel = newPart.files;
+      }
+    });
+  }
+
+  files.forEach(path => {
+    if (Array.isArray(path)) {
+      return modifyPath(path[0], path[1]);
+    } else {
+      return modifyPath(path);
+    }
+  });
+
   return structure;
 }
 
-function renderStructure(structure: FileObject, level = 0): ReactNode {
-  return Object.entries(structure).map(([key, value]) => {
-    const FileIcon = getIconForFile(key);
-    return Object.keys(value).length ? (
-      <div className="mt-1 pt-1 px-2 rounded-sm flex flex-col">
+function renderStructure(structure: FileObject[], level = 0): ReactNode {
+  return structure.map(({ name, note, files }) => {
+    const FileIcon = getIconForFile(name);
+    return files.length ? (
+      <div className="mt-1 pt-1 pl-2 rounded-sm flex flex-col">
         <div className="flex items-center">
           {' '.repeat(level)}
           <FolderIcon className="text-icon-tertiary mr-2 opacity-60" />
-          <code className="text-secondary">{key}</code>
+          <TextWithNote name={name} note={note} className="text-secondary" />
         </div>
-        {renderStructure(value, level + 1)}
+        {renderStructure(files, level + 1)}
       </div>
     ) : (
-      <div className="mt-1 pl-3 pt-1 px-2 rounded-sm flex items-center">
+      <div className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
         {' '.repeat(Math.max(level - 1, 0))}
         <FileIcon className="text-icon-tertiary mr-2" />
-        <code className="text-default">{key}</code>
+        <TextWithNote name={name} note={note} className="text-default" />
       </div>
     );
   });
+}
+
+function TextWithNote({
+  name,
+  note,
+  className,
+}: {
+  name: string;
+  note?: string;
+  className: string;
+}) {
+  return (
+    <span className="flex items-center flex-1">
+      {/* File/folder name  */}
+      <code className={className}>{name}</code>
+
+      {note && (
+        <>
+          {/* divider pushing  */}
+          <span className="flex-1 border-b border-default opacity-60 mx-3" />
+          {/* Optional note */}
+          <code className="text-default">{note}</code>
+        </>
+      )}
+    </span>
+  );
 }
 
 function getIconForFile(filename: string) {


### PR DESCRIPTION
# Why

The original doc was a large markdown file that we brought over. This PR aims to integrate the doc better with the Expo docs by using built-in components.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added the ability to pass a note to the `FileTree` and replaced the markdown blocks with `FileTree`s.


## Before

<img width="662" alt="Screenshot 2023-07-16 at 8 43 09 PM" src="https://github.com/expo/expo/assets/9664363/923ed351-e66a-40c5-a1d3-553c1f9e14e0">

## After

I'm not especially in love with this, but it is better than the code block.

<img width="670" alt="Screenshot 2023-07-16 at 8 42 57 PM" src="https://github.com/expo/expo/assets/9664363/df5e8106-ea10-4540-ab7b-c51a4eee228d">

On smaller screens, the note will scroll instead of wrap.

<img width="505" alt="Screenshot 2023-07-16 at 8 48 51 PM" src="https://github.com/expo/expo/assets/9664363/9ec54840-4765-4c5a-9e4a-f3e60d58d2b6">



