### PR TITLE
feat(cli): ensure port is running after build.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Add additional port check after build to ensure port is still available.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Add additional port check after build to ensure port is still available.
+- Add additional port check after build to ensure port is still available. ([#24315](https://github.com/expo/expo/pull/24315) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -72,7 +72,6 @@
     "graphql-tag": "^2.10.1",
     "https-proxy-agent": "^5.0.1",
     "internal-ip": "4.3.0",
-    "is-root": "^2.1.0",
     "js-yaml": "^3.13.1",
     "json-schema-deref-sync": "^0.13.0",
     "md5hex": "^1.0.0",

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -5,6 +5,7 @@ import { Options, ResolvedOptions, resolveOptionsAsync } from './resolveOptions'
 import { Log } from '../../log';
 import { assembleAsync, installAsync } from '../../start/platforms/android/gradle';
 import { setNodeEnv } from '../../utils/nodeEnv';
+import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { logProjectLogsLocation } from '../hints';
@@ -32,6 +33,11 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
     appName: props.appName,
     buildCache: props.buildCache,
   });
+
+  // Ensure the port hasn't become busy during the build.
+  if (props.shouldStartBundler && !(await ensurePortAvailabilityAsync(projectRoot, props))) {
+    props.shouldStartBundler = false;
+  }
 
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -7,6 +7,7 @@ import { resolveOptionsAsync } from './options/resolveOptions';
 import * as Log from '../../log';
 import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
 import { setNodeEnv } from '../../utils/nodeEnv';
+import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { profile } from '../../utils/profile';
 import { getSchemesForIosAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
@@ -34,6 +35,11 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   // Find the path to the built app binary, this will be used to install the binary
   // on a device.
   const binaryPath = await profile(XcodeBuild.getAppBinaryPath)(buildOutput);
+
+  // Ensure the port hasn't become busy during the build.
+  if (props.shouldStartBundler && !(await ensurePortAvailabilityAsync(projectRoot, props))) {
+    props.shouldStartBundler = false;
+  }
 
   // Start the dev server which creates all of the required info for
   // launching the app on a simulator.

--- a/packages/@expo/cli/src/utils/__mocks__/port.ts
+++ b/packages/@expo/cli/src/utils/__mocks__/port.ts
@@ -1,3 +1,4 @@
 export const resolvePortAsync = jest.fn(
   async (root, { defaultPort, fallbackPort }) => defaultPort ?? fallbackPort ?? 8081
 );
+export const ensurePortAvailabilityAsync = jest.fn(async () => true);

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -1,0 +1,83 @@
+// @ts-expect-error
+import freeportAsync from 'freeport-async';
+
+import { getRunningProcess } from '../getRunningProcess';
+import { choosePortAsync, ensurePortAvailabilityAsync } from '../port';
+import { confirmAsync } from '../prompts';
+
+jest.mock('../../log');
+jest.mock('freeport-async', () => jest.fn(async (port) => port));
+jest.mock('../prompts');
+jest.mock('../getRunningProcess', () => ({
+  getRunningProcess: jest.fn(() => null),
+}));
+
+describe(ensurePortAvailabilityAsync, () => {
+  it(`returns true if the port is available`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8081);
+    expect(await ensurePortAvailabilityAsync('/', { port: 8081 })).toBe(true);
+  });
+  it(`returns false if the port is unavailable due to running the same process`, async () => {
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/me',
+      command: 'npx expo',
+    });
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    expect(await ensurePortAvailabilityAsync('/me', { port: 8081 })).toBe(false);
+  });
+  it(`asserts if the port is busy because it's running a different process`, async () => {
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/other',
+      command: 'npx expo',
+    });
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    await expect(ensurePortAvailabilityAsync('/me', { port: 8081 })).rejects.toThrow();
+  });
+});
+
+describe(choosePortAsync, () => {
+  it(`returns same port when given port is available`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8081);
+    const port = await choosePortAsync('/', { defaultPort: 8081 });
+    expect(port).toBe(8081);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`chooses a new port if the default port is taken and isn't running the same process`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/other/project',
+      command: 'npx expo',
+    });
+    jest.mocked(confirmAsync).mockResolvedValueOnce(true);
+    const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
+    expect(port).toBe(8082);
+    expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
+  });
+  it(`returns null if the new suggested port is rejected`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/other/project',
+      command: 'npx expo',
+    });
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    const port = await choosePortAsync('/', { defaultPort: 8081, reuseExistingPort: false });
+    expect(port).toBe(null);
+    expect(confirmAsync).toHaveBeenCalledWith({ initial: true, message: 'Use port 8082 instead?' });
+  });
+  it(`returns null if the taken port is running the same process`, async () => {
+    jest.mocked(freeportAsync).mockResolvedValueOnce(8082);
+    jest.mocked(getRunningProcess).mockReturnValueOnce({
+      pid: 1,
+      directory: '/me',
+      command: 'npx expo',
+    });
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    const port = await choosePortAsync('/me', { defaultPort: 8081, reuseExistingPort: true });
+    expect(port).toBe(null);
+    expect(confirmAsync).not.toBeCalled();
+  });
+});

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -16,7 +16,10 @@ export async function getFreePortAsync(rangeStart: number): Promise<number> {
 }
 
 /** @return `true` if the port can still be used to start the dev server, `false` if the dev server should be skipped, and asserts if the port is now taken. */
-export async function ensurePortAvailabilityAsync(projectRoot: string, { port }: { port: number }) {
+export async function ensurePortAvailabilityAsync(
+  projectRoot: string,
+  { port }: { port: number }
+): Promise<boolean> {
   const freePort = await freeportAsync(port, { hostnames: [null] });
   // Check if port has become busy during the build.
   if (freePort === port) {


### PR DESCRIPTION
# Why

If a user runs either build command (`npx expo run:ios` or `npx expo run:android`) simultaneously, then there is chance for a port conflict. This change proposes we run a secondary port check after the build to provide a slightly better user experience. If the port is taken by the same app, the dev server will be skipped and the process will proceed in headless-mode, if the port is taken by a different process, then an error will be thrown.