### PR TITLE
[go] fix top crash for android expo-go

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -514,9 +514,11 @@ abstract class ReactNativeActivity :
       return true
     }
 
-    if (!KernelProvider.instance.reloadVisibleExperience(manifestUrl!!)) {
+    manifestUrl?.let {
       // Kernel couldn't reload, show error screen
-      return true
+      if (!KernelProvider.instance.reloadVisibleExperience(it)) {
+        return true
+      }
     }
 
     errorQueue.clear()


### PR DESCRIPTION
# Why

try to fix the top crash for android expo-go: https://console.firebase.google.com/project/exponent-5dd6d/crashlytics/app/android:host.exp.exponent/issues/9d584f4d6540e6fccac254f6f72db478

```
Fatal Exception: java.lang.RuntimeException: Unable to resume activity {host.exp.exponent/host.exp.exponent.experience.HomeActivity}: java.lang.NullPointerException
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4756)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4788)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2221)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:268)
       at android.app.ActivityThread.main(ActivityThread.java:8101)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:627)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:997)

Caused by java.lang.NullPointerException:
       at host.exp.exponent.experience.ReactNativeActivity.shouldShowErrorScreen(ReactNativeActivity.kt:517)
       at host.exp.exponent.experience.BaseExperienceActivity.consumeErrorQueue$lambda$2(BaseExperienceActivity.kt:140)
       at android.app.Activity.runOnUiThread(Activity.java:7146)
       at host.exp.exponent.experience.BaseExperienceActivity.consumeErrorQueue(BaseExperienceActivity.kt:135)
       at host.exp.exponent.experience.BaseExperienceActivity.onResume(BaseExperienceActivity.kt:49)
       at host.exp.exponent.experience.HomeActivity.onResume(HomeActivity.kt:83)
       at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1456)
       at android.app.Activity.performResume(Activity.java:8229)
       at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4741)
       at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4788)
       at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
       at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2221)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:268)
       at android.app.ActivityThread.main(ActivityThread.java:8101)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:627)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:997)
```

# How

i cannot reproduce the crash but the `manifestUrl` is null in the `HomeActivity`. not sure if the pr fixes the problem correct but it would prevent expo-go from crash.

# Test Plan

n/a but only expo-go smoke testing

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
