### PR TITLE
[screen-orientation][ios] Fix config plugin deleting the EXDefaultScreenOrientationMask key from Info.plist

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
+- [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`.
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
-- [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`.
+- [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`. ([#23637](https://github.com/expo/expo/pull/23637) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/plugin/build/withScreenOrientation.d.ts
+++ b/packages/expo-screen-orientation/plugin/build/withScreenOrientation.d.ts
@@ -15,7 +15,6 @@ type OrientationMasks = keyof typeof OrientationLock;
 interface ExpoConfigWithInitialOrientation extends ExpoConfig {
     initialOrientation?: OrientationMasks;
 }
-export declare function getInitialOrientation(config: Pick<ExpoConfigWithInitialOrientation, 'initialOrientation'>): OrientationMasks;
 export declare function setInitialOrientation(config: Pick<ExpoConfigWithInitialOrientation, 'initialOrientation'>, infoPlist: InfoPlist): InfoPlist;
 declare const _default: ConfigPlugin<void | {
     initialOrientation?: "DEFAULT" | "ALL" | "PORTRAIT" | "PORTRAIT_UP" | "PORTRAIT_DOWN" | "LANDSCAPE" | "LANDSCAPE_LEFT" | "LANDSCAPE_RIGHT" | undefined;

--- a/packages/expo-screen-orientation/plugin/build/withScreenOrientation.js
+++ b/packages/expo-screen-orientation/plugin/build/withScreenOrientation.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setInitialOrientation = exports.getInitialOrientation = exports.INITIAL_ORIENTATION_KEY = void 0;
+exports.setInitialOrientation = exports.INITIAL_ORIENTATION_KEY = void 0;
 const assert_1 = __importDefault(require("assert"));
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('expo-screen-orientation/package.json');
@@ -19,7 +19,7 @@ const OrientationLock = {
     LANDSCAPE_LEFT: 'UIInterfaceOrientationMaskLandscapeLeft',
     LANDSCAPE_RIGHT: 'UIInterfaceOrientationMaskLandscapeRight',
 };
-const withScreenOrientationViewController = (config, { initialOrientation = 'DEFAULT' } = {}) => {
+const withScreenOrientationViewController = (config, { initialOrientation } = {}) => {
     config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
         const extendedConfig = {
             ...config,
@@ -30,19 +30,14 @@ const withScreenOrientationViewController = (config, { initialOrientation = 'DEF
     });
     return config;
 };
-function getInitialOrientation(config) {
-    return config.initialOrientation ?? 'DEFAULT';
-}
-exports.getInitialOrientation = getInitialOrientation;
 function setInitialOrientation(config, infoPlist) {
-    const initialOrientation = getInitialOrientation(config);
-    (0, assert_1.default)(initialOrientation in OrientationLock, `Invalid initial orientation "${initialOrientation}" expected one of: ${Object.keys(OrientationLock).join(', ')}`);
-    if (initialOrientation === 'DEFAULT') {
+    const initialOrientation = config.initialOrientation;
+    if (!initialOrientation) {
         delete infoPlist[exports.INITIAL_ORIENTATION_KEY];
+        return infoPlist;
     }
-    else {
-        infoPlist[exports.INITIAL_ORIENTATION_KEY] = OrientationLock[initialOrientation];
-    }
+    (0, assert_1.default)(initialOrientation in OrientationLock, `Invalid initial orientation "${initialOrientation}" expected one of: ${Object.keys(OrientationLock).join(', ')}`);
+    infoPlist[exports.INITIAL_ORIENTATION_KEY] = OrientationLock[initialOrientation];
     return infoPlist;
 }
 exports.setInitialOrientation = setInitialOrientation;

--- a/packages/expo-screen-orientation/plugin/src/withScreenOrientation.ts
+++ b/packages/expo-screen-orientation/plugin/src/withScreenOrientation.ts
@@ -29,7 +29,7 @@ const withScreenOrientationViewController: ConfigPlugin<
   {
     initialOrientation?: keyof typeof OrientationLock;
   } | void
-> = (config, { initialOrientation = 'DEFAULT' } = {}) => {
+> = (config, { initialOrientation } = {}) => {
   config = withInfoPlist(config, (config) => {
     const extendedConfig = {
       ...config,
@@ -41,17 +41,16 @@ const withScreenOrientationViewController: ConfigPlugin<
   return config;
 };
 
-export function getInitialOrientation(
-  config: Pick<ExpoConfigWithInitialOrientation, 'initialOrientation'>
-): OrientationMasks {
-  return config.initialOrientation ?? 'DEFAULT';
-}
-
 export function setInitialOrientation(
   config: Pick<ExpoConfigWithInitialOrientation, 'initialOrientation'>,
   infoPlist: InfoPlist
 ): InfoPlist {
-  const initialOrientation = getInitialOrientation(config);
+  const initialOrientation = config.initialOrientation;
+
+  if (!initialOrientation) {
+    delete infoPlist[INITIAL_ORIENTATION_KEY];
+    return infoPlist;
+  }
 
   assert(
     initialOrientation in OrientationLock,
@@ -60,11 +59,8 @@ export function setInitialOrientation(
     ).join(', ')}`
   );
 
-  if (initialOrientation === 'DEFAULT') {
-    delete infoPlist[INITIAL_ORIENTATION_KEY];
-  } else {
-    infoPlist[INITIAL_ORIENTATION_KEY] = OrientationLock[initialOrientation];
-  }
+  infoPlist[INITIAL_ORIENTATION_KEY] = OrientationLock[initialOrientation];
+
   return infoPlist;
 }
 


### PR DESCRIPTION
# Why

https://github.com/expo/expo/issues/23141
When the `initialOrientation` value was set to `"DEFAULT"` the config plugin would delete the `EXDefaultScreenOrientationMask` key from `Info.plist`.

# How

Made the config plugin delete the key only if it isn't not configured

# Test Plan

Tested on iOS 16 simulator

