### PR TITLE
[ios] Remove detached constants

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -44,12 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
   jsResource.abiVersion = [[EXVersions sharedInstance] availableSdkVersionForManifest:manifest];
   jsResource.requestTimeoutInterval = timeoutInterval;
 
-  EXCachedResourceBehavior behavior = cacheBehavior;
-  // if we've disabled updates, ignore all other settings and only use the cache
-  if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    behavior = EXCachedResourceOnlyCache;
-  }
-
   if ([self.dataSource appFetcherShouldInvalidateBundleCache:self]) {
     [jsResource removeCache];
   }

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
@@ -89,24 +89,13 @@
 
 - (BOOL)isUsingEmbeddedResource
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    // if the URL of our request matches the remote URL of the embedded JS bundle,
-    // skip checking any caches and just immediately open the NSBundle copy
-    if ([EXEnvironment sharedEnvironment].embeddedBundleUrl &&
-        [self.remoteUrl isEqual:[EXApiUtil encodedUrlFromString:[EXEnvironment sharedEnvironment].embeddedBundleUrl]]) {
-      return YES;
-    } else {
-      return NO;
-    }
-  } else {
 #if DEBUG
-    return NO;
+  return NO;
 #else
-    // we only need this because the bundle URL of prod home never changes, so we need
-    // to use the legacy logic and load embedded home if and only if a cached copy doesn't exist.
-    return [super isUsingEmbeddedResource];
+  // we only need this because the bundle URL of prod home never changes, so we need
+  // to use the legacy logic and load embedded home if and only if a cached copy doesn't exist.
+  return [super isUsingEmbeddedResource];
 #endif
-  }
 }
 
 - (NSError *)_validateResponseData:(NSData *)data response:(NSURLResponse *)response

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -34,16 +34,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
   _originalUrl = originalUrl;
   _canBeWrittenToCache = NO;
   
-  NSString *resourceName;
-  if ([EXEnvironment sharedEnvironment].isDetached && [originalUrl.absoluteString isEqual:[EXEnvironment sharedEnvironment].standaloneManifestUrl]) {
-    resourceName = kEXEmbeddedManifestResourceName;
-    if ([EXEnvironment sharedEnvironment].releaseChannel){
-      self.releaseChannel = [EXEnvironment sharedEnvironment].releaseChannel;
-    }
-    NSLog(@"EXManifestResource: Standalone manifest remote url is %@ (%@)", url, originalUrl);
-  } else {
-    resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
-  }
+  NSString *resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
   
   if (self = [super initWithResourceName:resourceName resourceType:@"json" remoteUrl:url cachePath:[[self class] cachePath]]) {
     self.shouldVersionCache = NO;
@@ -141,7 +132,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
     };
     
     if ([self _isManifestVerificationBypassed:manifestObj]) {
-      if ([self _isThirdPartyHosted] && ![EXEnvironment sharedEnvironment].isDetached){
+      if ([self _isThirdPartyHosted]) {
         // the manifest id determines the namespace/experience id an app is sandboxed with
         // if manifest is hosted by third parties, we sandbox it with the hostname to avoid clobbering exp.host namespaces
         // for https urls, sandboxed id is of form quinlanj.github.io/myProj-myApp

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -13,11 +13,7 @@
 #import "EXUpdatesDatabaseManager.h"
 #import "EXVersions.h"
 
-#if defined(EX_DETACHED)
-#import "ExpoKit-Swift.h"
-#else
 #import "Expo_Go-Swift.h"
-#endif // defined(EX_DETACHED)
 
 #import <React/RCTUtils.h>
 #import <sys/utsname.h>
@@ -255,10 +251,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)appLoaderTask:(EXUpdatesAppLoaderTask *)appLoaderTask didFinishWithError:(NSError *)error
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    _isEmergencyLaunch = YES;
-    [self _launchWithNoDatabaseAndError:error];
-  } else if (!_error) {
+  if (!_error) {
     _error = error;
 
     // if the error payload conforms to the error protocol, we can parse it and display
@@ -334,30 +327,22 @@ NS_ASSUME_NONNULL_BEGIN
     shouldCheckOnLaunch = NO;
     launchWaitMs = @(0);
   } else {
-    if ([EXEnvironment sharedEnvironment].isDetached) {
-      shouldCheckOnLaunch = [EXEnvironment sharedEnvironment].updatesCheckAutomatically;
-      launchWaitMs = [EXEnvironment sharedEnvironment].updatesFallbackToCacheTimeout;
-    } else {
-      shouldCheckOnLaunch = YES;
-      launchWaitMs = @(60000);
-    }
+    shouldCheckOnLaunch = YES;
+    launchWaitMs = @(60000);
   }
 
   NSURL *httpManifestUrl = [[self class] _httpUrlFromManifestUrl:_manifestUrl];
 
-  NSString *releaseChannel = [EXEnvironment sharedEnvironment].releaseChannel;
-  if (![EXEnvironment sharedEnvironment].isDetached) {
-    // in Expo Go, the release channel can change at runtime depending on the URL we load
-    NSURLComponents *manifestUrlComponents = [NSURLComponents componentsWithURL:httpManifestUrl resolvingAgainstBaseURL:YES];
-    releaseChannel = [EXKernelLinkingManager releaseChannelWithUrlComponents:manifestUrlComponents];
-  }
+  // in Expo Go, the release channel can change at runtime depending on the URL we load
+  NSURLComponents *manifestUrlComponents = [NSURLComponents componentsWithURL:httpManifestUrl resolvingAgainstBaseURL:YES];
+  NSString *releaseChannel = [EXKernelLinkingManager releaseChannelWithUrlComponents:manifestUrlComponents];
 
   NSMutableDictionary *updatesConfig = [[NSMutableDictionary alloc] initWithDictionary:@{
     EXUpdatesConfig.EXUpdatesConfigUpdateUrlKey: httpManifestUrl.absoluteString,
     EXUpdatesConfig.EXUpdatesConfigSDKVersionKey: [self _sdkVersions],
     EXUpdatesConfig.EXUpdatesConfigScopeKeyKey: httpManifestUrl.absoluteString,
     EXUpdatesConfig.EXUpdatesConfigReleaseChannelKey: releaseChannel,
-    EXUpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: @([EXEnvironment sharedEnvironment].isDetached),
+    EXUpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: @NO,
     EXUpdatesConfig.EXUpdatesConfigEnabledKey: @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
     EXUpdatesConfig.EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
     EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueNever,
@@ -365,40 +350,37 @@ NS_ASSUME_NONNULL_BEGIN
     EXUpdatesConfig.EXUpdatesConfigRequestHeadersKey: [self _requestHeaders]
   }];
 
-  if (!EXEnvironment.sharedEnvironment.isDetached) {
-    // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates
-    // from the multipart manifest response part
-
-    NSString *expoRootCertPath = [[NSBundle mainBundle] pathForResource:@"expo-root" ofType:@"pem"];
-    if (!expoRootCertPath) {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"No expo-root certificate found in bundle"
-                                   userInfo:@{}];
-    }
-
-    NSError *error;
-    NSString *expoRootCert = [NSString stringWithContentsOfFile:expoRootCertPath encoding:NSUTF8StringEncoding error:&error];
-    if (error) {
-      expoRootCert = nil;
-    }
-    if (!expoRootCert) {
-      @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:@"Error reading expo-root certificate from bundle"
-                                   userInfo:@{ @"underlyingError": error.localizedDescription }];
-    }
-
-    updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey] = expoRootCert;
-    updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey] = @{
-      @"keyid": @"expo-root",
-      @"alg": @"rsa-v1_5-sha256",
-    };
-    updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey] = @YES;
-    updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey] = @YES;
-    
-    // in Expo Go, ignore directives in manifest responses and require a manifest. the current directives
-    // (no update available, roll back) don't have any practical use outside of standalone apps
-    updatesConfig[EXUpdatesConfig.EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey] = @YES;
+  // in Expo Go, embed the Expo Root Certificate and get the Expo Go intermediate certificate and development certificates
+  // from the multipart manifest response part
+  NSString *expoRootCertPath = [[NSBundle mainBundle] pathForResource:@"expo-root" ofType:@"pem"];
+  if (!expoRootCertPath) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"No expo-root certificate found in bundle"
+                                 userInfo:@{}];
   }
+
+  NSError *error;
+  NSString *expoRootCert = [NSString stringWithContentsOfFile:expoRootCertPath encoding:NSUTF8StringEncoding error:&error];
+  if (error) {
+    expoRootCert = nil;
+  }
+  if (!expoRootCert) {
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException
+                                   reason:@"Error reading expo-root certificate from bundle"
+                                 userInfo:@{ @"underlyingError": error.localizedDescription }];
+  }
+
+  updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningCertificateKey] = expoRootCert;
+  updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningMetadataKey] = @{
+    @"keyid": @"expo-root",
+    @"alg": @"rsa-v1_5-sha256",
+  };
+  updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningIncludeManifestResponseCertificateChainKey] = @YES;
+  updatesConfig[EXUpdatesConfig.EXUpdatesConfigCodeSigningAllowUnsignedManifestsKey] = @YES;
+
+  // in Expo Go, ignore directives in manifest responses and require a manifest. the current directives
+  // (no update available, roll back) don't have any practical use outside of standalone apps
+  updatesConfig[EXUpdatesConfig.EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey] = @YES;
 
   _config = [EXUpdatesConfig configFromDictionary:updatesConfig];
 
@@ -524,7 +506,6 @@ NS_ASSUME_NONNULL_BEGIN
     // If legacy manifest is not yet verified, served by a third party, not standalone, and not an anonymous experience
     // then scope it locally by using the manifest URL as a scopeKey (id) and consider it verified.
     if (!mutableManifest[@"isVerified"] &&
-        !EXEnvironment.sharedEnvironment.isDetached &&
         ![EXKernelLinkingManager isExpoHostedUrl:_httpManifestUrl] &&
         ![EXAppLoaderExpoUpdates _isAnonymousExperience:manifest] &&
         [manifest isKindOfClass:[EXManifestsLegacyManifest class]]) {
@@ -627,14 +608,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)_clientEnvironment
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return @"STANDALONE";
-  } else {
-    return @"EXPO_DEVICE";
 #if TARGET_IPHONE_SIMULATOR
-    return @"EXPO_SIMULATOR";
+  return @"EXPO_SIMULATOR";
 #endif
-  }
+  return @"EXPO_DEVICE";
 }
 
 - (NSString *)_sdkVersions

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -89,15 +89,10 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
   } else {
     releaseChannel = @"default";
   }
-  NSString *clientEnvironment;
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    clientEnvironment = @"STANDALONE";
-  } else {
-    clientEnvironment = @"EXPO_DEVICE";
+  NSString *clientEnvironment = @"EXPO_DEVICE";
 #if TARGET_IPHONE_SIMULATOR
-    clientEnvironment = @"EXPO_SIMULATOR";
+  clientEnvironment = @"EXPO_SIMULATOR";
 #endif
-  }
   
   [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];

--- a/ios/Exponent/Kernel/AppLoader/EXHomeLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXHomeLoader.m
@@ -212,8 +212,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 - (void)_beginRequestWithRemoteManifest
 {
   // if we're in dev mode, don't try loading cached manifest
-  if ([self.httpManifestUrl.host isEqualToString:@"localhost"]
-      || ([EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].isDebugXCodeScheme)) {
+  if ([self.httpManifestUrl.host isEqualToString:@"localhost"]) {
     // we can't pre-detect if this person is using a developer tool, but using localhost is a pretty solid indicator.
     [self _startAppFetcher:[[EXAppFetcherDevelopmentMode alloc] initWithAppLoader:self]];
   } else {
@@ -270,9 +269,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
   }
 
   // only support checkAutomatically: ON_ERROR_RECOVERY in detached apps
-  if (![EXEnvironment sharedEnvironment].isDetached) {
-    shouldCheckForUpdate = YES;
-  }
+  shouldCheckForUpdate = YES;
 
   // if this experience id encountered a loading error before,
   // we should always check for an update, even if the manifest says not to
@@ -282,8 +279,7 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
   // if remote updates are disabled, or we're using `reloadFromCache`, don't check for an update.
   // these checks need to be here because they need to happen after the dev mode check above.
-  if (self.shouldUseCacheOnly ||
-      ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled)) {
+  if (self.shouldUseCacheOnly) {
     shouldCheckForUpdate = NO;
   }
 
@@ -452,14 +448,6 @@ NSTimeInterval const kEXJSBundleTimeout = 60 * 5;
 
     success([EXManifestsManifestFactory manifestForManifestJSON:[NSDictionary dictionaryWithDictionary:mutableManifestJSON]]);
   } errorBlock:^(NSError * _Nonnull error) {
-#if DEBUG
-    if ([EXEnvironment sharedEnvironment].isDetached && error &&
-        (error.code == 404 || error.domain == EXNetworkErrorDomain)) {
-      NSString *message = error.localizedDescription;
-      message = [NSString stringWithFormat:@"Make sure you are serving your project with Expo CLI (%@)", message];
-      error = [NSError errorWithDomain:error.domain code:error.code userInfo:@{ NSLocalizedDescriptionKey: message }];
-    }
-#endif
     failure(error);
   }];
 }

--- a/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/ios/Exponent/Kernel/Core/EXKernel.m
@@ -17,14 +17,12 @@
 #import <React/RCTModuleData.h>
 #import <React/RCTUtils.h>
 
-#ifndef EX_DETACHED
 // Kernel is DevMenu's delegate only in non-detached builds.
 #import "EXDevMenuManager.h"
 #import "EXDevMenuDelegateProtocol.h"
 
 @interface EXKernel () <EXDevMenuDelegateProtocol>
 @end
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -70,10 +68,8 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
     // init service registry: classes which manage shared resources among all bridges
     _serviceRegistry = [[EXKernelServiceRegistry alloc] init];
 
-#ifndef EX_DETACHED
     // Set the delegate of dev menu manager. Maybe it should be a separate class? Will see later once the delegate protocol gets too big.
     [[EXDevMenuManager sharedInstance] setDelegate:self];
-#endif
 
     // register for notifications to request reloading the visible app
     [[NSNotificationCenter defaultCenter] addObserver:self
@@ -250,11 +246,10 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   }
   
   if (_visibleApp != _appRegistry.homeAppRecord) {
-#ifndef EX_DETACHED // Just to compile without access to EXDevMenuManager, we wouldn't get here either way because browser controller is unset in this case.
+    // Just to compile without access to EXDevMenuManager, we wouldn't get here either way because browser controller is unset in this case.
     [EXUtil performSynchronouslyOnMainThread:^{
       [[EXDevMenuManager sharedInstance] toggle];
     }];
-#endif
   } else {
     EXKernelAppRegistry *appRegistry = [EXKernel sharedInstance].appRegistry;
     for (NSString *recordId in appRegistry.appEnumerator) {
@@ -381,7 +376,6 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
   }
 }
 
-#ifndef EX_DETACHED
 #pragma mark - EXDevMenuDelegateProtocol
 
 - (RCTBridge *)mainBridgeForDevMenuManager:(EXDevMenuManager *)manager
@@ -401,8 +395,6 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
 {
   return !visibility || _visibleApp != _appRegistry.homeAppRecord;
 }
-
-#endif
 
 @end
 

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
@@ -77,15 +77,6 @@
 
 - (EXKernelAppRecord *)standaloneAppRecord
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    for (NSString *recordId in self.appEnumerator) {
-      EXKernelAppRecord *record = [self recordForId:recordId];
-      if (record.appLoader.manifestUrl
-          && [record.appLoader.manifestUrl.absoluteString isEqualToString:[EXEnvironment sharedEnvironment].standaloneManifestUrl]) {
-        return record;
-      }
-    }
-  }
   return nil;
 }
 

--- a/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
+++ b/ios/Exponent/Kernel/DevSupport/EXHomeModule.m
@@ -7,9 +7,7 @@
 #import "EXClientReleaseType.h"
 #import "EXKernelDevKeyCommands.h"
 
-#ifndef EX_DETACHED
 #import "EXDevMenuManager.h"
-#endif
 
 #import <React/RCTEventDispatcher.h>
 
@@ -99,12 +97,10 @@
  */
 - (void)requestToCloseDevMenu
 {
-#ifndef EX_DETACHED
   void (^callback)(id) = ^(id arg){
     [[EXDevMenuManager sharedInstance] closeWithoutAnimation];
   };
   [self dispatchJSEvent:@"requestToCloseDevMenu" body:nil onSuccess:callback onFailure:callback];
-#endif
 }
 
 /**
@@ -182,9 +178,7 @@ RCT_EXPORT_METHOD(reloadAppAsync)
  */
 RCT_EXPORT_METHOD(closeDevMenuAsync)
 {
-#ifndef EX_DETACHED
   [[EXDevMenuManager sharedInstance] closeWithoutAnimation];
-#endif
 }
 
 /**
@@ -211,16 +205,12 @@ RCT_REMAP_METHOD(getDevMenuSettingsAsync,
                  getDevMenuSettingsAsync:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-#ifndef EX_DETACHED
   EXDevMenuManager *manager = [EXDevMenuManager sharedInstance];
 
   resolve(@{
     @"motionGestureEnabled": @(manager.interceptMotionGesture),
     @"touchGestureEnabled": @(manager.interceptTouchGesture),
   });
-#else
-  resolve(@{});
-#endif
 }
 
 RCT_REMAP_METHOD(setDevMenuSettingAsync,
@@ -229,7 +219,6 @@ RCT_REMAP_METHOD(setDevMenuSettingAsync,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-#ifndef EX_DETACHED
   EXDevMenuManager *manager = [EXDevMenuManager sharedInstance];
 
   if ([key isEqualToString:@"motionGestureEnabled"]) {
@@ -239,7 +228,6 @@ RCT_REMAP_METHOD(setDevMenuSettingAsync,
   } else {
     return reject(@"ERR_DEV_MENU_SETTING_NOT_EXISTS", @"Specified dev menu setting doesn't exist.", nil);
   }
-#endif
   resolve(nil);
 }
 

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -248,11 +248,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)_handleMenuCommand
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
-  } else {
-    [[EXKernel sharedInstance] switchTasks];
-  }
+  [[EXKernel sharedInstance] switchTasks];
 }
 
 - (void)_handleRefreshCommand

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -13,11 +13,6 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 + (instancetype)sharedEnvironment;
 
 /**
- *  Whether the app is running as a detached/standalone app (true) or as Expo Go (false).
- */
-@property (nonatomic, readonly) BOOL isDetached;
-
-/**
  *  Whether the app was built with a Debug configuration.
  */
 @property (nonatomic, readonly) BOOL isDebugXCodeScheme;

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -46,7 +46,6 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
 
 - (void)_reset
 {
-  _isDetached = NO;
   _standaloneManifestUrl = nil;
   _urlScheme = nil;
   _areRemoteUpdatesEnabled = YES;
@@ -82,9 +81,6 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   }
   
   BOOL isDetached = NO;
-#ifdef EX_DETACHED
-  isDetached = YES;
-#endif
   
   BOOL isDebugXCodeScheme = NO;
 #if DEBUG
@@ -102,7 +98,6 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
            withInfoPlist:infoPlist
        withExpoKitDevUrl:expoKitDevelopmentUrl
     withEmbeddedManifest:embeddedManifest
-              isDetached:isDetached
       isDebugXCodeScheme:isDebugXCodeScheme
             isUserDetach:isUserDetach];
 }
@@ -111,45 +106,15 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
            withInfoPlist:(NSDictionary *)infoPlist
        withExpoKitDevUrl:(NSString *)expoKitDevelopmentUrl
     withEmbeddedManifest:(NSDictionary *)embeddedManifest
-              isDetached:(BOOL)isDetached
       isDebugXCodeScheme:(BOOL)isDebugScheme
             isUserDetach:(BOOL)isUserDetach
 {
   [self _reset];
   NSMutableArray *allManifestUrls = [NSMutableArray array];
-  _isDetached = isDetached;
   _isDebugXCodeScheme = isDebugScheme;
 
   if (shellConfig) {
     _testEnvironment = [EXTest testEnvironmentFromString:shellConfig[@"testEnvironment"]];
-
-    if (_isDetached) {
-      // configure published shell url
-      [self _loadProductionUrlFromConfig:shellConfig];
-      if (_standaloneManifestUrl) {
-        [allManifestUrls addObject:_standaloneManifestUrl];
-      }
-      if (isDetached && isDebugScheme) {
-        // local detach development: point shell manifest url at local development url
-        [self _loadDetachedDevelopmentUrl:expoKitDevelopmentUrl];
-        if (_standaloneManifestUrl) {
-          [allManifestUrls addObject:_standaloneManifestUrl];
-        }
-      }
-      // load standalone url scheme
-      [self _loadUrlSchemeFromInfoPlist:infoPlist];
-      if (!_standaloneManifestUrl) {
-        @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                       reason:@"This app is configured to be a standalone app, but does not specify a standalone manifest url."
-                                     userInfo:nil];
-      }
-      
-      // load bundleUrl from embedded manifest
-      [self _loadEmbeddedBundleUrlWithManifest:embeddedManifest];
-
-      // load everything else from EXShell
-      [self _loadMiscPropertiesWithConfig:shellConfig andInfoPlist:infoPlist];
-    }
   }
   _allManifestUrls = allManifestUrls;
 }

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -157,7 +157,6 @@
 - (NSDictionary *)extraParams
 {
   // we allow the vanilla RN dev menu in some circumstances.
-  BOOL isStandardDevMenuAllowed = [EXEnvironment sharedEnvironment].isDetached;
   NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
     @"manifest": _appRecord.appLoader.manifest.rawManifestJSON,
     @"constants": @{
@@ -173,7 +172,7 @@
     @"exceptionsManagerDelegate": _exceptionHandler,
     @"initialUri": RCTNullIfNil([EXKernelLinkingManager initialUriWithManifestUrl:_appRecord.appLoader.manifestUrl]),
     @"isDeveloper": @([self enablesDeveloperTools]),
-    @"isStandardDevMenuAllowed": @(isStandardDevMenuAllowed),
+    @"isStandardDevMenuAllowed": @NO,
     @"testEnvironment": @([EXEnvironment sharedEnvironment].testEnvironment),
     @"services": [EXKernel sharedInstance].serviceRegistry.allServices,
     @"singletonModules": [EXModuleRegistryProvider singletonModules],
@@ -271,12 +270,7 @@
 
 - (NSString *)bundleResourceNameForAppFetcher:(EXAppFetcher *)appFetcher withManifest:(nonnull EXManifestsManifest *)manifest
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    NSLog(@"Standalone bundle remote url is %@", [EXEnvironment sharedEnvironment].standaloneManifestUrl);
-    return kEXEmbeddedBundleResourceName;
-  } else {
-    return manifest.legacyId;
-  }
+  return manifest.legacyId;
 }
 
 - (BOOL)appFetcherShouldInvalidateBundleCache:(EXAppFetcher *)appFetcher
@@ -541,11 +535,7 @@
 
 - (void)toggleDevMenu
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
-  } else {
-    [[EXKernel sharedInstance] switchTasks];
-  }
+  [[EXKernel sharedInstance] switchTasks];
 }
 
 - (void)setupWebSocketControls
@@ -631,18 +621,11 @@
 
 - (NSDictionary *)launchOptionsForBridge
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    // pass the native app's launch options to standalone bridge.
-    return [ExpoKit sharedInstance].launchOptions;
-  }
   return @{};
 }
 
 - (Class)moduleRegistryDelegateClass
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return [ExpoKit sharedInstance].moduleRegistryDelegateClass;
-  }
   return nil;
 }
 
@@ -722,11 +705,7 @@
 
 - (NSString *)_executionEnvironment
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return EXConstantsExecutionEnvironmentStandalone;
-  } else {
-    return EXConstantsExecutionEnvironmentStoreClient;
-  }
+  return EXConstantsExecutionEnvironmentStoreClient;
 }
 
 - (NSString *)scopedDocumentDirectory

--- a/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -33,25 +33,21 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   EXKernelAppRecord *destinationApp = nil;
   NSURL *urlToRoute = url;
 
-  if (isUniversalLink && [EXEnvironment sharedEnvironment].isDetached) {
-    destinationApp = [EXKernel sharedInstance].appRegistry.standaloneAppRecord;
-  } else {
-    urlToRoute = [[self class] uriTransformedForLinking:url isUniversalLink:isUniversalLink];
+  urlToRoute = [[self class] uriTransformedForLinking:url isUniversalLink:isUniversalLink];
 
-    if (appRegistry.standaloneAppRecord) {
-      destinationApp = appRegistry.standaloneAppRecord;
-    } else {
-      for (NSString *recordId in [appRegistry appEnumerator]) {
-        EXKernelAppRecord *appRecord = [appRegistry recordForId:recordId];
-        if (!appRecord || appRecord.status != kEXKernelAppRecordStatusRunning) {
-          continue;
-        }
-        if (appRecord.appLoader.manifestUrl && [[self class] _isUrl:urlToRoute deepLinkIntoAppWithManifestUrl:appRecord.appLoader.manifestUrl]) {
-          // this is a link into a bridge we already have running.
-          // use this bridge as the link's destination instead of the kernel.
-          destinationApp = appRecord;
-          break;
-        }
+  if (appRegistry.standaloneAppRecord) {
+    destinationApp = appRegistry.standaloneAppRecord;
+  } else {
+    for (NSString *recordId in [appRegistry appEnumerator]) {
+      EXKernelAppRecord *appRecord = [appRegistry recordForId:recordId];
+      if (!appRecord || appRecord.status != kEXKernelAppRecordStatusRunning) {
+        continue;
+      }
+      if (appRecord.appLoader.manifestUrl && [[self class] _isUrl:urlToRoute deepLinkIntoAppWithManifestUrl:appRecord.appLoader.manifestUrl]) {
+        // this is a link into a bridge we already have running.
+        // use this bridge as the link's destination instead of the kernel.
+        destinationApp = appRecord;
+        break;
       }
     }
   }
@@ -59,8 +55,7 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   if (destinationApp) {
     [[EXKernel sharedInstance] sendUrl:urlToRoute.absoluteString toAppRecord:destinationApp];
   } else {
-    if (![EXEnvironment sharedEnvironment].isDetached
-        && [EXKernel sharedInstance].appRegistry.homeAppRecord
+    if ([EXKernel sharedInstance].appRegistry.homeAppRecord
         && [EXKernel sharedInstance].appRegistry.homeAppRecord.appManager.status == kEXReactAppManagerStatusRunning) {
       // if Home is present and running, open a new app with this url.
       // if home isn't running yet, we'll handle the LaunchOptions url after home finishes launching.
@@ -99,11 +94,6 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
 
 - (BOOL)linkingModule:(__unused id)linkingModule shouldOpenExpoUrl:(NSURL *)url
 {
-  // do not attempt to route internal exponent links at all if we're in a detached app.
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return NO;
-  }
-  
   // we don't need to explicitly include a standalone app custom URL scheme here
   // because the default iOS linking behavior will still hand those links back to Exponent.
   NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
@@ -127,17 +117,6 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
     return nil;
   }
   NSURLComponents *components = [NSURLComponents componentsWithURL:uri resolvingAgainstBaseURL:YES];
-
-  // if the provided uri is the standalone app manifest uri,
-  // this should have been transformed into customscheme://deep-link
-  // and then all we do here is strip off the deep-link part.
-  if ([EXEnvironment sharedEnvironment].isDetached && [[EXEnvironment sharedEnvironment] isStandaloneUrlScheme:components.scheme]) {
-    if (useLegacy) {
-      return [NSString stringWithFormat:@"%@://%@", components.scheme, kEXExpoLegacyDeepLinkSeparator];
-    } else {
-      return [NSString stringWithFormat:@"%@://", components.scheme];
-    }
-  }
 
   NSMutableString* path = [NSMutableString stringWithString:components.path];
 
@@ -179,47 +158,14 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
   if (!uri) {
     return nil;
   }
-  
-  // If the initial uri is a universal link in a standalone app don't touch it.
-  if ([EXEnvironment sharedEnvironment].isDetached && isUniversalLink) {
-    return uri;
-  }
 
   NSURL *normalizedUri = [self _uriNormalizedForLinking:uri];
-
-  if ([EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].hasUrlScheme) {
-    // if the provided uri is the standalone app manifest uri,
-    // transform this into customscheme://deep-link
-    if ([self _isStandaloneManifestUrl:normalizedUri]) {
-      NSString *uriString = normalizedUri.absoluteString;
-      NSRange deepLinkRange = [uriString rangeOfString:kEXExpoDeepLinkSeparator];
-      // deprecated but we still need to support these links
-      // TODO: remove this
-      NSRange deepLinkRangeLegacy = [uriString rangeOfString:kEXExpoLegacyDeepLinkSeparator];
-      NSString *deepLink = @"";
-      if (deepLinkRange.length > 0 && [[self class] isExpoHostedUrl:normalizedUri]) {
-        deepLink = [uriString substringFromIndex:deepLinkRange.location + kEXExpoDeepLinkSeparator.length];
-      } else if (deepLinkRangeLegacy.length > 0) {
-        deepLink = [uriString substringFromIndex:deepLinkRangeLegacy.location + kEXExpoLegacyDeepLinkSeparator.length];
-      }
-      NSString *result = [NSString stringWithFormat:@"%@://%@", [EXEnvironment sharedEnvironment].urlScheme, deepLink];
-      return [NSURL URLWithString:result];
-    }
-  }
   return normalizedUri;
 }
 
 + (NSURL *)initialUriWithManifestUrl:(NSURL *)manifestUrl
 {
   NSURL *urlToTransform = manifestUrl;
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    NSDictionary *launchOptions = [ExpoKit sharedInstance].launchOptions;
-    NSURL *launchOptionsUrl = [[self class] initialUrlFromLaunchOptions:launchOptions];
-    if (!launchOptionsUrl) {
-      return nil;
-    }
-    urlToTransform = launchOptionsUrl;
-  }
 
   NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:urlToTransform resolvingAgainstBaseURL:YES];
   
@@ -230,14 +176,10 @@ NSString *kEXExpoLegacyDeepLinkSeparator = @"+";
 {
   NSURLComponents *components = [NSURLComponents componentsWithURL:uri resolvingAgainstBaseURL:YES];
 
-  if ([EXEnvironment sharedEnvironment].isDetached && [[EXEnvironment sharedEnvironment] isStandaloneUrlScheme:components.scheme]) {
-    // if we're standalone and this uri had the standalone scheme, leave it alone.
+  if ([components.scheme isEqualToString:@"https"] || [components.scheme isEqualToString:@"exps"]) {
+    components.scheme = @"exps";
   } else {
-    if ([components.scheme isEqualToString:@"https"] || [components.scheme isEqualToString:@"exps"]) {
-      components.scheme = @"exps";
-    } else {
-      components.scheme = @"exp";
-    }
+    components.scheme = @"exp";
   }
 
   if ([components.scheme isEqualToString:@"exp"] && [components.port integerValue] == 80) {

--- a/ios/Exponent/Kernel/Services/EXPermissionsManager.m
+++ b/ios/Exponent/Kernel/Services/EXPermissionsManager.m
@@ -50,11 +50,7 @@ EX_REGISTER_SINGLETON_MODULE(Permissions)
 }
 
 - (BOOL)hasGrantedPermission:(NSString *)permission forExperience:(NSString *)scopeKey
-{
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return YES;
-  }
-  
+{  
   return [self getPermission:[EXPermissionsManager mapPermissionType:permission] forExperience:scopeKey] == EXPermissionStatusGranted;
 }
 

--- a/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/EXUserNotificationManager.m
@@ -20,10 +20,6 @@ static NSString * const scopedIdentifierSeparator = @":";
 
 - (EXPendingNotification *)initialNotification
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return _pendingNotification;
-  }
-
   return nil;
 }
 
@@ -31,17 +27,11 @@ static NSString * const scopedIdentifierSeparator = @":";
 
 - (NSString *)internalIdForIdentifier:(NSString *)identifier scopeKey:(nonnull NSString *)scopeKey
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return identifier;
-  }
   return [NSString stringWithFormat:@"%@%@%@", scopeKey, scopedIdentifierSeparator, identifier];
 }
 
 - (NSString *)exportedIdForInternalIdentifier:(NSString *)identifier
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return identifier;
-  }
   NSArray<NSString *> *components = [identifier componentsSeparatedByString:scopedIdentifierSeparator];
   return [[components subarrayWithRange:NSMakeRange(1, components.count - 1)] componentsJoinedByString:scopedIdentifierSeparator];
 }
@@ -51,9 +41,6 @@ static NSString * const scopedIdentifierSeparator = @":";
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
   EXPendingNotification *pendingNotification = [[EXPendingNotification alloc] initWithNotificationResponse:response identifiersManager:self];
-  if (![[EXKernel sharedInstance] sendNotification:pendingNotification] && [EXEnvironment sharedEnvironment].isDetached) {
-    _pendingNotification = pendingNotification;
-  }
   completionHandler();
 }
 
@@ -83,10 +70,6 @@ static NSString * const scopedIdentifierSeparator = @":";
   // If the app is active we do not show the alert, but we deliver the notification to the experience.
 
   EXPendingNotification *pendingNotification = [[EXPendingNotification alloc] initWithNotification:notification];
-  if (![[EXKernel sharedInstance] sendNotification:pendingNotification] && [EXEnvironment sharedEnvironment].isDetached) {
-    _pendingNotification = pendingNotification;
-  }
-
   completionHandler(UNNotificationPresentationOptionNone);
 }
 

--- a/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
+++ b/ios/Exponent/Kernel/Services/Notifications/EXRemoteNotificationManager.m
@@ -239,10 +239,6 @@ typedef void(^EXRemoteNotificationAPNSTokenHandler)(NSData * _Nullable apnsToken
 
 - (BOOL)supportsCurrentRuntimeEnvironment
 {
-  if (![EXEnvironment sharedEnvironment].isDetached) {
-    return YES;
-  }
-
 #ifdef EX_DETACHED_SERVICE
   BOOL isBuiltByService = YES;
 #else

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -36,11 +36,7 @@
 #import <ABI47_0_0React/ABI47_0_0RCTAppearance.h>
 #endif
 
-#if defined(EX_DETACHED)
-#import "ExpoKit-Swift.h"
-#else
 #import "Expo_Go-Swift.h"
-#endif // defined(EX_DETACHED)
 
 @import EXManifests;
 
@@ -77,7 +73,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) NSDate *dtmLastFatalErrorShown;
 @property (nonatomic, strong) NSMutableArray<UIViewController *> *backgroundedControllers;
 
-@property (nonatomic, assign) BOOL isStandalone;
 @property (nonatomic, assign) BOOL isHomeApp;
 @property (nonatomic, assign) UIInterfaceOrientation previousInterfaceOrientation;
 
@@ -113,7 +108,6 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (self = [super init]) {
     _appRecord = record;
-    _isStandalone = [EXEnvironment sharedEnvironment].isDetached;
     // For iPads traitCollectionDidChange will not be called (it's always in the same size class). It is necessary
     // to init it in here, so it's possible to return it in the didUpdateDimensionsEvent of the module
     if (ScreenOrientationRegistry.shared.currentTraitCollection == nil) {
@@ -138,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
   _isHomeApp = _appRecord == [EXKernel sharedInstance].appRegistry.homeAppRecord;
 
   // show LoadingCancelView in managed apps only
-  if (!self.isStandalone && !self.isHomeApp) {
+  if (!self.isHomeApp) {
     self.appLoadingCancelView = [EXAppLoadingCancelView new];
     // if home app is available then LoadingCancelView can show `go to home` button
     if ([EXKernel sharedInstance].appRegistry.homeAppRecord) {
@@ -150,15 +144,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   // show LoadingProgressWindow in the development client for all apps other than production home
   BOOL isProductionHomeApp = self.isHomeApp && ![EXEnvironment sharedEnvironment].isDebugXCodeScheme;
-  self.appLoadingProgressWindowController = [[EXAppLoadingProgressWindowController alloc] initWithEnabled:!self.isStandalone && !isProductionHomeApp];
+  self.appLoadingProgressWindowController = [[EXAppLoadingProgressWindowController alloc] initWithEnabled:true && !isProductionHomeApp];
 
   // show SplashScreen in standalone apps and home app only
   // SplashScreen for managed is shown once the manifest is available
   if (self.isHomeApp) {
     EXHomeAppSplashScreenViewProvider *homeAppSplashScreenViewProvider = [EXHomeAppSplashScreenViewProvider new];
     [self _showSplashScreenWithProvider:homeAppSplashScreenViewProvider];
-  } else if (self.isStandalone) {
-    [self _showSplashScreenWithProvider:[EXSplashScreenViewNativeProvider new]];
   }
 
   self.view.backgroundColor = [UIColor whiteColor];
@@ -229,14 +221,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert(NO, @"AppViewController error handler was called on an object that isn't an NSError");
 #endif
     return;
-  }
-
-  // we don't ever want to show any Expo UI in a production standalone app, so hard crash
-  if ([EXEnvironment sharedEnvironment].isDetached && ![_appRecord.appManager enablesDeveloperTools]) {
-    NSException *e = [NSException exceptionWithName:@"ExpoFatalError"
-                                             reason:[NSString stringWithFormat:@"Expo encountered a fatal error: %@", [error localizedDescription]]
-                                           userInfo:@{NSUnderlyingErrorKey: error}];
-    @throw e;
   }
 
   NSString *domain = (error && error.domain) ? error.domain : @"";
@@ -349,7 +333,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)_showOrReconfigureManagedAppSplashScreen:(EXManifestsManifest *)manifest
 {
-  if (_isStandalone || _isHomeApp) {
+  if (_isHomeApp) {
     return;
   }
   if (!_managedAppSplashScreenViewProvider) {
@@ -363,7 +347,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)_showCachedExperienceAlert
 {
-  if (self.isStandalone || self.isHomeApp) {
+  if (self.isHomeApp) {
     return;
   }
 

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -141,7 +141,7 @@
 {
   EXKernelAppRecord *homeRecord = [EXKernel sharedInstance].appRegistry.homeAppRecord;
   _btnBack.hidden = (!homeRecord || _appRecord == homeRecord);
-  _lblUrl.hidden = (!homeRecord && ![self _isDevDetached]);
+  _lblUrl.hidden = !homeRecord;
   _lblUrl.text = _appRecord.appLoader.manifestUrl.absoluteString;
   // TODO: maybe hide retry (see BrowserErrorView)
   [self setNeedsLayout];
@@ -171,11 +171,6 @@
       [url rangeOfString:@"172."].length > 0
     )
   );
-}
-
-- (BOOL)_isDevDetached
-{
-  return [EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].isDebugXCodeScheme;
 }
 
 // for creating a filled button background in iOS < 15

--- a/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -4,9 +4,7 @@
 
 #import <ExpoModulesCore/EXDefines.h>
 
-#if !defined(EX_DETACHED)
 #import "Expo_Go-Swift.h"
-#endif // !defined(EX_DETACHED)
 
 #import "EXUtil.h"
 
@@ -30,7 +28,6 @@
 
 - (void)show
 {
-#if !defined(EX_DETACHED)
   if (!_enabled) {
     return;
   }
@@ -68,12 +65,10 @@
     self.textLabel.text =  @"Waiting for server ...";
     self.window.hidden = NO;
   });
-#endif // !defined(EX_DETACHED)
 }
 
 - (void)hide
 {
-#if !defined(EX_DETACHED)
   if (!_enabled) {
     return;
   }
@@ -87,12 +82,10 @@
       self.window = nil;
     }
   });
-#endif // !defined(EX_DETACHED)
 }
 
 - (void)updateStatusWithProgress:(EXLoadingProgress *)progress
 {
-#if !defined(EX_DETACHED)
   if (!_enabled) {
     return;
   }
@@ -109,12 +102,10 @@
     // TODO: (@bbarthec) maybe it's better to show/hide this based on other thing than progress status reported by the fetcher?
     self.window.hidden = !(progress.total.floatValue > 0);
   });
-#endif // !defined(EX_DETACHED)
 }
 
 - (void)updateStatus:(EXAppLoaderRemoteUpdateStatus)status
 {
-#if !defined(EX_DETACHED)
   if (!_enabled) {
     return;
   }
@@ -132,7 +123,6 @@
     self.textLabel.text = statusText;
     [self.textLabel setNeedsDisplay];
   });
-#endif // !defined(EX_DETACHED)
 }
 
 + (nullable NSString *)_loadingViewTextForStatus:(EXAppLoaderRemoteUpdateStatus)status

--- a/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
+++ b/ios/Exponent/Versioned/Core/UniversalModules/EXConstantsBinding.m
@@ -30,9 +30,6 @@
   [constants setValue:[self expoClientVersion] forKey:@"expoVersion"];
 
   BOOL isDetached = NO;
-#ifdef EX_DETACHED
-  isDetached = YES;
-#endif
 
   constants[@"isDetached"] = @(isDetached);
   

--- a/packages/expo-constants/ios/EXConstantsService.h
+++ b/packages/expo-constants/ios/EXConstantsService.h
@@ -8,7 +8,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString * const EXConstantsExecutionEnvironmentBare;
-FOUNDATION_EXPORT NSString * const EXConstantsExecutionEnvironmentStandalone;
 FOUNDATION_EXPORT NSString * const EXConstantsExecutionEnvironmentStoreClient;
 
 @interface EXConstantsService : NSObject <EXInternalModule, EXConstantsInterface>

--- a/packages/expo-constants/ios/EXConstantsService.m
+++ b/packages/expo-constants/ios/EXConstantsService.m
@@ -9,7 +9,6 @@
 #import <EXConstants/EXConstantsInstallationIdProvider.h>
 
 NSString * const EXConstantsExecutionEnvironmentBare = @"bare";
-NSString * const EXConstantsExecutionEnvironmentStandalone = @"standalone";
 NSString * const EXConstantsExecutionEnvironmentStoreClient = @"storeClient";
 
 @interface EXConstantsService ()


### PR DESCRIPTION
# Why

This greps for and removes `isDetached` and `EX_DETACHED` variables/compiler flags since as far as I understand the only use of this code is Expo Go (as of removing classic builds).

# How

Grep, remove.

# Test Plan

Build Expo Go

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
