### PR TITLE
[expo-apple-authentication][docs] Remove managed project instruction from README

### DIFF
--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -40,8 +40,6 @@ To enable the **Sign In with Apple** capability in your app, set the [`ios.usesA
 
 <ConfigPluginExample>
 
-> This plugin is included automatically when installed.
-
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
 ```json app.json

--- a/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/unversioned/sdk/apple-authentication.mdx
@@ -13,8 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
-in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -22,12 +21,22 @@ in order to comply with App Store Review guidelines. For more information, see A
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
-You can configure `expo-apple-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins
-in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
-The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
-If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-apple-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
+The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+
+### Setup iOS project
+
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+
+```json app.json
+{
+  "ios": {
+    "usesAppleSignIn": true
+  }
+}
+```
 
 <ConfigPluginExample>
 

--- a/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
@@ -40,8 +40,6 @@ To enable the **Sign In with Apple** capability in your app, set the [`ios.usesA
 
 <ConfigPluginExample>
 
-> This plugin is included automatically when installed.
-
 Running [EAS Build](/build/introduction) locally will use [iOS capabilities signing](/build-reference/ios-capabilities) to enable the required capabilities before building.
 
 ```json app.json

--- a/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/apple-authentication.mdx
@@ -13,8 +13,7 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-apple-authentication` provides Apple authentication for iOS 13+. It does not yet support lower iOS versions, Android, or the web.
 
-Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option
-in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
+Beginning with iOS 13, any app that includes third-party authentication options **must** provide Apple authentication as an option in order to comply with App Store Review guidelines. For more information, see Apple authentication on the [Sign In with Apple](https://developer.apple.com/sign-in-with-apple/) website.
 
 <PlatformsSection ios simulator />
 
@@ -22,12 +21,22 @@ in order to comply with App Store Review guidelines. For more information, see A
 
 <APIInstallSection />
 
-## Configuration in app.json/app.config.js
+## Configuration in app config
 
-You can configure `expo-apple-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins
-in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
-The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect.
-If your app does **not** use EAS Build, then you'll need to manually configure the package.
+You can configure `expo-apple-authentication` using its built-in [config plugin](/config-plugins/introduction/) if you use config plugins in your project ([EAS Build](/build/introduction) or `npx expo run:[android|ios]`).
+The plugin allows you to configure various properties that cannot be set at runtime and require building a new app binary to take effect. If your app does **not** use EAS Build, then you'll need to manually configure the package.
+
+### Setup iOS project
+
+To enable the **Sign In with Apple** capability in your app, set the [`ios.usesAppleSignIn`](/versions/latest/config/app/#usesapplesignin) property to `true` in your project's app config:
+
+```json app.json
+{
+  "ios": {
+    "usesAppleSignIn": true
+  }
+}
+```
 
 <ConfigPluginExample>
 

--- a/packages/expo-apple-authentication/README.md
+++ b/packages/expo-apple-authentication/README.md
@@ -27,7 +27,7 @@ Run `npx pod-install` after installing the npm package.
 
 # Setup iOS project
 
-1. Enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later. For managed projects, set `ios.usesAppleSignIn` to `true` in app.json.
+1. Enable the "Sign In with Apple" capability in your app. For bare projects, enable the capability in Xcode under "Signing & Capabilities" -- you'll need to be on Xcode 11 or later.
 2. Log into the Apple Developer Console, go to "Certificates, Identifiers, & Profiles" and then "Identifiers".
 3. You need to choose a primary app for the Apple Sign In configuration. This is the app whose icon will show up in the Apple Sign In system UI. If you have a set of related apps you might choose the "main" app as the primary, but most likely you'll want to just use the app you're working on now as the primary.
 4. In the list of identifiers, click on the one corresponding to your primary app. Enable the "Sign In with Apple" capability, click "Edit", and choose the "Enable as a primary App ID" option. Save the new configuration.


### PR DESCRIPTION
<!-- disable:changelog-checks -->

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As described here in #20264, it is confusing to find the managed workflow instruction defined in the README file of the package rather than in the docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By removing managed workflow instruction for setting up iOS package from the README file.
- Adding that instruction to the SDK docs and backporting it to SDK 49.
- Also, remove the note about "plugin is included automatically when installing the library". It does not. Tested an example project with both `create-expo-app` and `yarn create expo`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/unversioned/sdk/apple-authentication/#setup-ios-project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
