### PR TITLE
[image-picker][android] Fix non-serializable type

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On Android, the `Uri` type is not serializable and causes a crash when recreating the activity.
+- On Android, the `Uri` type is not serializable and causes a crash when recreating the activity. ([#23768](https://github.com/expo/expo/pull/23768) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android, the `Uri` type is not serializable and causes a crash when recreating the activity.
+
 ### 💡 Others
 
 ## 14.4.0 — 2023-07-28

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -63,7 +63,7 @@ class ImagePickerModule : Module() {
 
       val mediaFile = createOutputFile(cacheDirectory, options.mediaTypes.toFileExtension())
       val uri = mediaFile.toContentUri(context)
-      val contractOptions = options.toCameraContractOptions(uri)
+      val contractOptions = options.toCameraContractOptions(uri.toString())
 
       launchContract({ cameraLauncher.launch(contractOptions) }, options)
     }
@@ -138,7 +138,7 @@ class ImagePickerModule : Module() {
         result.data[0].first == MediaType.IMAGE
       ) {
         result = launchPicker {
-          cropImageLauncher.launch(CropImageContractOptions(result.data[0].second, options))
+          cropImageLauncher.launch(CropImageContractOptions(result.data[0].second.toString(), options))
         }
       }
       mediaHandler.readExtras(result.data, options)

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -46,7 +46,7 @@ internal class ImagePickerOptions : Record, Serializable {
   @Field
   var cameraType: CameraType = CameraType.BACK
 
-  fun toCameraContractOptions(uri: Uri) = CameraContractOptions(uri, this)
+  fun toCameraContractOptions(uri: String) = CameraContractOptions(uri, this)
 
   fun toImageLibraryContractOptions() = ImageLibraryContractOptions(this)
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -1,7 +1,6 @@
 package expo.modules.imagepicker
 
 import java.io.Serializable
-import android.net.Uri
 import android.provider.MediaStore
 import androidx.annotation.FloatRange
 import androidx.annotation.IntRange

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CameraContract.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.net.toUri
 import expo.modules.imagepicker.ImagePickerOptions
 import expo.modules.imagepicker.CameraType
 import expo.modules.imagepicker.toMediaType
@@ -30,7 +31,7 @@ internal class CameraContract(
 
   override fun createIntent(context: Context, input: CameraContractOptions): Intent =
     Intent(input.options.mediaTypes.toCameraIntentAction())
-      .putExtra(MediaStore.EXTRA_OUTPUT, input.uri)
+      .putExtra(MediaStore.EXTRA_OUTPUT, input.uri.toUri())
       .apply {
         if (input.options.mediaTypes.toCameraIntentAction() == MediaStore.ACTION_VIDEO_CAPTURE) {
           putExtra(MediaStore.EXTRA_DURATION_LIMIT, input.options.videoMaxDuration)
@@ -48,9 +49,9 @@ internal class CameraContract(
 
   override fun parseResult(input: CameraContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult =
     if (resultCode == Activity.RESULT_CANCELED) {
-      ImagePickerContractResult.Cancelled()
+      ImagePickerContractResult.Cancelled
     } else {
-      val uri = input.uri
+      val uri = Uri.parse(input.uri)
       val type = uri.toMediaType(contentResolver)
       ImagePickerContractResult.Success(listOf(type to uri))
     }
@@ -60,6 +61,6 @@ internal data class CameraContractOptions(
   /**
    * Destination file in a form of content-[Uri] to save results coming from camera to.
    */
-  val uri: Uri,
+  val uri: String,
   val options: ImagePickerOptions,
 ) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ContractsUtils.kt
@@ -8,6 +8,6 @@ import expo.modules.imagepicker.MediaType
  */
 internal sealed class ImagePickerContractResult private constructor() {
   class Success(val data: List<Pair<MediaType, Uri>>) : ImagePickerContractResult()
-  class Cancelled : ImagePickerContractResult()
-  class Error : ImagePickerContractResult()
+  object Cancelled : ImagePickerContractResult()
+  object Error : ImagePickerContractResult()
 }

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/CropImageContract.kt
@@ -3,7 +3,6 @@ package expo.modules.imagepicker.contracts
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.core.net.toFile
 import androidx.core.net.toUri
@@ -26,7 +25,7 @@ internal class CropImageContract(
   private val appContextProvider: AppContextProvider,
 ) : AppContextActivityResultContract<CropImageContractOptions, ImagePickerContractResult> {
   override fun createIntent(context: Context, input: CropImageContractOptions) = Intent(context, CropImageActivity::class.java).apply {
-    val mediaType = expo.modules.imagepicker.getType(context.contentResolver, input.sourceUri)
+    val mediaType = expo.modules.imagepicker.getType(context.contentResolver, input.sourceUri.toUri())
     val compressFormat = mediaType.toBitmapCompressFormat()
     val cacheDirectory = appContextProvider.appContext.cacheDirectory
     val outputUri = createOutputFile(cacheDirectory, compressFormat.toImageFileExtension()).toUri()
@@ -34,7 +33,7 @@ internal class CropImageContract(
     putExtra(
       CropImage.CROP_IMAGE_EXTRA_BUNDLE,
       bundleOf(
-        CropImage.CROP_IMAGE_EXTRA_SOURCE to input.sourceUri,
+        CropImage.CROP_IMAGE_EXTRA_SOURCE to input.sourceUri.toUri(),
         CropImage.CROP_IMAGE_EXTRA_OPTIONS to CropImageOptions().apply {
           outputCompressFormat = compressFormat
           outputCompressQuality = (input.options.quality * 100).toInt()
@@ -47,8 +46,6 @@ internal class CropImageContract(
             fixAspectRatio = true
             initialCropWindowPaddingRatio = 0f
           }
-
-          validate()
         }
       )
     )
@@ -61,16 +58,16 @@ internal class CropImageContract(
       intent?.getParcelableExtra(CropImage.CROP_IMAGE_EXTRA_RESULT)
     }
     if (resultCode == Activity.RESULT_CANCELED || result == null) {
-      return ImagePickerContractResult.Cancelled()
+      return ImagePickerContractResult.Cancelled
     }
     val targetUri = requireNotNull(result.uriContent)
     val contentResolver = requireNotNull(appContextProvider.appContext.reactContext) { "React Application Context is null" }.contentResolver
-    runBlocking { copyExifData(input.sourceUri, targetUri.toFile(), contentResolver) }
+    runBlocking { copyExifData(input.sourceUri.toUri(), targetUri.toFile(), contentResolver) }
     return ImagePickerContractResult.Success(listOf(MediaType.IMAGE to targetUri))
   }
 }
 
 internal data class CropImageContractOptions(
-  val sourceUri: Uri,
+  val sourceUri: String,
   val options: ImagePickerOptions,
 ) : Serializable

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
@@ -75,7 +75,7 @@ internal class ImageLibraryContract(
 
   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
     if (resultCode == Activity.RESULT_CANCELED) {
-      ImagePickerContractResult.Cancelled()
+      ImagePickerContractResult.Cancelled
     } else {
       intent?.takeIf { resultCode == Activity.RESULT_OK }?.getAllDataUris()?.let { uris ->
         if (input.options.allowsMultipleSelection) {
@@ -94,10 +94,10 @@ internal class ImageLibraryContract(
             uris.firstOrNull()?.let { uri ->
               val type = uri.toMediaType(contentResolver)
               ImagePickerContractResult.Success(listOf(type to uri))
-            } ?: ImagePickerContractResult.Error()
+            } ?: ImagePickerContractResult.Error
           }
         }
-      } ?: ImagePickerContractResult.Error()
+      } ?: ImagePickerContractResult.Error
     }
 }
 


### PR DESCRIPTION
# Why
Partially addresses #23447. The `Uri` type is not serializable and will cause a crash when recreating the activity if it has been destroyed.

# How
Switch from using `Uri` to `String` and convert back and forth where necessary

# Test Plan
When setting the developer option `Don't keep activities` every activity is destroyed after they are left. While using a `Uri` this would crash with a `NotSerializableException`, using a `String` resolves this but it still crashes. When the activity is recreated, the expo module is not recreated or at least not soon enough to prevent a crash.
