### PR TITLE
fix(cli): make `NODE_ENV` from build type case insensitive

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `Runtime.callFunctionOn` messages from Vscode debugger to avoid Hermes crashes. ([#25270](https://github.com/expo/expo/pull/25270) by [@byCedric](https://github.com/byCedric))
+- Make `NODE_ENV` selector case insensitive when derriving from build type.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `Runtime.callFunctionOn` messages from Vscode debugger to avoid Hermes crashes. ([#25270](https://github.com/expo/expo/pull/25270) by [@byCedric](https://github.com/byCedric))
-- Make `NODE_ENV` selector case insensitive when derriving from build type.
+- Make `NODE_ENV` selector case insensitive when derriving from build type. ([#23716](https://github.com/expo/expo/pull/23716) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -15,7 +15,7 @@ const debug = require('debug')('expo:run:android');
 
 export async function runAndroidAsync(projectRoot: string, { install, ...options }: Options) {
   // NOTE: This is a guess, the developer can overwrite with `NODE_ENV`.
-  setNodeEnv(options.variant === 'release' ? 'production' : 'development');
+  setNodeEnv(options.variant?.toLowerCase() === 'release' ? 'production' : 'development');
   require('@expo/env').load(projectRoot);
 
   await ensureNativeProjectAsync(projectRoot, { platform: 'android', install });

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -15,7 +15,7 @@ import { logProjectLogsLocation } from '../hints';
 import { startBundlerAsync } from '../startBundler';
 
 export async function runIosAsync(projectRoot: string, options: Options) {
-  setNodeEnv(options.configuration === 'Release' ? 'production' : 'development');
+  setNodeEnv(options.configuration?.toLowerCase() === 'release' ? 'production' : 'development');
   require('@expo/env').load(projectRoot);
 
   assertPlatform();


### PR DESCRIPTION
# Why

Especially on Android, users might use `Release` as well. Moving this to be case insensitive is a saver bet in general.

# How

- Added `?.toLowerCase()` when setting `development` or `production` as fallback `NODE_ENV`.

# Test Plan

- `$ yarn create expo ./test-build-type -t blank@49`
- `$ cd ./test-build-type`
- `$ yarn expo prebuild`
- Change the build types in the native files
  - **android**: `RELEASE` ([docs](https://developer.android.com/build/build-variants))
  - **ios**: `RELEASE` ([docs](https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project))
- Create `app.config.js` with:
  - `console.log('Node environment:', process.env.NODE_ENV);`
  - `module.exports = (config) => config;`
- Try running the "release" version for both platforms
  - `$ yarn expo run:android --variant RELEASE`
  - `$ yarn expo run:ios --configuration RELEASE`
- Console should render `Node environment: production` for both platforms

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
