### PR TITLE
[fingerprint] remove unused dependencies

### DIFF
--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -45,17 +45,7 @@
   },
   "devDependencies": {
     "@types/find-up": "^4.0.0",
-    "@types/jest": "^29.2.1",
-    "@types/rimraf": "^3.0.0",
-    "eslint": "^8.29.0",
-    "eslint-config-universe": "^11.1.0",
-    "expo": "^49.0.0-alpha.1",
     "glob": "^7.1.7",
-    "jest": "^29.2.1",
-    "jest-watch-typeahead": "2.2.1",
-    "memfs": "^3.4.12",
-    "rimraf": "^3.0.2",
-    "temp-dir": "^2.0.0",
-    "typescript": "^5.1.3"
+    "temp-dir": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13108,7 +13108,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-memfs@^3.2.0, memfs@^3.4.12:
+memfs@^3.2.0:
   version "3.4.12"
   resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.12.tgz#d00f8ad8dab132dc277c659dc85bfd14b07d03bd"
   integrity sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==


### PR DESCRIPTION
# Why

leverage expo/expo monorepo dependencies, we could remove some dependencies from @expo/fingerprint and make the dependencies management easier.

# How

remove monorepo common dependencies, especially the `expo` package. that would prevent fingerprint from publishing after `expo` be published

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
