### PR TITLE
[tools] sync VERSION_EMPTY_PARAGRAPH_TEXT changelog

### DIFF
--- a/tools/src/commands/SyncSdkBranchChangelogs.ts
+++ b/tools/src/commands/SyncSdkBranchChangelogs.ts
@@ -78,10 +78,6 @@ async function syncChangelogAsync(pkg: Package, sourceBranch: string) {
 
   const changes = await sourceChangelog.getChangesAsync(targetLastVersion, sourceLastVersion);
 
-  if (changes.totalCount < 1) {
-    return false;
-  }
-
   delete changes.versions[UNPUBLISHED_VERSION_NAME];
   let updated = false;
   for (const version of Object.keys(changes.versions).sort((v1, v2) =>


### PR DESCRIPTION
# Why

fix the problem that `sync-sdk-branch-changelogs` does not sync changelog for `_This version does not introduce any user-facing changes._`

# How

the `_This version does not introduce any user-facing changes._` item is not in list form so that the `Changelogs.getChangesAsync()` does not count it into totalCount.

this pr ignores the `totalCount` and merge the changelogs anyway. 

# Test Plan

run `et ssbc -b sdk-49` and see if the **packages/expo/CHANGELOG.md** is updated

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
