### PR TITLE
[core] fix missing fabric startup property

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [Android] Refresh NativeModulesProxy if app bundle is reloaded. ([#23824](https://github.com/expo/expo/pull/23824) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix nullability of parameter type in `List` and `Map` when converting from JS to native. ([#23942](https://github.com/expo/expo/pull/23942) by [@lukmccall](https://github.com/lukmccall))
+- Fixed Fabric setup error on iOS. ([#24004](https://github.com/expo/expo/pull/24004) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/ReactDelegates/EXReactCompatibleHelpers.m
+++ b/packages/expo-modules-core/ios/ReactDelegates/EXReactCompatibleHelpers.m
@@ -4,22 +4,22 @@
 
 #import <React/RCTRootView.h>
 
-#if __has_include(<React/RCTAppSetupUtils.h>)
+#if __has_include(<React-RCTAppDelegate/RCTAppSetupUtils.h>)
+#import <React-RCTAppDelegate/RCTAppSetupUtils.h>
+#elif __has_include(<React_RCTAppDelegate/RCTAppSetupUtils.h>)
+// for importing the header from framework, the dash will be transformed to underscore
+#import <React_RCTAppDelegate/RCTAppSetupUtils.h>
+#else
+// react-native < 0.72
 #import <React/RCTAppSetupUtils.h>
 #endif
 
 UIView *EXAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties, BOOL fabricEnabled)
 {
-#if __has_include(<React/RCTAppSetupUtils.h>)
-
 #if REACT_NATIVE_MINOR_VERSION >= 71
   return RCTAppSetupDefaultRootView(bridge, moduleName, initialProperties, fabricEnabled);
 #else
   return RCTAppSetupDefaultRootView(bridge, moduleName, initialProperties);
 #endif // REACT_NATIVE_MINOR_VERSION >= 71
-
-#else
-  return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
-#endif // __has_include(<React/RCTAppSetupUtils.h>)
 }
 


### PR DESCRIPTION
# Why

fixes #23994
close ENG-9778
close ENG-9792

# How

the `RCTAppSetupUtils.h` was moved to `React-RCTAppDelegate` pod since react-native 0.72 but i didn't update the import path to the EXReactCompatibleHelper. we ultimately go to the `[RCTRootView alloc] initWithBridge:` call path which was for react-native 0.67. this pr also drops the react-native 0.67 support. in case we cannot find `RCTAppSetupDefaultRootView` in the future, we will be noticed by build errors.

# Test Plan

test #23994 repro

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
