### PR TITLE
[docs] SafeAreaContext API reference and docs update

### DIFF
--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -5,8 +5,12 @@ sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'
 ---
 
+import { CornerDownRightIcon } from '@expo/styleguide-icons';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { APIBox } from '~/components/plugins/APIBox';
+import { CALLOUT } from '~/ui/components/Text';
+import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -26,17 +30,20 @@ import {
   SafeAreaProvider,
   SafeAreaInsetsContext,
   useSafeAreaInsets,
-  initialWindowMetrics,
 } from 'react-native-safe-area-context';
 ```
+
+## Components
+
+<APIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
 If you set your own padding on the view, it will be added to the padding from the safe area.
 
-**If you are targeting web, you must set up `SafeAreaProvider` as described in the hooks section**. You do not need to for native platforms.
+> **info** If you are targeting web, you must set up `SafeAreaProvider` as described in the [Context](#context) section.
 
-```js
+```jsx
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function SomeComponent() {
@@ -48,39 +55,38 @@ function SomeComponent() {
 }
 ```
 
-### Props
+## Props
 
-All props are optional.
+<APIBox header="edges">
 
-#### `emulateUnlessSupported`
-
-`true` (default) or `false`
-
-On iOS 10, emulate the safe area using the status bar height and home indicator sizes.
-
-#### `edges`
-
-Array of `top`, `right`, `bottom`, and `left`. Defaults to all.
+<CALLOUT theme="secondary">
+  Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`
+</CALLOUT>
+<br />
 
 Sets the edges to apply the safe area insets to.
 
+</APIBox>
+
+<APIBox header="emulateUnlessSupported">
+
+<CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
+<br />
+
+On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
+
+</APIBox>
+</APIBox>
+
 ## Hooks
 
-Hooks give you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
+<APIBox header="useSafeAreaInsets()">
 
-First, add `SafeAreaProvider` in your app root component. You may need to add it in other places too, including at the root of any modals any any routes when using `react-native-screen`.
+Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
-```js
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+<BoxSectionHeader text="Example" />
 
-function App() {
-  return <SafeAreaProvider>...</SafeAreaProvider>;
-}
-```
-
-You use the `useSafeAreaInsets` hook to get the insets in the form of `{ top: number, right: number, bottom: number: number, left: number }`.
-
-```js
+```jsx
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 function HookComponent() {
@@ -90,29 +96,74 @@ function HookComponent() {
 }
 ```
 
-Usage with consumer api:
+<BoxSectionHeader text="Returns" />
 
-```js
-import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
 
-class ClassComponent extends React.Component {
-  render() {
-    return (
-      <SafeAreaInsetsContext.Consumer>
-        {insets => <View style={{ paddingTop: insets.top }} />}
-      </SafeAreaInsetsContext.Consumer>
-    );
-  }
+</APIBox>
+
+## Types
+
+<APIBox header="Edge">
+
+String union of possible edges.
+
+Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
+
+</APIBox>
+
+<APIBox header="EdgeInsets">
+
+Represent the hook result.
+
+<BoxSectionHeader text="EdgeInsets Properties" />
+
+| Name     | Type     | Description            |
+| -------- | -------- | ---------------------- |
+| `bottom` | `number` | Value of bottom inset. |
+| `left`   | `number` | Value of left inset.   |
+| `right`  | `number` | Value of right inset.  |
+| `top`    | `number` | Value of top inset.    |
+
+</APIBox>
+
+## Guides
+
+### Context
+
+To use safe area context, you need to add `SafeAreaProvider` in your app root component.
+
+> You may need to add it in other places too, including at the root of any modals any routes when using `react-native-screen`.
+
+```jsx
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+function App() {
+  return <SafeAreaProvider>...</SafeAreaProvider>;
 }
 ```
 
-## Optimization
+Then, you can use [`useSafeAreaInsets()`](#usesafeareainsets) hook and also consumer API to access inset data:
+
+```jsx
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+
+function Component() {
+  return (
+    <SafeAreaInsetsContext.Consumer>
+      {insets => <View style={{ paddingTop: insets.top }} />}
+    </SafeAreaInsetsContext.Consumer>
+  );
+}
+```
+
+### Optimization
 
 If you can, use `SafeAreaView`. It's implemented natively so when rotating the device, there is no delay from the asynchronous bridge.
 
 To speed up the initial render, you can import `initialWindowMetrics` from this package and set as the `initialMetrics` prop on the provider as described in Web SSR. You cannot do this if your provider remounts, or you are using `react-native-navigation`.
 
-```js
+```jsx
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 
 function App() {
@@ -120,19 +171,17 @@ function App() {
 }
 ```
 
-## Web SSR
+### Web SSR
 
 If you are doing server side rendering on the web, you can use `initialSafeAreaInsets` to inject values based on the device the user has, or simply pass zero. Otherwise, insets measurement will break rendering your page content since it is async.
 
-## Migrating from CSS
+### Migrating from CSS
 
 #### Before
 
 In a web-only app, you would use CSS environment variables to get the size of the screen's safe area insets.
 
-**styles.css**
-
-```css
+```css styles.css
 div {
   padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
@@ -145,14 +194,11 @@ div {
 
 Universally, the hook `useSafeAreaInsets()` can provide access to this information.
 
-**App.js**
-
-```jsx
+```jsx App.js
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 function App() {
   const insets = useSafeAreaInsets();
-
   return (
     <View
       style={{

--- a/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/safe-area-context.mdx
@@ -5,8 +5,12 @@ sourceCodeUrl: 'https://github.com/th3rdwave/react-native-safe-area-context'
 packageName: 'react-native-safe-area-context'
 ---
 
+import { CornerDownRightIcon } from '@expo/styleguide-icons';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
+import { APIBox } from '~/components/plugins/APIBox';
+import { CALLOUT } from '~/ui/components/Text';
+import { BoxSectionHeader } from '~/components/plugins/api/APISectionUtils';
 
 > **info** This library is listed in the Expo SDK reference because it is included in [Expo Go](/get-started/expo-go/). You may use any library of your choice with [development builds](/develop/development-builds/introduction/).
 
@@ -26,17 +30,20 @@ import {
   SafeAreaProvider,
   SafeAreaInsetsContext,
   useSafeAreaInsets,
-  initialWindowMetrics,
 } from 'react-native-safe-area-context';
 ```
+
+## Components
+
+<APIBox header="SafeAreaView">
 
 `SafeAreaView` is a regular `View` component with the safe area edges applied as padding.
 
 If you set your own padding on the view, it will be added to the padding from the safe area.
 
-**If you are targeting web, you must set up `SafeAreaProvider` as described in the hooks section**. You do not need to for native platforms.
+> **info** If you are targeting web, you must set up `SafeAreaProvider` as described in the [Context](#context) section.
 
-```js
+```jsx
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 function SomeComponent() {
@@ -48,39 +55,38 @@ function SomeComponent() {
 }
 ```
 
-### Props
+## Props
 
-All props are optional.
+<APIBox header="edges">
 
-#### `emulateUnlessSupported`
-
-`true` (default) or `false`
-
-On iOS 10, emulate the safe area using the status bar height and home indicator sizes.
-
-#### `edges`
-
-Array of `top`, `right`, `bottom`, and `left`. Defaults to all.
+<CALLOUT theme="secondary">Optional • Type: [`Edge[]`](#edge) • Default: `["top", "right", "bottom", "left"]`</CALLOUT>
+<br/>
 
 Sets the edges to apply the safe area insets to.
 
+</APIBox>
+
+<APIBox header="emulateUnlessSupported">
+
+<CALLOUT theme="secondary">Optional • Type: `boolean` • Default: `true`</CALLOUT>
+<br/>
+
+On iOS 10+, emulate the safe area using the status bar height and home indicator sizes.
+
+</APIBox>
+</APIBox>
+
 ## Hooks
 
-Hooks give you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
+<APIBox header="useSafeAreaInsets()">
 
-First, add `SafeAreaProvider` in your app root component. You may need to add it in other places too, including at the root of any modals any any routes when using `react-native-screen`.
+Hook gives you direct access to the safe area insets. This is a more advanced use-case, and might perform worse than `SafeAreaView` when rotating the device.
 
-```js
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+{' '}
 
-function App() {
-  return <SafeAreaProvider>...</SafeAreaProvider>;
-}
-```
+<BoxSectionHeader text="Example" />
 
-You use the `useSafeAreaInsets` hook to get the insets in the form of `{ top: number, right: number, bottom: number: number, left: number }`.
-
-```js
+```jsx
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 function HookComponent() {
@@ -90,29 +96,74 @@ function HookComponent() {
 }
 ```
 
-Usage with consumer api:
+<BoxSectionHeader text="Returns" />
 
-```js
-import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+<CornerDownRightIcon className="inline-block icon-sm text-icon-secondary align-middle mr-2" /> [`EdgeInsets`](#edgeinsets)
 
-class ClassComponent extends React.Component {
-  render() {
-    return (
-      <SafeAreaInsetsContext.Consumer>
-        {insets => <View style={{ paddingTop: insets.top }} />}
-      </SafeAreaInsetsContext.Consumer>
-    );
-  }
+</APIBox>
+
+## Types
+
+<APIBox header="Edge">
+
+String union of possible edges.
+
+Acceptable values are: `'top'`, `'right'`, `'bottom'`, `'left'`.
+
+</APIBox>
+
+<APIBox header="EdgeInsets">
+
+Represent the hook result.
+
+<BoxSectionHeader text="EdgeInsets Properties" />
+
+| Name     | Type     | Description            |
+| -------- | -------- | ---------------------- |
+| `bottom` | `number` | Value of bottom inset. |
+| `left`   | `number` | Value of left inset.   |
+| `right`  | `number` | Value of right inset.  |
+| `top`    | `number` | Value of top inset.    |
+
+</APIBox>
+
+## Guides
+
+### Context
+
+To use safe area context, you need to add `SafeAreaProvider` in your app root component.
+
+> You may need to add it in other places too, including at the root of any modals any routes when using `react-native-screen`.
+
+```jsx
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+function App() {
+  return <SafeAreaProvider>...</SafeAreaProvider>;
 }
 ```
 
-## Optimization
+Then, you can use [`useSafeAreaInsets()`](#usesafeareainsets) hook and also consumer API to access inset data:
+
+```jsx
+import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
+
+function Component() {
+  return (
+    <SafeAreaInsetsContext.Consumer>
+      {insets => <View style={{ paddingTop: insets.top }} />}
+    </SafeAreaInsetsContext.Consumer>
+  );
+}
+```
+
+### Optimization
 
 If you can, use `SafeAreaView`. It's implemented natively so when rotating the device, there is no delay from the asynchronous bridge.
 
 To speed up the initial render, you can import `initialWindowMetrics` from this package and set as the `initialMetrics` prop on the provider as described in Web SSR. You cannot do this if your provider remounts, or you are using `react-native-navigation`.
 
-```js
+```jsx
 import { SafeAreaProvider, initialWindowMetrics } from 'react-native-safe-area-context';
 
 function App() {
@@ -120,19 +171,17 @@ function App() {
 }
 ```
 
-## Web SSR
+### Web SSR
 
 If you are doing server side rendering on the web, you can use `initialSafeAreaInsets` to inject values based on the device the user has, or simply pass zero. Otherwise, insets measurement will break rendering your page content since it is async.
 
-## Migrating from CSS
+### Migrating from CSS
 
 #### Before
 
 In a web-only app, you would use CSS environment variables to get the size of the screen's safe area insets.
 
-**styles.css**
-
-```css
+```css styles.css
 div {
   padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
@@ -145,14 +194,11 @@ div {
 
 Universally, the hook `useSafeAreaInsets()` can provide access to this information.
 
-**App.js**
-
-```jsx
+```jsx App.js
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 function App() {
   const insets = useSafeAreaInsets();
-
   return (
     <View
       style={{


### PR DESCRIPTION
# Why

It's a community package, but we were listing almost complete docs for it, so let's update it a bit to align with other, proprietary packages, API references looks like.

# How

Use `APIBox` and other related component to mimic the usual appearance od APIs, reorder and reorganize a content, add some missing TS types definitions.

In general, we still don't cover 100% of exported by package code, but it should be a bit more clear how to use it.

The changes have been applied to the latest SDK and unversioned docs.

# Test Plan

The changes have been tested by running docs app locally.

# Preview

![screencapture-localhost-3002-versions-latest-sdk-safe-area-context-2023-08-30-13_18_37](https://github.com/expo/expo/assets/719641/f0e01ad7-7ba1-42a5-9272-61f55ad60c95)
