### PR TITLE
chore(router): Drop client-side mocking for `__dirname` and `__filename`.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Drop client-side mocking for `__dirname` and `__filename`.
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Drop client-side mocking for `__dirname` and `__filename`.
+- Drop client-side mocking for `__dirname` and `__filename`. ([#24348](https://github.com/expo/expo/pull/24348) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🎉 New features
 

--- a/packages/expo-router/babel.js
+++ b/packages/expo-router/babel.js
@@ -122,29 +122,11 @@ function getExpoRouterAbsoluteAppRoot(projectRoot) {
 
 module.exports = function (api) {
   const { types: t } = api;
-  const getRelPath = (state) => './' + nodePath.relative(state.file.opts.root, state.filename);
 
   const platform = api.caller((caller) => caller?.platform);
   return {
     name: 'expo-router',
     visitor: {
-      // Add support for Node.js __filename
-      Identifier(path, state) {
-        if (path.node.name === '__filename') {
-          path.replaceWith(
-            t.stringLiteral(
-              // `/index.js` is the value used by Webpack.
-              getRelPath(state)
-            )
-          );
-        }
-        // Add support for Node.js `__dirname`.
-        // This static value comes from Webpack somewhere.
-        if (path.node.name === '__dirname') {
-          path.replaceWith(t.stringLiteral('/'));
-        }
-      },
-
       // Convert `process.env.EXPO_ROUTER_APP_ROOT` to a string literal
       MemberExpression(path, state) {
         if (


### PR DESCRIPTION
# Why

This was a placeholder and it breaks API routes.

