### PR TITLE
[home][tools] Fix detecting home app for dynamic macros (try 2)

### DIFF
--- a/tools/src/dynamic-macros/macros.ts
+++ b/tools/src/dynamic-macros/macros.ts
@@ -172,7 +172,7 @@ export default {
     try {
       const manifest = await getManifestAsync(url, platform, null);
 
-      if (manifest.name !== 'expo-home') {
+      if (manifest.extra?.expoClient?.name !== 'expo-home') {
         console.log(
           `Manifest at ${url} is not expo-home; using published kernel manifest instead...`
         );


### PR DESCRIPTION
# Why

This is a revert of https://github.com/expo/expo/pull/23583.

I'm not sure what in the past caused home manifests to switch back to serving as a classic manifest, but now they can only be served as a new manifest locally.

Next up will be looking into the dev published manifest.

# Test Plan

`npx expo start --port=80` and building expo go on ios and android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
