### PR TITLE
[docs] Fix Bracket Typo in Push Notifications Guide

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -94,10 +94,9 @@ async function registerForPushNotificationsAsync() {
       return;
     }
     /* @info This provides the ExpoPushToken which is attributed based on the ID of the project. */
-     token = (
-      await Notifications.getExpoPushTokenAsync({
-        projectId: Constants.expoConfig.extra.eas.projectId,
-      })
+    token = await Notifications.getExpoPushTokenAsync({
+      projectId: Constants.expoConfig.extra.eas.projectId,
+    });
     /* @end */
     console.log(token);
   } else {


### PR DESCRIPTION
# Why

There is a small typo with the brackets making it so you can't just copy/paste this code.

# How

Removed the bracket

# Test Plan

Compile the doc page and make sure everything looks right

# What it looks like now

<img width="649" alt="Screen Shot 2023-08-12 at 10 45 33 AM" src="https://github.com/expo/expo/assets/48887088/1b6e7fbe-49c4-4d22-9597-e2d46d11c883">

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
