### PR TITLE
[docs] Add HTML tag for Google site verification

### DIFF
--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -32,6 +32,7 @@ const Head = ({ title, description, children }: HeadProps) => (
       content={description === '' ? BASE_DESCRIPTION : description}
     />
     <meta property="twitter:image" content="https://docs.expo.dev/static/images/twitter.png" />
+    <meta name="google-site-verification" content="izrqNurn_EXfYbNIFgVIhEXkkZk9DleELH4UouM8s3k" />
 
     {children}
   </NextHead>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We are adding our docs.expo.dev into Google Search Console. This step is required for verification.

# How

<!--
How did you build this feature or fix this bug and why?
-->

By adding the HTML tag provided by the Search Console.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, open dev tools in the browser and see the following tag in the top-level `<head>`:

<img width="722" alt="CleanShot 2023-09-08 at 23 56 25@2x" src="https://github.com/expo/expo/assets/10234615/d2c40d32-62c3-4646-a68c-4dccebd23308">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
