### PR TITLE
[core][Android] Add `ConstProperty` and static object declaration

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for Apple tvOS. ([#24329](https://github.com/expo/expo/pull/24329) by [@douglowder](https://github.com/douglowder))
+- Add `ConstProperty` component and static object declaration on Android.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -36,6 +36,13 @@ void decorateObjectWithProperties(
   JavaScriptModuleObject *objectData
 );
 
+void decorateObjectWithConstProperties(
+  jsi::Runtime &runtime,
+  JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+  jsi::Object *jsObject,
+  JavaScriptModuleObject *objectData
+);
+
 void decorateObjectWithConstants(
   jsi::Runtime &runtime,
   JSIInteropModuleRegistry *jsiInteropModuleRegistry,
@@ -130,6 +137,11 @@ public:
     jni::alias_ref<JNIFunctionBody::javaobject> setter
   );
 
+  void registerConstProperty(
+    jni::alias_ref<jstring> name,
+    jni::alias_ref<jobject> value
+  );
+
 private:
   explicit JavaScriptModuleObject(jni::alias_ref<jhybridobject> jThis);
 
@@ -144,6 +156,13 @@ private:
   );
 
   friend void decorateObjectWithProperties(
+    jsi::Runtime &runtime,
+    JSIInteropModuleRegistry *jsiInteropModuleRegistry,
+    jsi::Object *jsObject,
+    JavaScriptModuleObject *objectData
+  );
+
+  friend void decorateObjectWithConstProperties(
     jsi::Runtime &runtime,
     JSIInteropModuleRegistry *jsiInteropModuleRegistry,
     jsi::Object *jsObject,
@@ -181,6 +200,11 @@ private:
    * The first MethodMetadata points to the getter and the second one to the setter.
    */
   std::map<std::string, std::pair<MethodMetadata, MethodMetadata>> properties;
+
+  /**
+   * A registry of const properties
+   */
+  std::map<std::string, jni::global_ref<jobject>> constProperties;
 
   std::map<
     std::string,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptModuleObject.kt
@@ -75,6 +75,11 @@ class JavaScriptModuleObject(
     setter: JNIFunctionBody?
   )
 
+  external fun registerConstProperty(
+    name: String,
+    value: Any
+  )
+
   external fun registerClass(name: String, classModule: JavaScriptModuleObject, takesOwner: Boolean, args: Int, desiredTypes: Array<ExpectedType>, body: JNIFunctionBody)
 
   external fun registerViewPrototype(viewPrototype: JavaScriptModuleObject)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/AnyProperty.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/AnyProperty.kt
@@ -1,0 +1,8 @@
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.jni.JavaScriptModuleObject
+
+interface AnyProperty {
+  fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject)
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ConstPropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ConstPropertyComponent.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin.objects
+
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.jni.JavaScriptModuleObject
+
+class ConstPropertyComponent<T : Any>(
+  val name: String,
+  val value: T
+) : AnyProperty {
+  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+    jsObject.registerConstProperty(name, value)
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionData.kt
@@ -10,7 +10,7 @@ class ObjectDefinitionData(
   val syncFunctions: Map<String, SyncFunctionComponent>,
   val asyncFunctions: Map<String, BaseAsyncFunctionComponent>,
   val eventsDefinition: EventsDefinition?,
-  val properties: Map<String, PropertyComponent>
+  val properties: Map<String, AnyProperty>
 ) {
   val functions
     get() = ConcatIterator(syncFunctions.values.iterator(), asyncFunctions.values.iterator())

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponent.kt
@@ -21,11 +21,11 @@ class PropertyComponent(
    * Synchronous function that is called when the property is being set.
    */
   val setter: SyncFunctionComponent? = null
-) {
+) : AnyProperty {
   /**
    * Attaches property to the provided js object.
    */
-  fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
+  override fun attachToJSObject(appContext: AppContext, jsObject: JavaScriptModuleObject) {
     val jniGetter = if (getter != null) {
       JNIFunctionBody { args ->
         val result = getter.call(args, appContext)


### PR DESCRIPTION
# Why

Adds `ConstProperty` and static object declaration to allow exporting nested objects in the module definition. 

# How

Syntax like this is now possible:

```
ModuleDefinition {
	Object("innerObject") {
		// ...
	}
}
```


# Test Plan

- bare-expo ✅