### PR TITLE
Fix `npx expo upgrade` migration instructions

### DIFF
--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -127,7 +127,7 @@ if (!isSubcommand) {
     'client:install:ios': 'npx expo start --ios',
     'client:install:android': 'npx expo start --android',
     doctor: 'npx expo-doctor',
-    upgrade: 'expo-cli upgrade',
+    upgrade: 'npm install expo@latest && npx expo install --fix',
     'customize:web': 'npx expo customize',
 
     publish: 'eas update',


### PR DESCRIPTION

# Why

Fixes https://github.com/expo/expo/issues/22747

# How

Single-line documentation change.

# Test Plan

Verified locally. I successfully upgraded from Expo 48 to Expo 49 using these instructions.

# Checklist


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)