### PR TITLE
[sqlite] Update built-in SQLite on android

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.5.0):
     - ExpoModulesCore
-    - sqlite3 (~> 3.39.4)
+    - sqlite3 (= 3.39.2)
   - ExpoStoreReview (6.5.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.5.0):
@@ -800,9 +800,9 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.39.4):
-    - sqlite3/common (= 3.39.4)
-  - sqlite3/common (3.39.4)
+  - sqlite3 (3.39.2):
+    - sqlite3/common (= 3.39.2)
+  - sqlite3/common (3.39.2)
   - UMAppLoader (4.2.0)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
@@ -1345,7 +1345,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 134ecbecb2f81295d7dd5d66ce90ae050962ecfd
   ExpoSMS: c8079b3018ae5206b3f1f6f445fd4eee2a19a335
   ExpoSpeech: cd3a86aedd2340f22eeca8a93040a825be9a280b
-  ExpoSQLite: 1c54251abaf0864c76dc77a5a9949f266b174c43
+  ExpoSQLite: ec466eeedbc98480ee0c4b2df1fe55c215f12b94
   ExpoStoreReview: f0e23d74a1cfae7a75c2ca7dac9c762dda382f03
   ExpoSystemUI: 2fce488f61a0e2849988a40b34b49a99e8e72af5
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -1425,7 +1425,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: 401936402fe5aa242c07f87fccfee5fc2b606f45
+  sqlite3: d115522c740c457b805c018b0296b5ba003da280
   UMAppLoader: e83f024f75f07802fce99739f04b4537d188caaf
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb

--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -6,6 +6,7 @@ import * as SQLite from 'expo-sqlite';
 
 export const name = 'SQLite';
 
+// The version here needs to be the same as both the podspec and build.gradle for expo-sqlite
 const VERSION = '3.39.2';
 
 // TODO: Only tests successful cases, needs to test error cases like bad database name etc.

--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -77,7 +77,6 @@ export function test(t) {
       db.transaction((tx) => {
         tx.executeSql('SELECT sqlite_version()', [], (_, results) => {
           const queryVersion = results.rows._array[0]['sqlite_version()'];
-          console.log(queryVersion);
           t.expect(queryVersion).toEqual(VERSION);
         });
       });

--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -6,6 +6,8 @@ import * as SQLite from 'expo-sqlite';
 
 export const name = 'SQLite';
 
+const VERSION = '3.39.2';
+
 // TODO: Only tests successful cases, needs to test error cases like bad database name etc.
 export function test(t) {
   t.describe('SQLite', () => {
@@ -67,6 +69,29 @@ export function test(t) {
         const { exists } = await FS.getInfoAsync(`${FS.documentDirectory}SQLite/test.db`);
         t.expect(exists).toBeTruthy();
       }
+    });
+
+    t.it(`should use specified SQLite version: ${VERSION}`, () => {
+      const db = SQLite.openDatabase('test.db');
+
+      db.transaction((tx) => {
+        tx.executeSql('SELECT sqlite_version()', [], (_, results) => {
+          const queryVersion = results.rows._array[0]['sqlite_version()'];
+          console.log(queryVersion);
+          t.expect(queryVersion).toEqual(VERSION);
+        });
+      });
+    });
+
+    t.it(`unixepoch() is supported`, () => {
+      const db = SQLite.openDatabase('test.db');
+
+      db.transaction((tx) => {
+        tx.executeSql('SELECT unixepoch()', [], (_, results) => {
+          const epoch = results.rows._array[0]['unixepoch()'];
+          t.expect(epoch).toBeTruthy();
+        });
+      });
     });
 
     if (Platform.OS !== 'web') {
@@ -641,7 +666,7 @@ export function test(t) {
             await tx.executeSqlAsync('INSERT INTO Users (name) VALUES (?)', ['bbb']);
             await tx.executeSqlAsync('INSERT INTO Users (name) VALUES (?)', ['ccc']);
             // exeuting invalid sql statement will throw an exception
-            await tx.executeSqlAsync(undefined);
+            await tx.executeSqlAsync(null);
           })
         );
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2325,7 +2325,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.5.0):
     - ExpoModulesCore
-    - sqlite3 (~> 3.39.4)
+    - sqlite3 (= 3.39.2)
   - ExpoStoreReview (6.5.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.5.0):
@@ -3056,9 +3056,9 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.39.4):
-    - sqlite3/common (= 3.39.4)
-  - sqlite3/common (3.39.4)
+  - sqlite3 (3.39.2):
+    - sqlite3/common (= 3.39.2)
+  - sqlite3/common (3.39.2)
   - Stripe (23.8.0):
     - StripeApplePay (= 23.8.0)
     - StripeCore (= 23.8.0)
@@ -4955,7 +4955,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 134ecbecb2f81295d7dd5d66ce90ae050962ecfd
   ExpoSMS: c8079b3018ae5206b3f1f6f445fd4eee2a19a335
   ExpoSpeech: cd3a86aedd2340f22eeca8a93040a825be9a280b
-  ExpoSQLite: 1c54251abaf0864c76dc77a5a9949f266b174c43
+  ExpoSQLite: ec466eeedbc98480ee0c4b2df1fe55c215f12b94
   ExpoStoreReview: f0e23d74a1cfae7a75c2ca7dac9c762dda382f03
   ExpoSystemUI: 2fce488f61a0e2849988a40b34b49a99e8e72af5
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -5059,7 +5059,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: 401936402fe5aa242c07f87fccfee5fc2b606f45
+  sqlite3: d115522c740c457b805c018b0296b5ba003da280
   Stripe: 5432fbab660595a3bee937235dd71a99028ac68c
   stripe-react-native: 096d83ad94da350f08f5cd48275e7f9645dde297
   StripeApplePay: 5e686f50ee07c439b79b907dffeb144135e601c9

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Remove unneeded resource bundle. ([#23813](https://github.com/expo/expo/pull/23813) by [@alanjhughes](https://github.com/alanjhughes))
+- Update `SQLite` on `Android`.
 
 ## 11.5.0 — 2023-08-02
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 💡 Others
 
 - Remove unneeded resource bundle. ([#23813](https://github.com/expo/expo/pull/23813) by [@alanjhughes](https://github.com/alanjhughes))
-- Update `SQLite` on `Android`.
+- Update `SQLite` on `Android`. ([#23993](https://github.com/expo/expo/pull/23993) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 11.5.0 — 2023-08-02
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -82,5 +82,7 @@ android {
 dependencies {
   implementation project(':expo-modules-core')
 
+  implementation 'com.github.requery:sqlite-android:3.39.2'
+  implementation "androidx.sqlite:sqlite-ktx:2.3.1"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -83,7 +83,9 @@ class SQLiteModule : Module() {
           if (bindArgs[i - 1] == null) {
             statement.bindNull(i)
           } else {
-            statement.bindString(i, bindArgs[i - 1]!!)
+            bindArgs[i - 1]?.let {
+              statement.bindString(i, it)
+            } ?:  throw  IllegalArgumentException("the bind value at index $i is null");
           }
         }
       }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -80,12 +80,11 @@ class SQLiteModule : Module() {
     return db.compileStatement(sql).use { statement ->
       if (bindArgs != null) {
         for (i in bindArgs.size downTo 1) {
-          if (bindArgs[i - 1] == null) {
-            statement.bindNull(i)
+          val args = bindArgs[i - 1]
+          if (args != null) {
+            statement.bindString(i, args)
           } else {
-            bindArgs[i - 1]?.let {
-              statement.bindString(i, it)
-            } ?:  throw  IllegalArgumentException("the bind value at index $i is null");
+            statement.bindNull(i)
           }
         }
       }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -3,7 +3,7 @@ package expo.modules.sqlite
 
 import android.content.Context
 import android.database.Cursor
-import android.database.sqlite.SQLiteDatabase
+import io.requery.android.database.sqlite.SQLiteDatabase
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -83,7 +83,7 @@ class SQLiteModule : Module() {
           if (bindArgs[i - 1] == null) {
             statement.bindNull(i)
           } else {
-            statement.bindString(i, bindArgs[i - 1])
+            statement.bindString(i, bindArgs[i - 1]!!)
           }
         }
       }

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'ExpoModulesCore'
   # The builtin sqlite does not support extensions so we update it
-  s.dependency 'sqlite3', '~> 3.39.4'
+  s.dependency 'sqlite3', '3.39.2'
   
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
# Why
Closes #23970
We needed to update Android's built-in SQLite to integrate with CRSQLite anyway. 

# How
Slightly downgraded the iOS version and installed the library to update Androids so both platforms match

# Test Plan
Added tests for the version number and using SQLite functions that are only supported when you have a newer version installed.
