### PR TITLE
[expo-notifications][docs] Passed projectId into getExpoPushTokenAsync in the examples for SDK 49+

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -149,7 +149,7 @@ async function registerForPushNotificationsAsync() {
       alert('Failed to get push token for push notification!');
       return;
     }
-    token = (await Notifications.getExpoPushTokenAsync()).data;
+    token = (await Notifications.getExpoPushTokenAsync({ projectId: 'your-project-id' })).data;
     console.log(token);
   } else {
     alert('Must use physical device for Push Notifications');

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -149,6 +149,8 @@ async function registerForPushNotificationsAsync() {
       alert('Failed to get push token for push notification!');
       return;
     }
+    // Learn more about projectId:
+    // https://docs.expo.dev/push-notifications/push-notifications-setup/#configure-projectid
     token = (await Notifications.getExpoPushTokenAsync({ projectId: 'your-project-id' })).data;
     console.log(token);
   } else {

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -149,7 +149,7 @@ async function registerForPushNotificationsAsync() {
       alert('Failed to get push token for push notification!');
       return;
     }
-    token = (await Notifications.getExpoPushTokenAsync()).data;
+    token = (await Notifications.getExpoPushTokenAsync({ projectId: 'your-project-id' })).data;
     console.log(token);
   } else {
     alert('Must use physical device for Push Notifications');

--- a/docs/pages/versions/v49.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/notifications.mdx
@@ -149,6 +149,8 @@ async function registerForPushNotificationsAsync() {
       alert('Failed to get push token for push notification!');
       return;
     }
+    // Learn more about projectId:
+    // https://docs.expo.dev/push-notifications/push-notifications-setup/#configure-projectid
     token = (await Notifications.getExpoPushTokenAsync({ projectId: 'your-project-id' })).data;
     console.log(token);
   } else {


### PR DESCRIPTION
# Why
Close https://github.com/expo/expo/issues/23815#issuecomment-1695050124

The first example for https://docs.expo.dev/versions/latest/sdk/notifications/ does not show that **projectId** needs to be passed to **getExpoPushTokenAsync()**.

The error logged out is **"Calling getExpoPushTokenAsync without specifying a projectId is deprecated and will no longer be supported in SDK 49+"**

If someone missed the initial steps of creating an expo project as explained in my comment https://github.com/expo/expo/issues/23815#issuecomment-1695867536 , they may encounter this issue. Which can be avoided if projectId is shown in the first example.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- By updating the example to show that projectId needs to be passed to getExpoPushTokenAsync()
- Changes applied to unversioned and v49.0.0.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Run docs locally and visit: 
- http://localhost:3002/versions/49.0.0/sdk/notifications/
- http://localhost:3002/versions/unversioned/sdk/notifications/

```js
token = (await Notifications.getExpoPushTokenAsync()).data;  <-- from this
token = (await Notifications.getExpoPushTokenAsync({ projectId: 'your-project-id' })).data; <-- to this
```
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
