### PR TITLE
[android][image-loader] bump glide

### DIFF
--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Bump `Glide` version to resolve `SecurityException` on Android 13.
+- Bump `Glide` version to resolve `SecurityException` on Android 13. ([#24196](https://github.com/expo/expo/pull/24196) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image-loader/CHANGELOG.md
+++ b/packages/expo-image-loader/CHANGELOG.md
@@ -10,12 +10,16 @@
 
 ### 🐛 Bug fixes
 
+- Bump `Glide` version to resolve `SecurityException` on Android 13.
+
 ### 💡 Others
 
 ## 4.3.0 — 2023-06-13
 
 - Removed `com.facebook.fresco:fresco` dependency ([#22542](https://github.com/expo/expo/pull/22542) by [@josephyanks](https://github.com/josephyanks))
+
 ### 📚 3rd party library updates
+
 - Updated `com.github.bumptech.glide:glide` to `4.13.2` and added customizable `glideVersion` variable on ext. ([#22542](https://github.com/expo/expo/pull/22542) by [@josephyanks](https://github.com/josephyanks))
 
 ### 🐛 Bug fixes

--- a/packages/expo-image-loader/android/build.gradle
+++ b/packages/expo-image-loader/android/build.gradle
@@ -86,7 +86,7 @@ repositories {
   mavenCentral()
 }
 
-def glideVersion = safeExtGet('glideVersion', '4.13.2')
+def glideVersion = safeExtGet('glideVersion', '4.16.0')
 
 dependencies {
   implementation project(':expo-modules-core')


### PR DESCRIPTION
# Why
Closes #24172
Closes ENG-9935

The issue will only occur if you were using both `image-picker` and `media-library` and have accepted the permissions of both. Seems incorrect that android shows modals to request the same permissions instead of just a single time, I'll look into this separately. 

When using `image-loader` with androids new granular permissions, Glide was throwing a `SecurityException`. The latest version was released last week and resolves the issue. They don't explicitly call it out in the [changelog](https://github.com/bumptech/glide/compare/v4.15.0...v4.16.0) but they have closed some related [issues](https://github.com/bumptech/glide/issues/5174) 

# How
Bump glide version in `image-loader`

# Test Plan
Tested in bare-expo. The exception is thrown before the change and behaves correctly after.
