### PR TITLE
[docs] Remove `hideFromSearch` in Home > Routing docs

### DIFF
--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -1,7 +1,6 @@
 ---
 title: Appearance elements
 description: Learn how to use a splash screen, fonts and images in your app that is using Expo Router.
-hideFromSearch: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/routing/create-pages.mdx
+++ b/docs/pages/routing/create-pages.mdx
@@ -1,7 +1,6 @@
 ---
 title: Create pages with Expo Router
 description: Learn about the file-based routing convention used by Expo Router.
-hideFromSearch: true
 sidebar_title: Create pages
 ---
 

--- a/docs/pages/routing/error-handling.mdx
+++ b/docs/pages/routing/error-handling.mdx
@@ -1,7 +1,6 @@
 ---
 title: Error handling
 description: Learn how to handle unmatched routes and errors in your app when using Expo Router.
-hideFromSearch: true
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -1,7 +1,6 @@
 ---
 title: Install Expo Router
 description: Learn how to quickly get started by creating a new project with Expo Router or add the library to an existing project.
-hideFromSearch: true
 sidebar_title: Installation
 ---
 

--- a/docs/pages/routing/introduction.mdx
+++ b/docs/pages/routing/introduction.mdx
@@ -1,7 +1,6 @@
 ---
 title: Introduction to Expo Router
 description: Expo Router is an open-source routing library for Universal React Native applications built with Expo.
-hideFromSearch: true
 hideTOC: true
 sidebar_title: Introduction
 ---

--- a/docs/pages/routing/layouts.mdx
+++ b/docs/pages/routing/layouts.mdx
@@ -1,7 +1,6 @@
 ---
 title: Layout Routes
 description: Learn how to define shared UI elements like tab bars and headers.
-hideFromSearch: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';

--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -1,7 +1,6 @@
 ---
 title: Navigate between pages
 description: Create links to move between pages.
-hideFromSearch: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When publishing Expo Router docs for the Home > Routing, I forgot to remove `hideFromSearch` from frontmatter (: facepalm:)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove `hideFromSearch`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
