### PR TITLE
[docs] Analytics guide: hide TOC

### DIFF
--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -1,5 +1,6 @@
 ---
 title: Use Analytics
+hideTOC: true
 description: An overview of analytics services available in the Expo and React Native ecosystem.
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

[Analytics guide](https://docs.expo.dev/guides/using-analytics/) doesn't have a TOC.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `hideTOC` in page's frontmatter.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/guides/using-analytics/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
