### PR TITLE
[expo-dev-launcher][Android] Fix for "Can't toast on a thread that has not called Looper.prepare()"

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed "Can't toast on a thread that has not called Looper.prepare()" Exception when enabling "Sampling Profiler on init"
+
 ### 💡 Others
 
 ## 2.4.8 - 2023-07-12

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed "Can't toast on a thread that has not called Looper.prepare()" Exception when enabling "Sampling Profiler on init"
+- Fixed "Can't toast on a thread that has not called Looper.prepare()" Exception when enabling "Sampling Profiler on init" ([#23706](https://github.com/expo/expo/pull/23706) by [@hirbod](https://github.com/hirbod))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -223,10 +223,10 @@ class DevLauncherDevSupportManager(
   /** Starts of stops the sampling profiler  */
   private fun toggleJSSamplingProfiler() {
     val handler = Handler(Looper.getMainLooper())
-    val javaScriptExecutorFactory = reactInstanceManagerHelper?.javaScriptExecutorFactory
+    val javaScriptExecutorFactory = reactInstanceDevHelper.javaScriptExecutorFactory
     if (!mIsSamplingProfilerEnabled) {
       try {
-        javaScriptExecutorFactory?.startSamplingProfiler()
+        javaScriptExecutorFactory.startSamplingProfiler()
         handler.post {
           Toast.makeText(applicationContext, "Starting Sampling Profiler", Toast.LENGTH_SHORT)
             .show()
@@ -245,10 +245,10 @@ class DevLauncherDevSupportManager(
       }
     } else {
       try {
-        val outputPath = File.createTempFile(
+        val outputPath: String = File.createTempFile(
           "sampling-profiler-trace", ".cpuprofile", applicationContext.cacheDir
         ).path
-        javaScriptExecutorFactory?.stopSamplingProfiler(outputPath)
+        javaScriptExecutorFactory.stopSamplingProfiler(outputPath)
         handler.post {
           Toast.makeText(
             applicationContext,


### PR DESCRIPTION
# Why

When the toggleJSSamplingProfiler() method is triggered, the application throws an exception "Can't toast on a thread that has not called Looper.prepare()". This happens because the Toast.makeText().show() method is being invoked from a non-UI thread.


https://github.com/expo/expo/assets/504909/cff9a79a-261e-43e9-907a-1bb63aaa8c95



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

The solution involves using a Handler initialized with the Main Looper to post the toast operation on the main UI thread. By invoking the Toast.makeText().show() method inside the run() method of a Runnable posted to the main thread, we can ensure that the toast operation is performed on the main UI thread, thus preventing the exception from being thrown.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested on Pixel 7 (real device) and on an Pixel 5 emulator, both running Android 13

https://github.com/expo/expo/assets/504909/ea633904-7b8a-40e1-875c-7535ef48bb1d


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
