### PR TITLE
fix(cli): add additional isRouteFile check before generating Expo Router types

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix running typed routes without an app directory. ([#23661](https://github.com/expo/expo/pull/23661) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix Expo Router type generation for filenames with spaces. ([#23662](https://github.com/expo/expo/pull/23662) by [@marklawlor](https://github.com/marklawlor))
 - Fix ensure `.expo/types` folder exists during type generation. ([#23664](https://github.com/expo/expo/pull/23664) by [@marklawlor](https://github.com/marklawlor))
+- Added additional guard to prevent invalid route files type generation. ([#23694](https://github.com/expo/expo/pull/23694) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -199,9 +199,17 @@ describe(getTypedRoutesUtils, () => {
         '/user/project/app/(   group1  , my group    )/my page.tsx',
         { static: ['/(group1)/my page', '/(my group)/my page', '/my page'] },
       ],
+      ['/user/project/app/folder/_layout.tsx', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/_layout.tsx', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/folder/+html.tsx', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/+html.tsx', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/folder/_layout.js', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/_layout.js', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/folder/+html.js', { static: [], dynamicRoutes: [] }],
+      ['/user/project/app/+html.js', { static: [], dynamicRoutes: [] }],
     ] as const;
 
-    it.each(filepaths)('normalizes a filepath: %s', (filepath, expectedRoutes) => {
+    it.each(filepaths)('normalizes the filepath: %s', (filepath, expectedRoutes) => {
       addFilePath(filepath);
 
       if ('static' in expectedRoutes) {
@@ -210,6 +218,8 @@ describe(getTypedRoutesUtils, () => {
         for (const staticRoute of expectedRoutes.static) {
           expect(actualRoutes).toContain(staticRoute);
         }
+      } else {
+        expect(staticRoutes.get(filePathToRoute(filepath))).toBeUndefined();
       }
 
       if ('dynamic' in expectedRoutes) {
@@ -219,6 +229,8 @@ describe(getTypedRoutesUtils, () => {
           expect(actualRoutes).toContain(dynamicRoute);
         }
         expect(actualRoutes?.size).toEqual(expectedRoutes.dynamic.length);
+      } else {
+        expect(dynamicRoutes.get(filePathToRoute(filepath))).toBeUndefined();
       }
     });
   });

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -174,6 +174,10 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
   };
 
   const addFilePath = (filePath: string): boolean => {
+    if (!isRouteFile(filePath)) {
+      return false;
+    }
+
     const route = filePathToRoute(filePath);
 
     // We have already processed this file


### PR DESCRIPTION
# Why

Expo Router's is still generating some types for invalid files.

# How

Add additional guard inside the `addFilePath` method