### PR TITLE
fix(expo,cli): export `@expo/metro-config` from controlling `@expo/cli` instead of using implicit dependency

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added improved error message for static metro when a package is missing. ([#23499](https://github.com/expo/expo/pull/23499) by [@EvanBacon](https://github.com/EvanBacon))
 - Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
+- Export `@expo/metro-config` from controlling `@expo/cli` instead of using implicit dependency. ([#23580](https://github.com/expo/expo/pull/23580) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/metro-config.d.ts
+++ b/packages/@expo/cli/metro-config.d.ts
@@ -1,0 +1,1 @@
+export * from '@expo/metro-config';

--- a/packages/@expo/cli/metro-config.js
+++ b/packages/@expo/cli/metro-config.js
@@ -1,0 +1,1 @@
+module.exports = require('@expo/metro-config');

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "static",
-    "build"
+    "build",
+    "metro-config.js"
   ],
   "scripts": {
     "build": "taskr",

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -9,7 +9,8 @@
   "files": [
     "static",
     "build",
-    "metro-config.js"
+    "metro-config.js",
+    "metro-config.d.ts"
   ],
   "scripts": {
     "build": "taskr",

--- a/packages/@expo/cli/src/start/server/metro/resolveFromProject.ts
+++ b/packages/@expo/cli/src/start/server/metro/resolveFromProject.ts
@@ -44,9 +44,10 @@ export function importMetroHmrServerFromProject(
 }
 
 export function importExpoMetroConfig(projectRoot: string) {
-  return importFromProjectOrFallback<typeof import('@expo/metro-config')>(
+  // `@expo/metro-config` version is controlled by `@expo/cli` to avoid conflicting `@expo/metro-config` versions in project dependencies
+  return importFromProjectOrFallback<typeof import('@expo/cli/metro-config')>(
     projectRoot,
-    '@expo/metro-config'
+    '@expo/cli/metro-config'
   );
 }
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Move `pointerEvents` to `styles.pointerEvents`. ([#23446](https://github.com/expo/expo/pull/23446) by [@EvanBacon](https://github.com/EvanBacon))
+- Export `@expo/metro-config` from controlling `@expo/cli` instead of using implicit dependency. ([#23580](https://github.com/expo/expo/pull/23580) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo/metro-config.d.ts
+++ b/packages/expo/metro-config.d.ts
@@ -1,1 +1,1 @@
-export * from '@expo/metro-config';
+export * from '@expo/cli/metro-config';

--- a/packages/expo/metro-config.js
+++ b/packages/expo/metro-config.js
@@ -1,1 +1,1 @@
-module.exports = require('@expo/metro-config');
+module.exports = require('@expo/cli/metro-config');


### PR DESCRIPTION
# Why

With our change of import when customizing the Metro config (`@expo/metro-config` to `expo/metro-config`) we overlooked the implicit dependency issue. Basically what's happening is this:

- `expo` exports `@expo/metro-config` as `expo/metro-config`
- `expo` **does not** have `@expo/metro-config` as `dependencies` or `peerDependencies` and relies on `@expo/cli`'s version

For [isolated modules](https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md), pnpm and future npm versions, this is a nightmare and won't work properly. `@expo/metro-config` is not defined as dependency to `expo`, and thus never linked in the eventual **node_modules** structure.

But even with Yarn (v1) there are cases where this does not work as we want it to. When users add a different version of `@expo/metro-config` to their project dependencies, the version `expo/metro-config` exports is not implicitly inherited from `@expo/cli`, but from the project dependencies.

# Yarn v1's case

The reason why the project dependencies are taking priority over the `@expo/cli`'s metro config version is the implicitness of the `@expo/metro-config` relation to `expo`.

When users don't have `@expo/metro-config` listed, the dependency chain `expo` -> `@expo/cli` -> `@expo/metro-config` gets hoisted to the root of the **node_modules** folder:

<details><summary>See <b>node_modules</b> structure information without <code>@expo/metro-config</code> project dependency</summary>

<img width="691" alt="image" src="https://github.com/expo/expo/assets/1203991/c803481c-e1f7-4cdc-bdb7-d9f8131895aa">

</details>

But, when users add a different version of `@expo/metro-config` as project dependency, this will be placed inside the root **node_modules** instead. While the correct metro config version is installed in the **node_modules/@expo/cli/node_modules/@expo/metro-config** folder.

<details><summary>See <b>node_modules</b> structure information with incorrect <code>@expo/metro-config</code> project dependency</summary>

<img width="858" alt="image" src="https://github.com/expo/expo/assets/1203991/f7599b90-da48-4761-bc07-a16d274be70d">

</details>

# How

- Since `@expo/cli` should be "in control" of the compatible `@expo/metro-config`, I added the `@expo/cli/metro-config` export.
- Updated `expo/metro-config` to re-export `@expo/cli/metro-config` instead of `@expo/metro-config`

# Test Plan

- `$ yarn create expo ./test-metro-config -t tabs@49`
- `$ cd ./test-metro-config`
- `$ yarn add @expo/metro-config@0.0.1`
- `$ yarn expo start` -> should work fine with this change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
