### PR TITLE
[expo-updates] completely fix node execution on windows

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add rollback support to useUpdates(). ([#24071](https://github.com/expo/expo/pull/24071) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
-
+- [Android] completely fix `node` execution on Windows ([#24116](https://github.com/expo/expo/pull/24116) by [@weykon](https://github.com/weykon))
 - [Android] Fixed the `node` execution on Windows. ([#23983](https://github.com/expo/expo/pull/23983) by [@kudo](https://github.com/kudo))
 - Bare update manifest non-nullability parity. ([#23166](https://github.com/expo/expo/pull/23166) by [@wschurman](https://github.com/wschurman))
 

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -89,7 +89,7 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
       project.exec {
         val args = listOf(*nodeExecutableAndArgs.get().toTypedArray(), "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));")
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-          it.commandLine("cmd", "/c", args)
+          it.commandLine("cmd", "/c", *args.toTypedArray())
         } else {
           it.commandLine(args)
         }

--- a/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
+++ b/packages/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
@@ -75,7 +75,7 @@ abstract class ExpoUpdatesPlugin : Plugin<Project> {
         }
 
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-          it.commandLine("cmd", "/c", args)
+          it.commandLine("cmd", "/c", *args.toTypedArray())
         } else {
           it.commandLine(args)
         }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I encountered the same issue as described in https://github.com/expo/expo/issues/23344. Following the instructions provided in https://github.com/expo/expo/issues/23344#issuecomment-1625075541, I was able to successfully compile the release package on Windows. However, it was mentioned in https://github.com/expo/expo/issues/23344#issuecomment-1692018783 that the fix alone was not sufficient and that I also needed to add this code in order to run it completely.


# How

<!--
How did you build this feature or fix this bug and why?
-->

Based on the code in #23983, make the following modifications to the code around line 78 and 92 as shown in the image above.

> ```diff
> ./node_modules/expo-updates/expo-updates-gradle-plugin/src/main/kotlin/expo/modules/updates/ExpoUpdatesPlugin.kt
>  abstract class ExpoUpdatesPlugin : Plugin<Project> {
>          }
>  
>          if (Os.isFamily(Os.FAMILY_WINDOWS)) {
> - 78        it.commandLine("cmd", "/c", args)
> + 78        it.commandLine("cmd", "/c", *args.toTypedArray())
>          } else {
>            it.commandLine(args)
>          }
>    ..
>      project.exec {
>        val args = listOf(*nodeExecutableAndArgs.get().toTypedArray(), "-e", "console.log(require('path').dirname(require.resolve('expo-updates/package.json')));")
>        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
> -  92    it.commandLine("cmd", "/c", args)
> +  92    it.commandLine("cmd", "/c", *args.toTypedArray())
>        } else {
>          it.commandLine(args)
>        }
> ```


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

No, but if not, it will happen error with messy code in android studio at this computer
![image](https://github.com/expo/expo/assets/36456814/ab0d411f-9013-44b9-adba-721b89a81bb2)

and add this simple code fixed it.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

and I think I should mention #23983 and @Kudo 
