### PR TITLE
[go] try to fix android expo go top crash

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -507,10 +507,10 @@ abstract class ReactNativeActivity :
       // This is the same on iOS.
       return true
     }
-    val errorRecoveryManager = ErrorRecoveryManager.getInstance(experienceKey!!)
-    errorRecoveryManager.markErrored()
 
-    if (!errorRecoveryManager.shouldReloadOnError()) {
+    val errorRecoveryManager = experienceKey?.let { ErrorRecoveryManager.getInstance(it) }
+    errorRecoveryManager?.markErrored()
+    if (errorRecoveryManager?.shouldReloadOnError() != true) {
       return true
     }
 


### PR DESCRIPTION
# Why

it turns out #23974 doesn't fix all the call paths to the top one crash. it still happens on expo-go 2.29.6. the stacktrace is slightly different:

```
Fatal Exception: java.lang.NullPointerException:
       at host.exp.exponent.experience.ReactNativeActivity.shouldShowErrorScreen(ReactNativeActivity.kt:510)
       at host.exp.exponent.experience.BaseExperienceActivity.consumeErrorQueue$lambda$2(BaseExperienceActivity.kt:140)
       at android.app.Activity.runOnUiThread(Activity.java:7368)
       at host.exp.exponent.experience.BaseExperienceActivity.consumeErrorQueue(BaseExperienceActivity.kt:135)
       at host.exp.exponent.experience.BaseExperienceActivity$Companion.addError(BaseExperienceActivity.kt:194)
       at host.exp.exponent.kernel.Kernel$Companion.handleReactNativeError(Kernel.kt:1132)
       at host.exp.exponent.kernel.Kernel$Companion.access$handleReactNativeError(Kernel.kt:955)
       at host.exp.exponent.kernel.Kernel.handleError(Kernel.kt:947)
       at host.exp.exponent.kernel.Kernel$openManifestUrl$1.onError$lambda$3(Kernel.kt:731)
       at android.os.Handler.handleCallback(Handler.java:942)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loopOnce(Looper.java:201)
       at android.os.Looper.loop(Looper.java:288)
       at android.app.ActivityThread.main(ActivityThread.java:7918)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

# How

prevent crash when the `experienceKey` is null

# Test Plan

again i don't really know how to reproduce the crash. just to well handle when `experienceKey` is null

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
