### PR TITLE
[core][Android] Add type converter for the `ReadableArguments` class

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 💡 Others
 
-- [Android] Add type converter for the `ReadableArguments` class to allow backward compatibility with older modules.
+- [Android] Add type converter for the `ReadableArguments` class to allow backward compatibility with older modules. ([#24137](https://github.com/expo/expo/pull/24137) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.6.0 — 2023-07-28
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### 💡 Others
 
+- [Android] Add type converter for the `ReadableArguments` class to allow backward compatibility with older modules.
+
 ## 1.6.0 — 2023-07-28
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ReadableArgumentsTypeConverter.kt
@@ -1,0 +1,24 @@
+package expo.modules.kotlin.types
+
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.core.arguments.MapArguments
+import expo.modules.core.arguments.ReadableArguments
+import expo.modules.kotlin.jni.CppType
+import expo.modules.kotlin.jni.ExpectedType
+
+class ReadableArgumentsTypeConverter(
+  isOptional: Boolean,
+) : DynamicAwareTypeConverters<ReadableArguments>(isOptional) {
+  override fun convertFromDynamic(value: Dynamic): ReadableArguments {
+    return MapArguments(value.asMap().toHashMap())
+  }
+
+  override fun convertFromAny(value: Any): ReadableArguments {
+    return MapArguments((value as ReadableMap).toHashMap())
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.READABLE_MAP)
+
+  override fun isTrivial(): Boolean = false
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.annotation.Config
+import expo.modules.core.arguments.ReadableArguments
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.jni.CppType
@@ -286,6 +287,8 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       File::class to FileTypeConverter(isOptional),
 
       Any::class to AnyTypeConverter(isOptional),
+
+      ReadableArguments::class to ReadableArgumentsTypeConverter(isOptional),
     )
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {


### PR DESCRIPTION
# Why

Add a type converter for the `ReadableArguments` class to allow backward compatibility with older modules.

# How

Some modules, like `expo-calendar`, heavily use the `ReadableArguments` class to receive arguments. It's better to add a converter than change the underlying logic instead of changing the underlying logic.

# Test Plan

- bare-expo with https://github.com/expo/expo/pull/24103 ✅