### PR TITLE
[docs] add info about `rollout` property for Android submit profile

### DIFF
--- a/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-submit-android-schema.js
@@ -15,6 +15,11 @@ export default [
     description: ['The status of a release. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks).'],
   },
   {
+    name: 'rollout',
+    type: 'number',
+    description: ['The initial fraction of users who are eligible to receive the release. Should be a value from 0 (no users) to 1 (all users). Works only with `inProgress` release status. [Learn more](https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks)'],
+  },
+  {
     name: 'changesNotSentForReview',
     type: 'boolean',
     description: ['Indicates that the changes sent with this submission will not be reviewed until they are explicitly sent for review from the Google Play Console UI. Defaults to false.'],


### PR DESCRIPTION
# Why

Companion to https://github.com/expo/eas-cli/pull/1938

# How

Add info about `rollout` property for Android submit profile

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
