### PR TITLE
[docs] Update title, description & other improvements for Use Expo CLI doc

### DIFF
--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -55,7 +55,7 @@ After installing the `expo` package, you can use the following commands which ar
 
 When building your project, you can choose a device or simulator by using the `--device` flag. This also applies to any iOS device that is connected to your computer.
 
-## Independently start the bundler
+## Start the bundler independently
 
 `npx expo run:[android|ios]` automatically starts the bundler/development server. If you want to independently start the bundler with `npx expo start` command, pass the `--no-bundler` to the `npx expo run:[android|ios]` command.
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -8,7 +8,11 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { DEMI } from '~/ui/components/Text';
 
-To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package which includes the Expo Modules API and Expo CLI. For most apps, executing the following command in a project directory to install the package is all you need to do:
+To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package which includes the Expo Modules API and Expo CLI. This guide covers the installation step, the benefits of using Expo CLI, and how to compile and run your project after migrating to Expo CLI.
+
+## Install the `expo` package
+
+In most cases, executing the following command in a project directory to install the package is all you need to do:
 
 <Terminal cmd={['npx install-expo-modules@latest']} />
 
@@ -35,7 +39,7 @@ Expo CLI commands provide several benefits over the similar commands in `@react-
 - Support for Expo tooling such as [`expo-dev-client`](/develop/development-builds/introduction), the [Expo Updates protocol](/technical-specs/expo-updates-1) and [EAS Update](/eas-update/introduction).
 - Automated `pod install` execution when using `npx expo run:ios`.
 - `npx expo install` selects compatible dependency versions for well-known packages.
-- Automatic port detection when running `npx expo run:[android|ios]` and `npx expo start`. If another app is running on the default port, a different port is suggested.
+- Automatic port detection when running `npx expo run:[android|ios]` and `npx expo start`. If another app is running on the default port, a different port is used.
 - Android or iOS device launch selection shortcuts using <kbd>Shift</kbd> + <kbd>a</kbd> or <kbd>Shift</kbd> + <kbd>i</kbd> from the interactive prompt.
 - Built-in support for serving your app over an [ngrok tunnel](/develop/development-builds/development-workflows/#tunnel-urls).
 - Develop on any port with any entry JavaScript file.
@@ -45,12 +49,17 @@ Windows and macOS. If building for these platforms, you can utilize Expo CLI for
 
 ## Compile and run your app
 
-Once you have the `expo` package installed, use the `npx expo run:android` and `npx expo run:ios` commands as alternatives to `npx react-native run-android`
-and `npx react-native run-ios`. Pass in the `--device` flag to select a device or simulator to build for. This also works for any connected iOS device.
+After installing the `expo` package, you can use the following commands which are alternatives to `npx react-native run-android` and `npx react-native run-ios`:
 
-## Start the bundler
+<Terminal cmd={['# for Android', 'npx expo run:android', '', '# for iOS', 'npx expo run:ios']} />
 
-`npx expo run:[android|ios]` starts the bundler/development server. You can skip that by passing in `--no-bundler` flag and independently start the development server with `npx expo start`. For SDK 48 and lower, use the `--dev-client` flag with the command.
+When building your project, you can choose a device or simulator by using the `--device` flag. This also applies to any iOS device that is connected to your computer.
+
+## Independently start the bundler
+
+`npx expo run:[android|ios]` automatically starts the bundler/development server. If you want to independently start the bundler with `npx expo start` command, pass the `--no-bundler` to the `npx expo run:[android|ios]` command.
+
+> For SDK 48 and lower, use the `npx expo start --dev-client` command to start the bundler when using a development build or having `expo-dev-client` library installed in your project.
 
 ## Common questions
 
@@ -82,9 +91,9 @@ Yes! Refer to the [Customized Prebuild Example repository](https://github.com/by
 
 </Collapsible>
 
-## Learn more
+## Next steps
 
-With the `expo` package installed and configured in your project, you can start using all features from Expo CLI and SDK. To learn more, see:
+Now, with the `expo` package installed and configured in your project, you can start using all features from Expo CLI and SDK. Here are some recommended next steps to dive deep:
 
 <BoxLink
   title="Expo CLI Reference"

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -56,7 +56,7 @@ and `npx react-native run-ios`. Pass in the `--device` flag to select a device o
 
 <Collapsible summary="Can I use Expo CLI without installing the Expo Modules API?">
 
-When you install the `expo` package with `npx install-expo-modules`, the Expo Module API is also installed. If you want to try out Expo CLI for now, you can install the `expo` package with `npm install` and then configure the **react-native.config.js** to exclude the package from autolinking:
+Expo Modules API is also installed when you install the `expo` package with `npx install-expo-modules`. If you want to try out Expo CLI for now without installing Expo Modules API, install the `expo` package with `npm install` and then configure the **react-native.config.js** to exclude the package from autolinking:
 
 ```js react-native.config.js
 module.exports = {

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use Expo CLI
-description: Learn how and why you can use Expo CLI instead of @react-native-community/cli in any React Native project.
+title: Migrate to Expo CLI
+description: Learn how to migrate to use Expo CLI instead of @react-native-community/cli in any React Native project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -8,62 +8,57 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { DEMI } from '~/ui/components/Text';
 
-To use Expo CLI in a project created with `npx react-native init`, you will first need to install the `expo` package.
-This package includes the Expo Modules API and Expo CLI. For a complete explanation of how to install this, see the [Install Expo modules](/bare/installing-expo-modules.mdx) guide.
-For most apps, it's as simple as running the following command in your project directory:
+To migrate from `npx react-native init` to Expo CLI, you'll need to install the `expo` package which includes the Expo Modules API and Expo CLI. For most apps, executing the following command in a project directory to install the package is all you need to do:
 
 <Terminal cmd={['npx install-expo-modules@latest']} />
 
+For a detailed installation guide, see [Install Expo modules](/bare/installing-expo-modules).
+
 ## Why Expo CLI instead of `npx react-native`
 
-Expo CLI commands provide a number of benefits over the similar commands in `@react-native-community/cli`, including:
+Expo CLI commands provide several benefits over the similar commands in `@react-native-community/cli`, which includes:
 
-- You can open up the Hermes debugger in one keystroke: <kbd>J</kbd>.
+- Instant access to Hermes debugger with <kbd>j</kbd> keystroke.
 - The debugger ships with React Developer Tools (`react-devtools`) already installed.
-- Support for [Continuous Native Generation](/workflow/prebuild.mdx) (CNG) with `npx expo prebuild` for easy upgrades, white-labeling, simple third-party package setup,
-  and improved maintainability of your codebase (by reducing the surface area).
-- Support for file-based routing with [`expo-router`](https://expo.github.io/router/docs).
+- [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) support with [`expo prebuild`](/workflow/prebuild/) for upgrades, white-labeling, easy third-party package setup, and better maintainability of the codebase (by reducing the surface area).
+- Support for file-based routing with [`expo-router`](/routing/introduction/).
   - [Async bundling](/router/reference/async-routes) in development.
-- Built-in [environment variable support](/guides/environment-variables) and `**env** file loading.
-- View native logs directly in the terminal alongside your JavaScript logs.
-- Improved native build log formatting by using Expo CLI's own `xcpretty`-style tool that is built specifically for React Native apps.
-  For example, when compiling a Pod you can see which Node module included it.
+- Built-in [environment variable support](/guides/environment-variables) and **.env** file integration.
+- View native logs directly in the terminal alongside JavaScript logs.
+- Improved native build log formatting using Expo CLI's `xcpretty`-style tool built specifically for React Native apps. For example, when compiling a Pod, you can see which Node module included it.
 - [First-class TypeScript support](/guides/typescript).
 - Support for **tsconfig.json** aliases with `paths` and `baseUrl` [built-in to Metro](/guides/typescript#path-aliases).
 - [Web support](/guides/customizing-metro/#adding-web-support-to-metro) with Metro. Fully typed for React Native Web.
 - Modern [CSS support](/versions/latest/config/metro#css) with Tailwind, PostCSS, CSS Modules, SASS, and more.
 - Static site generation with Expo Router and Metro web.
-- Out of the box [support for monorepos](/guides/monorepos.mdx).
-- Support for Expo tooling such as [expo-dev-client](/develop/development-builds/introduction.mdx), the [Expo Updates protocol](/technical-specs/expo-updates-1.mdx)
-  and [EAS Update](/eas-update/introduction.mdx).
-- `npx expo run:ios` will invoke `pod install` automatically when needed.
-- `npx expo install` picks known compatible versions of dependencies for well-known packages.
-- `npx expo run:[android|ios]` and `npx expo start` automatically detect if an app is running on the default port and suggests another.
-- Select an Android or iOS device to launch into using <kbd>Shift</kbd> + <kbd>I</kbd> or <kbd>Shift</kbd> + <kbd>A</kbd> from the interactive prompt.
-- Built-in support for serving your app over an [ngrok tunnel](/develop/development-builds/development-workflows.mdx#tunnel-urls),
+- Out of the box [support for monorepos](/guides/monorepos).
+- Support for Expo tooling such as [`expo-dev-client`](/develop/development-builds/introduction), the [Expo Updates protocol](/technical-specs/expo-updates-1) and [EAS Update](/eas-update/introduction).
+- Automated `pod install` execution when using `npx expo run:ios`.
+- `npx expo install` selects compatible dependency versions for well-known packages.
+- Automatic port detection when running `npx expo run:[android|ios]` and `npx expo start`. If another app is running on the default port, a different port is suggested.
+- Android or iOS device launch selection shortcuts using <kbd>Shift</kbd> + <kbd>a</kbd> or <kbd>Shift</kbd> + <kbd>i</kbd> from the interactive prompt.
+- Built-in support for serving your app over an [ngrok tunnel](/develop/development-builds/development-workflows/#tunnel-urls).
 - Develop on any port with any entry JavaScript file.
 
-We recommend Expo CLI for most React Native projects that target Android, iOS, and/or web. It does not yet have built-in support for the most popular out-of-tree platforms,
-macOS and Windows — if you are building for those platforms, you can use Expo CLI for the supported platforms and `@react-native-community/cli` for the others.
+We recommend Expo CLI for most React Native projects that target Android, iOS, and/or web. It does not yet have built-in support for the most popular out-of-tree platforms, such as
+Windows and macOS. If building for these platforms, you can utilize Expo CLI for the supported platforms and `@react-native-community/cli` for the others.
 
-## Compiling and running your app
+## Compile and run your app
 
-Once you have the `expo` package installed, you can use the `npx expo run:android` and `npx expo run:ios` commands as alternatives to `npx react-native run-android`
-and `npx react-native run-ios`. You can pass in the `--device` flag to select a device/simulator to build for — this also works for any connected iOS device.
+Once you have the `expo` package installed, use the `npx expo run:android` and `npx expo run:ios` commands as alternatives to `npx react-native run-android`
+and `npx react-native run-ios`. Pass in the `--device` flag to select a device or simulator to build for. This also works for any connected iOS device.
 
-## Starting the bundler
+## Start the bundler
 
-`npx expo run:[android|ios]` will start the bundler/development server. You can skip that by passing in `--no-bundler` flag.
-Start the development server independently with `npx expo start` command. For SDK 48 and lower, use the `--dev-client` flag with the command.
+`npx expo run:[android|ios]` starts the bundler/development server. You can skip that by passing in `--no-bundler` flag and independently start the development server with `npx expo start`. For SDK 48 and lower, use the `--dev-client` flag with the command.
 
 ## Common questions
 
 <Collapsible summary="Can I use Expo CLI without installing the Expo Modules API?">
 
-When you install the `expo` package with `npx install-expo-modules`, you will also install the Expo Modules API. If you just want to try out Expo CLI for now,
-you can install the `expo` package with `npm install` and then configure your **react-native.config.js** to exclude the package from autolinking:
+When you install the `expo` package with `npx install-expo-modules`, the Expo Module API is also installed. If you want to try out Expo CLI for now, you can install the `expo` package with `npm install` and then configure the **react-native.config.js** to exclude the package from autolinking:
 
-```js
+```js react-native.config.js
 module.exports = {
   dependencies: {
     expo: {
@@ -77,7 +72,7 @@ module.exports = {
 };
 ```
 
-> **Note**: Not all features will work without the Expo Modules API installed. For example, you will not be able to use the `expo-dev-client` package or `expo-router`.
+> **Note:** Without Expo API Modules installed, certain features such as `expo-dev-client` or `expo-router` are unavailable.
 
 </Collapsible>
 
@@ -89,7 +84,7 @@ Yes! Refer to the [Customized Prebuild Example repository](https://github.com/by
 
 ## Learn more
 
-With the `expo` package installed and configured in your project, you can start using all features from Expo CLI and SDK.
+With the `expo` package installed and configured in your project, you can start using all features from Expo CLI and SDK. To learn more, see:
 
 <BoxLink
   title="Expo CLI Reference"
@@ -97,7 +92,7 @@ With the `expo` package installed and configured in your project, you can start 
   href="/more/expo-cli"
 />
 <BoxLink
-  title="Adopting Prebuild"
+  title="Adopt Prebuild"
   description={
     <>
       Automate your native directories using the <DEMI>app.json</DEMI>.
@@ -106,12 +101,12 @@ With the `expo` package installed and configured in your project, you can start 
   href="/guides/adopting-prebuild"
 />
 <BoxLink
-  title="Using the Expo SDK"
-  description="Try out modules from the Expo SDK in your app"
+  title="Use Expo SDK"
+  description="Try out libraries from the Expo SDK in your app."
   href="/versions/"
 />
 <BoxLink
-  title="Try Expo Router"
+  title="Expo Router"
   description="Expo Router brings the best routing concepts from the web to native Android and iOS apps."
-  href="https://expo.github.io/router/docs/"
+  href="/routing/introduction/"
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The page is hard to find from the search bar as referenced in [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1691191750123059).

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the page title and description to reflect what this is a migration guide.
- Describe the purpose of this guide in the introduction
- Create a new section about installing `expo` package to get started
- As a follow up for #23067, improve the overall verbiage, and fix links and typos.
- Use short form verbs instead of gerunds for section titles.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Changes can be tested by running docs locally: http://localhost:3002/bare/using-expo-cli/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
