### PR TITLE
[core][Android] Refactor dynamic properties to work well with shared objects

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Android] Enums can now be used to define events. ([#23875](https://github.com/expo/expo/pull/23875) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Promises can now be resolved without arguments. ([#23907](https://github.com/expo/expo/pull/23907) by [@lukmccall](https://github.com/lukmccall))
 - Added support for React Native 0.73. ([#24018](https://github.com/expo/expo/pull/24018), [#24019](https://github.com/expo/expo/pull/24019) by [@kudo](https://github.com/kudo))
+- [Android] `Property` component can now take the native shared object instance as the first argument.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 - [Android] Enums can now be used to define events. ([#23875](https://github.com/expo/expo/pull/23875) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Promises can now be resolved without arguments. ([#23907](https://github.com/expo/expo/pull/23907) by [@lukmccall](https://github.com/lukmccall))
 - Added support for React Native 0.73. ([#24018](https://github.com/expo/expo/pull/24018), [#24019](https://github.com/expo/expo/pull/24019) by [@kudo](https://github.com/kudo))
-- [Android] `Property` component can now take the native shared object instance as the first argument.
+- [Android] `Property` component can now take the native shared object instance as the first argument. ([#24206](https://github.com/expo/expo/pull/24206) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -122,8 +122,11 @@ public:
    */
   void registerProperty(
     jni::alias_ref<jstring> name,
-    jni::alias_ref<ExpectedType> expectedArgType,
+    jboolean getterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> getterExpectedArgsTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> getter,
+    jboolean setterTakesOwner,
+    jni::alias_ref<jni::JArrayClass<ExpectedType>> setterExpectedArgsTypes,
     jni::alias_ref<JNIFunctionBody::javaobject> setter
   );
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -2,8 +2,11 @@
 
 package expo.modules.kotlin.classcomponent
 
+import android.util.Property
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
+import expo.modules.kotlin.objects.PropertyComponentBuilder
+import expo.modules.kotlin.objects.PropertyComponentBuilderWithThis
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -12,7 +15,7 @@ import kotlin.reflect.typeOf
 class ClassComponentBuilder<SharedObjectType : Any>(
   val name: String,
   private val ownerClass: KClass<SharedObjectType>,
-  private val ownerType: KType
+  val ownerType: KType
 ) : ObjectDefinitionBuilder() {
   var constructor: SyncFunctionComponent? = null
 
@@ -107,6 +110,22 @@ class ClassComponentBuilder<SharedObjectType : Any>(
   ): SyncFunctionComponent {
     return SyncFunctionComponent("constructor", arrayOf({ typeOf<P0>() }.toAnyType<P0>(), { typeOf<P1>() }.toAnyType<P1>(), { typeOf<P2>() }.toAnyType<P2>(), { typeOf<P3>() }.toAnyType<P3>(), { typeOf<P4>() }.toAnyType<P4>(), { typeOf<P5>() }.toAnyType<P5>(), { typeOf<P6>() }.toAnyType<P6>(), { typeOf<P7>() }.toAnyType<P7>())) { body(it[0] as P0, it[1] as P1, it[2] as P2, it[3] as P3, it[4] as P4, it[5] as P5, it[6] as P6, it[7] as P7) }.also {
       constructor = it
+    }
+  }
+
+  /**
+   * Creates the read-only property whose getter takes the caller as an argument.
+   */
+  inline fun <T> Property(name: String, crossinline body: (owner: SharedObjectType) -> T): PropertyComponentBuilderWithThis<SharedObjectType> {
+    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType, name).also {
+      it.get(body)
+      properties[name] = it
+    }
+  }
+
+  override fun Property(name: String): PropertyComponentBuilderWithThis<SharedObjectType> {
+    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType, name).also {
+      properties[name] = it
     }
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -2,10 +2,8 @@
 
 package expo.modules.kotlin.classcomponent
 
-import android.util.Property
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
-import expo.modules.kotlin.objects.PropertyComponentBuilder
 import expo.modules.kotlin.objects.PropertyComponentBuilderWithThis
 import expo.modules.kotlin.types.toAnyType
 import kotlin.reflect.KClass

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -24,6 +24,7 @@ abstract class AnyFunction(
 ) {
   internal val argsCount get() = desiredArgsTypes.size
 
+  @PublishedApi
   internal var canTakeOwner: Boolean = false
 
   @PublishedApi

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -44,7 +44,7 @@ class JavaScriptModuleObject(
     definition
       .properties
       .forEach { (_, prop) ->
-        prop.attachToJSObject(this)
+        prop.attachToJSObject(appContext, this)
       }
   }
 
@@ -65,7 +65,15 @@ class JavaScriptModuleObject(
    */
   external fun registerAsyncFunction(name: String, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIAsyncFunctionBody)
 
-  external fun registerProperty(name: String, desiredType: ExpectedType, getter: JNIFunctionBody?, setter: JNIFunctionBody?)
+  external fun registerProperty(
+    name: String,
+    getterTakesOwner: Boolean,
+    getterExpectedType: Array<ExpectedType>,
+    getter: JNIFunctionBody?,
+    setterTakesOwner: Boolean,
+    setterExpectedType: Array<ExpectedType>,
+    setter: JNIFunctionBody?
+  )
 
   external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -361,7 +361,7 @@ open class ObjectDefinitionBuilder {
   /**
    * Creates the property with given name. The component is basically no-op if you don't call `.get()` or `.set()` on it.
    */
-  fun Property(name: String): PropertyComponentBuilder {
+  open fun Property(name: String): PropertyComponentBuilder {
     return PropertyComponentBuilder(name).also {
       properties[name] = it
     }
@@ -399,7 +399,7 @@ inline fun Module.Object(block: ObjectDefinitionBuilder.() -> Unit): JavaScriptM
       objectData
         .properties
         .forEach { (_, prop) ->
-          prop.attachToJSObject(this)
+          prop.attachToJSObject(appContext, this)
         }
     }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
@@ -1,10 +1,12 @@
 package expo.modules.kotlin.objects
 
 import expo.modules.kotlin.functions.SyncFunctionComponent
+import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.toAnyType
+import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 
-class PropertyComponentBuilder(
+open class PropertyComponentBuilder(
   val name: String
 ) {
   var getter: SyncFunctionComponent? = null
@@ -26,5 +28,37 @@ class PropertyComponentBuilder(
 
   fun build(): PropertyComponent {
     return PropertyComponent(name, getter, setter)
+  }
+}
+
+class PropertyComponentBuilderWithThis<ThisType>(
+  val thisType: KType,
+  name: String,
+) : PropertyComponentBuilder(name) {
+
+  /**
+   * Modifier that sets property getter that has caller.
+   */
+  inline fun <T> get(crossinline body: (ThisType) -> T) = apply {
+    getter = SyncFunctionComponent("get", arrayOf(AnyType(thisType))) {
+      @Suppress("UNCHECKED_CAST")
+      body(it[0] as ThisType)
+    }.also {
+      it.ownerType = thisType
+      it.canTakeOwner = true
+    }
+  }
+
+  /**
+   * Modifier that sets property setter that receives only the new value as an argument.
+   */
+  inline fun <reified T> set(crossinline body: (self: ThisType, newValue: T) -> Unit) = apply {
+    setter = SyncFunctionComponent("set", arrayOf(AnyType(thisType), { typeOf<T>() }.toAnyType<T>())) {
+      @Suppress("UNCHECKED_CAST")
+      body(it[0] as ThisType, it[1] as T)
+    }.also {
+      it.ownerType = thisType
+      it.canTakeOwner = true
+    }
   }
 }


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/20608.
Allows shared objects to be passed as a first argument of the dynamic properties. 

# Test Plan

- tests ✅