### PR TITLE
Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`.
+- Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`.
+
 ### 💡 Others
 
 ## 0.11.1 — 2023-08-02

--- a/packages/@expo/cli/src/run/ios/codeSigning/xcodeCodeSigning.ts
+++ b/packages/@expo/cli/src/run/ios/codeSigning/xcodeCodeSigning.ts
@@ -87,6 +87,10 @@ export function mutateXcodeProjectWithAutoCodeSigningInfo({
     Object.entries(IOSConfig.XcodeUtils.getProjectSection(project))
       .filter(IOSConfig.XcodeUtils.isNotComment)
       .forEach(([, item]: IOSConfig.XcodeUtils.ProjectSectionEntry) => {
+        if (!item.attributes.TargetAttributes) {
+          item.attributes.TargetAttributes = {};
+        }
+
         if (!item.attributes.TargetAttributes[nativeTargetId]) {
           item.attributes.TargetAttributes[nativeTargetId] = {};
         }


### PR DESCRIPTION
# Why

Bug discovered when running with `@bacons/xcode` which correctly asserts that `TargetAttributes` is not required. This bug shouldn't break standard SDK 49 since we do define `TargetAttributes` by default https://github.com/expo/expo/blob/ee9ef118cc3ddf1ae2ed311b4a50e770ce55f6db/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj#L165. But `@bacons/xcode` could "corrupt" the project, will take a pass at that next.
