### PR TITLE
[core][Android] Cleanup several Kotlin Opt-Ins

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -277,16 +277,6 @@ dependencies {
   }
 }
 
-/**
- * To make the users of annotations @OptIn and @RequiresOptIn aware of their experimental status,
- * the compiler raises warnings when compiling the code with these annotations:
- * This class can only be used with the compiler argument '-Xopt-in=kotlin.RequiresOptIn'
- * To remove the warnings, we add the compiler argument -Xopt-in=kotlin.RequiresOptIn.
- */
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-  kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-}
-
 def createNativeDepsDirectories = project.tasks.findByName('createNativeDepsDirectories') ?: project.tasks.register('createNativeDepsDirectories') {
   downloadsDir.mkdirs()
   thirdPartyNdkDir.mkdirs()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/ActivityResultsManager.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/ActivityResultsManager.kt
@@ -1,5 +1,3 @@
-@file:OptIn(DelicateCoroutinesApi::class)
-
 package expo.modules.kotlin.activityresult
 
 import android.app.Activity
@@ -22,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger
  * Manager class that takes care of proper communication with [AppContextActivityResultRegistry]
  * It also monitors the needed lifecycle state using [AppCompatActivityAwareHelper]
  */
+@OptIn(DelicateCoroutinesApi::class)
 class ActivityResultsManager(
   currentActivityProvider: CurrentActivityProvider
 ) : AppContextActivityResultCaller, AppCompatActivityAware {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
 @file:Suppress("FunctionName")
 
 package expo.modules.kotlin.functions

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -1,15 +1,3 @@
-/**
- * We used a function from the experimental STD API - typeOf (see kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/type-of.html).
- * We shouldn't have any problem with that function, cause it's widely used in other libraries created by JetBrains like kotlinx-serializer.
- * This function is super handy if we want to receive a collection type.
- * For example, it's very hard to obtain the generic parameter type from the list class.
- * In plain Java, it's almost impossible. There is a trick to getting such information using something called TypeToken.
- * For instance, the Gson library uses this workaround. But there still will be a problem with nullability.
- * We didn't find a good solution to distinguish between List<Any?> and List<Any>.
- * Mainly because from the JVM perspective it's the same type.
- * That's why we used typeOf. It solves all problems described above.
- */
-@file:OptIn(ExperimentalStdlibApi::class)
 @file:Suppress("FunctionName")
 
 package expo.modules.kotlin.objects

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.objects
 
 import expo.modules.kotlin.functions.SyncFunctionComponent

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.types
 
 import android.graphics.Color

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/viewevent/ViewEventDelegate.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.viewevent
 
 import android.view.View

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -1,4 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
 @file:Suppress("FunctionName")
 
 package expo.modules.kotlin.views

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.JavaOnlyArray

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/TypeConverterHelperTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/TypeConverterHelperTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.functions
 
 import com.facebook.react.bridge.DynamicFromObject

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/PairTypeConverterTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.DynamicFromObject

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalStdlibApi::class)
-
 package expo.modules.kotlin.views
 
 import android.view.View

--- a/packages/expo-modules-test-core/android/build.gradle
+++ b/packages/expo-modules-test-core/android/build.gradle
@@ -96,13 +96,3 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation "org.jetbrains.kotlin:kotlin-reflect:${getKotlinVersion()}"
 }
-
-/**
- * To make the users of annotations @OptIn and @RequiresOptIn aware of their experimental status,
- * the compiler raises warnings when compiling the code with these annotations:
- * This class can only be used with the compiler argument '-Xopt-in=kotlin.RequiresOptIn'
- * To remove the warnings, we add the compiler argument -Xopt-in=kotlin.RequiresOptIn.
- */
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-  kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
-}


### PR DESCRIPTION
# Why

Part of ENG-9805

# How

Removes unneeded `@OptIn(ExperimentalStdlibApi::class)`

# Test Plan

- bare-expo ✅