### PR TITLE
[expo-font][docs] Examples should include error handling

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -86,19 +86,19 @@ SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
-  const [fontsLoaded] = useFonts({
+  const [fontsLoaded, fontError] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded) {
+    if (fontsLoaded || fontError) {
       await SplashScreen.hideAsync();
     }
-  }, [fontsLoaded]);
+  }, [fontsLoaded, fontError]);
   /* @end */
 
-  if (!fontsLoaded) {
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 
@@ -171,11 +171,11 @@ import { View, Text, StyleSheet } from 'react-native';
 import { useFonts, Inter_900Black } from '@expo-google-fonts/inter';
 
 export default function App() {
-  let [fontsLoaded] = useFonts({
+  let [fontsLoaded, fontError] = useFonts({
     Inter_900Black,
   });
 
-  if (!fontsLoaded) {
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
 
 ## Wait for fonts to load
 
-Since your fonts won't be ready right away, it is generally a good practice to not render anything until the font is ready. Instead, you can continue to display the Splash Screen of your app until all fonts have loaded. It is done by using [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) package. See the [minimal example](#minimal-example) section on how to use it.
+Since your fonts won't be ready right away, it is generally a good practice to not render anything until the font is ready. Instead, you can continue to display the Splash Screen of your app until all fonts have loaded (or an error has been returned). It is done by using [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) package. See the [minimal example](#minimal-example) section on how to use it.
 
 ### Load fonts on the web
 

--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -34,20 +34,19 @@ SplashScreen.preventAutoHideAsync();
 
 export default function Layout() {
   // Load the font `Inter_500Medium`
-  const [fontsLoaded] = useFonts({
+  const [fontsLoaded, fontError] = useFonts({
     Inter_500Medium,
   });
 
   useEffect(() => {
-    if (fontsLoaded) {
-      // Hide the splash screen after the fonts have loaded and the
-      // UI is ready.
+    if (fontsLoaded || fontError) {
+      // Hide the splash screen after the fonts have loaded (or an error was returned) and the UI is ready.
       SplashScreen.hideAsync();
     }
-  }, [fontsLoaded]);
+  }, [fontsLoaded, fontError]);
 
-  // Prevent rendering until the font has loaded
-  if (!fontsLoaded) {
+  // Prevent rendering until the font has loaded or an error was returned
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -33,19 +33,19 @@ SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function App() {
-  const [fontsLoaded] = useFonts({
+  const [fontsLoaded, fontError] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
 
   /* @info After the custom fonts have loaded, we can hide the splash screen and display the app screen. */
   const onLayoutRootView = useCallback(async () => {
-    if (fontsLoaded) {
+    if (fontsLoaded || fontError) {
       await SplashScreen.hideAsync();
     }
-  }, [fontsLoaded]);
+  }, [fontsLoaded, fontError]);
   /* @end */
 
-  if (!fontsLoaded) {
+  if (!fontsLoaded && !fontError) {
     return null;
   }
 


### PR DESCRIPTION
Our examples of `useFonts()` usage do not include error handling. Because of this, a customer can have trouble debugging the problem if there is an error in loading fonts -- in our examples, the splash screen will never hide.  (See https://github.com/expo/expo/issues/21885 for such an issue.)

I've updated the examples to show correct error handling.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
