### PR TITLE
[expo-modules-core][Android] NativeModulesProxy should refresh on reload

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Refresh NativeModulesProxy if app bundle is reloaded. ([#23824](https://github.com/expo/expo/pull/23824) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 ## 1.6.0 — 2023-07-28

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -135,7 +135,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
     @Nullable ModuleRegistry moduleRegistry
   ) {
     if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
-      setModulesProxy(mModulesProxy);
+      mModulesProxy = null;
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/ModuleRegistryAdapter.java
@@ -135,7 +135,7 @@ public class ModuleRegistryAdapter implements ReactPackage {
     @Nullable ModuleRegistry moduleRegistry
   ) {
     if (mModulesProxy != null && mModulesProxy.getReactContext() != reactContext) {
-      mModulesProxy = null;
+      setModulesProxy(null);
     }
     if (mModulesProxy == null) {
       ModuleRegistry registry = moduleRegistry != null ? moduleRegistry : mModuleRegistryProvider.get(reactContext);


### PR DESCRIPTION
# Why

On Android, the `expo-updates` `reloadAsync()` API does correctly launch a downloaded update bundle. However, the values of several constants in the module are not refreshed with the new values for the new bundle as expected. Among other problems, this leads to incorrect behavior of `expo-asset`, which relies on the value of `Updates.isUsingEmbeddedAssets` to find the correct paths to application assets, so that fonts and images are missing until the app is restarted from scratch.

The root cause of this issue is that a reload on iOS causes the NativeModulesProxy object to be rebuilt, but Android continues to use a cached object created on app startup. Both platforms should behave identically and should rebuild NativeModulesProxy and refresh all module constants.

Note: the Android caching was introduced in https://github.com/expo/expo/pull/23710 .

# How

Modified the code that creates NativeModulesProxy to discard the cached value when being created on a reload.

# Test Plan

- Manually test using Updates API Demo
- All CI should continue to pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
