### PR TITLE
[android][file-system] Fixed external files access

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed getting content uri for external files on Android. by ([@G-Ray](https://github.com/G-Ray))
+- Fixed getting content uri for external files on Android. ([#23739](https://github.com/expo/expo/pull/23739) by [@G-Ray](https://github.com/G-Ray))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed getting content uri for external files on Android. by ([@G-Ray](https://github.com/G-Ray))
+
 ### 💡 Others
 
 - Fork `uuid@3.4.0` and move into `expo-modules-core`. Remove the original dependency. ([#23249](https://github.com/expo/expo/pull/23249) by [@alanhughes](https://github.com/alanjhughes))

--- a/packages/expo-file-system/android/src/main/res/xml/file_system_provider_paths.xml
+++ b/packages/expo-file-system/android/src/main/res/xml/file_system_provider_paths.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
+    <external-path name="expo_external_files" path="." />
     <files-path name="expo_files" path="." />
     <cache-path name="cached_expo_files" path="." />
 </paths>


### PR DESCRIPTION
# Why

Calling `getContentUriAsync` of a file stored at `/sdcard/Download` raises an exception:
`Failed to share the file: Failed to find configured root that contains /storage/emulated/0/Download/[file]`

This is the same issue as https://github.com/expo/expo/issues/9222
@barthap opened a pull-request to fix this in `expo-sharing` https://github.com/expo/expo/pull/9223.

# How

I only applied the same changes as @barthap  for `file-system`.

# Test Plan
Store a file in the Download folder, and try to get the contentUri
```js
const uri = await FileSystem.getContentUriAsync(
  'file://sdcard/Download/test.png'
)
```

This code should not raise an exception anymore with this fix.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).