### PR TITLE
[expo-status-bar] fix animation param should be optional

### DIFF
--- a/packages/expo-status-bar/CHANGELOG.md
+++ b/packages/expo-status-bar/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Made the `setStatusBarHidden` methods `animation` parameter optional to match the documentation. (#23866 by @DoctorJohn)
+- Made the `setStatusBarHidden` methods `animation` parameter optional to match the documentation. ([#23866](https://github.com/expo/expo/pull/23866) by [@DoctorJohn](https://github.com/DoctorJohn))
 
 ### 💡 Others
 

--- a/packages/expo-status-bar/CHANGELOG.md
+++ b/packages/expo-status-bar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Made the `setStatusBarHidden` methods `animation` parameter optional to match the documentation. (#23866 by @DoctorJohn)
+
 ### 💡 Others
 
 ## 1.7.1 — 2023-08-02

--- a/packages/expo-status-bar/src/setStatusBarHidden.ts
+++ b/packages/expo-status-bar/src/setStatusBarHidden.ts
@@ -8,6 +8,6 @@ import { StatusBarAnimation } from './StatusBar.types';
  * @param hidden If the status bar should be hidden.
  * @param animation Animation to use when toggling hidden, defaults to `'none'`.
  */
-export default function setStatusBarHidden(hidden: boolean, animation: StatusBarAnimation) {
+export default function setStatusBarHidden(hidden: boolean, animation?: StatusBarAnimation) {
   StatusBar.setHidden(hidden, animation);
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The `StatusBar.setStatusBarHidden` doc string claims that the `animation` parameter "defaults to `'none'`", suggesting that the `animation` parameter can be left out. However, without this change the `animation` parameter is required.

https://github.com/expo/expo/blob/dfd2837473f710ab2d98793b59205acf793af726/packages/expo-status-bar/src/setStatusBarHidden.ts#L6-L13

# How

<!--
How did you build this feature or fix this bug and why?
-->
I made the parameter optional and confirmed that it actually defaults to `"none"` if left out by checking the react-native source code:

https://github.com/facebook/react-native/blob/4343144c81955f50aa1bfc573dffa7d7a6ac1805/packages/react-native/Libraries/Components/StatusBar/StatusBar.js#L270

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
I used this change with patch-package for a bit. Works as expected, especially since this change is backwards compatible.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
