### PR TITLE
[ios][calendar] Fix url parsing when adding url in calendar event and reminder

### DIFF
--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
@@ -381,11 +381,11 @@ EX_EXPORT_METHOD_AS(saveEventAsync,
     calendarEvent.recurrenceRules = nil;
   }
 
-  NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
-  if (URL) {
-    calendarEvent.URL = URL;
-  } else if (details[@"url"] == [NSNull null]) {
-    calendarEvent.URL = nil;
+  if (url) {
+    NSURLComponents *URLComponents = [NSURLComponents componentsWithString:url];
+    if (URLComponents && URLComponents.URL) {
+      calendarEvent.URL = URLComponents.URL;
+    }
   }
 
   if (startDate) {
@@ -651,11 +651,11 @@ EX_EXPORT_METHOD_AS(saveReminderAsync,
     reminder.recurrenceRules = nil;
   }
 
-  NSURL *URL = [NSURL URLWithString:[url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]]];
-  if (URL) {
-    reminder.URL = URL;
-  } else if (details[@"url"] == [NSNull null]) {
-    reminder.URL = nil;
+  if (url) {
+    NSURLComponents *URLComponents = [NSURLComponents componentsWithString:url];
+    if (URLComponents && URLComponents.URL) {
+      reminder.URL = URLComponents.URL;
+    }
   }
 
   if (startDate) {


### PR DESCRIPTION
# Why

Resolves https://github.com/expo/expo/issues/13804 (the issue closed but the issue was actually never fixed)

When adding a url to an event or a reminder in expo-calendar, the entire url is url-encoded and it cannot be used

# How

Use `NSURLComponents componentsWithString` that correctly parses the url passed as string (see [doc](https://developer.apple.com/documentation/foundation/nsurlcomponents/1572054-componentswithstring?language=objc)) and set `url` in `calendarEvent` or `reminder` if `URL` of `URLComponents` is not `nil`

# Test Plan

Tested locally in my application by updating the source code

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
