### PR TITLE
[cli] Misleading build message

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fix lint. ([#23960](https://github.com/expo/expo/pull/23960) by [@EvanBacon](https://github.com/EvanBacon))
 - Enable static router tests. ([#23988](https://github.com/expo/expo/pull/23988) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce Metro bundles during `expo export` for Metro static web. ([#23987](https://github.com/expo/expo/pull/23987) by [@EvanBacon](https://github.com/EvanBacon))
+- Adjust build message when running prebuild to only output the directories that are actually being created. ([#24153](https://github.com/expo/expo/pull/24153) by [@alanhughes](https://github.com/alanjhughes))
 
 ## 0.11.1 — 2023-08-02
 

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -96,9 +96,7 @@ async function cloneTemplateAndCopyToProjectAsync({
   platforms: ModPlatform[];
 }): Promise<string[]> {
   const platformDirectories = unknownPlatforms
-    .map((platform) => {
-      return `./${platform}`;
-    })
+    .map((platform) => `./${platform}`)
     .reverse()
     .join(' and ');
 

--- a/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/updateFromTemplate.ts
@@ -95,8 +95,16 @@ async function cloneTemplateAndCopyToProjectAsync({
   exp: Pick<ExpoConfig, 'name' | 'sdkVersion'>;
   platforms: ModPlatform[];
 }): Promise<string[]> {
+  const platformDirectories = unknownPlatforms
+    .map((platform) => {
+      return `./${platform}`;
+    })
+    .reverse()
+    .join(' and ');
+
+  const pluralized = unknownPlatforms.length > 1 ? 'directories' : 'directory';
   const ora = logNewSection(
-    'Creating native project directories (./ios and ./android) and updating .gitignore'
+    `Creating native project ${pluralized} (${platformDirectories}) and updating .gitignore`
   );
 
   try {


### PR DESCRIPTION
# Why
Closes ENG-9074

Running `npx expo prebuild -p ios` or `npx expo run:ios` outputs `Creating native project directories (./ios and ./android)`. Including android in this example is misleading.

# How
Check what platforms the command is targeting and change output accordingly

# Test Plan
Tested locally

![Screenshot 2023-08-29 at 10 24 43](https://github.com/expo/expo/assets/30924086/05441585-ce3c-4d6e-8b08-25319ac7dd6f)

![Screenshot 2023-08-29 at 10 26 17](https://github.com/expo/expo/assets/30924086/d7dcf0d2-42bf-4bce-aaf2-b2ca931e49c6)

![Screenshot 2023-08-29 at 10 25 43](https://github.com/expo/expo/assets/30924086/7331e9b7-4609-461e-85c9-70538cebfed4)

