### PR TITLE
[iOS] Refactor version manager in Expo Go

### DIFF
--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -11,7 +11,7 @@
 #import "ExpoKit.h"
 #import "EXReactAppExceptionHandler.h"
 #import "EXReactAppManager+Private.h"
-#import "EXVersionManager.h"
+#import "EXVersionManagerObjC.h"
 #import "EXVersions.h"
 
 #import <EXConstants/EXConstantsService.h>

--- a/ios/Exponent-Bridging-Header.h
+++ b/ios/Exponent-Bridging-Header.h
@@ -6,5 +6,9 @@
 #import "EXKernel.h"
 #import "EXRootViewController.h"
 #import "EXAppViewController.h"
-
-#import <ExpoModulesCore/EXModuleRegistryProvider.h>
+#import "EXVersionManagerObjC.h"
+#import "EXScopedModuleRegistryDelegate.h"
+#import "EXScopedModuleRegistryAdapter.h"
+#import "EXAppState.h"
+#import "EXDisabledDevLoadingView.h"
+#import "EXStatusBarManager.h"

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -211,7 +211,7 @@
 		B5FB74AC1FF6DADC001C764B /* EXImageUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB738F1FF6DADB001C764B /* EXImageUtils.m */; };
 		B5FB74B51FF6DADC001C764B /* EXUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A11FF6DADB001C764B /* EXUtil.m */; };
 		B5FB74B61FF6DADC001C764B /* RNViewShot.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73A31FF6DADB001C764B /* RNViewShot.m */; };
-		B5FB74DE1FF6DADC001C764B /* EXVersionManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */; };
+		B5FB74DE1FF6DADC001C764B /* EXVersionManagerObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.m */; };
 		B5FB74DF1FF6DADC001C764B /* EXDevSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74001FF6DADB001C764B /* EXDevSettings.m */; };
 		B5FB74E01FF6DADC001C764B /* EXDevSettingsDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74021FF6DADB001C764B /* EXDevSettingsDataSource.m */; };
 		B5FB74E11FF6DADC001C764B /* EXDisabledDevLoadingView.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74041FF6DADB001C764B /* EXDisabledDevLoadingView.m */; };
@@ -237,6 +237,9 @@
 		F11E531121601059007ACF56 /* EXHeadlessAppRecord.m in Sources */ = {isa = PBXBuildFile; fileRef = F11E530D21601058007ACF56 /* EXHeadlessAppRecord.m */; };
 		F11E531221601059007ACF56 /* EXHeadlessAppLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = F11E531021601059007ACF56 /* EXHeadlessAppLoader.m */; };
 		F12A1AB922ABD4BA008542C6 /* generate-dynamic-macros.sh in Resources */ = {isa = PBXBuildFile; fileRef = F12A1AB822ABD4BA008542C6 /* generate-dynamic-macros.sh */; };
+		F138E0D32A5F1AE9002E15BC /* EXVersionUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = F11AEFE52A5EE20C00D49170 /* EXVersionUtils.mm */; };
+		F138E0D62A5F2090002E15BC /* ExpoGoModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F138E0D52A5F2090002E15BC /* ExpoGoModule.swift */; };
+		F138E0D72A5F2090002E15BC /* ExpoGoModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = F138E0D52A5F2090002E15BC /* ExpoGoModule.swift */; };
 		F14217DF262CB68600BB97E6 /* AIRMapPolygon.m in Sources */ = {isa = PBXBuildFile; fileRef = 31AD99FF2285B52C00F19090 /* AIRMapPolygon.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F14217E0262CB68600BB97E6 /* EXCachedResource.m in Sources */ = {isa = PBXBuildFile; fileRef = B5A72C1E20A0D13E00974CCE /* EXCachedResource.m */; };
 		F14217E1262CB68600BB97E6 /* EXScopedFontLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = BBE8539322B98828001FF9C2 /* EXScopedFontLoader.m */; };
@@ -352,7 +355,7 @@
 		F1421891262CB68600BB97E6 /* AIRWeakMapReference.m in Sources */ = {isa = PBXBuildFile; fileRef = 31AD9A2D2285B53000F19090 /* AIRWeakMapReference.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F1421892262CB68600BB97E6 /* EXPermissionsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 31361A602261C65A00662769 /* EXPermissionsManager.m */; };
 		F1421894262CB68600BB97E6 /* AIRMapCircleManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 31AD9A072285B52D00F19090 /* AIRMapCircleManager.m */; settings = {COMPILER_FLAGS = "-w"; }; };
-		F1421895262CB68600BB97E6 /* EXVersionManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */; };
+		F1421895262CB68600BB97E6 /* EXVersionManagerObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.m */; };
 		F1421897262CB68600BB97E6 /* AIRGoogleMapCallout.m in Sources */ = {isa = PBXBuildFile; fileRef = 31AD99C02285B50E00F19090 /* AIRGoogleMapCallout.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		F142189A262CB68600BB97E6 /* EXKernelServiceRegistry.m in Sources */ = {isa = PBXBuildFile; fileRef = B52217D51F146658002241BA /* EXKernelServiceRegistry.m */; };
 		F142189C262CB68600BB97E6 /* EXScopedEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = B5FB74281FF6DADB001C764B /* EXScopedEventEmitter.m */; };
@@ -428,8 +431,10 @@
 		F142191A262CB68600BB97E6 /* launch_background_image.png in Resources */ = {isa = PBXBuildFile; fileRef = B5EF826C1F55B8F100FC7424 /* launch_background_image.png */; };
 		F142191B262CB68600BB97E6 /* shell-app.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B575EEA31D54175B00DCABBC /* shell-app.bundle */; };
 		F142191E262CB68600BB97E6 /* ExpoNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FCF6D36D25B34BC200808BF5 /* ExpoNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		F151B1122A5C6881001BB70F /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F151B1112A5C6880001BB70F /* VersionManager.swift */; };
 		F156867823E19E3D0029DF16 /* EXKernelDevKeyCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = F156867723E19E3C0029DF16 /* EXKernelDevKeyCommands.m */; };
 		F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */ = {isa = PBXBuildFile; fileRef = F167C43A209C7EE600F01382 /* EXUtilService.m */; };
+		F1C3E81E2A5F0E3C0037BC7A /* EXVersionUtils.mm in Sources */ = {isa = PBXBuildFile; fileRef = F11AEFE52A5EE20C00D49170 /* EXVersionUtils.mm */; };
 		F1D6AF61244714C100AC1C74 /* EXDevMenuGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D6AF60244714C100AC1C74 /* EXDevMenuGestureRecognizer.m */; };
 		F1D6AF64244720E100AC1C74 /* EXDevMenuManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F1D6AF63244720E100AC1C74 /* EXDevMenuManager.m */; };
 		F1F7433E24ABECD500EA5023 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F7433D24ABECD500EA5023 /* AppDelegate.swift */; };
@@ -879,8 +884,8 @@
 		B5FB73A21FF6DADB001C764B /* RNViewShot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNViewShot.h; sourceTree = "<group>"; };
 		B5FB73A31FF6DADB001C764B /* RNViewShot.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNViewShot.m; sourceTree = "<group>"; };
 		B5FB73FA1FF6DADB001C764B /* EXUnversioned.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXUnversioned.h; sourceTree = "<group>"; };
-		B5FB73FB1FF6DADB001C764B /* EXVersionManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXVersionManager.h; sourceTree = "<group>"; };
-		B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = EXVersionManager.mm; sourceTree = "<group>"; };
+		B5FB73FB1FF6DADB001C764B /* EXVersionManagerObjC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXVersionManagerObjC.h; sourceTree = "<group>"; };
+		B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXVersionManagerObjC.m; sourceTree = "<group>"; };
 		B5FB73FF1FF6DADB001C764B /* EXDevSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXDevSettings.h; sourceTree = "<group>"; };
 		B5FB74001FF6DADB001C764B /* EXDevSettings.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXDevSettings.m; sourceTree = "<group>"; };
 		B5FB74011FF6DADB001C764B /* EXDevSettingsDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXDevSettingsDataSource.h; sourceTree = "<group>"; };
@@ -930,12 +935,16 @@
 		F108698D2448C6B900B7DC04 /* EXDevMenuGestureInterceptor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXDevMenuGestureInterceptor.m; sourceTree = "<group>"; };
 		F116A3BE2445EBBB008FA957 /* EXDevMenuWindow.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXDevMenuWindow.h; sourceTree = "<group>"; };
 		F116A3BF2445EBBB008FA957 /* EXDevMenuWindow.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXDevMenuWindow.m; sourceTree = "<group>"; };
+		F11AEFE52A5EE20C00D49170 /* EXVersionUtils.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = EXVersionUtils.mm; sourceTree = "<group>"; };
+		F11AEFE82A5EE37300D49170 /* EXVersionUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXVersionUtils.h; sourceTree = "<group>"; };
 		F11E530D21601058007ACF56 /* EXHeadlessAppRecord.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXHeadlessAppRecord.m; sourceTree = "<group>"; };
 		F11E530E21601058007ACF56 /* EXHeadlessAppLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXHeadlessAppLoader.h; sourceTree = "<group>"; };
 		F11E530F21601059007ACF56 /* EXHeadlessAppRecord.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXHeadlessAppRecord.h; sourceTree = "<group>"; };
 		F11E531021601059007ACF56 /* EXHeadlessAppLoader.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXHeadlessAppLoader.m; sourceTree = "<group>"; };
 		F12A1AB822ABD4BA008542C6 /* generate-dynamic-macros.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "generate-dynamic-macros.sh"; sourceTree = "<group>"; };
+		F138E0D52A5F2090002E15BC /* ExpoGoModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpoGoModule.swift; sourceTree = "<group>"; };
 		F1421923262CB68600BB97E6 /* Expo Go.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Expo Go.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F151B1112A5C6880001BB70F /* VersionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionManager.swift; sourceTree = "<group>"; };
 		F156867623E19E3C0029DF16 /* EXKernelDevKeyCommands.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EXKernelDevKeyCommands.h; sourceTree = "<group>"; };
 		F156867723E19E3C0029DF16 /* EXKernelDevKeyCommands.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EXKernelDevKeyCommands.m; sourceTree = "<group>"; };
 		F167C439209C7EE600F01382 /* EXUtilService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXUtilService.h; sourceTree = "<group>"; };
@@ -1637,6 +1646,7 @@
 		B5FB72701FF6DADB001C764B /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				F138E0D42A5F2071002E15BC /* Modules */,
 				B5FB72711FF6DADB001C764B /* Api */,
 				B5FB73FD1FF6DADB001C764B /* Internal */,
 				B5FB74241FF6DADB001C764B /* ScopedModule */,
@@ -1644,8 +1654,11 @@
 				B5FB73FA1FF6DADB001C764B /* EXUnversioned.h */,
 				837A38232A20D6730046BD8E /* EXVersionedNetworkInterceptor.h */,
 				837A38242A20D7090046BD8E /* EXVersionedNetworkInterceptor.m */,
-				B5FB73FB1FF6DADB001C764B /* EXVersionManager.h */,
-				B5FB73FC1FF6DADB001C764B /* EXVersionManager.mm */,
+				B5FB73FB1FF6DADB001C764B /* EXVersionManagerObjC.h */,
+				B5FB73FC1FF6DADB001C764B /* EXVersionManagerObjC.m */,
+				F11AEFE82A5EE37300D49170 /* EXVersionUtils.h */,
+				F11AEFE52A5EE20C00D49170 /* EXVersionUtils.mm */,
+				F151B1112A5C6880001BB70F /* VersionManager.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1914,6 +1927,14 @@
 				3451876A2368FE9E008C4171 /* cp-bundle-resources-conditionally.sh */,
 			);
 			path = "Build-Phases";
+			sourceTree = "<group>";
+		};
+		F138E0D42A5F2071002E15BC /* Modules */ = {
+			isa = PBXGroup;
+			children = (
+				F138E0D52A5F2090002E15BC /* ExpoGoModule.swift */,
+			);
+			path = Modules;
 			sourceTree = "<group>";
 		};
 		F2F4B300B300F7E0685B5A6A /* Expo Go (versioned) */ = {
@@ -2718,6 +2739,7 @@
 				31571B2A2265DC9700358D65 /* EXScopedSegment.m in Sources */,
 				A12E8B64266E8E51003ADA8F /* EXManagedAppSplashScreenViewController.m in Sources */,
 				87750C4D24EADFDC00CEF3DE /* EXManagedAppSplashScreenConfiguration.m in Sources */,
+				F138E0D62A5F2090002E15BC /* ExpoGoModule.swift in Sources */,
 				31AD99DE2285B51100F19090 /* AIRGoogleMapPolygonManager.m in Sources */,
 				B5A72C3020A0D1BF00974CCE /* EXAppFetcher.m in Sources */,
 				31E8B2FD23D090E200E6C2BF /* EXClientReleaseType.m in Sources */,
@@ -2745,7 +2767,7 @@
 				31AD9A4C2285B53100F19090 /* AIRWeakMapReference.m in Sources */,
 				31361A612261C65A00662769 /* EXPermissionsManager.m in Sources */,
 				31AD9A3C2285B53100F19090 /* AIRMapCircleManager.m in Sources */,
-				B5FB74DE1FF6DADC001C764B /* EXVersionManager.mm in Sources */,
+				B5FB74DE1FF6DADC001C764B /* EXVersionManagerObjC.m in Sources */,
 				31AD99E22285B51100F19090 /* AIRGoogleMapCallout.m in Sources */,
 				B52217D61F146658002241BA /* EXKernelServiceRegistry.m in Sources */,
 				B5FB74F11FF6DADC001C764B /* EXScopedEventEmitter.m in Sources */,
@@ -2760,6 +2782,7 @@
 				837A38252A20D7090046BD8E /* EXVersionedNetworkInterceptor.m in Sources */,
 				31AD9A4D2285B53100F19090 /* RCTConvert+AirMap.m in Sources */,
 				8767F97624D19FA7009F9372 /* EXHomeAppSplashScreenViewProvider.m in Sources */,
+				F151B1122A5C6881001BB70F /* VersionManager.swift in Sources */,
 				2168B25C23E3058600A94C0D /* EXScopedFirebaseCore.m in Sources */,
 				B5A473DC204A66F70035C61C /* EXErrorView.m in Sources */,
 				31AD99DD2285B51100F19090 /* AIRGoogleMapOverlayManager.m in Sources */,
@@ -2782,6 +2805,7 @@
 				31AD99EB2285B51100F19090 /* AIRGoogleMapMarker.m in Sources */,
 				F108698B2448B11D00B7DC04 /* EXDevMenuMotionInterceptor.m in Sources */,
 				F167C43B209C7EE600F01382 /* EXUtilService.m in Sources */,
+				F138E0D32A5F1AE9002E15BC /* EXVersionUtils.mm in Sources */,
 				31AD99DC2285B51100F19090 /* AIRGoogleMapPolygon.m in Sources */,
 				0761342424DB63AC001375B6 /* EXUpdatesDatabaseManager.m in Sources */,
 				31AD99F12285B51100F19090 /* AIRGoogleMapPolylineManager.m in Sources */,
@@ -2916,6 +2940,7 @@
 				F1421839262CB68600BB97E6 /* EXScopedNotificationSerializer.m in Sources */,
 				F142183B262CB68600BB97E6 /* RCTConvert+GMSMapViewType.m in Sources */,
 				F142183C262CB68600BB97E6 /* AIRGoogleMapPolyline.m in Sources */,
+				F1C3E81E2A5F0E3C0037BC7A /* EXVersionUtils.mm in Sources */,
 				F142183E262CB68600BB97E6 /* EXDisabledDevLoadingView.m in Sources */,
 				F1421843262CB68600BB97E6 /* EXManifestResource.m in Sources */,
 				F1421844262CB68600BB97E6 /* EXDisabledRedBox.mm in Sources */,
@@ -2939,6 +2964,7 @@
 				F142185D262CB68600BB97E6 /* EXScopedFilePermissionModule.m in Sources */,
 				F142185F262CB68600BB97E6 /* EXApiV2Result.m in Sources */,
 				F1421860262CB68600BB97E6 /* AppDelegate.swift in Sources */,
+				F138E0D72A5F2090002E15BC /* ExpoGoModule.swift in Sources */,
 				F1421863262CB68600BB97E6 /* EXDevMenuManager.m in Sources */,
 				F1421864262CB68600BB97E6 /* EXDevMenuViewController.m in Sources */,
 				F1421865262CB68600BB97E6 /* EXKernel.m in Sources */,
@@ -2975,7 +3001,7 @@
 				F1421891262CB68600BB97E6 /* AIRWeakMapReference.m in Sources */,
 				F1421892262CB68600BB97E6 /* EXPermissionsManager.m in Sources */,
 				F1421894262CB68600BB97E6 /* AIRMapCircleManager.m in Sources */,
-				F1421895262CB68600BB97E6 /* EXVersionManager.mm in Sources */,
+				F1421895262CB68600BB97E6 /* EXVersionManagerObjC.m in Sources */,
 				F1421897262CB68600BB97E6 /* AIRGoogleMapCallout.m in Sources */,
 				F142189A262CB68600BB97E6 /* EXKernelServiceRegistry.m in Sources */,
 				F142189C262CB68600BB97E6 /* EXScopedEventEmitter.m in Sources */,

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -12,7 +12,7 @@
 #import "ExpoKit.h"
 #import "EXReactAppManager.h"
 #import "EXReactAppManager+Private.h"
-#import "EXVersionManager.h"
+#import "EXVersionManagerObjC.h"
 #import "EXVersions.h"
 #import "EXAppViewController.h"
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
@@ -55,6 +55,18 @@
 @property (nonatomic, copy) RCTSourceLoadBlock loadCallback;
 @property (nonatomic, strong) NSDictionary *initialProps;
 @property (nonatomic, strong) NSTimer *viewTestTimer;
+
+@end
+
+@protocol EXVersionManagerProtocol
+
++ (instancetype)alloc;
+
+- (instancetype)initWithParams:(nonnull NSDictionary *)params
+                      manifest:(nonnull EXManifestsManifest *)manifest
+                  fatalHandler:(void (^)(NSError *))fatalHandler
+                   logFunction:(RCTLogFunction)logFunction
+                  logThreshold:(NSInteger)threshold;
 
 @end
 
@@ -114,7 +126,7 @@
 
 
   if ([self isReadyToLoad]) {
-    Class versionManagerClass = [self versionedClassFromString:@"EXVersionManager"];
+    Class<EXVersionManagerProtocol> versionManagerClass = [self versionedClassFromString:@"EXVersionManager"];
     Class bridgeClass = [self versionedClassFromString:@"RCTBridge"];
     Class rootViewClass = [self versionedClassFromString:@"RCTRootView"];
 
@@ -123,6 +135,7 @@
                                                      fatalHandler:handleFatalReactError
                                                       logFunction:[self logFunction]
                                                      logThreshold:[self logLevel]];
+
     _reactBridge = [[bridgeClass alloc] initWithDelegate:self launchOptions:[self launchOptionsForBridge]];
 
     if (!_isHeadless) {
@@ -485,7 +498,7 @@
 - (void)reloadBridge
 {
   if ([self enablesDeveloperTools]) {
-    [self.reactBridge reload];
+    [(RCTBridge *) self.reactBridge reload];
   }
 }
 

--- a/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
+++ b/ios/Exponent/Versioned/Core/EXVersionManagerObjC.h
@@ -2,17 +2,20 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTLog.h>
+#import <React/RCTBridge.h>
+
+#import "EXVersionUtils.h"
 
 @class EXManifestsManifest;
 
-@interface EXVersionManager : NSObject
+@interface EXVersionManagerObjC : NSObject
 
-// Uses a params dict since the internal workings may change over time, but we want to keep the interface the same.
-- (instancetype)initWithParams:(NSDictionary *)params
-                      manifest:(EXManifestsManifest *)manifest
-                  fatalHandler:(void (^)(NSError *))fatalHandler
-                   logFunction:(RCTLogFunction)logFunction
-                  logThreshold:(NSInteger)threshold;
+- (nonnull instancetype)initWithParams:(nonnull NSDictionary *)params
+                              manifest:(nonnull EXManifestsManifest *)manifest
+                          fatalHandler:(void (^ _Nonnull)(NSError * _Nullable))fatalHandler
+                           logFunction:(nonnull RCTLogFunction)logFunction
+                          logThreshold:(RCTLogLevel)logThreshold;
+
 - (void)bridgeWillStartLoading:(id)bridge;
 - (void)bridgeFinishedLoading:(id)bridge;
 - (void)invalidate;

--- a/ios/Exponent/Versioned/Core/EXVersionUtils.h
+++ b/ios/Exponent/Versioned/Core/EXVersionUtils.h
@@ -1,0 +1,10 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#import <React/RCTBridge.h>
+
+@interface EXVersionUtils : NSObject
+
++ (nonnull void *)versionedJsExecutorFactoryForBridge:(nonnull RCTBridge *)bridge
+                                               engine:(nonnull NSString *)jsEngine;
+
+@end

--- a/ios/Exponent/Versioned/Core/EXVersionUtils.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionUtils.mm
@@ -1,0 +1,86 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+#import <React/RCTUIManager.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/JSCExecutorFactory.h>
+#import <React/RCTJSIExecutorRuntimeInstaller.h>
+#import <React/CoreModulesPlugins.h>
+#import <ReactCommon/RCTTurboModule.h>
+#import <reacthermes/HermesExecutorFactory.h>
+
+#import <RNReanimated/REAModule.h>
+#import <RNReanimated/REAEventDispatcher.h>
+#import <RNReanimated/REAUIManager.h>
+#import <RNReanimated/NativeProxy.h>
+#import <RNReanimated/ReanimatedVersion.h>
+
+#import <ExpoModulesCore/EXDefines.h>
+
+#import "EXDevSettings.h"
+#import "EXDisabledDevMenu.h"
+#import "EXDisabledRedBox.h"
+#import "EXVersionUtils.h"
+
+@interface RCTEventDispatcher (REAnimated)
+- (void)setBridge:(RCTBridge*)bridge;
+@end
+
+@implementation EXVersionUtils
+
++ (nonnull void *)versionedJsExecutorFactoryForBridge:(nonnull RCTBridge *)bridge
+                                               engine:(nonnull NSString *)jsEngine
+{
+  [bridge moduleForClass:[RCTUIManager class]];
+  REAUIManager *reaUiManager = [REAUIManager new];
+  [reaUiManager setBridge:bridge];
+  RCTUIManager *uiManager = reaUiManager;
+  [bridge updateModuleWithInstance:uiManager];
+
+  [bridge moduleForClass:[RCTEventDispatcher class]];
+  RCTEventDispatcher *eventDispatcher = [REAEventDispatcher new];
+  RCTCallableJSModules *callableJSModules = [RCTCallableJSModules new];
+  [bridge setValue:callableJSModules forKey:@"_callableJSModules"];
+  [callableJSModules setBridge:bridge];
+  [eventDispatcher setValue:callableJSModules forKey:@"_callableJSModules"];
+  [eventDispatcher setValue:bridge forKey:@"_bridge"];
+  [eventDispatcher initialize];
+  [bridge updateModuleWithInstance:eventDispatcher];
+
+  EX_WEAKIFY(self);
+  const auto executor = [EXWeak_self, bridge](facebook::jsi::Runtime &runtime) {
+    if (!bridge) {
+      return;
+    }
+    EX_ENSURE_STRONGIFY(self);
+    auto reanimatedModule = reanimated::createReanimatedModule(bridge, bridge.jsCallInvoker);
+    auto workletRuntimeValue = runtime
+      .global()
+      .getProperty(runtime, "ArrayBuffer")
+      .asObject(runtime)
+      .asFunction(runtime)
+      .callAsConstructor(runtime, {static_cast<double>(sizeof(void*))});
+    uintptr_t* workletRuntimeData = reinterpret_cast<uintptr_t*>(
+                                                                 workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
+    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
+    runtime.global().setProperty(
+                                 runtime,
+                                 "_WORKLET_RUNTIME",
+                                 workletRuntimeValue);
+    runtime.global().setProperty(
+                                 runtime,
+                                 "_REANIMATED_VERSION_CPP",
+                                 reanimated::getReanimatedVersionString(runtime));
+
+    runtime.global().setProperty(
+                                 runtime,
+                                 jsi::PropNameID::forAscii(runtime, "__reanimatedModuleProxy"),
+                                 jsi::Object::createFromHostObject(runtime, reanimatedModule));
+  };
+  if ([jsEngine isEqualToString:@"hermes"]) {
+    return new facebook::react::HermesExecutorFactory(RCTJSIExecutorRuntimeInstaller(executor));
+  }
+  return new facebook::react::JSCExecutorFactory(RCTJSIExecutorRuntimeInstaller(executor));
+}
+
+
+@end

--- a/ios/Exponent/Versioned/Core/EXVersionUtils.mm
+++ b/ios/Exponent/Versioned/Core/EXVersionUtils.mm
@@ -82,5 +82,4 @@
   return new facebook::react::JSCExecutorFactory(RCTJSIExecutorRuntimeInstaller(executor));
 }
 
-
 @end

--- a/ios/Exponent/Versioned/Core/Modules/ExpoGoModule.swift
+++ b/ios/Exponent/Versioned/Core/Modules/ExpoGoModule.swift
@@ -1,0 +1,15 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+
+final class ExpoGoModule: Module {
+  func definition() -> ModuleDefinition {
+    Name("ExpoGoModule")
+
+    Constants {
+      return [
+        "isDetached": false
+      ]
+    }
+  }
+}

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.h
@@ -3,6 +3,7 @@
 
 #if __has_include(<EXConstants/EXConstantsService.h>)
 #import <EXConstants/EXConstantsService.h>
+#import <ExpoModulesCore/EXInternalModule.h>
 #import <ExpoModulesCore/EXConstantsInterface.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXScopedModuleRegistryAdapter.h
@@ -7,10 +7,10 @@
 
 @interface EXScopedModuleRegistryAdapter : EXModuleRegistryAdapter
 
-- (EXModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
-                  forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
-                                     scopeKey:(NSString *)scopeKey
-                                     manifest:(EXManifestsManifest *)manifest
-                           withKernelServices:(NSDictionary *)kernelServices;
+- (nonnull EXModuleRegistry *)moduleRegistryForParams:(NSDictionary *)params
+                          forExperienceStableLegacyId:(NSString *)experienceStableLegacyId
+                                             scopeKey:(NSString *)scopeKey
+                                             manifest:(EXManifestsManifest *)manifest
+                                   withKernelServices:(NSDictionary *)kernelServices;
 
 @end

--- a/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -1,0 +1,128 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+import React
+import ExpoModulesCore
+import EXManifests
+
+/**
+ Manages the React Native app opened in Expo Go. As opposed to ``EXReactAppManager`` and ``EXHomeAppManager``,
+ this manager is versioned and used by them under the hood like an adapter.
+ */
+@objc(EXVersionManager)
+final class VersionManager: EXVersionManagerObjC {
+  var appContext: AppContext?
+  var legacyModulesProxy: LegacyNativeModulesProxy?
+  var legacyModuleRegistry: EXModuleRegistry?
+
+  let params: [AnyHashable: Any]
+
+  let manifest: Manifest
+
+  @objc
+  override init(
+    params: [AnyHashable: Any],
+    manifest: Manifest,
+    fatalHandler: @escaping (Error?) -> Void,
+    logFunction: @escaping RCTLogFunction,
+    logThreshold: RCTLogLevel
+  ) {
+    self.params = params
+    self.manifest = manifest
+
+    configureReact(
+      enableTurboModules: manifest.experiments()?["turboModules"] as? Bool ?? false,
+      fatalHandler: fatalHandler,
+      logFunction: logFunction,
+      logThreshold: logThreshold
+    )
+    super.init(params: params, manifest: manifest, fatalHandler: fatalHandler, logFunction: logFunction, logThreshold: logThreshold)
+  }
+
+  /**
+   Invalidates the app context when the bridge is about to be rebuilt.
+   */
+  override func invalidate() {
+    appContext = nil
+    super.invalidate()
+  }
+
+  /**
+   Returns a list of bridge modules to register when the bridge initializes.
+   */
+  @objc
+  override func extraModules(forBridge bridge: Any) -> [Any] {
+    // Ideally if we don't initialize the app context here, but unfortunately there is no better place in bridge lifecycle
+    // that would work well for us (especially properly invalidating existing app context on reload).
+    let legacyModuleRegistry = createLegacyModuleRegistry(params: params, manifest: manifest)
+    let legacyModulesProxy = LegacyNativeModulesProxy(customModuleRegistry: legacyModuleRegistry)
+    let appContext = AppContext(legacyModulesProxy: legacyModulesProxy, legacyModuleRegistry: legacyModuleRegistry)
+
+    self.appContext = appContext
+    self.legacyModuleRegistry = legacyModuleRegistry
+    self.legacyModulesProxy = legacyModulesProxy
+
+    var modules: [Any] = [
+      EXAppState(),
+      EXDisabledDevLoadingView(),
+      EXStatusBarManager(),
+
+      // Adding EXNativeModulesProxy with the custom moduleRegistry.
+      legacyModulesProxy,
+
+      // Adding the way to access the module registry from RCTBridgeModules.
+      EXModuleRegistryHolderReactModule(moduleRegistry: legacyModuleRegistry) as Any,
+
+      // When ExpoBridgeModule is initialized by RN, it automatically creates the app context.
+      // In Expo Go, it has to use already created app context.
+      ExpoBridgeModule(appContext: appContext)
+    ]
+
+    // Register additional Expo modules, specific to Expo Go.
+    registerExpoModules()
+
+    return modules + super.extraModules(forBridge: bridge)
+  }
+
+  /**
+   Registers Expo modules that are not generated in ``ExpoModulesProvider``, but are necessary for Expo Go apps.
+   */
+  private func registerExpoModules() {
+    appContext?.moduleRegistry.register(moduleType: ExpoGoModule.self)
+  }
+}
+
+/**
+ Configures some React Native global options.
+ */
+private func configureReact(
+  enableTurboModules: Bool,
+  fatalHandler: @escaping (Error?) -> Void,
+  logFunction: @escaping RCTLogFunction,
+  logThreshold: RCTLogLevel
+) {
+  RCTEnableTurboModule(enableTurboModules)
+  RCTSetFatalHandler(fatalHandler)
+  RCTSetLogThreshold(logThreshold)
+  RCTSetLogFunction(logFunction)
+}
+
+/**
+ Creates a module registry for legacy Expo modules.
+ */
+private func createLegacyModuleRegistry(params: [AnyHashable: Any], manifest: Manifest) -> EXModuleRegistry {
+  guard let singletonModules = params["singletonModules"] as? Set<AnyHashable> else {
+    fatalError("Singleton modules param cannot be cast to Set<AnyHashable>")
+  }
+  let moduleRegistryProvider = ModuleRegistryProvider(singletonModules: singletonModules)
+  let moduleRegistryAdapter = EXScopedModuleRegistryAdapter(moduleRegistryProvider: moduleRegistryProvider)
+
+  moduleRegistryProvider.moduleRegistryDelegate = EXScopedModuleRegistryDelegate(params: params)
+
+  return moduleRegistryAdapter.moduleRegistry(
+    forParams: params,
+    forExperienceStableLegacyId: manifest.stableLegacyId(),
+    scopeKey: manifest.scopeKey(),
+    manifest: manifest,
+    withKernelServices: params["services"] as? [AnyHashable: Any]
+  )
+}

--- a/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -61,7 +61,7 @@ final class VersionManager: EXVersionManagerObjC {
     self.legacyModuleRegistry = legacyModuleRegistry
     self.legacyModulesProxy = legacyModulesProxy
 
-    var modules: [Any] = [
+    let modules: [Any] = [
       EXAppState(),
       EXDisabledDevLoadingView(),
       EXStatusBarManager(),
@@ -70,7 +70,7 @@ final class VersionManager: EXVersionManagerObjC {
       legacyModulesProxy,
 
       // Adding the way to access the module registry from RCTBridgeModules.
-      EXModuleRegistryHolderReactModule(moduleRegistry: legacyModuleRegistry) as Any,
+      EXModuleRegistryHolderReactModule(moduleRegistry: legacyModuleRegistry),
 
       // When ExpoBridgeModule is initialized by RN, it automatically creates the app context.
       // In Expo Go, it has to use already created app context.

--- a/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
+++ b/packages/expo-modules-core/ios/AppDelegates/EXLegacyAppDelegateWrapper.m
@@ -2,6 +2,7 @@
 
 #import <Foundation/FoundationErrors.h>
 
+#import <ExpoModulesCore/EXSingletonModule.h>
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 #import <ExpoModulesCore/EXLegacyAppDelegateWrapper.h>
 

--- a/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
+++ b/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.h
@@ -13,7 +13,7 @@ NS_SWIFT_NAME(ModuleRegistryAdapter)
 
 @property (nonnull, nonatomic, readonly) EXModuleRegistryProvider *moduleRegistryProvider;
 
-- (instancetype)initWithModuleRegistryProvider:(nonnull EXModuleRegistryProvider *)moduleRegistryProvider
+- (nonnull instancetype)initWithModuleRegistryProvider:(nonnull EXModuleRegistryProvider *)moduleRegistryProvider
 __deprecated_msg("Expo modules are now automatically registered. You can remove this method call.");
 
 - (nonnull NSArray<id<RCTBridgeModule>> *)extraModulesForModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;

--- a/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.m
+++ b/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryAdapter.m
@@ -14,7 +14,7 @@
 
 @implementation EXModuleRegistryAdapter
 
-- (instancetype)initWithModuleRegistryProvider:(EXModuleRegistryProvider *)moduleRegistryProvider
+- (nonnull instancetype)initWithModuleRegistryProvider:(EXModuleRegistryProvider *)moduleRegistryProvider
 {
   if (self = [super init]) {
     _moduleRegistryProvider = moduleRegistryProvider;

--- a/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
+++ b/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.h
@@ -6,7 +6,7 @@
 
 @interface EXModuleRegistryHolderReactModule : NSObject <RCTBridgeModule>
 
-- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry;
-- (EXModuleRegistry *)exModuleRegistry;
+- (nonnull instancetype)initWithModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry;
+- (nullable EXModuleRegistry *)exModuleRegistry;
 
 @end

--- a/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.m
+++ b/packages/expo-modules-core/ios/ModuleRegistryAdapter/EXModuleRegistryHolderReactModule.m
@@ -4,13 +4,13 @@
 
 @interface EXModuleRegistryHolderReactModule ()
 
-@property (nonatomic, weak) EXModuleRegistry *exModuleRegistry;
+@property (nonatomic, nullable, weak) EXModuleRegistry *exModuleRegistry;
 
 @end
 
 @implementation EXModuleRegistryHolderReactModule
 
-- (instancetype)initWithModuleRegistry:(EXModuleRegistry *)moduleRegistry
+- (nonnull instancetype)initWithModuleRegistry:(nonnull EXModuleRegistry *)moduleRegistry
 {
   if (self = [super init]) {
     _exModuleRegistry = moduleRegistry;
@@ -18,12 +18,12 @@
   return self;
 }
 
-- (EXModuleRegistry *)exModuleRegistry
+- (nullable EXModuleRegistry *)exModuleRegistry
 {
   return _exModuleRegistry;
 }
 
-+ (NSString *)moduleName {
++ (nullable NSString *)moduleName {
   return nil;
 }
 

--- a/packages/expo-modules-core/ios/ModuleRegistryProvider/EXModuleRegistryProvider.h
+++ b/packages/expo-modules-core/ios/ModuleRegistryProvider/EXModuleRegistryProvider.h
@@ -2,9 +2,10 @@
 
 #import <Foundation/Foundation.h>
 #import <ExpoModulesCore/EXModuleRegistry.h>
-#import <ExpoModulesCore/EXSingletonModule.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class EXSingletonModule;
 
 NS_SWIFT_NAME(ModuleRegistryProvider)
 @interface EXModuleRegistryProvider : NSObject

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -83,6 +83,12 @@ public final class AppContext: NSObject {
     listenToClientAppNotifications()
   }
 
+  public convenience init(legacyModulesProxy: Any, legacyModuleRegistry: Any) {
+    self.init()
+    self.legacyModulesProxy = legacyModulesProxy as? LegacyNativeModulesProxy
+    self.legacyModuleRegistry = legacyModuleRegistry as? EXModuleRegistry
+  }
+
   @discardableResult
   public func useModulesProvider(_ providerName: String) -> Self {
     return useModulesProvider(Self.modulesProvider(withName: providerName))

--- a/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
+++ b/packages/expo-modules-core/ios/Swift/ExpoBridgeModule.swift
@@ -19,8 +19,12 @@ public final class ExpoBridgeModule: NSObject, RCTBridgeModule {
    In this scenario, we create an `AppContext` that manages the
    architecture of Expo modules and the app itself.
    */
-  override init() {
-    appContext = AppContext()
+  override convenience init() {
+    self.init(appContext: AppContext())
+  }
+
+  public init(appContext: AppContext) {
+    self.appContext = appContext
     super.init()
   }
 


### PR DESCRIPTION
# Why

We need to be able to register custom ExpoGo-specific modules, which currently can only be done from Swift

# How

Registering additional modules should happen in `EXVersionManager`, however it's been an Objective-C++ file so it cannot import autogenerated Swift headers. I had to split this class into three pieces by:
- Extracting C++ code to a separate util class (`EXVersionUtils`)
- Renaming `EXVersionManager` into `EXVersionManagerObjC`
- Changing the extension from `.mm` to `.m`
- Creating a Swift subclass (`VersionManager`) and moving some parts of the implementation there (not everything can be moved now)

# Test Plan

Tested with local `home` app and NCL
