### PR TITLE
[docs] Update web instructions under manual installation in Expo Router doc

### DIFF
--- a/docs/pages/routing/installation.mdx
+++ b/docs/pages/routing/installation.mdx
@@ -116,15 +116,24 @@ The above command will install versions of these libraries that are compatible w
 
 ### Modify project configuration
 
-Add a deep linking `scheme` and enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) in your app config (**app.json** or **app.config.js**):
+Add a deep linking `scheme` in your [app config](/workflow/configuration/):
 
-```diff
+```json app.json
 {
-  "expo": {
-+   "scheme": "myapp",
-+   "web": {
-+     "bundler": "metro"
-+   }
+  "scheme": "your-app-scheme"
+}
+```
+
+If you are developing your app for web, install the following dependencies:
+
+<Terminal cmd={['$ npx expo install react-native-web react-dom']} />
+
+Then, enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) support:
+
+```json app.json
+{
+  "web": {
+    "bundler": "metro"
   }
 }
 ```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for #23649 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update manual installation instructions for web when on Step 4.
- Separate the instructions for `scheme` and `web` since `scheme` is required whether the project has `web` as an enabled platform or not.

**preview**

<img width="912" alt="CleanShot 2023-07-25 at 18 29 32@2x" src="https://github.com/expo/expo/assets/10234615/c1170050-69f2-4915-b778-d7cbc20a1f9a">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
