### PR TITLE
[docs][expo-web] Modified docs to remove webpack as default web bundler

### DIFF
--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -281,7 +281,7 @@ This will show an interactive breakdown of what makes up your JavaScript bundle.
 
 ## Web Support
 
-> **info** Metro web support is under development and only works with the [local Expo CLI](/more/expo-cli/) and Expo SDK 46 or newer. It's recommended you use it with [Expo Router](https://expo.github.io/router/docs).
+> **info** Metro is now recommended for web from Expo SDK 49 onwards. It's recommended you use it with [Expo Router](https://expo.github.io/router/docs).
 
 By default, Expo CLI uses webpack as the bundler on web platforms because Metro historically did not support web. Using different bundlers across platforms leads to some critical divergence in how an app works across platforms. Features such as Fast Refresh which works on native don't work on the web, and important production functionality such as assets are treated differently across bundlers.
 

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -5,6 +5,8 @@ description: Learn about different webpack bundler configurations that can be cu
 
 import { Terminal } from '~/ui/components/Snippet';
 
+> **warning** Metro is now recommended for web. The `@expo/webpack-config` package is currently in maintenance mode, and our efforts on web support are focused on Metro. We strongly recommend all new projects use Metro for web. Many existing projects should work well with Metro as long as they don’t require any of the few remaining features only supported by Webpack.
+
 When you run `npx expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
 
 > This is similar to `react-scripts` and `create-react-app`.

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -5,7 +5,7 @@ description: Learn about different webpack bundler configurations that can be cu
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** Metro is now recommended for web. The `@expo/webpack-config` package is currently in maintenance mode, and our efforts on web support are focused on Metro. It is strongly recommended that all new projects use Metro for web. Many existing projects should work well with Metro as long as they don’t require any of the few remaining features only supported by Webpack.
+> **warning** Metro is now recommended for web. The `@expo/webpack-config` package is currently in maintenance mode, and our efforts on web support are focused on Metro. It is strongly recommended that all new projects use Metro for web. Many existing projects should work well with Metro as long as they don’t require any of the few remaining features only supported by webpack.
 
 When you run `npx expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
 

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -5,7 +5,7 @@ description: Learn about different webpack bundler configurations that can be cu
 
 import { Terminal } from '~/ui/components/Snippet';
 
-> **warning** Metro is now recommended for web. The `@expo/webpack-config` package is currently in maintenance mode, and our efforts on web support are focused on Metro. We strongly recommend all new projects use Metro for web. Many existing projects should work well with Metro as long as they don’t require any of the few remaining features only supported by Webpack.
+> **warning** Metro is now recommended for web. The `@expo/webpack-config` package is currently in maintenance mode, and our efforts on web support are focused on Metro. It is strongly recommended that all new projects use Metro for web. Many existing projects should work well with Metro as long as they don’t require any of the few remaining features only supported by Webpack.
 
 When you run `npx expo start --web` or `expo export:web` the CLI will check to see if your project has a **webpack.config.js** in the root directory. If the project doesn't then Expo will use the default `@expo/webpack-config` (preferred).
 

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -16,7 +16,7 @@ Install the `expo` package which contains the [Expo CLI](/more/expo-cli/) used f
 
 Then you can use Expo CLI to install the web dependencies in your project:
 
-<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/webpack-config']} />
+<Terminal cmd={['$ npx expo install react-dom react-native-web']} />
 
 ### Update the entry file
 
@@ -35,6 +35,22 @@ import App from './App';
 
 > Learn more about [`registerRootComponent`](/versions/latest/sdk/register-root-component#registerrootcomponentcomponent).
 
+### Enable Metro on Web
+
+To enable Metro web support, modify your [app config](/workflow/configuration) to enable the feature using the `expo.web.bundler` field:
+
+```json app.json
+{
+  "expo": {
+    "web": {
+      "bundler": "metro"
+    }
+  }
+}
+```
+
+> Learn more about [Metro web support](/guides/customizing-metro#web-support).
+
 ### Start the dev server
 
 Finally you can start the webpack dev server with:
@@ -42,8 +58,6 @@ Finally you can start the webpack dev server with:
 <Terminal cmd={['$ npx expo start --web']} cmdCopy="npx expo start --web" />
 
 You can test secure web APIs like the camera and user location by adding the `--https` flag to `npx expo start`. This will host your app from a secure origin like `https://localhost:19006`.
-
-> You can try experimental [Metro web support](/guides/customizing-metro#web-support) instead of webpack.
 
 ## Alternative Rendering Patterns
 


### PR DESCRIPTION
# Why

Since Expo 49, Webpack is no longer the recommended bundler for web. The docs are still out of date and mention to install `webpack` and list `metro` on web as experimental.

# How

Doc changes on the following pages: 
1.  Customizing Metro: changing banner saying it's experimental and mentioning it's now recommended.
2. Customizing Webpack: putting a banner at the top warning users that it's in maintenance mode and no longer recommended.
3. Develop for Web: modifying the setup instructions to no longer use webpack and use metro instead.

# Test Plan

Doc changes only. Tested the links manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
