### PR TITLE
Bump minimum required Xcode version.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Bump minimum required Xcode version.
+- Bump minimum required Xcode version. ([#24205](https://github.com/expo/expo/pull/24205) by [@EvanBacon](https://github.com/EvanBacon))
 - Favor remote versions endpoint over bundled versions for version validation in `expo install`, `start`, `prebuild`. ([#24162](https://github.com/expo/expo/pull/24162) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove classic manifest types and classic updates. ([#24054](https://github.com/expo/expo/pull/24054), [#24066](https://github.com/expo/expo/pull/24066) by [@wschurman](https://github.com/wschurman))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Bump minimum required Xcode version.
 - Favor remote versions endpoint over bundled versions for version validation in `expo install`, `start`, `prebuild`. ([#24162](https://github.com/expo/expo/pull/24162) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove classic manifest types and classic updates. ([#24054](https://github.com/expo/expo/pull/24054), [#24066](https://github.com/expo/expo/pull/24066) by [@wschurman](https://github.com/wschurman))
 

--- a/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/XcodePrerequisite.ts
@@ -10,9 +10,9 @@ import { Prerequisite } from '../Prerequisite';
 
 const debug = require('debug')('expo:doctor:apple:xcode') as typeof console.log;
 
-// Based on the React Native docs (Aug 2023).
-// https://reactnative.dev/docs/environment-setup?platform=ios
-const MIN_XCODE_VERSION = '10.0';
+// Based on the Apple announcement (last updated: Aug 2023).
+// https://developer.apple.com/news/upcoming-requirements/?id=04252023a
+const MIN_XCODE_VERSION = '14.1';
 const APP_STORE_ID = '497799835';
 
 const SUGGESTED_XCODE_VERSION = `${MIN_XCODE_VERSION}.0`;

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcodePrerequisite-test.ts
@@ -9,8 +9,8 @@ jest.mock(`../../../../log`);
 jest.mock('../../../../utils/prompts');
 
 function mockXcodeInstalled() {
-  return asMock(execSync).mockReturnValue(`Xcode 13.1
-Build version 13A1030d`);
+  return asMock(execSync).mockReturnValue(`Xcode 14.3
+Build version 14E222b`);
 }
 
 describe(getXcodeVersionAsync, () => {
@@ -19,7 +19,7 @@ describe(getXcodeVersionAsync, () => {
   });
   it(`returns the xcode version`, () => {
     mockXcodeInstalled();
-    expect(getXcodeVersionAsync()).toEqual('13.1.0');
+    expect(getXcodeVersionAsync()).toEqual('14.3.0');
   });
   it(`logs an error when the xcode cli format is invalid`, () => {
     asMock(execSync).mockReturnValue(`foobar`);

--- a/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
+++ b/packages/@expo/cli/src/start/doctor/apple/__tests__/XcrunPrerequisite-test.ts
@@ -10,7 +10,7 @@ jest.mock('../../../../utils/prompts');
 
 it(`detects that xcrun is installed and is valid`, async () => {
   // Mock xcrun installed for CI
-  asMock(execSync).mockReset().mockReturnValueOnce(`xcrun version 60.`);
+  asMock(execSync).mockReset().mockReturnValueOnce(`xcrun version 64.`);
 
   // Ensure the confirmation is never called.
   asMock(confirmAsync)
@@ -30,7 +30,7 @@ it(`asserts that xcrun is not installed and installs it successfully`, async () 
     .mockImplementationOnce(() => {
       throw new Error('foobar');
     })
-    .mockReturnValueOnce(`xcrun version 60.`);
+    .mockReturnValueOnce(`xcrun version 64.`);
 
   asMock(confirmAsync)
     .mockReset()
@@ -53,7 +53,7 @@ it(`asserts that xcrun is not installed and the user cancels`, async () => {
     .mockImplementationOnce(() => {
       throw new Error('foobar');
     })
-    .mockReturnValueOnce(`xcrun version 60.`);
+    .mockReturnValueOnce(`xcrun version 64.`);
 
   asMock(confirmAsync)
     .mockReset()


### PR DESCRIPTION
# Why

- https://developer.apple.com/news/upcoming-requirements/?id=04252023a
- This is a breaking change for users as some might need to update Xcode, which is never fun.
