### PR TITLE
[jest] Ignore transforming react-native-reanimated/plugin

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Files under `/node_modules/react-native-reanimated/plugin/` are excluded from being transformed by Jest. This fixes a "Reentrant plugin detected" error that occurred when running tests that applied to multiple platforms, like `__tests__/example.native.js` (run for both Android and iOS tests). ([#23912](https://github.com/expo/expo/pull/23912) by [@ide](https://github.com/ide))
+
 ### 💡 Others
 
 ## 50.0.0-alpha.0 — 2023-07-28

--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -10,16 +10,15 @@ function getPlatformPreset(displayOptions, extensions) {
     isReact: true,
     isModern: false,
   });
-  const testMatch = ['', ...extensions].reduce((arr, cur) => {
-    const platformExtension = cur ? `.${cur}` : '';
+  const testMatch = ['', ...extensions].flatMap((extension) => {
+    const platformExtension = extension ? `.${extension}` : '';
     const sourceExtension = `.[jt]s?(x)`;
     return [
-      ...arr,
       `**/__tests__/**/*spec${platformExtension}${sourceExtension}`,
       `**/__tests__/**/*test${platformExtension}${sourceExtension}`,
       `**/?(*.)+(spec|test)${platformExtension}${sourceExtension}`,
     ];
-  }, []);
+  });
 
   return withWatchPlugins({
     displayName: displayOptions,

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -40,7 +40,8 @@ if (!Array.isArray(jestPreset.transformIgnorePatterns)) {
 
 // Also please keep `testing-with-jest.md` file up to date
 jestPreset.transformIgnorePatterns = [
-  'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
+  '/node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)',
+  '/node_modules/react-native-reanimated/plugin/',
 ];
 
 // setupFiles


### PR DESCRIPTION
Why
---
We use Jest projects to run multi-platform tests. For instance, there is an Android Jest project and an iOS Jest project. Some tests are run under multiple projects, like `test.native.js`. Such tests would cause Jest to fail with:
`
Error: [BABEL]: [BABEL] <path>/expo/node_modules/react-native-reanimated/plugin/index.js: Reentrant plugin detected trying to load "<path>/expo/node_modules/react-native-reanimated/plugin/index.js". This module is not ignored and is trying to load itself while compiling itself, leading to a dependency cycle. We recommend adding it to your "ignore" list in your babelrc, or to a .babelignore. (While processing: <path>/expo/node_modules/react-native-reanimated/plugin/index.js)
`

How
---
Added `'/node_modules/react-native-reanimated/plugin/'` to the `transformIgnorePatterns` setting in the preset defined by `jest-expo`.

Two other small enhancements: added a leading slash to the existing `node_modules`, which more closely matches how Jest's [default rule](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring) is formatted, and replaced a `reduce()` that wasn't reducing with a `flatMap()` call that is mapping.

Test Plan
---
- `jest-expo`'s own tests pass
- Run `yarn test` under `expo-sensors`. Previously it would fail. Now it passes.
