### PR TITLE
[core][Android] Promises can now be resolved without arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - [Android] Surfaced errorManager to allow throwing errors and warnings from modules. ([#23848](https://github.com/expo/expo/pull/23848) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Enums can now be used to define events. ([#23875](https://github.com/expo/expo/pull/23875) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Promises can now be resolved without arguments.
+- [Android] Promises can now be resolved without arguments. ([#23907](https://github.com/expo/expo/pull/23907) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Surfaced errorManager to allow throwing errors and warnings from modules. ([#23848](https://github.com/expo/expo/pull/23848) by [@aleqsio](https://github.com/aleqsio))
 - [Android] Enums can now be used to define events. ([#23875](https://github.com/expo/expo/pull/23875) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Promises can now be resolved without arguments.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/Promise.kt
@@ -9,6 +9,10 @@ private const val unknownCode = "UnknownCode"
 interface Promise {
   fun resolve(value: Any?)
 
+  fun resolve() {
+    resolve(null)
+  }
+
   fun reject(code: String, message: String?, cause: Throwable?)
 
   fun reject(exception: CodedException) {
@@ -18,7 +22,7 @@ interface Promise {
 
 fun Promise.toBridgePromise(): com.facebook.react.bridge.Promise {
   val expoPromise = this
-  val resolveMethod = if (expoPromise is PromiseImpl) {
+  val resolveMethod: (value: Any?) -> Unit = if (expoPromise is PromiseImpl) {
     expoPromise.resolveBlock::invoke
   } else {
     expoPromise::resolve


### PR DESCRIPTION
# Why

Promises can now be resolved without arguments.

# How

Adds a syntactic sugar for `promise.resolve(null)`. Now it can be resolved without any arguments: `promise.resolve()`.
