### PR TITLE
feature(cli): 'expo typescript' command

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added improved error message for static metro when a package is missing. ([#23499](https://github.com/expo/expo/pull/23499) by [@EvanBacon](https://github.com/EvanBacon))
 - Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix Expo Router generating types for invalid route files. ([#23421](https://github.com/expo/expo/pull/23421) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -31,6 +31,7 @@ const commands: { [command: string]: () => Promise<Command> } = {
   install: () => import('../src/install').then((i) => i.expoInstall),
   add: () => import('../src/install').then((i) => i.expoInstall),
   customize: () => import('../src/customize').then((i) => i.expoCustomize),
+  typescript: () => import('../src/typescript').then((i) => i.expoTypescript),
 
   // Auth
   login: () => import('../src/login').then((i) => i.expoLogin),

--- a/packages/@expo/cli/e2e/__tests__/typescript-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/typescript-test.ts
@@ -1,0 +1,90 @@
+/* eslint-env jest */
+import execa from 'execa';
+import { constants as fsConstants } from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { bin, execute, getLoadedModulesAsync, projectRoot, setupTestProjectAsync } from './utils';
+
+const originalForceColor = process.env.FORCE_COLOR;
+const originalCI = process.env.CI;
+beforeAll(async () => {
+  await fs.mkdir(projectRoot, { recursive: true });
+  process.env.FORCE_COLOR = '0';
+  process.env.CI = '1';
+  process.env._EXPO_E2E_USE_TYPED_ROUTES = '1';
+});
+afterAll(() => {
+  process.env.FORCE_COLOR = originalForceColor;
+  process.env.CI = originalCI;
+  delete process.env._EXPO_E2E_USE_TYPED_ROUTES;
+});
+
+it.only('loads expected modules by default', async () => {
+  const modules = await getLoadedModulesAsync(
+    `require('../../build/src/typescript/index').expoTypescript`
+  );
+  expect(modules).toStrictEqual([
+    '../node_modules/ansi-styles/index.js',
+    '../node_modules/arg/index.js',
+    '../node_modules/chalk/source/index.js',
+    '../node_modules/chalk/source/util.js',
+    '../node_modules/has-flag/index.js',
+    '../node_modules/supports-color/index.js',
+    '@expo/cli/build/src/export/web/index.js',
+    '@expo/cli/build/src/log.js',
+    '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/errors.js',
+  ]);
+});
+
+it('runs `npx expo typescript --help`', async () => {
+  const results = await execute('typescript', '--help');
+  expect(results.stdout).toMatchInlineSnapshot(`
+    "
+      Info
+        Automatically setup Typescript and generate types for Expo packages
+
+      Usage
+        $ npx expo typescript
+
+      Options
+        -h, --help               Usage info
+    "
+  `);
+});
+
+it(
+  'runs `npx expo typescript`',
+  async () => {
+    const projectRoot = await setupTestProjectAsync('expo-typescript', 'with-router', '48.0.0');
+
+    const generatedFiles = [
+      'tsconfig.json',
+      'expo-env.d.ts',
+      '.expo/types/router.d.ts',
+      '.gitignore',
+    ];
+
+    // Remove the generated files if they exist (when testing locally the folder may be cached)
+    await Promise.all(
+      generatedFiles.map((file) =>
+        fs.rm(path.join(projectRoot, file), { recursive: true, force: true })
+      )
+    );
+
+    // `npx expo typescript
+    await execa('node', [bin, 'typescript'], {
+      cwd: projectRoot,
+    });
+
+    // Expect them to exist with correct access controls
+    for (const file of generatedFiles) {
+      await expect(
+        fs.access(path.join(projectRoot, file), fsConstants.F_OK)
+      ).resolves.toBeUndefined();
+    }
+  },
+  // Could take 45s depending on how fast npm installs
+  120 * 1000
+);

--- a/packages/@expo/cli/e2e/fixtures/with-router/app.config.js
+++ b/packages/@expo/cli/e2e/fixtures/with-router/app.config.js
@@ -13,5 +13,6 @@ module.exports = {
   },
   experiments: {
     tsconfigPaths: process.env._EXPO_E2E_USE_PATH_ALIASES ? true : undefined,
+    typedRoutes: process.env._EXPO_E2E_USE_TYPED_ROUTES ? true : undefined
   },
 };

--- a/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/typescript/TypeScriptProjectPrerequisite.ts
@@ -56,6 +56,7 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite<boolean> 
     // Ensure TypeScript packages are installed
     await this._ensureDependenciesInstalledAsync({
       skipPrompt: true,
+      isProjectMutable: true,
     });
 
     const tsConfigPath = path.join(this.projectRoot, 'tsconfig.json');
@@ -95,11 +96,17 @@ export class TypeScriptProjectPrerequisite extends ProjectPrerequisite<boolean> 
   async _ensureDependenciesInstalledAsync({
     exp,
     skipPrompt,
-  }: { exp?: ExpoConfig; skipPrompt?: boolean } = {}): Promise<boolean> {
+    isProjectMutable,
+  }: {
+    exp?: ExpoConfig;
+    skipPrompt?: boolean;
+    isProjectMutable?: boolean;
+  } = {}): Promise<boolean> {
     try {
       return await ensureDependenciesAsync(this.projectRoot, {
         exp,
         skipPrompt,
+        isProjectMutable,
         installMessage: `It looks like you're trying to use TypeScript but don't have the required dependencies installed.`,
         warningMessage:
           "If you're not using TypeScript, please remove the TypeScript files from your project",

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -197,7 +197,7 @@ export class DevServerManager {
     if (!typescriptPrerequisite) {
       server.waitForTypeScriptAsync().then(async (success) => {
         if (success) {
-          await server.startTypeScriptServices();
+          server.startTypeScriptServices();
         }
       });
     } else {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -469,7 +469,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
   public async startTypeScriptServices() {
     startTypescriptTypeGenerationAsync({
-      server: this.instance!.server,
+      server: this.instance?.server,
       metro: this.metro,
       projectRoot: this.projectRoot,
     });

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -468,7 +468,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
   }
 
   public async startTypeScriptServices() {
-    startTypescriptTypeGenerationAsync({
+    return startTypescriptTypeGenerationAsync({
       server: this.instance?.server,
       metro: this.metro,
       projectRoot: this.projectRoot,

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -70,8 +70,26 @@ describe(`${CAPTURE_GROUP_REGEX}`, () => {
 });
 
 describe(getTypedRoutesUtils, () => {
-  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath } =
+  const { staticRoutes, dynamicRoutes, filePathToRoute, addFilePath, isRouteFile } =
     getTypedRoutesUtils('/user/project/app');
+
+  describe(isRouteFile, () => {
+    const filepaths = [
+      ['/user/project/app/file.tsx', true],
+      ['/user/project/app/folder/index.tsx', true],
+      ['/user/project/other/file.tsx', false],
+      ['/user/project/other/app/file.tsx', false],
+      ['/user/project/other/app/_layout.tsx', false],
+      ['/user/project/app/_layout.tsx', false],
+      ['/user/project/app/+html.tsx', false],
+      ['/user/project/app/folder/+html.tsx', false],
+      ['/user/project/app/folder/_layout.tsx', false],
+    ] as const;
+
+    it.each(filepaths)('is within the app root: %s', (filepath, expected) => {
+      expect(isRouteFile(filepath)).toEqual(expected);
+    });
+  });
 
   describe(filePathToRoute, () => {
     describe('unix paths', () => {
@@ -155,7 +173,9 @@ describe(getTypedRoutesUtils, () => {
         for (const staticRoute of expectedRoutes.static) {
           expect(actualRoutes).toContain(staticRoute);
         }
-      } else {
+      }
+
+      if ('dynamic' in expectedRoutes) {
         const actualRoutes = dynamicRoutes.get(filePathToRoute(filepath));
 
         expect(actualRoutes?.size).toEqual(expectedRoutes.dynamic.length);

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -35,7 +35,7 @@ export async function setupTypedRoutes({
 }: SetupTypedRoutesOptions) {
   const appRoot = path.join(projectRoot, routerDirectory);
 
-  const { filePathToRoute, staticRoutes, dynamicRoutes, addFilePath } =
+  const { filePathToRoute, staticRoutes, dynamicRoutes, addFilePath, isRouteFile } =
     getTypedRoutesUtils(appRoot);
 
   if (metro) {
@@ -46,7 +46,12 @@ export async function setupTypedRoutes({
       metro,
       eventTypes: ['add', 'delete', 'change'],
       async callback({ filePath, type }) {
+        if (!isRouteFile(filePath)) {
+          return;
+        }
+
         let shouldRegenerate = false;
+
         if (type === 'delete') {
           const route = filePathToRoute(filePath);
           staticRoutes.delete(route);
@@ -153,11 +158,18 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
       .replace(/\.[jt]sx?$/, '');
   };
 
-  const addFilePath = (filePath: string): boolean => {
-    if (filePath.match(/_layout\.[tj]sx?$/)) {
+  const isRouteFile = (filePath: string) => {
+    // Layout and filenames starting with `+` are not routes
+    if (filePath.match(/_layout\.[tj]sx?$/) || filePath.match(/\/\+/)) {
       return false;
     }
 
+    // Route files must be nested with in the appRoot
+    const relative = path.relative(appRoot, filePath);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+  };
+
+  const addFilePath = (filePath: string): boolean => {
     const route = filePathToRoute(filePath);
 
     // We have already processed this file
@@ -220,6 +232,7 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
     dynamicRoutes,
     filePathToRoute,
     addFilePath,
+    isRouteFile,
   };
 }
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -19,7 +19,7 @@ export const ARRAY_GROUP_REGEX = /\(\w+?,.*?\)/g;
 export const CAPTURE_GROUP_REGEX = /[\\(,](\w+?)(?=[,\\)])/g;
 
 export interface SetupTypedRoutesOptions {
-  server: ServerLike;
+  server?: ServerLike;
   metro?: Server | null;
   typesDirectory: string;
   projectRoot: string;
@@ -38,7 +38,7 @@ export async function setupTypedRoutes({
   const { filePathToRoute, staticRoutes, dynamicRoutes, addFilePath, isRouteFile } =
     getTypedRoutesUtils(appRoot);
 
-  if (metro) {
+  if (metro && server) {
     // Setup out watcher first
     metroWatchTypeScriptFiles({
       projectRoot: appRoot,

--- a/packages/@expo/cli/src/start/server/type-generation/startTypescriptTypeGeneration.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/startTypescriptTypeGeneration.ts
@@ -12,8 +12,8 @@ import { setupTypedRoutes } from './routes';
 import { forceRemovalTSConfig, forceUpdateTSConfig } from './tsconfig';
 
 export interface TypeScriptTypeGenerationOptions {
-  server: ServerLike;
-  metro: Server | null;
+  server?: ServerLike;
+  metro?: Server | null;
   projectRoot: string;
 }
 

--- a/packages/@expo/cli/src/typescript/index.ts
+++ b/packages/@expo/cli/src/typescript/index.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { getConfig } from '@expo/config';
+import chalk from 'chalk';
+
+import { Command } from '../../bin/cli';
+import { Log } from '../log';
+import { TypeScriptProjectPrerequisite } from '../start/doctor/typescript/TypeScriptProjectPrerequisite';
+import { MetroBundlerDevServer } from '../start/server/metro/MetroBundlerDevServer';
+import { getPlatformBundlers } from '../start/server/platformBundlers';
+import { assertArgs, printHelp, getProjectRoot } from '../utils/args';
+
+export const expoTypescript: Command = async (argv) => {
+  const args = assertArgs(
+    {
+      // Types
+      '--help': Boolean,
+      // Aliases
+      '-h': '--help',
+    },
+    argv
+  );
+
+  if (args['--help']) {
+    printHelp(
+      `Automatically setup Typescript and generate types for Expo packages`,
+      `npx expo typescript`,
+      [`-h, --help               Usage info`].join('\n')
+    );
+  }
+
+  const projectRoot = getProjectRoot(args);
+  const { exp } = getConfig(projectRoot, { skipSDKVersionRequirement: true });
+
+  try {
+    const req = new TypeScriptProjectPrerequisite(projectRoot);
+    await req.bootstrapAsync();
+  } catch (error: any) {
+    // Ensure the process doesn't fail if the TypeScript check fails.
+    // This could happen during the install.
+    Log.log();
+    Log.error(
+      chalk.red`Failed to automatically setup TypeScript for your project. Try restarting the dev server to fix.`
+    );
+    Log.exception(error);
+  }
+
+  await new MetroBundlerDevServer(
+    getProjectRoot(args),
+    getPlatformBundlers(exp),
+    true
+  ).startTypeScriptServices();
+};


### PR DESCRIPTION
# Why

The command serves two purposes
  - Allow users to manually start the Expo Typescript bootstrap process
  - Generate Expo Router types within CI environments. 
 
Unlike the automatic Typescript detection, this command will bypass prompts and simply enable Typescript support.

# How

Reuses `TypeScriptProjectPrerequisite` and the Typescript services from `MetroBundlerDevServer`.

This PR also modifies the `MetroBundlerDevServer.startTypeScriptServices()` to run without a started server (so file watching will be disabled)

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
