### PR TITLE
[expo] Add support for pnpm isolated modules

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Add support for pnpm isolated modules. ([#23937](https://github.com/expo/expo/pull/23937) by [@byCedric](https://github.com/byCedric))
+
 ### 💡 Others
 
 - Removed the environment validator. ([#23732](https://github.com/expo/expo/pull/23732) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/scripts/autolinking.gradle
+++ b/packages/expo/scripts/autolinking.gradle
@@ -1,2 +1,4 @@
-def autolinkingPath = ["node", "--print", "require.resolve('expo-modules-autolinking/package.json')"].execute(null, rootDir).text.trim()
+// Resolve `expo` > `expo-modules-autolinking` dependency chain
+def autolinkingPath = ["node", "--print", "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })"].execute(null, rootDir).text.trim()
 apply from: new File(autolinkingPath, "../scripts/android/autolinking_implementation.gradle");
+

--- a/packages/expo/scripts/autolinking.rb
+++ b/packages/expo/scripts/autolinking.rb
@@ -2,9 +2,9 @@ require 'json'
 require 'pathname'
 require 'colored2' # dependency of CocoaPods
 
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/autolinking_manager")
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/xcode_env_generator")
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/react_import_patcher")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['#{__dir__}'] })"`), "scripts/ios/autolinking_manager")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['#{__dir__}'] })"`), "scripts/ios/xcode_env_generator")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['#{__dir__}'] })"`), "scripts/ios/react_import_patcher")
 
 def use_expo_modules!(options = {})
   # When run from the Podfile, `self` points to Pod::Podfile object

--- a/packages/expo/scripts/autolinking.rb
+++ b/packages/expo/scripts/autolinking.rb
@@ -2,9 +2,9 @@ require 'json'
 require 'pathname'
 require 'colored2' # dependency of CocoaPods
 
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json')"`), "scripts/ios/autolinking_manager")
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json')"`), "scripts/ios/xcode_env_generator")
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json')"`), "scripts/ios/react_import_patcher")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/autolinking_manager")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/xcode_env_generator")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['` + __dir__ + `'] })"`), "scripts/ios/react_import_patcher")
 
 def use_expo_modules!(options = {})
   # When run from the Podfile, `self` points to Pod::Podfile object


### PR DESCRIPTION
# Why

This PR makes the `expo` autolinking scripts compatible with isolated modules (e.g. from pnpm). It's part of other PRs that make our packages compatible and more resilient in monorepo projects.

- https://github.com/expo/expo/pull/23867
- https://github.com/expo/expo/pull/23926

# How

- **iOS:** resolve `expo-modules-autolinking` from the `__dir__`
  _(current directory of the file `expo/scripts/autolinking.rb`)_
- **Android:** resolve `expo-modules-autolinking` from `expo` location 
  _(there is no __dir__ alternative, so we need to resolve the `expo` > `expo-modules-autolinking` chain from project root)_

# Test Plan

- `$ pnpm create expo ./test-isolated-modules -t tabs`
- `$ cd ./test-isolated-modules`
- Patch expo with the changes from this PR
- Both Android and iOS run commands should work:
  - `$ pnpm expo run:ios`
  - `$ pnpm expo run:android`

Or see this repo: https://github.com/byCedric/expo-pnpm-tests/blob/main/patches/expo%4049.0.6.patch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
