### PR TITLE
[ios][media-library] Fix using incorrect permissions requester

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On iOS, fix issue where the wrong requester class was used if the user had requested `writeOnly` permissions.
+- On iOS, fix issue where the wrong requester class was used if the user had requested `writeOnly` permissions. ([#23780](https://github.com/expo/expo/pull/23780) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On iOS, fix issue where the wrong requester class was used if the user had requested `writeOnly` permissions.
+
 ### 💡 Others
 
 ## 15.5.0 — 2023-07-28

--- a/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
+++ b/packages/expo-media-library/ios/EXMediaLibrary/EXMediaLibrary.m
@@ -37,6 +37,7 @@ NSString *const EXMediaLibraryShouldDownloadFromNetworkKey = @"shouldDownloadFro
 @property (nonatomic, weak) id<EXFileSystemInterface> fileSystem;
 @property (nonatomic, weak) id<EXEventEmitterService> eventEmitter;
 @property (nonatomic, strong) NSMutableSet *saveToLibraryDelegates;
+@property (nonatomic) BOOL writeOnly;
 
 @end
 
@@ -112,6 +113,7 @@ EX_EXPORT_METHOD_AS(getPermissionsAsync,
                     resolve:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
+  _writeOnly = writeOnly;
   [EXPermissionsMethodsDelegate getPermissionWithPermissionsManager:_permissionsManager
                                                       withRequester:[self requesterClass:writeOnly]
                                                             resolve:resolve
@@ -123,6 +125,7 @@ EX_EXPORT_METHOD_AS(requestPermissionsAsync,
                     resolve:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
+  _writeOnly = writeOnly;
   [EXPermissionsMethodsDelegate askForPermissionWithPermissionsManager:_permissionsManager
                                                          withRequester:[self requesterClass:writeOnly]
                                                                resolve:resolve
@@ -1177,7 +1180,7 @@ EX_EXPORT_METHOD_AS(getAssetsAsync,
 
 - (BOOL)_checkPermissions:(EXPromiseRejectBlock)reject
 {
-  if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[EXMediaLibraryMediaLibraryPermissionRequester class]]) {
+  if (![_permissionsManager hasGrantedPermissionUsingRequesterClass:[self requesterClass:_writeOnly]]) {
     reject(@"E_NO_PERMISSIONS", @"MEDIA_LIBRARY permission is required to do this operation.", nil);
     return NO;
   }


### PR DESCRIPTION
# Why
Closes #23631

# How
We weren't using the correct requester class when the user had requested `writeOnly` permissions.

# Test Plan
Tested in bare expo and with an app using the provided repro.