### PR TITLE
Use absolute motion reference frame if available

### DIFF
--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -304,7 +304,7 @@ EX_REGISTER_MODULE();
 {
   float interval = 1.0f / 60.0f;
   [[self manager] setDeviceMotionUpdateInterval:interval];
-  CMAttitudeReferenceFrame referenceFrame = ([CMMotionManager availableAttitudeReferenceFrames] & CMAttitudeReferenceFrameXMagneticNorthZVertical) ? CMAttitudeReferenceFrameXMagneticNorthZVertical : CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
+  CMAttitudeReferenceFrame referenceFrame = ([CMMotionManager availableAttitudeReferenceFrames] & CMAttitudeReferenceFrameXMagneticNorthZVertical) ? CMAttitudeReferenceFrameXMagneticNorthZVertical : CMAttitudeReferenceFrameXArbitraryCorrectedZVertical;
   __weak EXSensorsManager *weakSelf = self;
   [[self manager] startDeviceMotionUpdatesUsingReferenceFrame:referenceFrame toQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
     __strong EXSensorsManager *strongSelf = weakSelf;

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -304,9 +304,9 @@ EX_REGISTER_MODULE();
 {
   float interval = 1.0f / 60.0f;
   [[self manager] setDeviceMotionUpdateInterval:interval];
-  CMAttitudeReferenceFrame referenceFrame = ([[self manager] availableAttitudeReferenceFrames] & CMAttitudeReferenceFrameXMagneticNorthZVertical) ? CMAttitudeReferenceFrameXMagneticNorthZVertical : CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
+  CMAttitudeReferenceFrame referenceFrame = ([CMMotionManager availableAttitudeReferenceFrames] & CMAttitudeReferenceFrameXMagneticNorthZVertical) ? CMAttitudeReferenceFrameXMagneticNorthZVertical : CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
   __weak EXSensorsManager *weakSelf = self;
-  [[self manager] startDeviceMotionUpdatesUsingReferenceFrame:frame toQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
+  [[self manager] startDeviceMotionUpdatesUsingReferenceFrame:referenceFrame toQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
     __strong EXSensorsManager *strongSelf = weakSelf;
     if (!strongSelf) {
       return;

--- a/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
+++ b/packages/expo-sensors/ios/EXSensors/EXSensorsManager.m
@@ -304,8 +304,9 @@ EX_REGISTER_MODULE();
 {
   float interval = 1.0f / 60.0f;
   [[self manager] setDeviceMotionUpdateInterval:interval];
+  CMAttitudeReferenceFrame referenceFrame = ([[self manager] availableAttitudeReferenceFrames] & CMAttitudeReferenceFrameXMagneticNorthZVertical) ? CMAttitudeReferenceFrameXMagneticNorthZVertical : CMAttitudeReferenceFrameXArbitraryCorrectedZVertical
   __weak EXSensorsManager *weakSelf = self;
-  [[self manager] startDeviceMotionUpdatesUsingReferenceFrame:CMAttitudeReferenceFrameXArbitraryCorrectedZVertical toQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
+  [[self manager] startDeviceMotionUpdatesUsingReferenceFrame:frame toQueue:[NSOperationQueue mainQueue] withHandler:^(CMDeviceMotion *data, NSError *error) {
     __strong EXSensorsManager *strongSelf = weakSelf;
     if (!strongSelf) {
       return;
@@ -377,5 +378,4 @@ EX_REGISTER_MODULE();
 }
 
 @end
-
 


### PR DESCRIPTION
# Why

Expo DeviceMotion returns values for `rotation`. On Android, these values derive from `Sensor.TYPE_ROTATION_VECTOR`, a fused sensor that represents the orientation of the device relative to the ground and magnetic north. This sensor integrates accelerometer, gyroscope, and magnetometer readings behind the scenes and is not available on all devices. On iOS, Expo derives the values from `CoreMotion`, passing the reference frame `CMAttitudeReferenceFrameXArbitraryCorrectedZVertical`. Selecting this reference frame ensures that device motion updates are available for all iOS devices, but yields less-than-ideal results on devices that integrate a magnetometer. The last iOS device released without a magnetometer was the iPod Touch, which Apple discontinued in 2022.
# How

This PR updates Expo-Sensors to use the the magnetometer-aware attitude reference frame, `CMAttitudeReferenceFrameXMagneticNorthZVertical`, if available instead of the default X-arbitrary reference frame. While an exact match of the Android behavior would omit `rotation` values if the reference frame is not available, I did not want to introduce any breaking changes.

# Test Plan

None. I need to familiarize myself with the testing process.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
