### PR TITLE
[core][Android] `SharedObjectTypeConverter` now can work with `Dynamic` objects

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 💡 Others
 
 - [Android] Add type converter for the `ReadableArguments` class to allow backward compatibility with older modules. ([#24137](https://github.com/expo/expo/pull/24137) by [@lukmccall](https://github.com/lukmccall))
-- [Android] `SharedObjectTypeConverter` now can work with the `Dynamic` class.
+- [Android] `SharedObjectTypeConverter` now can work with the `Dynamic` class. ([#24207](https://github.com/expo/expo/pull/24207) by [@lukmccall](https://github.com/lukmccall))
 
 ## 1.6.0 — 2023-07-28
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### 💡 Others
 
 - [Android] Add type converter for the `ReadableArguments` class to allow backward compatibility with older modules. ([#24137](https://github.com/expo/expo/pull/24137) by [@lukmccall](https://github.com/lukmccall))
+- [Android] `SharedObjectTypeConverter` now can work with the `Dynamic` class.
 
 ## 1.6.0 — 2023-07-28
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.sharedobjects
 
+import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.InvalidSharedObjectException
 import expo.modules.kotlin.jni.CppType
@@ -13,7 +14,14 @@ class SharedObjectTypeConverter<T : SharedObject>(
 ) : NullAwareTypeConverter<T>(type.isMarkedNullable) {
   @Suppress("UNCHECKED_CAST")
   override fun convertNonOptional(value: Any, context: AppContext?): T {
-    val id = SharedObjectId(value as Int)
+    val id = SharedObjectId(
+      if (value is Dynamic) {
+        value.asInt()
+      } else {
+        value as Int
+      }
+    )
+
     val appContext = context.toStrongReference()
     val result = appContext.sharedObjectRegistry.toNativeObject(id)
       ?: throw InvalidSharedObjectException(type)
@@ -21,7 +29,7 @@ class SharedObjectTypeConverter<T : SharedObject>(
     return result as T
   }
 
-  override fun getCppRequiredTypes() = ExpectedType(CppType.SHARED_OBJECT_ID)
+  override fun getCppRequiredTypes() = ExpectedType(CppType.SHARED_OBJECT_ID, CppType.INT)
 
   override fun isTrivial(): Boolean = false
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/AnyViewProp.kt
@@ -2,13 +2,14 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.types.AnyType
 
 abstract class AnyViewProp(
   val name: String,
   internal val type: AnyType
 ) {
-  abstract fun set(prop: Dynamic, onView: View)
+  abstract fun set(prop: Dynamic, onView: View, appContext: AppContext? = null)
 
   abstract val isNullable: Boolean
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.views
 
 import android.view.View
 import com.facebook.react.bridge.Dynamic
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.types.AnyType
@@ -13,11 +14,11 @@ class ConcreteViewProp<ViewType : View, PropType>(
 ) : AnyViewProp(name, propType) {
 
   @Suppress("UNCHECKED_CAST")
-  override fun set(prop: Dynamic, onView: View) {
+  override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
     exceptionDecorator({
       PropSetException(name, onView::class, it)
     }) {
-      setter(onView as ViewType, type.convert(prop) as PropType)
+      setter(onView as ViewType, type.convert(prop, appContext) as PropType)
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewManagerWrapperDelegate.kt
@@ -73,7 +73,7 @@ class ViewManagerWrapperDelegate(internal var moduleHolder: ModuleHolder) {
       val key = iterator.nextKey()
       expoProps[key]?.let { expoProp ->
         try {
-          expoProp.set(propsMap.getDynamic(key), view)
+          expoProp.set(propsMap.getDynamic(key), view, moduleHolder.module._appContext)
         } catch (exception: Throwable) {
           // The view wasn't constructed correctly, so errors are expected.
           // We can ignore them.


### PR DESCRIPTION
# Why

Allows us to pass `SharedObject` as a prop. Note: It'll steal the required small workaround in JS to convert the shared object to int.

# Test Plan

- tbd