### PR TITLE
[docs] fix syntax highlight on Router pages

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -34,7 +34,7 @@ module.exports = {
 > After changing your `babel.config.js`, once run `npx expo start --clear` to start the development server and clear the babel cache.
 > Now you can use the `Drawer` layout to create a drawer navigator:
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Drawer } from 'expo-router/drawer';
 export default function Layout() {
   return <Drawer />;

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -19,7 +19,7 @@ You can implement a modal by creating a root layout route that renders certain r
 
 The layout route **app/\_layout.js** can present components as modals. Add a new route called **modal** that is used to render modals:
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 export default function Layout() {
   return (
@@ -43,7 +43,7 @@ export default function Layout() {
 }
 ```
 
-```js app/home.js
+```jsx app/home.js
 import { View, Text } from 'react-native';
 import { Link } from 'expo-router';
 export default function Home() {
@@ -58,7 +58,7 @@ export default function Home() {
 
 Now create a modal that adds a back button when the modal has lost its previous context and must be presented as a standalone page.
 
-```js app/modal.js
+```jsx app/modal.js
 import { View } from 'react-native';
 import { Link, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -26,19 +26,19 @@ Consider the following file structure which is used as an example in this guide:
 
 In the above example, **app/home/feed.js** matches `/home/feed` and **app/home/messages.js** matches `/home/messages`.
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 export default Stack;
 ```
 
 This is nested in the **\_layout.js** layout, so it will be rendered as a stack.
 
-```js app/home/_layout.js
+```jsx app/home/_layout.js
 import { Tabs } from 'expo-router';
 export default Tabs;
 ```
 
-```js app/index.js
+```jsx app/index.js
 import { Link } from 'expo-router';
 export default function Root() {
   return <Link href="/home/messages">Navigate to nested route</Link>;
@@ -47,7 +47,7 @@ export default function Root() {
 
 This is nested in the **home/\_layout.js** layout, so it will be rendered as a tab.
 
-```js app/home/feed.js
+```jsx app/home/feed.js
 import { View, Text } from 'react-native';
 export default function Feed() {
   return (
@@ -58,7 +58,7 @@ export default function Feed() {
 }
 ```
 
-```js app/home/messages.js
+```jsx app/home/messages.js
 import { View, Text } from 'react-native';
 export default function Messages() {
   return (

--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -14,7 +14,7 @@ While building your app, you may want to show specific content based on the curr
 
 You can use the [`Platform`](https://reactnative.dev/docs/platform-specific-code#platform-module) module from React Native to detect the current platform and render the appropriate content based on the result. For example, you can render a `Tabs` layout on native and a custom layout on the web.
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Platform } from 'react-native';
 import { Link, Tabs } from 'expo-router';
 

--- a/docs/pages/router/advanced/router-settings.mdx
+++ b/docs/pages/router/advanced/router-settings.mdx
@@ -16,7 +16,7 @@ When deep-linking to a route may want to provide a user with a "back" button. Th
 
 <FileTree files={['app/_layout.js', 'app/index.js', 'app/other.js']} />
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 
 export const unstable_settings = {

--- a/docs/pages/router/advanced/shared-routes.mdx
+++ b/docs/pages/router/advanced/shared-routes.mdx
@@ -36,7 +36,7 @@ Instead of defining the same route multiple times with different layouts, use th
 
 To distinguish between the two routes use a layout's `segment` prop:
 
-```js app/(home,search)/_layout.js
+```jsx app/(home,search)/_layout.js
 export default function DynamicLayout({ segment }) {
   if (segment === '(search)') {
     return <SearchStack />;

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -25,7 +25,7 @@ export default function Layout() {
 
 Use the `screenOptions` prop to configure the header bar.
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 
 export default function Layout() {
@@ -47,7 +47,7 @@ export default function Layout() {
 
 You can use a layout's Screen component to configure the header bar dynamically from within the route. This is good for interactions that change the UI.
 
-```js app/home.js
+```jsx app/home.js
 import { Link, Stack } from 'expo-router';
 import { Image, Text, View } from 'react-native';
 
@@ -86,7 +86,7 @@ export default function Home() {
 
 You can use the imperative API `router.setParams()` function to configure the route dynamically.
 
-```js app/details.js
+```jsx app/details.js
 import { View, Text } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 
@@ -120,7 +120,7 @@ With the following file structure:
 
 You can use the `<Stack.Screen name={routeName} />` component in the layout component route to statically configure screen options. This is useful for tab bars or drawers which need to have an icon defined ahead of time.
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 
 export default function Layout() {
@@ -149,9 +149,8 @@ export default function Layout() {
 
 Use the `<Stack.Screen />` component in the child route to dynamically configure options.
 
-```js app/home.js
-import { useLayoutEffect } from 'react';
-import { View, Button, Text, Image } from 'react-native';
+```jsx app/home.js
+import { Button, Text, Image } from 'react-native';
 /* @info */
 import { Stack } from 'expo-router';
 /* @end */

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -14,7 +14,7 @@ Expo Router adds `href` screen option which can only be used with screen options
 
 Sometimes you want a route to exist but not show up in the tab bar, you can pass `href: null` to disable the button:
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Tabs } from 'expo-router/tabs';
 export default function AppLayout() {
   return (
@@ -36,8 +36,7 @@ export default function AppLayout() {
 
 You may want to use a dynamic route in your tab bar (for example, a profile tab). For this case, you'll want the button to always link to a specific `href`.
 
-```js app/_layout.js
-import { Link } from 'expo-router';
+```jsx app/_layout.js
 import { Tabs } from 'expo-router/tabs';
 export default function AppLayout() {
   return (

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -89,7 +89,7 @@ Layout the structure of your app by creating files according to the [creating pa
 Replace navigators with directories, for example:
 
 {/* prettier-ignore */}
-```js React Navigation
+```jsx React Navigation
 function HomeTabs() {
   return (
     <Tab.Navigator>
@@ -150,7 +150,7 @@ function App() {
   ]}
 />
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Stack } from 'expo-router';
 
 export default function RootLayout() {
@@ -256,7 +256,7 @@ The `NavigationContainer` ref should not be accessed directly. Use the following
 
 Navigate to the initial route of the application. For example, if your app starts at `/` (recommended), then you can replace the current route with `/` using this method.
 
-```js
+```jsx
 import { useRouter } from 'expo-router';
 
 function Example() {
@@ -338,7 +338,7 @@ The [`fallback`](https://reactnavigation.org/docs/navigation-container/#fallback
 
 In React Navigation, you set the theme for the entire app using the [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/#theme) component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
 
-```js app/_layout.tsx
+```jsx app/_layout.tsx
 import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 import { Slot } from 'expo-router';
 
@@ -399,7 +399,7 @@ All of the `children` of a `<Navigator />` component will be rendered as-is.
 Custom layouts have an internal context that is ignored when using the `<Slot />` component without a `<Navigator />` component wrapping it.
 
 {/* prettier-ignore */}
-```js
+```jsx
 import { View } from 'react-native';
 import { TabRouter } from '@react-navigation/native';
 
@@ -418,7 +418,6 @@ export default function App() {
 
 function Header() {
   const { navigation, state, descriptors, router } = Navigator.useContext();
-
   const pathname = usePathname();
 
   return (
@@ -428,7 +427,7 @@ function Header() {
         href="/profile"
         /* @info Use <code>pathname</code> to determine if the link is active. */
         style={[pathname === '/profile' && { color: 'blue' }]}>
-        /* @end */ 
+        /* @end */
         Profile
       </Link>
       <Link href="/settings">Settings</Link>

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -14,7 +14,7 @@ Consider the following project:
 
 First, we'll setup a [React Context provider](https://react.dev/reference/react/createContext) that we can use to protect routes. This provider will use a mock implementation, you can replace it with your own [authentication provider](/guides/authentication/).
 
-```js context/auth.js
+```jsx context/auth.js
 import { router, useSegments } from 'expo-router';
 import React from 'react';
 
@@ -66,7 +66,7 @@ export function Provider(props) {
 
 Now we can use this context to control the access to the routes, we'll do this by using a Layout Route that wraps all the screens which require authentication.
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { Slot } from 'expo-router';
 import { Provider } from '../context/auth';
 
@@ -82,7 +82,7 @@ export default function Root() {
 
 Now we can create our `(auth)` group which is unprotected, this screen can toggle the authentication using `signIn()`.
 
-```js app/(auth)/sign-in.js
+```jsx app/(auth)/sign-in.js
 import { Text, View } from 'react-native';
 import { useAuth } from '../../context/auth';
 
@@ -98,7 +98,7 @@ export default function SignIn() {
 
 And finally we'll implement an authenticated screen which can sign out.
 
-```js app/index.js
+```jsx app/index.js
 import { Text, View } from 'react-native';
 
 import { useAuth } from '../context/auth';

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -16,7 +16,7 @@ Returns the currently selected route location without search parameters. For exa
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```js app/profile/[user].tsx
+```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { usePathname } from 'expo-router';
@@ -41,7 +41,7 @@ When `/abc/home` pushes `/123/shop`, `useGlobalSearchParams` returns `{ first: u
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```js app/profile/[user].tsx
+```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useLocalSearchParams } from 'expo-router';
@@ -63,7 +63,7 @@ Refer to the [local vs global search params](/router/reference/search-parameters
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
-```js app/profile/[user].tsx
+```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useGlobalSearchParams } from 'expo-router';
@@ -88,7 +88,7 @@ The `Href` type is a union of the following types:
 
 Returns a list of segments for the currently selected route. Segments are not normalized so that they will be the same as the file path. For example, `/[id]?id=normal` -> `["[id]"]`.
 
-```js app/profile/[user].tsx
+```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
 import { useSegments } from 'expo-router';
@@ -104,7 +104,7 @@ export default function Route() {
 
 This function can be typed using an abstract of string arrays:
 
-```js app/profile/[user].tsx
+```jsx app/profile/[user].tsx
 import { useSegments } from 'expo-router';
 
 export default function Route() {
@@ -120,7 +120,7 @@ export default function Route() {
 
 Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
 
-```js
+```jsx
 /* @info */
 import { useNavigation } from 'expo-router';
 /* @end */
@@ -148,13 +148,12 @@ export default function Route() {
 
 Given a function, the `useFocusEffect` hook will invoke the function whenever the route is "focused".
 
-```js
+```jsx
 /* @info */
 import { useFocusEffect } from 'expo-router';
 /* @end */
 
 export default function Route() {
-
   useFocusEffect(() => {
     /* @info Invoked whenever the route is focused */
     console.log('Hello')

--- a/docs/pages/router/reference/redirects.mdx
+++ b/docs/pages/router/reference/redirects.mdx
@@ -9,7 +9,7 @@ You can redirect a request to a different URL based on some in-app criteria. Exp
 
 You can immediately redirect from a particular screen by using the `Redirect` component:
 
-```js
+```jsx
 import { View, Text } from 'react-native';
 /* @info */
 import { Redirect } from 'expo-router';
@@ -36,7 +36,7 @@ export default function Page() {
 
 You can also redirect imperatively with the `useRouter` hook:
 
-```js
+```jsx
 import { Text } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 

--- a/docs/pages/router/reference/screen-tracking.mdx
+++ b/docs/pages/router/reference/screen-tracking.mdx
@@ -11,7 +11,7 @@ Unlike React Navigation, Expo Router always has access to a URL. This means scre
 
 <FileTree files={['app/_layout.js']} />
 
-```js app/_layout.js
+```jsx app/_layout.js
 import { useEffect } from 'react';
 import { usePathname, useGlobalSearchParams, Slot } from 'expo-router';
 

--- a/docs/pages/router/reference/search-parameters.mdx
+++ b/docs/pages/router/reference/search-parameters.mdx
@@ -8,7 +8,6 @@ sidebar_title: Search Parameters
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Search parameters (also known as query params) are serializable fields that can be added to a URL. They are commonly used to pass data between pages. Expo Router provides hooks for accessing and modifying these parameters.
 
@@ -29,7 +28,7 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
     The Root Layout is a stack navigator:
 
-    ```js app/_layout.js
+    ```jsx app/_layout.js
     import { Stack } from 'expo-router';
 
     export default function Layout() {
@@ -43,7 +42,7 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
     The initial route redirects to the dynamic route **app/[user].js**, with **user=evanbacon**:
 
-    ```js app/index.js
+    ```jsx app/index.js
     import { Redirect } from 'expo-router';
 
     export default function Route() {
@@ -57,7 +56,7 @@ The example below demonstrates the difference between `useLocalSearchParams` and
 
     The dynamic route **app/[user]** prints out the global and local search parameters. It also allows for pushing new instances of the same route with different search parameters:
 
-    ```js app/[user].js
+    ```jsx app/[user].js
     import { Text, View } from 'react-native';
     import { useLocalSearchParams, useGlobalSearchParams, Link } from 'expo-router';
 

--- a/docs/pages/router/reference/static-rendering.mdx
+++ b/docs/pages/router/reference/static-rendering.mdx
@@ -106,7 +106,7 @@ This project can be deployed to almost every hosting service. Note that this is 
 
 The `static` output will generate HTML files for each route. This means dynamic routes (**app/[id].tsx**) will not work out of the box. You can generate known routes ahead of time using the `generateStaticParams` function.
 
-```js app/blog/[id].tsx
+```tsx app/blog/[id].tsx
 import { Text } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 
@@ -134,7 +134,7 @@ This will output a file for each post in the **dist** directory. For example, if
 
 A server-only function evaluated at build-time in a Node.js environment by Expo CLI. This means it has access to `__dirname`, `process.cwd()`, `process.env`, and more. It also has access to every environment variable that's available in the process, not just the values prefixed with **EXPO*PUBLIC***. **generateStaticParams** is not run in a browser environment, so it cannot access browser APIs like **localStorage** or **document**, nor can it access native Expo APIs such as **expo-camera** or **expo-location**.
 
-```js app/[id].tsx
+```tsx app/[id].tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
   /* @info Prints the current working directory */
   console.log(process.cwd());
@@ -146,7 +146,7 @@ export async function generateStaticParams(): Promise<Record<string, string>[]> 
 
 **generateStaticParams** cascades from nested parents down to children. The cascading parameters are passed to every dynamic child route that exports **generateStaticParams**.
 
-```js app/[id]/_layout.tsx
+```tsx app/[id]/_layout.tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
   /* @info Any dynamic children that export <b>generateStaticParams</b> will be invoked once for every entry in the array. */
   return [{ id: 'one' }, { id: 'two' }];
@@ -156,7 +156,7 @@ export async function generateStaticParams(): Promise<Record<string, string>[]> 
 
 Now the dynamic child routes will be invoked twice, once with `{ id: 'one' }` and once with `{ id: 'two' }`. All variations must be accounted for.
 
-```js app/[id]/[comment].tsx
+```tsx app/[id]/[comment].tsx
 export async function generateStaticParams(params: {
   id: 'one' | 'two',
 }): Promise<Record<string, string>[]> {
@@ -180,14 +180,15 @@ You can customize the root HTML file by creating an **app/+html.tsx** file in yo
 
 > **Note**: Global context providers should go in the [Root Layout](/router/advanced/root-layout) component, not the Root HTML component.
 
-```js app/+html.tsx
+```tsx app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from "react";
 
 // This file is web-only and used to configure the root HTML for every
 // web page during static rendering.
 // The contents of this function only run in Node.js environments and
 // do not have access to the DOM or browser APIs.
-export default function Root({ children }: { children: React.ReactNode }) {
+export default function Root({ children }: PropsWithChildren) {
   return (
     <html lang="en">
       <head>
@@ -233,7 +234,7 @@ The exports from `expo-router/html` are related to the Root HTML component.
 
 You can add meta tags to your pages with the `<Head />` module from `expo-router`:
 
-```js app/about.tsx
+```tsx app/about.tsx
 import Head from 'expo-router/head';
 import { Text } from 'react-native';
 
@@ -275,7 +276,7 @@ These files will be copied to the **dist** folder during static rendering:
 
 > **info** **Web only**: Static assets can be accessed in runtime code using relative paths. For example, the **logo.png** can be accessed at `/logo.png`:
 
-```js app/index.tsx
+```tsx app/index.tsx
 import { Image } from 'react-native';
 
 export default function Page() {

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -24,7 +24,7 @@ This can happen when:
 
 Alternatively, you can circumvent this issue by creating an **index.js** file in the root of your project with the following contents:
 
-```js index.js
+```jsx index.js
 import { registerRootComponent } from 'expo';
 import { ExpoRoot } from 'expo-router';
 


### PR DESCRIPTION
# Why

On the router pages, besides the declared extension via file name, most of code block are in fact JSX/TSX code. Using JS as language for Prism could lead to unexpected effects and not correctly colored code blocks:

<img width="1001" alt="Screenshot 2023-07-18 at 23 05 57" src="https://github.com/expo/expo/assets/719641/0103e203-1106-4730-9cc1-0ff8593ff801">

# How

Correct the language passed via MD code blocks on the Router pages to improve the syntax highlight.

Additionally, during the process, I have removed few unused imports from pages and example code.

# Test Plan

Changes have been reviewed by running docs locally. Lint checks and test are passing.

# Preview

<img width="1001" alt="Screenshot 2023-07-18 at 23 05 24" src="https://github.com/expo/expo/assets/719641/c694b0c0-ddcb-4094-8c0f-eea7e356b3e0">

