### PR TITLE
[expo-notifications][docs][iOS] Specified that "remote-notification" …

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -430,7 +430,7 @@ In the table above, whenever `NotificationResponseReceivedListener` is triggered
 
 > **warning** Background event listeners are not supported in Expo Go.
 
-To handle notifications while the app is backgrounded on iOS, you _must_ add `remote-notification` as an element in an array within the `ios.infoPlist.UIBackgroundModes` key in your **app.json**,
+To handle notifications while the app is in the background on iOS, add `remote-notification` as a value to the array under `ios.infoPlist.UIBackgroundModes` key in your [app config](/versions/latest/config/app/),
 and add `"content-available": 1` to your push notification payload. Under normal circumstances, the "content-available" flag should launch your app if it isn't running
 and wasn't killed by the user, however, this is ultimately decided by the OS, so it might not always happen.
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -430,7 +430,7 @@ In the table above, whenever `NotificationResponseReceivedListener` is triggered
 
 > **warning** Background event listeners are not supported in Expo Go.
 
-To handle notifications while the app is backgrounded on iOS, you _must_ add `remote-notification` to the `ios.infoPlist.UIBackgroundModes` key in your **app.json**,
+To handle notifications while the app is backgrounded on iOS, you _must_ add `remote-notification` as an element in an array within the `ios.infoPlist.UIBackgroundModes` key in your **app.json**,
 and add `"content-available": 1` to your push notification payload. Under normal circumstances, the "content-available" flag should launch your app if it isn't running
 and wasn't killed by the user, however, this is ultimately decided by the OS, so it might not always happen.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
The "remote-notification" values should be under the  ios.infoPlist.UIBackgroundModes key, but the docs don't mention that the values should be an element under an array. 

This causes the app to crash on start-up without much information to go on.

**How it's currently understood:**
```
{
    "expo": {
        "ios": {
            "infoPlist": {
                "UIBackgroundModes": "remote-notification"
            }
        }
    }
}
```

**How it should be:**
```
{
    "expo": {
        "ios": {
            "infoPlist": {
                "UIBackgroundModes": [
                    "remote-notification"
                ]
            }
        }
    }
}
```

# How

<!--
How did you build this feature or fix this bug and why?
-->
Followed [this Stack Overflow](https://stackoverflow.com/a/69017731/11980260) advice after troubleshooting the crash logs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
- If you leave "remote-notification" just as a value, iOS builds will crash on launch.
- Put the "remote-notification" value as an element in an array.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
