### PR TITLE
[expo-go] Log graphql errors separately from primary account errors during sign in

### DIFF
--- a/home/screens/AccountModal/LoggedOutAccountView.tsx
+++ b/home/screens/AccountModal/LoggedOutAccountView.tsx
@@ -122,6 +122,13 @@ export function LoggedOutAccountView({ refetch }: Props) {
           },
         });
 
+        if (
+          viewerPrimaryAccountNameResult.errors &&
+          viewerPrimaryAccountNameResult.errors.length > 0
+        ) {
+          throw viewerPrimaryAccountNameResult.errors[0];
+        }
+
         const primaryAccountName =
           viewerPrimaryAccountNameResult.data.meUserActor?.primaryAccount.name;
         if (!primaryAccountName) {


### PR DESCRIPTION
# Why

While investigating recent reports of sign in issues, I realized that all errors were being categorized as "primary account missing" errors, but what would be more helpful is logging graphql errors when one occurs rather than always logging it as a "primary account" error.

# How

Log graphql errors as well.

# Test Plan

Inspect (I still haven't been able to repro this).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
