### PR TITLE
[tools] Fix detecting home app for dynamic macros

### DIFF
--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -172,7 +172,7 @@ export default {
     try {
       const manifest = await getManifestAsync(url, platform, null);
 
-      if (manifest.extra?.expoClient?.name !== 'expo-home') {
+      if (manifest.name !== 'expo-home') {
         console.log(
           `Manifest at ${url} is not expo-home; using published kernel manifest instead...`
         );


### PR DESCRIPTION
# Why

The iOS builds were failing when requesting for the local home. `manifest.extra` is no longer available for the home app, so we need to use `manifest.name` instead

# How

Updated the condition that checks if the downloaded manifest is a home's manifest.

# Test Plan

`npx expo start --port=80` and building the app works as expected