### PR TITLE
Update expo-router in bundledNativeModules.json

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -63,7 +63,7 @@
   "expo-permissions": "~14.2.1",
   "expo-print": "~12.4.2",
   "expo-random": "~13.2.0",
-  "expo-router": "2.0.0",
+  "expo-router": "^2.0.0",
   "expo-screen-capture": "~5.3.0",
   "expo-screen-orientation": "~6.0.5",
   "expo-secure-store": "~12.3.1",


### PR DESCRIPTION
# Why
Per @EvanBacon, SDK 49 should work with expo-router 2.x