### PR TITLE
[docs] Add missing icon on BoxLink for docs in Home route

### DIFF
--- a/docs/pages/config-plugins/introduction.mdx
+++ b/docs/pages/config-plugins/introduction.mdx
@@ -6,6 +6,7 @@ sidebar_title: Introduction
 
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 An automatic setup for adding a native module to your project is possible. Sometimes, a module requires a more complex setup. A config plugin can be used to automatically configure your native project for a module and reduce the complexity by avoiding interaction with the native project.
 
@@ -62,7 +63,8 @@ they will be applied during the prebuild phase on `eas build`**.
 ## Next step
 
 <BoxLink
-  title="Creating a plugin"
+  title="Create a plugin"
   description="Learn about how you can create a config plugin."
   href="/config-plugins/plugins-and-mods"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/config-plugins/plugins-and-mods.mdx
+++ b/docs/pages/config-plugins/plugins-and-mods.mdx
@@ -7,6 +7,7 @@ import { YesIcon, NoIcon, WarningIcon } from '~/ui/components/DocIcons';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { FileTree } from '~/ui/components/FileTree';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Plugins are **synchronous** functions that accept an [`ExpoConfig`](/versions/latest/config/app/) and return a modified [`ExpoConfig`](/versions/latest/config/app/).
 
@@ -509,6 +510,7 @@ if app config plugin resolution searched for **build/app.plugin.js** you'd lose 
   title="Development and debugging"
   description="Learn about development best practices and debugging techniques for app config plugins."
   href="/config-plugins/development-and-debugging"
+  Icon={BookOpen02Icon}
 />
 
 [xml2js]: https://www.npmjs.com/package/xml2js

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -5,6 +5,7 @@ description: Learn about Redbox errors and stack traces in your Expo project.
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 When developing an application using Expo, you'll encounter a **Redbox** error or **Yellowbox** warning. These logging experiences are provided by [LogBox in React Native](https://reactnative.dev/blog/2020/07/06/version-0.63).
 
@@ -38,4 +39,5 @@ Debugging errors is one of the most frustrating but satisfying parts of developm
   title="Debugging"
   description="Learn about different techniques available to debug runtime issues in your Expo project."
   href="/debugging/runtime-issues"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -8,6 +8,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Whether you're developing your app locally, sending it out to select beta testers, or launching your app live to the app stores, you'll always find yourself debugging issues. It's useful to split errors into two categories:
 
@@ -175,4 +176,5 @@ The Expo community and the React and React Native communities are great resource
   title="Debugging tools"
   description="Learn about different tools available to debug runtime issues in your Expo project."
   href="/debugging/tools"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { BoxLink } from '~/ui/components/BoxLink';
-import { BuildIcon, EasSubmitIcon, EasMetadataIcon } from '@expo/styleguide-icons';
+import { BuildIcon, EasSubmitIcon, EasMetadataIcon, BookOpen02Icon } from '@expo/styleguide-icons';
 
 EAS Build allows you to build a native app binary that is signed for app store submission. These types of builds are called **production builds**.
 
@@ -104,5 +104,6 @@ If you are a member of an organization and your build is on its behalf, you will
 <BoxLink
   title="App stores best practices"
   description="Learn about the best practices for submitting your app to app stores."
+  Icon={BookOpen02Icon}
   href="/distribution/app-stores/"
 />

--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -6,6 +6,7 @@ hideTOC: true
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Expo can be used to login to many popular providers on iOS, Android, and web. [`expo-auth-session`](/versions/latest/sdk/auth-session/) package allows [browser-based authentication](/versions/latest/sdk/auth-session/#how-web-browser-based-authentication-flows-work) (using OAuth or OpenID Connect) to your project for Android, iOS, and the web. You can also implement authentication using native libraries for third-party providers with [development builds](/develop/development-builds/create-a-build).
 
@@ -18,6 +19,7 @@ Expo can be used to login to many popular providers on iOS, Android, and web. [`
     </>
   }
   href="/versions/latest/sdk/auth-session"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
@@ -29,6 +31,8 @@ Expo can be used to login to many popular providers on iOS, Android, and web. [`
     </>
   }
   href="/guides/google-authentication"
+  Icon={BookOpen02Icon}
+
 />
 
 <BoxLink
@@ -40,6 +44,7 @@ Expo can be used to login to many popular providers on iOS, Android, and web. [`
     </>
   }
   href="/guides/facebook-authentication"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
@@ -50,10 +55,12 @@ Expo can be used to login to many popular providers on iOS, Android, and web. [`
     </>
   }
   href="/versions/latest/sdk/apple-authentication"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Other authentication examples"
   description="A collection of examples for implementing web-based authentication in your Expo app using AuthSession API and other OAuth providers. "
   href="/guides/authentication"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -10,12 +10,13 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Development builds can be created with [EAS Build](/build/introduction/) or [locally](/develop/development-builds/development-workflows/#build-locally-with-android-studio-and-xcode) on your computer if you have Android Studio and Xcode installed.
 
 <Video url="https://www.youtube.com/embed/LUFHXsBcW6w" />
 
-In this guide, you'll find information on how to create a development build and then install them on an emulator/simulator or a physical device to continue developing your app.
+In this guide, you'll find information on how to create a development build and then install it on an emulator/simulator or a physical device to continue developing your app.
 
 <Step label="1">
 
@@ -157,4 +158,5 @@ You can also find this QR code on the build page in the [Expo dashboard](https:/
   title="Share with your team"
   description="Learn about how you can install and share a development build with your team or run it on multiple devices."
   href="/develop/development-builds/share-with-your-team"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/installation.mdx
+++ b/docs/pages/develop/development-builds/installation.mdx
@@ -7,6 +7,7 @@ description: Learn what are the prerequisites and installation steps to create a
 import { Terminal } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Step } from '~/ui/components/Step';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 In this guide, you'll learn what you need to install in your project to create a development build.
 
@@ -48,4 +49,5 @@ You can check whether you are logged in by running `eas whoami`.
   title="Create development builds"
   description="Learn about how you can create a development build."
   href="/develop/development-builds/create-a-build"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -7,6 +7,7 @@ description: Development builds of your app are Debug builds of your project. It
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import Video from '~/components/plugins/Video';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Building your project with Expo allows you to make most changes in JavaScript. This helps iterate quickly and safely and allows your team to [achieve web-like iteration speeds](https://blog.expo.dev/javascript-driven-development-with-custom-runtimes-eda87d574c9d) by dividing your application into:
 
@@ -33,4 +34,5 @@ The [`expo-dev-client`](https://www.npmjs.com/package/expo-dev-client) package i
   title="Development Builds: Installation"
   description="Learn what are the prerequisites and installation steps to create a development build."
   href="/develop/development-builds/installation"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -6,6 +6,7 @@ sidebar_title: Share with your team
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Android and iOS both offer ways to install a build of your application directly on devices. This gives you full control of putting specific builds on devices, allowing you to iterate quickly and have multiple builds of your application available for review at the same time. You can also share it with your team or run it on multiple test devices.
 
@@ -41,10 +42,12 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
   title="Parallel installation"
   description="Learn about having a development build and a production build installed on the same device."
   href="/develop/development-builds/parallel-installation"
+  Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Sharing pre-release versions of your app"
   description="Learn more about sharing pre-release versions of your app."
   href="/guides/sharing-preview-releases"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -5,6 +5,7 @@ description: Learn how to integrate the react-native-reanimated library and use 
 
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Animations are a great way to enhance and provide a better user experience. In your Expo projects, you can use the [Animated API](https://reactnative.dev/docs/next/animations) from React Native. However, if you want to use more advanced animations with better performance, you can use the [`react-native-reanimated`](https://docs.swmansion.com/react-native-reanimated/) library. It provides an API that simplifies the process of creating smooth, powerful, and maintainable animations.
 
@@ -115,4 +116,5 @@ Other animation packages are available, such as Moti, that you also use in your 
   title="Store data"
   description="Learn about different libraries available to store data in your app."
   href="/develop/user-interface/store-data"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/app-icons.mdx
+++ b/docs/pages/develop/user-interface/app-icons.mdx
@@ -5,6 +5,7 @@ description: Learn about configuring the app's icon and best practices for Andro
 
 import Video from '~/components/plugins/Video';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 An app's icon is what your app users see on their device's home screen and app stores. Android and iOS have different and strict requirements.
 
@@ -58,4 +59,5 @@ For iOS, you app's icon should follow the [Apple Human Interface Guidelines](htt
   title="Safe areas"
   description="Learn more about creating a safe area is a great way to ensure that your app's content is appropriately positioned around notches, status bars, home indicators, and other device and operating system interface elements."
   href="/develop/user-interface/safe-areas"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -7,6 +7,7 @@ import { SnackInline, Terminal } from '~/ui/components/Snippet';
 import Video from '~/components/plugins/Video';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Whether you are personally on team light or team dark, it's becoming increasingly common for apps to support these two color schemes. Here is an example of how supporting both modes looks in an Expo project:
 
@@ -167,4 +168,5 @@ While you're developing your project, you can change your simulator's or device'
   title="Animation"
   description="Learn more about integrating the react-native-reanimated library to create animations in your app."
   href="/develop/user-interface/animation"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -7,6 +7,7 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Both Android and iOS and most desktop operating systems come with their own set of platform fonts. However, if you want to inject some more brand personality into your app, a well-picked font can go a long way.
 
@@ -326,4 +327,5 @@ const styles = StyleSheet.create({
   title="Color themes"
   description="Learn more about supporting light and dark modes in your app."
   href="/develop/user-interface/color-themes"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -1,9 +1,10 @@
 ---
 title: Next steps
+hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
-import { Brush01Icon, Settings02Icon, TableIcon } from "@expo/styleguide-icons";
+import { Brush01Icon, Settings02Icon, TableIcon } from '@expo/styleguide-icons';
 
 The following resources are useful when learning more about User Interface.
 

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -6,6 +6,7 @@ description: Learn how to add safe areas for your Expo project and other best pr
 import { Terminal, SnackInline } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Creating a safe area is a great way to ensure that your app's content is appropriately positioned around notches, status bars, home indicators, and other device and operating system interface elements.
 
@@ -117,4 +118,5 @@ If you are targeting the web, you must set up `<SafeAreaProvider>` as described 
   title="Fonts"
   description="Learn more about different ways to import a custom font and use it in your app."
   href="/develop/user-interface/fonts"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/splash-screen.mdx
+++ b/docs/pages/develop/user-interface/splash-screen.mdx
@@ -8,6 +8,7 @@ import Video from '~/components/plugins/Video';
 import { Terminal } from '~/ui/components/Snippet';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 A splash screen, also known as a launch screen, is the first screen a user sees when they open your app. It stays visible while the app is loading. You can also control the behavior of when a splash screen disappears by using the native [SplashScreen API](/versions/latest/sdk/splash-screen).
 
@@ -161,4 +162,5 @@ See [Apple's guide on testing launch screens](https://developer.apple.com/docume
   title="App icons"
   description="An app's icon is what your app users see on their device's home screen and app stores. Learn about how to customize your app's icon and what are the different requirements for Android and iOS."
   href="/develop/user-interface/app-icons"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/user-interface/store-data.mdx
+++ b/docs/pages/develop/user-interface/store-data.mdx
@@ -4,6 +4,7 @@ description: Learn about different libraries available to store data in your Exp
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { BookOpen02Icon } from '@expo/styleguide-icons';
 
 Storing data can be essential to the features implemented in your mobile app. There are different ways to save data in your Expo project depending on the type of data you want to store and the security requirements of your app. This page lists a variety of libraries to help you decide which solution is best for your project.
 
@@ -37,6 +38,7 @@ Storing data can be essential to the features implemented in your mobile app. Th
   title="Expo SQLite API reference"
   description="For more information on how to install and use expo-sqlite, see its API documentation."
   href="/versions/latest/sdk/sqlite"
+  Icon={BookOpen02Icon}
 />
 
 ## Async Storage

--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -127,4 +127,5 @@ You can use this technique at any layer of the app to set the theme for a specif
   title="Error handling"
   description="Improve the user experience by gracefully handling unexpected errors."
   href="/routing/error-handling/"
+  Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, a lot of BoxLink components are missing an icon. Previously, we thought, we'll add icons based on the nature of the guide, however, we've done that where required but here are some generic guides that require icons.

Open to suggestions if there are BoxLinks where we can use specific icons.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding `BookOpen02Icon` as a placeholder for the `BoxLink` that are missing icons.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit routes under Home.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
