### PR TITLE
[docs] add missing keys to enumerated elements

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -243,7 +243,7 @@ const Home = () => {
         <CellContainer>
           <Row>
             {TALKS.filter(talk => talk.home).map(talk => (
-              <TalkGridCell {...talk} />
+              <TalkGridCell key={talk.videoId} {...talk} />
             ))}
           </Row>
         </CellContainer>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -74,7 +74,7 @@ function renderStructure(structure: FileObject[], level = 0): ReactNode {
         {renderStructure(files, level + 1)}
       </div>
     ) : (
-      <div className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
+      <div key={name + '_' + index} className="mt-1 pt-1 pl-2 rounded-sm flex items-center">
         {' '.repeat(Math.max(level, 0))}
         <FileIcon className="text-icon-tertiary mr-2 min-w-[20px]" />
         <TextWithNote name={name} note={note} className="text-default" />


### PR DESCRIPTION
# Why

Fix console warnings related to missing element keys.

# How

Add keys on Home page and in FileTree path variant.

# Test Plan

The changes have been reviewed by running docs app locally.
