### PR TITLE
[go][ios] Fix Expo Go not respecting the orientation field on initial load

### DIFF
--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -578,10 +578,9 @@ NS_ASSUME_NONNULL_BEGIN
     return [super supportedInterfaceOrientations];
   }
 
-  if ([ScreenOrientationRegistry.shared requiredOrientationMask] > 0) {
+  if ([ScreenOrientationRegistry.shared requiredOrientationMask] > 0 && !self.isHomeApp) {
     return [ScreenOrientationRegistry.shared requiredOrientationMask];
   }
-
 
   return [self orientationMaskFromManifestOrDefault];
 }

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -79,7 +79,8 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   /**
    Rotates the view to currentScreenOrientation or default orientation from the orientationMask.
    */
-  func enforceDesiredDeviceOrientation(withOrientationMask orientationMask: UIInterfaceOrientationMask) {
+  @objc
+  public func enforceDesiredDeviceOrientation(withOrientationMask orientationMask: UIInterfaceOrientationMask) {
     var newOrientation = orientationMask.defaultOrientation()
 
     if orientationMask.contains(currentScreenOrientation) {


### PR DESCRIPTION

# Why

https://github.com/expo/expo/issues/23368, ENG-9262
On iOS 16+ Expo Go wouldn't respect the values under the `"orientation"` key in `app.json` until something caused the view controller to update it's orientation using `supportedInterfaceOrientaitons` (for example opening the dev-menu). 

On iOS 15 it would work on initial load but it was possible to cause the "orientation" field to stop working. (For example setting the "orientation" key to landscape, opening an app, opening the dev-menu, going home and opening the app again while keeping the device in portrait).

# How

When transitioning to an app Expo Go will make the root view controller check for the supported orientations.
On iOS 16+ this is archived with a built in method, and on iOS < 16 this is done by setting the UIDevice.orientation.current (via a `ScreenOrientationRegistry` method) to the desired orientation.

# Test Plan

Tested in Expo Go on iOS 16 and 15
