### PR TITLE
Update using-firebase.mdx metro config example

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -115,7 +115,7 @@ Then, update the file with the following configuration:
 const { getDefaultConfig } = require('@expo/metro-config');
 
 const defaultConfig = getDefaultConfig(__dirname);
-defaultConfig.resolver.assetExts.push('cjs');
+defaultConfig.resolver.sourceExts.push('cjs');
 
 module.exports = defaultConfig;
 ```


### PR DESCRIPTION
# Why

Bumped onto an issue while adding Apollo Client to an Expo project with Firebase. Apollo Client also suggests updating Metro config to add support to .cjs. But, [its example](https://www.apollographql.com/docs/react/integrations/react-native/#troubleshooting) uses `sourceExts` instead of `assetExts`.
I can confirm both Firebase and Apollo Client worked adding, and only adding, "cjs" to `sourceExts`.
Also, it does make sense as .cjs is not an asset, but a source code.
(Interestingly, Firebase itself seemed to work with `assetExts.push('cjs')`; using Firebase v10)
 
# Test Plan

Init Expo app, and add Apollo Client like in https://www.apollographql.com/docs/react/integrations/react-native/.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
