### PR TITLE
[docs] use `eas/run_gradle` command in custom built-in functions example

### DIFF
--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -1399,10 +1399,7 @@ build:
 
     - eas/inject_android_credentials
 
-    - run:
-        name: Build Android app
-        working_directory: ./android
-        command: ./gradlew :app:bundleRelease
+    - eas/run_gradle
 
     - eas/find_and_upload_build_artifacts
 ```


### PR DESCRIPTION
# Why

use `eas/run_gradle` command in custom built-in functions example

# How

use `eas/run_gradle` command in custom built-in functions example

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
