### PR TITLE
Migrate router theme doc

### DIFF
--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -97,7 +97,7 @@ export default function App() {
 
 ## React Navigation themes
 
-React Navigation navigators `<Stack>`, `<Drawer>` and `<Tabs>` use a shared appearance provider. In React Navigation, you set the theme for the entire app using the `<NavigationContainer />` component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
+React Navigation navigators `<Stack>`, `<Drawer>`, and `<Tabs>` use a shared appearance provider. In React Navigation, you set the theme for the entire app using the `<NavigationContainer />` component. Expo Router manages the root container so that you can set the theme using the `ThemeProvider` directly.
 
 ```tsx app/_layout.tsx
 /* @info Import theme APIs from React Navigation directly. */

--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -95,6 +95,30 @@ export default function App() {
 }
 ```
 
+## React Navigation themes
+
+React Navigation navigators `<Stack>`, `<Drawer>` and `<Tabs>` use a shared appearance provider. In React Navigation, you set the theme for the entire app using the `<NavigationContainer />` component. Expo Router manages the root container for you, so instead you should set the theme using the `ThemeProvider` directly.
+
+```tsx app/_layout.tsx
+/* @info Import theme APIs from React Navigation directly. */
+import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
+/* @end */
+
+import { Slot } from 'expo-router';
+
+export default function RootLayout() {
+  return (
+    /* @info All layouts inside this provider will use the dark theme. */
+    <ThemeProvider value={DarkTheme}>
+      /* @end */
+      <Slot />
+    </ThemeProvider>
+  );
+}
+```
+
+You can use this technique at any layer of the app to set the theme for a specific layout. The current theme can be accessed with `useTheme` from `@react-navigation/native`.
+
 ## Next steps
 
 <BoxLink


### PR DESCRIPTION


# Why

- Migrate this doc to expo docs https://expo.github.io/router/docs/migration/react-navigation/themes/

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
