### PR TITLE
[ios][sqlite] Add minimum OS version to Info.plist

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed the return type from `executeSqlAsync` to only successful `ResultSet`. ([#24336](https://github.com/expo/expo/pull/24336) by [@kudo](https://github.com/kudo))
+- [iOS] Fixed an issue with CRSQLite missing a minimum OS version on iOS, causing rejections on AppStore Connect submission. ([#24347](https://github.com/expo/expo/pull/24347) by [@derekstavis](https://github.com/derekstavis))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/ios/crsqlite.xcframework/ios-arm64/crsqlite.framework/Info.plist
+++ b/packages/expo-sqlite/ios/crsqlite.xcframework/ios-arm64/crsqlite.framework/Info.plist
@@ -14,5 +14,7 @@
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>MinimumOSVersion</key>
+  <string>8.0</string>
 </dict>
 </plist>

--- a/packages/expo-sqlite/ios/crsqlite.xcframework/ios-arm64_x86_64-simulator/crsqlite.framework/Info.plist
+++ b/packages/expo-sqlite/ios/crsqlite.xcframework/ios-arm64_x86_64-simulator/crsqlite.framework/Info.plist
@@ -14,5 +14,7 @@
   <string>FMWK</string>
   <key>CFBundleSignature</key>
   <string>????</string>
+  <key>MinimumOSVersion</key>
+  <string>8.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Why

I've upgraded to the alpha version of `expo-sqlite`. Upon trying to submit the app through `eas submit` I've got this error:

```
Asset validation failed Invalid MinimumOSVersion.
Apps that only support 64-bit devices must specify a deployment target of 8.0 or later. 
MinimumOSVersion in 'Kilowatt.app/Frameworks/crsqlite.framework' is ''.
```

# How

Introduces the `MinimumOSVersion` key to `Info.plist` that lives inside `crsqlite.framework`. Since this is pre-compiled only to `arm64`, I've set the minimum version to `8.0` as recommended by Apple.

# Test Plan

I've patched locally with `patch-package`. After that, the submission worked.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
