### PR TITLE
fix: ensure folder exists

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix Expo Router generating types for invalid route files. ([#23421](https://github.com/expo/expo/pull/23421) by [@marklawlor](https://github.com/marklawlor))
 - Add missing `router` type, and `canGoBack` when typed routes are enabled. Preserve deprecation comment for `useSearchParams` hook. ([#23636](https://github.com/expo/expo/pull/23636) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix running typed routes without an app directory. ([#23661](https://github.com/expo/expo/pull/23661) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix ensure `.expo/types` folder exists during type generation. ([#23664](https://github.com/expo/expo/pull/23664) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -93,13 +93,14 @@ export async function setupTypedRoutes({
  * Should be debounced as its very common for developers to make changes to multiple files at once (eg Save All)
  */
 const regenerateRouterDotTS = debounce(
-  (
+  async (
     typesDir: string,
     staticRoutes: Set<string>,
     dynamicRoutes: Set<string>,
     dynamicRouteTemplates: Set<string>
   ) => {
-    fs.writeFile(
+    await fs.mkdir(typesDir, { recursive: true });
+    await fs.writeFile(
       path.resolve(typesDir, './router.d.ts'),
       getTemplateString(staticRoutes, dynamicRoutes, dynamicRouteTemplates)
     );


### PR DESCRIPTION
# Why

If the user deletes the `.expo` or `.expo/types` folder while running Expo Router type generation, the CLI process would crash. This ensures the folder always exists before writing to it.