### PR TITLE
[docs] Add info about defining `EXPO_USE_METRO_WORKSPACE_ROOT` for monorepo

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -197,11 +197,13 @@ import App from './App';
 registerRootComponent(App);
 ```
 
-**If you are using [Expo Router](/routing/introduction/)**, define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
+> This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
+
+If you are using [Expo Router](/routing/introduction/), define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
 
 <Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 
-> This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
+This variable can also be defined inside a **.env** file.
 
 ### Create a package
 

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -197,11 +197,9 @@ import App from './App';
 registerRootComponent(App);
 ```
 
-If you are using [Expo Router](/routing/introduction/), change the default entry point (`main`) to **index.js** in **package.json**. Then, create the **index.js** file within the root of your project with the following:
+**If you are using [Expo Router](/routing/introduction/)**, define the [`EXPO_USE_METRO_WORKSPACE_ROOT`](/more/expo-cli/#environment-variables) environment variable when running the `npx expo start` command. It enables the auto server root detection for Metro.
 
-```js index.js
-import 'expo-router/entry';
-```
+<Terminal cmd={['$ EXPO_USE_METRO_WORKSPACE_ROOT=1 npx expo start']} />
 
 > This new entrypoint already exists for bare projects. You only need to add this if you have a managed project.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Refs [slack](https://exponent-internal.slack.com/archives/C0447EFTS74/p1691702737684219)

# How

<!--
How did you build this feature or fix this bug and why?
-->

By updating the info the default entrypoint when using Expo Router to use `EXPO_USE_METRO_WORKSPACE_ROOT`.

**Preview**

<img width="872" alt="CleanShot 2023-08-11 at 23 19 56@2x" src="https://github.com/expo/expo/assets/10234615/03a2e88f-0e6f-4b4a-a845-71cfd819bdce">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/monorepos/#change-default-entrypoint

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
