### PR TITLE
[ENG-9562][docs] update rollout instructions

### DIFF
--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rollouts
-hideTOC: true
+description: Incrementally deploy updates on a new branch to a channel.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -28,5 +28,5 @@ Two methods are available to end a rollout when you choose the `End` option in t
 
 - Only one branch can be rolled out on a channel at a single time.
 - To see the state of the rollout, use the `eas channel:rollout` command.
-- When a rollout is in progress, you can publish updates to both branches by running `eas update --branch [branch]`, for example.
+- When a rollout is in progress, you can publish updates to both rolled out and current branches by running `eas update --branch [branch]`, for example.
 - `eas update --channel [channel]` cannot be used when a rollout is in progress since it cannot know which branch to associate the update with.

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -19,7 +19,7 @@ In the terminal, an interactive guide will assist you in selecting a channel, ch
 
 ## End a rollout
 
-Two methods are available to end a rollout when we choose the `End` option in the interactive guide:
+Two methods are available to end a rollout when you choose the `End` option in the interactive guide:
 
 - **Republish and revert:** This option can be used once you are confident with the update served from the new branch. This will publish the update again on the old branch and users will be reverted back to it.
 - **Revert:** Choose to disregard the updates on the new branch and return users to the old branch.

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -15,7 +15,7 @@ To start a rollout, we use `npx eas-cli@latest` or ensure we have version \<TODO
 
 In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 
-### Ending a rollout
+## End a rollout
 
 Two methods are available to end a rollout when we choose the `End` option in the interactive guide:
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 > This feature is in Developer Preview. It's not advised to use this feature in any production environments.
 
-Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, we can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
+Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, you can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 
 ## Start a rollout
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -13,7 +13,7 @@ Rollouts incrementally deploy updates on a new branch to a specific channel. Wit
 
 To start a rollout, use `npx eas-cli@latest` or ensure you have version \<TODO\> or above for `eas-cli`. Then, run the following command:
 
-<Terminal cmd={['npx eas-cli@latest channel:rollout [channel]']} />
+<Terminal cmd={['npx eas-cli@latest channel:rollout']} />
 
 In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 
@@ -27,6 +27,6 @@ Two methods are available to end a rollout when you choose the `End` option in t
 ## Work with rollouts
 
 - Only one branch can be rolled out on a channel at a single time.
-- To see the state of the rollout, use the `eas channel:rollout [channel]` command.
+- To see the state of the rollout, use the `eas channel:rollout` command.
 - When a rollout is in progress, you can publish updates to both branches by running `eas update --branch [branch]`, for example.
 - `eas update --channel [channel]` cannot be used when a rollout is in progress since it cannot know which branch to associate the update with.

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -21,7 +21,7 @@ In the terminal, an interactive guide will assist you in selecting a channel, ch
 
 Two methods are available to end a rollout when we choose the `End` option in the interactive guide:
 
-- Republish and revert: This option can be used once we are confident with the update served from our new branch. By choosing this, we'll republish the update onto the old branch and revert users back to it.
+- **Republish and revert:** This option can be used once you are confident with the update served from the new branch. This will publish the update again on the old branch and users will be reverted back to it.
 - Revert: Disregard the updates on the new branch and return users to the old branch.
 
 ### Working with rollouts

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -9,7 +9,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, we can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 
-To start a rollout, we use `npx eas-cli@latest` or ensure we have version \<TODO\> or above for `eas-cli`. Then we run the following command:
+## Start a rollout
+
+To start a rollout, use `npx eas-cli@latest` or ensure you have version \<TODO\> or above for `eas-cli`. Then, run the following command:
 
 <Terminal cmd={['npx eas-cli@latest channel:rollout [channel]']} />
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -27,6 +27,6 @@ Two methods are available to end a rollout when you choose the `End` option in t
 ## Work with rollouts
 
 - Only one branch can be rolled out on a channel at a single time.
-- To see the state of the rollout, we use the `eas channel:rollout [channel]` command.
-- When a rollout is in progress, we can publish updates to both branches by running `eas update --branch [branch]`, for example.
-- `eas update --channel [channel]` cannot be used when a rollout is in progress, since it cannot know which branch to associate the update with.
+- To see the state of the rollout, use the `eas channel:rollout [channel]` command.
+- When a rollout is in progress, you can publish updates to both branches by running `eas update --branch [branch]`, for example.
+- `eas update --channel [channel]` cannot be used when a rollout is in progress since it cannot know which branch to associate the update with.

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -22,7 +22,7 @@ In the terminal, an interactive guide will assist you in selecting a channel, ch
 Two methods are available to end a rollout when we choose the `End` option in the interactive guide:
 
 - **Republish and revert:** This option can be used once you are confident with the update served from the new branch. This will publish the update again on the old branch and users will be reverted back to it.
-- Revert: Disregard the updates on the new branch and return users to the old branch.
+- **Revert:** Choose to disregard the updates on the new branch and return users to the old branch.
 
 ### Working with rollouts
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -13,7 +13,7 @@ To start a rollout, we use `npx eas-cli@latest` or ensure we have version \<TODO
 
 <Terminal cmd={['npx eas-cli@latest channel:rollout [channel]']} />
 
-An interactive guide will assist us in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, we run the command again and choose the `Edit` option to adjust the rollout percentage.
+In the terminal, an interactive guide will assist you in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, run the command again and choose the `Edit` option to adjust the rollout percentage.
 
 ### Ending a rollout
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -2,24 +2,29 @@
 title: Rollouts
 hideTOC: true
 ---
+
 import { Terminal } from '~/ui/components/Snippet';
 
+> This feature is in Developer Preview. It's not advised to use this feature in any production environments.
 
-Rollouts allow deploying a new branch to a specific channel incrementally. With rollouts, we can roll out one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to your production environment.
+Rollouts incrementally deploy updates on a new branch to a specific channel. With rollouts, we can roll out updates from one branch to a percentage of end users and leave the remaining percentage of users on the current branch. This is useful when testing a new feature to minimize the risk of introducing bugs or other issues to our production environment.
 
-To initiate a rollout, use the following command:
+To start a rollout, we use `npx eas-cli@latest` or ensure we have version \<TODO\> or above for `eas-cli`. Then we run the following command:
 
-<Terminal cmd={["eas channel:rollout [channel]"]} />
+<Terminal cmd={['npx eas-cli@latest channel:rollout [channel]']} />
 
-The interactive prompts will guide you through choosing a channel, a branch to begin rolling out, and the percentage of your users to rollout to. To increase or decrease the rollout amount, run the `eas channel:rollout [channel]` command again to adjust the rollout percentage.
+An interactive guide will assist us in selecting a channel, choosing a branch for the rollout, and setting the percentage of users for the rollout. To increase or decrease the rollout amount, we run the command again and choose the `Edit` option to adjust the rollout percentage.
 
-Once you feel confident with your new branch, or if you want to revert to your original branch, you can end the rollout with the `--end` flag:
+### Ending a rollout
 
-<Terminal cmd={["eas channel:rollout [channel] --end"]} />
+Two methods are available to end a rollout when we choose the `End` option in the interactive guide:
 
-Facts that will help you when working with rollouts:
-- You can only have one branch rolling out on a channel at a single time.
-- To see the state of the rollout, use the `eas channel:view [channel]` command.
-- When a rollout is in progress, you can publish updates to both branches by running `eas update --branch [branch]`, for example.
-- You cannot use `eas update --channel [channel]` when a rollout is in progress, since it cannot know which branch to associate the update with.
+- Republish and revert: This option can be used once we are confident with the update served from our new branch. By choosing this, we'll republish the update onto the old branch and revert users back to it.
+- Revert: Disregard the updates on the new branch and return users to the old branch.
 
+### Working with rollouts
+
+- Only one branch can be rolled out on a channel at a single time.
+- To see the state of the rollout, we use the `eas channel:rollout [channel]` command.
+- When a rollout is in progress, we can publish updates to both branches by running `eas update --branch [branch]`, for example.
+- `eas update --channel [channel]` cannot be used when a rollout is in progress, since it cannot know which branch to associate the update with.

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -11,7 +11,7 @@ Rollouts incrementally deploy updates on a new branch to a specific channel. Wit
 
 ## Start a rollout
 
-To start a rollout, use `npx eas-cli@latest` or ensure you have version \<TODO\> or above for `eas-cli`. Then, run the following command:
+To start a rollout, use `npx eas-cli@latest` or ensure you have `eas-cli` version `4.0.0` or above. Then, run the following command:
 
 <Terminal cmd={['npx eas-cli@latest channel:rollout']} />
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -24,7 +24,7 @@ Two methods are available to end a rollout when you choose the `End` option in t
 - **Republish and revert:** This option can be used once you are confident with the update served from the new branch. This will publish the update again on the old branch and users will be reverted back to it.
 - **Revert:** Choose to disregard the updates on the new branch and return users to the old branch.
 
-### Working with rollouts
+## Work with rollouts
 
 - Only one branch can be rolled out on a channel at a single time.
 - To see the state of the rollout, we use the `eas channel:rollout [channel]` command.


### PR DESCRIPTION
# Why

Update the rollout docs for developer preview 

# Before merging
release `eas-cli` and update the doc with the latest version

# Test Plan

manually tested

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
