### PR TITLE
feat(cli): validate android package name

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Validate android package name ahead of time. ([#24194](https://github.com/expo/expo/pull/24194) by [@EvanBacon](https://github.com/EvanBacon))
 - Add Ngrok status page to ngrok error message. ([#24188](https://github.com/expo/expo/pull/24188) by [@EvanBacon](https://github.com/EvanBacon))
 - Support monorepo assets with `npx expo export:embed`. ([#24095](https://github.com/expo/expo/pull/24095) by [@EvanBacon](https://github.com/EvanBacon))
 - Forward exact Metro server error during static rendering. ([#23909](https://github.com/expo/expo/pull/23909) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/validateApplicationId-test.ts
@@ -8,6 +8,7 @@ import {
   getPackageNameWarningInternalAsync,
   validateBundleId,
   validatePackage,
+  validatePackageWithWarning,
 } from '../validateApplicationId';
 
 jest.mock('node-fetch');
@@ -34,6 +35,19 @@ describe(validateBundleId, () => {
   });
 });
 
+describe(validatePackageWithWarning, () => {
+  it(`validates with warnings`, () => {
+    expect(validatePackageWithWarning('bacon.native')).toEqual(
+      `"native" is a reserved Java keyword.`
+    );
+    expect(validatePackageWithWarning('bacon')).toEqual(
+      'Package name must contain more than one segment, separated by ".", e.g. com.bacon'
+    );
+    expect(validatePackageWithWarning(',')).toEqual(
+      `Package name must contain more than one segment, separated by ".", e.g. com.,`
+    );
+  });
+});
 describe(validatePackage, () => {
   it(`validates`, () => {
     expect(validatePackage('bacon.com.hey')).toBe(true);
@@ -43,6 +57,10 @@ describe(validatePackage, () => {
     expect(validatePackage('. ..')).toBe(false);
     expect(validatePackage('_')).toBe(false);
     expect(validatePackage(',')).toBe(false);
+  });
+  it(`prevents using reserved java keywords`, () => {
+    expect(validatePackage('bacon.native.com')).toBe(false);
+    expect(validatePackage('byte')).toBe(false);
   });
 });
 

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -11,6 +11,7 @@ import {
   getPackageNameWarningAsync,
   validateBundleId,
   validatePackage,
+  validatePackageWithWarning,
 } from './validateApplicationId';
 import * as Log from '../log';
 
@@ -164,7 +165,7 @@ async function promptForPackageAsync(projectRoot: string, exp: ExpoConfig): Prom
       name: 'packageName',
       initial: (await getRecommendedPackageNameAsync(exp)) ?? undefined,
       message: `What would you like your Android package name to be?`,
-      validate: validatePackage,
+      validate: validatePackageWithWarning,
     },
     {
       nonInteractiveHelp: NO_PACKAGE_MESSAGE,

--- a/packages/@expo/cli/src/utils/validateApplicationId.ts
+++ b/packages/@expo/cli/src/utils/validateApplicationId.ts
@@ -20,8 +20,91 @@ export function validateBundleId(value: string): boolean {
 
 /** Validate an Android package name. */
 export function validatePackage(value: string): boolean {
-  return ANDROID_PACKAGE_REGEX.test(value);
+  return validatePackageWithWarning(value) === true;
 }
+
+/** Validate an Android package name and return the reason if invalid. */
+export function validatePackageWithWarning(value: string): true | string {
+  const parts = value.split('.');
+  for (const segment of parts) {
+    if (RESERVED_ANDROID_PACKAGE_NAME_SEGMENTS.includes(segment)) {
+      return `"${segment}" is a reserved Java keyword.`;
+    }
+  }
+  if (parts.length < 2) {
+    return `Package name must contain more than one segment, separated by ".", e.g. com.${value}`;
+  }
+  if (!ANDROID_PACKAGE_REGEX.test(value)) {
+    return 'Invalid characters in Android package name. Only alphanumeric characters, "." and "_" are allowed, and each "." must be followed by a letter or number.';
+  }
+
+  return true;
+}
+
+// https://en.wikipedia.org/wiki/List_of_Java_keywords
+// Running the following in the console and pruning the "Reserved Identifiers" section:
+// [...document.querySelectorAll('dl > dt > code')].map(node => node.innerText)
+const RESERVED_ANDROID_PACKAGE_NAME_SEGMENTS = [
+  // List of Java keywords
+  '_',
+  'abstract',
+  'assert',
+  'boolean',
+  'break',
+  'byte',
+  'case',
+  'catch',
+  'char',
+  'class',
+  'const',
+  'continue',
+  'default',
+  'do',
+  'double',
+  'else',
+  'enum',
+  'extends',
+  'final',
+  'finally',
+  'float',
+  'for',
+  'goto',
+  'if',
+  'implements',
+  'import',
+  'instanceof',
+  'int',
+  'interface',
+  'long',
+  'native',
+  'new',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'short',
+  'static',
+  'super',
+  'switch',
+  'synchronized',
+  'this',
+  'throw',
+  'throws',
+  'transient',
+  'try',
+  'void',
+  'volatile',
+  'while',
+  // Reserved words for literal values
+  'true',
+  'false',
+  'null',
+  // Unused
+  'const',
+  'goto',
+  'strictfp',
+];
 
 export function assertValidBundleId(value: string) {
   assert.match(


### PR DESCRIPTION
# Why

- resolve https://github.com/expo/expo/issues/22428

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Added a list of reserved java keywords from wikipedia.
- Tested each category against a gradle build.
- Added additional info to the validation prompt so users have a hint as to what is incorrect.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Added unit tests, ran locally

<img width="491" alt="Screenshot 2023-08-30 at 3 23 02 PM" src="https://github.com/expo/expo/assets/9664363/e5d42702-3818-48f4-ad23-f9f6e821223f">
