### PR TITLE
[bare-expo] fix test-suite ios broken

### DIFF
--- a/apps/bare-expo/detox.config.js
+++ b/apps/bare-expo/detox.config.js
@@ -45,6 +45,7 @@ module.exports = {
       headless: Boolean(process.env.CI),
       device: {
         type: 'iPhone 14 Pro',
+        os: 'iOS 16.4',
       },
     },
     emulator: {


### PR DESCRIPTION
# Why

since github runner has xcode 15 beta and the ios 17 simulators take about 10mins to start, it is the root cause of timeout.

# How

use ios 16.4 simulator for detox

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
