### PR TITLE
Prevent writing unused bundles with static Metro web.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `EXPO_SKIP_MANIFEST_VALIDATION_TOKEN` usage. ([#23890](https://github.com/expo/expo/pull/23890) by [@EvanBacon](https://github.com/EvanBacon))
 - Prohibit dev client URLs containing `_` in protocol. ([#23519](https://github.com/expo/expo/pull/23519) by [@byCedric](https://github.com/byCedric))
+- Prevent writing unused bundles with static Metro web.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `EXPO_SKIP_MANIFEST_VALIDATION_TOKEN` usage. ([#23890](https://github.com/expo/expo/pull/23890) by [@EvanBacon](https://github.com/EvanBacon))
 - Prohibit dev client URLs containing `_` in protocol. ([#23519](https://github.com/expo/expo/pull/23519) by [@byCedric](https://github.com/byCedric))
-- Prevent writing unused bundles with static Metro web.
+- Prevent writing unused bundles with static Metro web. ([#24092](https://github.com/expo/expo/pull/24092) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/e2e/__tests__/export-router.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export-router.test.ts
@@ -93,19 +93,6 @@ describe('static-rendering', () => {
         })
         .filter(Boolean);
 
-      const metadata = await JsonFile.readAsync(path.resolve(outputDir, 'metadata.json'));
-
-      expect(metadata).toEqual({
-        bundler: 'metro',
-        fileMetadata: {
-          web: {
-            assets: expect.anything(),
-            bundle: expect.stringMatching(/bundles\/web-.*\.js/),
-          },
-        },
-        version: 0,
-      });
-
       // The wrapper should not be included as a route.
       expect(files).not.toContain('+html.html');
       expect(files).not.toContain('_layout.html');
@@ -386,19 +373,6 @@ describe('single-page', () => {
           return path.posix.relative(outputDir, entry.path);
         })
         .filter(Boolean);
-
-      const metadata = await JsonFile.readAsync(path.resolve(outputDir, 'metadata.json'));
-
-      expect(metadata).toEqual({
-        bundler: 'metro',
-        fileMetadata: {
-          web: {
-            assets: expect.anything(),
-            bundle: expect.stringMatching(/bundles\/web-.*\.js/),
-          },
-        },
-        version: 0,
-      });
 
       // The wrapper should not be included as a route.
       expect(files).not.toContain('+html.html');

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -38,9 +38,11 @@ function createBundleHash(bundle: string | Uint8Array): string {
 export async function writeBundlesAsync({
   bundles,
   outputDir,
+  useWebSSG,
 }: {
   bundles: Partial<Record<Platform, Pick<BundleOutput, 'hermesBytecodeBundle' | 'code'>>>;
   outputDir: string;
+  useWebSSG?: boolean;
 }) {
   const hashes: Partial<Record<Platform, string>> = {};
   const fileNames: Partial<Record<Platform, string>> = {};
@@ -49,6 +51,10 @@ export async function writeBundlesAsync({
     Platform,
     Pick<BundleOutput, 'hermesBytecodeBundle' | 'code'>,
   ][]) {
+    // TODO: Move native to use the newer `_expo/...` bundle writing system.
+    if (platform === 'web' && useWebSSG) {
+      continue;
+    }
     const bundle = bundleOutput.hermesBytecodeBundle ?? bundleOutput.code;
     const hash = createBundleHash(bundle);
     const fileName = createBundleFileName({


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Prevent writing a `metadata.json` and `bundles/web-xxx.js` with static Metro web.
- We have two systems for exporting with Metro in here, just haven't had time to migrate native over to use the new one. Also haven't had time to add sourcemap support or asset manifests to the new one either.
- Split out of https://github.com/expo/expo/pull/23911


# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
