### PR TITLE
[rfc][expo-updates] Remove isEnabled config option altogether

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -358,7 +358,6 @@ NS_ASSUME_NONNULL_BEGIN
     EXUpdatesConfig.EXUpdatesConfigScopeKeyKey: httpManifestUrl.absoluteString,
     EXUpdatesConfig.EXUpdatesConfigReleaseChannelKey: releaseChannel,
     EXUpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: @([EXEnvironment sharedEnvironment].isDetached),
-    EXUpdatesConfig.EXUpdatesConfigEnabledKey: @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
     EXUpdatesConfig.EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
     EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueNever,
     EXUpdatesConfig.EXUpdatesConfigExpectsSignedManifestKey: @YES,

--- a/packages/@expo/config-plugins/src/ios/IosConfig.types.ts
+++ b/packages/@expo/config-plugins/src/ios/IosConfig.types.ts
@@ -38,7 +38,6 @@ export type InfoPlist = Record<string, JSONValue | undefined> & {
 
 export type ExpoPlist = {
   EXUpdatesCheckOnLaunch?: string;
-  EXUpdatesEnabled?: boolean;
   EXUpdatesLaunchWaitMs?: number;
   EXUpdatesReleaseChannel?: string;
   EXUpdatesRuntimeVersion?: string;

--- a/packages/@expo/config-plugins/src/ios/Updates.ts
+++ b/packages/@expo/config-plugins/src/ios/Updates.ts
@@ -14,7 +14,6 @@ import {
   getUpdatesCodeSigningCertificate,
   getUpdatesCodeSigningMetadata,
   getUpdatesRequestHeaders,
-  getUpdatesEnabled,
   getUpdatesTimeout,
   getUpdateUrl,
 } from '../utils/Updates';
@@ -22,7 +21,6 @@ import {
 const CREATE_MANIFEST_IOS_PATH = 'expo-updates/scripts/create-manifest-ios.sh';
 
 export enum Config {
-  ENABLED = 'EXUpdatesEnabled',
   CHECK_ON_LAUNCH = 'EXUpdatesCheckOnLaunch',
   LAUNCH_WAIT_MS = 'EXUpdatesLaunchWaitMs',
   RUNTIME_VERSION = 'EXUpdatesRuntimeVersion',
@@ -59,17 +57,11 @@ export function setUpdatesConfig(
 ): ExpoPlist {
   const newExpoPlist = {
     ...expoPlist,
-    [Config.ENABLED]: getUpdatesEnabled(config),
     [Config.CHECK_ON_LAUNCH]: getUpdatesCheckOnLaunch(config, expoUpdatesPackageVersion),
     [Config.LAUNCH_WAIT_MS]: getUpdatesTimeout(config),
   };
 
-  const updateUrl = getUpdateUrl(config);
-  if (updateUrl) {
-    newExpoPlist[Config.UPDATE_URL] = updateUrl;
-  } else {
-    delete newExpoPlist[Config.UPDATE_URL];
-  }
+  newExpoPlist[Config.UPDATE_URL] = getUpdateUrl(config);
 
   const codeSigningCertificate = getUpdatesCodeSigningCertificate(projectRoot, config);
   if (codeSigningCertificate) {
@@ -205,7 +197,6 @@ export function isPlistConfigurationSynced(
 ): boolean {
   return (
     getUpdateUrl(config) === expoPlist.EXUpdatesURL &&
-    getUpdatesEnabled(config) === expoPlist.EXUpdatesEnabled &&
     getUpdatesTimeout(config) === expoPlist.EXUpdatesLaunchWaitMs &&
     getUpdatesCheckOnLaunch(config) === expoPlist.EXUpdatesCheckOnLaunch &&
     getUpdatesCodeSigningCertificate(projectRoot, config) ===

--- a/packages/@expo/config-plugins/src/utils/Updates.ts
+++ b/packages/@expo/config-plugins/src/utils/Updates.ts
@@ -22,8 +22,22 @@ export function getExpoUpdatesPackageVersion(projectRoot: string): string | null
   return packageJson.version;
 }
 
-export function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'updates'>): string | null {
-  return config.updates?.url ?? null;
+export function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'updates'>): string {
+  const updateUrl = config.updates?.url;
+  if (!updateUrl) {
+    const hasEnabledConfigProperty = config.updates?.enabled !== undefined;
+    if (hasEnabledConfigProperty) {
+      throw new Error(
+        'The enabled setting has been removed from expo-updates. In the past, this was set to false by default. To fix this, either remove the expo-updates package from your project or configure expo-updates using EAS Update or your own configuration.'
+      );
+    } else {
+      throw new Error(
+        "The expo-updates library has not been configured, and must be configured before being built into a project. To fix this, either remove the expo-updates package from your project if you don't use it or configure expo-updates using EAS Update or your own configuration."
+      );
+    }
+  }
+
+  return updateUrl;
 }
 
 export function getAppVersion(config: Pick<ExpoConfig, 'version'>): string {
@@ -129,15 +143,6 @@ export function getRuntimeVersion(
 
 export function getSDKVersion(config: Pick<ExpoConfigUpdates, 'sdkVersion'>): string | null {
   return typeof config.sdkVersion === 'string' ? config.sdkVersion : null;
-}
-
-export function getUpdatesEnabled(config: Pick<ExpoConfigUpdates, 'updates'>): boolean {
-  // allow override of enabled property
-  if (config.updates?.enabled !== undefined) {
-    return config.updates.enabled;
-  }
-
-  return getUpdateUrl(config) !== null;
 }
 
 export function getUpdatesTimeout(config: Pick<ExpoConfigUpdates, 'updates'>): number {

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/UpdatesConfigurationInstrumentationTest.kt
@@ -84,7 +84,6 @@ class UpdatesConfigurationInstrumentationTest {
       every { packageManager } returns mockk {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
           metaData = Bundle().apply {
-            putBoolean("expo.modules.updates.ENABLED", false)
             putInt("expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS", 1000)
             putBoolean("expo.modules.updates.HAS_EMBEDDED_UPDATE", false)
             putBoolean("expo.modules.updates.CODE_SIGNING_INCLUDE_MANIFEST_RESPONSE_CERTIFICATE_CHAIN", true)
@@ -109,7 +108,6 @@ class UpdatesConfigurationInstrumentationTest {
       every { packageManager } returns mockk {
         every { getApplicationInfo(testPackageName, PackageManager.GET_META_DATA) } returns mockk {
           metaData = Bundle().apply {
-            putBoolean("expo.modules.updates.ENABLED", true)
             putString("expo.modules.updates.EXPO_SCOPE_KEY", "invalid")
             putString("expo.modules.updates.EXPO_UPDATE_URL", "http://invalid.com")
             putString("expo.modules.updates.EXPO_SDK_VERSION", "invalid")
@@ -129,7 +127,6 @@ class UpdatesConfigurationInstrumentationTest {
     val config = UpdatesConfiguration(
       context,
       mapOf(
-        UpdatesConfiguration.UPDATES_CONFIGURATION_ENABLED_KEY to false,
         UpdatesConfiguration.UPDATES_CONFIGURATION_SCOPE_KEY_KEY to "override",
         UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("http://override.com"),
         UpdatesConfiguration.UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY to mapOf("test" to "override"),

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -19,10 +19,9 @@ import expo.modules.updates.codesigning.CodeSigningConfiguration
  * class may be created over the lifetime of the app, but only one should be active at a time.
  */
 data class UpdatesConfiguration(
-  val isEnabled: Boolean,
   val expectsSignedManifest: Boolean,
-  val scopeKey: String?,
-  val updateUrl: Uri?,
+  val scopeKey: String,
+  val updateUrl: Uri,
   val sdkVersion: String?,
   val runtimeVersion: String?,
   val releaseChannel: String,
@@ -55,13 +54,12 @@ data class UpdatesConfiguration(
   }
 
   constructor(context: Context?, overrideMap: Map<String, Any>?) : this(
-    isEnabled = overrideMap?.readValueCheckingType<Boolean>(UPDATES_CONFIGURATION_ENABLED_KEY) ?: context?.getMetadataValue("expo.modules.updates.ENABLED") ?: true,
     expectsSignedManifest = overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_EXPECTS_EXPO_SIGNED_MANIFEST) ?: false,
     scopeKey = maybeGetDefaultScopeKey(
       overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SCOPE_KEY_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SCOPE_KEY"),
-      updateUrl = overrideMap?.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?: context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) },
+      updateUrl = getUpdatesUrl(context, overrideMap),
     ),
-    updateUrl = overrideMap?.readValueCheckingType<Uri>(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?: context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) },
+    updateUrl = getUpdatesUrl(context, overrideMap),
     sdkVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_SDK_VERSION_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_SDK_VERSION"),
     runtimeVersion = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RUNTIME_VERSION_KEY) ?: context?.getMetadataValue<Any>("expo.modules.updates.EXPO_RUNTIME_VERSION")?.toString()?.replaceFirst("^string:".toRegex(), ""),
     releaseChannel = overrideMap?.readValueCheckingType<String>(UPDATES_CONFIGURATION_RELEASE_CHANNEL_KEY) ?: context?.getMetadataValue("expo.modules.updates.EXPO_RELEASE_CHANNEL") ?: UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE,
@@ -101,8 +99,7 @@ data class UpdatesConfiguration(
   )
 
   val isMissingRuntimeVersion: Boolean
-    get() = (runtimeVersion == null || runtimeVersion.isEmpty()) &&
-      (sdkVersion == null || sdkVersion.isEmpty())
+    get() = runtimeVersion.isNullOrEmpty() && sdkVersion.isNullOrEmpty()
 
   val codeSigningConfiguration: CodeSigningConfiguration? by lazy {
     codeSigningCertificate?.let {
@@ -113,7 +110,6 @@ data class UpdatesConfiguration(
   companion object {
     private val TAG = UpdatesConfiguration::class.java.simpleName
 
-    const val UPDATES_CONFIGURATION_ENABLED_KEY = "enabled"
     const val UPDATES_CONFIGURATION_SCOPE_KEY_KEY = "scopeKey"
     const val UPDATES_CONFIGURATION_UPDATE_URL_KEY = "updateUrl"
     const val UPDATES_CONFIGURATION_REQUEST_HEADERS_KEY = "requestHeaders"
@@ -133,6 +129,12 @@ data class UpdatesConfiguration(
 
     private const val UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default"
     private const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0
+
+    private fun getUpdatesUrl(context: Context?, overrideMap: Map<String, Any>?): Uri {
+      return overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?:
+        context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) } ?:
+        throw InvalidArgumentException("Missing update URL. Ensure it is set up in your app configuration or AndroidManifest.xml. Or, if you don't wish to use expo-updates, remove the package.")
+    }
   }
 }
 
@@ -181,12 +183,10 @@ internal fun getNormalizedUrlOrigin(url: Uri): String {
   return if (port > -1) "$scheme://${url.host}:$port" else "$scheme://${url.host}"
 }
 
-private fun maybeGetDefaultScopeKey(scopeKey: String?, updateUrl: Uri?): String? {
+private fun maybeGetDefaultScopeKey(scopeKey: String?, updateUrl: Uri): String {
   // set updateUrl as the default value if none is provided
   if (scopeKey == null) {
-    if (updateUrl != null) {
-      return getNormalizedUrlOrigin(updateUrl)
-    }
+    return getNormalizedUrlOrigin(updateUrl)
   }
   return scopeKey
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -120,7 +120,7 @@ class UpdatesController private constructor(
     private set
 
   fun onDidCreateReactInstanceManager(reactInstanceManager: ReactInstanceManager) {
-    if (isEmergencyLaunch || !updatesConfiguration.isEnabled) {
+    if (isEmergencyLaunch) {
       return
     }
     errorRecovery.startMonitoring(reactInstanceManager)
@@ -189,9 +189,6 @@ class UpdatesController private constructor(
     databaseHolder.releaseDatabase()
   }
 
-  val updateUrl: Uri?
-    get() = updatesConfiguration.updateUrl
-
   val launchedUpdate: UpdateEntity?
     get() = launcher?.launchedUpdate
 
@@ -239,14 +236,6 @@ class UpdatesController private constructor(
     }
     isStarted = true
 
-    if (!updatesConfiguration.isEnabled) {
-      launcher = NoDatabaseLauncher(context, updatesConfiguration)
-      notifyController()
-      return
-    }
-    if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
-      throw AssertionError("expo-updates is enabled, but no valid URL is configured in AndroidManifest.xml. If you are making a release build for the first time, make sure you have run `expo publish` at least once.")
-    }
     if (updatesDirectory == null) {
       launcher = NoDatabaseLauncher(context, updatesConfiguration, updatesDirectoryException)
       isEmergencyLaunch = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -44,10 +44,6 @@ class UpdatesDevLauncherController : UpdatesInterface {
   ) {
     val controller = UpdatesController.instance
     val updatesConfiguration = UpdatesConfiguration(context, configuration)
-    if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
-      callback.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
-      return
-    }
     if (controller.updatesDirectory == null) {
       callback.onFailure(controller.updatesDirectoryException)
       return
@@ -170,10 +166,6 @@ class UpdatesDevLauncherController : UpdatesInterface {
   override fun storedUpdateIdsWithConfiguration(configuration: HashMap<String, Any>, context: Context, callback: QueryCallback) {
     val controller = UpdatesController.instance
     val updatesConfiguration = UpdatesConfiguration(context, configuration)
-    if (updatesConfiguration.updateUrl == null || updatesConfiguration.scopeKey == null) {
-      callback.onFailure(Exception("Failed to load update: UpdatesConfiguration object must include a valid update URL"))
-      return
-    }
     val updatesDirectory = controller.updatesDirectory
     if (updatesDirectory == null) {
       callback.onFailure(controller.updatesDirectoryException)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -68,7 +68,6 @@ class UpdatesModule(
         constants["isEmbeddedLaunch"] = updatesServiceLocal.isEmbeddedLaunch
         constants["isMissingRuntimeVersion"] =
           updatesServiceLocal.configuration.isMissingRuntimeVersion
-        constants["isEnabled"] = updatesServiceLocal.configuration.isEnabled
         constants["releaseChannel"] = updatesServiceLocal.configuration.releaseChannel
         constants["isUsingEmbeddedAssets"] = updatesServiceLocal.isUsingEmbeddedAssets
         constants["runtimeVersion"] = updatesServiceLocal.configuration.runtimeVersion ?: ""
@@ -111,8 +110,8 @@ class UpdatesModule(
   @ExpoMethod
   fun reload(promise: Promise) {
     try {
-      val updatesServiceLocal = updatesService
-      if (!updatesServiceLocal!!.canRelaunch()) {
+      val updatesServiceLocal = updatesService!!
+      if (!updatesServiceLocal.canRelaunch()) {
         promise.reject(
           "ERR_UPDATES_DISABLED",
           "You cannot reload when expo-updates is not enabled."
@@ -141,15 +140,7 @@ class UpdatesModule(
   @ExpoMethod
   fun getNativeStateMachineContextAsync(promise: Promise) {
     try {
-      val updatesServiceLocal = updatesService
-      if (!updatesServiceLocal!!.configuration.isEnabled) {
-        promise.reject(
-          "ERR_UPDATES_DISABLED",
-          "You cannot check for updates when expo-updates is not enabled."
-        )
-        return
-      }
-      val context = updatesServiceLocal.stateMachine?.context ?: UpdatesStateContext()
+      val context = updatesService!!.stateMachine?.context ?: UpdatesStateContext()
       promise.resolve(context.bundle)
     } catch (e: IllegalStateException) {
       promise.reject(
@@ -162,14 +153,7 @@ class UpdatesModule(
   @ExpoMethod
   fun checkForUpdateAsync(promise: Promise) {
     try {
-      val updatesServiceLocal = updatesService
-      if (!updatesServiceLocal!!.configuration.isEnabled) {
-        promise.reject(
-          "ERR_UPDATES_DISABLED",
-          "You cannot check for updates when expo-updates is not enabled."
-        )
-        return
-      }
+      val updatesServiceLocal = updatesService!!
       updatesServiceLocal.stateMachine?.processEvent(UpdatesStateEvent.Check())
       AsyncTask.execute {
         val databaseHolder = updatesServiceLocal.databaseHolder
@@ -307,14 +291,7 @@ class UpdatesModule(
   @ExpoMethod
   fun fetchUpdateAsync(promise: Promise) {
     try {
-      val updatesServiceLocal = updatesService
-      if (!updatesServiceLocal!!.configuration.isEnabled) {
-        promise.reject(
-          "ERR_UPDATES_DISABLED",
-          "You cannot fetch updates when expo-updates is not enabled."
-        )
-        return
-      }
+      val updatesServiceLocal = updatesService!!
       updatesServiceLocal.stateMachine?.processEvent(UpdatesStateEvent.Download())
       AsyncTask.execute {
         val databaseHolder = updatesServiceLocal.databaseHolder
@@ -435,14 +412,7 @@ class UpdatesModule(
   @ExpoMethod
   fun getExtraParamsAsync(promise: Promise) {
     logger.debug("Called getExtraParamsAsync")
-    val updatesServiceLocal = updatesService
-    if (!updatesServiceLocal!!.configuration.isEnabled) {
-      promise.reject(
-        "ERR_UPDATES_DISABLED",
-        "You cannot get extra params when expo-updates is not enabled."
-      )
-      return
-    }
+    val updatesServiceLocal = updatesService!!
 
     AsyncTask.execute {
       val databaseHolder = updatesServiceLocal.databaseHolder
@@ -476,14 +446,7 @@ class UpdatesModule(
   @ExpoMethod
   fun setExtraParamAsync(key: String, value: String?, promise: Promise) {
     logger.debug("Called setExtraParamAsync with key = $key, value = $value")
-    val updatesServiceLocal = updatesService
-    if (!updatesServiceLocal!!.configuration.isEnabled) {
-      promise.reject(
-        "ERR_UPDATES_DISABLED",
-        "You cannot set extra client params when expo-updates is not enabled."
-      )
-      return
-    }
+    val updatesServiceLocal = updatesService!!
 
     AsyncTask.execute {
       val databaseHolder = updatesServiceLocal.databaseHolder

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesService.kt
@@ -52,7 +52,7 @@ open class UpdatesService(protected var context: Context) : InternalModule, Upda
     get() = UpdatesController.instance.stateMachine
 
   override fun canRelaunch(): Boolean {
-    return configuration.isEnabled && launchedUpdate != null
+    return launchedUpdate != null
   }
 
   override val embeddedUpdate: UpdateEntity?

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -211,9 +211,6 @@ object UpdatesUtils {
     updatesConfiguration: UpdatesConfiguration,
     context: Context
   ): Boolean {
-    if (updatesConfiguration.updateUrl == null) {
-      return false
-    }
     return when (updatesConfiguration.checkOnLaunch) {
       CheckAutomaticallyConfiguration.NEVER -> false
       // check will happen later on if there's an error

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/BuildData.kt
@@ -36,7 +36,6 @@ object BuildData {
     database: UpdatesDatabase,
   ) {
     val scopeKey = updatesConfiguration.scopeKey
-      ?: throw AssertionError("expo-updates is enabled, but no valid URL is configured in AndroidManifest.xml. If you are making a release build for the first time, make sure you have run `expo publish` at least once.")
     val buildJSON = getBuildDataFromDatabase(database, scopeKey)
     if (buildJSON == null) {
       setBuildDataInDatabase(database, updatesConfiguration)
@@ -82,7 +81,7 @@ object BuildData {
     updatesConfiguration: UpdatesConfiguration,
   ) {
     val buildDataJSON = getBuildDataFromConfig(updatesConfiguration)
-    database.jsonDataDao()?.setJSONStringForKey(staticBuildDataKey, buildDataJSON.toString(), updatesConfiguration.scopeKey as String)
+    database.jsonDataDao()?.setJSONStringForKey(staticBuildDataKey, buildDataJSON.toString(), updatesConfiguration.scopeKey)
   }
 
   fun getBuildDataFromDatabase(database: UpdatesDatabase, scopeKey: String): JSONObject? {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -20,7 +20,7 @@ abstract class UpdateDao {
   // if an update has successfully launched at least once, we treat it as launchable
   // even if it has also failed to launch at least once
   @Query("SELECT * FROM updates WHERE scope_key = :scopeKey AND (successful_launch_count > 0 OR failed_launch_count < 1) AND status IN (:statuses);")
-  abstract fun _loadLaunchableUpdatesForProjectWithStatuses(scopeKey: String?, statuses: List<UpdateStatus>): List<UpdateEntity>
+  abstract fun _loadLaunchableUpdatesForProjectWithStatuses(scopeKey: String, statuses: List<UpdateStatus>): List<UpdateEntity>
 
   @Query("SELECT * FROM updates WHERE id = :id;")
   abstract fun _loadUpdatesWithId(id: UUID): List<UpdateEntity>
@@ -46,7 +46,7 @@ abstract class UpdateDao {
   @Query("SELECT * FROM updates;")
   abstract fun loadAllUpdates(): List<UpdateEntity>
 
-  fun loadLaunchableUpdatesForScope(scopeKey: String?): List<UpdateEntity> {
+  fun loadLaunchableUpdatesForScope(scopeKey: String): List<UpdateEntity> {
     return _loadLaunchableUpdatesForProjectWithStatuses(
       scopeKey,
       listOf(UpdateStatus.READY, UpdateStatus.EMBEDDED, UpdateStatus.DEVELOPMENT)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
@@ -109,16 +109,6 @@ class LoaderTask(
   private var finalizedLauncher: Launcher? = null
 
   fun start(context: Context) {
-    if (!configuration.isEnabled) {
-      callback.onFailure(Exception("LoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling LoaderTask, or enable updates in the configuration."))
-      return
-    }
-
-    if (configuration.updateUrl == null) {
-      callback.onFailure(Exception("LoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use LoaderTask to load updates."))
-      return
-    }
-
     if (directory == null) {
       throw AssertionError("LoaderTask directory must be nonnull.")
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
@@ -94,7 +94,7 @@ class BareUpdateManifest private constructor(
       return BareUpdateManifest(
         manifest,
         id,
-        configuration.scopeKey!!,
+        configuration.scopeKey,
         commitTime,
         runtimeVersion,
         assets

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/LegacyUpdateManifest.kt
@@ -118,9 +118,9 @@ class LegacyUpdateManifest private constructor(
       val bundledAssets = manifest.getBundledAssets()
       return LegacyUpdateManifest(
         manifest,
-        configuration.updateUrl!!,
+        configuration.updateUrl,
         id,
-        configuration.scopeKey!!,
+        configuration.scopeKey,
         commitTime,
         runtimeVersion,
         bundleUrl,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ManifestMetadata.kt
@@ -25,8 +25,7 @@ object ManifestMetadata {
     configuration: UpdatesConfiguration
   ): JSONObject? {
     return try {
-      val jsonString = database.jsonDataDao()!!
-        .loadJSONStringForKey(key, configuration.scopeKey!!)
+      val jsonString = database.jsonDataDao()!!.loadJSONStringForKey(key, configuration.scopeKey)
       if (jsonString != null) JSONObject(jsonString) else null
     } catch (e: Exception) {
       Log.e(TAG, "Error retrieving $key from database", e)
@@ -62,7 +61,7 @@ object ManifestMetadata {
     value: String?
   ) {
     // this is done within a transaction to ensure consistency
-    database.jsonDataDao()!!.updateJSONStringForKey(EXTRA_PARAMS_KEY, configuration.scopeKey!!) { previousValue ->
+    database.jsonDataDao()!!.updateJSONStringForKey(EXTRA_PARAMS_KEY, configuration.scopeKey) { previousValue ->
       val jsonObject = previousValue?.let { JSONObject(it) }
       val extraParamsToWrite = (jsonObject?.asStringStringMap()?.toMutableMap() ?: mutableMapOf()).also {
         if (value != null) {
@@ -93,7 +92,7 @@ object ManifestMetadata {
       fieldsToSet[MANIFEST_FILTERS_KEY] = responseHeaderData.manifestFilters.toString()
     }
     if (fieldsToSet.isNotEmpty()) {
-      database.jsonDataDao()!!.setMultipleFields(fieldsToSet, configuration.scopeKey!!)
+      database.jsonDataDao()!!.setMultipleFields(fieldsToSet, configuration.scopeKey)
     }
   }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/NewUpdateManifest.kt
@@ -105,7 +105,7 @@ class NewUpdateManifest private constructor(
       return NewUpdateManifest(
         manifest,
         id,
-        configuration.scopeKey!!,
+        configuration.scopeKey,
         commitTime,
         runtimeVersion,
         launchAsset,

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -214,39 +214,6 @@ public class AppController: NSObject, AppLoaderTaskDelegate, AppLoaderTaskSwiftD
   public func start() {
     precondition(!isStarted, "AppController:start should only be called once per instance")
 
-    if !config.isEnabled {
-      let launcherNoDatabase = AppLauncherNoDatabase()
-      launcher = launcherNoDatabase
-      launcherNoDatabase.launchUpdate(withConfig: config)
-
-      delegate.let { _ in
-        DispatchQueue.main.async { [weak self] in
-          if let strongSelf = self {
-            strongSelf.delegate?.appController(strongSelf, didStartWithSuccess: strongSelf.launchAssetUrl() != nil)
-            strongSelf.sendQueuedEventsToBridge()
-          }
-        }
-      }
-
-      return
-    }
-
-    if config.updateUrl == nil {
-      NSException(
-        name: .internalInconsistencyException,
-        reason: "expo-updates is enabled, but no valid URL is configured under EXUpdatesURL. If you are making a release build for the first time, make sure you have run `expo publish` at least once."
-      )
-      .raise()
-    }
-
-    if config.scopeKey == nil {
-      NSException(
-        name: .internalInconsistencyException,
-        reason: "expo-updates was configured with no scope key. Make sure a valid URL is configured under EXUpdatesURL."
-      )
-      .raise()
-    }
-
     isStarted = true
 
     purgeUpdatesLogsOlderThanOneDay()
@@ -638,7 +605,7 @@ public class AppController: NSObject, AppLoaderTaskDelegate, AppLoaderTaskSwiftD
       completionQueue: controllerQueue
     )
     remoteAppLoader.loadUpdate(
-      fromURL: config.updateUrl!
+      fromURL: config.updateUrl
     ) { updateResponse in
       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
         switch updateDirective {

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -79,7 +79,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       var manifestFilters: [String: Any]?
       var manifestFiltersError: Error?
       do {
-        manifestFilters = try database.manifestFilters(withScopeKey: config.scopeKey!)
+        manifestFilters = try database.manifestFilters(withScopeKey: config.scopeKey)
       } catch {
         manifestFiltersError = error
       }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -151,11 +151,9 @@ public class AppLoader: NSObject {
       // but different scope keys, we should try to launch something rather than show a cryptic
       // error to the user.
       if let existingUpdate = existingUpdate,
-        let existingUpdateScopeKey = existingUpdate.scopeKey,
-        let updateManifestScopeKey = updateManifest.scopeKey,
-        existingUpdateScopeKey != updateManifestScopeKey {
+        existingUpdate.scopeKey != updateManifest.scopeKey {
         do {
-          try self.database.setScopeKey(updateManifestScopeKey, onUpdate: existingUpdate)
+          try self.database.setScopeKey(updateManifest.scopeKey, onUpdate: existingUpdate)
         } catch {
           self.finish(withError: error)
           return

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -119,40 +119,6 @@ public final class AppLoaderTask: NSObject {
   }
 
   public func start() {
-    guard config.isEnabled else {
-      // swiftlint:disable:next line_length
-      let errorMessage = "AppLoaderTask was passed a configuration object with updates disabled. You should load updates from an embedded source rather than calling AppLoaderTask, or enable updates in the configuration."
-      logger.error(message: errorMessage, code: .updateFailedToLoad)
-      delegateQueue.async {
-        self.delegate?.appLoaderTask(
-          self,
-          didFinishWithError: NSError(
-            domain: AppLoaderTask.ErrorDomain,
-            code: 1030,
-            userInfo: [NSLocalizedDescriptionKey: errorMessage]
-          )
-        )
-      }
-      return
-    }
-
-    guard config.updateUrl != nil else {
-      // swiftlint:disable:next line_length
-      let errorMessage = "AppLoaderTask was passed a configuration object with a null URL. You must pass a nonnull URL in order to use AppLoaderTask to load updates."
-      logger.error(message: errorMessage, code: .updateFailedToLoad)
-      delegateQueue.async {
-        self.delegate?.appLoaderTask(
-          self,
-          didFinishWithError: NSError(
-            domain: AppLoaderTask.ErrorDomain,
-            code: 1030,
-            userInfo: [NSLocalizedDescriptionKey: errorMessage]
-          )
-        )
-      }
-      return
-    }
-
     isRunning = true
 
     var shouldCheckForUpdate = UpdatesUtils.shouldCheckForUpdate(withConfig: config)
@@ -280,7 +246,7 @@ public final class AppLoaderTask: NSObject {
         var manifestFiltersError: Error?
         var manifestFilters: [String: Any]?
         do {
-          manifestFilters = try self.database.manifestFilters(withScopeKey: self.config.scopeKey!)
+          manifestFilters = try self.database.manifestFilters(withScopeKey: self.config.scopeKey)
         } catch {
           manifestFiltersError = error
         }
@@ -346,7 +312,7 @@ public final class AppLoaderTask: NSObject {
       }
     }
     remoteAppLoader!.loadUpdate(
-      fromURL: config.updateUrl!
+      fromURL: config.updateUrl
     ) { updateResponse in
       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
         switch updateDirective {

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -227,7 +227,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
     launchedUpdate: Update?,
     embeddedUpdate: Update?
   ) -> [String: Any] {
-    let scopeKey = config.scopeKey.require("Must have scopeKey in config")
+    let scopeKey = config.scopeKey
 
     var extraHeaders: [String: Any] = [:]
     do {
@@ -861,7 +861,7 @@ internal final class FileDownloader: NSObject, URLSessionDataDelegate {
       userInfo: [
         NSLocalizedDescriptionKey: String(
           format: "No compatible update found at %@. Only %@ are supported.",
-          config.updateUrl?.absoluteString ?? "(missing config updateUrl)",
+          config.updateUrl.absoluteString,
           config.sdkVersion ?? "(missing sdkVersion field)"
         )
       ]

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -50,7 +50,7 @@ internal final class RemoteAppLoader: AppLoader {
         strongSelf.database.databaseQueue.async {
           do {
             // swiftlint:disable:next force_unwrapping
-            try strongSelf.database.setMetadata(withResponseHeaderData: responseHeaderData, scopeKey: strongSelf.config.scopeKey!)
+            try strongSelf.database.setMetadata(withResponseHeaderData: responseHeaderData, scopeKey: strongSelf.config.scopeKey)
             successBlockArg(updateResponse)
           } catch {
             NSLog("Error persisting header data to disk: %@", error.localizedDescription)

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesBuildData.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesBuildData.swift
@@ -28,14 +28,7 @@ import Foundation
 internal final class UpdatesBuildData {
   static func ensureBuildDataIsConsistentAsync(database: UpdatesDatabase, config: UpdatesConfig) {
     database.databaseQueue.async {
-      guard let scopeKey = config.scopeKey else {
-        NSException(
-          name: .internalInconsistencyException,
-          reason: "expo-updates was configured with no scope key. Make sure a valid URL is configured under EXUpdatesURL."
-        ).raise()
-        return
-      }
-
+      let scopeKey = config.scopeKey
       let staticBuildData: [AnyHashable: Any]?
       do {
         staticBuildData = try database.staticBuildData(withScopeKey: scopeKey)
@@ -64,7 +57,7 @@ internal final class UpdatesBuildData {
 
   static func getBuildDataFromConfig(_ config: UpdatesConfig) -> [String: Any] {
     return [
-      "EXUpdatesURL": config.updateUrl.require("Must supply updateUrl in config").absoluteString,
+      "EXUpdatesURL": config.updateUrl.absoluteString,
       "EXUpdatesReleaseChannel": config.releaseChannel,
       "EXUpdatesRequestHeaders": config.requestHeaders
     ]

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -99,7 +99,7 @@ public final class UpdatesDatabase: NSObject {
       sql: sql,
       withArgs: [
         update.updateId,
-        update.scopeKey.require("Update must have scopeKey to be stored in database"),
+        update.scopeKey,
         update.commitTime,
         update.runtimeVersion,
         update.manifest.rawManifestJSON(),

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
@@ -39,7 +39,7 @@ public final class UpdatesReaper: NSObject {
 
       var manifestFilters: [String: Any]?
       do {
-        manifestFilters = try database.manifestFilters(withScopeKey: config.scopeKey.require("Must have scopeKey in config"))
+        manifestFilters = try database.manifestFilters(withScopeKey: config.scopeKey)
       } catch {
         NSLog("Error selecting manifest filters while reaping updates: %@", [error.localizedDescription])
         return

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherController.swift
@@ -82,7 +82,7 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
       completionQueue: controller.controllerQueue
     )
     loader.loadUpdate(
-      fromURL: updatesConfiguration.updateUrl!
+      fromURL: updatesConfiguration.updateUrl
     ) { updateResponse in
       if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
         switch updateDirective {
@@ -155,17 +155,6 @@ public final class DevLauncherController: NSObject, UpdatesExternalInterface {
         userInfo: [
           // swiftlint:disable:next line_length
           NSLocalizedDescriptionKey: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
-        ]
-      ))
-      return nil
-    }
-
-    guard updatesConfiguration.updateUrl != nil && updatesConfiguration.scopeKey != nil else {
-      errorBlock(NSError(
-        domain: DevLauncherController.ErrorDomain,
-        code: ErrorCode.invalidUpdateURL.rawValue,
-        userInfo: [
-          NSLocalizedDescriptionKey: "Failed to read stored updates: configuration object must include a valid update URL"
         ]
       ))
       return nil

--- a/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
+++ b/packages/expo-updates/ios/EXUpdates/SelectionPolicy/ReaperSelectionPolicyFilterAware.swift
@@ -25,10 +25,8 @@ public final class ReaperSelectionPolicyFilterAware: NSObject, ReaperSelectionPo
     var nextNewestUpdateMatchingFilters: Update?
 
     for update in updates {
-      guard let launchedUpdateScopeKey = launchedUpdate.scopeKey,
-        let updateScopeKey = update.scopeKey else {
-        continue
-      }
+      let launchedUpdateScopeKey = launchedUpdate.scopeKey
+      let updateScopeKey = update.scopeKey
 
       // ignore any updates whose scopeKey doesn't match that of the launched update
       if launchedUpdateScopeKey != updateScopeKey {

--- a/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/LegacyUpdate.swift
@@ -104,7 +104,7 @@ internal final class LegacyUpdate: Update {
       config: config,
       database: database,
       updateId: updateId,
-      scopeKey: config.scopeKey.require("Must supply scopeKey in configuration"),
+      scopeKey: config.scopeKey,
       commitTime: commitTime,
       runtimeVersion: runtimeVersion,
       keep: true,
@@ -121,7 +121,7 @@ internal final class LegacyUpdate: Update {
 
   static func bundledAssetBaseUrl(withManifest: LegacyManifest, config: UpdatesConfig) -> URL {
     let manifestUrl = config.updateUrl
-    let host = manifestUrl?.host
+    let host = manifestUrl.host
 
     guard let host = host else {
       // The URL is valid and constant, so it'll never throw

--- a/packages/expo-updates/ios/EXUpdates/Update/NewUpdate.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/NewUpdate.swift
@@ -73,7 +73,7 @@ internal final class NewUpdate: Update {
       config: config,
       database: database,
       updateId: uuid,
-      scopeKey: config.scopeKey.require("Must supply scopeKey in configuration"),
+      scopeKey: config.scopeKey,
       commitTime: RCTConvert.nsDate(commitTime),
       runtimeVersion: runtimeVersion,
       keep: true,

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -81,7 +81,7 @@ public enum UpdateError: Int, Error {
 @objcMembers
 public class Update: NSObject {
   public let updateId: UUID
-  public let scopeKey: String?
+  public let scopeKey: String
   public var commitTime: Date
   public let runtimeVersion: String
   public let keep: Bool
@@ -103,7 +103,7 @@ public class Update: NSObject {
     config: UpdatesConfig,
     database: UpdatesDatabase?,
     updateId: UUID,
-    scopeKey: String?,
+    scopeKey: String,
     commitTime: Date,
     runtimeVersion: String,
     keep: Bool,

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -68,7 +68,7 @@ public final class UpdatesModule: Module {
     }
 
     AsyncFunction("reload") { (promise: Promise) in
-      guard let updatesService = updatesService, let config = updatesService.config, config.isEnabled else {
+      guard let updatesService = updatesService, let config = updatesService.config else {
         throw UpdatesDisabledException()
       }
       guard updatesService.canRelaunch else {
@@ -119,14 +119,11 @@ public final class UpdatesModule: Module {
 
     AsyncFunction("getExtraParamsAsync") { (promise: Promise) in
       guard let updatesService = updatesService,
-        let config = updatesService.config,
-        config.isEnabled else {
+        let config = updatesService.config else {
         throw UpdatesDisabledException()
       }
 
-      guard let scopeKey = config.scopeKey else {
-        throw Exception(name: "ERR_UPDATES_SCOPE_KEY", description: "Muse have scopeKey in config")
-      }
+      let scopeKey = config.scopeKey
 
       updatesService.database.databaseQueue.async {
         do {
@@ -139,14 +136,11 @@ public final class UpdatesModule: Module {
 
     AsyncFunction("setExtraParamAsync") { (key: String, value: String?, promise: Promise) in
       guard let updatesService = updatesService,
-        let config = updatesService.config,
-        config.isEnabled else {
+        let config = updatesService.config else {
         throw UpdatesDisabledException()
       }
 
-      guard let scopeKey = config.scopeKey else {
-        throw Exception(name: "ERR_UPDATES_SCOPE_KEY", description: "Muse have scopeKey in config")
-      }
+      let scopeKey = config.scopeKey
 
       updatesService.database.databaseQueue.async {
         do {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -73,7 +73,7 @@ public final class UpdatesUtils: NSObject {
 
       let fileDownloader = FileDownloader(config: constants.config)
       fileDownloader.downloadRemoteUpdate(
-        fromURL: constants.config.updateUrl!,
+        fromURL: constants.config.updateUrl,
         withDatabase: constants.database,
         extraHeaders: extraHeaders
       ) { updateResponse in
@@ -167,7 +167,7 @@ public final class UpdatesUtils: NSObject {
         completionQueue: methodQueue
       )
       remoteAppLoader.loadUpdate(
-        fromURL: constants.config.updateUrl!
+        fromURL: constants.config.updateUrl
       ) { updateResponse in
         if let updateDirective = updateResponse.directiveUpdateResponsePart?.updateDirective {
           switch updateDirective {
@@ -414,8 +414,7 @@ public final class UpdatesUtils: NSObject {
     let maybeIsStarted: Bool? = AppController.sharedInstance.isStarted
 
     guard let config = maybeConfig,
-      let selectionPolicy = maybeSelectionPolicy,
-      config.isEnabled
+      let selectionPolicy = maybeSelectionPolicy
     else {
       throw UpdatesDisabledException()
     }


### PR DESCRIPTION
# Why

First RFC proposal to solve ENG-9880.

The issue is that people are setting isEnabled to false but the system still expects a URL in order to generate a scopeKey in order to start the NoDatabaseLauncher.

This PR fixes this by removing isEnabled altogether and assuming if expo-updates is installed, it needs to be configured. @kbrandwijk correctly pointed out that this could make initial development and configuration more difficult, so what we might do in an alternative RFC is a combination of this plus just not starting any updates stuff in the UpdatesPackage if URL is not configured.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
