### PR TITLE
[expo-blur][docs] Add a section about workaround for using `borderRadius`

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -90,4 +90,4 @@ import { BlurView } from 'expo-blur';
 
 ## Using `borderRadius` with `BlurView`
 
-When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`.
+When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`. See [Usage](#usage) for an example.

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -87,3 +87,7 @@ import { BlurView } from 'expo-blur';
 ```
 
 <APISection packageName="expo-blur" />
+
+## Using `borderRadius` with `BlurView`
+
+When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`.

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -90,4 +90,4 @@ import { BlurView } from 'expo-blur';
 
 ## Using `borderRadius` with `BlurView`
 
-When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`.
+When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`. See [Usage](#usage) for an example.

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -87,3 +87,7 @@ import { BlurView } from 'expo-blur';
 ```
 
 <APISection packageName="expo-blur" />
+
+## Using `borderRadius` with `BlurView`
+
+When using `BlurView` on Android and iOS, the `borderRadius` property is not applied when provided explicitly. To fix this, you can use the `overflow: 'hidden'` style since `BlurView` inherits props from `<View>`.


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes #22385

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding a section to document using `overflow` when using `borderRadius` on a `BlurView`.
- Changes applied to unversioned and SDK 49 docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/latest/sdk/blur-view/#using-borderradius-with-blurview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
