### PR TITLE
[core][Android] Add tracing

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))
 - Improved error handling when working with native promises on Android. ([#23571](https://github.com/expo/expo/pull/23571) by [@lukmccall](https://github.com/lukmccall))
-- Added tracing to avoid slow app startup on Android.
+- Added tracing to avoid slow app startup on Android. ([#23653](https://github.com/expo/expo/pull/23653) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.5.7 — 2023-07-12
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))
 - Improved error handling when working with native promises on Android. ([#23571](https://github.com/expo/expo/pull/23571) by [@lukmccall](https://github.com/lukmccall))
+- Added tracing to avoid slow app startup on Android.
 
 ## 1.5.7 — 2023-07-12
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -246,6 +246,8 @@ dependencies {
   implementation "androidx.activity:activity-ktx:1.7.1" // androidx.appcompat:appcompat:1.4.1 depends on version 1.2.3, so we enforce higher one here
   implementation "androidx.fragment:fragment-ktx:1.5.7" // androidx.appcomapt:appcompat:1.4.1 depends on version 1.3.4, so we enforce higher one here
 
+  implementation("androidx.tracing:tracing-ktx:1.1.0")
+
   //noinspection GradleDynamicVersion
   implementation 'com.facebook.react:react-native:+'
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -40,6 +40,7 @@ import expo.modules.kotlin.jni.JSIInteropModuleRegistry
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.providers.CurrentActivityProvider
 import expo.modules.kotlin.sharedobjects.SharedObjectRegistry
+import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -120,26 +121,28 @@ class AppContext(
    * Initializes a JSI part of the module registry.
    * It will be a NOOP if the remote debugging was activated.
    */
-  fun installJSIInterop() = synchronized<Unit>(this) {
-    try {
-      jsiInterop = JSIInteropModuleRegistry(this)
-      val reactContext = reactContextHolder.get() ?: return
-      val jsContextProvider = legacyModule<JavaScriptContextProvider>() ?: return
-      val jsContextHolder = jsContextProvider.javaScriptContextRef
-      val catalystInstance = reactContext.catalystInstance ?: return
-      jsContextHolder
-        .takeIf { it != 0L }
-        ?.let {
-          jsiInterop.installJSI(
-            it,
-            jniDeallocator,
-            jsContextProvider.jsCallInvokerHolder,
-            catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
-          )
-          logger.info("✅ JSI interop was installed")
-        }
-    } catch (e: Throwable) {
-      logger.error("❌ Cannot install JSI interop: $e", e)
+  fun installJSIInterop() = synchronized(this) {
+    trace("AppContext.installJSIInterop") {
+      try {
+        jsiInterop = JSIInteropModuleRegistry(this)
+        val reactContext = reactContextHolder.get() ?: return@trace
+        val jsContextProvider = legacyModule<JavaScriptContextProvider>() ?: return@trace
+        val jsContextHolder = jsContextProvider.javaScriptContextRef
+        val catalystInstance = reactContext.catalystInstance ?: return@trace
+        jsContextHolder
+          .takeIf { it != 0L }
+          ?.let {
+            jsiInterop.installJSI(
+              it,
+              jniDeallocator,
+              jsContextProvider.jsCallInvokerHolder,
+              catalystInstance.nativeCallInvokerHolder as CallInvokerHolderImpl
+            )
+            logger.info("✅ JSI interop was installed")
+          }
+      } catch (e: Throwable) {
+        logger.error("❌ Cannot install JSI interop: $e", e)
+      }
     }
   }
 
@@ -271,7 +274,7 @@ class AppContext(
   internal val errorManager: ErrorManagerModule?
     get() = registry.getModule()
 
-  internal fun onDestroy() {
+  internal fun onDestroy() = trace("AppContext.onDestroy") {
     reactContextHolder.get()?.removeLifecycleEventListener(reactLifecycleDelegate)
     registry.post(EventName.MODULE_DESTROY)
     registry.cleanUp()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/KotlinInteropModuleRegistry.kt
@@ -7,6 +7,7 @@ import expo.modules.adapters.react.NativeModulesProxy
 import expo.modules.kotlin.defaultmodules.NativeModulesProxyModuleName
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
+import expo.modules.kotlin.tracing.trace
 import expo.modules.kotlin.views.GroupViewManagerWrapper
 import expo.modules.kotlin.views.SimpleViewManagerWrapper
 import expo.modules.kotlin.views.ViewManagerWrapperDelegate
@@ -42,55 +43,61 @@ class KotlinInteropModuleRegistry(
     }
   }
 
-  fun exportedModulesConstants(): Map<ModuleName, ModuleConstants> {
-    return registry
-      // prevent infinite recursion - exclude NativeProxyModule constants
-      .filter { holder -> holder.name != NativeModulesProxyModuleName }
-      .associate { holder ->
-        holder.name to holder.definition.constantsProvider()
-      }
-  }
+  fun exportedModulesConstants(): Map<ModuleName, ModuleConstants> =
+    trace("KotlinInteropModuleRegistry.exportedModulesConstants") {
+      registry
+        // prevent infinite recursion - exclude NativeProxyModule constants
+        .filter { holder -> holder.name != NativeModulesProxyModuleName }
+        .associate { holder ->
+          holder.name to holder.definition.constantsProvider()
+        }
+    }
 
-  fun exportMethods(exportKey: (String, List<ModuleMethodInfo>) -> Unit = { _, _ -> }): Map<ModuleName, List<ModuleMethodInfo>> {
-    return registry.associate { holder ->
-      val methodsInfo = holder
-        .definition
-        .asyncFunctions
-        .map { (name, method) ->
-          mapOf(
-            "name" to name,
-            "argumentsCount" to method.argsCount
+  fun exportMethods(exportKey: (String, List<ModuleMethodInfo>) -> Unit = { _, _ -> }): Map<ModuleName, List<ModuleMethodInfo>> =
+    trace("KotlinInteropModuleRegistry.exportMethods") {
+      registry.associate { holder ->
+        val methodsInfo = holder
+          .definition
+          .asyncFunctions
+          .map { (name, method) ->
+            mapOf(
+              "name" to name,
+              "argumentsCount" to method.argsCount
+            )
+          }
+        exportKey(holder.name, methodsInfo)
+        holder.name to methodsInfo
+      }
+    }
+
+  fun exportViewManagers(): List<ViewManager<*, *>> =
+    trace("KotlinInteropModuleRegistry.exportViewManagers") {
+      registry
+        .filter { it.definition.viewManagerDefinition != null }
+        .map {
+          val wrapperDelegate = ViewManagerWrapperDelegate(it)
+          when (it.definition.viewManagerDefinition!!.getViewManagerType()) {
+            expo.modules.core.ViewManager.ViewManagerType.SIMPLE -> SimpleViewManagerWrapper(wrapperDelegate)
+            expo.modules.core.ViewManager.ViewManagerType.GROUP -> GroupViewManagerWrapper(wrapperDelegate)
+          }
+        }
+    }
+
+  fun viewManagersMetadata(): Map<String, Map<String, Any>> =
+    trace("KotlinInteropModuleRegistry.viewManagersMetadata") {
+      registry
+        .filter { it.definition.viewManagerDefinition != null }
+        .associate { holder ->
+          holder.name to mapOf(
+            "propsNames" to (holder.definition.viewManagerDefinition?.propsNames ?: emptyList())
           )
         }
-      exportKey(holder.name, methodsInfo)
-      holder.name to methodsInfo
     }
-  }
-
-  fun exportViewManagers(): List<ViewManager<*, *>> {
-    return registry
-      .filter { it.definition.viewManagerDefinition != null }
-      .map {
-        val wrapperDelegate = ViewManagerWrapperDelegate(it)
-        when (it.definition.viewManagerDefinition!!.getViewManagerType()) {
-          expo.modules.core.ViewManager.ViewManagerType.SIMPLE -> SimpleViewManagerWrapper(wrapperDelegate)
-          expo.modules.core.ViewManager.ViewManagerType.GROUP -> GroupViewManagerWrapper(wrapperDelegate)
-        }
-      }
-  }
-
-  fun viewManagersMetadata(): Map<String, Map<String, Any>> {
-    return registry
-      .filter { it.definition.viewManagerDefinition != null }
-      .associate { holder ->
-        holder.name to mapOf(
-          "propsNames" to (holder.definition.viewManagerDefinition?.propsNames ?: emptyList())
-        )
-      }
-  }
 
   fun extractViewManagersDelegateHolders(viewManagers: List<ViewManager<*, *>>): List<ViewWrapperDelegateHolder> =
-    viewManagers.filterIsInstance<ViewWrapperDelegateHolder>()
+    trace("KotlinInteropModuleRegistry.extractViewManagersDelegateHolders") {
+      viewManagers.filterIsInstance<ViewWrapperDelegateHolder>()
+    }
 
   /**
    * Since React Native v0.55, {@link com.facebook.react.ReactPackage#createViewManagers(ReactApplicationContext)}
@@ -100,15 +107,16 @@ class KotlinInteropModuleRegistry(
    * the instance that was bound with the prop method won't be the same as the instance returned by module registry.
    * To fix that we need to update all modules holder in exported view managers.
    */
-  fun updateModuleHoldersInViewManagers(viewWrapperHolders: List<ViewWrapperDelegateHolder>) {
-    viewWrapperHolders
-      .map { it.viewWrapperDelegate }
-      .forEach { holderWrapper ->
-        holderWrapper.moduleHolder = requireNotNull(registry.getModuleHolder(holderWrapper.moduleHolder.name)) {
-          "Cannot update the module holder for ${holderWrapper.moduleHolder.name}."
+  fun updateModuleHoldersInViewManagers(viewWrapperHolders: List<ViewWrapperDelegateHolder>) =
+    trace("KotlinInteropModuleRegistry.updateModuleHoldersInViewManagers") {
+      viewWrapperHolders
+        .map { it.viewWrapperDelegate }
+        .forEach { holderWrapper ->
+          holderWrapper.moduleHolder = requireNotNull(registry.getModuleHolder(holderWrapper.moduleHolder.name)) {
+            "Cannot update the module holder for ${holderWrapper.moduleHolder.name}."
+          }
         }
-      }
-  }
+    }
 
   fun onDestroy() {
     appContext.onDestroy()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ModuleRegistry.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin
 
 import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +17,7 @@ class ModuleRegistry(
   @PublishedApi
   internal val registry = mutableMapOf<String, ModuleHolder>()
 
-  fun register(module: Module) {
+  fun register(module: Module) = trace("ModuleRegistry.register(${module.javaClass})") {
     module._appContext = requireNotNull(appContext.get()) { "Cannot create a module for invalid app context." }
 
     val holder = ModuleHolder(module)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.modules
 import android.os.Bundle
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.providers.AppContextProvider
+import expo.modules.kotlin.tracing.trace
 import kotlinx.coroutines.CoroutineScope
 
 abstract class Module : AppContextProvider {
@@ -35,6 +36,6 @@ abstract class Module : AppContextProvider {
 }
 
 @Suppress("FunctionName")
-inline fun Module.ModuleDefinition(block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
-  return ModuleDefinitionBuilder(this).also(block).buildModule()
+inline fun Module.ModuleDefinition(crossinline block: ModuleDefinitionBuilder.() -> Unit): ModuleDefinitionData {
+  return trace("${this.javaClass}.ModuleDefinition") { ModuleDefinitionBuilder(this).also(block).buildModule() }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/tracing/ExpoTrace.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/tracing/ExpoTrace.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin.tracing
+
+import androidx.tracing.Trace
+
+/**
+ * Wrap the specified [block] in calls to [Trace.beginSection] (with expo tag and the supplied [blockName])
+ * and [Trace.endSection].
+ *
+ * @param blockName A name of the code section to appear in the trace.
+ * @param block A block of code which is being traced.
+ */
+inline fun <T> trace(blockName: String, crossinline block: () -> T) =
+  androidx.tracing.trace("[ExpoModulesCore] $blockName", block)


### PR DESCRIPTION
# Why

Adds tracing to the time-consuming functions inside of the `expo-modules-core`.

# How

We need good tools to better understand the application's startup time, and we can't detect parts that must be improved. I've added a systrace to crucial functions then we can use tools like [Perfetto](https://perfetto.dev/) to visualize and understand what is going on when the app starts. Also, we can share our Perfetto profile with the community, and if someone finds something odd, it'll be easier to report and fix the issue. 

# Test Plan

- bare-expo compiles ✅