### PR TITLE
[guides] add metro-config to versions endpoint update section

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -339,6 +339,7 @@ Once everything above is completed and Apple has approved Expo Go (iOS) for the 
   - `react-native-web`
   - `babel-preset-expo`
   - `@expo/config-plugins`
+  - `@expo/metro-config`
   - `@expo/webpack-config`
   - `@expo/prebuild-config`
   - `expo-modules-autolinking`


### PR DESCRIPTION
# Why
We started checking `@expo/metro-config` version against the versions endpoint in https://github.com/expo/expo-cli/pull/4742. Updating the releasing guide accordingly.
