### PR TITLE
[doc] Add a known issue section for Android

### DIFF
--- a/docs/pages/versions/v47.0.0/sdk/stripe.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/stripe.mdx
@@ -8,6 +8,7 @@ packageName: '@stripe/stripe-react-native'
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
+import { PlatformTags } from '~/ui/components/Tag';
 
 Expo includes support for [`@stripe/stripe-react-native`](https://github.com/stripe/stripe-react-native), which allows you to build delightful payment experiences in your native Android and iOS apps using React Native & Expo. This library provides powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details.
 
@@ -44,6 +45,10 @@ If you're using EAS Build, you can do most of your Stripe setup using the `@stri
 
 - **merchantIdentifier**: iOS only. This is the Apple merchant ID obtained [here](https://stripe.com/docs/apple-pay?platform=react-native). Otherwise, Apple Pay will not work as expected. If you have multiple merchantIdentifiers, you can set them in an array.
 - **enableGooglePay**: Android only. Boolean indicating whether or not Google Pay is enabled. Defaults to `false`.
+
+#### Known issues&ensp;<PlatformTags platforms={['android']} />
+
+SDK 47 onwards, `@stripe/stripe-react-native` library version `0.19.x` requires `compileSdkVersion` on Android to be `33`. However, on SDK 47, it is `31`. To override this `compileSdkVersion` value, use [`expo-build-properties`](/versions/v47.0.0/sdk/build-properties/#pluginconfigtypeandroid) config plugin.
 
 ## Example
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

An issue with SDK 47 and `@stripe/stripe-react-native": "0.19.0` was brought up in Discord today. After researching, I found a couple of similar issues with the resolution:
- https://github.com/expo/expo/issues/20597#issuecomment-1367943522
- https://github.com/expo/expo/issues/20195#issuecomment-1326696737

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a known issue section to describe the problem and provide a solution on resolving the issue by using `expo-build-properties` config plugin to override `compileSdkVersion` value.
- Changes only applied to SDK 47.

<img width="890" alt="CleanShot 2023-07-27 at 20 02 23@2x" src="https://github.com/expo/expo/assets/10234615/d9c4dc37-0d8d-4e7c-af0a-e8b62959b9c9">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v47.0.0/sdk/stripe/#common-issues

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
