### PR TITLE
[docs] Update preview.yml example in EAS Update docs

### DIFF
--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -103,6 +103,7 @@ jobs:
     name: EAS Update
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Check for EXPO_TOKEN


### PR DESCRIPTION
Small change to fix an example workflow in the docs so it works after copy-pasting.

# Why

The current example for preview action on [this page](https://docs.expo.dev/eas-update/github-actions/#publish-previews-on-pull-requests) doesn't work due to issue with permissions. In order for `actions/checkout` to have access to the repo, workflow needs to have `contents: read` permission. This permission is granted by default, unless `permissions` are overwritten, which is the case for `update` job in the sample.

Without this change, trying sample preview job leads to `Error: fatal: repository 'https://github.com/user/repo' not found` error from checkout action.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
