### PR TITLE
[docs] Fix typo on 'Sharing Preview Releases'

### DIFF
--- a/docs/pages/guides/sharing-preview-releases.mdx
+++ b/docs/pages/guides/sharing-preview-releases.mdx
@@ -5,7 +5,7 @@ sidebar_title: Share preview releases
 
 import Video from '~/components/plugins/Video';
 
-During the development process you'll want share your progress with both technical and non-technical stakeholders of the project to gather feedback and test it,
+During the development process you'll want to share your progress with both technical and non-technical stakeholders of the project to gather feedback and test it,
 and there are several official approaches you can take for doing this.
 
 ## Internal Distribution


### PR DESCRIPTION
Update sharing-preview-releases.mdx, per sushnag22's suggestion on Discord

# Why

https://discord.com/channels/695411232856997968/1012054197409165387/1130371937554677820

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add missing word: "to"

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

¯\\\_(ツ)_/¯

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
