### PR TITLE
[image][Android] Fix the image components rendering incorrect assets when the Proguard is enabled

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix the image components rendering incorrect assets when the Proguard is enabled on Android.
+- Fix the image components rendering incorrect assets when the Proguard is enabled on Android. ([#23704](https://github.com/expo/expo/pull/23704) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix the image components rendering incorrect assets when the Proguard is enabled on Android.
+
 ### 💡 Others
 
 - [Web] Refactored and split some functions for better readability. ([#23465](https://github.com/expo/expo/pull/23465) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -51,6 +51,7 @@ android {
     targetSdkVersion safeExtGet("targetSdkVersion", 33)
     versionCode 1
     versionName "1.3.0"
+    consumerProguardFiles("proguard-rules.pro")
   }
   lintOptions {
     abortOnError false

--- a/packages/expo-image/android/proguard-rules.pro
+++ b/packages/expo-image/android/proguard-rules.pro
@@ -1,25 +1,28 @@
 # https://bumptech.github.io/glide/doc/download-setup.html#proguard
 
--keep public class * implements com.bumptech.glide.module.LibraryGlideModule
+-keep public class * extends com.bumptech.glide.module.LibraryGlideModule
 -keep public class * implements com.bumptech.glide.module.GlideModule
--keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep class * extends com.bumptech.glide.module.AppGlideModule {
+ <init>(...);
+}
 -keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
   **[] $VALUES;
   public *;
+}
+-keep class com.bumptech.glide.load.data.ParcelFileDescriptorRewinder$InternalRewinder {
+  *** rewind();
+}
+
+-keep public class com.bumptech.glide.request.ThumbnailRequestCoordinator {
+  *;
 }
 
 -dontwarn com.bumptech.glide.load.resource.bitmap.VideoDecoder
 
 # https://bumptech.github.io/glide/doc/configuration.html#applications
 
--keep public class * extends com.bumptech.glide.module.AppGlideModule
--keep public class expo.modules.image.svg.SVGModule
 -keep class com.bumptech.glide.GeneratedAppGlideModuleImpl
 
 -keep public class com.bumptech.glide.integration.webp.WebpImage { *; }
 -keep public class com.bumptech.glide.integration.webp.WebpFrame { *; }
 -keep public class com.bumptech.glide.integration.webp.WebpBitmapFactory { *; }
-
--keep public class com.bumptech.glide.requestThumbnailRequestCoordinator {
-  *;
-}

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
@@ -73,7 +73,7 @@ class ImageViewWrapperTarget(
     val isPlaceholder = if (request is ThumbnailRequestCoordinator) {
       (request as? ThumbnailRequestCoordinator)
         ?.getPrivateFullRequest()
-        ?.isComplete != true
+        ?.isComplete == false
     } else {
       false
     }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ThumbnailRequestCoordinatorExtension.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ThumbnailRequestCoordinatorExtension.kt
@@ -1,18 +1,21 @@
 package expo.modules.image
 
+import android.util.Log
 import com.bumptech.glide.request.Request
 import com.bumptech.glide.request.ThumbnailRequestCoordinator
 
 fun ThumbnailRequestCoordinator.getPrivateFullRequest(): Request? {
-  return getPrivateRequest("full")
+  return getPrivateFiled("full")
 }
 
-private fun ThumbnailRequestCoordinator.getPrivateRequest(name: String): Request? {
+private fun <T> ThumbnailRequestCoordinator.getPrivateFiled(name: String): T? {
   return try {
     val filed = this.javaClass.getDeclaredField(name)
     filed.isAccessible = true
-    filed.get(this) as Request
+    @Suppress("UNCHECKED_CAST")
+    filed.get(this) as T
   } catch (e: Throwable) {
+    Log.e("ExpoImage", "Couldn't receive the `$name` field", e)
     null
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/22515.

# How

It turns out our proguard file is omitted and also not all rules are correct. I've managed to fix that, but invoking `consumerProguardFiles` function in `build.gradle` and checking all the rules manually. 

# Test Plan

- bare-expo ✅
- https://gist.github.com/buraks/ed0e69c0267d1c92c9bdb0b61d4e21e7 ✅