### PR TITLE
[core][Android] Made `generateExpoModulesPackageList` task cacheable

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Made `generateExpoModulesPackageList` task cacheable. ([#23847](https://github.com/expo/expo/pull/23847) by [@lukmccall](https://github.com/lukmccall))
+
 ## 1.5.0 — 2023-06-21
 
 ### 🎉 New features

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -79,9 +79,12 @@ class ExpoAutolinkingManager {
     this.options = options
   }
 
-  Object resolve() {
+  Object resolve(shouldUseCachedValue=false) {
     if (cachedResolvingResults) {
       return cachedResolvingResults
+    }
+    if (shouldUseCachedValue) {
+      logger.warn("Warning: Expo modules were resolved multiple times. Probably something is wrong with the project configuration.")
     }
     String[] args = convertOptionsToCommandArgs('resolve', this.options)
     args += ['--json']
@@ -97,32 +100,36 @@ class ExpoAutolinkingManager {
     return options?.useAAR == true
   }
 
-  ExpoModule[] getModules() {
-    Object json = resolve()
+  ExpoModule[] getModules(shouldUseCachedValue=false) {
+    Object json = resolve(shouldUseCachedValue)
     return json.modules.collect { new ExpoModule(it) }
   }
 
-  MavenRepo[] getExtraMavenRepos() {
-    Object json = resolve()
+  MavenRepo[] getExtraMavenRepos(shouldUseCachedValue=false) {
+    Object json = resolve(shouldUseCachedValue)
     return json.extraDependencies.androidMavenRepos.collect { new MavenRepo(it) }
+  }
+
+  static String getGeneratedFilePath(Project project) {
+    return Paths.get(
+      project.buildDir.toString(),
+      generatedFilesSrcDir,
+      generatedPackageListNamespace.replace('.', '/'),
+      generatedPackageListFilename
+    ).toString()
   }
 
   static void generatePackageList(Project project, Map options) {
     String[] args = convertOptionsToCommandArgs('generate-package-list', options)
 
     // Construct absolute path to generated package list.
-    def generatedFilePath = Paths.get(
-      project.buildDir.toString(),
-      generatedFilesSrcDir,
-      generatedPackageListNamespace.replace('.', '/'),
-      generatedPackageListFilename
-    )
+    def generatedFilePath = getGeneratedFilePath(project)
 
     args += [
       '--namespace',
       generatedPackageListNamespace,
       '--target',
-      generatedFilePath.toString()
+      generatedFilePath
     ]
 
     if (options == null) {
@@ -267,7 +274,7 @@ if (rootProject instanceof ProjectDescriptor) {
 
   def addDependencies = { DependencyHandler handler, Project project ->
     def manager = validateExpoAutolinkingManager(gradle.ext.expoAutolinkingManager)
-    def modules = manager.getModules()
+    def modules = manager.getModules(true)
 
     if (!modules.length) {
       return
@@ -334,12 +341,25 @@ if (rootProject instanceof ProjectDescriptor) {
     ExpoAutolinkingManager.generatePackageList(project, options)
   }
 
+  ext.getGenerateExpoModulesPackagesListPath = {
+    return ExpoAutolinkingManager.getGeneratedFilePath(project)
+  }
+
+  ext.getModulesConfig = {
+    if (!gradle.ext.has('expoAutolinkingManager')) {
+      return null
+    }
+
+    def modules = gradle.ext.expoAutolinkingManager.resolve(true).modules
+    return modules.toString()
+  }
+
   ext.ensureDependeciesWereEvaluated = { Project project ->
     if (!gradle.ext.has('expoAutolinkingManager')) {
       return
     }
 
-    def modules = gradle.ext.expoAutolinkingManager.getModules()
+    def modules = gradle.ext.expoAutolinkingManager.getModules(true)
     for (module in modules) {
       for (moduleProject in module.projects) {
         def dependency = project.findProject(":${moduleProject.name}")

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Made `generateExpoModulesPackageList` task cacheable.
+
 ## 1.6.0 — 2023-07-28
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### 💡 Others
 
-- [Android] Made `generateExpoModulesPackageList` task cacheable.
-
 ## 1.6.0 — 2023-07-28
 
 ### 🐛 Bug fixes

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -148,6 +148,13 @@ dependencies { dependencyHandler ->
 
 // A task generating a package list of expo modules.
 task generateExpoModulesPackageList {
+  def modulesConfig = getModulesConfig()
+  def outputPath = getGenerateExpoModulesPackagesListPath()
+  if (modulesConfig) {
+    outputs.file(file(outputPath))
+    inputs.property("modulesConfig", modulesConfig)
+  }
+
   doLast {
     generateExpoModulesPackageList()
   }


### PR DESCRIPTION
# Why

Made the `generateExpoModulesPackageList` task cache friendly to save a little time during compilation. 
It's not much - on my M1, it saves around 1.7 seconds.  

# How

Added task `inputs` and `outputs`.

# Test Plan

- bare-expo ✅
![Screenshot 2023-08-07 at 16 07 51](https://github.com/expo/expo/assets/9578601/f6e999df-ab98-485d-b6e7-2ed22cb58a68)
