### PR TITLE
[docs] Fix broken link in CNG docs

### DIFF
--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -14,7 +14,7 @@ Continuous Native Generation is an abstract concept that describes the process o
 
 ## Usage in React Native
 
-Any React Native app can leverage **Continuous Native Generation** by using [Expo Prebuild](/workflow/prebuild). This enables you to automate upgrading React Native, installing/uninstalling libraries, white-labeling at scale, sharing config across multiple apps, generating assets, reducing [orphaned code](workflow/prebuild/#orphaned-code), and more &mdash; generally, it allows you to build more powerful apps, at larger scales, without compromising on iteration speed.
+Any React Native app can leverage **Continuous Native Generation** by using [Expo Prebuild](/workflow/prebuild). This enables you to automate upgrading React Native, installing/uninstalling libraries, white-labeling at scale, sharing config across multiple apps, generating assets, reducing [orphaned code](/workflow/prebuild/#orphaned-code), and more &mdash; generally, it allows you to build more powerful apps, at larger scales, without compromising on iteration speed.
 
 Expo as a framework enables **Continuous Native Generation** by combining the following tools:
 


### PR DESCRIPTION
# Why

A missing `/` caused a link to be relative, and broken.

# How

Changed it to be an absolute link like all others.

# Test Plan

Tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
