### PR TITLE
[go] update lottie-react-native to 6.2.0

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -134,7 +134,7 @@
     "gl-mat4": "^1.1.4",
     "hsv2rgb": "^1.1.0",
     "i18n-js": "^3.1.0",
-    "lottie-react-native": "6.1.2",
+    "lottie-react-native": "6.2.0",
     "moment": "^2.29.4",
     "path": "^0.12.7",
     "pixi.js": "^4.6.1",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2549,7 +2549,7 @@ PODS:
   - libwebp/webp (1.3.1):
     - libwebp/sharpyuv
   - lottie-ios (4.2.0)
-  - lottie-react-native (6.1.2):
+  - lottie-react-native (6.2.0):
     - lottie-ios (~> 4.2.0)
     - React-Core
   - MBProgressHUD (1.2.0)
@@ -5001,7 +5001,7 @@ SPEC CHECKSUMS:
   libvmaf: 27f523f1e63c694d14d534cd0fddd2fab0ae8711
   libwebp: 33dc822fbbf4503668d09f7885bbfedc76c45e96
   lottie-ios: 809ecf2d460ed650a6aed7aa88b2ec45fab4779c
-  lottie-react-native: 3d6f1b0db1fd9e18b92af1fbfbf67037611bae67
+  lottie-react-native: b04640d81bfc87915cd5c9058caa1112374691ff
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   Nimble: d954d0accfd082f2225e62d71008440493e318f4

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/AnimationViewManagerModule.swift
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/AnimationViewManagerModule.swift
@@ -18,21 +18,21 @@ class AnimationViewManagerModule: RCTViewManager {
         return ContainerView()
     }
 
-    @objc override func constantsToExport() -> [AnyHashable : Any]! {
+    @objc override func constantsToExport() -> [AnyHashable: Any]! {
         return ["VERSION": 1]
     }
 
     @objc(play:fromFrame:toFrame:)
     public func play(_ reactTag: NSNumber, startFrame: NSNumber, endFrame: NSNumber) {
-        self.bridge.uiManager.addUIBlock { (uiManager, viewRegistry) in
+        self.bridge.uiManager.addUIBlock { (_, viewRegistry) in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
             }
 
-            if (startFrame.intValue != -1 && endFrame.intValue != -1) {
+            if startFrame.intValue != -1 && endFrame.intValue != -1 {
                 view.play(fromFrame: AnimationFrameTime(truncating: startFrame), toFrame: AnimationFrameTime(truncating: endFrame))
             } else {
                 view.play()
@@ -42,9 +42,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(reset:)
     public func reset(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -56,9 +56,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(pause:)
     public func pause(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return
@@ -70,9 +70,9 @@ class AnimationViewManagerModule: RCTViewManager {
 
     @objc(resume:)
     public func resume(_ reactTag: NSNumber) {
-        self.bridge.uiManager.addUIBlock { uiManager, viewRegistry in
+        self.bridge.uiManager.addUIBlock { _, viewRegistry in
             guard let view = viewRegistry?[reactTag] as? ContainerView else {
-                if (RCT_DEBUG == 1) {
+                if RCT_DEBUG == 1 {
                     print("Invalid view returned from registry, expecting ContainerView")
                 }
                 return

--- a/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
+++ b/ios/vendored/unversioned/lottie-react-native/ios/LottieReactNative/ContainerView.swift
@@ -2,8 +2,8 @@ import Lottie
 import Foundation
 
 @objc protocol LottieContainerViewDelegate {
-    func onAnimationFinish(isCancelled: Bool);
-    func onAnimationFailure(error: String);
+    func onAnimationFinish(isCancelled: Bool)
+    func onAnimationFailure(error: String)
 }
 
 /* There are Two Views being implemented here:
@@ -22,215 +22,211 @@ class ContainerView: RCTView {
     private var colorFilters: [NSDictionary] = []
     private var textFilters: [NSDictionary] = []
     private var renderMode: RenderingEngineOption = .automatic
-    @objc weak var delegate: LottieContainerViewDelegate? = nil
+    @objc weak var delegate: LottieContainerViewDelegate?
     var animationView: LottieAnimationView?
     @objc var onAnimationFinish: RCTBubblingEventBlock?
     @objc var onAnimationFailure: RCTBubblingEventBlock?
-    
+
     @objc var completionCallback: LottieCompletionBlock {
         return { [weak self] animationFinished in
             guard let self = self else { return }
-            
+
             if let onFinish = self.onAnimationFinish {
                 onFinish(["isCancelled": !animationFinished])
             }
-            
-            self.delegate?.onAnimationFinish(isCancelled: !animationFinished);
-        };
+
+            self.delegate?.onAnimationFinish(isCancelled: !animationFinished)
+        }
     }
-    
+
     @objc var failureCallback: (_ error: String) -> Void {
         return { [weak self] error in
             guard let self = self else { return }
-            
+
             if let onFinish = self.onAnimationFailure {
                 onFinish(["error": error])
             }
-            
+
             self.delegate?.onAnimationFailure(error: error)
-        };
+        }
     }
-    
+
 #if !(os(OSX))
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, tvOS 13.0, *) {
-            if (self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection)) {
-                if(!colorFilters.isEmpty) {
+            if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                if !colorFilters.isEmpty {
                     applyColorProperties()
                 }
             }
         }
     }
 #endif
-    
+
     @objc func setSpeed(_ newSpeed: CGFloat) {
         speed = newSpeed
-        
-        if (newSpeed != 0.0) {
+
+        if newSpeed != 0.0 {
             animationView?.animationSpeed = newSpeed
-            if (!(animationView?.isAnimationPlaying ?? true)) {
+            if !(animationView?.isAnimationPlaying ?? true) {
                 animationView?.play()
             }
-        } else if (animationView?.isAnimationPlaying ?? false) {
+        } else if animationView?.isAnimationPlaying ?? false {
             animationView?.pause()
         }
     }
-    
+
     @objc func setProgress(_ newProgress: CGFloat) {
         progress = newProgress
         animationView?.currentProgress = progress
     }
-    
+
     @objc func setLoop(_ isLooping: Bool) {
         loop = isLooping ? .loop : .playOnce
         animationView?.loopMode = loop
     }
-    
+
     @objc func setAutoPlay(_ autoPlay: Bool) {
         self.autoPlay = autoPlay
         playIfNeeded()
     }
-    
+
     @objc func setTextFiltersIOS(_ newTextFilters: [NSDictionary]) {
         textFilters = newTextFilters
-        
-        if (textFilters.count > 0) {
-            var filters = [String:String]()
+
+        if textFilters.count > 0 {
+            var filters = [String: String]()
             for filter in textFilters {
-                let key = filter.value(forKey: "keypath") as! String
-                let value = filter.value(forKey: "text") as! String
-                filters[key] = value;
+                guard let key = filter.value(forKey: "keypath") as? String,
+                      let value = filter.value(forKey: "text") as? String else { break }
+                filters[key] = value
             }
-            
+
             let nextAnimationView = LottieAnimationView()
             nextAnimationView.textProvider = DictionaryTextProvider(filters)
             nextAnimationView.animation = animationView?.animation
             replaceAnimationView(next: nextAnimationView)
         }
     }
-    
+
     var lottieConfiguration: LottieConfiguration {
         return LottieConfiguration(
             renderingEngine: renderMode
         )
     }
-    
+
     @objc func setRenderMode(_ newRenderMode: String) {
         switch newRenderMode {
         case "SOFTWARE":
-            if (renderMode == .mainThread) {
+            if renderMode == .mainThread {
                 return
             }
             renderMode = .mainThread
         case "HARDWARE":
-            if (renderMode == .coreAnimation) {
+            if renderMode == .coreAnimation {
                 return
             }
             renderMode = .coreAnimation
-        case "AUTOMATIC":
-            fallthrough
         default:
-            if (renderMode == .automatic) {
+            if renderMode == .automatic {
                 return
             }
             renderMode = .automatic
         }
-        
-        if (animationView != nil) {
+
+        if animationView != nil {
             let nextAnimationView = LottieAnimationView(
                 animation: animationView?.animation,
                 configuration: lottieConfiguration
             )
-            
+
             replaceAnimationView(next: nextAnimationView)
         }
     }
-    
+
     @objc func setSourceDotLottieURI(_ uri: String) {
-        if(checkReactSourceString(uri)) {
+        if checkReactSourceString(uri) {
             return
         }
-        
+
         guard let url = URL(string: uri) else {
             return
         }
-        
+
         _ = LottieAnimationView(
             dotLottieUrl: url,
             configuration: lottieConfiguration,
             completion: { [weak self] view, error in
                 guard let self = self else { return }
-                
                 if let error = error {
                     self.failureCallback(error.localizedDescription)
                     return
                 }
-                
                 self.replaceAnimationView(next: view)
             }
         )
     }
-    
+
     @objc func setSourceURL(_ newSourceURLString: String) {
-        if(checkReactSourceString(newSourceURLString)) {
+        if checkReactSourceString(newSourceURLString) {
             return
         }
-        
+
         var url = URL(string: newSourceURLString)
-        
-        if(url?.scheme == nil) {
+
+        if url?.scheme == nil {
             // interpret raw URL paths as relative to the resource bundle
             url = URL(fileURLWithPath: newSourceURLString, relativeTo: Bundle.main.resourceURL)
         }
-        
+
         guard let url = url else { return }
-        
+
         self.fetchRemoteAnimation(from: url)
     }
-    
+
     @objc func setSourceJson(_ newSourceJson: String) {
-        if(checkReactSourceString(newSourceJson)) {
+        if checkReactSourceString(newSourceJson) {
             return
         }
-        
+
         sourceJson = newSourceJson
-        
+
         guard let data = sourceJson.data(using: String.Encoding.utf8),
               let animation = try? JSONDecoder().decode(LottieAnimation.self, from: data) else {
             failureCallback("Unable to create the lottie animation object from the JSON source")
             return
         }
-        
+
         let nextAnimationView = LottieAnimationView(
             animation: animation,
             configuration: lottieConfiguration
         )
-        
+
         replaceAnimationView(next: nextAnimationView)
     }
-    
+
     @objc func setSourceName(_ newSourceName: String) {
-        if(checkReactSourceString(newSourceName)) {
+        if checkReactSourceString(newSourceName) {
             return
         }
-        
-        if (newSourceName == sourceName) {
+
+        if newSourceName == sourceName {
             return
         }
-        
+
         sourceName = newSourceName
-        
+
         let nextAnimationView = LottieAnimationView(
             name: sourceName,
             configuration: lottieConfiguration
         )
-        
+
         replaceAnimationView(next: nextAnimationView)
     }
-    
+
     @objc func setResizeMode(_ resizeMode: String) {
-        switch (resizeMode) {
+        switch resizeMode {
         case "cover":
             animationView?.contentMode = .scaleAspectFill
         case "contain":
@@ -240,121 +236,121 @@ class ContainerView: RCTView {
         default: break
         }
     }
-    
+
     @objc func setColorFilters(_ newColorFilters: [NSDictionary]) {
         colorFilters = newColorFilters
         applyColorProperties()
     }
-    
+
     // There is no Nullable CGFloat in Objective-C, so this function uses a Nullable NSNumber and converts it later
     @objc(playFromFrame:toFrame:)
     func objcCompatiblePlay(fromFrame: NSNumber? = nil, toFrame: AnimationFrameTime) {
-        let convertedFromFrame = fromFrame != nil ? CGFloat(truncating: fromFrame!) : nil;
-        play(fromFrame: convertedFromFrame, toFrame: toFrame);
+        let convertedFromFrame = fromFrame != nil ? CGFloat(truncating: fromFrame!) : nil
+        play(fromFrame: convertedFromFrame, toFrame: toFrame)
     }
-    
+
     func play(fromFrame: AnimationFrameTime? = nil, toFrame: AnimationFrameTime) {
-        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completionCallback);
+        animationView?.play(fromFrame: fromFrame, toFrame: toFrame, loopMode: self.loop, completion: completionCallback)
     }
-    
+
     @objc func play() {
         animationView?.play(completion: completionCallback)
     }
-    
+
     @objc func reset() {
-        animationView?.currentProgress = 0;
+        animationView?.currentProgress = 0
         animationView?.pause()
     }
-    
+
     @objc func pause() {
         animationView?.pause()
     }
-    
+
     @objc func resume() {
         play()
     }
-    
+
     // The animation view is a child of the RCTView, so if the bounds ever change, add those changes to the animation view as well
     override var bounds: CGRect {
         didSet {
             animationView?.frame = self.bounds
         }
     }
-    
+
     // MARK: Private
     func replaceAnimationView(next: LottieAnimationView) {
         super.removeReactSubview(animationView)
-        
+
         let contentMode = animationView?.contentMode ?? .scaleAspectFit
-        
+
         animationView = next
-        
+
         animationView?.contentMode = contentMode
         animationView?.backgroundBehavior = .pauseAndRestore
         animationView?.animationSpeed = speed
         animationView?.loopMode = loop
         animationView?.frame = self.bounds
-        
+
         addSubview(next)
-        
+
         applyColorProperties()
         playIfNeeded()
     }
-    
-    
-    
+
     func applyColorProperties() {
         guard let animationView = animationView else { return }
-        
-        if (colorFilters.count > 0) {
+
+        if colorFilters.count > 0 {
             for filter in colorFilters {
-                let keypath: String = "\(filter.value(forKey: "keypath") as! String).**.Color"
+                guard let key = filter.value(forKey: "keypath") as? String,
+                      let platformColor = filter.value(forKey: "color") as? PlatformColor else { break }
+                let keypath: String = "\(key).**.Color"
                 let fillKeypath = AnimationKeypath(keypath: keypath)
-                let colorFilterValueProvider = ColorValueProvider((filter.value(forKey: "color") as! PlatformColor).lottieColorValue)
+                let colorFilterValueProvider = ColorValueProvider(platformColor.lottieColorValue)
                 animationView.setValueProvider(colorFilterValueProvider, keypath: fillKeypath)
             }
         }
     }
-    
+
     func playIfNeeded() {
-        if(autoPlay && animationView?.isAnimationPlaying == false) {
+        if autoPlay && animationView?.isAnimationPlaying == false {
             self.play()
         }
     }
-    
+
     private func checkReactSourceString(_ sourceStr: String?) -> Bool {
         guard let sourceStr = sourceStr else {
             return false
         }
-        
+
         return sourceStr.isEmpty
     }
-    
+
     private func fetchRemoteAnimation(from url: URL) {
-        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, error in
             guard let self = self else { return }
 
             if let error = error {
                 self.failureCallback("Unable to fetch the Lottie animation from the URL: \(error.localizedDescription)")
                 return
             }
-            
+
             guard let data = data else {
                 self.failureCallback("No data received for the Lottie animation from the URL.")
                 return
             }
-            
+
             do {
                 let animation = try JSONDecoder().decode(LottieAnimation.self, from: data)
-                
+
                 DispatchQueue.main.async { [weak self] in
                     guard let self = self else { return }
-                    
+
                     let nextAnimationView = LottieAnimationView(
                         animation: animation,
                         configuration: self.lottieConfiguration
                     )
-                    
+
                     self.replaceAnimationView(next: nextAnimationView)
                 }
             } catch {

--- a/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
+++ b/ios/vendored/unversioned/lottie-react-native/lottie-react-native.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "lottie-react-native",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "summary": "React Native bindings for Lottie",
   "license": "Apache-2.0",
   "authors": "Emilio Rodriguez <emiliorodriguez@gmail.com>",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/lottie-react-native/lottie-react-native.git",
-    "tag": "v6.1.2"
+    "tag": "v6.2.0"
   },
   "source_files": "ios/**/*.{h,m,mm,swift}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -81,7 +81,7 @@
   "expo-updates": "~0.19.1",
   "expo-video-thumbnails": "~7.5.0",
   "expo-web-browser": "~12.4.1",
-  "lottie-react-native": "6.1.2",
+  "lottie-react-native": "6.2.0",
   "react": "18.2.0",
   "react-dom": "18.2.0",
   "react-native": "0.72.3",


### PR DESCRIPTION
# Why

Release link: 

https://github.com/lottie-react-native/lottie-react-native/releases/tag/v6.2.0

# How

- Ran `et uvm -m lottie-react-native -c 6.2.0 -p all`

# Test Plan

- [x] Lottie React Native should work as expected in Expo Go


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
