### PR TITLE
[cli] Extend android package name validation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Enable static router tests. ([#23988](https://github.com/expo/expo/pull/23988) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce Metro bundles during `expo export` for Metro static web. ([#23987](https://github.com/expo/expo/pull/23987) by [@EvanBacon](https://github.com/EvanBacon))
 - Adjust build message when running prebuild to only output the directories that are actually being created. ([#24153](https://github.com/expo/expo/pull/24153) by [@alanhughes](https://github.com/alanjhughes))
+- Extend `Android` package name validation to disallow the `Java` ketword `native`.
 
 ## 0.11.1 — 2023-08-02
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Enable static router tests. ([#23988](https://github.com/expo/expo/pull/23988) by [@EvanBacon](https://github.com/EvanBacon))
 - Reduce Metro bundles during `expo export` for Metro static web. ([#23987](https://github.com/expo/expo/pull/23987) by [@EvanBacon](https://github.com/EvanBacon))
 - Adjust build message when running prebuild to only output the directories that are actually being created. ([#24153](https://github.com/expo/expo/pull/24153) by [@alanhughes](https://github.com/alanjhughes))
-- Extend `Android` package name validation to disallow the `Java` ketword `native`.
+- Extend `Android` package name validation to disallow the `Java` keyword `native`. ([#24155](https://github.com/expo/expo/pull/24155) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.11.1 — 2023-08-02
 

--- a/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
@@ -52,6 +52,8 @@ describe(validatePackage, () => {
   it(`validates`, () => {
     expect(validatePackage('bacon.com.hey')).toBe(true);
     expect(validatePackage('bacon')).toBe(false);
+    expect(validatePackage('com.native')).toBe(false);
+    expect(validatePackage('native.android')).toBe(false);
     expect(validatePackage('...b.a.-c.0.n...')).toBe(false);
     expect(validatePackage('.')).toBe(false);
     expect(validatePackage('. ..')).toBe(false);

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -11,7 +11,7 @@ import { Log } from '../log';
 const debug = require('debug')('expo:utils:validateApplicationId') as typeof console.log;
 
 const IOS_BUNDLE_ID_REGEX = /^[a-zA-Z0-9-.]+$/;
-const ANDROID_PACKAGE_REGEX = /^(?!.*\bnative\b)[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
+const ANDROID_PACKAGE_REGEX = /^(?!.*\bnative\b)[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
 
 /** Validate an iOS bundle identifier. */
 export function validateBundleId(value: string): boolean {

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -118,7 +118,7 @@ export function assertValidPackage(value: string) {
   assert.match(
     value,
     ANDROID_PACKAGE_REGEX,
-    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is also not allowed.`
+    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is not allowed.`
   );
 }
 

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -110,7 +110,7 @@ export function assertValidBundleId(value: string) {
   assert.match(
     value,
     IOS_BUNDLE_ID_REGEX,
-    `The ios.bundleIdentifier defined in your Expo config is not formatted properly. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is also not allowed.`
+    `The ios.bundleIdentifier defined in your Expo config is not formatted properly. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter.`
   );
 }
 
@@ -118,7 +118,7 @@ export function assertValidPackage(value: string) {
   assert.match(
     value,
     ANDROID_PACKAGE_REGEX,
-    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter.`
+    `Invalid format of Android package name. Only alphanumeric characters, '.' and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is also not allowed.`
   );
 }
 

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -11,7 +11,7 @@ import { Log } from '../log';
 const debug = require('debug')('expo:utils:validateApplicationId') as typeof console.log;
 
 const IOS_BUNDLE_ID_REGEX = /^[a-zA-Z0-9-.]+$/;
-const ANDROID_PACKAGE_REGEX = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/;
+const ANDROID_PACKAGE_REGEX = /^(?!.*\bnative\b)[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/;
 
 /** Validate an iOS bundle identifier. */
 export function validateBundleId(value: string): boolean {
@@ -110,7 +110,7 @@ export function assertValidBundleId(value: string) {
   assert.match(
     value,
     IOS_BUNDLE_ID_REGEX,
-    `The ios.bundleIdentifier defined in your Expo config is not formatted properly. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter.`
+    `The ios.bundleIdentifier defined in your Expo config is not formatted properly. Only alphanumeric characters, '.', '-', and '_' are allowed, and each '.' must be followed by a letter. The Java keyword 'native' is also not allowed.`
   );
 }
 


### PR DESCRIPTION
# Why
Closes ENG-7243
The Java keyword `native` is not allowed to be in the package name

# How
Extend the package name regex to fail if the word `native` is included

# Test Plan
Added to the test suite. All tests pass.