### PR TITLE
[docs] Fix link for bare React Native in SDK  docs

### DIFF
--- a/docs/components/plugins/InstallSection.tsx
+++ b/docs/components/plugins/InstallSection.tsx
@@ -29,9 +29,8 @@ const InstallSection = ({
       <Terminal cmd={cmd} />
       {hideBareInstructions ? null : (
         <P>
-          If you're installing this in a{' '}
-          <A href="/archive/managed-vs-bare/#bare-workflow">bare React Native app</A>, you should
-          also follow{' '}
+          If you're installing this in a <A href="/bare/overview/">bare React Native app</A>, you
+          should also follow{' '}
           <A href={sourceCodeUrl ?? href}>
             <DEMI>these additional installation instructions</DEMI>
           </A>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs [slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1689812308263859)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the link to the bare React Native > Overview doc

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit the installation section of a doc in Reference (for example: http://localhost:3002/versions/latest/sdk/location/#installation) and then click the link that says "bare React Native app".

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
