### PR TITLE
[image][Android] Fixed placeholders aren't always replaced by full-size images

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed placeholders aren't always replaced by full-size images on Android.
+- Fixed placeholders aren't always replaced by full-size images on Android. ([#23705](https://github.com/expo/expo/pull/23705) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed placeholders aren't always replaced by full-size images on Android.
+
 ### 💡 Others
 
 - [Web] Refactored and split some functions for better readability. ([#23465](https://github.com/expo/expo/pull/23465) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -315,7 +315,12 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
         firstView
           .recycleView()
-          ?.clear(requestManager)
+          ?.apply {
+            // The current target is already bound to the view. We don't want to cancel it in that case.
+            if (this != target) {
+              clear(requestManager)
+            }
+          }
 
         configureView(firstView, target, resource, isPlaceholder)
         if (transitionDuration > 0) {


### PR DESCRIPTION
# Why

When debugging https://github.com/expo/expo/issues/22515, I noticed that full-size images only sometimes replace placeholders which is incorrect behavior. 
 
# How

For some reason, the RN changes the image view box's size multiple times, leading to numerous Glide requests. Those requests cancel each other to save CPU and other resources, but we cancel too much because of a minor bug in our code. 

# Test Plan

- bare-expo ✅
- https://gist.github.com/buraks/ed0e69c0267d1c92c9bdb0b61d4e21e7 ✅