### PR TITLE
[docs] Fix `HeaderCell` padding on mobile views

### DIFF
--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -23,4 +23,8 @@ const tableHeadersCellStyle = css({
   '&:last-child': {
     borderRight: 0,
   },
+
+  '@media (max-width: 600px)': {
+    padding: spacing[1],
+  },
 });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs [slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1689789036510169)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a media query for mobile.

<img width="490" alt="CleanShot 2023-07-20 at 12 36 49@2x" src="https://github.com/expo/expo/assets/10234615/2ff5a6a7-8d54-4f16-989e-b9193d3cb8fe">
<img width="502" alt="CleanShot 2023-07-20 at 12 37 12@2x" src="https://github.com/expo/expo/assets/10234615/bd676e55-7ed2-48dd-9116-9985bb05e911">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
