### PR TITLE
[docs] Fix "app stores" inconsistent usage

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/AppStores.yml
+++ b/docs/.vale/writing-styles/expo-docs/AppStores.yml
@@ -2,8 +2,7 @@ extends: substitution
 message: "Consider using '%s' instead of '%s'"
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-app-stores'
 level: warning
-ignorecase: true
+ignorecase: false
 swap:
   App Stores: app stores
   app Stores: app stores
-  App stores: app stores

--- a/docs/.vale/writing-styles/expo-docs/Lists.yml
+++ b/docs/.vale/writing-styles/expo-docs/Lists.yml
@@ -5,4 +5,4 @@ level: warning
 scope: raw
 nonword: true
 tokens:
-  - '^\s[0]*\.\D'
+  - '^\s0\.'

--- a/docs/pages/archive/classic-updates/building-standalone-apps.mdx
+++ b/docs/pages/archive/classic-updates/building-standalone-apps.mdx
@@ -10,7 +10,7 @@ Classic Build service allows you to create standalone binaries for the Expo app 
 
 An Apple Developer account is required to build a standalone iOS app, but a Google Play Developer account is not required to build the standalone Android app. To submit to either app store, you need a developer account on that store.
 
-> We recommend that you read the best practices about [Deploying to App Stores](/distribution/app-stores) to ensure your app gets accepted into the Apple and Google stores. Once you've created an amazing app, EAS Build can help you build it and then submit it to the app stores.
+> We recommend that you read the [best practices about app stores](/distribution/app-stores) to ensure your app gets accepted into the Apple and Google stores. Once you've created an amazing app, EAS Build can help you build it and then submit it to the app stores.
 
 ## 1. Install Expo CLI
 
@@ -54,7 +54,7 @@ Here are the required fields that you have to pay attention to when configuring 
 - The `slug` should be a URL safe value. The slug will be included in the URL that your app's JavaScript is published to. For example: `expo.dev/@community/native-component-list`, where `community` is the username and `native-component-list` is the slug.
 - The `ios.buildNumber` and `android.versionCode` distinguish different binaries of your app. Make sure to increment these for each build you upload to the App Store or Google Play Store.
 
-There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you to go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [Deploying to App Stores](/distribution/app-stores) documentation. It provides details on what types of metadata are required for the app stores.
+There are other options you can add to **app.json**. For example, some developers like to configure their own build number, linking scheme, etc. We recommend you go through [Configuration with app.json/app.config.js](/workflow/configuration) for the full specification. At this step, also check [App stores best practices](/distribution/app-stores). It provides details on what types of metadata are required for the app stores.
 
 ## 3. Start the build
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Vale throw warnings for inconsistent usage of "app stores". A few of them were false alarms.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR 
- updates the AppStore style in Vale
- fixes the inconsistent usage of the term
- fixes minor grammatical issues
- also fix Lists regex

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `yarn run lint-prose` and `expo-docs.AppStores` warnings are not shown.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
