### PR TITLE
feat(cli): improved entry errors during metro static web rendering

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Forward exact Metro server error during static rendering.
+
 ### 🐛 Bug fixes
 
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Forward exact Metro server error during static rendering.
+- Forward exact Metro server error during static rendering. ([#23909](https://github.com/expo/expo/pull/23909) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -41,6 +41,13 @@ import { instantiateMetroAsync } from './instantiateMetro';
 import { getErrorOverlayHtmlAsync } from './metroErrorInterface';
 import { metroWatchTypeScriptFiles } from './metroWatchTypeScriptFiles';
 import { observeFileChanges } from './waitForMetroToObserveTypeScriptFile';
+import { CommandError } from '../../../utils/errors';
+
+class ForwardHtmlError extends CommandError {
+  constructor(message: string, public html: string, public statusCode: number) {
+    super(message);
+  }
+}
 
 const debug = require('debug')('expo:start:server:metro') as typeof console.log;
 
@@ -149,14 +156,25 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
     const txt = await results.text();
 
+    // console.log('STAT:', results.status, results.statusText);
     let data: any;
     try {
       data = JSON.parse(txt);
     } catch (error: any) {
+      debug(txt);
+
+      // Metro can throw this error when the initial module id cannot be resolved.
+      if (!results.ok && txt.startsWith('<!DOCTYPE html>')) {
+        throw new ForwardHtmlError(
+          `Metro failed to bundle the project. Check the console for more information.`,
+          txt,
+          results.status
+        );
+      }
+
       Log.error(
         'Failed to generate resources with Metro, the Metro config may not be using the correct serializer. Ensure the metro.config.js is extending the expo/metro-config and is not overriding the serializer.'
       );
-      debug(txt);
       throw error;
     }
 
@@ -375,6 +393,12 @@ export class MetroBundlerDevServer extends BundlerDevServer {
             return;
           } catch (error: any) {
             res.setHeader('Content-Type', 'text/html');
+            // Forward the Metro server response as-is. It won't be pretty, but at least it will be accurate.
+            if (error instanceof ForwardHtmlError) {
+              res.statusCode = error.statusCode;
+              res.end(error.html);
+              return;
+            }
             try {
               res.end(await this.renderStaticErrorAsync(error));
             } catch (staticError: any) {

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -16,6 +16,7 @@ import path from 'path';
 import { Log } from '../../../log';
 import getDevClientProperties from '../../../utils/analytics/getDevClientProperties';
 import { logEventAsync } from '../../../utils/analytics/rudderstackClient';
+import { CommandError } from '../../../utils/errors';
 import { getFreePortAsync } from '../../../utils/port';
 import { BundlerDevServer, BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
 import { getStaticRenderFunctions } from '../getStaticRenderFunctions';
@@ -41,7 +42,6 @@ import { instantiateMetroAsync } from './instantiateMetro';
 import { getErrorOverlayHtmlAsync } from './metroErrorInterface';
 import { metroWatchTypeScriptFiles } from './metroWatchTypeScriptFiles';
 import { observeFileChanges } from './waitForMetroToObserveTypeScriptFile';
-import { CommandError } from '../../../utils/errors';
 
 class ForwardHtmlError extends CommandError {
   constructor(message: string, public html: string, public statusCode: number) {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -132,4 +132,42 @@ describe('getStaticResourcesAsync', () => {
 
     expect(scope.isDone()).toBe(true);
   });
+  it(`throws from a metro server error`, async () => {
+    vol.fromJSON(
+      {
+        'index.js': '',
+        'package.json': JSON.stringify({}),
+      },
+      '/'
+    );
+    const scope = nock('http://localhost:8081')
+      .get(
+        '/index.bundle?platform=web&dev=true&hot=false&resolver.environment=client&transform.environment=client&serializer.output=static'
+      )
+      .reply(
+        500,
+        `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+        <meta charset="utf-8">
+        <title>Error</title>
+        </head>
+        <body>
+        <pre>Error: Unable to resolve module ./packages/expo-router/entry from /Users/evanbacon/Documents/GitHub/expo/apps/sandbox/.: <br><br>None of these files exist:<br> &nbsp;* packages/expo-router/entry(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css|.web.cjs|.cjs)<br> &nbsp;* packages/expo-router/entry/index(.web.ts|.ts|.web.tsx|.tsx|.web.mjs|.mjs|.web.js|.js|.web.jsx|.jsx|.web.json|.json|.web.cjs|.cjs|.web.scss|.scss|.web.sass|.sass|.web.css|.css|.web.cjs|.cjs)<br> &nbsp; &nbsp;at ModuleResolver.resolveDependency (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/node-haste/DependencyGraph/ModuleResolution.js:114:15)<br> &nbsp; &nbsp;at DependencyGraph.resolveDependency (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/node-haste/DependencyGraph.js:277:43)<br> &nbsp; &nbsp;at /Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/lib/transformHelpers.js:169:21<br> &nbsp; &nbsp;at Server._resolveRelativePath (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:1045:12)<br> &nbsp; &nbsp;at process.processTicksAndRejections (node:internal/process/task_queues:95:5)<br> &nbsp; &nbsp;at async Server.requestProcessor [as _processBundleRequest] (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:449:37)<br> &nbsp; &nbsp;at async Server._processRequest (/Users/evanbacon/Documents/GitHub/expo/node_modules/metro/src/Server.js:383:7)</pre>
+        </body>
+        </html>`
+      );
+
+    const devServer = await getStartedDevServer();
+
+    expect(devServer['postStartAsync']).toHaveBeenCalled();
+
+    await expect(
+      devServer.getStaticResourcesAsync({ mode: 'development', minify: false })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"Metro failed to bundle the project. Check the console for more information."`
+    );
+
+    expect(scope.isDone()).toBe(true);
+  });
 });


### PR DESCRIPTION
# Why

- Surface static rendering errors exactly to increase visibility.
