### PR TITLE
Update installation.mdx

### DIFF
--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -116,7 +116,7 @@ The above command will install versions of these libraries that are compatible w
 
 ### Modify project configuration
 
-Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) in your app config (**app.json** or **app.config.js**):
+Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) in your app config (**app.json** or **app.config.js**). Also you need to run `npx expo install react-native-web@~0.18.10` to use web support.:
 
 ```diff
 {


### PR DESCRIPTION
added react-native-web install line to prevent running issues.

# Why

I get an error when i successfully followed the manual instructions.

# How

Completed all steps in page. Tried to run app. Get the error below

`CommandError: It looks like you're trying to use web support but don't have the required
dependencies installed.`

`Please install react-native-web@~0.18.10 by running:`

`npx expo install react-native-web@~0.18.10`

# Test Plan

i installed the package as the error message says.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
