### PR TITLE
[docs] Update nesting-navigators.mdx for file structure clarity

### DIFF
--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -31,7 +31,7 @@ import { Stack } from 'expo-router';
 export default Stack;
 ```
 
-Both **app/_layout.js** and **app/index.js** below are nested in the **\_layout.js** layout, so it will be rendered as a stack.
+Both **app/home/\_layout.js** and **app/index.js** below are nested in the **app/\_layout.js** layout, so it will be rendered as a stack.
 
 ```jsx app/home/_layout.js
 import { Tabs } from 'expo-router';

--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -31,7 +31,7 @@ import { Stack } from 'expo-router';
 export default Stack;
 ```
 
-Both **app/home/\_layout.js** and **app/index.js** below are nested in the **app/\_layout.js** layout, so it will be rendered as a stack.
+Both **app/home/_layout.js** and **app/index.js** below are nested in the **app/_layout.js** layout so that it will be rendered as a stack.
 
 ```jsx app/home/_layout.js
 import { Tabs } from 'expo-router';


### PR DESCRIPTION
# Why

Fix minor typo for nesting layouts. Previous revision stated the app/_layout.js was nested inside /_layout.js, but those are the same file.

# How

Docs fix - clarity.

# Test Plan

No testing performed.

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
