### PR TITLE
[docs] Lower Sentry samplerate

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -40,7 +40,7 @@ Sentry.init({
         /https:\/\/docs\.expo\.dev\/index\.html/,
       ],
   integrations: [new BrowserTracing()],
-  tracesSampleRate: 1.0,
+  tracesSampleRate: 0.001,
 });
 
 const rootMarkdownComponents = {


### PR DESCRIPTION
Why
---
A sample rate of 100% uses our quota very quickly. Adjust to 0.1%.

How
---
Set [`tracesSampleRate`](https://develop.sentry.dev/sdk/performance/#tracessamplerate) to 0.001.

Test Plan
---
None, but will keep an eye on the [Performance](https://expoio.sentry.io/performance/?landingDisplay=all&project=1526800&query=&statsPeriod=30d) page after deployment.
