### PR TITLE
fix: broken link to official docs

### DIFF
--- a/packages/@expo/config-plugins/README.md
+++ b/packages/@expo/config-plugins/README.md
@@ -17,7 +17,7 @@
 
 Most basic functionality can be controlled by using the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
 
-For more info, please refer to the official Expo docs: [Config Plugins](https://docs.expo.dev/home/config-plugins/introduction/).
+For more info, please refer to the official Expo docs: [Config Plugins](https://docs.expo.dev/config-plugins/introduction/).
 
 ## Environment Variables
 


### PR DESCRIPTION
Fixing broken link to official Expo docs

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Link is currently broken and directs users to a 404 page.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the link. Saving users the trouble of googling the official docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Click on the link

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
