### PR TITLE
[docs] Add a next steps doc in Routing to link to some Advanced, Reference and Migration guides

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -82,6 +82,7 @@ const home = [
         makePage('routing/layouts.mdx'),
         makePage('routing/appearance.mdx'),
         makePage('routing/error-handling.mdx'),
+        makePage('routing/next-steps.mdx'),
       ],
       { expanded: false }
     ),

--- a/docs/pages/routing/error-handling.mdx
+++ b/docs/pages/routing/error-handling.mdx
@@ -94,21 +94,3 @@ export { ErrorBoundary } from 'expo-router';
 ### Work in progress
 
 React Native LogBox needs to be presented less aggressively to develop with errors. Currently, it shows for `console.error` and `console.warn`. However, it should ideally only show for uncaught errors.
-
-## Next steps
-
-<BoxLink
-  title="Stack navigation"
-  Icon={BookOpen02Icon}
-  description={
-    'Render a stack of screens like a deck of cards with a header on top. This is a native stack navigator that uses native animations and gestures.'
-  }
-  href="/router/advanced/stack"
-/>
-
-<BoxLink
-  title="Tab navigation"
-  Icon={BookOpen02Icon}
-  description="Render screens with a tab bar below them."
-  href="/router/advanced/tabs"
-/>

--- a/docs/pages/routing/introduction.mdx
+++ b/docs/pages/routing/introduction.mdx
@@ -44,9 +44,3 @@ It brings the best file-system routing concepts from the web to a universal appl
   description="See the source code for the example app on GitHub."
   href="https://github.com/expo/expo/tree/main/templates/expo-template-tabs"
 />
-<BoxLink
-  title="Reference"
-  Icon={BookOpen02Icon}
-  description="See the reference section for detailed information about the Hooks API, Redirects, Sitemap, Static Rendering and more."
-  href="/router/reference/hooks"
-/>

--- a/docs/pages/routing/introduction.mdx
+++ b/docs/pages/routing/introduction.mdx
@@ -44,3 +44,9 @@ It brings the best file-system routing concepts from the web to a universal appl
   description="See the source code for the example app on GitHub."
   href="https://github.com/expo/expo/tree/main/templates/expo-template-tabs"
 />
+<BoxLink
+  title="Reference"
+  Icon={BookOpen02Icon}
+  description="See the reference section for detailed information about the Hooks API, Redirects, Sitemap, Static Rendering and more."
+  href="/router/reference/hooks"
+/>

--- a/docs/pages/routing/next-steps.mdx
+++ b/docs/pages/routing/next-steps.mdx
@@ -1,0 +1,58 @@
+---
+title: Expo Router - Next steps
+description: The following resources are some of the hand-picked guides that will help you learn more about Expo Router.
+hideTOC: true
+sidebar_title: Next steps
+---
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { GithubIcon, BookOpen02Icon, Rocket02Icon } from '@expo/styleguide-icons';
+
+<BoxLink
+  title="Stack navigation"
+  Icon={BookOpen02Icon}
+  description="Render a stack of screens like a deck of cards with a header on top. This is a native stack navigator that uses native animations and gestures."
+  href="/router/advanced/stack"
+/>
+
+<BoxLink
+  title="Tab navigation"
+  Icon={BookOpen02Icon}
+  description="Render screens with a tab bar below them."
+  href="/router/advanced/tabs"
+/>
+
+<BoxLink
+  title="Hooks API"
+  Icon={BookOpen02Icon}
+  description="Learn how to interact with the in-app URL in Expo Router.."
+  href="/router/reference/hooks/"
+/>
+
+<BoxLink
+  title="Search Parameters"
+  Icon={BookOpen02Icon}
+  description="Learn how to access and modify search parameters in your app."
+  href="/router/reference/search-parameters/"
+/>
+
+<BoxLink
+  title="Migrate from React Navigation"
+  Icon={BookOpen02Icon}
+  description="Learn how to migrate a project using React Navigation to Expo Router."
+  href="/router/migrate/from-react-navigation/"
+/>
+
+<BoxLink
+  title="Troubleshooting"
+  Icon={BookOpen02Icon}
+  description="If you are facing an issue with Expo Router setup, check the troubleshooting guide."
+  href="/router/reference/troubleshooting/"
+/>
+
+<BoxLink
+  title="FAQs"
+  Icon={BookOpen02Icon}
+  description="Dive into commonly asked questions about Expo Router."
+  href="/router/reference/faq/"
+/>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [on slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1692469964882169)

# How

<!--
How did you build this feature or fix this bug and why?
-->

~~By adding a BoxLink for the first page in Reference section and adding a description that Reference section contains more than just Hooks API.~~

By adding a Next steps page under Home > Routing that links to different guides under Expo Router's Advanced, Reference and Migration.

**Preview**

![CleanShot 2023-08-23 at 18 40 14](https://github.com/expo/expo/assets/10234615/f33144e4-17e9-40c5-b123-8378f24d2e58)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: ~~http://localhost:3002/routing/introduction/~~ http://localhost:3002/routing/next-steps/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
