### PR TITLE
fix!(cli): Favor remote versions endpoint over bundled versions

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Favor remote versions endpoint over bundled versions for version validation in `expo install`, `start`, `prebuild`.
 - Remove classic manifest types and classic updates. ([#24054](https://github.com/expo/expo/pull/24054), [#24066](https://github.com/expo/expo/pull/24066) by [@wschurman](https://github.com/wschurman))
 
 ### 🎉 New features

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Favor remote versions endpoint over bundled versions for version validation in `expo install`, `start`, `prebuild`.
+- Favor remote versions endpoint over bundled versions for version validation in `expo install`, `start`, `prebuild`. ([#24162](https://github.com/expo/expo/pull/24162) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove classic manifest types and classic updates. ([#24054](https://github.com/expo/expo/pull/24054), [#24066](https://github.com/expo/expo/pull/24066) by [@wschurman](https://github.com/wschurman))
 
 ### 🎉 New features

--- a/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/getVersionedPackages.ts
@@ -49,8 +49,10 @@ export async function getCombinedKnownVersionsAsync({
     : {};
   const versionsForSdk = await getRemoteVersionsForSdkAsync({ sdkVersion, skipCache });
   return {
-    ...versionsForSdk,
     ...bundledNativeModules,
+    // Prefer the remote versions over the bundled versions, this enables us to push
+    // emergency fixes that users can access without having to update the `expo` package.
+    ...versionsForSdk,
   };
 }
 


### PR DESCRIPTION
# Why

- We have a versions endpoint with minimal libraries in it, we should favor it over the bundled versions so we can push emergency bumps that users can access without having to update `expo`.
