### PR TITLE
[doc] Add note about PWAs and Metro/expo-router

### DIFF
--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -7,7 +7,7 @@ import { CODE } from '~/ui/components/Text';
 
 A progressive web app (or PWA for short) is a website that can be installed on the user's device and used offline. If you build your native app with Expo, then Expo CLI can generate a lot of the PWA automatically based on how the native app works. Ex: icons, splash screens, orientation, and so on. [Add service workers](https://expo.fyi/enabling-web-service-workers) to get a complete PWA.
 
-> This guide is oriented towards apps using webpack. If you use [Metro for web](/guides/customizing-metro.mdx#web-support) (such as with [Expo Router](/routing/introduction.mdx)), you can still build a PWA, but the Expo tooling suggested in this guide is not all intended for it. You likely want to use the default `web.output` configuration of `single` to generate a SPA, and then you can modify your **public/index.html** to add meta tags and PWA assets, and use [expo-router/head](/router/reference/static-rendering.mdx#meta-tags) to set meta tags on each route. [Workbox](https://web.dev/learn/pwa/workbox/) is recommended for service workers.
+> This guide is oriented towards apps using webpack. If you use [Metro for web](/guides/customizing-metro/#web-support) (such as with [Expo Router](/routing/introduction)), you can still build a PWA. However, the Expo tooling suggested in this guide is not all intended for it. Use the [`web.output`](/versions/latest/config/app/#output) property with `single` as its default value to generate a SPA. You can then modify your **public/index.html** to add meta tags and PWA assets, and use [`expo-router/head`](/router/reference/static-rendering/#meta-tags) to set meta tags on each route. [Workbox](https://web.dev/learn/pwa/workbox/) is recommended for service workers.
 
 ## Usage
 

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -7,6 +7,8 @@ import { CODE } from '~/ui/components/Text';
 
 A progressive web app (or PWA for short) is a website that can be installed on the user's device and used offline. If you build your native app with Expo, then Expo CLI can generate a lot of the PWA automatically based on how the native app works. Ex: icons, splash screens, orientation, and so on. [Add service workers](https://expo.fyi/enabling-web-service-workers) to get a complete PWA.
 
+> This guide is oriented towards apps using webpack. If you use [Metro for web](/guides/customizing-metro.mdx#web-support) (such as with [Expo Router](/routing/introduction.mdx)), you can still build a PWA, but the Expo tooling suggested in this guide is not all intended for it. You likely want to use the default `web.output` configuration of `single` to generate a SPA, and then you can modify your **public/index.html** to add meta tags and PWA assets, and use [expo-router/head](/router/reference/static-rendering.mdx#meta-tags) to set meta tags on each route. [Workbox](https://web.dev/learn/pwa/workbox/) is recommended for service workers.
+
 ## Usage
 
 Expo web projects generate PWA assets and manifests by default, you only need to [add offline web support](https://expo.fyi/enabling-web-service-workers) to get a full PWA.


### PR DESCRIPTION
# Why

It's unclear how to proceed with building a PWA if you're using Expo Router / Metro web, so we should acknowledge it here and provide the small amount of guidance that we can given that we haven't spent time on this yet.

# How

![image](https://github.com/expo/expo/assets/90494/c27386f7-13a2-4007-9eda-5cf546334b54)