### PR TITLE
[home] Make apollo client setup on login consistent with website

### DIFF
--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -7,74 +7,74 @@ import Config from './Config';
 import Connectivity from './Connectivity';
 import Store from '../redux/Store';
 
-export function createApolloClient() {
-  const httpLink = new HttpLink({
-    uri: `${Config.api.origin}/--/graphql`,
-  });
+const httpLink = new HttpLink({
+  uri: `${Config.api.origin}/--/graphql`,
+});
 
-  const connectivityLink = setContext(async (): Promise<any> => {
-    const isConnected = await Connectivity.isAvailableAsync();
-    if (!isConnected) {
-      throw new Error('No connection available');
-    }
-  });
+const connectivityLink = setContext(async (): Promise<any> => {
+  const isConnected = await Connectivity.isAvailableAsync();
+  if (!isConnected) {
+    throw new Error('No connection available');
+  }
+});
 
-  const authMiddlewareLink = setContext((_request, previousContext): any => {
-    const { sessionSecret } = Store.getState().session;
+const authMiddlewareLink = setContext((_request, previousContext): any => {
+  const { sessionSecret } = Store.getState().session;
 
-    if (sessionSecret) {
-      return {
-        headers: { 'expo-session': sessionSecret },
-      };
-    }
-
-    return previousContext;
-  });
-
-  const link = from([connectivityLink, authMiddlewareLink, httpLink]);
-
-  const cache = new InMemoryCache({
-    possibleTypes: {
-      AccountUsageMetadata: ['AccountUsageEASBuildMetadata'],
-      ActivityTimelineProjectActivity: ['Build', 'BuildJob', 'Submission', 'Update'],
-      Actor: ['Robot', 'SSOUser', 'User'],
-      BuildOrBuildJob: ['Build', 'BuildJob'],
-      EASBuildOrClassicBuildJob: ['Build', 'BuildJob'],
-      FcmSnippet: ['FcmSnippetLegacy', 'FcmSnippetV1'],
-      PlanEnablement: ['Concurrencies', 'EASTotalPlanEnablement'],
-      Project: ['App', 'Snack'],
-      UserActor: ['SSOUser', 'User'],
-    },
-    addTypename: true,
-    typePolicies: {
-      Query: {
-        fields: {
-          account: {
-            merge: false,
-          },
-          app: {
-            merge: false,
-          },
-        },
+  if (sessionSecret) {
+    return {
+      ...previousContext,
+      headers: {
+        ...previousContext.headers,
+        'expo-session': sessionSecret,
       },
-      Account: {
-        fields: {
-          apps: offsetLimitPagination(),
-          snacks: offsetLimitPagination(),
+    };
+  }
+
+  return previousContext;
+});
+
+const link = from([connectivityLink, authMiddlewareLink, httpLink]);
+
+const cache = new InMemoryCache({
+  possibleTypes: {
+    AccountUsageMetadata: ['AccountUsageEASBuildMetadata'],
+    ActivityTimelineProjectActivity: ['Build', 'BuildJob', 'Submission', 'Update'],
+    Actor: ['Robot', 'SSOUser', 'User'],
+    BuildOrBuildJob: ['Build', 'BuildJob'],
+    EASBuildOrClassicBuildJob: ['Build', 'BuildJob'],
+    FcmSnippet: ['FcmSnippetLegacy', 'FcmSnippetV1'],
+    PlanEnablement: ['Concurrencies', 'EASTotalPlanEnablement'],
+    Project: ['App', 'Snack'],
+    UserActor: ['SSOUser', 'User'],
+  },
+  addTypename: true,
+  typePolicies: {
+    Query: {
+      fields: {
+        account: {
+          merge: false,
         },
-      },
-      App: {
-        fields: {
-          updateBranches: offsetLimitPagination(),
+        app: {
+          merge: false,
         },
       },
     },
-  });
+    Account: {
+      fields: {
+        apps: offsetLimitPagination(),
+        snacks: offsetLimitPagination(),
+      },
+    },
+    App: {
+      fields: {
+        updateBranches: offsetLimitPagination(),
+      },
+    },
+  },
+});
 
-  return new ApolloClient({
-    link,
-    cache,
-  });
-}
-
-export default createApolloClient();
+export default new ApolloClient({
+  link,
+  cache,
+});

--- a/home/menu/DevMenuBottomSheet.tsx
+++ b/home/menu/DevMenuBottomSheet.tsx
@@ -57,7 +57,7 @@ function DevMenuBottomSheet({ children, uuid }: Props) {
   useEffect(() => {
     const closeSubscription = DevMenu.listenForCloseRequests(() => {
       bottomSheetRef.current?.collapse();
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         resolve();
       });
     });

--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 import url from 'url';
 
-import { createApolloClient } from '../../api/ApolloClient';
+import ApolloClient from '../../api/ApolloClient';
 import Config from '../../api/Config';
 import {
   Home_ViewerPrimaryAccountNameDocument,
@@ -111,11 +111,12 @@ export function LoggedOutAccountView({ refetch }: Props) {
 
         const sessionSecret = decodeURIComponent(encodedSessionSecret);
 
-        const viewerPrimaryAccountNameResult = await createApolloClient().query<
+        const viewerPrimaryAccountNameResult = await ApolloClient.query<
           Home_ViewerPrimaryAccountNameQuery,
           Home_ViewerPrimaryAccountNameQueryVariables
         >({
           query: Home_ViewerPrimaryAccountNameDocument,
+          fetchPolicy: 'network-only',
           context: {
             headers: { 'expo-session': sessionSecret },
           },


### PR DESCRIPTION
# Why

https://github.com/expo/expo/commit/4dde425725d57dc1cdac5f1797da0f5d99e61adf changed the semantics of this call to avoid the problem of a cached context being used instead of the session provided in the context override. This should have worked. But we're seeing reports of this not working (seeing `Logged in user must have a primary account` error messages in reports).

So, we change the semantics of this back to the original semantics but with lessons learned in the Expo website apollo client merged in, namely that a network-only fetchPolicy recomputes the context, and that the context must be merged in.

Website PRs:
https://github.com/expo/universe/pull/12897
https://github.com/expo/universe/pull/12959

# How

Copy ideas from website PRs.

# Test Plan

Log in to expo go running locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
