### PR TITLE
[ci] try to improve ci stability

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 100
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
     steps:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
@@ -42,6 +42,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: 🧹 Cleanup GitHub Linux runner disk space
+        uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/client-android-eas.yml
+++ b/.github/workflows/client-android-eas.yml
@@ -22,6 +22,19 @@ on:
     paths:
       - .github/workflows/client-android-eas.yml
       - apps/eas-expo-go/**
+      - android/versioned-abis/**
+      - android/versioned-react-native/**
+      - android/expoview/**
+      - android/**/*.gradle
+  push:
+    branches: [main, sdk-*]
+    paths:
+      - .github/workflows/client-android-eas.yml
+      - apps/eas-expo-go/**
+      - android/versioned-abis/**
+      - android/versioned-react-native/**
+      - android/expoview/**
+      - android/**/*.gradle
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -30,7 +43,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/client-android.yml
+++ b/.github/workflows/client-android.yml
@@ -2,13 +2,6 @@ name: Android Client
 
 on:
   workflow_dispatch:
-    inputs:
-      releaseAPK:
-        description: 'type "release-apk" to confirm upload to S3'
-        required: false
-      releaseGooglePlay:
-        description: 'type "release-google-play" to confirm release to Google Play'
-        required: false
   schedule:
     - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
   pull_request:
@@ -35,16 +28,22 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    # NOTE(kudo): [macos-temp] Temporarily use macos runner because the limited resource on linux runners does not allow to build Expo Go
+    # runs-on: ubuntu-22.04
+    runs-on: macos-13
     env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3072m -XX:MaxMetaspaceSize=1024m
+      ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+      # [macos-temp] Increase JVM memory because macOS runners have more memory available
+      # GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx3072m -XX:MaxMetaspaceSize=1024m"
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🧹 Cleanup GitHub Linux runner disk space
-        uses: ./.github/actions/cleanup-linux-disk-space
+      # [macos-temp]
+      # - name: 🧹 Cleanup GitHub Linux runner disk space
+      #   uses: ./.github/actions/cleanup-linux-disk-space
       - name: 🔨 Use JDK 11
         uses: actions/setup-java@v3
         with:
@@ -63,7 +62,6 @@ jobs:
           yarn-tools: 'true'
           gradle: 'true'
           hermes-engine-aar: 'true'
-          ndk: 'true'
           react-native-gradle-downloads: 'true'
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
@@ -89,31 +87,12 @@ jobs:
               - android/**/*.gradle
       - name: 🏭 Build APK
         env:
-          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ExponentKey
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          IS_APP_BUNDLE: ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}
-          IS_RELEASE_BUILD: ${{ github.event.inputs.releaseAPK == 'release-apk' || github.event.inputs.releaseGooglePlay == 'release-google-play' }}
           IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
+          BUILD_TYPE: Debug
         run: |
-          if [ "$IS_RELEASE_BUILD" == "false" ]; then
-            export ORG_GRADLE_PROJECT_reactNativeArchitectures="x86_64"
-            BUILD_TYPE="Debug"
-            echo "Using ABI filters: $ORG_GRADLE_PROJECT_reactNativeArchitectures"
-          else
-            BUILD_TYPE="Release"
-          fi
           [[ "$IS_VERSIONED_FLAVOR" == "true" ]] && FLAVOR="Versioned" || FLAVOR="Unversioned"
-          echo "Building with $FLAVOR flavor"
-          if [ -z "$ANDROID_KEYSTORE_B64" ]; then
-            echo "External build detected, APK will not be signed"
-            fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR sign:false
-          else
-            echo "Internal build detected, APK will be signed"
-            echo $ANDROID_KEYSTORE_B64 | base64 -d > android/app/release-key.jks
-            fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR aab:$IS_APP_BUNDLE
-          fi
+          echo "Building: flavor[${FLAVOR}] type[${BUILD_TYPE}]"
+          fastlane android build build_type:$BUILD_TYPE flavor:$FLAVOR sign:false
       - name: 📤 Upload APK artifact
         uses: actions/upload-artifact@v3
         with:
@@ -125,19 +104,6 @@ jobs:
         with:
           name: gradle-daemon-logs
           path: ~/.gradle/daemon
-      - name: 📤 Upload APK to S3 and update staging versions endpoint
-        if: ${{ github.event.inputs.releaseAPK == 'release-apk' }}
-        run: expotools client-build --platform android --release
-        env:
-          AWS_ACCESS_KEY_ID: AKIAJ3SWUQ4QLNQC7FXA
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.android_client_build_aws_secret_key }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-          EXPO_VERSIONS_SECRET: ${{ secrets.expo_versions_secret }}
-      - name: 📤 Upload APK to Google Play and release to production
-        if: ${{ github.event.inputs.releaseGooglePlay == 'release-google-play' }}
-        run: fastlane android prod_release
-        env:
-          SUPPLY_JSON_KEY_DATA: ${{ secrets.SUPPLY_JSON_KEY_DATA }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/client-ios-eas.yml
+++ b/.github/workflows/client-ios-eas.yml
@@ -25,8 +25,6 @@ on:
       - ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
-      - tools/src/client-build/**
-      - tools/src/commands/ClientBuild.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock
@@ -39,8 +37,6 @@ on:
       - ios/**
       - tools/src/dynamic-macros/**
       - tools/src/commands/IosGenerateDynamicMacros.ts
-      - tools/src/client-build/**
-      - tools/src/commands/ClientBuild.ts
       - secrets/**
       - fastlane/**
       - Gemfile.lock
@@ -53,7 +49,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/client-ios.yml
+++ b/.github/workflows/client-ios.yml
@@ -2,10 +2,6 @@ name: iOS Client
 
 on:
   workflow_dispatch:
-    inputs:
-      releaseSimulator:
-        description: 'type "release-simulator" to confirm upload'
-        required: false
   schedule:
     - cron: '20 5 * * 1,3,5' # 5:20 AM UTC time on every Monday, Wednesday and Friday
   pull_request:
@@ -92,9 +88,6 @@ jobs:
           expotools client-build --platform ios --flavor $FLAVOR
         timeout-minutes: 120
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
           IS_VERSIONED_FLAVOR: ${{ github.event_name == 'schedule' || steps.flavor.outputs.versioned == 'true' }}
       - name: 💾 Save test results
         if: always()
@@ -102,14 +95,6 @@ jobs:
         with:
           name: fastlane-logs
           path: ~/Library/Logs/fastlane
-      - name: 🚚 Release the simulator build
-        run: expotools client-build --platform ios --release # should only upload already-built app
-        if: ${{ github.event.inputs.releaseSimulator == 'release-simulator' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: 'us-east-1'
-          EXPO_VERSIONS_SECRET: ${{ secrets.EXPO_VERSIONS_SECRET }}
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   build:
     runs-on: macos-13
-    timeout-minutes: 60
+    timeout-minutes: 75
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
         run: pod install
         working-directory: apps/native-tests/ios
       - name: 🧪 Run native iOS unit tests
-        timeout-minutes: 45
+        timeout-minutes: 60
         env:
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -265,10 +265,8 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 - **iOS**:
 
   - Bump Expo Go versions (CFBundleVersion, CFBundleShortVersionString) in `ios/Exponent/Supporting/Info.plist`.
-  - We use `fastlane match` to sync our iOS credentials (certificates and provisioning profiles) - you will need them to properly archive and upload the distribution build to App Store Connect. Run `fastlane match appstore` from the project root folder to download them. You'll need to be authorized and have Google Cloud keys to do this, if you don't have them ask someone who has been publishing Expo Go in the past.
-  - Make sure build's metadata are up to date (see files under `fastlane/metadata/en-US`).
   - Make sure that production home app is published and new JS bundles are up-to-date - they're gonna be bundled within the binary and used at the first app run (before Expo Go downloads an OTA update).
-  - Run `fastlane ios release` from the project root folder and follow the prompt. This step can take 30+ minutes, as fastlane will update (or create) the App Store Connect record, generate a signed archive, and upload it. If for some reason you have to archive and upload the app through Xcode (without Fastlane), make sure to use `Expo Go (versioned)` Xcode scheme.
+  - Run `et eas ios-client-build-and-submit` from the project root folder and follow the prompt. This step can take 30+ minutes.
   - Wait for Apple to finish processing your new build. This step can take another 30+ minutes (but sometimes just a few).
   - Once the processing is done, go to TestFlight section in App Store Connect, click on the new build and then click `Provide Export Compliance Information` button and select **"None of the algorithms mentioned above"** in the dialog - we generally have not made changes to encryption.
     - Alternatively, you can set the [`ios.config.usesNonExemptEncryption` to `false`](https://docs.expo.dev/versions/latest/sdk/securestore/#exempting-encryption-prompt) in the Expo config. This will automatically set the export compliance to **"None of the algorithms mentioned above"** and will avoid displaying this prompt each time you are going through this process in App Store Connect.
@@ -277,8 +275,8 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 - **Android**:
   - Unlike for iOS, we will not submit the Android app to the store at this point. We just need to bump the version so we can do an APK build for distribution through Expo CLI.
-  - Bump the `versionCode` and `versionName` in android/app/build.gradle. Commit this to main and cherry-pick to the release branch. You might need to check the previous release branch to make sure the new `versionCode` is greater than the previous patch version, in case that commit never made it to main.
-  - The APK will be available as an artifact from the "Android Client" CI job. If no CI jobs are running on the release branch, you just need to open a PR from the release branch to main. (Don't merge it; it only exists to make CI jobs run.)
+  - Bump the `versionName` in android/app/build.gradle. Commit this to main and cherry-pick to the release branch. EAS Build will automatically manage the `versionCode` for you.
+  - Run `et dispatch client-android-eas-release` and wait for EAS Build to finish the APK building.
   - Download the APK and do a quick smoke test: install it in your local emulator or on a device and open a project.
 
 ## 3.3. Make a simulator/emulator build
@@ -291,7 +289,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 **How:**
 
-- Run `et dispatch client-{ios,android}-simulator` to trigger building Expo Go for simulators, uploading the archive to S3 and updating URL in versions endpoint.
+- Run `et eas ios-simulator-client-build-and-publish` or `et eas android-apk-build-and-publish` to trigger building Expo Go for simulators, uploading the archive to S3 and updating URL in versions endpoint.
 - Once the job is finished, test if this simulator build work as expected. You can install and launch it using expotools command `et client-install -p {ios,android}`.
 - Ensure that you update the root `iosVersion`/`androidVersion` `iosUrl`/`androidUrl` properties, eg:
   - `et update-versions-endpoint -k 'iosVersion' -v '2.19.3' --root`
@@ -422,9 +420,8 @@ Once everything above is completed and Apple has approved Expo Go (iOS) for the 
 - **iOS**:
   - Log into [App Store Connect](https://appstoreconnect.apple.com) and release the approved version.
 - **Android**:
-  - Add a new file under `/fastlane/android/metadata/en-US/changelogs/[versionCode].txt` (it should usually read “Add support for Expo SDK XX”).
-  - Open `Android Client` workflow on GitHub Actions and when it completes, download the APK from Artifacts and do a smoke test -- install it on a fresh Android device, turn on airplane mode, and make sure Home loads.
-  - Run `et dispatch client-android-release` to trigger appropriate job on GitHub Actions. About 45 minutes later the update should be **downloadable** via Play Store.
+  - Download the APK from (step [3.2](#32-build-and-submit)) and do a smoke test -- install it on a fresh Android device, turn on airplane mode, and make sure Home loads.
+  - Run `et eas android-client-build-and-submit` to trigger appropriate job on EAS Build. About 60 minutes later the update should be **downloadable** via Play Store.
 
 ## 6.2. Promote packages to latest on NPM registry
 

--- a/packages/expo-clipboard/ios/NSAttributedString+utilities.swift
+++ b/packages/expo-clipboard/ios/NSAttributedString+utilities.swift
@@ -3,6 +3,7 @@
 import MobileCoreServices
 
 extension NSAttributedString {
+  @objc
   convenience init(htmlString: String) throws {
     let initOptions: [DocumentReadingOptionKey: Any] = [
       .documentType: NSAttributedString.DocumentType.html
@@ -10,6 +11,7 @@ extension NSAttributedString {
     try self.init(data: Data(htmlString.utf8), options: initOptions, documentAttributes: nil)
   }
 
+  @objc
   var rtfData: Data? {
     let range = NSRange(location: 0, length: self.length)
     let attributes: [DocumentAttributeKey: Any] = [
@@ -19,6 +21,7 @@ extension NSAttributedString {
     return try? self.data(from: range, documentAttributes: attributes)
   }
 
+  @objc
   var htmlString: String? {
     do {
       let range = NSRange(location: 0, length: self.length)

--- a/packages/expo-clipboard/ios/Tests/ClipboardModuleSpec.swift
+++ b/packages/expo-clipboard/ios/Tests/ClipboardModuleSpec.swift
@@ -11,7 +11,7 @@ class ClipboardModuleSpec: ExpoSpec {
     let holder = ModuleHolder(appContext: appContext, module: ClipboardModule(appContext: appContext))
 
     func testModuleFunction<T>(_ functionName: String, args: [Any], _ block: @escaping (T?) -> Void) {
-      waitUntil { done in
+      waitUntil(timeout: .seconds(2)) { done in
         holder.call(function: functionName, args: args) { result in
           let value = try! result.get()
           expect(value).to(beAKindOf(T?.self))
@@ -22,7 +22,7 @@ class ClipboardModuleSpec: ExpoSpec {
     }
 
     func expectModuleFunctionThrows<T>(_ functionName: String, args: [Any], exception: T.Type) where T: Exception {
-      waitUntil { done in
+      waitUntil(timeout: .seconds(2)) { done in
         holder.call(function: functionName, args: args) { result in
           expect(result).to(beFailure(exception: exception))
           done()
@@ -32,6 +32,7 @@ class ClipboardModuleSpec: ExpoSpec {
 
     beforeSuite {
       swizzleGeneralPasteboard()
+      swizzleNSAttributedString()
     }
 
     // MARK: - Strings

--- a/packages/expo-clipboard/ios/Tests/MockNSAttributedString.swift
+++ b/packages/expo-clipboard/ios/Tests/MockNSAttributedString.swift
@@ -1,0 +1,40 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+import Foundation
+@testable import ExpoClipboard
+
+/**
+ A  mocked `NSAttributedString+utilities` for unit tests
+ `NSAttributedString` HTML processor requires main thread and it is slow. It may break unit test occasionally.
+ This mocked version just returns the raw string.
+ */
+class MockNSAttributedString: NSAttributedString {
+  convenience init(htmlString: String) throws {
+    self.init(string: htmlString)
+  }
+
+  override var rtfData: Data? {
+    return try? self.data(from: NSRange(location: 0, length: self.length))
+  }
+
+  override var htmlString: String? {
+    return self.string
+  }
+}
+
+func swizzleNSAttributedString() {
+  // swiftlint:disable force_unwrapping
+  method_exchangeImplementations(
+    class_getInstanceMethod(NSAttributedString.self, #selector(NSAttributedString.init(htmlString:)))!,
+    class_getInstanceMethod(MockNSAttributedString.self, #selector(MockNSAttributedString.init(htmlString:)))!
+  )
+  method_exchangeImplementations(
+    class_getInstanceMethod(NSAttributedString.self, #selector(getter: NSAttributedString.rtfData))!,
+    class_getInstanceMethod(MockNSAttributedString.self, #selector(getter: MockNSAttributedString.rtfData))!
+  )
+  method_exchangeImplementations(
+    class_getInstanceMethod(NSAttributedString.self, #selector(getter: NSAttributedString.htmlString))!,
+    class_getInstanceMethod(MockNSAttributedString.self, #selector(getter: MockNSAttributedString.htmlString))!
+  )
+  // swiftlint:enable force_unwrapping
+}

--- a/tools/src/commands/WorkflowDispatch.ts
+++ b/tools/src/commands/WorkflowDispatch.ts
@@ -22,39 +22,11 @@ type CommandOptions = {
 // Object containing configs for custom workflows.
 // Custom workflows extends common workflows by providing specific inputs.
 const CUSTOM_WORKFLOWS = {
-  'ad-hoc-client-shell-app-ios-upload': {
-    name: 'Ad-hoc iOS Client Shell App (with Upload to S3)',
-    baseWorkflowSlug: 'ad-hoc-client-shell-app-ios',
+  'client-android-eas-release': {
+    name: 'Android Expo Go Release',
+    baseWorkflowSlug: 'client-android-eas',
     inputs: {
-      upload: 'upload',
-    },
-  },
-  'client-android-release': {
-    name: 'Android Client Release',
-    baseWorkflowSlug: 'client-android',
-    inputs: {
-      releaseGooglePlay: 'release-google-play',
-    },
-  },
-  'client-android-simulator': {
-    name: 'Android Client Simulator Release',
-    baseWorkflowSlug: 'client-android',
-    inputs: {
-      releaseAPK: 'release-apk',
-    },
-  },
-  'client-ios-simulator': {
-    name: 'iOS Client Simulator Release',
-    baseWorkflowSlug: 'client-ios',
-    inputs: {
-      releaseSimulator: 'release-simulator',
-    },
-  },
-  'shell-app-ios-upload': {
-    name: 'iOS Shell App (with newest SDK version and Upload to S3)',
-    baseWorkflowSlug: 'shell-app-ios',
-    inputs: {
-      upload: 'upload',
+      buildType: 'versioned-client',
     },
   },
   'sdk-all': {


### PR DESCRIPTION
# Why

try to improve ci stability

# How

- android-unit-tests
  - prevent timeout and out of disk space
- client-android-eas
  - since client-android is not stable, try to broad the client-android-eas path coverage
  - for external contributors (forked repo), just ignore the workflow
- client-ios-eas
  - for external contributors (forked repo), just ignore the workflow
- client-android
  - TBD
- client-ios
  - remove s3 and store publish
- ios-unit-tests
  - prevent timeout
- clipboard
  - fix timeout issue because of slow NSAttributedString html processing
- `et dispatch`: remove unused workflows
- releasing guide: update to the newer `et eas` releasing workflows

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
