### PR TITLE
[docs] Grammar fix on `using-hermes.mdx`

### DIFF
--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -74,7 +74,7 @@ Alternatively, you can use the JavaScript inspector from the following tools:
 > **warning** `No compatible apps connected. JavaScript Debugging can only be used with the Hermes engine.` when opening the debugger.
 
 - Make sure you [set up Hermes in the `jsEngine` field](#setup).
-- If your app is built by `eas build`, `npx expo run:android` or `npx expo run:ios`, make sure it is debug build.
+- If your app is built by `eas build`, `npx expo run:android` or `npx expo run:ios`, make sure it is a debug build.
 - Internally, the app will establish a WebSocket connection, make sure your app is connected to the development server.
 
   - Try to reload the app by pressing <kbd>r</kbd> in the Expo CLI Terminal UI.


### PR DESCRIPTION
# Why
A minor grammatical error in the documentation.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
Fixes a minor grammatical issue in the documentation.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
N/A

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
