### PR TITLE
[go] fix ios expo go crash from exceptions

### DIFF
--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -3314,6 +3314,7 @@
 					"\"$(PODS_ROOT)/RCT-Folly\"",
 				);
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Werror=protocol";
 			};
 			name = Debug;
 		};
@@ -3380,6 +3381,7 @@
 					"\"$(PODS_ROOT)/RCT-Folly\"",
 				);
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Werror=protocol";
 			};
 			name = Release;
 		};
@@ -3558,6 +3560,7 @@
 					"\"$(PODS_ROOT)/RCT-Folly\"",
 				);
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Werror=protocol";
 			};
 			name = Debug;
 		};
@@ -3626,6 +3629,7 @@
 					"\"$(PODS_ROOT)/RCT-Folly\"",
 				);
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Werror=protocol";
 			};
 			name = Release;
 		};

--- a/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.m
+++ b/ios/Exponent/Kernel/HeadlessApp/EXHeadlessAppRecord.m
@@ -76,6 +76,9 @@
 - (void)reactAppManagerDidInvalidate:(EXReactAppManager *)appManager {}
 - (void)reactAppManagerFinishedLoadingJavaScript:(EXReactAppManager *)appManager {}
 - (void)reactAppManagerStartedLoadingJavaScript:(EXReactAppManager *)appManager {}
+- (void)reactAppManagerAppContentDidAppear:(EXReactAppManager *)appManager {}
+- (void)reactAppManagerAppContentWillReload:(EXReactAppManager *)appManager {}
+
 
 # pragma mark - EXAppLoaderDelegate
 

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -51,6 +51,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 - (void)handleSoftJSExceptionWithMessage:(nullable NSString *)message
                                    stack:(nullable NSArray<NSDictionary<NSString *, id> *> *)stack
                              exceptionId:(NSNumber *)exceptionId
+                         extraDataAsJSON:(nullable NSString *)extraDataAsJSON
 {
   // In RN 0.8 this was used to invoke the native red box errors (via `showErrorMessage`).
   // The invocation has since been moved into the method that invokes this delegate method.
@@ -60,6 +61,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 - (void)handleFatalJSExceptionWithMessage:(nullable NSString *)message
                                     stack:(nullable NSArray<NSDictionary<NSString *, id> *> *)stack
                               exceptionId:(NSNumber *)exceptionId
+                          extraDataAsJSON:(nullable NSString *)extraDataAsJSON
 {
   NSString *description = [@"Unhandled JS Exception: " stringByAppendingString:message];
   NSDictionary *errorInfo = @{ NSLocalizedDescriptionKey: description, RCTJSStackTraceKey: stack };


### PR DESCRIPTION
# Why

potentially to fix the strange ios crash after login

# How

- the root cause is that we didn't implement correct `RCTExceptionsManagerDelegate` protocol from react-native upgrade. that would probably cause the error stacktrace:
  ```
  Last Exception Backtrace:
  0   CoreFoundation                      0x1c938ce38 __exceptionPreprocess + 164 (NSException.m:202)
  1   libobjc.A.dylib                     0x1c25238d8 objc_exception_throw + 60 (objc-exception.mm:356)
  2   CoreFoundation                      0x1c950181c -[NSObject(NSObject) doesNotRecognizeSelector:] + 136 (NSObject.m:140)
  3   CoreFoundation                      0x1c93a2ce8 ___forwarding___ + 976 (NSForwarding.m:3620)
  4   CoreFoundation                      0x1c940b320 _CF_forwarding_prep_0 + 96 (:-1)
  5   Expo Go                             0x105588678 -[RCTExceptionsManager reportSoft:stack:exceptionId:extraDataAsJSON:] + 244 (RCTExceptionsManager.mm:50)
  6   Expo Go                             0x105589010 -[RCTExceptionsManager reportException:] + 1320 (RCTExceptionsManager.mm:156)
  7   CoreFoundation                      0x1c93f76b4 __invoking___ + 148 (:-1)
  8   CoreFoundation                      0x1c93a3b1c -[NSInvocation invoke] + 428 (NSForwarding.m:3377)
  9   CoreFoundation                      0x1c93a3534 -[NSInvocation invokeWithTarget:] + 64 (NSForwarding.m:3474)
  10  Expo Go                             0x105542a60 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 388 (RCTModuleMethod.mm:584)
  11  Expo Go                             0x105544ac0 facebook::react::invokeInner(RCTBridge*, RCTModuleData*, unsigned int, folly::dynamic const&, int, (anonymous namespace)::SchedulingContext) + 456 (RCTNativeModule.mm:197)
  12  Expo Go                             0x105544710 facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int)::$_0::operator()() const + 68 (RCTNativeModule.mm:114)
  13  Expo Go                             0x105544710 invocation function for block in facebook::react::RCTNativeModule::invoke(unsigned int, folly::dynamic&&, int) + 112 (RCTNativeModule.mm:105)
  14  libdispatch.dylib                   0x1d09a3460 _dispatch_call_block_and_release + 32 (init.c:1518)
  15  libdispatch.dylib                   0x1d09a4f88 _dispatch_client_callout + 20 (object.m:560)
  16  libdispatch.dylib                   0x1d09ac640 _dispatch_lane_serial_drain + 672 (inline_internal.h:2632)
  17  libdispatch.dylib                   0x1d09ad18c _dispatch_lane_invoke + 384 (queue.c:3940)
  18  libdispatch.dylib                   0x1d09b7e10 _dispatch_workloop_worker_thread + 652 (queue.c:6876)
  19  libsystem_pthread.dylib             0x217604df8 _pthread_wqthread + 288 (pthread.c:2618)
  20  libsystem_pthread.dylib             0x217604b98 start_wqthread + 8 (:-1)
  ```
- add `-Werror=protocol` to have compiler error if we don't implement correct protocol in the future.

# Test Plan

expo go release build + local build production home with some `console.error()`

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
