### PR TITLE
[core][Android] Add ability to use enums as events

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Surfaced errorManager to allow throwing errors and warnings from modules. ([#23848](https://github.com/expo/expo/pull/23848) by [@aleqsio](https://github.com/aleqsio))
+- [Android] Enums can now be used to define events.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [Android] Surfaced errorManager to allow throwing errors and warnings from modules. ([#23848](https://github.com/expo/expo/pull/23848) by [@aleqsio](https://github.com/aleqsio))
-- [Android] Enums can now be used to define events.
+- [Android] Enums can now be used to define events. ([#23875](https://github.com/expo/expo/pull/23875) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.providers.AppContextProvider
 import expo.modules.kotlin.tracing.trace
+import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.CoroutineScope
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.primaryConstructor
 
 abstract class Module : AppContextProvider {
 
@@ -28,11 +32,39 @@ abstract class Module : AppContextProvider {
     moduleEventEmitter?.emit(name, body)
   }
 
-  fun sendEvent(name: String, body: Map<String, Any?>?) {
+  fun sendEvent(name: String, body: Map<String, Any?>? = null) {
     moduleEventEmitter?.emit(name, body)
   }
 
+  fun <T> sendEvent(enum: T, body: Bundle? = Bundle.EMPTY) where T : Enumerable, T : Enum<T> {
+    moduleEventEmitter?.emit(convertEnumToString(enum), body)
+  }
+
+
+  fun <T> sendEvent(enum: T, body: Map<String, Any?>? = null) where T : Enumerable, T : Enum<T> {
+    moduleEventEmitter?.emit(convertEnumToString(enum), body)
+  }
+
   abstract fun definition(): ModuleDefinitionData
+
+  private fun <T> convertEnumToString(enumValue: T): String where T : Enumerable, T : Enum<T> {
+    val enumClass = enumValue::class
+    val primaryConstructor = enumClass.primaryConstructor
+    if (primaryConstructor?.parameters?.size == 1) {
+      val parameterName = primaryConstructor.parameters.first().name
+      val parameterProperty = enumClass
+        .declaredMemberProperties
+        .find { it.name == parameterName }
+
+      requireNotNull(parameterProperty) { "Cannot find a property for $parameterName parameter" }
+      require(parameterProperty.returnType.classifier == String::class) { "The enum parameter has to be a string." }
+
+      @Suppress("UNCHECKED_CAST")
+      return (parameterProperty as KProperty1<T, String>).get(enumValue)
+    }
+
+    return enumValue.name
+  }
 }
 
 @Suppress("FunctionName")

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/Module.kt
@@ -40,7 +40,6 @@ abstract class Module : AppContextProvider {
     moduleEventEmitter?.emit(convertEnumToString(enum), body)
   }
 
-
   fun <T> sendEvent(enum: T, body: Map<String, Any?>? = null) where T : Enumerable, T : Enum<T> {
     moduleEventEmitter?.emit(convertEnumToString(enum), body)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -88,7 +88,6 @@ class EnumTypeConverter(
     parameterName: String
   ): Enum<*> {
     // To obtain the value of parameter, we have to find a property that is connected with this parameter.
-    @Suppress("UNCHECKED_CAST")
     val parameterProperty = enumClass
       .declaredMemberProperties
       .find { it.name == parameterName }


### PR DESCRIPTION
# Why

Adds the ability to use enums as events. 

# How

Add support for new syntax looking like this:
```kotlin
enum class CustomEvent : Enumerable {
	onResume, onPause, onStart
}

Module {
	Events<CustomEvent>()

	Function("triggerEvent") {
       sendEvent(CustomEvent.onStart)
    }
}
```

I've also added support for enums with string values like:
```kotlin
enum class CustomEvent(val value: String) : Enumerable {
	onResume("resume"), onPause("pause"), onStart("start")
}
```

# Test Plan

- bare-expo ✅