### PR TITLE
[splash-screen][ios] Remove 'No native splash screen registered' warning

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Removed 'No native splash screen registered' warning on iOS when opening and reloading the app.
+
 ## 0.21.1 — 2023-08-02
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- Removed 'No native splash screen registered' warning on iOS when opening and reloading the app.
+- Removed 'No native splash screen registered' warning on iOS when opening and reloading the app. ([#24210](https://github.com/expo/expo/pull/24210) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.21.1 — 2023-08-02
 

--- a/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
+++ b/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m
@@ -114,9 +114,6 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 - (void)onAppContentDidAppear:(UIViewController *)viewController
 {
-  if ([self isAppActive] && ![self.splashScreenControllers objectForKey:viewController]) {
-    EXLogWarn(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
-  }
   BOOL needsHide = [[self.splashScreenControllers objectForKey:viewController] needsHideOnAppContentDidAppear];
   if (needsHide) {
     [self hideSplashScreenFor:viewController
@@ -128,9 +125,6 @@ EX_REGISTER_SINGLETON_MODULE(SplashScreen);
 
 - (void)onAppContentWillReload:(UIViewController *)viewController
 {
-  if ([self isAppActive] && ![self.splashScreenControllers objectForKey:viewController]) {
-    EXLogWarn(@"No native splash screen registered for given view controller. Call 'SplashScreen.show' for given view controller first.");
-  }
   BOOL needsShow = [[self.splashScreenControllers objectForKey:viewController] needsShowOnAppContentWillReload];
   if (needsShow) {
     // For reloading apps, specify `EXSplashScreenForceShow` to show splash screen again


### PR DESCRIPTION
# Why

Closes ENG-9730

Historically the 'No native splash screen registered' warning has raised many questions/reports from the community.  The warning itself is not very useful and people constantly ask about it, because of that we should we just get rid of it.

# How

This PR removes the `No native splash screen registered` warning from `expo-splash-screen` `onAppContentDidAppear` and `onAppContentWillReload`. I decided to keep the warning in [preventSplashScreenAutoHideFor](https://github.com/expo/expo/blob/63c9cee2ae80d04a55a2aa8035afece2e9186df8/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m#L107-L108) and [hideSplashScreenFor](https://github.com/expo/expo/blob/63c9cee2ae80d04a55a2aa8035afece2e9186df8/packages/expo-splash-screen/ios/EXSplashScreen/EXSplashScreenService.m#L94) methods as both use `failureCallback` and would otherwise silently fail.

# Test Plan

Run BareExpo NCL locally and ensure no warnings related to native splash are shown

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
