### PR TITLE
[ios][expo-av] Fixes recording status not reset when paused before stopping

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed recording status not being reset when recording is paused before being stopping. ([#21747](https://github.com/expo/expo/issues/21747))
+
 ### 💡 Others
 
 ## 13.5.1 — 2023-08-02

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed recording status not being reset when recording is paused before being stopping. ([#21747](https://github.com/expo/expo/issues/21747))
+- Fixed recording status not being reset when recording is paused before being stopping. ([#21747](https://github.com/expo/expo/issues/21747)) ([#23816](https://github.com/expo/expo/pull/23816) by [@mojavad](https://github.com/mojavad))
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -971,13 +971,14 @@ EX_EXPORT_METHOD_AS(stopAudioRecording,
                     rejecter:(EXPromiseRejectBlock)reject)
 {
   if ([self _checkAudioRecorderExistsOrReject:reject]) {
+    _audioRecorderDurationMillis = [self _getDurationMillisOfRecordingAudioRecorder];
     if (_audioRecorder.recording) {
-      _audioRecorderDurationMillis = [self _getDurationMillisOfRecordingAudioRecorder];
       [_audioRecorder stop];
+    }
       _prevAudioRecorderDurationMillis = 0;
       _audioRecorderStartTimestamp = 0;
       [self demoteAudioSessionIfPossible];
-    }
+
     resolve([self _getAudioRecorderStatus]);
   }
 }


### PR DESCRIPTION
# Why

Currently, there is an edge case where the status of a recording is not reset if the user pauses a recording before stopping on iOS. 

This means that when they start a new recording the time duration shows incorrectly.

Fixes #21747
Fixes #22878
Fixes #22972

# How

The status was only being updated on stop when `audioRecorder`'s `recording` property was `true`. I've moved that logic outside and only call the `stop` method of `audioRecorder` when `recording`.

# Test Plan

E2E Test Runners Passing Fully: 
<img width="349" alt="image" src="https://github.com/expo/expo/assets/34189022/a3a581df-ca49-42de-99da-a38e706311a4">

To manually test, open the Recording component in `bare-expo`: 

- User starts a recording
- Talk for 3sec
- User hit pause
- User ends the recording
- Timer resets to 0
- User starts recording again
- *Timer should be reset to 0 second*

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
