### PR TITLE
[rfc][expo-updates] Don't initialize expo-updates if URL isn't configured

### DIFF
--- a/packages/@expo/config-plugins/src/android/Updates.ts
+++ b/packages/@expo/config-plugins/src/android/Updates.ts
@@ -103,7 +103,12 @@ export function setUpdatesConfig(
     String(getUpdatesTimeout(config))
   );
 
-  addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, getUpdateUrl(config));
+  const updateUrl = getUpdateUrl(config);
+  if (updateUrl) {
+    addMetaDataItemToMainApplication(mainApplication, Config.UPDATE_URL, updateUrl);
+  } else {
+    removeMetaDataItemFromMainApplication(mainApplication, Config.UPDATE_URL);
+  }
 
   const codeSigningCertificate = getUpdatesCodeSigningCertificate(projectRoot, config);
   if (codeSigningCertificate) {

--- a/packages/@expo/config-plugins/src/ios/Updates.ts
+++ b/packages/@expo/config-plugins/src/ios/Updates.ts
@@ -61,7 +61,12 @@ export function setUpdatesConfig(
     [Config.LAUNCH_WAIT_MS]: getUpdatesTimeout(config),
   };
 
-  newExpoPlist[Config.UPDATE_URL] = getUpdateUrl(config);
+  const updateUrl = getUpdateUrl(config);
+  if (updateUrl) {
+    newExpoPlist[Config.UPDATE_URL] = updateUrl;
+  } else {
+    delete newExpoPlist[Config.UPDATE_URL];
+  }
 
   const codeSigningCertificate = getUpdatesCodeSigningCertificate(projectRoot, config);
   if (codeSigningCertificate) {

--- a/packages/@expo/config-plugins/src/utils/Updates.ts
+++ b/packages/@expo/config-plugins/src/utils/Updates.ts
@@ -22,22 +22,8 @@ export function getExpoUpdatesPackageVersion(projectRoot: string): string | null
   return packageJson.version;
 }
 
-export function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'updates'>): string {
-  const updateUrl = config.updates?.url;
-  if (!updateUrl) {
-    const hasEnabledConfigProperty = config.updates?.enabled !== undefined;
-    if (hasEnabledConfigProperty) {
-      throw new Error(
-        'The enabled setting has been removed from expo-updates. In the past, this was set to false by default. To fix this, either remove the expo-updates package from your project or configure expo-updates using EAS Update or your own configuration.'
-      );
-    } else {
-      throw new Error(
-        "The expo-updates library has not been configured, and must be configured before being built into a project. To fix this, either remove the expo-updates package from your project if you don't use it or configure expo-updates using EAS Update or your own configuration."
-      );
-    }
-  }
-
-  return updateUrl;
+export function getUpdateUrl(config: Pick<ExpoConfigUpdates, 'updates'>): string | null {
+  return config.updates?.url ?? null;
 }
 
 export function getAppVersion(config: Pick<ExpoConfig, 'version'>): string {

--- a/packages/expo-updates/android/build.gradle
+++ b/packages/expo-updates/android/build.gradle
@@ -27,7 +27,7 @@ def getBoolStringFromPropOrEnv(String name, Boolean defaultValue) {
 
 // If true, app will use bundled manifest and updates will be enabled, even for
 // debug builds. (default false)
-def exUpdatesNativeDebug = getBoolStringFromPropOrEnv("EX_UPDATES_NATIVE_DEBUG", false)
+def exUpdatesNativeDebug = getBoolStringFromPropOrEnv("EX_UPDATES_NATIVE_DEBUG", true)
 
 // If true, code will run that delays app loading until updates is initialized, to prevent ANR issues.
 // (default true)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesConfiguration.kt
@@ -130,15 +130,19 @@ data class UpdatesConfiguration(
     private const val UPDATES_CONFIGURATION_RELEASE_CHANNEL_DEFAULT_VALUE = "default"
     private const val UPDATES_CONFIGURATION_LAUNCH_WAIT_MS_DEFAULT_VALUE = 0
 
+    fun Context.getUpdateUrl(): Uri? {
+      return getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) }
+    }
+
     private fun getUpdatesUrl(context: Context?, overrideMap: Map<String, Any>?): Uri {
       return overrideMap?.readValueCheckingType(UPDATES_CONFIGURATION_UPDATE_URL_KEY) ?:
-        context?.getMetadataValue<String>("expo.modules.updates.EXPO_UPDATE_URL")?.let { Uri.parse(it) } ?:
+        context?.getUpdateUrl() ?:
         throw InvalidArgumentException("Missing update URL. Ensure it is set up in your app configuration or AndroidManifest.xml. Or, if you don't wish to use expo-updates, remove the package.")
     }
   }
 }
 
-private inline fun <reified T : Any> Context.getMetadataValue(key: String): T? {
+inline fun <reified T : Any> Context.getMetadataValue(key: String): T? {
   val ai = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA).metaData
   if (!ai.containsKey(key)) {
     return null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -101,8 +101,13 @@ class UpdatesModule(
       // and warn the developer if not. This does not take into account any extra configuration
       // provided at runtime in MainApplication.java, because we don't have access to that in a
       // debug build.
-      val configuration = UpdatesConfiguration(context, null)
-      constants["isMissingRuntimeVersion"] = configuration.isMissingRuntimeVersion
+      constants["isMissingRuntimeVersion"] = try {
+        val configuration = UpdatesConfiguration(context, null)
+        configuration.isMissingRuntimeVersion
+      } catch (e2: Exception) {
+        false
+      }
+
     }
     return constants
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -13,6 +13,7 @@ import expo.modules.core.interfaces.Package
 import expo.modules.core.interfaces.InternalModule
 import expo.modules.core.interfaces.ReactActivityHandler
 import expo.modules.core.interfaces.ReactNativeHostHandler
+import expo.modules.updates.UpdatesConfiguration.Companion.getUpdateUrl
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -111,9 +112,9 @@ class UpdatesPackage : Package {
   private fun shouldAutoSetup(context: Context): Boolean {
     if (mShouldAutoSetup == null) {
       mShouldAutoSetup = try {
-        val pm = context.packageManager
-        val ai = pm.getApplicationInfo(context.packageName, PackageManager.GET_META_DATA)
-        ai.metaData.getBoolean("expo.modules.updates.AUTO_SETUP", true)
+        val updateUrl = context.getUpdateUrl()
+        val autoSetup = context.getMetadataValue("expo.modules.updates.AUTO_SETUP") ?: true
+        updateUrl != null && autoSetup
       } catch (e: Exception) {
         Log.e(TAG, "Could not read expo-updates configuration data in AndroidManifest", e)
         true

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -117,7 +117,7 @@ public class AppController: NSObject, AppLoaderTaskDelegate, AppLoaderTaskSwiftD
     } catch {
       NSException(
         name: .internalInconsistencyException,
-        reason: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project."
+        reason: "Cannot load configuration from Expo.plist. Please ensure you've followed the setup and installation instructions for expo-updates to create Expo.plist and add it to your Xcode project. (\((error as? UpdatesConfigError)?.asString ?? error.localizedDescription))"
       )
       .raise()
     }

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -23,7 +23,7 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     // if Expo.plist not found or its content is invalid, disable the auto setup
     guard
       let configPath = Bundle.main.path(forResource: UpdatesConfig.PlistName, ofType: "plist"),
-      let config = NSDictionary(contentsOfFile: configPath)
+      let config = NSDictionary(contentsOfFile: configPath) as? [String: Any]
     else {
       return false
     }
@@ -31,6 +31,12 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     // if `EXUpdatesAutoSetup` is false, disable the auto setup
     let enableAutoSetupValue = config[UpdatesConfig.EXUpdatesConfigEnableAutoSetupKey]
     if let enableAutoSetup = enableAutoSetupValue as? NSNumber, enableAutoSetup.boolValue == false {
+      return false
+    }
+
+    // if no `EXUpdatesURL` value in config, disable the auto setup
+    let updatesURL = UpdatesConfig.updateUrlString(fromDictionary: config)
+    if updatesURL == nil {
       return false
     }
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesModule.swift
@@ -28,6 +28,12 @@ public final class UpdatesModule: Module {
     Name("ExpoUpdates")
 
     Constants {
+      guard let defaultConfig = try? UpdatesConfig.configWithExpoPlist(mergingOtherDictionary: nil) else {
+        return [
+          "isEnabled": false,
+        ]
+      }
+
       let releaseChannel = updatesService?.config?.releaseChannel
       let channel = updatesService?.config?.requestHeaders["expo-channel-name"] ?? ""
       let runtimeVersion = updatesService?.config?.runtimeVersion ?? ""


### PR DESCRIPTION
# Why

This is the second iteration and RFC of https://github.com/expo/expo/pull/24141 as mentioned in the summary of that PR.

The idea is that we shouldn't initialize the module if there is no URL, but still allow the package to be installed.

# How

Revert change to config plugin that required URL, don't instantiate the service unless URL is present.

# Test Plan

Build and run an unconfigured app.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
