### PR TITLE
[docs] mark in-app-purchases as deprecated

### DIFF
--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. We recommend using either [`react-native-iap`](https://github.com/dooboolab/react-native-iap) or [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/unversioned/sdk/in-app-purchases.mdx
@@ -9,7 +9,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. We recommend using either [`react-native-iap`](https://github.com/dooboolab/react-native-iap) or [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/).
+> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. Development was paused in June 2022 and the package was deprecated in August 2023. We recommend one of the following, both of which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/):<br/><br/>
+> • [`react-native-iap`](https://github.com/dooboolab/react-native-iap), which provides an interface to client-side Google Play Billing and StoreKit API's<br/>
+> • [`react-native-purchases`](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which also integrates with RevenueCat's services for server-side receipt validation and more.
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
@@ -1,7 +1,7 @@
 ---
 title: InAppPurchases
 description: A library for accepting in-app purchases.
-sourceCodeUrl: 'https://github.com/expo/expo/tree/sdk-49/packages/expo-in-app-purchases'
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-in-app-purchases'
 packageName: 'expo-in-app-purchases'
 ---
 
@@ -9,7 +9,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Development of `expo-in-app-purchases` is currently paused to focus on other projects**. Alternative libraries include [`react-native-iap`](https://github.com/dooboolab/react-native-iap) and [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/).
+> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. We recommend using either [`react-native-iap`](https://github.com/dooboolab/react-native-iap) or [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/).
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 

--- a/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/in-app-purchases.mdx
@@ -9,7 +9,9 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import APISection from '~/components/plugins/APISection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 
-> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. We recommend using either [`react-native-iap`](https://github.com/dooboolab/react-native-iap) or [`react-native-purchases` from RevenueCat](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/).
+> **warning** **Deprecated:** This module is no longer maintained and will be removed in a future SDK release. Development was paused in June 2022 and the package was deprecated in August 2023. We recommend one of the following, both of which are compatible with [EAS Build](/build/introduction/) and [development builds](/development-builds/use-development-builds/):<br/><br/>
+> • [`react-native-iap`](https://github.com/dooboolab/react-native-iap), which provides an interface to client-side Google Play Billing and StoreKit API's<br/>
+> • [`react-native-purchases`](https://www.revenuecat.com/blog/using-revenuecat-with-expos-managed-workflow/), which also integrates with RevenueCat's services for server-side receipt validation and more.
 
 **`expo-in-app-purchases`** provides an API to accept payments for in-app products. Internally this relies on the [Google Play Billing](https://developer.android.com/google/play/billing/billing_library_overview) library on Android and the [StoreKit](https://developer.apple.com/documentation/storekit?language=objc) framework on iOS.
 


### PR DESCRIPTION
# Why
https://linear.app/expo/issue/ENG-9833/deprecate-expo-in-app-purchases

It's not maintained, it's not compatible with the latest stuff. There's better options.

# How
Changed the "paused" warning to deprecated.

Notes:
- Per Brent, added pause and deprecated timeframes
- I found some essential info on the differences between the two packages, and added it in there. However, I'm kind of breaking the bounds of what we typically put in a callout, so I had to hack it with HTML and Unicode. Not sure if it's worth/ possible to fix our `Callout` to support unordered lists (the lines just disappear if you try to use them)
# Test Plan
<img width="832" alt="image" src="https://github.com/expo/expo/assets/8053974/f7656561-094a-48b8-b4da-456c29f8bf3f">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
