### PR TITLE
[docs] Add 'Star Us on GitHub' link like on the website

### DIFF
--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -34,17 +34,6 @@ export const Header = ({
           <Button
             openInNewTab
             theme="quaternary"
-            css={hideOnMobileStyle}
-            className="px-2 text-secondary"
-            href="https://github.com/expo/expo">
-            <span className="flex gap-2 items-center">
-              <Star01Icon className="icon-sm" />
-              Star Us on GitHub
-            </span>
-          </Button>
-          <Button
-            openInNewTab
-            theme="quaternary"
             className="px-2 text-secondary"
             href="https://blog.expo.dev">
             Blog
@@ -52,7 +41,17 @@ export const Header = ({
           <Button
             openInNewTab
             theme="quaternary"
+            css={hideOnMobileStyle}
+            className="px-2 text-secondary"
+            leftSlot={<Star01Icon className="icon-sm" />}
+            href="https://github.com/expo/expo">
+            Star Us on GitHub
+          </Button>
+          <Button
+            openInNewTab
+            theme="quaternary"
             href="https://github.com/expo/expo"
+            css={showOnMobileStyle}
             aria-label="GitHub"
             className="px-2">
             <GithubIcon className="icon-lg" />

--- a/docs/ui/components/Header/Header.tsx
+++ b/docs/ui/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { theme, Button } from '@expo/styleguide';
 import { breakpoints, spacing } from '@expo/styleguide-base';
-import { GithubIcon, Menu01Icon } from '@expo/styleguide-icons';
+import { GithubIcon, Menu01Icon, Star01Icon } from '@expo/styleguide-icons';
 import type { ReactNode } from 'react';
 
 import { Logo } from './Logo';
@@ -31,6 +31,17 @@ export const Header = ({
           <Logo subgroup={isArchive ? 'Archive' : undefined} />
         </div>
         <div css={[columnStyle, rightColumnStyle]}>
+          <Button
+            openInNewTab
+            theme="quaternary"
+            css={hideOnMobileStyle}
+            className="px-2 text-secondary"
+            href="https://github.com/expo/expo">
+            <span className="flex gap-2 items-center">
+              <Star01Icon className="icon-sm" />
+              Star Us on GitHub
+            </span>
+          </Button>
           <Button
             openInNewTab
             theme="quaternary"


### PR DESCRIPTION
# Why

We decided to follow what we are doing on the website and add a 'Star Us on GitHub' link.

# How

By adding a button like on the website.

I added a similar button which just links to the GitHub page, so it's a bit redundant with current GitHub link (do we want to change URL to something more specific? I am not sure if it makes sense to replace the existing GitHub link as people want to go there even if they already starred us and it feels incorrect to use this button for that).

Button is displayed on only desktop browser size (not enough space on mobile and if we were to replace it with icon it would directly duplicate the existing link).

# Test Plan

\-

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
