### PR TITLE
[updates] fix node execution on windows

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed the `node` execution on Windows. ([#23983](https://github.com/expo/expo/pull/23983) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 0.19.1 — 2023-08-02

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -87,7 +87,12 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
     private fun getExpoUpdatesPackageDir(): String {
       val stdoutBuffer = ByteArrayOutputStream()
       project.exec {
-        it.commandLine(*nodeExecutableAndArgs.get().toTypedArray(), "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));")
+        val args = listOf(*nodeExecutableAndArgs.get().toTypedArray(), "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));")
+        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+          it.commandLine("cmd", "/c", args)
+        } else {
+          it.commandLine(args)
+        }
         it.workingDir(projectRoot.get())
         it.standardOutput = stdoutBuffer
       }


### PR DESCRIPTION
# Why

fix the `node` execution on windows
fixes #23930
close ENG-9737

# How

use `cmd /c` on windows

# Test Plan

ci passed

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
