### PR TITLE
Update typescript.mdx

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -33,7 +33,7 @@ For npm, add the following `script` to the **package.json**:
 ```json package.json
 {
   "scripts": {
-    "tsc": "tsc"
+    "ts:check": "tsc"
     /* @hide ... */ /* @end */
   }
 }
@@ -44,7 +44,7 @@ Then, to type-check the project, run the following command:
 <Tabs>
 <Tab label="npm">
 
-<Terminal cmd={['$ npm run tsc']} />
+<Terminal cmd={['$ npm run ts:check']} />
 
 </Tab>
 
@@ -71,13 +71,13 @@ For npm, add the following `script` to the **package.json**:
 ```json package.json
 {
   "scripts": {
-    "tsc": "tsc"
+    "ts:check": "tsc"
     /* @hide ... */ /* @end */
   }
 }
 ```
 
-You can now run `npm run tsc` or `yarn tsc` to type-check the project.
+You can now run `npm run ts:check` or `yarn tsc` to type-check the project.
 
 ## Base configuration
 


### PR DESCRIPTION
Replace npm command `tsc` to `ts:check` for avoiding getting a warning from `expo-doctor`:

# Why

![image](https://github.com/expo/expo/assets/7753600/13061797-54e7-4d56-93e3-f9007294cdda)

4, 14 lines

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
