### PR TITLE
[android][image-picker] Restore backported photo picker

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android, restore behavior from [#22658](https://github.com/expo/expo/pull/22658). ([#23617](https://github.com/expo/expo/pull/23617) by [@alanhughes](https://github.com/alanjhughes))
+
 ## 14.3.1 - 2023-07-04
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-picker/android/build.gradle
+++ b/packages/expo-image-picker/android/build.gradle
@@ -82,8 +82,8 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
-  implementation "androidx.activity:activity-ktx:1.7.1"
-  implementation "androidx.appcompat:appcompat:1.4.2"
+  implementation "androidx.activity:activity-ktx:1.7.2"
+  implementation "androidx.appcompat:appcompat:1.6.1"
   implementation "androidx.exifinterface:exifinterface:1.3.3"
   implementation "com.github.CanHub:Android-Image-Cropper:4.3.1"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -1,37 +1,51 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- Required for picking images from camera directly -->
-    <uses-permission android:name="android.permission.CAMERA"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+  <!-- Required for picking images from camera directly -->
+  <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Required for picking images from camera roll -->
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+  <!-- Required for picking images from camera roll -->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
 
-    <application>
-      <activity
-        android:name="com.canhub.cropper.CropImageActivity"
-        android:theme="@style/Base.Theme.AppCompat"/>
-        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
-        <provider
-            android:name=".fileprovider.ImagePickerFileProvider"
-            android:authorities="${applicationId}.ImagePickerFileProvider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/image_picker_provider_paths"/>
-        </provider>
-    </application>
+  <application>
+    <service
+      android:name="com.google.android.gms.metadata.ModuleDependencies"
+      android:enabled="false"
+      android:exported="false"
+      tools:ignore="MissingClass">
+      <intent-filter>
+        <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+      </intent-filter>
+      <meta-data
+        android:name="photopicker_activity:0:required"
+        android:value="" />
+    </service>
 
-    <queries>
-        <intent>
-            <!-- Required for picking images from the camera roll if targeting API 30 -->
-            <action android:name="android.media.action.IMAGE_CAPTURE" />
-        </intent>
-        <intent>
-            <!-- Required for picking images from the camera if targeting API 30 -->
-            <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
-        </intent>
-    </queries>
+    <activity
+      android:name="com.canhub.cropper.CropImageActivity"
+      android:theme="@style/Base.Theme.AppCompat" />
+    <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
+    <provider
+      android:name=".fileprovider.ImagePickerFileProvider"
+      android:authorities="${applicationId}.ImagePickerFileProvider"
+      android:exported="false"
+      android:grantUriPermissions="true">
+      <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/image_picker_provider_paths" />
+    </provider>
+  </application>
+
+  <queries>
+    <intent>
+      <!-- Required for picking images from the camera roll if targeting API 30 -->
+      <action android:name="android.media.action.IMAGE_CAPTURE" />
+    </intent>
+    <intent>
+      <!-- Required for picking images from the camera if targeting API 30 -->
+      <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
+    </intent>
+  </queries>
 </manifest>

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerExceptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerExceptions.kt
@@ -10,6 +10,9 @@ internal class FailedToDeduceTypeException :
 internal class FailedToCreateFileException(path: String, cause: Throwable? = null) :
   CodedException("Failed to create the file '$path'", cause)
 
+internal class FailedToPickMediaException :
+  CodedException("Failed to parse PhotoPicker result")
+
 internal class FailedToExtractVideoMetadataException(file: File? = null, cause: Throwable? = null) :
   CodedException("Failed to extract metadata from video file '${file?.toUri()?.toString() ?: ""}'", cause)
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -166,6 +166,7 @@ class ImagePickerModule : Module() {
     when (val pickingResult = pickerLauncher()) {
       is ImagePickerContractResult.Success -> pickingResult
       is ImagePickerContractResult.Cancelled -> throw OperationCanceledException()
+      is ImagePickerContractResult.Error -> throw FailedToPickMediaException()
     }
   }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -23,7 +23,7 @@ import java.io.Serializable
 internal class CameraContract(
   private val appContextProvider: AppContextProvider,
 ) : AppContextActivityResultContract<CameraContractOptions, ImagePickerContractResult> {
-  val contentResolver: ContentResolver
+  private val contentResolver: ContentResolver
     get() = requireNotNull(appContextProvider.appContext.reactContext) {
       "React Application Context is null"
     }.contentResolver

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -9,5 +9,5 @@ import expo.modules.imagepicker.MediaType
 internal sealed class ImagePickerContractResult private constructor() {
   class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
   class Cancelled : ImagePickerContractResult()
-  class Error: ImagePickerContractResult()
+  class Error : ImagePickerContractResult()
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -7,6 +7,7 @@ import expo.modules.imagepicker.MediaType
  * Data required to be returned upon successful contract completion
  */
 internal sealed class ImagePickerContractResult private constructor() {
-  class Cancelled : ImagePickerContractResult()
   class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
+  class Cancelled : ImagePickerContractResult()
+  class Error: ImagePickerContractResult()
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.core.os.bundleOf
@@ -54,7 +55,11 @@ internal class CropImageContract(
   }
 
   override fun parseResult(input: CropImageContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult {
-    val result = intent?.getParcelableExtra<CropImage.ActivityResult?>(CropImage.CROP_IMAGE_EXTRA_RESULT)
+    val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT, CropImage.ActivityResult::class.java)
+    } else {
+      intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT)
+    }
     if (resultCode == Activity.RESULT_CANCELED || result == null) {
       return ImagePickerContractResult.Cancelled()
     }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -78,9 +78,11 @@ internal class ImageLibraryContract(
       ImagePickerContractResult.Cancelled()
     } else if (input.options.allowsMultipleSelection) {
       val uris = intent.getAllDataUris()
-      ImagePickerContractResult.Success(uris.map { uri ->
-        uri.toMediaType(contentResolver) to uri
-      })
+      ImagePickerContractResult.Success(
+        uris.map { uri ->
+          uri.toMediaType(contentResolver) to uri
+        }
+      )
     } else {
       intent.data?.let { uri ->
         val type = uri.toMediaType(contentResolver)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -27,75 +27,65 @@ import java.io.Serializable
 internal class ImageLibraryContract(
   private val appContextProvider: AppContextProvider,
 ) : AppContextActivityResultContract<ImageLibraryContractOptions, ImagePickerContractResult> {
-  val contentResolver: ContentResolver
+  private val contentResolver: ContentResolver
     get() = requireNotNull(appContextProvider.appContext.reactContext) {
       "React Application Context is null"
     }.contentResolver
 
   override fun createIntent(context: Context, input: ImageLibraryContractOptions): Intent {
-    if (PickVisualMedia.isPhotoPickerAvailable(context)) {
-      val request = PickVisualMediaRequest.Builder()
-        .setMediaType(
-          when (input.options.mediaTypes) {
-            MediaTypes.VIDEOS -> {
-              PickVisualMedia.VideoOnly
-            }
-
-            MediaTypes.IMAGES -> {
-              PickVisualMedia.ImageOnly
-            }
-
-            else -> {
-              PickVisualMedia.ImageAndVideo
-            }
+    val request = PickVisualMediaRequest.Builder()
+      .setMediaType(
+        when (input.options.mediaTypes) {
+          MediaTypes.VIDEOS -> {
+            PickVisualMedia.VideoOnly
           }
-        ).build()
 
-      if (input.options.allowsMultipleSelection) {
-        val selectionLimit = input.options.selectionLimit
+          MediaTypes.IMAGES -> {
+            PickVisualMedia.ImageOnly
+          }
 
-        if (selectionLimit == 1) {
-          // If multiple selection is allowed but the limit is 1, we should ignore
-          // the multiple selection flag and just treat it as a single selection.
-          return PickVisualMedia().createIntent(context, request)
+          else -> {
+            PickVisualMedia.ImageAndVideo
+          }
         }
+      )
+      .build()
 
-        if (selectionLimit > 1) {
-          return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
-        }
+    if (input.options.allowsMultipleSelection) {
+      val selectionLimit = input.options.selectionLimit
 
-        // If the selection limit is 0, it is the same as unlimited selection.
-        if (selectionLimit == UNLIMITED_SELECTION) {
-          return PickMultipleVisualMedia().createIntent(context, request)
-        }
+      if (selectionLimit == 1) {
+        // If multiple selection is allowed but the limit is 1, we should ignore
+        // the multiple selection flag and just treat it as a single selection.
+        return PickVisualMedia().createIntent(context, request)
       }
 
-      return PickVisualMedia().createIntent(context, request)
+      if (selectionLimit > 1) {
+        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
+      }
+
+      // If the selection limit is 0, it is the same as unlimited selection.
+      if (selectionLimit == UNLIMITED_SELECTION) {
+        return PickMultipleVisualMedia().createIntent(context, request)
+      }
     }
 
-    return Intent(Intent.ACTION_GET_CONTENT)
-      .addCategory(Intent.CATEGORY_OPENABLE)
-      .setType(input.options.mediaTypes.toMimeType())
-      .apply {
-        if (input.options.allowsMultipleSelection) {
-          putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-        }
-        if (input.options.mediaTypes == MediaTypes.ALL) {
-          putExtra(Intent.EXTRA_MIME_TYPES, arrayOf(MediaTypes.IMAGES.toMimeType(), MediaTypes.VIDEOS.toMimeType()))
-        }
-      }
+    return PickVisualMedia().createIntent(context, request)
   }
 
   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
-    if (resultCode == Activity.RESULT_CANCELED) {
+    if (resultCode == Activity.RESULT_CANCELED || intent == null) {
       ImagePickerContractResult.Cancelled()
     } else if (input.options.allowsMultipleSelection) {
-      val uris = requireNotNull(intent).getAllDataUris()
-      ImagePickerContractResult.Success(uris.map { uri -> uri.toMediaType(contentResolver) to uri })
+      val uris = intent.getAllDataUris()
+      ImagePickerContractResult.Success(uris.map { uri ->
+        uri.toMediaType(contentResolver) to uri
+      })
     } else {
-      val uri = requireNotNull(requireNotNull(intent).data)
-      val type = uri.toMediaType(contentResolver)
-      ImagePickerContractResult.Success(listOf(type to uri))
+      intent.data?.let { uri ->
+        val type = uri.toMediaType(contentResolver)
+        ImagePickerContractResult.Success(listOf(type to uri))
+      } ?: ImagePickerContractResult.Cancelled()
     }
 }
 

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -74,20 +74,30 @@ internal class ImageLibraryContract(
   }
 
   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
-    if (resultCode == Activity.RESULT_CANCELED || intent == null) {
+    if (resultCode == Activity.RESULT_CANCELED) {
       ImagePickerContractResult.Cancelled()
-    } else if (input.options.allowsMultipleSelection) {
-      val uris = intent.getAllDataUris()
-      ImagePickerContractResult.Success(
-        uris.map { uri ->
-          uri.toMediaType(contentResolver) to uri
-        }
-      )
     } else {
-      intent.data?.let { uri ->
-        val type = uri.toMediaType(contentResolver)
-        ImagePickerContractResult.Success(listOf(type to uri))
-      } ?: ImagePickerContractResult.Cancelled()
+      intent?.takeIf { resultCode == Activity.RESULT_OK }?.getAllDataUris()?.let { uris ->
+        if (input.options.allowsMultipleSelection) {
+          ImagePickerContractResult.Success(
+            uris.map { uri ->
+              uri.toMediaType(contentResolver) to uri
+            }
+          )
+        } else {
+          if (intent.data != null) {
+            intent.data?.let {
+              val type = it.toMediaType(contentResolver)
+              ImagePickerContractResult.Success(listOf(type to it))
+            }
+          } else {
+            uris.firstOrNull()?.let { uri ->
+              val type = uri.toMediaType(contentResolver)
+              ImagePickerContractResult.Success(listOf(type to uri))
+            } ?: ImagePickerContractResult.Error()
+          }
+        }
+      } ?: ImagePickerContractResult.Error()
     }
 }
 


### PR DESCRIPTION
# Why
Restores the changes from #22658 so we can use the back ported image picker features on all api levels. We want to use this picker because it does not require asking the user for permission. 

# How
Handles crashes that were reported in #23020

# Test Plan
Tested on emulators back to api level 23 and physical devices running android 10 and 13
