### PR TITLE
[docs] chore: Update navigating-pages with a missing import

### DIFF
--- a/docs/pages/routing/navigating-pages.mdx
+++ b/docs/pages/routing/navigating-pages.mdx
@@ -15,6 +15,7 @@ In the following example, there are two `<Link />` components which navigate to 
 
 {/* prettier-ignore */}
 ```js app/index.js
+import { View } from 'react-native';
 /* @info Import the <b>Link</b> React component from <b>expo-router</b> */
 import { Link } from 'expo-router';
 /* @end */


### PR DESCRIPTION
# Why

Missing import on the example provided.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
