### PR TITLE
fix(cli): Fix running typed routes without an app directory.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Expo Router generating types for invalid route files. ([#23421](https://github.com/expo/expo/pull/23421) by [@marklawlor](https://github.com/marklawlor))
 - Add missing `router` type, and `canGoBack` when typed routes are enabled. Preserve deprecation comment for `useSearchParams` hook. ([#23636](https://github.com/expo/expo/pull/23636) by [@EvanBacon](https://github.com/EvanBacon))
-- Fix running typed routes without an app directory.
+- Fix running typed routes without an app directory. ([#23661](https://github.com/expo/expo/pull/23661) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Set `preferNativePlatform` to `false` for all web requests. ([#23527](https://github.com/expo/expo/pull/23527) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Expo Router generating types for invalid route files. ([#23421](https://github.com/expo/expo/pull/23421) by [@marklawlor](https://github.com/marklawlor))
 - Add missing `router` type, and `canGoBack` when typed routes are enabled. Preserve deprecation comment for `useSearchParams` hook. ([#23636](https://github.com/expo/expo/pull/23636) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix running typed routes without an app directory.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/metroWatchTypeScriptFiles.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroWatchTypeScriptFiles.ts
@@ -2,7 +2,9 @@ import path from 'path';
 
 import type { ServerLike } from '../BundlerDevServer';
 
-const debug = require('debug')('expo:start:server:metro:waitForTypescript') as typeof console.log;
+const debug = require('debug')(
+  'expo:start:server:metro:metroWatchTypeScriptFiles'
+) as typeof console.log;
 
 export interface MetroWatchTypeScriptFilesOptions {
   projectRoot: string;

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -3,6 +3,7 @@ import { debounce } from 'lodash';
 import { Server } from 'metro';
 import path from 'path';
 
+import { directoryExistsAsync } from '../../../utils/dir';
 import { unsafeTemplate } from '../../../utils/template';
 import { ServerLike } from '../BundlerDevServer';
 import { metroWatchTypeScriptFiles } from '../metro/metroWatchTypeScriptFiles';
@@ -41,7 +42,7 @@ export async function setupTypedRoutes({
   if (metro) {
     // Setup out watcher first
     metroWatchTypeScriptFiles({
-      projectRoot: appRoot,
+      projectRoot,
       server,
       metro,
       eventTypes: ['add', 'delete', 'change'],
@@ -73,9 +74,11 @@ export async function setupTypedRoutes({
     });
   }
 
-  // Do we need to walk the entire tree on startup?
-  // Idea: Store the list of files in the last write, then simply check Git for what files have changed
-  await walk(appRoot, addFilePath);
+  if (await directoryExistsAsync(appRoot)) {
+    // Do we need to walk the entire tree on startup?
+    // Idea: Store the list of files in the last write, then simply check Git for what files have changed
+    await walk(appRoot, addFilePath);
+  }
 
   regenerateRouterDotTS(
     typesDirectory,
@@ -154,7 +157,7 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
   const filePathToRoute = (filePath: string) => {
     return normalizedFilePath(filePath)
       .replace(normalizedAppRoot, '')
-      .replace(/index.[jt]sx?/, '')
+      .replace(/index\.[jt]sx?/, '')
       .replace(/\.[jt]sx?$/, '');
   };
 


### PR DESCRIPTION
# Why

- Using typed routes without an app directory doesn't work.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
