### PR TITLE
[template] update react types to the latest version

### DIFF
--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@types/react": "~18.0.14",
+    "@types/react": "~18.2.14",
     "typescript": "^5.1.3"
   }
 }


### PR DESCRIPTION
# Why

There's a version mismatch warning when creating a project using the latest TypeScript template.

# Test Plan

```bash
npx create-expo-app -t expo-template-blank-typescript some-test
cd some-test
npx expo install --check
```
Before:
<img width="762" alt="Screenshot 2023-09-07 at 08 13 57" src="https://github.com/expo/expo/assets/6534400/3c5060d0-b42b-4e05-bd18-941f3e692c75">

After:
<img width="303" alt="Screenshot 2023-09-07 at 08 14 51" src="https://github.com/expo/expo/assets/6534400/605e6756-3ee0-4d12-b042-6f981c54cce7">
