### PR TITLE
[expo-updates][[iOS] Fix error handling on iOS during startup check for updates

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Correctly handle roll backs in JS module methods. ([#23356](https://github.com/expo/expo/pull/23356), [#23377](https://github.com/expo/expo/pull/23377) by [@wschurman](https://github.com/wschurman))
 - [iOS] Fix unmatched selection policy. ([#23535](https://github.com/expo/expo/pull/23535) by [@chochihim](https://github.com/chochihim))
 - Handle initialization errors in useUpdates(). ([#23640](https://github.com/expo/expo/pull/23640) by [@douglowder](https://github.com/douglowder))
+- [iOS] Fix error handling on iOS during startup check for updates. ([#23663](https://github.com/expo/expo/pull/23663) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -48,6 +48,7 @@ export default function App() {
     downloadedUpdate,
     isUpdateAvailable,
     isUpdatePending,
+    checkError,
   } = Updates.useUpdates();
 
   Updates.useUpdateEvents((event) => {
@@ -180,6 +181,7 @@ export default function App() {
       <TestValue testID="state.isUpdateAvailable" value={`${isUpdateAvailable}`} />
       <TestValue testID="state.isUpdatePending" value={`${isUpdatePending}`} />
       <TestValue testID="state.isRollback" value={`${isRollback}`} />
+      <TestValue testID="state.checkError" value={`${checkError?.message ?? ''}`} />
       {/*
       <TestValue testID="state.isRollback" value={`${availableUpdate?.isRollback ?? false}`} />
         */}

--- a/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
+++ b/packages/expo-updates/e2e/fixtures/Updates.e2e.ts
@@ -533,8 +533,6 @@ describe('JS API tests', () => {
       projectRoot
     );
 
-    console.warn(`signed manifest = ${JSON.stringify(manifest, null, 2)}`);
-
     // Launch app
     await device.installApp();
     await device.launchApp({
@@ -746,9 +744,14 @@ describe('JS API tests', () => {
     // Server is not running, so error received
     console.warn(`lastUpdateEventType = ${lastUpdateEventType}`);
 
+    // Error should be surfaced in checkError
+    const checkErrorMessage = await testElementValueAsync('state.checkError');
+    console.warn(`checkErrorMessage = ${checkErrorMessage}`);
+
     // Start server with no update available directive,
     // then restart app, we should get "No update available" event
     let lastUpdateEventType2 = '';
+    let checkErrorMessage2 = '';
     if (protocolVersion === 1) {
       Server.start(Update.serverPort, protocolVersion);
       const directive = Update.getNoUpdateAvailableDirective();
@@ -759,7 +762,9 @@ describe('JS API tests', () => {
       await readLogEntriesAsync();
 
       lastUpdateEventType2 = await testElementValueAsync('lastUpdateEventType');
+      checkErrorMessage2 = await testElementValueAsync('state.checkError');
       console.warn(`lastUpdateEventType2 = ${lastUpdateEventType2}`);
+      console.warn(`checkErrorMessage2 = ${checkErrorMessage2}`);
       Server.stop();
     }
 
@@ -772,7 +777,9 @@ describe('JS API tests', () => {
     await waitForAppToBecomeVisible();
 
     const lastUpdateEventType3 = await testElementValueAsync('lastUpdateEventType');
+    const checkErrorMessage3 = await testElementValueAsync('state.checkError');
     console.warn(`lastUpdateEventType3 = ${lastUpdateEventType3}`);
+    console.warn(`checkErrorMessage3 = ${checkErrorMessage3}`);
 
     // Test passes if all the event types seen are the expected ones
     // This test not working on Android in 0.72 in the CI environment, so disable it for now.
@@ -780,6 +787,9 @@ describe('JS API tests', () => {
       jestExpect(lastUpdateEventType).toEqual('error');
       jestExpect(lastUpdateEventType2).toEqual('noUpdateAvailable');
       jestExpect(lastUpdateEventType3).toEqual('updateAvailable');
+      jestExpect(checkErrorMessage).toEqual('Could not connect to the server.');
+      jestExpect(checkErrorMessage2).toEqual('');
+      jestExpect(checkErrorMessage3).toEqual('');
     }
   });
 });

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -2,6 +2,7 @@
 
 // swiftlint:disable closure_body_length
 // swiftlint:disable superfluous_else
+// swiftlint:disable cyclomatic_complexity
 
 // this class uses a ton of implicit non-null properties based on method call order. not worth changing to appease lint
 // swiftlint:disable force_unwrapping
@@ -33,6 +34,7 @@ public enum RemoteCheckResult {
   case noUpdateAvailable
   case updateAvailable(manifest: [String: Any])
   case rollBackToEmbedded
+  case error(error: Error)
 }
 
 public protocol AppLoaderTaskSwiftDelegate: AnyObject {
@@ -437,6 +439,11 @@ public final class AppLoaderTask: NSObject {
     } success: { updateResponse in
       completion(nil, updateResponse)
     } error: { error in
+      if let swiftDelegate = self.swiftDelegate {
+        self.delegateQueue.async {
+          swiftDelegate.appLoaderTask(self, didFinishCheckingForRemoteUpdateWithRemoteCheckResult: RemoteCheckResult.error(error: error))
+        }
+      }
       completion(error, nil)
     }
   }
@@ -518,3 +525,4 @@ public final class AppLoaderTask: NSObject {
 // swiftlint:enable closure_body_length
 // swiftlint:enable force_unwrapping
 // swiftlint:enable superfluous_else
+// swiftlint:enable cyclomatic_complexity

--- a/packages/expo-updates/ios/EXUpdates/Exceptions.swift
+++ b/packages/expo-updates/ios/EXUpdates/Exceptions.swift
@@ -43,9 +43,3 @@ internal final class UpdatesUnsupportedDirectiveException: Exception {
     "Updates service response included a directive that this client does not support."
   }
 }
-
-internal final class UpdatesStateException: Exception {
-  convenience init(_ message: String) {
-    self.init(name: "UpdatesStateException", description: message, code: "ERR_UPDATES_STATE_EXCEPTION", file: #fileID, line: #line, function: #function)
-  }
-}

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -51,7 +51,7 @@ internal protocol UpdatesStateEvent {
   var manifest: [String: Any]? { get }
   var message: String? { get }
   var isRollback: Bool { get }
-  var error: Error? { get }
+  var error: [String: String]? { get }
 }
 
 internal struct UpdatesStateEventCheck: UpdatesStateEvent {
@@ -59,7 +59,7 @@ internal struct UpdatesStateEventCheck: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventDownload: UpdatesStateEvent {
@@ -67,7 +67,7 @@ internal struct UpdatesStateEventDownload: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventRestart: UpdatesStateEvent {
@@ -75,7 +75,7 @@ internal struct UpdatesStateEventRestart: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventCheckError: UpdatesStateEvent {
@@ -83,8 +83,8 @@ internal struct UpdatesStateEventCheckError: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String?
   let isRollback: Bool = false
-  var error: Error? {
-    return (message != nil) ? UpdatesStateException(message ?? "") : nil
+  var error: [String: String]? {
+    return (message != nil) ? ["message": message ?? ""] : nil
   }
 }
 
@@ -93,8 +93,8 @@ internal struct UpdatesStateEventDownloadError: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String?
   let isRollback: Bool = false
-  var error: Error? {
-    return (message != nil) ? UpdatesStateException(message ?? "") : nil
+  var error: [String: String]? {
+    return (message != nil) ? ["message": message ?? ""] : nil
   }
 }
 
@@ -103,7 +103,7 @@ internal struct UpdatesStateEventCheckCompleteWithUpdate: UpdatesStateEvent {
   let manifest: [String: Any]?
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventCheckCompleteWithRollback: UpdatesStateEvent {
@@ -111,7 +111,7 @@ internal struct UpdatesStateEventCheckCompleteWithRollback: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = true
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventCheckComplete: UpdatesStateEvent {
@@ -119,7 +119,7 @@ internal struct UpdatesStateEventCheckComplete: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventDownloadCompleteWithUpdate: UpdatesStateEvent {
@@ -127,7 +127,7 @@ internal struct UpdatesStateEventDownloadCompleteWithUpdate: UpdatesStateEvent {
   let manifest: [String: Any]?
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventDownloadCompleteWithRollback: UpdatesStateEvent {
@@ -135,7 +135,7 @@ internal struct UpdatesStateEventDownloadCompleteWithRollback: UpdatesStateEvent
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = true
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 internal struct UpdatesStateEventDownloadComplete: UpdatesStateEvent {
@@ -143,7 +143,7 @@ internal struct UpdatesStateEventDownloadComplete: UpdatesStateEvent {
   let manifest: [String: Any]? = nil
   let message: String? = nil
   let isRollback: Bool = false
-  let error: Error? = nil
+  let error: [String: String]? = nil
 }
 
 /**
@@ -158,8 +158,8 @@ internal struct UpdatesStateContext {
   let isRestarting: Bool
   let latestManifest: [String: Any]?
   let downloadedManifest: [String: Any]?
-  let checkError: Error?
-  let downloadError: Error?
+  let checkError: [String: String]?
+  let downloadError: [String: String]?
 
   var json: [String: Any?] {
     return [
@@ -208,8 +208,8 @@ extension UpdatesStateContext {
     var isRestarting: Bool = false
     var latestManifest: [String: Any]?
     var downloadedManifest: [String: Any]?
-    var checkError: Error?
-    var downloadError: Error?
+    var checkError: [String: String]?
+    var downloadError: [String: String]?
 
     fileprivate init(original: UpdatesStateContext) {
       self.isUpdateAvailable = original.isUpdateAvailable


### PR DESCRIPTION
# Why

In manual testing of the new state machine and the JS API, found issues on iOS:

- An error in the way JS events were being emitted if they occurred before the bridge was fully initialized in `AppController`.
- If an error occurs during the check for update in `AppLoaderTask` remote app load, a `checkError` state machine event should happen in the error handler. This is not happening, which leads to awkward handling of the error in a different delegate method.
- The `checkError` and `downloadError` fields in the state machine context are `Error` objects, whereas on Android they are maps/dictionaries with a `message` field. This leads to cases where errors don't have the `message` property as expected when surfaced in JS.

# How

- Fix the incorrect JS emission code in `AppController`
- Add a new error type to the `RemoteCheckResult` used by the `didFinishCheckingForRemoteUpdateWithRemoteCheckResult` delegate method (`AppLoaderTask`)
- Call this delegate method in the `AppLoaderTask` remote loader error handler
- In `AppController`, fire the correct state machine change event in the delegate method implementation
- Modify `UpdatesStateMachine` to align with the Android implementation
- 
# Test Plan

- Existing unit tests should pass on iOS
- Existing E2E tests should pass on iOS
- New code in the test for events on startup to verify surfacing of `checkError`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
