### PR TITLE
[go][sqlite] fix broken state for ios expo go

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -74,4 +74,6 @@ jobs:
         timeout-minutes: 45
         env:
           FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30
+          FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 8
         run: expotools native-unit-tests --platform ios

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.5.0):
     - ExpoModulesCore
-    - sqlite3
+    - sqlite3 (~> 3.39.4)
   - ExpoStoreReview (6.5.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.5.0):
@@ -800,9 +800,9 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
+  - sqlite3 (3.39.4):
+    - sqlite3/common (= 3.39.4)
+  - sqlite3/common (3.39.4)
   - UMAppLoader (4.2.0)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
@@ -1345,7 +1345,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 134ecbecb2f81295d7dd5d66ce90ae050962ecfd
   ExpoSMS: c8079b3018ae5206b3f1f6f445fd4eee2a19a335
   ExpoSpeech: cd3a86aedd2340f22eeca8a93040a825be9a280b
-  ExpoSQLite: 1634b80b00d7292b38ce64e1c0ed523a0e745f53
+  ExpoSQLite: ee6a9a91c593750e1904a364110d48e9162cd729
   ExpoStoreReview: f0e23d74a1cfae7a75c2ca7dac9c762dda382f03
   ExpoSystemUI: 2fce488f61a0e2849988a40b34b49a99e8e72af5
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -1425,7 +1425,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
+  sqlite3: 401936402fe5aa242c07f87fccfee5fc2b606f45
   UMAppLoader: e83f024f75f07802fce99739f04b4537d188caaf
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -123,6 +123,10 @@
 		837A38252A20D7090046BD8E /* EXVersionedNetworkInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 837A38242A20D7090046BD8E /* EXVersionedNetworkInterceptor.m */; };
 		837A38262A20D7090046BD8E /* EXVersionedNetworkInterceptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 837A38242A20D7090046BD8E /* EXVersionedNetworkInterceptor.m */; };
 		83D00C72292CABD400CCEFAB /* EXTextDirectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F885A328FEC26000CFD75C /* EXTextDirectionController.swift */; };
+		83D25AE62A83E78C00D8DAFA /* VersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F151B1112A5C6880001BB70F /* VersionManager.swift */; };
+		83D25AE72A83ED5600D8DAFA /* RNCPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = A60CC11587F645D0BF1C832F /* RNCPicker.m */; };
+		83D25AE82A83ED5900D8DAFA /* RNCPickerLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = E37EA5BB197945508A6A14F0 /* RNCPickerLabel.m */; };
+		83D25AE92A83ED5C00D8DAFA /* RNCPickerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 36B3AC83321C444B879BD737 /* RNCPickerManager.m */; };
 		84713BFB28584A0100E86B56 /* EXErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84713BFA28584A0100E86B56 /* EXErrorView.xib */; };
 		84713BFC28584A0100E86B56 /* EXErrorView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84713BFA28584A0100E86B56 /* EXErrorView.xib */; };
 		8704B111C11841D78D77E3E7 /* RNDateTimePickerShadowView.m in Sources */ = {isa = PBXBuildFile; fileRef = 76E808C4949F497592E26673 /* RNDateTimePickerShadowView.m */; settings = {COMPILER_FLAGS = "-w"; }; };
@@ -2895,6 +2899,7 @@
 				F14217E0262CB68600BB97E6 /* EXCachedResource.m in Sources */,
 				8215F58228F08D1900D66BE5 /* RNDateTimePickerShadowView.m in Sources */,
 				F14217E1262CB68600BB97E6 /* EXScopedFontLoader.m in Sources */,
+				83D25AE62A83E78C00D8DAFA /* VersionManager.swift in Sources */,
 				F14217E3262CB68600BB97E6 /* RNAWSCognito.m in Sources */,
 				F14217E4262CB68600BB97E6 /* AIRMapCalloutSubviewManager.m in Sources */,
 				F14217E5262CB68600BB97E6 /* EXDisabledDevMenu.mm in Sources */,
@@ -2968,6 +2973,7 @@
 				F1421854262CB68600BB97E6 /* AIRGMSPolyline.m in Sources */,
 				F1421855262CB68600BB97E6 /* EXScopedNotificationsEmitter.m in Sources */,
 				F1421856262CB68600BB97E6 /* RNViewShot.m in Sources */,
+				83D25AE82A83ED5900D8DAFA /* RNCPickerLabel.m in Sources */,
 				F1421857262CB68600BB97E6 /* EXScopedServerRegistrationModule.m in Sources */,
 				F1421858262CB68600BB97E6 /* EXUserNotificationManager.m in Sources */,
 				F1421859262CB68600BB97E6 /* AIRMapMarker.m in Sources */,
@@ -2993,6 +2999,7 @@
 				F1421877262CB68600BB97E6 /* EXScopedErrorRecoveryModule.m in Sources */,
 				F1421879262CB68600BB97E6 /* EXSession.m in Sources */,
 				F142187B262CB68600BB97E6 /* AIRGMSMarker.m in Sources */,
+				83D25AE72A83ED5600D8DAFA /* RNCPicker.m in Sources */,
 				F142187C262CB68600BB97E6 /* AIRMapWMSTile.m in Sources */,
 				F142187D262CB68600BB97E6 /* AIRMapOverlay.m in Sources */,
 				F142187F262CB68600BB97E6 /* EXAppLoadingCancelView.m in Sources */,
@@ -3051,6 +3058,7 @@
 				F14218C9262CB68600BB97E6 /* EXUpdatesBinding.m in Sources */,
 				F14218CA262CB68600BB97E6 /* AIRGoogleMapMarker.m in Sources */,
 				F14218CB262CB68600BB97E6 /* EXDevMenuMotionInterceptor.m in Sources */,
+				83D25AE92A83ED5C00D8DAFA /* RNCPickerManager.m in Sources */,
 				F14218CC262CB68600BB97E6 /* EXUtilService.m in Sources */,
 				F14218CD262CB68600BB97E6 /* AIRGoogleMapPolygon.m in Sources */,
 				F14218CE262CB68600BB97E6 /* EXUpdatesDatabaseManager.m in Sources */,

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -727,10 +727,10 @@ PODS:
     - ABI48_0_0ExpoModulesCore
   - ABI48_0_0ExpoImage (1.0.0):
     - ABI48_0_0ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ABI48_0_0ExpoImageManipulator (11.1.1):
     - ABI48_0_0EXImageLoader
     - ABI48_0_0ExpoModulesCore
@@ -1452,10 +1452,10 @@ PODS:
     - ABI49_0_0ExpoModulesCore
   - ABI49_0_0ExpoImage (1.3.2):
     - ABI49_0_0ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ABI49_0_0ExpoImageManipulator (11.3.0):
     - ABI49_0_0EXImageLoader
     - ABI49_0_0ExpoModulesCore
@@ -2268,10 +2268,10 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.4.1):
     - ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ExpoImageManipulator (11.4.1):
     - EXImageLoader
     - ExpoModulesCore
@@ -2325,7 +2325,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.5.0):
     - ExpoModulesCore
-    - sqlite3
+    - sqlite3 (~> 3.39.4)
   - ExpoStoreReview (6.5.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.5.0):
@@ -2536,16 +2536,19 @@ PODS:
     - libavif/core
   - libevent (2.1.12)
   - libvmaf (2.3.1)
-  - libwebp (1.2.4):
-    - libwebp/demux (= 1.2.4)
-    - libwebp/mux (= 1.2.4)
-    - libwebp/webp (= 1.2.4)
-  - libwebp/demux (1.2.4):
+  - libwebp (1.3.1):
+    - libwebp/demux (= 1.3.1)
+    - libwebp/mux (= 1.3.1)
+    - libwebp/sharpyuv (= 1.3.1)
+    - libwebp/webp (= 1.3.1)
+  - libwebp/demux (1.3.1):
     - libwebp/webp
-  - libwebp/mux (1.2.4):
+  - libwebp/mux (1.3.1):
     - libwebp/demux
-  - libwebp/webp (1.2.4)
-  - lottie-ios (3.4.4)
+  - libwebp/sharpyuv (1.3.1)
+  - libwebp/webp (1.3.1):
+    - libwebp/sharpyuv
+  - lottie-ios (3.4.0)
   - lottie-react-native (5.1.6):
     - lottie-ios (~> 3.4.0)
     - React-Core
@@ -3041,21 +3044,21 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - SDWebImage (5.15.8):
-    - SDWebImage/Core (= 5.15.8)
-  - SDWebImage/Core (5.15.8)
-  - SDWebImageAVIFCoder (0.10.0):
+  - SDWebImage (5.17.0):
+    - SDWebImage/Core (= 5.17.0)
+  - SDWebImage/Core (5.17.0)
+  - SDWebImageAVIFCoder (0.10.1):
     - libavif (>= 0.11.0)
     - SDWebImage (~> 5.10)
   - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageWebPCoder (0.11.0):
+  - SDWebImageWebPCoder (0.13.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.15)
+    - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.42.0):
-    - sqlite3/common (= 3.42.0)
-  - sqlite3/common (3.42.0)
+  - sqlite3 (3.39.4):
+    - sqlite3/common (= 3.39.4)
+  - sqlite3/common (3.39.4)
   - Stripe (23.8.0):
     - StripeApplePay (= 23.8.0)
     - StripeCore (= 23.8.0)
@@ -4699,7 +4702,7 @@ SPEC CHECKSUMS:
   ABI48_0_0ExpoDevice: c119dd7e98df279cb9d06f58eede18289be95ea1
   ABI48_0_0ExpoGL: 158cdc822ab1831c6c91a0e62524c1a004b61b31
   ABI48_0_0ExpoHaptics: 4ece00d4b8aa47a1d45abc46ac9ae1d3e0a5edfb
-  ABI48_0_0ExpoImage: 24bf210cc71f3d8c8f804032b25b7c6f8088babf
+  ABI48_0_0ExpoImage: 2aa4ab9c9c68dacd08e7506695ef88728cef2ecc
   ABI48_0_0ExpoImageManipulator: 9d61e40b13268e04e51e868c770fea324dd5ac8d
   ABI48_0_0ExpoImagePicker: f55b4ae78f26481bec5a769f2b23c864c22f2608
   ABI48_0_0ExpoKeepAwake: 956461c0639ea092f296010edf75e17a7b827336
@@ -4809,7 +4812,7 @@ SPEC CHECKSUMS:
   ABI49_0_0ExpoDocumentPicker: 158d12950ecbbc2d46de7bdcfce5f6903b22990f
   ABI49_0_0ExpoGL: 55996b25b777b4a684c470dea45900847db979e0
   ABI49_0_0ExpoHaptics: 83ad7550f581abf75c5df4d7ff9c6a9731eb25cf
-  ABI49_0_0ExpoImage: 04236edaa4946cc98e85950b51ab2335ba3c9afe
+  ABI49_0_0ExpoImage: 7fe9af1c554ced66e8afea22bf10ecece416437e
   ABI49_0_0ExpoImageManipulator: 62a8f6a9004f916d4973c084ef84fc306472a3e5
   ABI49_0_0ExpoImagePicker: b218499effe8ff4aac3cae1a467071fe2eb8e97f
   ABI49_0_0ExpoInsights: d4433e3114fc7fd01edbc82aa8cb72c0e346f40d
@@ -4934,7 +4937,7 @@ SPEC CHECKSUMS:
   ExpoGL: ff70ada41e42fceefc9e8c8342f18e8cf6b339b1
   ExpoHaptics: c7b4bdec1d791b93a79cd3da9e57f206acff656e
   ExpoHead: 88ba3aa09d8a194b98bf33809c436b40f9122b30
-  ExpoImage: f345323299804fe839c92a4e18f9a1bc82784029
+  ExpoImage: d932e3923f0826c29831841d8c45a489471f86e5
   ExpoImageManipulator: 8ea73d1961367b881a767f4a0554bdf06eacbabc
   ExpoImagePicker: 6d6b75f99ca2115f83a86c90b7dd421c3e256fbb
   ExpoKeepAwake: cfa0bd035420d6b2398c3baea0bcb0f2ff87943c
@@ -4952,7 +4955,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 134ecbecb2f81295d7dd5d66ce90ae050962ecfd
   ExpoSMS: c8079b3018ae5206b3f1f6f445fd4eee2a19a335
   ExpoSpeech: cd3a86aedd2340f22eeca8a93040a825be9a280b
-  ExpoSQLite: 1634b80b00d7292b38ce64e1c0ed523a0e745f53
+  ExpoSQLite: ee6a9a91c593750e1904a364110d48e9162cd729
   ExpoStoreReview: f0e23d74a1cfae7a75c2ca7dac9c762dda382f03
   ExpoSystemUI: 2fce488f61a0e2849988a40b34b49a99e8e72af5
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -4996,8 +4999,8 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
-  libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
-  lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
+  libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
+  lottie-ios: 69495122151a378fdc7d1bb4c5930347e37baf1f
   lottie-react-native: 8f9d4be452e23f6e5ca0fdc11669dc99ab52be81
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
@@ -5051,12 +5054,12 @@ SPEC CHECKSUMS:
   RNReanimated: c540188fb085b7bf60678f5f5ca3ced906faaab7
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
-  SDWebImageAVIFCoder: 4aeea8fdf65af5c18525ecb5bdd8b8ed9bb45019
+  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
-  SDWebImageWebPCoder: 295a6573c512f54ad2dd58098e64e17dcf008499
+  SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
+  sqlite3: 401936402fe5aa242c07f87fccfee5fc2b606f45
   Stripe: 5432fbab660595a3bee937235dd71a99028ac68c
   stripe-react-native: 096d83ad94da350f08f5cd48275e7f9645dde297
   StripeApplePay: 5e686f50ee07c439b79b907dffeb144135e601c9

--- a/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
+++ b/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
@@ -16,13 +16,13 @@
   "static_framework": true,
   "dependencies": {
     "SDWebImage": [
-      "~> 5.15.8"
+      "~> 5.17.0"
     ],
     "SDWebImageWebPCoder": [
-      "~> 0.11.0"
+      "~> 0.13.0"
     ],
     "SDWebImageAVIFCoder": [
-      "~> 0.10.0"
+      "~> 0.10.1"
     ],
     "SDWebImageSVGCoder": [
       "~> 1.7.0"

--- a/ios/versioned/sdk49/ExpoImage/ABI49_0_0ExpoImage.podspec.json
+++ b/ios/versioned/sdk49/ExpoImage/ABI49_0_0ExpoImage.podspec.json
@@ -16,13 +16,13 @@
   "static_framework": true,
   "dependencies": {
     "SDWebImage": [
-      "~> 5.15.8"
+      "~> 5.17.0"
     ],
     "SDWebImageWebPCoder": [
-      "~> 0.11.0"
+      "~> 0.13.0"
     ],
     "SDWebImageAVIFCoder": [
-      "~> 0.10.0"
+      "~> 0.10.1"
     ],
     "SDWebImageSVGCoder": [
       "~> 1.7.0"

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed build error when mixing with iOS built-in SQLite3. ([#23885](https://github.com/expo/expo/pull/23885) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 11.5.0 — 2023-08-02

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
   
   s.dependency 'ExpoModulesCore'
-  s.dependency 'sqlite3'
+  s.dependency 'sqlite3', '~> 3.39.4'
   s.resource_bundles = { 'ExpoSQLite' => ['../crsqlite.dylib'] }
   
   # Swift/Objective-C compatibility


### PR DESCRIPTION
# Why

ios expo-go has a couple error in the mean time, this pr is to address them all.

# How

- `pod install` error: outdated podfile.lock since #23858
- build error from sqlite, since expo-go mixes ios builtin sqlite3 and community sqlite3. for example, sqlite3 `create_filename` is different. we should use older sqlite3 to make sure everything is compatible.
    - `char *(*create_filename)(const char*,const char*,const char*,
                           int,const char**);`
    - `const char *(*create_filename)(const char*,const char*,const char*,
                           int,const char**);`
- missing some files to build for versioned expo-go, when testing with versioned expo-go. it will have runtime error because of missing modules.

# Test Plan

- ci passed
- versioned expo go + NCL `EXPO_SDK_VERSION=UNVERSIONED npx expo start`

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
