### PR TITLE
[core][Android] Add function builders

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -3,68 +3,163 @@
 
 package expo.modules.kotlin.functions
 
+import expo.modules.kotlin.Promise
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.typeOf
 
 class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
-  internal var suspendFunctionComponent: SuspendFunctionComponent? = null
+  internal var asyncFunctionComponent: BaseAsyncFunctionComponent? = null
 
-  inline fun <reified R> SuspendBody(crossinline block: suspend () -> R): SuspendFunctionComponent {
+  inline fun <reified R> SuspendBody(crossinline block: suspend () -> R): BaseAsyncFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf()) { block() }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0> SuspendBody(crossinline block: suspend (p0: P0) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>())) { block(it[0] as P0) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1> SuspendBody(crossinline block: suspend (p0: P0, p1: P1) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>())) { block(it[0] as P0, it[1] as P1) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>())) { block(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
   inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> SuspendBody(crossinline block: suspend (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): SuspendFunctionComponent {
     return SuspendFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>(), { typeOf<P7>() }.toAnyType<P7>())) { block(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
-      suspendFunctionComponent = it
+      asyncFunctionComponent = it
     }
   }
 
-  internal fun build() = requireNotNull(suspendFunctionComponent)
+
+  @JvmName("AsyncBodyWithoutArgs")
+  inline fun AsyncBody(crossinline body: () -> Any?): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R> AsyncBody(crossinline body: () -> R): AsyncFunction {
+    return AsyncFunctionComponent(name, arrayOf()) { body() }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0> AsyncBody(crossinline body: (p0: P0) -> R): AsyncFunction {
+    return if (P0::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf()) { _, promise -> body(promise as P0) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>())) { body(it[0] as P0) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> AsyncBody(crossinline body: (p0: P0, p1: P1) -> R): AsyncFunction {
+    return if (P1::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>())) { args, promise -> body(args[0] as P0, promise as P1) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2) -> R): AsyncFunction {
+    return if (P2::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>())) { args, promise -> body(args[0] as P0, args[1] as P1, promise as P2) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R): AsyncFunction {
+    return if (P3::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, promise as P3) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R): AsyncFunction {
+    return if (P4::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, promise as P4) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R): AsyncFunction {
+    return if (P5::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, promise as P5) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R): AsyncFunction {
+    return if (P6::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, promise as P6) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> AsyncBody(crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R): AsyncFunction {
+    return if (P7::class == Promise::class) {
+      AsyncFunctionWithPromiseComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>())) { args, promise -> body(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6, promise as P7) }
+    } else {
+      AsyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>(), { typeOf<P7>() }.toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }
+    }.also {
+      asyncFunctionComponent = it
+    }
+  }
+
+  internal fun build() = requireNotNull(asyncFunctionComponent)
 }
 
 inline infix fun <reified R> AsyncFunctionBuilder.Coroutine(crossinline block: suspend () -> R) = SuspendBody(block)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AsyncFunctionBuilder.kt
@@ -65,7 +65,6 @@ class AsyncFunctionBuilder(@PublishedApi internal val name: String) {
     }
   }
 
-
   @JvmName("AsyncBodyWithoutArgs")
   inline fun AsyncBody(crossinline body: () -> Any?): AsyncFunction {
     return AsyncFunctionComponent(name, arrayOf()) { body() }.also {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
@@ -9,7 +9,6 @@ class FunctionBuilder(@PublishedApi internal val name: String) {
   @PublishedApi
   internal var functionComponent: SyncFunctionComponent? = null
 
-
   @JvmName("BodyWithoutArgs")
   inline fun Body(
     crossinline body: () -> Any?

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/FunctionBuilder.kt
@@ -1,0 +1,104 @@
+@file:Suppress("FunctionName")
+
+package expo.modules.kotlin.functions
+
+import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.typeOf
+
+class FunctionBuilder(@PublishedApi internal val name: String) {
+  @PublishedApi
+  internal var functionComponent: SyncFunctionComponent? = null
+
+
+  @JvmName("BodyWithoutArgs")
+  inline fun Body(
+    crossinline body: () -> Any?
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf()) { body() }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R> Body(
+    name: String,
+    crossinline body: () -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf()) { body() }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0> Body(
+    name: String,
+    crossinline body: (p0: P0) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>())) { body(it[0] as P0) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>())) { body(it[0] as P0, it[1] as P1) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>())) { body(it[0] as P0, it[1] as P1, it[2] as P2) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6) }.also {
+      functionComponent = it
+    }
+  }
+
+  inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> Body(
+    name: String,
+    crossinline body: (p0: P0, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7) -> R
+  ): SyncFunctionComponent {
+    return SyncFunctionComponent(name, arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>(), { typeOf<P7>() }.toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
+      functionComponent = it
+    }
+  }
+
+  internal fun build() = requireNotNull(functionComponent)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -21,6 +21,7 @@ import expo.modules.kotlin.functions.AsyncFunction
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
 import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
+import expo.modules.kotlin.functions.FunctionBuilder
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.jni.JavaScriptModuleObject
 import expo.modules.kotlin.modules.Module
@@ -44,9 +45,12 @@ open class ObjectDefinitionBuilder {
   internal var syncFunctions = mutableMapOf<String, SyncFunctionComponent>()
 
   @PublishedApi
+  internal var syncFunctionBuilder = mutableMapOf<String, FunctionBuilder>()
+
+  @PublishedApi
   internal var asyncFunctions = mutableMapOf<String, AsyncFunction>()
 
-  private var functionBuilders = mutableMapOf<String, AsyncFunctionBuilder>()
+  private var asyncFunctionBuilders = mutableMapOf<String, AsyncFunctionBuilder>()
 
   @PublishedApi
   internal var properties = mutableMapOf<String, PropertyComponentBuilder>()
@@ -66,8 +70,8 @@ open class ObjectDefinitionBuilder {
 
     return ObjectDefinitionData(
       constantsProvider,
-      syncFunctions,
-      asyncFunctions + functionBuilders.mapValues { (_, value) -> value.build() },
+      syncFunctions + syncFunctionBuilder.mapValues { (_, value) -> value.build() },
+      asyncFunctions + asyncFunctionBuilders.mapValues { (_, value) -> value.build() },
       eventsDefinition,
       properties.mapValues { (_, value) -> value.build() }
     )
@@ -76,7 +80,7 @@ open class ObjectDefinitionBuilder {
   private fun containsFunction(functionName: String): Boolean {
     return syncFunctions.containsKey(functionName) ||
       asyncFunctions.containsKey(functionName) ||
-      functionBuilders.containsKey(functionName)
+      asyncFunctionBuilders.containsKey(functionName)
   }
 
   /**
@@ -92,6 +96,10 @@ open class ObjectDefinitionBuilder {
   fun Constants(vararg constants: Pair<String, Any?>) {
     constantsProvider = { constants.toMap() }
   }
+
+  fun Function(
+    name: String
+  ) = FunctionBuilder(name).also { syncFunctionBuilder[name] = it }
 
   @JvmName("FunctionWithoutArgs")
   inline fun Function(
@@ -309,7 +317,7 @@ open class ObjectDefinitionBuilder {
 
   fun AsyncFunction(
     name: String
-  ) = AsyncFunctionBuilder(name).also { functionBuilders[name] = it }
+  ) = AsyncFunctionBuilder(name).also { asyncFunctionBuilders[name] = it }
 
   /**
    * Defines event names that this module can send to JavaScript.


### PR DESCRIPTION
# Why

Adds a sync function builder and extends the capability of the async function builder. 

# How

In the public version of `expo-modules-core`, we use an async builder to export suspendable functions. However, we cannot decorate exported functions, and the concept of function builder can help here. For example, if we want to check if the user granted permissions in each function call, we must do it imperatively. I would like to add a more declarative approach. So I've extended the capability of correct function builders implementation to allow such an approach in the future.

With that change, syntaxes like this are possible:

```kotlin
AsyncFunction("getReadPermissionAsync") With Manifest.permission.READ_EXTERNAL_STORAGE Permission { status: Int -> 

}
```

```kotlin
AsyncFunction("getReadPermissionAsync")
  .With(Manifest.permission.READ_EXTERNAL_STORAGE)
  .Permission { status: Int ->

}
```

# Test Plan

- bare-expo ✅
