### PR TITLE
[expo-updates][ios] Fix updates enabled defaulting

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix updates enabled defaulting on iOS. ([#24327](https://github.com/expo/expo/pull/24327) by [@wschurman](https://github.com/wschurman))
+
 ### 💡 Others
 
 - Update E2E test. ([#24272](https://github.com/expo/expo/pull/24272) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -145,7 +145,7 @@ public final class UpdatesConfig: NSObject {
   }
 
   public static func config(fromDictionary config: [String: Any]) -> UpdatesConfig {
-    let isEnabled = config.optionalValue(forKey: EXUpdatesConfigEnabledKey) ?? false
+    let isEnabled = config.optionalValue(forKey: EXUpdatesConfigEnabledKey) ?? true
     let expectsSignedManifest = config.optionalValue(forKey: EXUpdatesConfigExpectsSignedManifestKey) ?? false
     let updateUrl: URL? = config.optionalValue(forKey: EXUpdatesConfigUpdateUrlKey).let { it in
       URL(string: it)


### PR DESCRIPTION
# Why

Noticed in https://linear.app/expo/issue/ENG-9880/one-should-be-able-to-specify-enabledfalse-in-updates-configuration investigation that the two platforms had different defaults for this param.

https://github.com/expo/expo/pull/21391 configuration to swift and erroneously defaulted it to false when it should have defaulted to true.

Plan to merge this to SDK 49, which was the first SDK to have this issue.

Luckily the config plugin defaulted this to true when updates.url != null in the app config. Otherwise this would've turned updates off in a lot of other apps. Instead, it probably only turned updates off in bare apps that set their own updates config, which is very few most likely.

# How

Fix defaulting.

# Test Plan

Inspect.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
