### PR TITLE
[go][Android] Create a `ModuleProvider` for home app

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/HomeActivity.kt
@@ -13,19 +13,33 @@ import com.facebook.react.ReactRootView
 import com.facebook.soloader.SoLoader
 import com.squareup.leakcanary.LeakCanary
 import de.greenrobot.event.EventBus
+import expo.modules.barcodescanner.BarCodeScannerModule
 import expo.modules.barcodescanner.BarCodeScannerPackage
+import expo.modules.blur.BlurModule
+import expo.modules.camera.CameraViewModule
+import expo.modules.clipboard.ClipboardModule
+import expo.modules.constants.ConstantsModule
 import expo.modules.constants.ConstantsPackage
 import expo.modules.core.interfaces.Package
+import expo.modules.device.DeviceModule
+import expo.modules.easclient.EASClientModule
 import expo.modules.facedetector.FaceDetectorPackage
+import expo.modules.filesystem.FileSystemModule
 import expo.modules.filesystem.FileSystemPackage
 import expo.modules.font.FontLoaderPackage
+import expo.modules.haptics.HapticsModule
 import expo.modules.keepawake.KeepAwakePackage
+import expo.modules.kotlin.ModulesProvider
+import expo.modules.kotlin.modules.Module
+import expo.modules.lineargradient.LinearGradientModule
 import expo.modules.notifications.NotificationsPackage
 import expo.modules.permissions.PermissionsPackage
 import expo.modules.splashscreen.SplashScreenImageResizeMode
+import expo.modules.splashscreen.SplashScreenModule
 import expo.modules.splashscreen.SplashScreenPackage
 import expo.modules.splashscreen.singletons.SplashScreen
 import expo.modules.taskManager.TaskManagerPackage
+import expo.modules.webbrowser.WebBrowserModule
 import host.exp.exponent.Constants
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.RNObject
@@ -136,7 +150,7 @@ open class HomeActivity : BaseExperienceActivity() {
     kernel.setHasError()
   }
 
-  companion object {
+  companion object : ModulesProvider {
     fun homeExpoPackages(): List<Package> {
       return listOf(
         ConstantsPackage(),
@@ -149,6 +163,23 @@ open class HomeActivity : BaseExperienceActivity() {
         NotificationsPackage(), // home doesn't use notifications, but we want the singleton modules created
         TaskManagerPackage(), // load expo-task-manager to restore tasks once the client is opened
         SplashScreenPackage()
+      )
+    }
+
+    override fun getModulesList(): List<Class<out Module>> {
+      return listOf(
+        BarCodeScannerModule::class.java,
+        BlurModule::class.java,
+        CameraViewModule::class.java,
+        ClipboardModule::class.java,
+        ConstantsModule::class.java,
+        DeviceModule::class.java,
+        EASClientModule::class.java,
+        FileSystemModule::class.java,
+        HapticsModule::class.java,
+        LinearGradientModule::class.java,
+        SplashScreenModule::class.java,
+        WebBrowserModule::class.java,
       )
     }
   }

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -269,6 +269,7 @@ class Kernel : KernelInterface() {
                 context,
                 exponentManifest.getKernelManifest(),
                 HomeActivity.homeExpoPackages(),
+                HomeActivity.Companion,
                 initialURL
               )
             )

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -63,12 +63,13 @@ class ExponentPackage : ReactPackage {
     experienceProperties: Map<String, Any?>,
     manifest: Manifest,
     expoPackages: List<Package>,
+    moduleProvider: ModulesProvider,
     singletonModules: List<SingletonModule>?
   ) {
     this.isKernel = isKernel
     this.experienceProperties = experienceProperties
     this.manifest = manifest
-    moduleRegistryAdapter = createDefaultModuleRegistryAdapterForPackages(expoPackages, singletonModules)
+    moduleRegistryAdapter = createDefaultModuleRegistryAdapterForPackages(expoPackages, singletonModules, moduleProvider)
   }
 
   constructor(
@@ -221,6 +222,7 @@ class ExponentPackage : ReactPackage {
       context: Context,
       manifest: Manifest,
       expoPackages: List<Package>,
+      modulesProvider: ModulesProvider,
       initialURL: String?
     ): ExponentPackage {
       val kernelExperienceProperties = mutableMapOf(
@@ -237,6 +239,7 @@ class ExponentPackage : ReactPackage {
         kernelExperienceProperties,
         manifest,
         expoPackages,
+        modulesProvider,
         singletonModules
       )
     }


### PR DESCRIPTION
# Why

Creates a dedicated `ModuleProvider` for the home app. 

# How

We're currently initializing all modules written in the new API when creating a home bridge. It's unnecessary, so I've made a dedicated `ModuleProvider` for the main app. 
Also, this change will allow us to add the Expo Go specific module to the home app. 

# Test Plan

- expo go ✅