### PR TITLE
Always apply custom Metro resolver in Expo CLI.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Always apply custom Metro resolver in Expo CLI.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Always apply custom Metro resolver in Expo CLI.
+- Always apply custom Metro resolver in Expo CLI. ([#23784](https://github.com/expo/expo/pull/23784) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -373,9 +373,6 @@ export async function withMetroMultiPlatformAsync(
 
   if (platformBundlers.web === 'metro') {
     await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
-  } else if (!isTsconfigPathsEnabled) {
-    // Bail out early for performance enhancements if no special features are enabled.
-    return config;
   }
 
   let tsconfig: null | TsConfigPaths = null;


### PR DESCRIPTION
# Why

- mjs resolver must always be applied.
- There are probably other side effects but everything is getting more test coverage this way.
