### PR TITLE
cli(fix): prevent `expo config --json` from logging env var logs

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent additional logs from showing in `expo config --json`.
+- Prevent additional logs from showing in `expo config --json`. ([#24192](https://github.com/expo/expo/pull/24192) by [@EvanBacon](https://github.com/EvanBacon))
 - Patch `react-native-web` for static rendering with Expo Router. ([#24093](https://github.com/expo/expo/pull/24093) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve file formatting when `EXPO_USE_METRO_WORKSPACE_ROOT` is used. ([#23910](https://github.com/expo/expo/pull/23910) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent additional logs from showing in `expo config --json`.
 - Patch `react-native-web` for static rendering with Expo Router. ([#24093](https://github.com/expo/expo/pull/24093) by [@EvanBacon](https://github.com/EvanBacon))
 - Improve file formatting when `EXPO_USE_METRO_WORKSPACE_ROOT` is used. ([#23910](https://github.com/expo/expo/pull/23910) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix bug preventing non-standard xcode projects from running with `npx expo run:ios`. ([#23831](https://github.com/expo/expo/pull/23831) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -6,10 +6,12 @@ import path from 'path';
 import { execute, projectRoot, getRoot, getLoadedModulesAsync } from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
+
 beforeAll(async () => {
   await fs.mkdir(projectRoot, { recursive: true });
   process.env.FORCE_COLOR = '0';
 });
+
 afterAll(() => {
   process.env.FORCE_COLOR = originalForceColor;
 });
@@ -59,6 +61,8 @@ it(
     // Create a fake package.json -- this is a terminal file that cannot be overwritten.
     await fs.writeFile(path.join(projectRoot, 'package.json'), '{ "version": "1.0.0" }');
     await fs.writeFile(path.join(projectRoot, 'app.json'), '{ "expo": { "name": "foobar" } }');
+    // Add an environment variable file to test that it's not included in the config.
+    await fs.writeFile(path.join(projectRoot, '.env'), 'FOOBAR=1');
 
     const results = await execute('config', projectName, '--json');
     // @ts-ignore

--- a/packages/@expo/cli/src/config/configAsync.ts
+++ b/packages/@expo/cli/src/config/configAsync.ts
@@ -32,6 +32,18 @@ export function logConfig(config: ExpoConfig | ProjectConfig) {
 }
 
 export async function configAsync(projectRoot: string, options: Options) {
+  const loggingFunctions = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+  };
+  // Disable logging for this command if the user wants to get JSON output.
+  // This will ensure that only the JSON is printed to stdout.
+  if (options.json) {
+    console.log = function () {};
+    console.warn = function () {};
+    console.error = function () {};
+  }
   setNodeEnv('development');
   require('@expo/env').load(projectRoot);
 
@@ -87,6 +99,11 @@ export async function configAsync(projectRoot: string, options: Options) {
     logConfig(configOutput);
     Log.log();
   } else {
-    Log.log(JSON.stringify(configOutput));
+    process.stdout.write(JSON.stringify(configOutput));
+
+    // Re-enable logging functions for testing.
+    console.log = loggingFunctions.log;
+    console.warn = loggingFunctions.warn;
+    console.error = loggingFunctions.error;
   }
 }


### PR DESCRIPTION
# Why

- fix #23325

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Mock the logs before and after the config evaluation.

# Test Plan

- Updated E2E tests to include an env var file and value.