### PR TITLE
[autolinking] Resolve cli for isolated modules before running node scripts

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add support for pnpm isolated modules ([#23867](https://github.com/expo/expo/pull/23867) by [@byCedric](https://github.com/byCedric))
+- Resolve cli for isolated modules before running node scripts. ([#23926](https://github.com/expo/expo/pull/23926) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+++ b/packages/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
@@ -153,7 +153,8 @@ class ExpoAutolinkingManager {
       'node',
       '--no-warnings',
       '--eval',
-      'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
+      // Resolve the `expo` > `expo-modules-autolinking` chain from the project root
+      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo\')] }))(process.argv.slice(1))',
       '--',
       command,
       '--platform',

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -178,7 +178,7 @@ module Expo
         'node',
         '--no-warnings',
         '--eval',
-        'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
+        'require(require.resolve(\'expo-modules-autolinking\', { paths: [\'' +  __dir__ + '\'] }))(process.argv.slice(1))',
         command_name,
         '--platform',
         'ios'

--- a/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/react_import_patcher.rb
@@ -14,7 +14,7 @@ module Expo
         'node',
         '--no-warnings',
         '--eval',
-        'require(\'expo-modules-autolinking\')(process.argv.slice(1))',
+        'require(require.resolve(\'expo-modules-autolinking\', { paths: [\'' + __dir__ + '\'] }))(process.argv.slice(1))',
         'patch-react-imports',
         '--pods-root',
         File.expand_path(@root),


### PR DESCRIPTION
# Why

This is the last fix to make `expo-modules-autolinking` work with isolated modules (e.g. pnpm).

> ~~⚠️ Note: this only fixes the iOS part, since we can use `__dir__`. I haven't found a proper alternative for Android's gradle unfortunately.~~ Android is now also fixed, see comments for more info.

With isolated modules, we can only require direct project or package dependencies. Meaning that for `expo-modules-autolinking`, we have two options:

1. Resolve `expo-modules-autolinking` from the actual `.../expo-modules-autolinking/scripts` folder (parent folder is the module)
2. Resolve the full dependency chain from the root of the project: `expo > expo-modules-autolinking`

# How

- Resolve `expo-modules-autolinking` from script's directory before executing Node command from iOS cocoapods script (option 1)
- Resolve `expo` > `expo-modules-autolinking` from the project root before executing Node command in gradle (option 2 - no viable option 1 alternative in gradle)

# Test Plan

- `$ pnpm create expo ./test-isolated-modules -t tabs`
- `$ cd ./test-isolated-modules`
- Patch autolinking
- `$ pnpm expo install expo-dev-client` _(or any other module, containing other modules)_
- `$ pnpm expo run:ios` _(should work and include all nested dependencies of `expo-dev-client`)_

Or see this repo: https://github.com/byCedric/expo-pnpm-tests/blob/main/patches/expo-modules-autolinking%401.5.0.patch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
