### PR TITLE
[android][image] fix gif and awebp memory leak (#24259)

### DIFF
--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -100,7 +100,7 @@ dependencies {
   kapt "com.github.bumptech.glide:compiler:${GLIDE_VERSION}"
   api 'com.caverock:androidsvg-aar:1.4'
 
-  implementation "com.github.penfeizhou.android.animation:glide-plugin:2.24.0"
+  implementation "com.github.penfeizhou.android.animation:glide-plugin:2.28.0"
   implementation "com.github.bumptech.glide:avif-integration:${GLIDE_VERSION}"
 
   api 'com.github.bumptech.glide:okhttp3-integration:4.11.0'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As this Issue: https://github.com/expo/expo/issues/24259. Currently, expo-image use glide to load animated images in `onResourceReady` method, but here only called the `com.github.penfeizhou.animation.FrameAnimationDrawable`'s start method but ignore the stop method which could lead a memory leak

![image](https://github.com/expo/expo/assets/5223226/9f5b675e-3209-40d9-b8d4-90402600b66f)


# How

<!--
How did you build this feature or fix this bug and why?
-->

In `com.github.penfeizhou.animation.glide.FrameDrawableTranscoder`, we implements the `recycle `method which is provided by glide:
![image](https://github.com/expo/expo/assets/5223226/9a9adde6-c28a-4903-a49d-0ed1ea90311e)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

For demo project, this project can be used as a test case: https://github.com/terrysahaidak/expo-image-gifs-memory-leak

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
