### PR TITLE
[docs] tweak outline style

### DIFF
--- a/docs/global-styles/extras.ts
+++ b/docs/global-styles/extras.ts
@@ -14,7 +14,7 @@ export const globalExtras = css`
   }
 
   *:focus-visible {
-    outline: 3px ridge ${theme.button.tertiary.icon};
+    outline: 3px solid ${theme.button.tertiary.icon};
     outline-offset: 1px;
     border-radius: 3px;
   }


### PR DESCRIPTION
# Why

Pointed out on design sync.

# How

Switch `ridge` border style to `solid` for global outline.

# Preview

<img width="312" alt="Screenshot 2023-07-18 at 19 01 29" src="https://github.com/expo/expo/assets/719641/b1c62db4-f899-4572-959e-324f1539621b">

