### PR TITLE
[sqlite] Detect CTEs with SELECT query in Android

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed build error when mixing with iOS built-in SQLite3. ([#23885](https://github.com/expo/expo/pull/23885) by [@kudo](https://github.com/kudo))
+- [Android] Fixed select queries with CTEs crashing on Android. ([#24132](https://github.com/expo/expo/pull/24132) by [@derekstavis](https://github.com/derekstavis))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteHelpers.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteHelpers.kt
@@ -52,12 +52,16 @@ private fun isPragma(str: String): Boolean {
   return startsWithCaseInsensitive(str, "pragma")
 }
 
+private fun isSelectCTE(str: String): Boolean {
+  return startsWithCaseInsensitive(str, "with") && containsCaseInsensitive(str, "select")
+}
+
 private fun isPragmaReadOnly(str: String): Boolean {
   return isPragma(str) && !str.contains('=')
 }
 
 internal fun isSelect(str: String): Boolean {
-  return startsWithCaseInsensitive(str, "select") || isPragmaReadOnly(str)
+  return startsWithCaseInsensitive(str, "select") || isSelectCTE(str) || isPragmaReadOnly(str)
 }
 
 internal fun isInsert(str: String): Boolean {
@@ -74,6 +78,10 @@ internal fun isDelete(str: String): Boolean {
 
 private fun startsWithCaseInsensitive(str: String, substr: String): Boolean {
   return str.trimStart().startsWith(substr, true)
+}
+
+private fun containsCaseInsensitive(str: String, substr: String): Boolean {
+  return str.trimStart().contains(substr, true)
 }
 
 internal fun convertParamsToStringArray(paramArrayArg: List<Any?>): Array<String?> {


### PR DESCRIPTION
# Why
When performing a select query that starts with a CTE (`WITH` keyword) Android is throwing this exception:

```
error: unknown error (code 0): Queries can be performed using SQLiteDatabase query or rawQuery methods only.
```

Since this is not a breaking API change, I suggest that this bugfix gets backported to previous `expo-sqlite` versions too.

# How
In addition to queries that starts with `SELECT`, queries that start with `WITH` and contains `INSERT` are also detected as select in `isSelect` function.

I personally don't love the `contains` comparison here (and overall all the string logic being done), but it is necessary since CTEs can also be used with DMLs too -- per the [SQLite spec](https://www.sqlite.org/lang_with.html):

>All common table expressions (ordinary and recursive) are created by prepending a WITH clause in front of a [SELECT](https://www.sqlite.org/lang_select.html), [INSERT](https://www.sqlite.org/lang_insert.html), [DELETE](https://www.sqlite.org/lang_delete.html), or [UPDATE](https://www.sqlite.org/lang_update.html) statement. A single WITH clause can specify one or more common table expressions, some of which are ordinary and some of which are recursive.

This means that this implementation is also incomplete as it's not handling CTEs in `INSERT`, `DELETE` and `UPDATE` DMLs. Ideally we want to refactor this such that the query type detection logic is not needed at all.

# Test Plan
The following Snack should not error out on Android.
https://snack.expo.dev/@derekstavis/android-sqlite-cte

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
