### PR TITLE
[ios][camera] Fix flash not enabled during recording

### DIFF
--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -626,6 +626,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       NSString *path = [self.fileSystem generatePathInDirectory:directory withExtension:@".mov"];
       NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
       [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
+      [self updateFlashMode];
       self.videoRecordedResolve = resolve;
       self.videoRecordedReject = reject;
     });


### PR DESCRIPTION
# Why
Fixes #21749 (and also closed issues #16246 #6361).

# How

As noted in the code, the tochMode needs to be configured after the session / recording is started: https://github.com/tszheichoi/expo/blob/d25b21ada34bd06acf5716ff0246e6a867e49901/packages/expo-camera/ios/EXCamera/EXCamera.m#L842-L843


# Test Plan

Verified on device