### PR TITLE
[docs] fix links to reanimated

### DIFF
--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -47,7 +47,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Minimal example
 
-The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [**`react-native-reanimated` documentation**](https://docs.swmansion.com/react-native-reanimated/docs/).
+The following example shows how to use the `react-native-reanimated` library to create a simple animation. For more information on the API and its usage, see [**`react-native-reanimated` documentation**](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation).
 
 <SnackInline label="Using react-native-reanimated" dependencies={['react-native-reanimated']}>
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -22,7 +22,7 @@ In this chapter, we are going to add two different gestures using the React Nati
 ## Install and configure libraries
 
 The React Native Gesture Handler library provides a way to interact with the native platform's gesture response system.
-To animate between gesture states, we will use the [Reanimated library](https://docs.swmansion.com/react-native-reanimated/docs/).
+To animate between gesture states, we will use the [Reanimated library](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/handling-gestures).
 
 To install them, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> and run the following command in the terminal:
 

--- a/docs/pages/versions/unversioned/sdk/reanimated.mdx
+++ b/docs/pages/versions/unversioned/sdk/reanimated.mdx
@@ -22,7 +22,7 @@ import PlatformsSection from '~/components/plugins/PlatformsSection';
 
 ## Usage
 
-You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import Animated, {

--- a/docs/pages/versions/v46.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/reanimated.mdx
@@ -38,7 +38,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Usage
 
-You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import Animated, {

--- a/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/reanimated.mdx
@@ -52,7 +52,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Usage
 
-You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import Animated, {

--- a/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/reanimated.mdx
@@ -52,7 +52,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Usage
 
-You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import Animated, {

--- a/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/reanimated.mdx
@@ -52,7 +52,7 @@ After you add the Babel plugin, restart your development server and clear the bu
 
 ## Usage
 
-You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
+You should refer to the [react-native-reanimated docs](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/your-first-animation) for more information on the API and its usage. But the following example (courtesy of that repo) is a quick way to get started.
 
 ```js
 import Animated, {


### PR DESCRIPTION
# Why

404 does not spark joy

# How

I decided to link directly to "Your First Animation" instead of "Getting Started" to save 1 click assuming people have followed the setup guide.

# Test Plan

before
![image](https://github.com/expo/expo/assets/360936/d5bb8ff4-1fed-4486-a818-d4aca33f30fd)


after
![image](https://github.com/expo/expo/assets/360936/b35c9038-d8ee-45cb-a29b-56689450ff01)


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
