### PR TITLE
[expo-dev-launcher][iOS] fix dev-client compatibility with Reanimated 3.4.0

### DIFF
--- a/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
+++ b/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
@@ -60,8 +60,9 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
 #if __has_include(<RNReanimated/REAInitializer.h>) \
-  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \ // Removed in react-native-reanimated@3.4.0
+  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \ // removed in react-native-reanimated@3.4.0
   && !RCT_NEW_ARCH_ENABLED
+  // required and available only for react-native-reanimated < 3.4.0
   reanimated::REAInitializer(bridge);
 #endif // __has_inclide(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED
 

--- a/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
+++ b/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
@@ -59,7 +59,9 @@
 
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
-#if __has_include(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED
+#if __has_include(<RNReanimated/REAInitializer.h>) \
+  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \
+  && !RCT_NEW_ARCH_ENABLED
   reanimated::REAInitializer(bridge);
 #endif // __has_inclide(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED
 

--- a/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
+++ b/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
@@ -60,7 +60,7 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
 #if __has_include(<RNReanimated/REAInitializer.h>) \
-  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \
+  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \ // Removed in react-native-reanimated@3.4.0
   && !RCT_NEW_ARCH_ENABLED
   reanimated::REAInitializer(bridge);
 #endif // __has_inclide(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED

--- a/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
+++ b/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
@@ -60,7 +60,7 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
 #if __has_include(<RNReanimated/REAInitializer.h>) \
-  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) \ // removed in react-native-reanimated@3.4.0
+  && __has_include(<RNReanimated/UIResponder+Reanimated.h>) /* removed in react-native-reanimated@3.4.0 */ \
   && !RCT_NEW_ARCH_ENABLED
   // required and available only for react-native-reanimated < 3.4.0
   reanimated::REAInitializer(bridge);

--- a/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
+++ b/packages/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm
@@ -64,7 +64,7 @@
   && !RCT_NEW_ARCH_ENABLED
   // required and available only for react-native-reanimated < 3.4.0
   reanimated::REAInitializer(bridge);
-#endif // __has_inclide(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED
+#endif
 
   return [super jsExecutorFactoryForBridge:bridge];
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/23719

Dev client with Reanimated 3.4.0 fails on compilation error.
```
❌  (node_modules/expo-dev-launcher/ios/EXRCTAppDelegateInterceptor.mm:64:15)

  62 | #if __has_include(<RNReanimated/REAInitializer.h>) \
  63 |   && !RCT_NEW_ARCH_ENABLED
> 64 |   reanimated::REAInitializer(bridge);
     |               ^ no type named 'REAInitializer' in namespace 'reanimated'
  65 | #endif // __has_inclide(<RNReanimated/REAInitializer.h>) && !RCT_NEW_ARCH_ENABLED
  66 | 
  67 |   return [super jsExecutorFactoryForBridge:bridge];
```

# How

In Reanimated 3.4.0 we simplified the initialization process, so the method `reanimated::REAInitializer(bridge)` is no longer required. I added check to determine if the Reanimated version is lower than 3.4.0.

# Test Plan
Run:
```bash
npx create-expo-app dev-client
cd dev-client
npx expo install expo-dev-client
npm install react-native-reanimated@3.4.0
npx expo run:ios
```
And application should lunch without any problems.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
