### PR TITLE
[docs] BlurView: update example, avoid using asset

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -32,16 +32,21 @@ A React component that blurs everything underneath the view. Common usage of thi
 
 ```jsx
 import React from 'react';
-import { Image, Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
-
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
     <View style={styles.container}>
-      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <View style={styles.background}>
+        {[...Array(20).keys()].map((i) => (
+          <View
+            key={`box-${i}`}
+            style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}
+          />
+        ))}
+      </View>
       <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
@@ -60,15 +65,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  image: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-  },
   blurContainer: {
     flex: 1,
     padding: 20,
     justifyContent: 'center',
+  },
+  background: {
+    flex: 1,
+    flexWrap: 'wrap',
+    ...StyleSheet.absoluteFill,
+  },
+  box: {
+    width: '25%',
+    height: '20%',
+  },
+  boxEven: {
+    backgroundColor: 'orangered',
+  },
+  boxOdd: {
+    backgroundColor: 'gold',
   },
   text: {
     fontSize: 24,

--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -31,14 +31,13 @@ A React component that blurs everything underneath the view. Common usage of thi
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map((i) => (
           <View
@@ -56,7 +55,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -68,7 +67,11 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
+    margin: 16,
+    textAlign: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 20,
   },
   background: {
     flex: 1,

--- a/docs/pages/versions/v46.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/blur-view.mdx
@@ -24,14 +24,13 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map((i) => (
           <View
@@ -49,7 +48,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -61,7 +60,11 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
+    margin: 16,
+    textAlign: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 20,
   },
   background: {
     flex: 1,

--- a/docs/pages/versions/v46.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/blur-view.mdx
@@ -25,16 +25,21 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ```jsx
 import React from 'react';
-import { Image, Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
-
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
     <View style={styles.container}>
-      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <View style={styles.background}>
+        {[...Array(20).keys()].map((i) => (
+          <View
+            key={`box-${i}`}
+            style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}
+          />
+        ))}
+      </View>
       <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
@@ -53,15 +58,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  image: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-  },
   blurContainer: {
     flex: 1,
     padding: 20,
     justifyContent: 'center',
+  },
+  background: {
+    flex: 1,
+    flexWrap: 'wrap',
+    ...StyleSheet.absoluteFill,
+  },
+  box: {
+    width: '25%',
+    height: '20%',
+  },
+  boxEven: {
+    backgroundColor: 'orangered',
+  },
+  boxOdd: {
+    backgroundColor: 'gold',
   },
   text: {
     fontSize: 24,

--- a/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
@@ -24,14 +24,13 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map((i) => (
           <View
@@ -49,7 +48,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -61,7 +60,11 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
+    margin: 16,
+    textAlign: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 20,
   },
   background: {
     flex: 1,

--- a/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/blur-view.mdx
@@ -25,16 +25,21 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ```jsx
 import React from 'react';
-import { Image, Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
-
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
     <View style={styles.container}>
-      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <View style={styles.background}>
+        {[...Array(20).keys()].map((i) => (
+          <View
+            key={`box-${i}`}
+            style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}
+          />
+        ))}
+      </View>
       <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
@@ -53,15 +58,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  image: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-  },
   blurContainer: {
     flex: 1,
     padding: 20,
     justifyContent: 'center',
+  },
+  background: {
+    flex: 1,
+    flexWrap: 'wrap',
+    ...StyleSheet.absoluteFill,
+  },
+  box: {
+    width: '25%',
+    height: '20%',
+  },
+  boxEven: {
+    backgroundColor: 'orangered',
+  },
+  boxOdd: {
+    backgroundColor: 'gold',
   },
   text: {
     fontSize: 24,

--- a/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
@@ -24,14 +24,13 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map((i) => (
           <View
@@ -49,7 +48,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -61,7 +60,11 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
+    margin: 16,
+    textAlign: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 20,
   },
   background: {
     flex: 1,

--- a/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/blur-view.mdx
@@ -25,16 +25,21 @@ A React component that blurs everything underneath the view. On iOS, it renders 
 
 ```jsx
 import React from 'react';
-import { Image, Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
-
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
     <View style={styles.container}>
-      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <View style={styles.background}>
+        {[...Array(20).keys()].map((i) => (
+          <View
+            key={`box-${i}`}
+            style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}
+          />
+        ))}
+      </View>
       <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
@@ -53,15 +58,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  image: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-  },
   blurContainer: {
     flex: 1,
     padding: 20,
     justifyContent: 'center',
+  },
+  background: {
+    flex: 1,
+    flexWrap: 'wrap',
+    ...StyleSheet.absoluteFill,
+  },
+  box: {
+    width: '25%',
+    height: '20%',
+  },
+  boxEven: {
+    backgroundColor: 'orangered',
+  },
+  boxOdd: {
+    backgroundColor: 'gold',
   },
   text: {
     fontSize: 24,

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -32,16 +32,21 @@ A React component that blurs everything underneath the view. Common usage of thi
 
 ```jsx
 import React from 'react';
-import { Image, Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View } from 'react-native';
 import { BlurView } from 'expo-blur';
-
-const uri = 'https://s3.amazonaws.com/exp-icon-assets/ExpoEmptyManifest_192.png';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
     <View style={styles.container}>
-      <Image style={[StyleSheet.absoluteFill, styles.image]} source={{ uri }} />
+      <View style={styles.background}>
+        {[...Array(20).keys()].map((i) => (
+          <View
+            key={`box-${i}`}
+            style={[styles.box, i % 2 === 1 ? styles.boxOdd : styles.boxEven]}
+          />
+        ))}
+      </View>
       <BlurView intensity={100} style={styles.blurContainer}>
         <Text style={styles.text}>{text}</Text>
       </BlurView>
@@ -60,15 +65,25 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
-  image: {
-    width: '100%',
-    height: '100%',
-    resizeMode: 'cover',
-  },
   blurContainer: {
     flex: 1,
     padding: 20,
     justifyContent: 'center',
+  },
+  background: {
+    flex: 1,
+    flexWrap: 'wrap',
+    ...StyleSheet.absoluteFill,
+  },
+  box: {
+    width: '25%',
+    height: '20%',
+  },
+  boxEven: {
+    backgroundColor: 'orangered',
+  },
+  boxOdd: {
+    backgroundColor: 'gold',
   },
   text: {
     fontSize: 24,

--- a/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/blur-view.mdx
@@ -31,14 +31,13 @@ A React component that blurs everything underneath the view. Common usage of thi
 <SnackInline label='Basic BlurView usage' dependencies={['expo-blur']}>
 
 ```jsx
-import React from 'react';
-import { Text, StyleSheet, View } from 'react-native';
+import { Text, StyleSheet, View, SafeAreaView } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 export default function App() {
   const text = 'Hello, my container is blurring contents underneath!';
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <View style={styles.background}>
         {[...Array(20).keys()].map((i) => (
           <View
@@ -56,7 +55,7 @@ export default function App() {
       <BlurView intensity={90} tint="dark" style={styles.blurContainer}>
         <Text style={[styles.text, { color: '#fff' }]}>{text}</Text>
       </BlurView>
-    </View>
+    </SafeAreaView>
   );
 }
 
@@ -68,7 +67,11 @@ const styles = StyleSheet.create({
   blurContainer: {
     flex: 1,
     padding: 20,
+    margin: 16,
+    textAlign: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
+    borderRadius: 20,
   },
   background: {
     flex: 1,


### PR DESCRIPTION
# Why

Refs #24110

# How

Refactor BlurView example so it is no longer dependent on a remote asset.

Backport changes to all versioned docs.

# Test Plan

The changes have been tested by running docs locally. Example app has been tested on Snack.

# Preview
<img width="320" src="https://github.com/expo/expo/assets/719641/8ff1ca2f-89e0-46da-a94b-3bc8c19b7de3">

<img width="460" src="https://github.com/expo/expo/assets/719641/f4867222-e4cd-489a-af0d-ba47575d1b22">


# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
