### PR TITLE
[go] Update expo image dependencies in podspec.json files

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -727,10 +727,10 @@ PODS:
     - ABI48_0_0ExpoModulesCore
   - ABI48_0_0ExpoImage (1.0.0):
     - ABI48_0_0ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ABI48_0_0ExpoImageManipulator (11.1.1):
     - ABI48_0_0EXImageLoader
     - ABI48_0_0ExpoModulesCore
@@ -1452,10 +1452,10 @@ PODS:
     - ABI49_0_0ExpoModulesCore
   - ABI49_0_0ExpoImage (1.3.2):
     - ABI49_0_0ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ABI49_0_0ExpoImageManipulator (11.3.0):
     - ABI49_0_0EXImageLoader
     - ABI49_0_0ExpoModulesCore
@@ -2268,10 +2268,10 @@ PODS:
     - ExpoModulesCore
   - ExpoImage (1.4.1):
     - ExpoModulesCore
-    - SDWebImage (~> 5.15.8)
-    - SDWebImageAVIFCoder (~> 0.10.0)
+    - SDWebImage (~> 5.17.0)
+    - SDWebImageAVIFCoder (~> 0.10.1)
     - SDWebImageSVGCoder (~> 1.7.0)
-    - SDWebImageWebPCoder (~> 0.11.0)
+    - SDWebImageWebPCoder (~> 0.13.0)
   - ExpoImageManipulator (11.4.1):
     - EXImageLoader
     - ExpoModulesCore
@@ -2536,15 +2536,18 @@ PODS:
     - libavif/core
   - libevent (2.1.12)
   - libvmaf (2.3.1)
-  - libwebp (1.2.4):
-    - libwebp/demux (= 1.2.4)
-    - libwebp/mux (= 1.2.4)
-    - libwebp/webp (= 1.2.4)
-  - libwebp/demux (1.2.4):
+  - libwebp (1.3.1):
+    - libwebp/demux (= 1.3.1)
+    - libwebp/mux (= 1.3.1)
+    - libwebp/sharpyuv (= 1.3.1)
+    - libwebp/webp (= 1.3.1)
+  - libwebp/demux (1.3.1):
     - libwebp/webp
-  - libwebp/mux (1.2.4):
+  - libwebp/mux (1.3.1):
     - libwebp/demux
-  - libwebp/webp (1.2.4)
+  - libwebp/sharpyuv (1.3.1)
+  - libwebp/webp (1.3.1):
+    - libwebp/sharpyuv
   - lottie-ios (3.4.4)
   - lottie-react-native (5.1.6):
     - lottie-ios (~> 3.4.0)
@@ -3041,17 +3044,17 @@ PODS:
     - React-RCTImage
   - RNSVG (13.9.0):
     - React-Core
-  - SDWebImage (5.15.8):
-    - SDWebImage/Core (= 5.15.8)
-  - SDWebImage/Core (5.15.8)
-  - SDWebImageAVIFCoder (0.10.0):
+  - SDWebImage (5.17.0):
+    - SDWebImage/Core (= 5.17.0)
+  - SDWebImage/Core (5.17.0)
+  - SDWebImageAVIFCoder (0.10.1):
     - libavif (>= 0.11.0)
     - SDWebImage (~> 5.10)
   - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - SDWebImageWebPCoder (0.11.0):
+  - SDWebImageWebPCoder (0.13.0):
     - libwebp (~> 1.0)
-    - SDWebImage/Core (~> 5.15)
+    - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
   - sqlite3 (3.42.0):
     - sqlite3/common (= 3.42.0)
@@ -4699,7 +4702,7 @@ SPEC CHECKSUMS:
   ABI48_0_0ExpoDevice: c119dd7e98df279cb9d06f58eede18289be95ea1
   ABI48_0_0ExpoGL: 158cdc822ab1831c6c91a0e62524c1a004b61b31
   ABI48_0_0ExpoHaptics: 4ece00d4b8aa47a1d45abc46ac9ae1d3e0a5edfb
-  ABI48_0_0ExpoImage: 24bf210cc71f3d8c8f804032b25b7c6f8088babf
+  ABI48_0_0ExpoImage: 2aa4ab9c9c68dacd08e7506695ef88728cef2ecc
   ABI48_0_0ExpoImageManipulator: 9d61e40b13268e04e51e868c770fea324dd5ac8d
   ABI48_0_0ExpoImagePicker: f55b4ae78f26481bec5a769f2b23c864c22f2608
   ABI48_0_0ExpoKeepAwake: 956461c0639ea092f296010edf75e17a7b827336
@@ -4809,7 +4812,7 @@ SPEC CHECKSUMS:
   ABI49_0_0ExpoDocumentPicker: 158d12950ecbbc2d46de7bdcfce5f6903b22990f
   ABI49_0_0ExpoGL: 55996b25b777b4a684c470dea45900847db979e0
   ABI49_0_0ExpoHaptics: 83ad7550f581abf75c5df4d7ff9c6a9731eb25cf
-  ABI49_0_0ExpoImage: 04236edaa4946cc98e85950b51ab2335ba3c9afe
+  ABI49_0_0ExpoImage: 7fe9af1c554ced66e8afea22bf10ecece416437e
   ABI49_0_0ExpoImageManipulator: 62a8f6a9004f916d4973c084ef84fc306472a3e5
   ABI49_0_0ExpoImagePicker: b218499effe8ff4aac3cae1a467071fe2eb8e97f
   ABI49_0_0ExpoInsights: d4433e3114fc7fd01edbc82aa8cb72c0e346f40d
@@ -4934,7 +4937,7 @@ SPEC CHECKSUMS:
   ExpoGL: ff70ada41e42fceefc9e8c8342f18e8cf6b339b1
   ExpoHaptics: c7b4bdec1d791b93a79cd3da9e57f206acff656e
   ExpoHead: 88ba3aa09d8a194b98bf33809c436b40f9122b30
-  ExpoImage: f345323299804fe839c92a4e18f9a1bc82784029
+  ExpoImage: d932e3923f0826c29831841d8c45a489471f86e5
   ExpoImageManipulator: 8ea73d1961367b881a767f4a0554bdf06eacbabc
   ExpoImagePicker: 6d6b75f99ca2115f83a86c90b7dd421c3e256fbb
   ExpoKeepAwake: cfa0bd035420d6b2398c3baea0bcb0f2ff87943c
@@ -4996,7 +4999,7 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
-  libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
+  libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
   lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
   lottie-react-native: 8f9d4be452e23f6e5ca0fdc11669dc99ab52be81
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
@@ -5051,10 +5054,10 @@ SPEC CHECKSUMS:
   RNReanimated: c540188fb085b7bf60678f5f5ca3ced906faaab7
   RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: 53c661b76829783cdaf9b7a57258f3d3b4c28315
-  SDWebImage: cb032eba469c54e0000e78bcb0a13cdde0a52798
-  SDWebImageAVIFCoder: 4aeea8fdf65af5c18525ecb5bdd8b8ed9bb45019
+  SDWebImage: 750adf017a315a280c60fde706ab1e552a3ae4e9
+  SDWebImageAVIFCoder: 8348fef6d0ec69e129c66c9fe4d74fbfbf366112
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
-  SDWebImageWebPCoder: 295a6573c512f54ad2dd58098e64e17dcf008499
+  SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   Stripe: 5432fbab660595a3bee937235dd71a99028ac68c

--- a/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
+++ b/ios/versioned/sdk48/ExpoImage/ABI48_0_0ExpoImage.podspec.json
@@ -16,13 +16,13 @@
   "static_framework": true,
   "dependencies": {
     "SDWebImage": [
-      "~> 5.15.8"
+      "~> 5.17.0"
     ],
     "SDWebImageWebPCoder": [
-      "~> 0.11.0"
+      "~> 0.13.0"
     ],
     "SDWebImageAVIFCoder": [
-      "~> 0.10.0"
+      "~> 0.10.1"
     ],
     "SDWebImageSVGCoder": [
       "~> 1.7.0"

--- a/ios/versioned/sdk49/ExpoImage/ABI49_0_0ExpoImage.podspec.json
+++ b/ios/versioned/sdk49/ExpoImage/ABI49_0_0ExpoImage.podspec.json
@@ -16,13 +16,13 @@
   "static_framework": true,
   "dependencies": {
     "SDWebImage": [
-      "~> 5.15.8"
+      "~> 5.17.0"
     ],
     "SDWebImageWebPCoder": [
-      "~> 0.11.0"
+      "~> 0.13.0"
     ],
     "SDWebImageAVIFCoder": [
-      "~> 0.10.0"
+      "~> 0.10.1"
     ],
     "SDWebImageSVGCoder": [
       "~> 1.7.0"


### PR DESCRIPTION
# Why
Fixed an issue with installing pods in expo go.  

# How
Updated the SDWebImage dependencies in the 48 and 49 podspec.json files

# Test Plan
Pod install finishes successfully