### PR TITLE
[docs] Remove unused import in example

### DIFF
--- a/docs/pages/ui-programming/react-native-styling-buttons.mdx
+++ b/docs/pages/ui-programming/react-native-styling-buttons.mdx
@@ -25,7 +25,7 @@ Here's an example of using `<Pressable>` to create a button component:
 {/* prettier-ignore */}
 ```jsx
 import React from 'react';
-import { Text, View, StyleSheet, Pressable } from 'react-native';
+import { Text, StyleSheet, Pressable } from 'react-native';
 
 export default function Button(props) {
   const { onPress, title = 'Save' } = props;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
`View` isn't used in the component example provided in `react-native-styling-buttons`. ESlint warns/errors on copying to a blank file.

# How

<!--
How did you build this feature or fix this bug and why?
-->
Removed the import from the example.
