### PR TITLE
[docs] Fix typo in troubleshooting.mdx

### DIFF
--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -23,7 +23,7 @@ Before you go further, you need to be sure that you have located the error messa
 
 Common questions that fall under this category are: "my app runs well locally by crashes immediately when I run a build" or "my app works in Expo Go but hangs on the splash screen in my build". When your app builds successfully but crashes or hangs when you run it, this is considered a runtime error.
 
-Refer to the ["Proudction errors" section of the debugging guide](/debugging/runtime-issues/#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
+Refer to the ["Production errors" section of the debugging guide](/debugging/runtime-issues/#production-errors) to learn how to locate logs when your release builds are crashing at runtime.
 
 If can't find any useful information through this approch, try [narrowing down the source of the crash step by step](https://expo.fyi/manual-debugging).
 


### PR DESCRIPTION
# Why
Incorrect spelling of "Production"

# How
Correct spelling

# Test Plan
Check dictionary: [Production](https://www.dictionary.com/browse/production)

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
