### PR TITLE
[AV][Android] Remove empty `createViewManagers` function from the package

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVPackage.java
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVPackage.java
@@ -3,14 +3,12 @@ package expo.modules.av;
 import android.content.Context;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
+import expo.modules.av.player.datasource.SharedCookiesDataSourceFactoryProvider;
 import expo.modules.core.BasePackage;
 import expo.modules.core.ExportedModule;
-import expo.modules.core.ViewManager;
 import expo.modules.core.interfaces.InternalModule;
-import expo.modules.av.player.datasource.SharedCookiesDataSourceFactoryProvider;
 
 public class AVPackage extends BasePackage {
 
@@ -27,10 +25,5 @@ public class AVPackage extends BasePackage {
     return Arrays.<ExportedModule>asList(
         new AVModule(context)
     );
-  }
-
-  @Override
-  public List<ViewManager> createViewManagers(Context context) {
-    return Collections.emptyList();
   }
 }


### PR DESCRIPTION
# Why

Clean up the package file. 