### PR TITLE
feat(router): Add `unstable_styles` types.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🎉 New features
 
-- Add types for the `unstable_styles` export of CSS Modules.
+- Add types for the `unstable_styles` export of CSS Modules. ([#24244](https://github.com/expo/expo/pull/24244) by [@EvanBacon](https://github.com/EvanBacon))
 - Tree shake error symbolication code in production. ([#24215](https://github.com/expo/expo/pull/24215) by [@EvanBacon](https://github.com/EvanBacon))
 - Add static font extraction support with `expo-font`. ([#24027](https://github.com/expo/expo/pull/24027) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- Add types for the `unstable_styles` export of CSS Modules.
 - Tree shake error symbolication code in production. ([#24215](https://github.com/expo/expo/pull/24215) by [@EvanBacon](https://github.com/EvanBacon))
 - Add static font extraction support with `expo-font`. ([#24027](https://github.com/expo/expo/pull/24027) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-router/types/global.d.ts
+++ b/packages/expo-router/types/global.d.ts
@@ -7,23 +7,32 @@ declare namespace NodeJS {
   }
 }
 
-// Allow for css imports, but don't export anything
-declare module '*.css';
-declare module '*.sass';
-declare module '*.scss';
-
 // Create types for CSS modules
 declare module '*.module.css' {
+  /** **Experimental:** Import styles that can be used with `react-native-web` components, using the `style` prop. */
+  export const unstable_styles: { readonly [key: string]: object };
+
   const classes: { readonly [key: string]: string };
   export default classes;
 }
 
 declare module '*.module.sass' {
+  /** **Experimental:** Import styles that can be used with `react-native-web` components, using the `style` prop. */
+  export const unstable_styles: { readonly [key: string]: object };
+
   const classes: { readonly [key: string]: string };
   export default classes;
 }
 
 declare module '*.module.scss' {
+  /** **Experimental:** Import styles that can be used with `react-native-web` components, using the `style` prop. */
+  export const unstable_styles: { readonly [key: string]: object };
+
   const classes: { readonly [key: string]: string };
   export default classes;
 }
+
+// Allow for css imports, but don't export anything
+declare module '*.css';
+declare module '*.sass';
+declare module '*.scss';


### PR DESCRIPTION
# Why

- We add the `unstable_styles` export in CSS modules to support easily working with `react-native-web`, but these aren't on the types.
- Ensure the more specific CSS modules types come before the `*.css` types so the user sees the type suggestions.
