### PR TITLE
[ios][camera] Fix dead or dark frames when video starts

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed flash is not enabled during recordings. ([#23776](https://github.com/expo/expo/pull/23776) by [@tszheichoi](https://github.com/tszheichoi))
+- On iOS, fix dead frames when starting a video recording. ([#22037](https://github.com/expo/expo/pull/22037) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -62,13 +62,12 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     _previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:_session];
     _previewLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
     _previewLayer.needsDisplayOnBoundsChange = YES;
+    _previewLayer.session = _session;
 #endif
     _paused = NO;
     _isValidVideoOptions = YES;
     _pictureSize = AVCaptureSessionPresetHigh;
     [self changePreviewOrientation:[UIApplication sharedApplication].statusBarOrientation];
-    [self initializeCaptureSessionInput];
-    [self startSession];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(orientationChanged:)
                                                  name:UIDeviceOrientationDidChangeNotification
@@ -77,6 +76,8 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     _motionManager = [[CMMotionManager alloc] init];
     _motionManager.accelerometerUpdateInterval = 0.2;
     _motionManager.gyroUpdateInterval = 0.2;
+    [self initializeCaptureSessionInput];
+    [self startSession];
   }
   return self;
 }
@@ -322,7 +323,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)updatePictureSize
 {
-  [self updateSessionPreset:_pictureSize];
+  dispatch_async(self.sessionQueue, ^{
+    [self updateSessionPreset:_pictureSize];
+  });
 }
 
 - (void)updateResponsiveOrientationWhenOrientationLocked
@@ -561,22 +564,58 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 - (void)record:(NSDictionary *)options resolve:(EXPromiseResolveBlock)resolve reject:(EXPromiseRejectBlock)reject
 {
-  if (_movieFileOutput == nil) {
-    // At the time of writing AVCaptureMovieFileOutput and AVCaptureVideoDataOutput (> GMVDataOutput)
-    // cannot coexist on the same AVSession (see: https://stackoverflow.com/a/4986032/1123156).
-    // We stop face detection here and restart it in when AVCaptureMovieFileOutput finishes recording.
-    if (_faceDetectorManager) {
-      [_faceDetectorManager stopFaceDetection];
-    }
-    [self setupMovieFileCapture];
+  if (_faceDetectorManager) {
+    [_faceDetectorManager stopFaceDetection];
   }
+  
+  dispatch_async(self.sessionQueue, ^{
+    [self configureVideoSessionWith:options reject:reject];
 
-  if (_movieFileOutput != nil && !_movieFileOutput.isRecording && _videoRecordedResolve == nil && _videoRecordedReject == nil) {
-    bool shouldBeMuted = options[@"mute"] && [options[@"mute"] boolValue];
-    [self updateSessionAudioIsMuted:shouldBeMuted];
+    // it is possible that the session has been invalidated at this point
+    // for example, the video codec option is invalid and so this call has already rejected
+    if (!self.isValidVideoOptions) {
+      return;
+    }
+    
+    if (!self) {
+      reject(@"E_IMAGE_SAVE_FAILED", @"Camera view has been unmounted.", nil);
+      return;
+    }
+    if (!self.fileSystem) {
+      reject(@"E_IMAGE_SAVE_FAILED", @"No file system module", nil);
+      return;
+    }
+    NSString *directory = [self.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"];
+    NSString *path = [self.fileSystem generatePathInDirectory:directory withExtension:@".mov"];
+    NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
+    self.videoRecordedResolve = resolve;
+    self.videoRecordedReject = reject;
+    [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
+  });
+}
 
-    AVCaptureConnection *connection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-    // TODO: Add support for videoStabilizationMode (right now it is not only read, never written to)
+- (void)configureVideoSessionWith:(NSDictionary *)options reject:(EXPromiseRejectBlock)reject
+{
+  [self.session beginConfiguration];
+  bool shouldBeMuted = options[@"mute"] && [options[@"mute"] boolValue];
+  [self setupMovieFileCapture];
+  [self updateSessionAudioIsMuted:shouldBeMuted];
+  
+  AVCaptureConnection *connection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
+  // TODO: Add support for videoStabilizationMode (right now it is not only read, never written to)
+  if (connection) {
+    AVCaptureSessionPreset preset;
+    if (options[@"quality"]) {
+      EXCameraVideoResolution resolution = [options[@"quality"] integerValue];
+      preset = [EXCameraUtils captureSessionPresetForVideoResolution:resolution];
+    } else if ([self.session.sessionPreset isEqual:AVCaptureSessionPresetPhoto]) {
+      preset = AVCaptureSessionPresetHigh;
+    }
+      
+    if (preset != nil) {
+      [self updateSessionPreset:preset];
+    }
+    
     if (connection.isVideoStabilizationSupported == NO) {
       EXLogWarn(@"%s: Video Stabilization is not supported on this device.", __func__);
     } else {
@@ -585,18 +624,6 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     UIDeviceOrientation deviceOrientation = self.responsiveOrientationWhenOrientationLocked ? self.physicalOrientation : [[UIDevice currentDevice] orientation];
     [connection setVideoOrientation:[EXCameraUtils videoOrientationForDeviceOrientation:deviceOrientation]];
     
-    AVCaptureSessionPreset preset;
-    if (options[@"quality"]) {
-      EXCameraVideoResolution resolution = [options[@"quality"] integerValue];
-      preset = [EXCameraUtils captureSessionPresetForVideoResolution:resolution];
-    } else if ([self.session.sessionPreset isEqual:AVCaptureSessionPresetPhoto]) {
-      preset = AVCaptureSessionPresetHigh;
-    }
-
-    if (preset != nil) {
-      [self updateSessionPreset:preset];
-    }
-    
     [self setVideoOptions:options forConnection:connection onReject:reject];
     
     bool canBeMirrored = connection.isVideoMirroringSupported;
@@ -604,42 +631,17 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     if (canBeMirrored && shouldBeMirrored) {
       [connection setVideoMirrored:shouldBeMirrored];
     }
-
-    EX_WEAKIFY(self);
-    dispatch_async(self.sessionQueue, ^{
-      EX_STRONGIFY(self);
-      // it is possible that the session has been invalidated at this point
-      // for example, the video codec option is invalid and so this call has already rejected
-      if (!self.isValidVideoOptions) {
-        return;
-      }
-
-      if (!self) {
-        reject(@"E_IMAGE_SAVE_FAILED", @"Camera view has been unmounted.", nil);
-        return;
-      }
-      if (!self.fileSystem) {
-        reject(@"E_IMAGE_SAVE_FAILED", @"No file system module", nil);
-        return;
-      }
-      NSString *directory = [self.fileSystem.cachesDirectory stringByAppendingPathComponent:@"Camera"];
-      NSString *path = [self.fileSystem generatePathInDirectory:directory withExtension:@".mov"];
-      NSURL *outputURL = [[NSURL alloc] initFileURLWithPath:path];
-      [self.movieFileOutput startRecordingToOutputFileURL:outputURL recordingDelegate:self];
-      [self updateFlashMode];
-      self.videoRecordedResolve = resolve;
-      self.videoRecordedReject = reject;
-    });
   }
+
+  [self updateFlashMode];
+  [self.session commitConfiguration];
 }
 
 // Video options are set in an async block to prevent the possible race condition outlined here:
 // https://github.com/react-native-camera/react-native-camera/pull/2694
 - (void)setVideoOptions:(NSDictionary *)options forConnection:(AVCaptureConnection *)connection onReject:(EXPromiseRejectBlock)reject
 {
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_STRONGIFY(self);
+  dispatch_async(self.sessionQueue, ^{
     // Reset validation flag
     self.isValidVideoOptions = YES;
 
@@ -691,7 +693,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 - (void)stopRecording
 {
-  [_movieFileOutput stopRecording];
+  dispatch_async(self.sessionQueue, ^{
+    [self.movieFileOutput stopRecording];
+  });
 }
 
 - (void)resumePreview
@@ -715,13 +719,11 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
     return;
   }
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_ENSURE_STRONGIFY(self);
-
+  dispatch_async(self.sessionQueue, ^{
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       return;
     }
+    [self.session beginConfiguration];
 
     AVCapturePhotoOutput *photoOutput = [AVCapturePhotoOutput new];
     photoOutput.highResolutionCaptureEnabled = YES;
@@ -730,12 +732,11 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       [self.session addOutput:photoOutput];
       self.photoOutput = photoOutput;
     }
+    [self.session commitConfiguration];
 
     [self setRuntimeErrorHandlingObserver:
      [[NSNotificationCenter defaultCenter] addObserverForName:AVCaptureSessionRuntimeErrorNotification object:self.session queue:nil usingBlock:^(NSNotification *note) {
-      EX_ENSURE_STRONGIFY(self);
       dispatch_async(self.sessionQueue, ^{
-        EX_ENSURE_STRONGIFY(self)
         // Manually restarting the session since it must
         // have been stopped due to an error.
         [self.session startRunning];
@@ -747,7 +748,6 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     // when BarCodeScanner is enabled since the beginning of camera component lifecycle,
     // some race condition occurs in reconfiguration and barcodes aren't scanned at all
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
-      EX_ENSURE_STRONGIFY(self);
       [self maybeStartFaceDetection:self.presetCamera!=1];
       if (self.barCodeScanner) {
         [self.barCodeScanner maybeStartBarCodeScanning];
@@ -758,6 +758,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
       [self onReady:nil];
     });
   });
+
 #pragma clang diagnostic pop
 }
 
@@ -766,10 +767,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_ENSURE_STRONGIFY(self);
-
+  dispatch_async(self.sessionQueue, ^{
     if (self.faceDetectorManager) {
       [self.faceDetectorManager stopFaceDetection];
     }
@@ -778,8 +776,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     }
     [self.motionManager stopAccelerometerUpdates];
     [self.previewLayer removeFromSuperlayer];
-    [self.session commitConfiguration];
-    [self.session stopRunning];
+    [self.session beginConfiguration];
     for (AVCaptureInput *input in self.session.inputs) {
       [self.session removeInput:input];
     }
@@ -787,6 +784,8 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     for (AVCaptureOutput *output in self.session.outputs) {
       [self.session removeOutput:output];
     }
+    [self.session commitConfiguration];
+    [self.session stopRunning];
   });
 }
 
@@ -802,10 +801,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   }];
   AVCaptureVideoOrientation orientation = [EXCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
 
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_ENSURE_STRONGIFY(self);
-
+  dispatch_async(self.sessionQueue, ^{
     [self.session beginConfiguration];
 
     NSError *error = nil;
@@ -843,9 +839,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 // - torchMode: https://stackoverflow.com/a/53666293/4337317
 - (void)ensureSessionConfiguration
 {
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_ENSURE_STRONGIFY(self);
+  dispatch_async(self.sessionQueue, ^{
     [self updateFlashMode];
   });
 }
@@ -856,63 +850,48 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
 #if !(TARGET_IPHONE_SIMULATOR)
   if (preset) {
-    EX_WEAKIFY(self);
-    dispatch_async(_sessionQueue, ^{
-      EX_ENSURE_STRONGIFY(self);
-      [self.session beginConfiguration];
-      if ([self.session canSetSessionPreset:preset]) {
-        self.session.sessionPreset = preset;
-      }
-      [self.session commitConfiguration];
-    });
+    [self.session beginConfiguration];
+    if ([self.session canSetSessionPreset:preset]) {
+      self.session.sessionPreset = preset;
+    }
+    [self.session commitConfiguration];
   }
 #endif
 }
 
 - (void)updateSessionAudioIsMuted:(BOOL)isMuted
 {
-  EX_WEAKIFY(self);
-  dispatch_async(_sessionQueue, ^{
-    EX_ENSURE_STRONGIFY(self);
-    [self.session beginConfiguration];
-
-    for (AVCaptureDeviceInput* input in [self.session inputs]) {
-      if ([input.device hasMediaType:AVMediaTypeAudio]) {
-        if (isMuted) {
-          [self.session removeInput:input];
-        }
-        [self.session commitConfiguration];
-        return;
+  for (AVCaptureDeviceInput* input in [self.session inputs]) {
+    if ([input.device hasMediaType:AVMediaTypeAudio]) {
+      if (isMuted) {
+        [self.session removeInput:input];
       }
+      return;
     }
-
-    if (!isMuted) {
-      NSError *error = nil;
-
-      AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-      AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
-
-      if (error || audioDeviceInput == nil) {
-        EXLogInfo(@"%s: %@", __func__, error);
-        return;
-      }
-
-      if ([self.session canAddInput:audioDeviceInput]) {
-        [self.session addInput:audioDeviceInput];
-      }
+  }
+  
+  if (!isMuted) {
+    NSError *error = nil;
+    
+    AVCaptureDevice *audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+    AVCaptureDeviceInput *audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:audioCaptureDevice error:&error];
+    
+    if (error || audioDeviceInput == nil) {
+      EXLogInfo(@"%s: %@", __func__, error);
+      return;
     }
-
-    [self.session commitConfiguration];
-  });
+    
+    if ([self.session canAddInput:audioDeviceInput]) {
+      [self.session addInput:audioDeviceInput];
+    }
+  }
 }
 
 - (void)onAppForegrounded
 {
   if (![_session isRunning] && [self isSessionPaused]) {
     _paused = NO;
-    EX_WEAKIFY(self);
-    dispatch_async(_sessionQueue, ^{
-      EX_ENSURE_STRONGIFY(self);
+    dispatch_async(self.sessionQueue, ^{
       [self.session startRunning];
       [self ensureSessionConfiguration];
     });
@@ -923,9 +902,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
   if ([_session isRunning] && ![self isSessionPaused]) {
     _paused = YES;
-    EX_WEAKIFY(self);
-    dispatch_async(_sessionQueue, ^{
-      EX_ENSURE_STRONGIFY(self);
+    dispatch_async(self.sessionQueue, ^{
       [self.session stopRunning];
     });
   }
@@ -954,7 +931,6 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 - (void)setupMovieFileCapture
 {
   AVCaptureMovieFileOutput *movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
-
   if ([_session canAddOutput:movieFileOutput]) {
     [_session addOutput:movieFileOutput];
     _movieFileOutput = movieFileOutput;
@@ -964,8 +940,10 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 - (void)cleanupMovieFileCapture
 {
   if ([_session.outputs containsObject:_movieFileOutput]) {
+    [_session beginConfiguration];
     [_session removeOutput:_movieFileOutput];
     _movieFileOutput = nil;
+    [_session commitConfiguration];
   }
 }
 
@@ -987,13 +965,15 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   _videoRecordedReject = nil;
   _videoCodecType = nil;
 
-  [self cleanupMovieFileCapture];
   // If face detection has been running prior to recording to file
   // we reenable it here (see comment in -record).
   [self maybeStartFaceDetection:false];
 
   if (_session.sessionPreset != _pictureSize) {
-    [self updateSessionPreset:_pictureSize];
+    dispatch_async(self.sessionQueue, ^{
+      [self updateSessionPreset:_pictureSize];
+      [self cleanupMovieFileCapture];
+    });
   }
 }
 

--- a/packages/expo-camera/ios/EXCamera/EXCamera.m
+++ b/packages/expo-camera/ios/EXCamera/EXCamera.m
@@ -323,7 +323,9 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
 
 - (void)updatePictureSize
 {
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     [self updateSessionPreset:_pictureSize];
   });
 }
@@ -568,7 +570,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     [_faceDetectorManager stopFaceDetection];
   }
   
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     [self configureVideoSessionWith:options reject:reject];
 
     // it is possible that the session has been invalidated at this point
@@ -690,7 +694,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 
 - (void)stopRecording
 {
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     [self.movieFileOutput stopRecording];
   });
 }
@@ -716,7 +722,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     [self onMountingError:@{@"message": @"Camera permissions not granted - component could not be rendered."}];
     return;
   }
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       return;
     }
@@ -734,6 +742,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     [self setRuntimeErrorHandlingObserver:
      [[NSNotificationCenter defaultCenter] addObserverForName:AVCaptureSessionRuntimeErrorNotification object:self.session queue:nil usingBlock:^(NSNotification *note) {
       dispatch_async(self.sessionQueue, ^{
+        EX_STRONGIFY(self);
         // Manually restarting the session since it must
         // have been stopped due to an error.
         [self.session startRunning];
@@ -745,6 +754,7 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
     // when BarCodeScanner is enabled since the beginning of camera component lifecycle,
     // some race condition occurs in reconfiguration and barcodes aren't scanned at all
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 50 * NSEC_PER_USEC), self.sessionQueue, ^{
+      EX_STRONGIFY(self);
       [self maybeStartFaceDetection:self.presetCamera!=1];
       if (self.barCodeScanner) {
         [self.barCodeScanner maybeStartBarCodeScanning];
@@ -764,7 +774,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 #if TARGET_IPHONE_SIMULATOR
   return;
 #endif
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     if (self.faceDetectorManager) {
       [self.faceDetectorManager stopFaceDetection];
     }
@@ -798,7 +810,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   }];
   AVCaptureVideoOrientation orientation = [EXCameraUtils videoOrientationForInterfaceOrientation:interfaceOrientation];
 
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     [self.session beginConfiguration];
 
     NSError *error = nil;
@@ -836,7 +850,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 // - torchMode: https://stackoverflow.com/a/53666293/4337317
 - (void)ensureSessionConfiguration
 {
+  EX_WEAKIFY(self);
   dispatch_async(self.sessionQueue, ^{
+    EX_STRONGIFY(self);
     [self updateFlashMode];
   });
 }
@@ -888,7 +904,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
   if (![_session isRunning] && [self isSessionPaused]) {
     _paused = NO;
+    EX_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{
+      EX_STRONGIFY(self);
       [self.session startRunning];
       [self ensureSessionConfiguration];
     });
@@ -899,7 +917,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
 {
   if ([_session isRunning] && ![self isSessionPaused]) {
     _paused = YES;
+    EX_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{
+      EX_STRONGIFY(self);
       [self.session stopRunning];
     });
   }
@@ -967,7 +987,9 @@ previewPhotoSampleBuffer:(CMSampleBufferRef)previewPhotoSampleBuffer
   [self maybeStartFaceDetection:false];
 
   if (_session.sessionPreset != _pictureSize) {
+    EX_WEAKIFY(self);
     dispatch_async(self.sessionQueue, ^{
+      EX_STRONGIFY(self);
       [self updateSessionPreset:_pictureSize];
       [self cleanupMovieFileCapture];
     });


### PR DESCRIPTION
# Why
Closes #23130

# How
Some session configuration was happening off the `sessionQueue`. This causes the preview to be blocked. The same issue occurs when starting bar code scanner but will need to be fixed there. 

# Test Plan
Tested in bare expo. 
