### PR TITLE
[expo-go] Add expo.fyi link to home unverified badge

### DIFF
--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -2,7 +2,7 @@ import Ionicons from '@expo/vector-icons/build/Ionicons';
 import Constants from 'expo-constants';
 import { Row, View, Text, useExpoTheme } from 'expo-dev-client-components';
 import React from 'react';
-import { Image, Platform, StyleSheet } from 'react-native';
+import { Image, Linking, Platform, StyleSheet, TouchableOpacity } from 'react-native';
 
 type Props = {
   task: { manifestUrl: string; manifestString: string };
@@ -80,36 +80,39 @@ export function DevMenuTaskInfo({ task }: Props) {
             </Text>
           )}
           {!manifestInfo?.isVerified && (
-            <Row
-              bg="warning"
-              border="warning"
-              rounded="medium"
-              padding="0"
-              align="center"
-              style={{
-                alignSelf: 'flex-start',
-                marginTop: 3,
-              }}>
-              <Ionicons
-                name={Platform.select({ ios: 'ios-warning', default: 'md-warning' })}
-                size={14}
-                color={theme.text.warning}
-                lightColor={theme.text.warning}
-                darkColor={theme.text.warning}
+            <TouchableOpacity
+              onPress={() => Linking.openURL('https://expo.fyi/unverified-app-expo-go')}>
+              <Row
+                bg="warning"
+                border="warning"
+                rounded="medium"
+                padding="0"
+                align="center"
                 style={{
-                  marginHorizontal: 4,
-                }}
-              />
-              <Text
-                color="warning"
-                type="InterSemiBold"
-                size="small"
-                style={{
-                  marginRight: 4,
+                  alignSelf: 'flex-start',
+                  marginTop: 3,
                 }}>
-                Unverified
-              </Text>
-            </Row>
+                <Ionicons
+                  name={Platform.select({ ios: 'ios-warning', default: 'md-warning' })}
+                  size={14}
+                  color={theme.text.warning}
+                  lightColor={theme.text.warning}
+                  darkColor={theme.text.warning}
+                  style={{
+                    marginHorizontal: 4,
+                  }}
+                />
+                <Text
+                  color="warning"
+                  type="InterSemiBold"
+                  size="small"
+                  style={{
+                    marginRight: 4,
+                  }}>
+                  Unverified
+                </Text>
+              </Row>
+            </TouchableOpacity>
           )}
         </View>
       </Row>


### PR DESCRIPTION
# Why

Closes ENG-9080. Depends on https://github.com/expo/fyi/pull/126.

# How

Add link to FYI article about what this means.

# Test Plan

Tap on badge running locally, see it switches to safari and opens the FYI page.

<img width="272" alt="Screenshot 2023-08-16 at 11 13 37 AM" src="https://github.com/expo/expo/assets/189568/225fcef9-8de5-41e9-80e6-3a8b619904f9">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
