### PR TITLE
fix(expo): add `jest-expo` to bundled native modules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -81,6 +81,7 @@
   "expo-updates": "~0.18.12",
   "expo-video-thumbnails": "~7.4.0",
   "expo-web-browser": "~12.3.2",
+  "jest-expo": "~49.0.0",
   "lottie-react-native": "5.1.6",
   "react": "18.2.0",
   "react-dom": "18.2.0",


### PR DESCRIPTION
# Why

When upgrading Snack, I noticed this was not changed since SDK 47. Looks like we had it in the versions API, but that was removed after SDK 43.

# How

- Added `jest-expo` to `expo@49` bundled native modules

# Test Plan

Just a config change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
