### PR TITLE
[ios] Remove more standalone stuff

### DIFF
--- a/ios/Exponent/ExpoKit/EXViewController.m
+++ b/ios/Exponent/ExpoKit/EXViewController.m
@@ -36,9 +36,8 @@
 
 - (void)createRootAppAndMakeVisible
 {
-  NSURL *standaloneAppUrl = [NSURL URLWithString:[EXEnvironment sharedEnvironment].standaloneManifestUrl];
   NSDictionary *initialProps = [[EXKernel sharedInstance] initialAppPropsFromLaunchOptions:[ExpoKit sharedInstance].launchOptions];
-  EXKernelAppRecord *appRecord = [[EXKernel sharedInstance] createNewAppWithUrl:standaloneAppUrl
+  EXKernelAppRecord *appRecord = [[EXKernel sharedInstance] createNewAppWithUrl:nil
                                                                    initialProps:initialProps];
 
   UIViewController *viewControllerToShow = (UIViewController *)appRecord.viewController;

--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcherCacheOnly.m
@@ -39,15 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)_fetchJSBundle
 {
   EXCachedResourceBehavior cacheBehavior = EXCachedResourceOnlyCache;
-  // This is a bit messy, but essentially as long as remote updates are enabled
-  // we never want to 100% fall back to cache, since the OS can reap files from
-  // the cache and we might not have a JS bundle even if we have its corresponding
-  // manifest cached. We always prefer using the network as a last ditch effort to
-  // download a bundle rather than failing to launch or showing an error screen.
-  // TODO(eric): in new updates impl make this less messy
-  if ([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    cacheBehavior = EXCachedResourceFallBackToNetwork;
-  }
   __weak typeof(self) weakSelf = self;
   [self fetchJSBundleWithManifest:self.manifest cacheBehavior:cacheBehavior timeoutInterval:kEXJSBundleTimeout progress:nil success:^(NSData * _Nonnull data) {
     __strong typeof(weakSelf) strongSelf = weakSelf;

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -285,9 +285,6 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
                                   // HACK: because `SecItemCopyMatching` doesn't work in older iOS (see EXApiUtil.m)
                                   ([UIDevice currentDevice].systemVersion.floatValue < 10) ||
                                   
-                                  // the developer disabled manifest verification
-                                  [EXEnvironment sharedEnvironment].isManifestVerificationBypassed ||
-                                  
                                   // we're using a copy that came with the NSBundle and was therefore already codesigned
                                   [self isUsingEmbeddedResource] ||
                                   

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -343,7 +343,7 @@ NS_ASSUME_NONNULL_BEGIN
     EXUpdatesConfig.EXUpdatesConfigScopeKeyKey: httpManifestUrl.absoluteString,
     EXUpdatesConfig.EXUpdatesConfigReleaseChannelKey: releaseChannel,
     EXUpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: @NO,
-    EXUpdatesConfig.EXUpdatesConfigEnabledKey: @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
+    EXUpdatesConfig.EXUpdatesConfigEnabledKey: @YES,
     EXUpdatesConfig.EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
     EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueNever,
     EXUpdatesConfig.EXUpdatesConfigExpectsSignedManifestKey: @YES,
@@ -383,11 +383,6 @@ NS_ASSUME_NONNULL_BEGIN
   updatesConfig[EXUpdatesConfig.EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey] = @YES;
 
   _config = [EXUpdatesConfig configFromDictionary:updatesConfig];
-
-  if (![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    [self _launchWithNoDatabaseAndError:nil];
-    return;
-  }
 
   EXUpdatesDatabaseManager *updatesDatabaseManager = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
 
@@ -526,7 +521,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // if the app bypassed verification or the manifest is scoped to a random anonymous
     // scope key, automatically verify it
-    if (![mutableManifest[@"isVerified"] boolValue] && (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [EXAppLoaderExpoUpdates _isAnonymousExperience:manifest])) {
+    if (![mutableManifest[@"isVerified"] boolValue] && ([EXAppLoaderExpoUpdates _isAnonymousExperience:manifest])) {
       mutableManifest[@"isVerified"] = @(YES);
     }
 

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -18,19 +18,9 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 @property (nonatomic, readonly) BOOL isDebugXCodeScheme;
 
 /**
- *  The manifest url of the standalone app (if isDetached == true).
- */
-@property (nonatomic, readonly, nullable) NSString *standaloneManifestUrl;
-
-/**
  *  The custom url scheme for the standalone app (if isDetached == true).
  */
 @property (nonatomic, readonly, nullable) NSString *urlScheme;
-
-/**
- *  The release channel from which to fetch the standalone app (if isDetached == true).
- */
-@property (nonatomic, readonly, nonnull) NSString *releaseChannel;
 
 /**
  *  The `bundleUrl` given by the embedded manifest that shipped with this NSBundle, if any.
@@ -41,27 +31,6 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
  *  Contains `standaloneManifestUrl`, and may also contain a local development url for a detached project.
  */
 @property (nonatomic, readonly, nonnull) NSArray *allManifestUrls;
-
-/**
- *  True by default in ExpoKit apps created with `expo eject`, because the owner of the app needs to
- *  manually modify their App Id to enable keychain sharing.
- */
-@property (nonatomic, readonly) BOOL isManifestVerificationBypassed;
-
-/**
- *  Whether remote updates are allowed at all for this standalone app.
- */
-@property (nonatomic, readonly) BOOL areRemoteUpdatesEnabled;
-
-/**
-*  Whether to check for updates to this app automatically on launch. Applies to standalone apps only.
-*/
-@property (nonatomic, readonly) BOOL updatesCheckAutomatically;
-
-/**
-*  Timeout when checking for updates on launch after which to fall back to cache. Applies to standalone apps only.
-*/
-@property (nonatomic, readonly) NSNumber *updatesFallbackToCacheTimeout;
 
 /**
  *  Whether the app is running in a test environment (local Xcode test target, CI, or not at all).

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -46,14 +46,9 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
 
 - (void)_reset
 {
-  _standaloneManifestUrl = nil;
   _urlScheme = nil;
-  _areRemoteUpdatesEnabled = YES;
-  _updatesCheckAutomatically = YES;
-  _updatesFallbackToCacheTimeout = @(0);
   _allManifestUrls = @[];
   _isDebugXCodeScheme = NO;
-  _releaseChannel = @"default";
 }
 
 - (void)_loadDefaultConfig
@@ -119,26 +114,6 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
   _allManifestUrls = allManifestUrls;
 }
 
-- (void)_loadProductionUrlFromConfig:(NSDictionary *)shellConfig
-{
-  _standaloneManifestUrl = shellConfig[@"manifestUrl"];
-  if ([ExpoKit sharedInstance].publishedManifestUrlOverride) {
-    _standaloneManifestUrl = [ExpoKit sharedInstance].publishedManifestUrlOverride;
-  }
-}
-
-- (void)_loadDetachedDevelopmentUrl:(NSString *)expoKitDevelopmentUrl
-{
-  if (expoKitDevelopmentUrl) {
-    _standaloneManifestUrl = expoKitDevelopmentUrl;
-  } else {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:@"You are running a detached app from Xcode, but it hasn't been configured for local development yet. "
-                                           "You must run a packager for this Expo project before running it from XCode."
-                                 userInfo:nil];
-  }
-}
-
 - (void)_loadUrlSchemeFromInfoPlist:(NSDictionary *)infoPlist
 {
   if (infoPlist[@"CFBundleURLTypes"]) {
@@ -158,27 +133,6 @@ NSString * const kEXEmbeddedManifestResourceName = @"shell-app-manifest";
       }
     }
   }
-}
-
-- (void)_loadMiscPropertiesWithConfig:(NSDictionary *)shellConfig andInfoPlist:(NSDictionary *)infoPlist
-{
-  _isManifestVerificationBypassed = [shellConfig[@"isManifestVerificationBypassed"] boolValue];
-  _areRemoteUpdatesEnabled = (shellConfig[@"areRemoteUpdatesEnabled"] == nil)
-    ? YES
-    : [shellConfig[@"areRemoteUpdatesEnabled"] boolValue];
-  _updatesCheckAutomatically = (shellConfig[@"updatesCheckAutomatically"] == nil)
-    ? YES
-    : [shellConfig[@"updatesCheckAutomatically"] boolValue];
-  _updatesFallbackToCacheTimeout = (shellConfig[@"updatesFallbackToCacheTimeout"] &&
-                                    [shellConfig[@"updatesFallbackToCacheTimeout"] isKindOfClass:[NSNumber class]])
-    ? shellConfig[@"updatesFallbackToCacheTimeout"]
-    : @(0);
-  if (infoPlist[@"ExpoReleaseChannel"]) {
-    _releaseChannel = infoPlist[@"ExpoReleaseChannel"];
-  } else {
-    _releaseChannel = (shellConfig[@"releaseChannel"] == nil) ? @"default" : shellConfig[@"releaseChannel"];
-  }
-  // other shell config goes here
 }
 
 - (void)_loadEmbeddedBundleUrlWithManifest:(NSDictionary *)manifest

--- a/ios/Tests/Environment/EXEnvironmentTests.m
+++ b/ios/Tests/Environment/EXEnvironmentTests.m
@@ -28,9 +28,6 @@
   NSDictionary *expectedShellConfig = [EXEnvironmentMocks shellConfig];
   NSString *expectedUrlScheme = [EXEnvironmentMocks prodUrlScheme];
   NSDictionary *expectedEmbeddedManifest = [EXEnvironmentMocks embeddedManifest];
-  XCTAssert(_environment.isDetached, @"EXEnvironment should indicate isDetached == true when a valid standalone config is provided");
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedShellConfig[@"manifestUrl"]], @"EXEnvironment should adopt the manifest url specified in the config");
-  XCTAssert([_environment.releaseChannel isEqualToString:@"default"], @"EXEnvironment should use default release channel when none is specified");
   XCTAssert([_environment.urlScheme isEqualToString:expectedUrlScheme], @"EXEnvironment should adopt url scheme %@ when configured", expectedUrlScheme);
   XCTAssert([_environment.embeddedBundleUrl isEqualToString:expectedEmbeddedManifest[@"bundleUrl"]], @"EXEnvironment should adopt the bundle url specified in the embedded manifest");
 }
@@ -41,9 +38,6 @@
   NSString *expectedUrl = [EXEnvironmentMocks expoKitDevUrl];
   NSString *expectedUrlScheme = [EXEnvironmentMocks prodUrlScheme];
   NSDictionary *expectedEmbeddedManifest = [EXEnvironmentMocks embeddedManifest];
-  XCTAssert(_environment.isDetached, @"EXEnvironment should indicate isDetached == true when a dev detach config is provided");
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedUrl], @"EXEnvironment should adopt the local dev url when a dev detach config is provided");
-  XCTAssert([_environment.releaseChannel isEqualToString:@"default"], @"EXEnvironment should use default release channel when a dev detach config is provided");
   XCTAssert([_environment.urlScheme isEqualToString:expectedUrlScheme], @"EXEnvironment should adopt url scheme %@ when configured", expectedUrlScheme);
   XCTAssert([_environment.embeddedBundleUrl isEqualToString:expectedEmbeddedManifest[@"bundleUrl"]], @"EXEnvironment should adopt the bundle url specified in the embedded manifest");
 }
@@ -86,7 +80,6 @@
                       isDetached:YES
               isDebugXCodeScheme:NO
                     isUserDetach:YES];
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedShellConfig[@"manifestUrl"]], @"EXEnvironment should ignore the ExpoKit dev url when using a prod build scheme");
 }
 
 - (void)testDoesDefaultConfigRespectXcodeScheme


### PR DESCRIPTION
# Why

This removes more standalone stuff from Expo Go

# How

Grep and remove

# Test Plan

Build Expo Go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
