### PR TITLE
fix(router): navigate by screen key when names are ambiguous

### DIFF
--- a/packages/expo-router/src/__tests__/navigation.test.tsx
+++ b/packages/expo-router/src/__tests__/navigation.test.tsx
@@ -377,3 +377,32 @@ it('can pop back from a nested modal to a nested sibling', async () => {
   act(() => router.back());
   expect(screen).toHavePathname('/slot');
 });
+
+it('asdf', async () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="one" />
+        <Tabs.Screen name="two" />
+      </Tabs>
+    ),
+    'one/_layout': () => <Stack />,
+    'one/screen': () => <Text testID="one/screen" />,
+    'two/_layout': () => <Stack />,
+    'two/screen': () => <Text testID="two/screen" />,
+  });
+
+  expect(screen).toHavePathname('/');
+
+  act(() => router.push('/two/screen'));
+  expect(screen).toHavePathname('/two/screen');
+  expect(screen.getByTestId('two/screen')).toBeTruthy();
+
+  act(() => router.push('/one/screen'));
+  expect(screen).toHavePathname('/one/screen');
+  expect(screen.getByTestId('one/screen')).toBeTruthy();
+
+  act(() => router.push('/two/screen'));
+  expect(screen).toHavePathname('/two/screen');
+  expect(screen.getByTestId('two/screen')).toBeTruthy();
+});

--- a/packages/expo-router/src/link/stateOperations.ts
+++ b/packages/expo-router/src/link/stateOperations.ts
@@ -42,6 +42,21 @@ function findTopStateForTarget(state: ResultState) {
   return current;
 }
 
+export function findKeyForPath(currentState: NavigationState | ResultState, path: string) {
+  for (const route of currentState.routes) {
+    const name = `/${route.name}`;
+    if (path.startsWith(name)) {
+      if (route.state) {
+        return findKeyForPath(route.state, path.replace(name, ''));
+      } else {
+        return route.key;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 /** Return the absolute last route to move to. */
 export function findTopRouteForTarget(state: ResultState) {
   const nextState = findTopStateForTarget(state)!;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
