### PR TITLE
[docs] Minor fixes in config plugin intro and third-party authentication guide

### DIFF
--- a/docs/pages/config-plugins/introduction.mdx
+++ b/docs/pages/config-plugins/introduction.mdx
@@ -23,7 +23,7 @@ Expo config plugins mostly come from Node.js modules. You can install them just 
 
 For example, `expo-camera` has a plugin that adds camera permissions to the **AndroidManifest.xml** and **Info.plist**. To install it in your project, run the following command:
 
-<Terminal cmd={['$ expo install expo-camera']} />
+<Terminal cmd={['$ npx expo install expo-camera']} />
 
 In your app's config (**app.json**, or **app.config.js**), you can add `expo-camera` to the list of plugins:
 

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -135,13 +135,12 @@ export default function App() {
   image={ASSETS.asgardeo}
 >
 
-| Website                       | Provider | PKCE      | Auto Discovery |
-| ----------------------------- | -------- | --------- | -------------- |
+| Website                                         | Provider | PKCE      | Auto Discovery |
+| ----------------------------------------------- | -------- | --------- | -------------- |
 | [Get Your Config](https://console.asgardeo.io/) | OpenID   | Supported | Available      |
 
-
 - Make sure to check `Public Client` option in the console.
-- Choose the intended grant in the  Allowed grant types  section.
+- Choose the intended grant in the Allowed grant types section.
 
 <Tabs tabs={["Auth Code", "Implicit Flow"]}>
 
@@ -1409,9 +1408,9 @@ export default function App() {
   image={ASSETS.keycloak}
 >
 
-| Website                  | Provider | PKCE     | Auto Discovery |
-| ------------------------ | -------- | -------- | -------------- |
-| - | OpenID   | Required | Available      |
+| Website | Provider | PKCE     | Auto Discovery |
+| ------- | -------- | -------- | -------------- |
+| -       | OpenID   | Required | Available      |
 
 {/* prettier-ignore */}
 ```tsx Keycloak Example
@@ -1426,7 +1425,7 @@ export default function App() {
   /* @info If the provider supports auto discovery then you can pass an issuer to the `useAutoDiscovery` hook to fetch the discovery document. */
   const discovery = useAutoDiscovery('https://YOUR_KEYCLOAK/realms/YOUR_REALM');
   /* @end */
-  
+
 // Create and load an auth request
   const [request, result, promptAsync] = useAuthRequest(
     {

--- a/docs/ui/components/Authentication/index.ts
+++ b/docs/ui/components/Authentication/index.ts
@@ -19,6 +19,7 @@ export const ASSETS = {
   github: ASSETS_PATH + 'github.png',
   google: ASSETS_PATH + 'google.png',
   imgur: ASSETS_PATH + 'imgur.png',
+  keycloak: ASSETS_PATH + 'keycloak.png',
   okta: ASSETS_PATH + 'okta.png',
   reddit: ASSETS_PATH + 'reddit.png',
   slack: ASSETS_PATH + 'slack.png',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- The command described doesn't use `npx` in config plugin intro doc
- Keycloak logo not shown in third party auth guide

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `npx` as the prefix to the installation command in config plugin intro doc
- Add path of the image asset to display the logo in the third party auth guide

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes have been tested by running docs locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
