### PR TITLE
[screen-orientation][ios] Fix addOrientationChangeListener for iPadOS

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
 - [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`. ([#23637](https://github.com/expo/expo/pull/23637) by [@behenate](https://github.com/behenate))
-
+- Fix addOrientationChangeListener not working on iPadOS.
 ### 💡 Others
 
 ## 6.0.3 - 2023-07-12

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
 - [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`. ([#23637](https://github.com/expo/expo/pull/23637) by [@behenate](https://github.com/behenate))
-- Fix addOrientationChangeListener not working on iPadOS.
+- Fix addOrientationChangeListener not working on iPadOS. ([#23656](https://github.com/expo/expo/pull/23656) by [@behenate](https://github.com/behenate))
 ### 💡 Others
 
 ## 6.0.3 - 2023-07-12

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Fix event emitter sending events with no registered listeners. ([#23462](https://github.com/expo/expo/pull/23462) by [@behenate](https://github.com/behenate))
 - [iOS] Fix config plugin deleting the orientations key from `Info.plist` when the initial orientation value is set to `DEFAULT`. ([#23637](https://github.com/expo/expo/pull/23637) by [@behenate](https://github.com/behenate))
 - Fix addOrientationChangeListener not working on iPadOS. ([#23656](https://github.com/expo/expo/pull/23656) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 ## 6.0.3 - 2023-07-12

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -46,13 +46,6 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
 
     super.init()
 
-    NotificationCenter.default.addObserver(
-      self,
-      selector: #selector(self.handleDeviceOrientationChange(notification:)),
-      name: UIDevice.orientationDidChangeNotification,
-      object: UIDevice.current
-    )
-
     // This is most likely already executed on the main thread, but we need to be sure
     RCTExecuteOnMainQueue {
       UIDevice.current.beginGeneratingDeviceOrientationNotifications()
@@ -143,25 +136,6 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   }
 
   // MARK: - Events
-
-  /**
-   Called when the OS sends an OrientationDidChange notification.
-   */
-  @objc
-  func handleDeviceOrientationChange(notification: Notification) {
-    let newScreenOrientation = UIDevice.current.orientation.toInterfaceOrientation()
-
-    interfaceOrientationDidChange(newScreenOrientation)
-  }
-
-  /**
-   Called when the device is physically rotated. Checks if screen orientation should be changed after user rotated the device.
-   */
-  func interfaceOrientationDidChange(_ newScreenOrientation: UIInterfaceOrientation) {
-    if currentScreenOrientation == newScreenOrientation || newScreenOrientation == .unknown {
-      return
-    }
-  }
 
   /**
    Called by ScreenOrientationViewController when the dimensions of the view change.

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -7,10 +7,20 @@ let ipadSupportedOrientationsKey = "UISupportedInterfaceOrientations~ipad"
 class ScreenOrientationViewController: UIViewController {
   let screenOrientationRegistry = ScreenOrientationRegistry.shared
   private var defaultOrientationMask: UIInterfaceOrientationMask
+  private var previousInterfaceOrientation: UIInterfaceOrientation = .unknown
+  private var windowInterfaceOrientation: UIInterfaceOrientation? {
+    return UIApplication.shared.windows.first?.windowScene?.interfaceOrientation
+  }
 
   init(defaultOrientationMask: UIInterfaceOrientationMask = doesDeviceHaveNotch ? .allButUpsideDown : .all) {
     self.defaultOrientationMask = defaultOrientationMask
     super.init(nibName: nil, bundle: nil)
+
+    // For iPads traitCollectionDidChange will not be called (it's always in the same size class). It is necessary
+    // to init it in here, so it's possible to return it in the didUpdateDimensionsEvent of the module
+    if (self.screenOrientationRegistry.currentTraitCollection == nil) {
+      self.screenOrientationRegistry.traitCollectionDidChange(to: self.traitCollection)
+    }
   }
 
   convenience init(defaultScreenOrientationFromPlist: Void) {
@@ -57,11 +67,23 @@ class ScreenOrientationViewController: UIViewController {
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
+    screenOrientationRegistry.traitCollectionDidChange(to: traitCollection)
+  }
 
-    if traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass ||
-      traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
-      screenOrientationRegistry.traitCollectionDidChange(to: traitCollection)
-    }
+  public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    super.viewWillTransition(to: size, with: coordinator)
+
+    // Update after the transition ends, this ensures that the trait collection passed to didUpdateDimensionsEvent is already updated
+    coordinator.animate(alongsideTransition: { [weak self] (context) in
+      guard let self = self, let windowInterfaceOrientation = self.windowInterfaceOrientation else {
+        return
+      }
+
+      if windowInterfaceOrientation != self.previousInterfaceOrientation {
+        self.screenOrientationRegistry.viewDidTransition(toOrientation: windowInterfaceOrientation)
+      }
+      self.previousInterfaceOrientation = windowInterfaceOrientation
+    })
   }
 
   private func shouldUseRNScreenOrientation() -> Bool {

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -18,7 +18,7 @@ class ScreenOrientationViewController: UIViewController {
 
     // For iPads traitCollectionDidChange will not be called (it's always in the same size class). It is necessary
     // to init it in here, so it's possible to return it in the didUpdateDimensionsEvent of the module
-    if (self.screenOrientationRegistry.currentTraitCollection == nil) {
+    if self.screenOrientationRegistry.currentTraitCollection == nil {
       self.screenOrientationRegistry.traitCollectionDidChange(to: self.traitCollection)
     }
   }
@@ -70,11 +70,11 @@ class ScreenOrientationViewController: UIViewController {
     screenOrientationRegistry.traitCollectionDidChange(to: traitCollection)
   }
 
-  public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+  override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
     // Update after the transition ends, this ensures that the trait collection passed to didUpdateDimensionsEvent is already updated
-    coordinator.animate(alongsideTransition: { [weak self] (context) in
+    coordinator.animate(alongsideTransition: { [weak self] _ in
       guard let self = self, let windowInterfaceOrientation = self.windowInterfaceOrientation else {
         return
       }


### PR DESCRIPTION
# Why

`addOrientationChangeListener` would not work on iPadOS due to the `traitCollectionDidChange` not being called (both vertical and horizontal trait collections are the same on iPads). 

closes https://github.com/expo/expo/issues/23387 ENG-9260


# How

Refactored the ViewControllers to use `viewWillTransition(to size: ...` instead of `traitCollectionDidChange(to traitCollection: UITraitCollection)` as the source of the orientation events. `viewWillTransition` is correctly called on iPads and  phones. 
The difference in timing of the event is now marginally different. I measured less than 1ms of a difference between the old and new version (new version is always called later than the old one), so users shouldn't notice any side-effects. 
This also allows us to remove some code that was necessary in cases when the `traitCollectionDidChange` wasn't called by the view controller.

# Test Plan

Tested in Expo Go and bare expo on iOS 16,  iPadOS 16 and iPadOS 15. Used a real iPad for iOS 16 tests and simulators for the rest.

