### PR TITLE
[docs] Add a deprecation on Work together doc under Expo accounts

### DIFF
--- a/docs/pages/accounts/working-together.mdx
+++ b/docs/pages/accounts/working-together.mdx
@@ -3,6 +3,8 @@ title: Work together
 description: Learn how to work with other developers on Expo projects.
 ---
 
+> **warning** **Deprecation:** The following guidelines on giving access to other developers or team members have been deprecated and are no longer valid on a Personal Account. If you creating a new account and looking to add team members, we recommend creating an [Organization](/accounts/account-types/#organizations) instead of a Personal Account. Organizations are more flexible and allow you to manage and share access to your projects within a team.
+
 You can grant other users access to the projects belonging to your Personal Account or Organizations. The type of access depends on the granted role.
 
 ## Add members


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The guidelines in Work together doc about adding new team members from a Personal account are not valid for new users.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding a deprecation notice about the guidelines we offer and recommend using Organizations for new users.

**Preview**

![CleanShot 2023-09-01 at 02 01 11](https://github.com/expo/expo/assets/10234615/79c82464-56ec-4898-b14e-adb7a9b499da)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/accounts/working-together/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
