### PR TITLE
[docs] Update UI libraries list

### DIFF
--- a/docs/pages/ui-programming/user-interface-libraries.mdx
+++ b/docs/pages/ui-programming/user-interface-libraries.mdx
@@ -19,5 +19,6 @@ Below are some of the most popular UI Libraries. Test them all out and see what 
 | [Fluent UI](https://github.com/microsoft/fluentui-react-native)           | [Link](https://developer.microsoft.com/en-us/fluentui#/get-started)                                             |
 | [Tamagui](https://tamagui.dev)                                            | [Link](https://tamagui.dev/docs/intro/installation)                                                             |
 | [NativeWind](https://www.nativewind.dev/)                                 | [Link](https://www.nativewind.dev/)                                                                             |
+| [Gluestack UI](https://ui.gluestack.io/)                                  | [Link](https://ui.gluestack.io/)                                                                                |
 
 > As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.

--- a/docs/pages/ui-programming/user-interface-libraries.mdx
+++ b/docs/pages/ui-programming/user-interface-libraries.mdx
@@ -14,10 +14,10 @@ Below are some of the most popular UI Libraries. Test them all out and see what 
 | [React Native Paper](https://github.com/callstack/react-native-paper)     | [Link](https://callstack.github.io/react-native-paper)                                                          |
 | [React Native UI Lib](https://github.com/wix/react-native-ui-lib)         | [Link](https://wix.github.io/react-native-ui-lib/)                                                              |
 | [React Native Elements](https://reactnativeelements.com/)                 | [Link](https://reactnativeelements.com/docs)                                                                    |
-| [NativeBase](https://nativebase.io/)                                      | [Link](https://docs.nativebase.io/)                                                                             |
 | [React Native UI Kitten](https://github.com/akveo/react-native-ui-kitten) | [Link](https://akveo.github.io/react-native-ui-kitten/docs/getting-started/what-is-ui-kitten#what-is-ui-kitten) |
 | [React Native iOS Kit](https://github.com/callstack/react-native-ios-kit) | [Link](https://callstack.github.io/react-native-ios-kit/docs/installation)                                      |
 | [Fluent UI](https://github.com/microsoft/fluentui-react-native)           | [Link](https://developer.microsoft.com/en-us/fluentui#/get-started)                                             |
 | [Tamagui](https://tamagui.dev)                                            | [Link](https://tamagui.dev/docs/intro/installation)                                                             |
+| [NativeWind](https://www.nativewind.dev/)                                 | [Link](https://www.nativewind.dev/)                                                                             |
 
 > As with any library, it's always best to find one with a large and active community. This way, help is easy to come by. Check out any project's GitHub page to see what the activity is like.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The list is outdated since NatievBase team has stop recommending the library.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Remove NativeBase from User Interface component libraries doc.
- Add NativeWind and Gluestack UI

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/ui-programming/user-interface-libraries/

**Preview**

<img width="1128" alt="CleanShot 2023-08-29 at 22 52 40@2x" src="https://github.com/expo/expo/assets/10234615/8bcbbc38-bc41-425f-b63b-1507e8b537d0">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
