### PR TITLE
[home] Fix tsc for expo-constants changes

### DIFF
--- a/home/menu/DevMenuServerInfo.tsx
+++ b/home/menu/DevMenuServerInfo.tsx
@@ -16,7 +16,9 @@ export function DevMenuServerInfo({ task }: Props) {
     : null;
   const taskUrl = task.manifestUrl ? FriendlyUrls.toFriendlyString(task.manifestUrl) : '';
   const devServerName =
-    manifest && manifest.extra?.expoGo?.developer ? manifest.extra.expoGo.developer.tool : null;
+    manifest && 'extra' in manifest && manifest.extra?.expoGo?.developer
+      ? manifest.extra.expoGo.developer.tool
+      : null;
 
   return (
     <View bg="default" padding="medium">

--- a/home/menu/DevMenuTaskInfo.tsx
+++ b/home/menu/DevMenuTaskInfo.tsx
@@ -35,12 +35,13 @@ function getInfoFromManifest(
       isVerified: (manifest as any).isVerified,
     };
   } else {
+    // no properties for bare manifests
     return {
-      iconUrl: manifest.iconUrl,
-      taskName: manifest.name,
-      sdkVersion: manifest.sdkVersion,
-      runtimeVersion: stringOrUndefined(manifest.runtimeVersion),
-      isVerified: manifest.isVerified,
+      iconUrl: undefined,
+      taskName: undefined,
+      sdkVersion: undefined,
+      runtimeVersion: undefined,
+      isVerified: undefined,
     };
   }
 }

--- a/home/redux/HistoryActions.ts
+++ b/home/redux/HistoryActions.ts
@@ -26,8 +26,6 @@ export default {
   addHistoryItem(manifestUrl: string, manifest: Manifest): AppThunk {
     return async (dispatch: AppDispatch) => {
       const historyItem: HistoryItem = {
-        // TODO(wschurman): audit for new manifests
-        bundleUrl: manifest && 'bundleUrl' in manifest ? manifest.bundleUrl : '',
         manifestUrl,
         manifest,
         url: manifestUrl,

--- a/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedListItem/index.tsx
@@ -1,33 +1,21 @@
 import { ChevronDownIcon, spacing } from '@expo/styleguide-native';
-import { Text, useExpoPalette, useExpoTheme, View } from 'expo-dev-client-components';
+import { Text, useExpoTheme, View } from 'expo-dev-client-components';
 import * as React from 'react';
 import { View as RNView, StyleSheet, ViewStyle, Share } from 'react-native';
 import { TouchableOpacity } from 'react-native-gesture-handler';
 
 import * as UrlUtils from '../../../utils/UrlUtils';
-import { AppIcon } from '../AppIcon';
 
 type Props = {
   style?: ViewStyle;
   disabled?: boolean;
   title?: string;
-  image?: number | string | null;
   url: string;
   onPress?: () => void;
-  releaseChannel?: string;
 };
 
-export function RecentlyOpenedListItem({
-  title,
-  url,
-  image,
-  disabled,
-  style,
-  onPress,
-  releaseChannel,
-}: Props) {
+export function RecentlyOpenedListItem({ title, url, disabled, style, onPress }: Props) {
   const theme = useExpoTheme();
-  const palette = useExpoPalette();
 
   const handleLongPress = () => {
     const message = UrlUtils.normalizeUrl(url);
@@ -45,34 +33,11 @@ export function RecentlyOpenedListItem({
       onLongPress={handleLongPress}
       style={[styles.container, style, disabled && styles.disabled]}
       disabled={disabled}>
-      <AppIcon image={image} />
       <RNView style={[styles.contentContainer]}>
         <View>
           <Text type="InterSemiBold" ellipsizeMode="tail" numberOfLines={1}>
             {title}
           </Text>
-          {releaseChannel && (
-            <View
-              style={{
-                marginTop: 8,
-                backgroundColor: palette.blue['100'],
-                borderRadius: 4,
-                paddingVertical: 2,
-                paddingHorizontal: 8,
-                flexDirection: 'row',
-                alignItems: 'center',
-                alignSelf: 'flex-start',
-              }}>
-              <Text
-                type="InterRegular"
-                style={{ color: palette.blue['800'] }}
-                size="small"
-                ellipsizeMode="tail"
-                numberOfLines={1}>
-                Channel: {releaseChannel}
-              </Text>
-            </View>
-          )}
         </View>
         <RNView style={styles.chevronRightContainer}>
           <ChevronDownIcon

--- a/home/screens/HomeScreen/RecentlyOpenedSection.tsx
+++ b/home/screens/HomeScreen/RecentlyOpenedSection.tsx
@@ -15,29 +15,23 @@ export function RecentlyOpenedSection({ recentHistory }: Props) {
       {recentHistory.map((project, i) => {
         if (!project) return null;
 
+        // EAS Update app names are under the extra.expoClient.name key
+        const title =
+          (project.manifest && 'extra' in project.manifest
+            ? project.manifest.extra?.expoClient?.name
+            : undefined) ??
+          (project.manifest && 'name' in project.manifest
+            ? String(project.manifest.name)
+            : undefined);
+
         return (
           <Fragment key={project.manifestUrl}>
             <RecentlyOpenedListItem
               url={project.manifestUrl}
-              image={
-                // TODO(wschurman): audit for new manifests
-                project.manifest && 'iconUrl' in project.manifest
-                  ? project.manifest.iconUrl
-                  : undefined
-              }
-              title={
-                // EAS Update app names are under the extra.expoClient.name key
-                project.manifest?.extra?.expoClient?.name ??
-                (project.manifest && 'name' in project.manifest ? project.manifest.name : undefined)
-              }
+              title={title}
               onPress={() => {
                 Linking.openURL(project.url);
               }}
-              releaseChannel={
-                project.manifest && 'releaseChannel' in project.manifest
-                  ? project.manifest.releaseChannel
-                  : undefined
-              }
             />
             {i < recentHistory.count() - 1 && <Divider style={{ height: 1 }} />}
           </Fragment>

--- a/home/types/HistoryItem.ts
+++ b/home/types/HistoryItem.ts
@@ -1,7 +1,6 @@
 import { Manifest } from './Manifest';
 
 export type HistoryItem = {
-  bundleUrl: string;
   manifestUrl: string;
   manifest?: Manifest;
   url: string; // Same as manifestUrl

--- a/home/utils/Environment.ts
+++ b/home/utils/Environment.ts
@@ -4,20 +4,6 @@ import semver from 'semver';
 
 import * as Kernel from '../kernel/Kernel';
 
-const PRODUCTION_EXPONENT_HOME_PROJECT_ID = '6b6c6660-df76-11e6-b9b4-59d1587e6774';
-
-const isProductionClassicManifest =
-  (Constants.manifest?.originalFullName === '@exponent/home' ||
-    Constants.manifest?.id === '@exponent/home' ||
-    Constants.manifest?.projectId === PRODUCTION_EXPONENT_HOME_PROJECT_ID) &&
-  Constants.manifest?.publishedTime;
-
-const isProductionManifest =
-  Constants.manifest2?.extra?.eas?.projectId === PRODUCTION_EXPONENT_HOME_PROJECT_ID &&
-  !Constants.manifest2.extra.expoGo;
-
-const isProduction = isProductionClassicManifest || isProductionManifest;
-
 const IOSClientReleaseType = Kernel.iosClientReleaseType;
 
 const IsIOSRestrictedBuild =
@@ -40,7 +26,6 @@ const supportedSdksString = `SDK${
 } ${sortedSupportedExpoSdks.map((sdk) => semver.major(sdk)).join(', ')}`;
 
 export default {
-  isProduction,
   IOSClientReleaseType,
   IsIOSRestrictedBuild,
   lowestSupportedSdkVersion,


### PR DESCRIPTION
# Why

Types for classic manifests were removed in 50. This puts home in a weird state where it could still get classic updates but not have the types for them.

# How

The fix that I applied here was just to design for EAS Update. In places that used to have special UI for classic updates, we now just show a generic UI. This is the lowest attention cost and is the fastest way forward (rather than reverting all the type changes and supporting classic manifest types for longer in the home app).

# Test Plan

`yarn tsc`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
