### PR TITLE
[docs] Remove expo-updates install from sentry-expo setup guide

### DIFF
--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -74,7 +74,7 @@ In your project directory, run:
 
 <Terminal
   cmd={[
-    '$ npx expo install expo-application expo-constants expo-device expo-updates @sentry/react-native',
+    '$ npx expo install expo-application expo-constants expo-device @sentry/react-native',
   ]}
 />
 


### PR DESCRIPTION
# Why

This dependency was removed in https://github.com/expo/sentry-expo/pull/356 and published in sentry-expo 7.0.1.

Closes https://github.com/expo/expo/issues/23599.
Closes ENG-9826.

# Test Plan

1. Create app, follow instructions but omitting expo-updates, run release android build, see it works.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
