### PR TITLE
[go][Android] Add `ExpoGoModule`

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/DetachedModuleRegistryAdapter.kt
@@ -69,7 +69,7 @@ open class DetachedModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegi
       }
     }
     configureModuleRegistry(moduleRegistry, reactApplicationContext)
-    return getNativeModulesFromModuleRegistry(reactApplicationContext, moduleRegistry)
+    return getNativeModulesFromModuleRegistry(reactApplicationContext, moduleRegistry, null)
   }
 
   protected open fun configureModuleRegistry(

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
@@ -7,7 +7,7 @@ import host.exp.exponent.kernel.ExpoViewKernel
 
 class ExpoGoModule(private val manifest: Manifest) : Module() {
   override fun definition() = ModuleDefinition {
-    Name("ExpoGoModules")
+    Name("ExpoGo")
 
     Constants {
       mapOf(

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
@@ -1,0 +1,10 @@
+package versioned.host.exp.exponent.core.modules
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class ExpoGoModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("ExpoGoModules")
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
@@ -5,9 +5,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.kernel.ExpoViewKernel
 
-class ExpoGoModule(
-  private val manifest: Manifest
-  ) : Module() {
+class ExpoGoModule(private val manifest: Manifest) : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoGoModules")
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoModule.kt
@@ -2,9 +2,20 @@ package versioned.host.exp.exponent.core.modules
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.manifests.core.Manifest
+import host.exp.exponent.kernel.ExpoViewKernel
 
-class ExpoGoModule : Module() {
+class ExpoGoModule(
+  private val manifest: Manifest
+  ) : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoGoModules")
+
+    Constants {
+      mapOf(
+        "expoVersion" to ExpoViewKernel.instance.versionName,
+        "manifest" to manifest.toString(),
+      )
+    }
   }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
@@ -80,9 +80,13 @@ open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistry
         moduleRegistry.registerExtraListener(otherModule as RegistryLifecycleListener)
       }
     }
-    return getNativeModulesFromModuleRegistry(reactContext, moduleRegistry, Consumer { appContext ->
-      appContext.registry.register(ExpoGoModule())
-    })
+    return getNativeModulesFromModuleRegistry(
+      reactContext,
+      moduleRegistry,
+      Consumer { appContext ->
+        appContext.registry.register(ExpoGoModule())
+      }
+    )
   }
 
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
@@ -84,7 +84,9 @@ open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistry
       reactContext,
       moduleRegistry,
       Consumer { appContext ->
-        appContext.registry.register(ExpoGoModule())
+        appContext.registry.register(
+          ExpoGoModule(manifest)
+        )
       }
     )
   }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ExpoModuleRegistryAdapter.kt
@@ -4,11 +4,13 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import expo.modules.adapters.react.ModuleRegistryAdapter
 import expo.modules.adapters.react.ReactModuleRegistryProvider
+import expo.modules.core.interfaces.Consumer
 import expo.modules.core.interfaces.RegistryLifecycleListener
 import expo.modules.kotlin.ModulesProvider
 import expo.modules.manifests.core.Manifest
 import host.exp.exponent.utils.ScopedContext
 import host.exp.exponent.kernel.ExperienceKey
+import versioned.host.exp.exponent.core.modules.ExpoGoModule
 import versioned.host.exp.exponent.modules.api.notifications.ScopedNotificationsCategoriesSerializer
 import versioned.host.exp.exponent.modules.api.notifications.channels.ScopedNotificationsChannelsProvider
 import versioned.host.exp.exponent.modules.universal.av.SharedCookiesDataSourceFactoryProvider
@@ -78,7 +80,9 @@ open class ExpoModuleRegistryAdapter(moduleRegistryProvider: ReactModuleRegistry
         moduleRegistry.registerExtraListener(otherModule as RegistryLifecycleListener)
       }
     }
-    return getNativeModulesFromModuleRegistry(reactContext, moduleRegistry)
+    return getNativeModulesFromModuleRegistry(reactContext, moduleRegistry, Consumer { appContext ->
+      appContext.registry.register(ExpoGoModule())
+    })
   }
 
   override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -10,12 +10,15 @@ import java.util.List;
 import java.util.Objects;
 
 import androidx.annotation.Nullable;
+
 import expo.modules.BuildConfig;
 import expo.modules.adapters.react.views.SimpleViewManagerAdapter;
 import expo.modules.adapters.react.views.ViewGroupManagerAdapter;
 import expo.modules.core.ModuleRegistry;
+import expo.modules.core.interfaces.Consumer;
 import expo.modules.core.interfaces.InternalModule;
 import expo.modules.core.interfaces.Package;
+import expo.modules.kotlin.AppContext;
 import expo.modules.kotlin.CoreLoggerKt;
 import expo.modules.kotlin.KotlinInteropModuleRegistry;
 import expo.modules.kotlin.ModulesProvider;
@@ -31,6 +34,14 @@ public class ModuleRegistryAdapter implements ReactPackage {
   protected ModulesProvider mModulesProvider;
   protected ReactAdapterPackage mReactAdapterPackage = new ReactAdapterPackage();
   private NativeModulesProxy mModulesProxy;
+
+  private void setModulesProxy(@Nullable NativeModulesProxy newProxy) {
+    mModulesProxy = newProxy;
+    if (mModulesProxy != null) {
+      mModulesProxy.getKotlinInteropModuleRegistry().setLegacyModulesProxy(mModulesProxy);
+    }
+  }
+
   // We need to save all view holders to update them when the new kotlin module registry will be created.
   private List<ViewWrapperDelegateHolder> mWrapperDelegateHolders = null;
   private FabricComponentsRegistry mFabricComponentsRegistry = null;
@@ -57,7 +68,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
       moduleRegistry.registerInternalModule(internalModule);
     }
 
-    List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry);
+    List<NativeModule> nativeModules = getNativeModulesFromModuleRegistry(reactContext, moduleRegistry, null);
     if (mWrapperDelegateHolders != null) {
       KotlinInteropModuleRegistry kotlinInteropModuleRegistry = proxy.getKotlinInteropModuleRegistry();
       kotlinInteropModuleRegistry.updateModuleHoldersInViewManagers(mWrapperDelegateHolders);
@@ -66,10 +77,17 @@ public class ModuleRegistryAdapter implements ReactPackage {
     return nativeModules;
   }
 
-  protected List<NativeModule> getNativeModulesFromModuleRegistry(ReactApplicationContext reactContext, ModuleRegistry moduleRegistry) {
+  protected List<NativeModule> getNativeModulesFromModuleRegistry(
+    ReactApplicationContext reactContext,
+    ModuleRegistry moduleRegistry,
+    @Nullable Consumer<AppContext> appContextConsumer
+  ) {
     List<NativeModule> nativeModulesList = new ArrayList<>(2);
-
-    nativeModulesList.add(getOrCreateNativeModulesProxy(reactContext, moduleRegistry));
+    NativeModulesProxy nativeModulesProxy = getOrCreateNativeModulesProxy(reactContext, moduleRegistry);
+    if (appContextConsumer != null) {
+      appContextConsumer.apply(nativeModulesProxy.getKotlinInteropModuleRegistry().getAppContext());
+    }
+    nativeModulesList.add(nativeModulesProxy);
 
     // Add listener that will notify expo.modules.core.ModuleRegistry when all modules are ready
     nativeModulesList.add(new ModuleRegistryReadyNotifier(moduleRegistry));
@@ -117,17 +135,15 @@ public class ModuleRegistryAdapter implements ReactPackage {
     @Nullable ModuleRegistry moduleRegistry
   ) {
     if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
-      mModulesProxy = null;
+      setModulesProxy(mModulesProxy);
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);
       if (mModulesProvider != null) {
-        mModulesProxy = new NativeModulesProxy(reactContext, registry, mModulesProvider);
+        setModulesProxy(new NativeModulesProxy(reactContext, registry, mModulesProvider));
       } else {
-        mModulesProxy = new NativeModulesProxy(reactContext, registry);
+        setModulesProxy(new NativeModulesProxy(reactContext, registry));
       }
-
-      mModulesProxy.getKotlinInteropModuleRegistry().setLegacyModulesProxy(mModulesProxy);
     }
 
     if (moduleRegistry != null && moduleRegistry != mModulesProxy.getModuleRegistry()) {


### PR DESCRIPTION
# Why

Adds an almost empty `ExpoGoModule` specific to the Expo Go app. This module is present in the Home app too. 

# How

Add a decorator function that allows us to extend created `AppContext`. 

# Test Plan

- run an experience in the expo go app and check if the `ExpoGoModule` is present ✅