### PR TITLE
[image][iOS] Suppress operation canceled error

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Suppress "Operation cancelled by user during sending the request" error when the load request is canceled (interrupted) by a new one.
+
 ### 💡 Others
 
 ## 1.5.0 — 2023-09-04

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Suppress "Operation cancelled by user during sending the request" error when the load request is canceled (interrupted) by a new one.
+- Suppress "Operation cancelled by user during sending the request" error when the load request is canceled (interrupted) by a new one. ([#24279](https://github.com/expo/expo/pull/24279) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -197,7 +197,13 @@ public final class ImageView: ExpoView {
     _ imageUrl: URL?
   ) {
     if let error = error {
-      onError(["error": error.localizedDescription])
+      let code = (error as NSError).code
+
+      // SDWebImage throws an error when loading operation is canceled (interrupted) by another load request.
+      // We do want to ignore that one and wait for the new request to load.
+      if code != SDWebImageError.cancelled.rawValue {
+        onError(["error": error.localizedDescription])
+      }
       return
     }
     guard finished else {


### PR DESCRIPTION
# Why

Fixes #24125 

# How

`SDWebImage` throws `SDWebImageErrorCancelled` error when the load request is canceled (interrupted) by another load request for the same resource. It doesn't make much sense to pass this error to JS as the image may eventually load, so I'm suppressing it in this PR.

# Test Plan

Tested using the snack provided in the issue (https://snack.expo.dev/@brodanoel/expo-image-error) and confirmed that `onError` is no longer getting called.
