### PR TITLE
[docs] Concept: secret quick-copy for links from search results

### DIFF
--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -30,11 +30,23 @@ export const CommandItemBase = ({
 }: Props) => {
   const [copyDone, setCopyDone] = useState(false);
 
+  const copyUrl = () => {
+    navigator.clipboard?.writeText(url);
+    setCopyDone(true);
+    setTimeout(() => setCopyDone(false), 1500);
+  };
+
   return (
     <Command.Item
       className={className}
       value={value}
       data-nested={isNested ? true : undefined}
+      onMouseUp={event => {
+        // middle click (typical *nix copy shortcut)
+        if (event.button === 1) {
+          copyUrl();
+        }
+      }}
       onSelect={() => {
         openLink(url, isExternalLink);
         onSelect && onSelect();
@@ -42,11 +54,7 @@ export const CommandItemBase = ({
       onContextMenu={event => {
         event.preventDefault();
       }}
-      onAuxClick={() => {
-        navigator.clipboard?.writeText(url);
-        setCopyDone(true);
-        setTimeout(() => setCopyDone(false), 1500);
-      }}>
+      onAuxClick={copyUrl}>
       {children}
       {copyDone && (
         <Tag

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -39,7 +39,7 @@ export const CommandItemBase = ({
 
   return (
     <Command.Item
-      className={mergeClasses(className, 'relative')}
+      className={mergeClasses('relative', className)}
       value={value}
       data-nested={isNested ? true : undefined}
       onMouseUp={event => {

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -6,8 +6,7 @@ import { openLink } from '../utils';
 
 import { Tag } from '~/ui/components/Tag';
 
-type Props = {
-  children: React.ReactNode;
+type Props = PropsWithChildren<{
   url: string;
   onSelect?: () => void;
   isExternalLink?: boolean;
@@ -15,7 +14,7 @@ type Props = {
   // Props forwarded to Command.Item
   className?: string;
   value?: string;
-};
+}>;
 
 /**
  * Wrapper for Command.Item that adds copy link on right/ middle click + visual copy indicator.

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -1,0 +1,59 @@
+import { Command } from 'cmdk';
+import { useState } from 'react';
+
+import { openLink } from '../utils';
+
+import { Tag } from '~/ui/components/Tag';
+
+type Props = {
+  children: React.ReactNode;
+  url: string;
+  onSelect?: () => void;
+  isExternalLink?: boolean;
+  isNested?: boolean;
+  // Props forwarded to Command.Item
+  className?: string;
+  value?: string;
+};
+
+/**
+ * Wrapper for Command.Item that adds copy link on right/ middle click + visual copy indicator.
+ */
+export const CommandItemBase = ({
+  children,
+  url,
+  isExternalLink,
+  isNested,
+  onSelect,
+  className,
+  value,
+}: Props) => {
+  const [copyDone, setCopyDone] = useState(false);
+
+  return (
+    <Command.Item
+      className={className}
+      value={value}
+      data-nested={isNested ? true : undefined}
+      onSelect={() => {
+        openLink(url, isExternalLink);
+        onSelect && onSelect();
+      }}
+      onContextMenu={event => {
+        event.preventDefault();
+      }}
+      onAuxClick={() => {
+        navigator.clipboard?.writeText(url);
+        setCopyDone(true);
+        setTimeout(() => setCopyDone(false), 1500);
+      }}>
+      {children}
+      {copyDone && (
+        <Tag
+          name="Copied!"
+          className="absolute right-2.5 top-[calc(50%-13px)] !m-0 !border-secondary !bg-default"
+        />
+      )}
+    </Command.Item>
+  );
+};

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -43,9 +43,9 @@ export const CommandItemBase = ({
       value={value}
       data-nested={isNested ? true : undefined}
       onMouseUp={event => {
-        // middle click (typical *nix copy shortcut) and
+        // note(Keith): middle click (typical *nix copy shortcut) 
         // right click (works with Mac trackpads)
-        // NOTE: onAuxClick is not supported in Safari
+        // onAuxClick is not supported in Safari
         if (event.button === 1 || event.button === 2) {
           copyUrl();
         }

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -1,3 +1,4 @@
+import { mergeClasses } from '@expo/styleguide';
 import { Command } from 'cmdk';
 import { useState } from 'react';
 
@@ -38,12 +39,14 @@ export const CommandItemBase = ({
 
   return (
     <Command.Item
-      className={className}
+      className={mergeClasses(className, 'relative')}
       value={value}
       data-nested={isNested ? true : undefined}
       onMouseUp={event => {
-        // middle click (typical *nix copy shortcut)
-        if (event.button === 1) {
+        // middle click (typical *nix copy shortcut) and
+        // right click (works with Mac trackpads)
+        // NOTE: onAuxClick is not supported in Safari
+        if (event.button === 1 || event.button === 2) {
           copyUrl();
         }
       }}
@@ -53,8 +56,7 @@ export const CommandItemBase = ({
       }}
       onContextMenu={event => {
         event.preventDefault();
-      }}
-      onAuxClick={copyUrl}>
+      }}>
       {children}
       {copyDone && (
         <Tag

--- a/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
+++ b/docs/ui/components/CommandMenu/Items/CommandItemBase.tsx
@@ -1,6 +1,6 @@
 import { mergeClasses } from '@expo/styleguide';
 import { Command } from 'cmdk';
-import { useState } from 'react';
+import { PropsWithChildren, useState } from 'react';
 
 import { openLink } from '../utils';
 
@@ -42,7 +42,7 @@ export const CommandItemBase = ({
       value={value}
       data-nested={isNested ? true : undefined}
       onMouseUp={event => {
-        // note(Keith): middle click (typical *nix copy shortcut) 
+        // note(Keith): middle click (typical *nix copy shortcut)
         // right click (works with Mac trackpads)
         // onAuxClick is not supported in Safari
         if (event.button === 1 || event.button === 2) {

--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -7,6 +7,7 @@ import {
   Hash02Icon,
 } from '@expo/styleguide-icons';
 import { Command } from 'cmdk';
+import { useState } from 'react';
 
 import type { AlgoliaItemType } from '../types';
 import {
@@ -22,6 +23,7 @@ import { FootnoteSection } from './FootnoteSection';
 import { FootnoteArrowIcon } from './icons';
 
 import versions from '~/public/static/constants/versions.json';
+import { Tag } from '~/ui/components/Tag';
 import { CALLOUT, CAPTION, FOOTNOTE } from '~/ui/components/Text';
 
 const { LATEST_VERSION } = versions;
@@ -99,10 +101,13 @@ const transformUrl = (url: string) => {
 };
 
 export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
+  const [copyDone, setCopyDone] = useState(false);
+
   const { lvl0, lvl2, lvl3, lvl4, lvl6 } = item.hierarchy;
   const TitleElement = isNested ? FOOTNOTE : CALLOUT;
   const ContentElement = isNested ? CAPTION : FOOTNOTE;
   const titleWeight = isNested ? 'regular' : 'medium';
+
   return (
     <Command.Item
       className={mergeClasses(isNested && 'ml-8 !mt-0.5 !min-h-[32px]')}
@@ -116,6 +121,8 @@ export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
       }}
       onAuxClick={() => {
         navigator.clipboard?.writeText(transformUrl(item.url));
+        setCopyDone(true);
+        setTimeout(() => setCopyDone(false), 1500);
       }}
       data-nested={isNested ? true : undefined}>
       <div className={mergeClasses('inline-flex items-center gap-3 break-words')}>
@@ -181,6 +188,12 @@ export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
             <ContentElement theme="secondary" {...getContentHighlightHTML(item)} />
           )}
         </div>
+        {copyDone && (
+          <Tag
+            name="Copied!"
+            className="absolute right-2.5 top-[calc(50%-13px)] !m-0 !border-secondary !bg-default"
+          />
+        )}
       </div>
     </Command.Item>
   );

--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -7,7 +7,6 @@ import {
   Hash02Icon,
 } from '@expo/styleguide-icons';
 import { Command } from 'cmdk';
-import { copy } from 'fs-extra';
 
 import type { AlgoliaItemType } from '../types';
 import {

--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -6,8 +6,6 @@ import {
   Home02Icon,
   Hash02Icon,
 } from '@expo/styleguide-icons';
-import { Command } from 'cmdk';
-import { useState } from 'react';
 
 import type { AlgoliaItemType } from '../types';
 import {
@@ -15,15 +13,14 @@ import {
   getHighlightHTML,
   isReferencePath,
   isEASPath,
-  openLink,
   isHomePath,
   isLearnPath,
 } from '../utils';
+import { CommandItemBase } from './CommandItemBase';
 import { FootnoteSection } from './FootnoteSection';
 import { FootnoteArrowIcon } from './icons';
 
 import versions from '~/public/static/constants/versions.json';
-import { Tag } from '~/ui/components/Tag';
 import { CALLOUT, CAPTION, FOOTNOTE } from '~/ui/components/Text';
 
 const { LATEST_VERSION } = versions;
@@ -101,30 +98,18 @@ const transformUrl = (url: string) => {
 };
 
 export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
-  const [copyDone, setCopyDone] = useState(false);
-
   const { lvl0, lvl2, lvl3, lvl4, lvl6 } = item.hierarchy;
   const TitleElement = isNested ? FOOTNOTE : CALLOUT;
   const ContentElement = isNested ? CAPTION : FOOTNOTE;
   const titleWeight = isNested ? 'regular' : 'medium';
 
   return (
-    <Command.Item
+    <CommandItemBase
       className={mergeClasses(isNested && 'ml-8 !mt-0.5 !min-h-[32px]')}
       value={`expodocs-${item.objectID}`}
-      onSelect={() => {
-        openLink(transformUrl(item.url));
-        onSelect && onSelect();
-      }}
-      onContextMenu={event => {
-        event.preventDefault();
-      }}
-      onAuxClick={() => {
-        navigator.clipboard?.writeText(transformUrl(item.url));
-        setCopyDone(true);
-        setTimeout(() => setCopyDone(false), 1500);
-      }}
-      data-nested={isNested ? true : undefined}>
+      onSelect={onSelect}
+      url={transformUrl(item.url)}
+      isNested={isNested}>
       <div className={mergeClasses('inline-flex items-center gap-3 break-words')}>
         <ItemIcon url={item.url} isNested={isNested} className="shrink-0" />
         <div>
@@ -188,13 +173,7 @@ export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
             <ContentElement theme="secondary" {...getContentHighlightHTML(item)} />
           )}
         </div>
-        {copyDone && (
-          <Tag
-            name="Copied!"
-            className="absolute right-2.5 top-[calc(50%-13px)] !m-0 !border-secondary !bg-default"
-          />
-        )}
       </div>
-    </Command.Item>
+    </CommandItemBase>
   );
 };

--- a/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoDocsItem.tsx
@@ -7,6 +7,7 @@ import {
   Hash02Icon,
 } from '@expo/styleguide-icons';
 import { Command } from 'cmdk';
+import { copy } from 'fs-extra';
 
 import type { AlgoliaItemType } from '../types';
 import {
@@ -110,6 +111,12 @@ export const ExpoDocsItem = ({ item, onSelect, isNested }: Props) => {
       onSelect={() => {
         openLink(transformUrl(item.url));
         onSelect && onSelect();
+      }}
+      onContextMenu={event => {
+        event.preventDefault();
+      }}
+      onAuxClick={() => {
+        navigator.clipboard?.writeText(transformUrl(item.url));
       }}
       data-nested={isNested ? true : undefined}>
       <div className={mergeClasses('inline-flex items-center gap-3 break-words')}>

--- a/docs/ui/components/CommandMenu/Items/ExpoItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/ExpoItem.tsx
@@ -1,8 +1,8 @@
 import { BuildIcon } from '@expo/styleguide-icons';
-import { Command } from 'cmdk';
 
 import type { ExpoItemType } from '../types';
-import { addHighlight, openLink } from '../utils';
+import { addHighlight } from '../utils';
+import { CommandItemBase } from './CommandItemBase';
 
 import { CALLOUT } from '~/ui/components/Text';
 
@@ -15,12 +15,7 @@ type Props = {
 export const ExpoItem = ({ item, onSelect, query }: Props) => {
   const Icon = item.Icon ?? BuildIcon;
   return (
-    <Command.Item
-      value={`expo-${item.url}`}
-      onSelect={() => {
-        openLink(item.url);
-        onSelect && onSelect();
-      }}>
+    <CommandItemBase value={`expo-${item.url}`} url={item.url} onSelect={onSelect}>
       <div className="inline-flex gap-3 items-center">
         <Icon className="text-icon-secondary" />
         <CALLOUT
@@ -28,6 +23,6 @@ export const ExpoItem = ({ item, onSelect, query }: Props) => {
           dangerouslySetInnerHTML={{ __html: addHighlight(item.label, query) }}
         />
       </div>
-    </Command.Item>
+    </CommandItemBase>
   );
 };

--- a/docs/ui/components/CommandMenu/Items/RNDirectoryItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/RNDirectoryItem.tsx
@@ -1,8 +1,8 @@
 import { GithubIcon } from '@expo/styleguide-icons';
-import { Command } from 'cmdk';
 
 import type { RNDirectoryItemType } from '../types';
-import { addHighlight, openLink } from '../utils';
+import { addHighlight } from '../utils';
+import { CommandItemBase } from './CommandItemBase';
 import { ExternalLinkIcon } from './icons';
 
 import { CALLOUT, CAPTION } from '~/ui/components/Text';
@@ -17,12 +17,11 @@ const numberFormat = new Intl.NumberFormat();
 
 export const RNDirectoryItem = ({ item, onSelect, query }: Props) => {
   return (
-    <Command.Item
+    <CommandItemBase
       value={`rnd-${item.npmPkg}`}
-      onSelect={() => {
-        openLink(item.githubUrl, true);
-        onSelect && onSelect();
-      }}>
+      url={item.githubUrl}
+      isExternalLink
+      onSelect={onSelect}>
       <div className="inline-flex gap-3 items-center">
         <GithubIcon className="text-icon-secondary" />
         <div>
@@ -37,6 +36,6 @@ export const RNDirectoryItem = ({ item, onSelect, query }: Props) => {
         </div>
         <ExternalLinkIcon />
       </div>
-    </Command.Item>
+    </CommandItemBase>
   );
 };

--- a/docs/ui/components/CommandMenu/Items/RNDocsItem.tsx
+++ b/docs/ui/components/CommandMenu/Items/RNDocsItem.tsx
@@ -1,7 +1,6 @@
-import { Command } from 'cmdk';
-
 import type { AlgoliaItemType } from '../types';
-import { getContentHighlightHTML, getHighlightHTML, openLink } from '../utils';
+import { getContentHighlightHTML, getHighlightHTML } from '../utils';
+import { CommandItemBase } from './CommandItemBase';
 import { FootnoteSection } from './FootnoteSection';
 import { ExternalLinkIcon, ReactIcon } from './icons';
 
@@ -15,12 +14,11 @@ type Props = {
 export const RNDocsItem = ({ item, onSelect }: Props) => {
   const { lvl0, lvl1, lvl2, lvl3, lvl4 } = item.hierarchy;
   return (
-    <Command.Item
+    <CommandItemBase
       value={`rn-${item.objectID}`}
-      onSelect={() => {
-        openLink(item.url, true);
-        onSelect && onSelect();
-      }}>
+      url={item.url}
+      isExternalLink
+      onSelect={onSelect}>
       <div className="inline-flex gap-3 items-center">
         <ReactIcon className="shrink-0" />
         <div>
@@ -67,6 +65,6 @@ export const RNDocsItem = ({ item, onSelect }: Props) => {
         </div>
         <ExternalLinkIcon />
       </div>
-    </Command.Item>
+    </CommandItemBase>
   );
 };

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -11,7 +11,7 @@ type PlatformTagProps = Omit<TagProps, 'name'> & {
   platform: PlatformName;
 };
 
-export const PlatformTag = ({ platform, type }: PlatformTagProps) => {
+export const PlatformTag = ({ platform, type, className }: PlatformTagProps) => {
   const platformName = getPlatformName(platform);
 
   return (
@@ -22,7 +22,8 @@ export const PlatformTag = ({ platform, type }: PlatformTagProps) => {
           platformName === 'ios' ||
           platformName === 'web' ||
           platformName === 'expo') &&
-          TAG_CLASSES[platformName]
+          TAG_CLASSES[platformName],
+        className
       )}>
       {type !== 'toc' && <PlatformIcon platform={platformName} />}
       <span css={labelStyle}>{formatName(platform)}</span>

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -11,12 +11,13 @@ type StatusTagProps = Omit<TagProps, 'name'> & {
   note?: string;
 };
 
-export const StatusTag = ({ status, type, note }: StatusTagProps) => {
+export const StatusTag = ({ status, type, note, className }: StatusTagProps) => {
   return (
     <div
       className={mergeClasses(
         status === 'deprecated' && TAG_CLASSES['deprecated'],
-        status === 'experimental' && TAG_CLASSES['experimental']
+        status === 'experimental' && TAG_CLASSES['experimental'],
+        className
       )}
       css={[tagStyle, type === 'toc' && tagToCStyle]}>
       {status === 'experimental' && <Stars02Icon className="icon-xs text-palette-pink11" />}

--- a/docs/ui/components/Tag/Tag.tsx
+++ b/docs/ui/components/Tag/Tag.tsx
@@ -1,3 +1,5 @@
+import type { HTMLAttributes } from 'react';
+
 import { PlatformTag } from './PlatformTag';
 import { StatusTag } from './StatusTag';
 
@@ -7,7 +9,7 @@ export type TagProps = {
   name: string;
   firstElement?: boolean;
   type?: 'regular' | 'toc';
-};
+} & HTMLAttributes<HTMLDivElement>;
 
 export const Tag = ({ name, ...rest }: TagProps) => {
   if (getPlatformName(name).length) {


### PR DESCRIPTION
# Why
I copy links from the docs dozens of times a day for support responses, Discord, etc., and I'm sure I'm not the only one. I typically memorize what search results give me what links. I don't need to watch the search result page load, except so that I can copy that link. So, I was wondering... what if I didn't have to? What if I could get the link without ever leaving the search results?

I'm not very confident this is right way to do it, so I wanted to ask (in the form of the PR), does anybody else want this? And what would be the right way to do it?

# How
I've been using Linux a lot lately, which is big on copying-via-middle-click. Unfortunately, macOS doesn't have middle-click, so, it would have to be right-click, so all I did was suppress the context menu when right-clicking on a search result.

If it worked like this, IMO it'd be better with some actual feedback, like a toast. Or it could be something like this copy feedback:
![image](https://github.com/expo/expo/assets/8053974/12066a45-eabb-4f67-a1d4-a2751bc42700)
(just didn't want to go too far without feedback on the concept itself)

Is there another sort of secret shortcut that could work? Like a keypress + click?

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
