### PR TITLE
[docs] Update verbiage on Expo Router authentication guide

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Step } from '~/ui/components/Step';
 
-With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens based on **authorization**. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
+With Expo Router, all routes are always defined and accessible. You can use runtime logic to redirect users away from specific screens depending on whether they are authenticated. There are two different techniques for authenticating users within routes. This guide provides an example that demonstrates the functionality of standard native apps.
 
 ## Using React Context and Route Groups
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up for #24185. [Context in this comment](https://github.com/expo/expo/pull/24185#discussion_r1316672299).

# How

<!--
How did you build this feature or fix this bug and why?
-->

By update the verbiage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/router/reference/authentication/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
