### PR TITLE
[docs] Update nesting-navigators.mdx

### DIFF
--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -24,14 +24,14 @@ Consider the following file structure which is used as an example in this guide:
   ]}
 />
 
-In the above example, **app/home/feed.js** matches `/home/feed` and **app/home/messages.js** matches `/home/messages`.
+In the example above, **app/home/feed.js** matches `/home/feed` and **app/home/messages.js** matches `/home/messages`.
 
 ```jsx app/_layout.js
 import { Stack } from 'expo-router';
 export default Stack;
 ```
 
-This is nested in the **\_layout.js** layout, so it will be rendered as a stack.
+Both **app/_layout.js** and **app/index.js** below are nested in the **\_layout.js** layout, so it will be rendered as a stack.
 
 ```jsx app/home/_layout.js
 import { Tabs } from 'expo-router';
@@ -45,7 +45,7 @@ export default function Root() {
 }
 ```
 
-This is nested in the **home/\_layout.js** layout, so it will be rendered as a tab.
+Both **app/home/feed.js** and **app/home/messages.js** below are nested in the **home/\_layout.js** layout, so it will be rendered as a tab.
 
 ```jsx app/home/feed.js
 import { View, Text } from 'react-native';

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -24,7 +24,7 @@ Consider the following file structure which is used as an example in this guide:
   ]}
 />
 
-In the example above, **app/home/feed.js** matches `/home/feed` and **app/home/messages.js** matches `/home/messages`.
+In the above example, **app/home/feed.js** matches `/home/feed`, and **app/home/messages.js** matches `/home/messages`.
 
 ```jsx app/_layout.js
 import { Stack } from 'expo-router';


### PR DESCRIPTION

# Why

For the documentation for the nesting-navigators it was unclear which code blocks were being referenced with the explanation text to accompany it. It refers to **This is nested** but it isn't clear at first glance if you are meant to look at the above or below code block.


<img width="1121" alt="Screenshot 2023-07-30 at 1 24 17 AM" src="https://github.com/expo/expo/assets/43126781/59bf2627-7d03-4828-8f38-f2072dcb4c9a">

# How

I updated the "nesting-navigators" documentation to be more clear on what is being referenced in the code blocks and the explanation text provided.


- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
