### PR TITLE
[docs] Make Copiable header links / Anchor tags for collapsible headers 

### DIFF
--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { LinkBase } from '@expo/styleguide';
 import * as React from 'react';
+import tippy from 'tippy.js';
 
 import { AdditionalProps } from '~/common/headingManager';
 import PermalinkIcon from '~/components/icons/Permalink';
@@ -75,6 +76,10 @@ const PermalinkBase = ({ component, children, className, ...rest }: BaseProps) =
 
 const Permalink: React.FC<EnhancedProps> = withHeadingManager(
   (props: EnhancedProps & HeadingManagerProps) => {
+    React.useEffect(() => {
+      tippy('#docs-anchor-permalink-' + heading.slug);
+    }, []);
+
     // NOTE(jim): Not the greatest way to generate permalinks.
     // for now I've shortened the length of permalinks.
     const component = props.children as JSX.Element;
@@ -96,7 +101,14 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(
         <LinkBase css={STYLES_PERMALINK_LINK} href={'#' + heading.slug} ref={heading.ref}>
           <span css={STYLES_PERMALINK_TARGET} id={heading.slug} />
           <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
-          <span css={STYLES_PERMALINK_ICON}>
+          <span
+            id={'docs-anchor-permalink-' + heading.slug}
+            data-tippy-content="Click to copy anchor link"
+            onClick={() => {
+              const url = window.location.href.replace(/#.*/, '') + '#' + heading.slug;
+              navigator.clipboard?.writeText(url);
+            }}
+            css={STYLES_PERMALINK_ICON}>
             <PermalinkIcon />
           </span>
         </LinkBase>

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { LinkBase } from '@expo/styleguide';
 import * as React from 'react';
-import tippy from 'tippy.js';
+import tippy, { roundArrow } from 'tippy.js';
 
 import { AdditionalProps } from '~/common/headingManager';
 import PermalinkIcon from '~/components/icons/Permalink';

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -74,9 +74,13 @@ const PermalinkBase = ({ component, children, className, ...rest }: BaseProps) =
     children
   );
 
+// @ts-ignore Jest ESM issue https://github.com/facebook/jest/issues/9430
+const { default: testTippy } = tippy;
+
 const PermalinkCopyIcon = ({ slug }: { slug: string }) => {
+  const tippyFunc = testTippy || tippy;
   React.useEffect(() => {
-    tippy('#docs-anchor-permalink-' + slug, {
+    tippyFunc('#docs-anchor-permalink-' + slug, {
       content: 'Click to copy anchor link',
     });
   }, []);

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -74,12 +74,31 @@ const PermalinkBase = ({ component, children, className, ...rest }: BaseProps) =
     children
   );
 
+const PermalinkCopyIcon = ({ slug }: { slug: string }) => {
+  React.useEffect(() => {
+    tippy('#docs-anchor-permalink-' + slug, {
+      content: 'Click to copy anchor link',
+    });
+  }, []);
+
+  return (
+    <span
+      id={'docs-anchor-permalink-' + slug}
+      onClick={event => {
+        event.preventDefault();
+        const url = window.location.href.replace(/#.*/, '') + '#' + slug;
+        navigator.clipboard?.writeText(url);
+      }}
+      css={STYLES_PERMALINK_ICON}>
+      <PermalinkIcon />
+    </span>
+  );
+};
+
+export { PermalinkCopyIcon };
+
 const Permalink: React.FC<EnhancedProps> = withHeadingManager(
   (props: EnhancedProps & HeadingManagerProps) => {
-    React.useEffect(() => {
-      tippy('#docs-anchor-permalink-' + heading.slug);
-    }, []);
-
     // NOTE(jim): Not the greatest way to generate permalinks.
     // for now I've shortened the length of permalinks.
     const component = props.children as JSX.Element;
@@ -101,16 +120,7 @@ const Permalink: React.FC<EnhancedProps> = withHeadingManager(
         <LinkBase css={STYLES_PERMALINK_LINK} href={'#' + heading.slug} ref={heading.ref}>
           <span css={STYLES_PERMALINK_TARGET} id={heading.slug} />
           <span css={STYLED_PERMALINK_CONTENT}>{children}</span>
-          <span
-            id={'docs-anchor-permalink-' + heading.slug}
-            data-tippy-content="Click to copy anchor link"
-            onClick={() => {
-              const url = window.location.href.replace(/#.*/, '') + '#' + heading.slug;
-              navigator.clipboard?.writeText(url);
-            }}
-            css={STYLES_PERMALINK_ICON}>
-            <PermalinkIcon />
-          </span>
+          <PermalinkCopyIcon slug={heading.slug} />
         </LinkBase>
       </PermalinkBase>
     );

--- a/docs/components/Permalink.tsx
+++ b/docs/components/Permalink.tsx
@@ -82,6 +82,8 @@ const PermalinkCopyIcon = ({ slug }: { slug: string }) => {
   React.useEffect(() => {
     tippyFunc('#docs-anchor-permalink-' + slug, {
       content: 'Click to copy anchor link',
+      arrow: roundArrow,
+      offset: [0, 0],
     });
   }, []);
 

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -20,7 +20,8 @@ exports[`APISection expo-apple-authentication 1`] = `
         Component
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-component"
       >
         <svg
           aria-label="permalink"
@@ -75,7 +76,8 @@ exports[`APISection expo-apple-authentication 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationbutton"
         >
           <svg
             aria-label="permalink"
@@ -308,7 +310,8 @@ for more details.
           Props
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-props"
         >
           <svg
             aria-label="permalink"
@@ -364,7 +367,8 @@ for more details.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-buttonstyle"
             >
               <svg
                 aria-label="permalink"
@@ -448,7 +452,8 @@ for more details.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-buttontype"
             >
               <svg
                 aria-label="permalink"
@@ -532,7 +537,8 @@ for more details.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-cornerradius"
             >
               <svg
                 aria-label="permalink"
@@ -624,7 +630,8 @@ for more details.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-onpress"
             >
               <svg
                 aria-label="permalink"
@@ -718,7 +725,8 @@ in here.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-style"
             >
               <svg
                 aria-label="permalink"
@@ -843,7 +851,8 @@ properties.
             Inherited Props
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-inherited-props"
           >
             <svg
               aria-label="permalink"
@@ -914,7 +923,8 @@ properties.
         Methods
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-methods"
       >
         <svg
           aria-label="permalink"
@@ -969,7 +979,8 @@ properties.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-getcredentialstateasyncuser"
         >
           <svg
             aria-label="permalink"
@@ -1237,7 +1248,8 @@ value depending on the state of the credential.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-isavailableasync"
         >
           <svg
             aria-label="permalink"
@@ -1373,7 +1385,8 @@ value depending on the state of the credential.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-refreshasyncoptions"
         >
           <svg
             aria-label="permalink"
@@ -1606,7 +1619,8 @@ refresh operation.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-signinasyncoptions"
         >
           <svg
             aria-label="permalink"
@@ -1886,7 +1900,8 @@ sign-in operation.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-signoutasyncoptions"
         >
           <svg
             aria-label="permalink"
@@ -2145,7 +2160,8 @@ sign-out operation.
         Event Subscriptions
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-event-subscriptions"
       >
         <svg
           aria-label="permalink"
@@ -2200,7 +2216,8 @@ sign-out operation.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-addrevokelistenerlistener"
         >
           <svg
             aria-label="permalink"
@@ -2359,7 +2376,8 @@ sign-out operation.
         Types
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-types"
       >
         <svg
           aria-label="permalink"
@@ -2414,7 +2432,8 @@ sign-out operation.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationcredential"
         >
           <svg
             aria-label="permalink"
@@ -2939,7 +2958,8 @@ developers.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationfullname"
         >
           <svg
             aria-label="permalink"
@@ -3246,7 +3266,8 @@ may be
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationrefreshoptions"
         >
           <svg
             aria-label="permalink"
@@ -3556,7 +3577,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationsigninoptions"
         >
           <svg
             aria-label="permalink"
@@ -3887,7 +3909,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationsignoutoptions"
         >
           <svg
             aria-label="permalink"
@@ -4127,7 +4150,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-subscription"
         >
           <svg
             aria-label="permalink"
@@ -4238,7 +4262,8 @@ OAuth 2.0 protocol
         Enums
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-enums"
       >
         <svg
           aria-label="permalink"
@@ -4293,7 +4318,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationbuttonstyle"
         >
           <svg
             aria-label="permalink"
@@ -4366,7 +4392,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-white"
           >
             <svg
               aria-label="permalink"
@@ -4434,7 +4461,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-white_outline"
           >
             <svg
               aria-label="permalink"
@@ -4502,7 +4530,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-black"
           >
             <svg
               aria-label="permalink"
@@ -4571,7 +4600,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationbuttontype"
         >
           <svg
             aria-label="permalink"
@@ -4644,7 +4674,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-sign_in"
           >
             <svg
               aria-label="permalink"
@@ -4712,7 +4743,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-continue"
           >
             <svg
               aria-label="permalink"
@@ -4813,7 +4845,8 @@ OAuth 2.0 protocol
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-sign_up"
           >
             <svg
               aria-label="permalink"
@@ -4882,7 +4915,8 @@ OAuth 2.0 protocol
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationcredentialstate"
         >
           <svg
             aria-label="permalink"
@@ -5008,7 +5042,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-revoked"
           >
             <svg
               aria-label="permalink"
@@ -5070,7 +5105,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-authorized"
           >
             <svg
               aria-label="permalink"
@@ -5132,7 +5168,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-not_found"
           >
             <svg
               aria-label="permalink"
@@ -5194,7 +5231,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-transferred"
           >
             <svg
               aria-label="permalink"
@@ -5257,7 +5295,8 @@ for more details.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationoperation"
         >
           <svg
             aria-label="permalink"
@@ -5312,7 +5351,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-implicit"
           >
             <svg
               aria-label="permalink"
@@ -5380,7 +5420,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-login"
           >
             <svg
               aria-label="permalink"
@@ -5442,7 +5483,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-refresh"
           >
             <svg
               aria-label="permalink"
@@ -5504,7 +5546,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-logout"
           >
             <svg
               aria-label="permalink"
@@ -5567,7 +5610,8 @@ for more details.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationscope"
         >
           <svg
             aria-label="permalink"
@@ -5737,7 +5781,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-full_name"
           >
             <svg
               aria-label="permalink"
@@ -5799,7 +5844,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-email"
           >
             <svg
               aria-label="permalink"
@@ -5862,7 +5908,8 @@ for more details.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-appleauthenticationuserdetectionstatus"
         >
           <svg
             aria-label="permalink"
@@ -5976,7 +6023,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-unsupported"
           >
             <svg
               aria-label="permalink"
@@ -6044,7 +6092,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-unknown"
           >
             <svg
               aria-label="permalink"
@@ -6112,7 +6161,8 @@ for more details.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-likely_real"
           >
             <svg
               aria-label="permalink"
@@ -6178,7 +6228,8 @@ exports[`APISection expo-barcode-scanner 1`] = `
         Component
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-component"
       >
         <svg
           aria-label="permalink"
@@ -6233,7 +6284,8 @@ exports[`APISection expo-barcode-scanner 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescanner"
         >
           <svg
             aria-label="permalink"
@@ -6308,7 +6360,8 @@ exports[`APISection expo-barcode-scanner 1`] = `
           Props
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-props"
         >
           <svg
             aria-label="permalink"
@@ -6364,7 +6417,8 @@ exports[`APISection expo-barcode-scanner 1`] = `
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-barcodetypes"
             >
               <svg
                 aria-label="permalink"
@@ -6487,7 +6541,8 @@ minimize battery usage.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-onbarcodescanned"
             >
               <svg
                 aria-label="permalink"
@@ -6648,7 +6703,8 @@ data has been retrieved.
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-type"
             >
               <svg
                 aria-label="permalink"
@@ -6777,7 +6833,8 @@ Same as
             Inherited Props
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-inherited-props"
           >
             <svg
               aria-label="permalink"
@@ -6848,7 +6905,8 @@ Same as
         Hooks
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-hooks"
       >
         <svg
           aria-label="permalink"
@@ -6903,7 +6961,8 @@ Same as
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-usepermissionsoptions"
         >
           <svg
             aria-label="permalink"
@@ -7214,7 +7273,8 @@ This uses both
         Methods
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-methods"
       >
         <svg
           aria-label="permalink"
@@ -7269,7 +7329,8 @@ This uses both
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescannergetpermissionsasync"
         >
           <svg
             aria-label="permalink"
@@ -7408,7 +7469,8 @@ This uses both
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescannerrequestpermissionsasync"
         >
           <svg
             aria-label="permalink"
@@ -7569,7 +7631,8 @@ This uses both
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescannerscanfromurlasyncurl-barcodetypes"
         >
           <svg
             aria-label="permalink"
@@ -7853,7 +7916,8 @@ code.
         Interfaces
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-interfaces"
       >
         <svg
           aria-label="permalink"
@@ -7908,7 +7972,8 @@ code.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionresponse"
         >
           <svg
             aria-label="permalink"
@@ -8146,7 +8211,8 @@ in order to enable/disable the permission.
         Types
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-types"
       >
         <svg
           aria-label="permalink"
@@ -8201,7 +8267,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodebounds"
         >
           <svg
             aria-label="permalink"
@@ -8366,7 +8433,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodeevent"
         >
           <svg
             aria-label="permalink"
@@ -8508,7 +8576,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodeeventcallbackarguments"
         >
           <svg
             aria-label="permalink"
@@ -8630,7 +8699,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodepoint"
         >
           <svg
             aria-label="permalink"
@@ -8807,7 +8877,8 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescannedcallback"
         >
           <svg
             aria-label="permalink"
@@ -8931,7 +9002,8 @@ are using the barcode scanner view, these values are adjusted to the dimensions 
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodescannerresult"
         >
           <svg
             aria-label="permalink"
@@ -9210,7 +9282,8 @@ you don't get this value.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-barcodesize"
         >
           <svg
             aria-label="permalink"
@@ -9365,7 +9438,8 @@ you don't get this value.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionhookoptions"
         >
           <svg
             aria-label="permalink"
@@ -9438,7 +9512,8 @@ you don't get this value.
         Enums
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-enums"
       >
         <svg
           aria-label="permalink"
@@ -9493,7 +9568,8 @@ you don't get this value.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionstatus"
         >
           <svg
             aria-label="permalink"
@@ -9548,7 +9624,8 @@ you don't get this value.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-denied"
           >
             <svg
               aria-label="permalink"
@@ -9616,7 +9693,8 @@ you don't get this value.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-granted"
           >
             <svg
               aria-label="permalink"
@@ -9684,7 +9762,8 @@ you don't get this value.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-undetermined"
           >
             <svg
               aria-label="permalink"
@@ -9750,7 +9829,8 @@ exports[`APISection expo-pedometer 1`] = `
         Methods
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-methods"
       >
         <svg
           aria-label="permalink"
@@ -9805,7 +9885,8 @@ exports[`APISection expo-pedometer 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-getpermissionsasync"
         >
           <svg
             aria-label="permalink"
@@ -9959,7 +10040,8 @@ exports[`APISection expo-pedometer 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-getstepcountasyncstart-end"
         >
           <svg
             aria-label="permalink"
@@ -10273,7 +10355,8 @@ a start date that is more than seven days in the past returns only the available
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-isavailableasync"
         >
           <svg
             aria-label="permalink"
@@ -10403,7 +10486,8 @@ available on this device.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-requestpermissionsasync"
         >
           <svg
             aria-label="permalink"
@@ -10524,7 +10608,8 @@ available on this device.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-watchstepcountcallback"
         >
           <svg
             aria-label="permalink"
@@ -10736,7 +10821,8 @@ provided with a single argument that is
         Interfaces
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-interfaces"
       >
         <svg
           aria-label="permalink"
@@ -10791,7 +10877,8 @@ provided with a single argument that is
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionresponse"
         >
           <svg
             aria-label="permalink"
@@ -11029,7 +11116,8 @@ in order to enable/disable the permission.
         Types
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-types"
       >
         <svg
           aria-label="permalink"
@@ -11084,7 +11172,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-pedometerresult"
         >
           <svg
             aria-label="permalink"
@@ -11207,7 +11296,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-pedometerupdatecallback"
         >
           <svg
             aria-label="permalink"
@@ -11337,7 +11427,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionexpiration"
         >
           <svg
             aria-label="permalink"
@@ -11424,7 +11515,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-subscription"
         >
           <svg
             aria-label="permalink"
@@ -11535,7 +11627,8 @@ in order to enable/disable the permission.
         Enums
       </span>
       <span
-        class="css-13330di"
+        class="css-15j1jyt-PermalinkCopyIcon"
+        id="docs-anchor-permalink-enums"
       >
         <svg
           aria-label="permalink"
@@ -11590,7 +11683,8 @@ in order to enable/disable the permission.
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-permissionstatus"
         >
           <svg
             aria-label="permalink"
@@ -11645,7 +11739,8 @@ in order to enable/disable the permission.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-denied"
           >
             <svg
               aria-label="permalink"
@@ -11713,7 +11808,8 @@ in order to enable/disable the permission.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-granted"
           >
             <svg
               aria-label="permalink"
@@ -11781,7 +11877,8 @@ in order to enable/disable the permission.
             </code>
           </span>
           <span
-            class="css-13330di"
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-undetermined"
           >
             <svg
               aria-label="permalink"

--- a/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/AppConfigSchemaPropertiesTable.test.tsx.snap
@@ -28,7 +28,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-name"
         >
           <svg
             aria-label="permalink"
@@ -76,16 +77,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Name of your app.
     </p>
     <details
-      class="css-u1z7e0-Collapsible"
+      class="css-834wmb"
+      id="bare-workflow"
     >
       <summary
-        class="css-1iomq2j-Collapsible"
+        class="css-zjlxe1"
       >
         <div
-          class="css-166ujkg-Collapsible"
+          class="css-qos8r6"
         >
           <svg
-            class="icon-sm text-icon-default css-1wgpnk4-Collapsible"
+            class="icon-sm text-icon-default css-nlesit"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -102,15 +104,48 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <span
-          class="css-1n5kx9e-TextComponent"
-          data-text="true"
+        <a
+          href="#bare-workflow"
         >
-          Bare Workflow
-        </span>
+          <span
+            class="css-1n5kx9e-TextComponent"
+            data-text="true"
+          >
+            Bare Workflow
+          </span>
+          <span
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-bare-workflow"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </summary>
       <div
-        class="css-b8vpa7-Collapsible"
+        class="css-16wdqb0"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -148,7 +183,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-androidnavigationbar"
         >
           <svg
             aria-label="permalink"
@@ -196,16 +232,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Configuration for the bottom navigation bar on Android.
     </p>
     <details
-      class="css-u1z7e0-Collapsible"
+      class="css-834wmb"
+      id="expokit"
     >
       <summary
-        class="css-1iomq2j-Collapsible"
+        class="css-zjlxe1"
       >
         <div
-          class="css-166ujkg-Collapsible"
+          class="css-qos8r6"
         >
           <svg
-            class="icon-sm text-icon-default css-1wgpnk4-Collapsible"
+            class="icon-sm text-icon-default css-nlesit"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -222,15 +259,48 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <span
-          class="css-1n5kx9e-TextComponent"
-          data-text="true"
+        <a
+          href="#expokit"
         >
-          ExpoKit
-        </span>
+          <span
+            class="css-1n5kx9e-TextComponent"
+            data-text="true"
+          >
+            ExpoKit
+          </span>
+          <span
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-expokit"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </summary>
       <div
-        class="css-b8vpa7-Collapsible"
+        class="css-16wdqb0"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -241,16 +311,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       </div>
     </details>
     <details
-      class="css-u1z7e0-Collapsible"
+      class="css-834wmb"
+      id="bare-workflow-1"
     >
       <summary
-        class="css-1iomq2j-Collapsible"
+        class="css-zjlxe1"
       >
         <div
-          class="css-166ujkg-Collapsible"
+          class="css-qos8r6"
         >
           <svg
-            class="icon-sm text-icon-default css-1wgpnk4-Collapsible"
+            class="icon-sm text-icon-default css-nlesit"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -267,15 +338,48 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <span
-          class="css-1n5kx9e-TextComponent"
-          data-text="true"
+        <a
+          href="#bare-workflow-1"
         >
-          Bare Workflow
-        </span>
+          <span
+            class="css-1n5kx9e-TextComponent"
+            data-text="true"
+          >
+            Bare Workflow
+          </span>
+          <span
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-bare-workflow-1"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </summary>
       <div
-        class="css-b8vpa7-Collapsible"
+        class="css-16wdqb0"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -312,7 +416,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-visible"
             >
               <svg
                 aria-label="permalink"
@@ -369,16 +474,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           Determines how and when the navigation bar is shown.
         </p>
         <details
-          class="css-u1z7e0-Collapsible"
+          class="css-834wmb"
+          id="expokit-1"
         >
           <summary
-            class="css-1iomq2j-Collapsible"
+            class="css-zjlxe1"
           >
             <div
-              class="css-166ujkg-Collapsible"
+              class="css-qos8r6"
             >
               <svg
-                class="icon-sm text-icon-default css-1wgpnk4-Collapsible"
+                class="icon-sm text-icon-default css-nlesit"
                 fill="none"
                 role="img"
                 viewBox="0 0 24 24"
@@ -395,15 +501,48 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                 </g>
               </svg>
             </div>
-            <span
-              class="css-1n5kx9e-TextComponent"
-              data-text="true"
+            <a
+              href="#expokit-1"
             >
-              ExpoKit
-            </span>
+              <span
+                class="css-1n5kx9e-TextComponent"
+                data-text="true"
+              >
+                ExpoKit
+              </span>
+              <span
+                class="css-15j1jyt-PermalinkCopyIcon"
+                id="docs-anchor-permalink-expokit-1"
+              >
+                <svg
+                  aria-label="permalink"
+                  class="anchor-icon"
+                  fill="none"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                  <path
+                    d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    stroke="#9B9B9B"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                  />
+                </svg>
+              </span>
+            </a>
           </summary>
           <div
-            class="css-b8vpa7-Collapsible"
+            class="css-16wdqb0"
           >
             <p
               class="mb-4 css-1kfqm4n-TextComponent"
@@ -440,7 +579,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   </code>
                 </span>
                 <span
-                  class="css-13330di"
+                  class="css-15j1jyt-PermalinkCopyIcon"
+                  id="docs-anchor-permalink-always"
                 >
                   <svg
                     aria-label="permalink"
@@ -526,7 +666,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-backgroundcolor"
             >
               <svg
                 aria-label="permalink"
@@ -626,7 +767,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           </code>
         </span>
         <span
-          class="css-13330di"
+          class="css-15j1jyt-PermalinkCopyIcon"
+          id="docs-anchor-permalink-intentfilters"
         >
           <svg
             aria-label="permalink"
@@ -674,16 +816,17 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
       Configuration for setting an array of custom intent filters in Android manifest.
     </p>
     <details
-      class="css-u1z7e0-Collapsible"
+      class="css-834wmb"
+      id="bare-workflow-2"
     >
       <summary
-        class="css-1iomq2j-Collapsible"
+        class="css-zjlxe1"
       >
         <div
-          class="css-166ujkg-Collapsible"
+          class="css-qos8r6"
         >
           <svg
-            class="icon-sm text-icon-default css-1wgpnk4-Collapsible"
+            class="icon-sm text-icon-default css-nlesit"
             fill="none"
             role="img"
             viewBox="0 0 24 24"
@@ -700,15 +843,48 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             </g>
           </svg>
         </div>
-        <span
-          class="css-1n5kx9e-TextComponent"
-          data-text="true"
+        <a
+          href="#bare-workflow-2"
         >
-          Bare Workflow
-        </span>
+          <span
+            class="css-1n5kx9e-TextComponent"
+            data-text="true"
+          >
+            Bare Workflow
+          </span>
+          <span
+            class="css-15j1jyt-PermalinkCopyIcon"
+            id="docs-anchor-permalink-bare-workflow-2"
+          >
+            <svg
+              aria-label="permalink"
+              class="anchor-icon"
+              fill="none"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+              <path
+                d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                stroke="#9B9B9B"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+              />
+            </svg>
+          </span>
+        </a>
       </summary>
       <div
-        class="css-b8vpa7-Collapsible"
+        class="css-16wdqb0"
       >
         <p
           class="mb-4 css-1kfqm4n-TextComponent"
@@ -787,7 +963,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-autoverify"
             >
               <svg
                 aria-label="permalink"
@@ -871,7 +1048,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
               </code>
             </span>
             <span
-              class="css-13330di"
+              class="css-15j1jyt-PermalinkCopyIcon"
+              id="docs-anchor-permalink-data"
             >
               <svg
                 aria-label="permalink"
@@ -948,7 +1126,8 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
                   </code>
                 </span>
                 <span
-                  class="css-13330di"
+                  class="css-15j1jyt-PermalinkCopyIcon"
+                  id="docs-anchor-permalink-host"
                 >
                   <svg
                     aria-label="permalink"

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -1,17 +1,27 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import GithubSlugger from 'github-slugger';
 import { PropsWithChildren } from 'react';
 
 import { Collapsible } from '.';
 
+import { HeadingManager, HeadingType } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
+const prepareHeadingManager = () => {
+  const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
+  headingManager.addHeading('Base level heading', undefined, {});
+  headingManager.addHeading('Level 3 subheading', 3, {});
+  headingManager.addHeading('Code heading depth 1', 0, {
+    sidebarDepth: 1,
+    sidebarType: HeadingType.InlineCode,
+  });
+
+  return headingManager;
+};
+
 const WrapWithContext = ({ children }: PropsWithChildren) => {
-  return (
-    // @ts-ignore
-    <HeadingsContext.Provider value={{ addHeading: () => ({ slug: 'blah' }) }}>
-      {children}
-    </HeadingsContext.Provider>
-  );
+  const headingManager = prepareHeadingManager();
+  return <HeadingsContext.Provider value={headingManager}>{children}</HeadingsContext.Provider>;
 };
 
 describe('Collapsible', () => {

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -4,17 +4,11 @@ import { PropsWithChildren } from 'react';
 
 import { Collapsible } from '.';
 
-import { HeadingManager, HeadingType } from '~/common/headingManager';
+import { HeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
 const prepareHeadingManager = () => {
   const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
-  headingManager.addHeading('Base level heading', undefined, {});
-  headingManager.addHeading('Level 3 subheading', 3, {});
-  headingManager.addHeading('Code heading depth 1', 0, {
-    sidebarDepth: 1,
-    sidebarType: HeadingType.InlineCode,
-  });
 
   return headingManager;
 };

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -1,23 +1,36 @@
-import { jest } from '@jest/globals';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
 
 import { Collapsible } from '.';
 
-jest.mock('~/components/page-higher-order/withHeadingManager', () => ({
-  __esModule: true,
-  default: (Component: React.FC) => (props: any) =>
-    <Component headingManager={{ addHeading: jest.fn() }} {...props} />,
-}));
+import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
-describe(Collapsible, () => {
+const WrapWithContext = ({ children }: PropsWithChildren) => {
+  return (
+    // @ts-ignore
+    <HeadingsContext.Provider value={{ addHeading: () => ({ slug: 'blah' }) }}>
+      {children}
+    </HeadingsContext.Provider>
+  );
+};
+
+describe('Collapsible', () => {
   it('hides content by default', () => {
-    render(<Collapsible summary="Summary">Content</Collapsible>);
+    render(
+      <WrapWithContext>
+        <Collapsible summary="Summary">Content</Collapsible>
+      </WrapWithContext>
+    );
     expect(screen.getByText('Summary')).toBeVisible();
     expect(screen.getByText('Content')).not.toBeVisible();
   });
 
   it('shows content when opened', () => {
-    render(<Collapsible summary="Summary">Content</Collapsible>);
+    render(
+      <WrapWithContext>
+        <Collapsible summary="Summary">Content</Collapsible>
+      </WrapWithContext>
+    );
     fireEvent.click(screen.getByText('Summary'));
     expect(screen.getByText('Summary')).toBeVisible();
     expect(screen.getByText('Content')).toBeVisible();
@@ -25,9 +38,11 @@ describe(Collapsible, () => {
 
   it('shows content when rendered with open', () => {
     render(
-      <Collapsible summary="Summary" open>
-        Content
-      </Collapsible>
+      <WrapWithContext>
+        <Collapsible summary="Summary" open>
+          Content
+        </Collapsible>
+      </WrapWithContext>
     );
     expect(screen.getByText('Summary')).toBeVisible();
     expect(screen.getByText('Content')).toBeVisible();

--- a/docs/ui/components/Collapsible/Collapsible.test.tsx
+++ b/docs/ui/components/Collapsible/Collapsible.test.tsx
@@ -1,6 +1,13 @@
+import { jest } from '@jest/globals';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { Collapsible } from '.';
+
+jest.mock('~/components/page-higher-order/withHeadingManager', () => ({
+  __esModule: true,
+  default: (Component: React.FC) => (props: any) =>
+    <Component headingManager={{ addHeading: jest.fn() }} {...props} />,
+}));
 
 describe(Collapsible, () => {
   it('hides content by default', () => {

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -2,10 +2,9 @@ import { css } from '@emotion/react';
 import { LinkBase, shadows, theme } from '@expo/styleguide';
 import { borderRadius, spacing } from '@expo/styleguide-base';
 import { TriangleDownIcon } from '@expo/styleguide-icons';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/compat/router';
 import type { PropsWithChildren, ReactNode } from 'react';
 import React from 'react';
-import tippy from 'tippy.js';
 
 import { PermalinkCopyIcon } from '~/components/Permalink';
 import withHeadingManager, {
@@ -29,18 +28,17 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
   (props: CollapsibleProps & HeadingManagerProps) => {
     const { summary, testID, children } = props;
 
-    const { asPath } = useRouter();
-
-    React.useEffect(() => {
-      tippy('#docs-anchor-permalink-' + heading.current.slug);
-    }, []);
+    const router = useRouter();
+    const { asPath } = router || {};
 
     // expand collapsible if the current hash matches the heading
     React.useEffect(() => {
-      const splitUrl = asPath.split('#');
-      const hash = splitUrl.length ? splitUrl[1] : undefined;
-      if (hash && hash === heading.current.slug) {
-        setOpen(true);
+      if (asPath) {
+        const splitUrl = asPath.split('#');
+        const hash = splitUrl.length ? splitUrl[1] : undefined;
+        if (hash && hash === heading.current.slug) {
+          setOpen(true);
+        }
       }
     }, [asPath]);
 

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -50,7 +50,9 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
       setOpen(!open);
     };
 
-    // will keep incrementing the number on any matching tags if this isn't a ref
+    // HeadingManager is used to generate a slug that corresponds to the collapsible summary.
+    // These are normally generated for MD (#) headings, but Collapsible doesn't have those.
+    // This is a ref because identical tags will keep incrementing the number if it is not.
     const heading = React.useRef(props.headingManager.addHeading(summary, 1, undefined));
 
     return (

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -39,7 +39,7 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
     React.useEffect(() => {
       const splitUrl = asPath.split('#');
       const hash = splitUrl.length ? splitUrl[1] : undefined;
-      if (hash && hash === '#' + heading.current.slug) {
+      if (hash && hash === heading.current.slug) {
         setOpen(true);
       }
     }, [asPath]);
@@ -57,7 +57,7 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
 
     return (
       <details
-        id={`details-${heading.current.slug}`}
+        id={heading.current.slug}
         onClick={onToggle}
         css={detailsStyle}
         open={open}

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -7,7 +7,7 @@ import type { PropsWithChildren, ReactNode } from 'react';
 import React from 'react';
 import tippy from 'tippy.js';
 
-import PermalinkIcon from '~/components/icons/Permalink';
+import { PermalinkCopyIcon } from '~/components/Permalink';
 import withHeadingManager, {
   HeadingManagerProps,
 } from '~/components/page-higher-order/withHeadingManager';
@@ -68,17 +68,7 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
           </div>
           <LinkBase href={'#' + heading.current.slug} ref={heading.current.ref}>
             <DEMI>{summary}</DEMI>
-            <span
-              id={'docs-anchor-permalink-' + heading.current.slug}
-              data-tippy-content="Click to copy anchor link"
-              onClick={e => {
-                e.preventDefault();
-                const url = window.location.href.replace(/#.*/, '') + '#' + heading.current.slug;
-                navigator.clipboard?.writeText(url);
-              }}
-              css={STYLES_PERMALINK_ICON}>
-              <PermalinkIcon />
-            </span>
+            <PermalinkCopyIcon slug={heading.current.slug} />
           </LinkBase>
         </summary>
         <div css={contentStyle}>{children}</div>
@@ -88,26 +78,6 @@ const Collapsible: React.FC<CollapsibleProps> = withHeadingManager(
 );
 
 export { Collapsible };
-
-const STYLES_PERMALINK_ICON = css`
-  cursor: pointer;
-  vertical-align: middle;
-  display: inline-block;
-  width: 1.2em;
-  height: 1em;
-  padding: 0 0.2em;
-  visibility: hidden;
-
-  a:hover &,
-  a:focus-visible & {
-    visibility: visible;
-  }
-
-  svg {
-    width: 100%;
-    height: auto;
-  }
-`;
 
 const detailsStyle = css({
   overflow: 'hidden',

--- a/docs/ui/components/Navigation/Navigation.test.tsx
+++ b/docs/ui/components/Navigation/Navigation.test.tsx
@@ -9,17 +9,11 @@ import { visit } from 'unist-util-visit';
 import { findActiveRoute, Navigation } from './Navigation';
 import { NavigationNode } from './types';
 
-import { HeadingManager, HeadingType } from '~/common/headingManager';
+import { HeadingManager } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
 
 const prepareHeadingManager = () => {
   const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
-  headingManager.addHeading('Base level heading', undefined, {});
-  headingManager.addHeading('Level 3 subheading', 3, {});
-  headingManager.addHeading('Code heading depth 1', 0, {
-    sidebarDepth: 1,
-    sidebarType: HeadingType.InlineCode,
-  });
 
   return headingManager;
 };

--- a/docs/ui/components/Navigation/Navigation.test.tsx
+++ b/docs/ui/components/Navigation/Navigation.test.tsx
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
+import GithubSlugger from 'github-slugger';
 import mockRouter from 'next-router-mock';
 import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 import { u as node } from 'unist-builder';
@@ -8,7 +9,20 @@ import { visit } from 'unist-util-visit';
 import { findActiveRoute, Navigation } from './Navigation';
 import { NavigationNode } from './types';
 
+import { HeadingManager, HeadingType } from '~/common/headingManager';
 import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
+
+const prepareHeadingManager = () => {
+  const headingManager = new HeadingManager(new GithubSlugger(), { headings: [] });
+  headingManager.addHeading('Base level heading', undefined, {});
+  headingManager.addHeading('Level 3 subheading', 3, {});
+  headingManager.addHeading('Code heading depth 1', 0, {
+    sidebarDepth: 1,
+    sidebarType: HeadingType.InlineCode,
+  });
+
+  return headingManager;
+};
 
 jest.mock('next/router', () => mockRouter);
 
@@ -66,10 +80,10 @@ describe(Navigation, () => {
   });
 
   it('renders pages inside groups inside sections', () => {
+    const headingManager = prepareHeadingManager();
     render(
       // Need context due to withHeadingManager in Collapsible, which enables anchor links
-      // @ts-ignore
-      <HeadingsContext.Provider value={{ addHeading: () => ({ slug: 'blah' }) }}>
+      <HeadingsContext.Provider value={headingManager}>
         <MemoryRouterProvider>
           <Navigation routes={nodes} />
         </MemoryRouterProvider>

--- a/docs/ui/components/Navigation/Navigation.test.tsx
+++ b/docs/ui/components/Navigation/Navigation.test.tsx
@@ -8,6 +8,8 @@ import { visit } from 'unist-util-visit';
 import { findActiveRoute, Navigation } from './Navigation';
 import { NavigationNode } from './types';
 
+import { HeadingsContext } from '~/components/page-higher-order/withHeadingManager';
+
 jest.mock('next/router', () => mockRouter);
 
 /** A set of navigation nodes to test with */
@@ -65,9 +67,13 @@ describe(Navigation, () => {
 
   it('renders pages inside groups inside sections', () => {
     render(
-      <MemoryRouterProvider>
-        <Navigation routes={nodes} />
-      </MemoryRouterProvider>
+      // Need context due to withHeadingManager in Collapsible, which enables anchor links
+      // @ts-ignore
+      <HeadingsContext.Provider value={{ addHeading: () => ({ slug: 'blah' }) }}>
+        <MemoryRouterProvider>
+          <Navigation routes={nodes} />
+        </MemoryRouterProvider>
+      </HeadingsContext.Provider>
     );
     // Get started ->
     expect(screen.getByText('Introduction')).toBeInTheDocument();


### PR DESCRIPTION
# Why
https://linear.app/expo/issue/ENG-9863/make-collapsible-headers-as-anchor-links

Fun story:
1. I originally though @brentvatne was asking for a quick copy button for the anchor links for headers
2. So I did that, and __then__ I read @amandeepmittal's Linear issue.
3. So then I made anchor tags for collapsible headers
4. ...which required the quick copy button to be useful.

# How
## Copiable header links
I took inspiration from the [React Native Upgrade Advisor](https://react-native-community.github.io/upgrade-helper/?from=0.71.11&to=0.72.1):
<img width="428" alt="image" src="https://github.com/expo/expo/assets/8053974/d6bf26e5-2ade-481a-ad01-16a264b3e480">
Right now, it only shows the first tooltip. I would like it have it change on copy like the upgrade advisor, but the tooltip disappears on copy, and then when you hover over it again, it shows both tooltips, so there's some figuring out about how tippy.js works to do to make this work:
<img width="221" alt="image" src="https://github.com/expo/expo/assets/8053974/304639f9-e146-4a6e-87b8-249a0cbec029">

Like the Upgrade Advisor links, I made the anchor button itself not move the page/ set the URL, since it seemed kind of nice to be able to do just do the copy. I could see going the other way, though

## Anchors for collapsible links
Some of this code is copied from `Permalink` in order to make the `details` component be aware of the anchor tag, opening the details when navigating to the anchor.

These headers/ anchor links definitely do not set the URL, so the page doesn't jump while it's also expanding an element. Thus, the only way to get the anchor is by pressing the copy icon. But pasting in the URL will take you to the collapsible section and expand it, while still allowing you to collapse it again.

# Test Plan
- [x] didn't break existing headers/ permalink functionality
- [x] copy works
- [x] didn't break existing collapsible functionality
- [x] can copy a collapsible link
- [x] can navigate directly to a collapsible and it expands
- [x] can still collapse a collapsible after navigating

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
