### PR TITLE
[docs] fix wrong link

### DIFF
--- a/packages/expo-file-system/build/FileSystem.d.ts
+++ b/packages/expo-file-system/build/FileSystem.d.ts
@@ -15,7 +15,7 @@ export declare const bundledAssets: string | null, bundleDirectory: string | nul
 /**
  * Get metadata information about a file, directory or external content/asset.
  * @param fileUri URI to the file or directory. See [supported URI schemes](#supported-uri-schemes).
- * @param options A map of options represented by [`GetInfoAsyncOptions`](#getinfoasyncoptions) type.
+ * @param options A map of options represented by [`InfoOptions`](#infooptions) type.
  * @return A Promise that resolves to a `FileInfo` object. If no item exists at this URI,
  * the returned Promise resolves to `FileInfo` object in form of `{ exists: false, isDirectory: false }`.
  */

--- a/packages/expo-file-system/src/FileSystem.ts
+++ b/packages/expo-file-system/src/FileSystem.ts
@@ -60,7 +60,7 @@ export const { bundledAssets, bundleDirectory } = ExponentFileSystem;
 /**
  * Get metadata information about a file, directory or external content/asset.
  * @param fileUri URI to the file or directory. See [supported URI schemes](#supported-uri-schemes).
- * @param options A map of options represented by [`GetInfoAsyncOptions`](#getinfoasyncoptions) type.
+ * @param options A map of options represented by [`InfoOptions`](#infooptions) type.
  * @return A Promise that resolves to a `FileInfo` object. If no item exists at this URI,
  * the returned Promise resolves to `FileInfo` object in form of `{ exists: false, isDirectory: false }`.
  */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The "GetInfoAsyncOptions" link is dead on https://docs.expo.dev/versions/latest/sdk/filesystem/#filesystemgetinfoasyncfileuri-options 

# How

<!--
How did you build this feature or fix this bug and why?
-->
I fixed the link by using the function return type

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

I didn't test this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
