### PR TITLE
[core][Android] Fix nullability of parameter type when converting from js to native

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Refresh NativeModulesProxy if app bundle is reloaded. ([#23824](https://github.com/expo/expo/pull/23824) by [@douglowder](https://github.com/douglowder))
+- [Android] Fix nullability of parameter type in `List` and `Map` when converting from js to native.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Refresh NativeModulesProxy if app bundle is reloaded. ([#23824](https://github.com/expo/expo/pull/23824) by [@douglowder](https://github.com/douglowder))
-- [Android] Fix nullability of parameter type in `List` and `Map` when converting from js to native.
+- [Android] Fix nullability of parameter type in `List` and `Map` when converting from JS to native.
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

When declaring a native parameter as `Map<String, Any?>`, passing nulls is not allowed in the cpp code. This PR will enable nulls, but it is not the correct solution. The right solution requires sending more information to the cpp side. I will do it later, but I need to unblock my other PRs for now.

# Test Plan

- bare-expo ✅