### PR TITLE
[docs] Use `APIBox` to apply API doc formatting in Expo Router Hooks API

### DIFF
--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -11,23 +11,48 @@ import { APIBox } from '~/components/plugins/APIBox';
 
 In Expo Router, there's always a valid URL that represents the currently focused route. Use hooks to observe changes and interact with the URL.
 
-<APIBox header="usePathname">
+## Hooks
 
-Returns the currently selected route location without search parameters. For example, `/acme?foo=bar` -> `/acme`. Segments will be normalized: `/[id]?id=normal` -> `/normal`
+<APIBox header="useFocusEffect">
+
+Given a function, the `useFocusEffect` hook will invoke the function whenever the route is "focused".
+
+```jsx
+/* @info */
+import { useFocusEffect } from 'expo-router';
+/* @end */
+
+export default function Route() {
+  useFocusEffect(() => {
+    /* @info Invoked whenever the route is focused */
+    console.log('Hello')
+    /* @end */
+  })
+
+  return </>
+}
+```
+
+</APIBox>
+
+<APIBox header="useGlobalSearchParams">
+
+Returns the URL search parameters for the globally selected route. For example, `/acme?foo=bar` -> `{ foo: "bar" }`.
+
+Refer to the [local vs global search params](/router/reference/search-parameters/#local-vs-global-search-parameters) guide for more info.
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
 ```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
-import { usePathname } from 'expo-router';
+import { useGlobalSearchParams } from 'expo-router';
 /* @end */
 
 export default function Route() {
-  /* @info <b>pathname = "/profile/baconbrix"</b> */
-  const pathname = usePathname();
+  /* @info <b>user=baconbrix</b> & <b>extra=info</b> */
+  const { user, extra } = useGlobalSearchParams();
   /* @end */
-
   return <Text>User: {user}</Text>;
 }
 ```
@@ -60,36 +85,56 @@ export default function Route() {
 
 </APIBox>
 
-<APIBox header="useGlobalSearchParams">
+<APIBox header="useNavigation">
 
-Returns the URL search parameters for the globally selected route. For example, `/acme?foo=bar` -> `{ foo: "bar" }`.
+Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
 
-Refer to the [local vs global search params](/router/reference/search-parameters/#local-vs-global-search-parameters) guide for more info.
+```jsx
+/* @info */
+import { useNavigation } from 'expo-router';
+/* @end */
+
+export default function Route() {
+  /* @info Access the current navigation object for the current route */
+  const navigation = useNavigation();
+  /* @end */
+  return (
+    <View>
+      <Text
+        onPress={() => {
+          /* @info Open the drawer view */
+          navigation.openDrawer();
+          /* @end */
+        }}>
+        Open Drawer
+      </Text>
+    </View>
+  );
+}
+```
+
+</APIBox>
+
+<APIBox header="usePathname">
+
+Returns the currently selected route location without search parameters. For example, `/acme?foo=bar` -> `/acme`. Segments will be normalized: `/[id]?id=normal` -> `/normal`
 
 <RouteUrl>/profile/baconbrix?extra=info</RouteUrl>
 
 ```jsx app/profile/[user].tsx
 import { Text } from 'react-native';
 /* @info */
-import { useGlobalSearchParams } from 'expo-router';
+import { usePathname } from 'expo-router';
 /* @end */
 
 export default function Route() {
-  /* @info <b>user=baconbrix</b> & <b>extra=info</b> */
-  const { user, extra } = useGlobalSearchParams();
+  /* @info <b>pathname = "/profile/baconbrix"</b> */
+  const pathname = usePathname();
   /* @end */
+
   return <Text>User: {user}</Text>;
 }
 ```
-
-<APIBox header="Href">
-
-The `Href` type is a union of the following types:
-
-- **string**: A full path like `/profile/settings` or a relative path like `../settings`.
-- **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
-
-</APIBox>
 
 </APIBox>
 
@@ -127,55 +172,15 @@ export default function Route() {
 
 </APIBox>
 
-<APIBox header="useNavigation">
+## Types
 
-Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
+<APIBox header="Href">
 
-```jsx
-/* @info */
-import { useNavigation } from 'expo-router';
-/* @end */
+The `Href` type is a union of the following types:
 
-export default function Route() {
-  /* @info Access the current navigation object for the current route */
-  const navigation = useNavigation();
-  /* @end */
-  return (
-    <View>
-      <Text
-        onPress={() => {
-          /* @info Open the drawer view */
-          navigation.openDrawer();
-          /* @end */
-        }}>
-        Open Drawer
-      </Text>
-    </View>
-  );
-}
-```
+- **string**: A full path like `/profile/settings` or a relative path like `../settings`.
+- **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
 
 </APIBox>
 
-<APIBox header="useFocusEffect">
-
-Given a function, the `useFocusEffect` hook will invoke the function whenever the route is "focused".
-
-```jsx
-/* @info */
-import { useFocusEffect } from 'expo-router';
-/* @end */
-
-export default function Route() {
-  useFocusEffect(() => {
-    /* @info Invoked whenever the route is focused */
-    console.log('Hello')
-    /* @end */
-  })
-
-  return </>
-}
-```
-
-</APIBox>
 </RouteUrlGroup>

--- a/docs/pages/router/reference/hooks.mdx
+++ b/docs/pages/router/reference/hooks.mdx
@@ -5,12 +5,13 @@ description: Learn how to interact with the in-app URL in Expo Router.
 
 import { FileTree } from '~/ui/components/FileTree';
 import { RouteUrlGroup, RouteUrl } from '~/ui/components/RouteUrl';
+import { APIBox } from '~/components/plugins/APIBox';
 
 <RouteUrlGroup>
 
 In Expo Router, there's always a valid URL that represents the currently focused route. Use hooks to observe changes and interact with the URL.
 
-## `usePathname`
+<APIBox header="usePathname">
 
 Returns the currently selected route location without search parameters. For example, `/acme?foo=bar` -> `/acme`. Segments will be normalized: `/[id]?id=normal` -> `/normal`
 
@@ -31,7 +32,9 @@ export default function Route() {
 }
 ```
 
-## `useLocalSearchParams`
+</APIBox>
+
+<APIBox header="useLocalSearchParams">
 
 Returns the URL search parameters for the contextually selected route. Refer to the [local vs. global search params](/router/reference/search-parameters/#local-vs-global-search-parameters) guide for more information.
 
@@ -55,7 +58,9 @@ export default function Route() {
 }
 ```
 
-## `useGlobalSearchParams`
+</APIBox>
+
+<APIBox header="useGlobalSearchParams">
 
 Returns the URL search parameters for the globally selected route. For example, `/acme?foo=bar` -> `{ foo: "bar" }`.
 
@@ -77,14 +82,18 @@ export default function Route() {
 }
 ```
 
-### `Href` type
+<APIBox header="Href">
 
 The `Href` type is a union of the following types:
 
 - **string**: A full path like `/profile/settings` or a relative path like `../settings`.
 - **object**: An object with a `pathname` and optional `params` object. The `pathname` can be a full path like `/profile/settings` or a relative path like `../settings`. The `params` can be an object of key/value pairs.
 
-## `useSegments`
+</APIBox>
+
+</APIBox>
+
+<APIBox header="useSegments">
 
 Returns a list of segments for the currently selected route. Segments are not normalized so that they will be the same as the file path. For example, `/[id]?id=normal` -> `["[id]"]`.
 
@@ -116,7 +125,9 @@ export default function Route() {
 }
 ```
 
-## `useNavigation`
+</APIBox>
+
+<APIBox header="useNavigation">
 
 Access the underlying React Navigation [`navigation` prop](https://reactnavigation.org/docs/navigation-prop) to imperatively access layout-specific functionality like `navigation.openDrawer()` in a Drawer layout. [Learn more](https://reactnavigation.org/docs/navigation-prop/#navigator-dependent-functions).
 
@@ -144,7 +155,9 @@ export default function Route() {
 }
 ```
 
-## `useFocusEffect`
+</APIBox>
+
+<APIBox header="useFocusEffect">
 
 Given a function, the `useFocusEffect` hook will invoke the function whenever the route is "focused".
 
@@ -164,4 +177,5 @@ export default function Route() {
 }
 ```
 
+</APIBox>
 </RouteUrlGroup>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As discussed in the [docs sync](https://www.notion.so/expo/08-22-23-672991355c8a4a28b97d1035f72f028a?pvs=4#c01a3f3cbe8a409d9c2ad760a759b9f0), the Hooks API page is not formatted as per an API doc.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By using `APIBox` component to format the Hooks API doc.

**Preview**

<img width="1221" alt="CleanShot 2023-08-30 at 00 57 35@2x" src="https://github.com/expo/expo/assets/10234615/6ecf1c4b-baa1-4f95-ad05-f4eb1ae16cec">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/reference/hooks/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
