### PR TITLE
fix(cli): only enable actual async require handling when available

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added additional guard to prevent invalid route files type generation. ([#23694](https://github.com/expo/expo/pull/23694) by [@marklawlor](https://github.com/marklawlor))
+- Only enable actual async require handling when available.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed JavaScript Inspector does not work on Windows. ([#23367](https://github.com/expo/expo/pull/23367) by [@kudo](https://github.com/kudo))
 - Fixed route types generation on Windows not working. ([#23386](https://github.com/expo/expo/pull/23386) by [@gsporto](https://github.com/gsporto) and [@marklawlor](https://github.com/marklawlor))
 - Added additional guard to prevent invalid route files type generation. ([#23694](https://github.com/expo/expo/pull/23694) by [@marklawlor](https://github.com/marklawlor))
-- Only enable actual async require handling when available.
+- Only enable actual async require handling when available. ([#23715](https://github.com/expo/expo/pull/23715) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -173,7 +173,7 @@ describe('server', () => {
 
       // URLs
       expect(manifest.launchAsset.url).toBe(
-        'http://127.0.0.1:8081/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false&lazy=true'
+        'http://127.0.0.1:8081/node_modules/expo/AppEntry.bundle?platform=ios&dev=true&hot=false&lazy=false'
       );
       expect(manifest.extra.expoGo.debuggerHost).toBe('127.0.0.1:8081');
       expect(manifest.extra.expoGo.logUrl).toBe('http://127.0.0.1:8081/logs');

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -97,7 +97,7 @@ describe('getStaticResourcesAsync', () => {
     );
     const scope = nock('http://localhost:8081')
       .get(
-        '/index.bundle?platform=web&dev=true&hot=false&lazy=true&resolver.environment=client&transform.environment=client&serializer.output=static'
+        '/index.bundle?platform=web&dev=true&hot=false&lazy=false&resolver.environment=client&transform.environment=client&serializer.output=static'
       )
       .reply(
         200,

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -93,7 +93,7 @@ describe('checkBrowserRequestAsync', () => {
         // NOTE(EvanBacon): Browsers won't pass the `expo-platform` header so we need to
         // provide the `platform=web` query parameter in order for the multi-platform dev server
         // to return the correct bundle.
-        '/index.bundle?platform=web&dev=true&hot=false&lazy=true',
+        '/index.bundle?platform=web&dev=true&hot=false&lazy=false',
       ],
     });
     expect(res.setHeader).toBeCalledWith('Content-Type', 'text/html');
@@ -139,7 +139,7 @@ describe('_getBundleUrl', () => {
         platform: 'android',
       })
     ).toEqual(
-      'http://evanbacon.dev:8080/index.bundle?platform=android&dev=true&hot=false&lazy=true'
+      'http://evanbacon.dev:8080/index.bundle?platform=android&dev=true&hot=false&lazy=false'
     );
 
     expect(constructUrl).toHaveBeenCalledWith({ hostname: 'evanbacon.dev', scheme: 'http' });
@@ -157,7 +157,7 @@ describe('_getBundleUrl', () => {
         platform: 'ios',
       })
     ).toEqual(
-      'http://localhost:8080/node_modules/expo/AppEntry.bundle?platform=ios&dev=false&hot=false&lazy=true&minify=true'
+      'http://localhost:8080/node_modules/expo/AppEntry.bundle?platform=ios&dev=false&hot=false&lazy=false&minify=true'
     );
 
     expect(constructUrl).toHaveBeenCalledWith({ hostname: undefined, scheme: 'http' });


### PR DESCRIPTION
# Why

Fixes #23570

# How

- Only enabled `?lazy=true` when either `@expo/metro-runtime` or `expo-router` is installed

> The additional check for `expo-router` could be removed, but in Expo Router projects `@expo/metro-runtime` is _not_ installed as project dep (nested dependency)

# Test Plan

- `$ yarn create expo ./test-lazy -t blank@49`
- `$ cd ./test-lazy`
- Add a lazy import in the code, as described in #23570
- `$ yarn expo start` should work fine

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
