### PR TITLE
[ios][av] fix: don't stop audio on other apps when backgrounding

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed recording status not being reset when recording is paused before being stopping. ([#21747](https://github.com/expo/expo/issues/21747)) ([#23816](https://github.com/expo/expo/pull/23816) by [@mojavad](https://github.com/mojavad))
-- Prevent audio from other apps being stopped when users app is backgrounded.
+- Prevent audio from other apps being stopped when users app is backgrounded. ([#24198](https://github.com/expo/expo/pull/24198) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed recording status not being reset when recording is paused before being stopping. ([#21747](https://github.com/expo/expo/issues/21747)) ([#23816](https://github.com/expo/expo/pull/23816) by [@mojavad](https://github.com/mojavad))
+- Prevent audio from other apps being stopped when users app is backgrounded.
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
+++ b/packages/expo-av/ios/EXAV/EXAudioSessionManager.m
@@ -284,7 +284,7 @@ EX_REGISTER_SINGLETON_MODULE(AudioSessionManager);
     }
   }
 
-  return AVAudioSessionCategorySoloAmbient;
+  return AVAudioSessionCategoryAmbient;
 }
 
 - (AVAudioSessionCategoryOptions)_getCategoryOptions


### PR DESCRIPTION
# Why
Closes #23945

# How
Changed our default sound category from `AVAudioSessionCategorySoloAmbient` to `AVAudioSessionCategoryAmbient`. The former stops audio from other apps when the app moves to the background. 

# Test Plan
Tested in bare-expo. Apple music etc. continues to play after backgrounding the app. 