### PR TITLE
[docs] remove misleading Google Service Account link

### DIFF
--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -11,7 +11,7 @@ This guide outlines how to submit your app to the Google Play Store from your ow
 ## Prerequisites
 
 - A paid developer account is required &mdash; You can create a Google Play Developer account on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
-- You have to create a [Google Service Account](#creating-a-google-service-account) and download its JSON private key.
+- You have to create a [Google Service Account](https://expo.fyi/creating-google-service-account) and download its JSON private key.
 - After that, you'll have to create an app on [Google Play Console](https://play.google.com/apps/publish/) and upload your app manually at least once.
 - You will also need to have EAS CLI installed and authenticated with your Expo account: `npm install -g eas-cli && eas login`.
 

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -11,7 +11,7 @@ This guide outlines how to submit your app to the Google Play Store from your ow
 ## Prerequisites
 
 - A paid developer account is required &mdash; You can create a Google Play Developer account on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
-- You have to create a [Google Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) and download its JSON private key.
+- You have to create a [Google Service Account](#creating-a-google-service-account) and download its JSON private key.
 - After that, you'll have to create an app on [Google Play Console](https://play.google.com/apps/publish/) and upload your app manually at least once.
 - You will also need to have EAS CLI installed and authenticated with your Expo account: `npm install -g eas-cli && eas login`.
 


### PR DESCRIPTION
# Why

Currently, the docs link to https://cloud.google.com/iam/docs/service-accounts-create . All of the links on this page link you to the Google Developer Console, not the Play Store console. As someone new to the Play Store, this confused me. I didn't know if I needed to create a new "Project" in the Cloud Console or not.

Then I realized that there's an `expo.fyi` guide that shows you how to set this up in the Play Store console.

Therefore, I think we should remove the misleading link instead link to the better Expo docs on how to do this.

# How

Docs only

# Test Plan

N/A
