### PR TITLE
[docs] Clarify what "push" means for `<Link>`

### DIFF
--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -107,7 +107,7 @@ export default function Page() {
 
 ## Replacing screens
 
-By default, links "push" routes onto the navigation stack. This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
+By default, links "push" routes onto the navigation stack (specifically, they follow the same [rules React Navigation uses for navigation.navigate()](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times)). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
 
 {/* prettier-ignore */}
 ```js app/index.js

--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -107,7 +107,7 @@ export default function Page() {
 
 ## Replacing screens
 
-By default, links "push" routes onto the navigation stack (specifically, they follow the same [rules React Navigation uses for navigation.navigate()](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times)). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
+By default, links "push" routes onto the navigation stack. Specifically, they follow the same [rules React Navigation uses for navigation.navigate()](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
 
 {/* prettier-ignore */}
 ```js app/index.js

--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -107,7 +107,7 @@ export default function Page() {
 
 ## Replacing screens
 
-By default, links "push" routes onto the navigation stack. Specifically, they follow the same [rules React Navigation uses for navigation.navigate()](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
+By default, links "push" routes onto the navigation stack. It follows the same rules as [`navigation.navigate()`](https://reactnavigation.org/docs/navigating/#navigate-to-a-route-multiple-times). This means that the previous screen will be available when the user navigates back. You can use the `replace` prop to replace the current screen instead of pushing a new one.
 
 {/* prettier-ignore */}
 ```js app/index.js


### PR DESCRIPTION
# Why

"By default links push" makes me think that it'll work just like `navigation.push()` in React Navigation. But that's not the case! It works like `navigation.navigate()`! We shouldn't use the word "push" here imprecisely, we should either use a word that doesn't map to a specific React Navigation / Expo Router concept, or be precise in the language.

# How

Clarify how it actually works

# Test Plan

N/A

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
