### PR TITLE
[core][splash-screen] fix splash screen missing from delay loading

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed custom fonts support on Fabric. ([#23666](https://github.com/expo/expo/pull/23666) by [@aleqsio](https://github.com/aleqsio))
+- [Android] Fixed splash screen is missing when using the `getDelayLoadAppHandler()` from expo-updates. ([#23747](https://github.com/expo/expo/pull/23747) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/ReactActivityLifecycleListener.java
@@ -34,4 +34,9 @@ public interface ReactActivityLifecycleListener {
   default boolean onBackPressed() {
     return false;
   }
+
+  /**
+   * This method is called when the {@link Activity#setContentView} method is invoked on an Activity.
+   */
+  default void onContentChanged(Activity activity) {}
 }

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed splash screen is missing when using the `getDelayLoadAppHandler()` from expo-updates. ([#23747](https://github.com/expo/expo/pull/23747) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.20.2 — 2023-06-28

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -2,8 +2,6 @@ package expo.modules.splashscreen
 
 import android.app.Activity
 import android.content.Context
-import android.os.Bundle
-import android.os.Handler
 import com.facebook.react.ReactRootView
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.splashscreen.singletons.SplashScreen

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenReactActivityLifecycleListener.kt
@@ -15,19 +15,13 @@ import expo.modules.splashscreen.SplashScreenImageResizeMode
 /* ktlint-enable no-unused-imports */
 
 class SplashScreenReactActivityLifecycleListener(activityContext: Context) : ReactActivityLifecycleListener {
-  override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
-    // To support backward compatible or SplashScreenImageResizeMode customization
-    // that calling `SplashScreen.show()` in MainActivity,
-    // we postpone the in-module call to the end of main loop.
-    // If MainActivity.onCreate has `SplashScreen.show()`, it will override the call here.
-    Handler(activity.mainLooper).post {
-      SplashScreen.show(
-        activity,
-        getResizeMode(activity),
-        ReactRootView::class.java,
-        getStatusBarTranslucent(activity)
-      )
-    }
+  override fun onContentChanged(activity: Activity) {
+    SplashScreen.show(
+      activity,
+      getResizeMode(activity),
+      ReactRootView::class.java,
+      getStatusBarTranslucent(activity)
+    )
   }
 
   private fun getResizeMode(context: Context): SplashScreenImageResizeMode =

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Move `pointerEvents` to `styles.pointerEvents`. ([#23446](https://github.com/expo/expo/pull/23446) by [@EvanBacon](https://github.com/EvanBacon))
+- [Android] Fixed splash screen is missing when using the `getDelayLoadAppHandler()` from expo-updates. ([#23747](https://github.com/expo/expo/pull/23747) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -17,6 +17,7 @@ import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.PermissionListener
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
+import expo.modules.kotlin.Utils
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
@@ -84,6 +85,9 @@ class ReactActivityDelegateWrapper(
       reactDelegate.loadApp(appKey)
       rootViewContainer.addView(reactDelegate.reactRootView, ViewGroup.LayoutParams.MATCH_PARENT)
       activity.setContentView(rootViewContainer)
+      reactActivityLifecycleListeners.forEach { listener ->
+        listener.onContentChanged(activity)
+      }
       return
     }
 
@@ -92,7 +96,11 @@ class ReactActivityDelegateWrapper(
       .firstOrNull()
     if (delayLoadAppHandler != null) {
       delayLoadAppHandler.whenReady {
+        Utils.assertMainThread()
         invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
+        reactActivityLifecycleListeners.forEach { listener ->
+          listener.onContentChanged(activity)
+        }
         if (shouldEmitPendingResume) {
           onResume()
         }
@@ -100,7 +108,10 @@ class ReactActivityDelegateWrapper(
       return
     }
 
-    return invokeDelegateMethod("loadApp", arrayOf(String::class.java), arrayOf(appKey))
+    invokeDelegateMethod<Unit, String?>("loadApp", arrayOf(String::class.java), arrayOf(appKey))
+    reactActivityLifecycleListeners.forEach { listener ->
+      listener.onContentChanged(activity)
+    }
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
# Why

close ENG-9269
fixes #23363

# How

splash screen is missing because of different call flows from delay loading #20273.

the original flow sequences are:
  - `ReactActivityDelegateWrapper.onCreate()`
  - `ReactActivityDelegate.loadApp()`
  - `Activity.setContentView()`
  - `SplashScreenViewController.showSplashScreen()`
  - `contentView.addView()` for splash view

the delay loading will change the sequences to:
  - `ReactActivityDelegateWrapper.onCreate()`
  - `SplashScreenViewController.showSplashScreen()`
  - `contentView.addView()` for splash view
  - `ReactActivityDelegate.loadApp()`
  - `Activity.setContentView()`

the splash screen will dismiss because the whole content view is replaced.

this pr tries to introduce a new `onContentChanged` lifecycle for expo-splash-screen to show splash screen at correct point.

# Test Plan

patch to https://github.com/islamouzou/expo-updates-demo provided from #23363 to see if the splash screen will not dismiss. 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
