### PR TITLE
fix(expo-cli): corrected typo in devtools page

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unpublished
 
+- Fixed typo in connection message when opening React DevTools ([#23672](https://github.com/expo/expo/pull/23672) by [@frankcalise](https://github.com/frankcalise))
+
 ### 🛠 Breaking changes
 
 ### 🎉 New features

--- a/packages/@expo/cli/static/react-devtools-page/index.html
+++ b/packages/@expo/cli/static/react-devtools-page/index.html
@@ -43,7 +43,7 @@
   <noscript>
     You need to enable JavaScript to run this app.
   </noscript>
-  <div id="hint">Conntecting to ReactDevToolsProxy...</div>
+  <div id="hint">Connecting to ReactDevToolsProxy...</div>
   <div id="root"></div>
   <!--
     JSPM Generator Import Map


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

There is a typo in the waiting to connect static page when launching React DevTools

![image](https://github.com/expo/expo/assets/374022/a1d89537-b63b-4782-9973-270aa44c4aa0)


# How

<!--
How did you build this feature or fix this bug and why?
-->

Fixed the typo

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
