### PR TITLE
[docs] Fix broken image

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -35,7 +35,7 @@ import React from 'react';
 import { Image, Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
 
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
+const uri = 'https://images.unsplash.com/photo-1603473511024-9b4cb9226f17?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1080&q=80';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';


### PR DESCRIPTION
# Why
The current image was not working, thus, it was impossible to understand the benefit of BlurView

# How
I changed the image with another one that I know will never be remved.
I used an image from Unsplash, which is free domain without limitation, and I AM the photographer, so, there won't be a problem at all.

# Test Plan
N/A

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
