### PR TITLE
[docs] Remove /home from /development-builds and /config-plugins paths

### DIFF
--- a/packages/@expo/config-plugins/README.md
+++ b/packages/@expo/config-plugins/README.md
@@ -17,7 +17,7 @@
 
 Most basic functionality can be controlled by using the [static Expo config](https://docs.expo.dev/versions/latest/config/app/), but some features require manipulation of the native project files. To support complex behavior we've created config plugins, and mods (short for modifiers).
 
-For more info, please refer to the official Expo docs: [Config Plugins](https://docs.expo.dev/home/config-plugins/introduction/).
+For more info, please refer to the official Expo docs: [Config Plugins](https://docs.expo.dev/config-plugins/introduction/).
 
 ## Environment Variables
 

--- a/packages/expo-build-properties/README.md
+++ b/packages/expo-build-properties/README.md
@@ -46,4 +46,4 @@ Contributions are very welcome! Please refer to guidelines described in the [con
 [docs-main]: https://github.com/expo/expo/blob/main/docs/pages/versions/unversioned/sdk/build-properties.mdx
 [docs-stable]: https://docs.expo.dev/versions/latest/sdk/build-properties/
 [contributing]: https://github.com/expo/expo#contributing
-[config-plugins]: https://docs.expo.dev/home/config-plugins/introduction
+[config-plugins]: https://docs.expo.dev/config-plugins/introduction

--- a/packages/expo-dev-client/README.md
+++ b/packages/expo-dev-client/README.md
@@ -12,7 +12,7 @@ next time you need to upgrade, install a new module, or otherwise change the nat
 
 ## Documentation
 
-You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/develop/development-builds/introduction).
 
 ## Issues
 

--- a/packages/expo-dev-launcher/README.md
+++ b/packages/expo-dev-launcher/README.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/develop/development-builds/introduction).
 
 ## Contributing
 

--- a/packages/expo-dev-menu/README.md
+++ b/packages/expo-dev-menu/README.md
@@ -1,10 +1,10 @@
 # 📦 expo-dev-menu
 
-Expo/React Native module to add developer menu to Debug builds of your application. This package is intended to be included in your project through [`expo-dev-client`](https://docs.expo.dev/home/develop/development-builds/introduction/#what-is-an-expo-dev-client).
+Expo/React Native module to add developer menu to Debug builds of your application. This package is intended to be included in your project through [`expo-dev-client`](https://docs.expo.dev/develop/development-builds/introduction/#what-is-an-expo-dev-client).
 
 ## Documentation
 
-You can find more information in the [Expo documentation](https://docs.expo.dev/home/develop/development-builds/introduction).
+You can find more information in the [Expo documentation](https://docs.expo.dev/develop/development-builds/introduction).
 
 ## Contributing
 

--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -62,7 +62,7 @@ This package automatically adds the `CAMERA`, `READ_EXTERNAL_STORAGE`, and `WRIT
 
 > This plugin is applied automatically in EAS Build, only add the config plugin if you want to pass in extra properties.
 
-After installing this npm package, add the [config plugin](https://docs.expo.dev/home/config-plugins/introduction) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+After installing this npm package, add the [config plugin](https://docs.expo.dev/config-plugins/introduction) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
 
 ```json
 {

--- a/packages/expo-notifications/README.md
+++ b/packages/expo-notifications/README.md
@@ -126,7 +126,7 @@ This module requires permission to subscribe to device boot. It's used to setup 
 
 ### Config plugin setup (optional)
 
-If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the expo-notifications config plugin ([what's a config plugin?](https://docs.expo.dev/home/config-plugins/introduction)). To setup, just add the config plugin to the plugins array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
+If you're using EAS Build, you can set your Android notification icon and color tint, add custom push notification sounds, and set your iOS notification environment using the expo-notifications config plugin ([what's a config plugin?](https://docs.expo.dev/config-plugins/introduction)). To setup, just add the config plugin to the plugins array of your `app.json` or `app.config.js` as shown below, then rebuild the app.
 
 ```json
 {


### PR DESCRIPTION
# Why

In some places in docs urls like https://docs.expo.dev/home/config-plugins/introduction or https://docs.expo.dev/home/develop/development-builds/introduction were not properly handled.

<img width="840" alt="image" src="https://github.com/expo/expo/assets/17254885/d85716d9-fd2d-4b45-9515-0068e45339a1">
<img width="820" alt="image" src="https://github.com/expo/expo/assets/17254885/6cb55b3c-6f86-4e97-bba9-b124a0b1dc95">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# How

Remove /home from urls in readme files.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
