### PR TITLE
[docs] Update monorepos docs for Expo-Router 49SDK Web support

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -197,10 +197,10 @@ import App from './App';
 registerRootComponent(App);
 ```
 
-If you are using expo-router, we have to change our default entrypoint to `index.js`. Then you need to create a `index.js` file within the root of the project that contains the content below.
+If you are using [Expo Router](/routing/introduction/), change the default entry point (`main`) to **index.js** in **package.json**. Then, create the **index.js** file within the root of your project with the following:
 
 ```js index.js
-import "expo-router/entry";
+import 'expo-router/entry';
 ```
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -197,6 +197,12 @@ import App from './App';
 registerRootComponent(App);
 ```
 
+If you are using expo-router, we have to change our default entrypoint to `index.js`. Then you need to create a `index.js` file within the root of the project that contains the content below.
+
+```js index.js
+import "expo-router/entry";
+```
+
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 
 ### Create a package


### PR DESCRIPTION
# Why

I started a new expo 49 sdk project from scratch in an already exisiting monorepo project, using the create-expo-app. I followed the monorepo setup but it seemed outdated for the expo-router template. After doing all the changes in the monorepo docs, I still got an error from expo web. So once adding the updated entry, I got it working like normal.

# How

Just updated the docs.

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
