### PR TITLE
[android][keep-awake] Migrate to Expo Modules API

### DIFF
--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- On Android, migrate to Expo Modules Api.
+- On Android, migrate to Expo Modules Api. ([#24012](https://github.com/expo/expo/pull/24012) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 12.4.1 — 2023-08-02
 

--- a/packages/expo-keep-awake/CHANGELOG.md
+++ b/packages/expo-keep-awake/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- On Android, migrate to Expo Modules Api.
+
 ## 12.4.1 — 2023-08-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeExceptions.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeExceptions.kt
@@ -1,0 +1,12 @@
+package expo.modules.keepawake
+
+import expo.modules.kotlin.exception.CodedException
+
+internal class ActivateKeepAwakeException :
+  CodedException("Unable to activate keep awake")
+
+internal class DeactivateKeepAwakeException :
+  CodedException("Unable to deactivate keep awake. However, it probably is deactivated already")
+
+internal class MissingModuleException(moduleName: String) :
+  CodedException("Module '$moduleName' not found. Are you sure all modules are linked correctly?")

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakeModule.kt
@@ -1,54 +1,37 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package expo.modules.keepawake
 
-import android.content.Context
-
-import expo.modules.core.ExportedModule
-import expo.modules.core.ModuleRegistry
-import expo.modules.core.interfaces.services.KeepAwakeManager
-import expo.modules.core.ModuleRegistryDelegate
-import expo.modules.core.Promise
-import expo.modules.core.interfaces.ExpoMethod
 import expo.modules.core.errors.CurrentActivityNotFoundException
+import expo.modules.core.interfaces.services.KeepAwakeManager
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
 
-private const val NAME = "ExpoKeepAwake"
-private const val NO_ACTIVITY_ERROR_CODE = "NO_CURRENT_ACTIVITY"
+class KeepAwakeModule : Module() {
+  private val keepAwakeManager: KeepAwakeManager
+    get() = appContext.legacyModule() ?: throw MissingModuleException("KeepAwakeManager")
 
-class KeepAwakeModule(
-  context: Context,
-  private val moduleRegistryDelegate: ModuleRegistryDelegate = ModuleRegistryDelegate()
-) : ExportedModule(context) {
+  override fun definition() = ModuleDefinition {
+    Name("ExpoKeepAwake")
 
-  private val keepAwakeManager: KeepAwakeManager by moduleRegistry()
+    AsyncFunction("activate") { tag: String, promise: Promise ->
+      try {
+        keepAwakeManager.activate(tag) { promise.resolve(true) }
+      } catch (ex: CurrentActivityNotFoundException) {
+        promise.reject(ActivateKeepAwakeException())
+      }
+    }
 
-  private inline fun <reified T> moduleRegistry() = moduleRegistryDelegate.getFromModuleRegistry<T>()
+    AsyncFunction("deactivate") { tag: String, promise: Promise ->
+      try {
+        keepAwakeManager.deactivate(tag) { promise.resolve(true) }
+      } catch (ex: CurrentActivityNotFoundException) {
+        promise.reject(DeactivateKeepAwakeException())
+      }
+    }
 
-  override fun onCreate(moduleRegistry: ModuleRegistry) {
-    moduleRegistryDelegate.onCreate(moduleRegistry)
-  }
-
-  override fun getName(): String {
-    return NAME
-  }
-
-  @ExpoMethod
-  fun activate(tag: String, promise: Promise) {
-    try {
-      keepAwakeManager.activate(tag) { promise.resolve(true) }
-    } catch (ex: CurrentActivityNotFoundException) {
-      promise.reject(NO_ACTIVITY_ERROR_CODE, "Unable to activate keep awake")
+    AsyncFunction("isActivated") {
+      return@AsyncFunction keepAwakeManager.isActivated
     }
   }
-
-  @ExpoMethod
-  fun deactivate(tag: String, promise: Promise) {
-    try {
-      keepAwakeManager.deactivate(tag) { promise.resolve(true) }
-    } catch (ex: CurrentActivityNotFoundException) {
-      promise.reject(NO_ACTIVITY_ERROR_CODE, "Unable to deactivate keep awake. However, it probably is deactivated already.")
-    }
-  }
-
-  val isActivated: Boolean
-    get() = keepAwakeManager.isActivated
 }

--- a/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakePackage.kt
+++ b/packages/expo-keep-awake/android/src/main/java/expo/modules/keepawake/KeepAwakePackage.kt
@@ -2,15 +2,10 @@ package expo.modules.keepawake
 
 import android.content.Context
 
-import expo.modules.core.ExportedModule
 import expo.modules.core.interfaces.InternalModule
 import expo.modules.core.interfaces.Package
 
 class KeepAwakePackage : Package {
-  override fun createExportedModules(context: Context): List<ExportedModule> {
-    return listOf(KeepAwakeModule(context))
-  }
-
   override fun createInternalModules(context: Context): List<InternalModule> {
     return listOf(ExpoKeepAwakeManager())
   }

--- a/packages/expo-keep-awake/expo-module.config.json
+++ b/packages/expo-keep-awake/expo-module.config.json
@@ -1,6 +1,9 @@
 {
   "platforms": ["ios", "android"],
   "ios": {
-    "modulesClassNames": ["KeepAwakeModule"]
+    "modules": ["KeepAwakeModule"]
+  },
+  "android": {
+    "modules": ["expo.modules.keepawake.KeepAwakeModule"]
   }
 }


### PR DESCRIPTION
# Why
Continue module migration

# How
Typical migration steps

# Test Plan
Tested in `bare-expo`. Also tested with the release variant
