### PR TITLE
[core][iOS] AppContext configuration

### DIFF
--- a/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -55,7 +55,8 @@ final class VersionManager: EXVersionManagerObjC {
     // that would work well for us (especially properly invalidating existing app context on reload).
     let legacyModuleRegistry = createLegacyModuleRegistry(params: params, manifest: manifest)
     let legacyModulesProxy = LegacyNativeModulesProxy(customModuleRegistry: legacyModuleRegistry)
-    let appContext = AppContext(legacyModulesProxy: legacyModulesProxy, legacyModuleRegistry: legacyModuleRegistry)
+    let config = createAppContextConfig()
+    let appContext = AppContext(legacyModulesProxy: legacyModulesProxy, legacyModuleRegistry: legacyModuleRegistry, config: config)
 
     self.appContext = appContext
     self.legacyModuleRegistry = legacyModuleRegistry
@@ -92,6 +93,22 @@ final class VersionManager: EXVersionManagerObjC {
       return
     }
     appContext.moduleRegistry.register(module: ExpoGoModule(appContext: appContext, manifest: manifest))
+  }
+
+  private func createAppContextConfig() -> AppContextConfig {
+    guard let fileSystemDirectories = params["fileSystemDirectories"] as? [AnyHashable: Any] else {
+      fatalError("Missing file system directories in the params")
+    }
+    guard let documentDirectory = fileSystemDirectories["documentDirectory"] as? String else {
+      fatalError("Missing document directory param")
+    }
+    guard let cacheDirectory = fileSystemDirectories["cachesDirectory"] as? String else {
+      fatalError("Missing caches directory param")
+    }
+    return AppContextConfig(
+      documentDirectory: URL(fileURLWithPath: documentDirectory),
+      cacheDirectory: URL(fileURLWithPath: cacheDirectory)
+    )
   }
 }
 

--- a/packages/expo-modules-core/ios/Swift/AppContext.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContext.swift
@@ -13,6 +13,11 @@ public final class AppContext: NSObject {
   }
 
   /**
+   The app context configuration.
+   */
+  public let config: AppContextConfig
+
+  /**
    The module registry for the app context.
    */
   public private(set) lazy var moduleRegistry: ModuleRegistry = {
@@ -78,12 +83,14 @@ public final class AppContext: NSObject {
   /**
    Designated initializer without modules provider.
    */
-  public override init() {
+  public init(config: AppContextConfig = .default) {
+    self.config = config
+
     super.init()
     listenToClientAppNotifications()
   }
 
-  public convenience init(legacyModulesProxy: Any, legacyModuleRegistry: Any) {
+  public convenience init(legacyModulesProxy: Any, legacyModuleRegistry: Any, config: AppContextConfig = .default) {
     self.init()
     self.legacyModulesProxy = legacyModulesProxy as? LegacyNativeModulesProxy
     self.legacyModuleRegistry = legacyModuleRegistry as? EXModuleRegistry

--- a/packages/expo-modules-core/ios/Swift/AppContextConfig.swift
+++ b/packages/expo-modules-core/ios/Swift/AppContextConfig.swift
@@ -1,0 +1,13 @@
+// Copyright 2023-present 650 Industries. All rights reserved.
+
+public struct AppContextConfig {
+  public static var `default` = AppContextConfig()
+
+  public let documentDirectory: URL?
+  public let cacheDirectory: URL?
+
+  public init(documentDirectory: URL? = nil, cacheDirectory: URL? = nil) {
+    self.documentDirectory = documentDirectory ?? FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+    self.cacheDirectory = cacheDirectory ?? FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+  }
+}


### PR DESCRIPTION
# Why

We need a way to pass some configuration params to the AppContext that can be read from other modules (e.g. file directories from `expo-file-system`)

# How

Introduced a `AppContextConfig` struct that can be passed to `AppContext` initializer

I accidentally already pushed a changelog entry to main 🙈 (https://github.com/expo/expo/commit/9ea1e41b813c9d99c58077180c11b784d5b85720)

# Test Plan

Tested as part of #23943