### PR TITLE
[docs] Updating steps to connect to the dev server for apple devices

### DIFF
--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -19,7 +19,7 @@ It is available on both the Android Play Store and iOS App Store.
 
 ## How it works
 
-Expo Go is a native app that is installed on your device. When you run `npx expo start` in your project, [Expo CLI](/more/expo-cli/) starts a [development server](/more/expo-cli/#develop) and generates a QR code. You can then open the Expo Go app on your device and scan the QR code to connect to the dev server.
+Expo Go is a native app that is installed on your device. When you run `npx expo start` in your project, [Expo CLI](/more/expo-cli/) starts a [development server](/more/expo-cli/#develop) and generates a QR code. You can then open the Expo Go app on your device and scan the QR code to connect to the dev server. If you are running the app on iOS, use the device's camera app to scan the QR code.
 
 <Terminal cmd={['$ npx expo start']} />
 

--- a/docs/pages/get-started/expo-go.mdx
+++ b/docs/pages/get-started/expo-go.mdx
@@ -19,7 +19,7 @@ It is available on both the Android Play Store and iOS App Store.
 
 ## How it works
 
-Expo Go is a native app that is installed on your device. When you run `npx expo start` in your project, [Expo CLI](/more/expo-cli/) starts a [development server](/more/expo-cli/#develop) and generates a QR code. You can then open the Expo Go app on your device and scan the QR code to connect to the dev server. If you are running the app on iOS, use the device's camera app to scan the QR code.
+Expo Go is a native app that is installed on your device. When you run `npx expo start` in your project, [Expo CLI](/more/expo-cli/) starts a [development server](/more/expo-cli/#develop) and generates a QR code. On Android, you can open the Expo Go app on your device and scan the QR code to connect to the dev server. On iOS, use the device's camera to scan the QR code.
 
 <Terminal cmd={['$ npx expo start']} />
 


### PR DESCRIPTION
# Why

Currently, the expo go app does not allow QR scanning on iOS based devices. This needs to be done via the preinstalled camera app. However, the documentation does not reflect the same and can lead the developer astray.

# How

By updating the documentation.

# Test Plan

Read the updated documentation and test the workflow of using Expo Go on Android and iOS devices.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin) - NA
