### PR TITLE
[docs] Update BoxLink order in EAS Submit > Introduction

### DIFF
--- a/docs/pages/submit/introduction.mdx
+++ b/docs/pages/submit/introduction.mdx
@@ -14,20 +14,6 @@ import { AppleAppStoreIcon, GoogleAppStoreIcon, Settings01Icon } from '@expo/sty
 ### Get started
 
 <BoxLink
-  title="Submitting to the Apple App Store"
-  description="Learn how to submit an iOS/iPadOS app to the Apple App Store from any operating system."
-  href="/submit/ios"
-  Icon={AppleAppStoreIcon}
-/>
-
-<BoxLink
-  title="Submitting to the Google Play Store"
-  description="Learn how to submit an Android app to the Google Play Store."
-  href="/submit/android"
-  Icon={GoogleAppStoreIcon}
-/>
-
-<BoxLink
   title="Configuration with eas.json"
   description={
     <>
@@ -36,4 +22,18 @@ import { AppleAppStoreIcon, GoogleAppStoreIcon, Settings01Icon } from '@expo/sty
   }
   href="/submit/eas-json"
   Icon={Settings01Icon}
+/>
+
+<BoxLink
+  title="Submit to the Google Play Store"
+  description="Learn how to submit an Android app to the Google Play Store."
+  href="/submit/android"
+  Icon={GoogleAppStoreIcon}
+/>
+
+<BoxLink
+  title="Submit to the Apple App Store"
+  description="Learn how to submit an iOS/iPadOS app to the Apple App Store from any operating system."
+  href="/submit/ios"
+  Icon={AppleAppStoreIcon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in a discussion with @keith-kurak during dev success sync that the order of BoxLink components do not follow the order of the docs specified in sidebar.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the order of BoxLinks:

<img width="1134" alt="CleanShot 2023-07-17 at 18 17 23@2x" src="https://github.com/expo/expo/assets/10234615/edefa8cb-5cdb-430d-83e5-4c12c09eee2f">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/submit/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
