### PR TITLE
[core][Android] Improve error handling when working with promises

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 💡 Others
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))
-- Improved error handling when working with native promises on Android.
+- Improved error handling when working with native promises on Android. ([#23571](https://github.com/expo/expo/pull/23571) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.5.7 — 2023-07-12
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))
+- Improved error handling when working with native promises on Android.
 
 ## 1.5.7 — 2023-07-12
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIModuleMock.kt
@@ -72,6 +72,8 @@ internal inline fun withJSIInterop(
     installJSIForTests(jniDeallocator)
   }
 
+  every { appContextMock.jsiInterop } answers { jsiIterop }
+
   block(jsiIterop, methodQueue)
 
   jniDeallocator.deallocate()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -58,7 +58,7 @@ class AppContext(
   private val reactLifecycleDelegate = ReactLifecycleDelegate(this)
 
   // We postpone creating the `JSIInteropModuleRegistry` to not load so files in unit tests.
-  private lateinit var jsiInterop: JSIInteropModuleRegistry
+  internal lateinit var jsiInterop: JSIInteropModuleRegistry
 
   internal val sharedObjectRegistry = SharedObjectRegistry()
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -10,6 +10,7 @@ import kotlin.reflect.KType
 @Suppress("NOTHING_TO_INLINE")
 inline fun Throwable.toCodedException() = when (this) {
   is CodedException -> this
+  is expo.modules.core.errors.CodedException -> CodedException(this.code, this.message, this.cause)
   else -> UnexpectedException(this)
 }
 
@@ -243,3 +244,7 @@ class JavaScriptEvaluateException(
 internal class UnsupportedClass(
   clazz: KClass<*>,
 ) : CodedException(message = "Unsupported type: '$clazz'")
+
+internal class PromiseWasAlreadyResolved(functionName: String) : CodedException(
+  message = "Promised pass to '$functionName' was already resolved. It will lead to a crash in the production environment!"
+)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -245,6 +245,6 @@ internal class UnsupportedClass(
   clazz: KClass<*>,
 ) : CodedException(message = "Unsupported type: '$clazz'")
 
-internal class PromiseWasAlreadyResolved(functionName: String) : CodedException(
-  message = "Promised pass to '$functionName' was already resolved. It will lead to a crash in the production environment!"
+internal class PromiseAlreadySettledException(functionName: String) : CodedException(
+  message = "Promised pass to '$functionName' was already settled. It will lead to a crash in the production environment!"
 )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/ExceptionDecorator.kt
@@ -4,11 +4,7 @@ package expo.modules.kotlin.exception
 internal inline fun <T> exceptionDecorator(decoratorBlock: (e: CodedException) -> Throwable, block: () -> T): T {
   return try {
     block()
-  } catch (e: CodedException) {
-    throw decoratorBlock(e)
-  } catch (e: expo.modules.core.errors.CodedException) {
-    throw decoratorBlock(CodedException(e.code, e.message, e.cause))
   } catch (e: Throwable) {
-    throw decoratorBlock(UnexpectedException(e))
+    throw decoratorBlock(e.toCodedException())
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -83,7 +83,7 @@ abstract class AsyncFunction(
           }
         } catch (e: Throwable) {
           // The promise was resolved, so we should rethrow the error.
-          if (promiseImpl.wasResolve) {
+          if (promiseImpl.wasSettled) {
             throw e
           }
           promiseImpl.reject(e.toCodedException())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunction.kt
@@ -14,6 +14,7 @@ import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.launch
@@ -57,23 +58,35 @@ abstract class AsyncFunction(
   internal abstract fun callUserImplementation(args: Array<Any?>, promise: Promise, appContext: AppContext)
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+    val appContextHolder = appContext.jsiInterop.appContextHolder
+    val moduleName = jsObject.name
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
-    ) { args, bridgePromise ->
+    ) { args, promiseImpl ->
+      if (BuildConfig.DEBUG) {
+        promiseImpl.decorateWithDebugInformation(
+          appContextHolder,
+          moduleName,
+          name
+        )
+      }
+
       val functionBody = {
         try {
           exceptionDecorator({
-            FunctionCallException(name, jsObject.name, it)
+            FunctionCallException(name, moduleName, it)
           }) {
-            callUserImplementation(args, bridgePromise, appContext)
+            callUserImplementation(args, promiseImpl, appContext)
           }
-        } catch (e: CodedException) {
-          bridgePromise.reject(e)
         } catch (e: Throwable) {
-          bridgePromise.reject(UnexpectedException(e))
+          // The promise was resolved, so we should rethrow the error.
+          if (promiseImpl.wasResolve) {
+            throw e
+          }
+          promiseImpl.reject(e.toCodedException())
         }
       }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -80,7 +80,7 @@ class SuspendFunctionComponent(
             }
           }
         } catch (e: Throwable) {
-          if (promiseImpl.wasResolve) {
+          if (promiseImpl.wasSettled) {
             throw e
           }
           promiseImpl.reject(e.toCodedException())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/SuspendFunctionComponent.kt
@@ -1,6 +1,7 @@
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.ReadableArray
+import expo.modules.BuildConfig
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.ModuleHolder
 import expo.modules.kotlin.Promise
@@ -8,6 +9,7 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.FunctionCallException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.exception.exceptionDecorator
+import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.types.AnyType
 import kotlinx.coroutines.CoroutineScope
@@ -46,12 +48,22 @@ class SuspendFunctionComponent(
   }
 
   override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+    val appContextHolder = appContext.jsiInterop.appContextHolder
+    val moduleName = jsObject.name
     jsObject.registerAsyncFunction(
       name,
       takesOwner,
       argsCount,
       desiredArgsTypes.map { it.getCppRequiredTypes() }.toTypedArray()
-    ) { args, bridgePromise ->
+    ) { args, promiseImpl ->
+      if (BuildConfig.DEBUG) {
+        promiseImpl.decorateWithDebugInformation(
+          appContextHolder,
+          moduleName,
+          name
+        )
+      }
+
       val queue = when (queue) {
         Queues.MAIN -> appContext.mainQueue
         Queues.DEFAULT -> appContext.modulesQueue
@@ -60,17 +72,18 @@ class SuspendFunctionComponent(
       queue.launch {
         try {
           exceptionDecorator({
-            FunctionCallException(name, jsObject.name, it)
+            FunctionCallException(name, moduleName, it)
           }) {
             val result = body.invoke(this, convertArgs(args))
             if (isActive) {
-              bridgePromise.resolve(result)
+              promiseImpl.resolve(result)
             }
           }
-        } catch (e: CodedException) {
-          bridgePromise.reject(e)
         } catch (e: Throwable) {
-          bridgePromise.reject(UnexpectedException(e))
+          if (promiseImpl.wasResolve) {
+            throw e
+          }
+          promiseImpl.reject(e.toCodedException())
         }
       }
     }


### PR DESCRIPTION
# Why

Improves error handling when working with promises.

# How

Previously when a promise was resolved twice, we ignored that. However, that leads to undefined behaviors and bugs in the user code. So I've decided to report that as an exception. That information will be piped to the js console in the development, but the app will crash in production. 

# Test Plan

- bare-expo with simple module ✅