### PR TITLE
Create issue template for Expo Router

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_router.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_router.yml
@@ -1,0 +1,57 @@
+name: "\U0001F41B Expo Router Bug Report"
+description: 'Report a reproducible bug with Expo Router'
+labels: ['needs validation']
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug report! If you are convinced that you have found a bug in Expo Router, this is the right place. Please fill out this entire form. The most important piece is a minimal reproducible example.
+  - type: markdown
+    attributes:
+      value: If you have a question or you think your issue might be caused by your application code, you can get help from the community on the [forums](https://forums.expo.dev/) or on [Discord](https://chat.expo.dev).
+  - type: input
+    attributes:
+      label: Minimal reproducible example
+      description: |
+        This should include as little code as possible, and no extraneous dependencies. Do not share your entire project.
+        You should also test your issue against the latest SDK version to ensure that it hasn't already been resolved.
+        Sharing a link to a GitHub repository is best. Include any instructions to run the project in the README or the summary field below.
+        If a reproducible demo is not provided, your issue will be closed.
+        [Learn more about creating a minimal reproducible example](https://stackoverflow.com/help/mcve).
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Realize that it is up to you to debug your code and be as certain as possible that the bug is with Expo Router, not with your own app.**
+        [Here's an excellent guide to debugging you can follow](https://gist.github.com/brentvatne/5ac00cba0c70b7a06b89a56787d6bc4a).
+  - type: dropdown
+    attributes:
+      label: Which package manager are you using? (Yarn is recommended)
+      multiple: false
+      options:
+        - yarn
+        - npm
+        - pnpm
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: If the issue is web-related, please select the bundler (`web.bundler` in the `app.json`)
+      multiple: false
+      options:
+        - metro
+        - webpack (unsupported)
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Clearly describe what the expected behavior is and what instead is actually happening. Be concise and precise in your description. Include any affected platforms (iOS, Android, web).
+        Ex: if you report that "X library/method isn't working", then you will need to [continue debugging on your own](https://expo.fyi/manual-debugging) to more precisely define your issue before proceeding.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Environment
+      description: Run the `npx expo-env-info` command and paste its output in the field below.
+    validations:
+      required: true


### PR DESCRIPTION
# Why

- Part of migrating `expo-router` from https://github.com/expo/router to this repo.
- Too many low-quality, unrelated, non-reproducible, and duplicate issues on the `expo-router` repo. The additional criteria will help us move faster.

# How

- Copy the Expo SDK issue template and add fields for selecting the package manager and bundler (this helps prevent users from opening issues regarding webpack).

