### PR TITLE
fix(cli): allow multiple `--platform` flags in `expo export`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for SSO users. ([#22945](https://github.com/expo/expo/pull/22945) by [@lzkb](https://github.com/lzkb))
 - Use node server default port selection for SSO login server. ([#23505](https://github.com/expo/expo/pull/23505) by [@wschurman](https://github.com/wschurman))
 - Add styling to SSO auth redirect completion page. ([#23477](https://github.com/expo/expo/pull/23477) by [@wschurman](https://github.com/wschurman))
+- Allow multiple `--platform` flags in `expo export`. ([#23621](https://github.com/expo/expo/pull/23621) by [@byCedric](https://github.com/byCedric))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -15,9 +15,15 @@ jest.mock('@expo/config', () => ({
 }));
 
 describe(resolveOptionsAsync, () => {
-  it(`asserts invalid platform`, async () => {
+  it(`asserts unknown platform`, async () => {
     await expect(resolveOptionsAsync('/', { '--platform': ['foobar'] })).rejects.toThrow(
       /^Unsupported platform "foobar"\./
+    );
+  });
+
+  it(`asserts not-configured platform`, async () => {
+    await expect(resolveOptionsAsync('/', { '--platform': ['web'] })).rejects.toThrow(
+      /^Platform "web" is not configured to use the Metro bundler in the project Expo config\./
     );
   });
 

--- a/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/resolveOptions-test.ts
@@ -16,16 +16,40 @@ jest.mock('@expo/config', () => ({
 
 describe(resolveOptionsAsync, () => {
   it(`asserts invalid platform`, async () => {
-    await expect(resolveOptionsAsync('/', { '--platform': 'foobar' })).rejects.toThrow(
+    await expect(resolveOptionsAsync('/', { '--platform': ['foobar'] })).rejects.toThrow(
       /^Unsupported platform "foobar"\./
     );
+  });
+
+  it(`allows multiple platform flags`, async () => {
+    await expect(
+      resolveOptionsAsync('/', { '--platform': ['android', 'ios'] })
+    ).resolves.toMatchObject({
+      platforms: ['android', 'ios'],
+    });
+  });
+
+  it(`filters duplicated platform flags`, async () => {
+    await expect(
+      resolveOptionsAsync('/', { '--platform': ['android', 'android', 'ios', 'ios'] })
+    ).resolves.toMatchObject({
+      platforms: ['android', 'ios'],
+    });
+  });
+
+  it(`filters duplicated platform flags including all`, async () => {
+    await expect(
+      resolveOptionsAsync('/', { '--platform': ['android', 'all'] })
+    ).resolves.toMatchObject({
+      platforms: ['android', 'ios'],
+    });
   });
 
   it(`parses qualified options`, async () => {
     await expect(
       resolveOptionsAsync('/', {
         '--output-dir': 'foobar',
-        '--platform': 'android',
+        '--platform': ['android'],
         '--clear': true,
         '--dev': true,
         '--dump-assetmap': true,

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -16,7 +16,7 @@ export const expoExport: Command = async (argv) => {
       '--dump-sourcemap': Boolean,
       '--max-workers': Number,
       '--output-dir': String,
-      '--platform': String,
+      '--platform': [String],
       '--no-minify': Boolean,
 
       // Hack: This is added because EAS CLI always includes the flag.

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -44,7 +44,7 @@ export function resolvePlatformOption(
   const assertPlatformIsKnown = (platform: string): Platform => {
     if (!knownPlatforms.includes(platform as Platform)) {
       throw new CommandError(
-        `Unsupported platform "${platform}". Options are: ${knownPlatforms.join(',')}`
+        `Unsupported platform "${platform}". Options are: ${knownPlatforms.join(',')},all`
       );
     }
 

--- a/packages/@expo/cli/src/export/resolveOptions.ts
+++ b/packages/@expo/cli/src/export/resolveOptions.ts
@@ -17,57 +17,60 @@ export type Options = {
 /** Returns an array of platforms based on the input platform identifier and runtime constraints. */
 export function resolvePlatformOption(
   platformBundlers: PlatformBundlers,
-  platform: string = 'all'
+  platform: string[] = ['all']
 ): Platform[] {
-  const platforms: Partial<PlatformBundlers> = Object.fromEntries(
+  const platformsAvailable: Partial<PlatformBundlers> = Object.fromEntries(
     Object.entries(platformBundlers).filter(([, bundler]) => bundler === 'metro')
   );
 
-  if (!Object.keys(platforms).length) {
+  if (!Object.keys(platformsAvailable).length) {
     throw new CommandError(
       `No platforms are configured to use the Metro bundler in the project Expo config.`
     );
   }
 
-  const assertPlatformBundler = (platform: Platform) => {
-    if (!platforms[platform]) {
+  const assertPlatformBundler = (platform: Platform): Platform => {
+    if (!platformsAvailable[platform]) {
       throw new CommandError(
         'BAD_ARGS',
         `Platform "${platform}" is not configured to use the Metro bundler in the project Expo config.`
       );
     }
+
+    return platform;
   };
 
-  switch (platform) {
-    case 'ios':
-      assertPlatformBundler('ios');
-      return ['ios'];
-    case 'web':
-      assertPlatformBundler('web');
-      return ['web'];
-    case 'android':
-      assertPlatformBundler('android');
-      return ['android'];
-    case 'all':
-      return Object.keys(platforms) as Platform[];
-    default:
+  const knownPlatforms = ['android', 'ios', 'web'] as Platform[];
+  const assertPlatformIsKnown = (platform: string): Platform => {
+    if (!knownPlatforms.includes(platform as Platform)) {
       throw new CommandError(
-        `Unsupported platform "${platform}". Options are: ${Object.keys(platforms).join(',')}, all`
+        `Unsupported platform "${platform}". Options are: ${knownPlatforms.join(',')}`
       );
-  }
+    }
+
+    return platform as Platform;
+  };
+
+  return (
+    platform
+      // Expand `all` to all available platforms.
+      .map((platform) => (platform === 'all' ? Object.keys(platformsAvailable) : platform))
+      .flat()
+      // Remove duplicated platforms
+      .filter((platform, index, list) => list.indexOf(platform) === index)
+      // Assert platforms are valid
+      .map((platform) => assertPlatformIsKnown(platform))
+      .map((platform) => assertPlatformBundler(platform))
+  );
 }
 
 export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
   const { exp } = getConfig(projectRoot, { skipPlugins: true, skipSDKVersionRequirement: true });
   const platformBundlers = getPlatformBundlers(exp);
-  const platforms: Platform[] = resolvePlatformOption(
-    platformBundlers,
-    args['--platform'] ?? 'all'
-  );
 
   return {
+    platforms: resolvePlatformOption(platformBundlers, args['--platform']),
     outputDir: args['--output-dir'] ?? 'dist',
-    platforms,
     minify: !args['--no-minify'],
     clear: !!args['--clear'],
     dev: !!args['--dev'],


### PR DESCRIPTION
# Why

Part of ENG-9308

When creating an export for EAS updates, we need to be able to select specific platforms with more flexibility than the current `all`. If users have configured Metro web, we still need to be able to _only_ build for `android` and `ios` (the only 2 supported platforms for EAS updates at the moment).

Running multiple separate instances of `expo export` doesn't seem like a great alternative either. On every `expo export` run, the exported folder is emptied. That would force EAS CLI to stitch this together, which requires assumptions that we likely want to keep in `expo export` only.

Unfortunately, we likely have to backport this to older SDK versions, or we have to add a check in the EAS CLI to warn users about this incompatibility.

# How

- Made `expo export --platform` a variadic flag
- Updated platform resolution to only return a combination of unique `android`, `ios`, or `web` values

# Test Plan

See added tests, and to manually test it:

- `$ yarn create expo ./test-export -t tabs@49` (comes with Metro web configured)
- `$ cd ./test-export`
- `$ yarn expo export -p android -p=ios`
  → _Should export `android` and `ios`_
- `$ yarn expo export -p android -p all`
  → _Should export `android`, `ios`, and `web`_
- `$ yarn expo export -p web -p ios`
  → _Should export `ios` and `web`_

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
