### PR TITLE
[docs] disable font ligatures in code elements

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -75,4 +75,8 @@ export const globalExtras = css`
   .strike {
     text-decoration: line-through;
   }
+
+  code {
+    font-variant-ligatures: none;
+  }
 `;


### PR DESCRIPTION
# Why

Refs [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1689549566323249)

# How

Add global `font-variant-ligatures` property set to `"none"` to `code` elements, which disables the ligatures, if present in used by device font.

# Test Plan

The changes have been tested by running docs app locally and accessing it on iOS device.

# Preview

### Before

![IMG_1235](https://github.com/expo/expo/assets/719641/9705e74e-79bd-4692-8343-808b58f89406)

### After

![IMG_1236](https://github.com/expo/expo/assets/719641/b4231fb8-a191-48cb-a0ff-9781b5f9a166)

