### PR TITLE
[ios][updates] bump sqlite version

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -239,7 +239,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.6.0):
     - ExpoModulesCore
-    - sqlite3 (= 3.39.2)
+    - sqlite3 (= 3.42.0)
   - ExpoStoreReview (6.6.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.6.0):
@@ -804,9 +804,9 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.39.2):
-    - sqlite3/common (= 3.39.2)
-  - sqlite3/common (3.39.2)
+  - sqlite3 (3.42.0):
+    - sqlite3/common (= 3.42.0)
+  - sqlite3/common (3.42.0)
   - UMAppLoader (4.3.0)
   - Yoga (1.14.0)
   - ZXingObjC/Core (3.6.5)
@@ -1350,7 +1350,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 5366dab0e9a270a6da3acbb1e3471d5522044baf
   ExpoSMS: fbd73390bb7abf0388c8631d6b78186e1342049f
   ExpoSpeech: 8a73bb7e6e84a5b5b8dbaabd5b4f287bec39bf3b
-  ExpoSQLite: 64d51a9a529b581d9b2b716c3e0a376f438dba52
+  ExpoSQLite: 9c22c140dc7c8afe3e8e27909392d5d1ade96d2f
   ExpoStoreReview: 6a63b9ae177bc6b46ec1679eb800ecc8a83a649a
   ExpoSystemUI: e4afa05539f42fe3be09d21a6498e5495019a5b2
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -1429,7 +1429,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: d115522c740c457b805c018b0296b5ba003da280
+  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   UMAppLoader: ca277561ba99dfaec72d6c29bc45843d11407a1f
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - EASClient (0.8.0):
+  - EASClient (0.9.0):
     - ExpoModulesCore
-  - EASClient/Tests (0.8.0):
+  - EASClient/Tests (0.9.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - EXApplication (5.4.0):
+  - EXApplication (5.5.0):
     - ExpoModulesCore
-  - EXAV (13.6.0):
+  - EXAV (13.7.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - EXBarCodeScanner (12.7.0):
@@ -18,37 +18,37 @@ PODS:
     - ZXingObjC/PDF417
   - EXCalendar (12.0.0):
     - ExpoModulesCore
-  - EXCamera (13.6.0):
+  - EXCamera (13.7.0):
     - ExpoModulesCore
-  - EXConstants (15.0.0):
+  - EXConstants (15.1.0):
     - ExpoModulesCore
-  - EXContacts (12.4.0):
+  - EXContacts (12.5.0):
     - ExpoModulesCore
-  - EXFont (11.6.0):
+  - EXFont (11.7.0):
     - ExpoModulesCore
   - EXImageLoader (4.4.0):
     - ExpoModulesCore
     - React-Core
   - EXInAppPurchases (14.5.0):
     - ExpoModulesCore
-  - EXJSONUtils (0.9.0)
-  - EXJSONUtils/Tests (0.9.0)
+  - EXJSONUtils (0.10.0)
+  - EXJSONUtils/Tests (0.10.0)
   - EXLocation (16.3.0):
     - ExpoModulesCore
-  - EXManifests (0.9.0):
+  - EXManifests (0.10.0):
     - ExpoModulesCore
-  - EXManifests/Tests (0.9.0):
+  - EXManifests/Tests (0.10.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - EXMediaLibrary (15.6.0):
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - EXNotifications (0.23.0):
+  - EXNotifications (0.24.1):
     - ExpoModulesCore
   - EXPermissions (14.4.0):
     - ExpoModulesCore
-  - Expo (50.0.0-alpha.2):
+  - Expo (50.0.0-alpha.4):
     - ExpoModulesCore
   - expo-dev-client (3.1.0):
     - EXManifests
@@ -56,9 +56,9 @@ PODS:
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (3.1.0):
+  - expo-dev-launcher (3.2.0):
     - EXManifests
-    - expo-dev-launcher/Main (= 3.1.0)
+    - expo-dev-launcher/Main (= 3.2.0)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -66,7 +66,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Main (3.1.0):
+  - expo-dev-launcher/Main (3.2.0):
     - EXManifests
     - expo-dev-launcher/Unsafe
     - expo-dev-menu
@@ -76,7 +76,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-launcher/Tests (3.1.0):
+  - expo-dev-launcher/Tests (3.2.0):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -90,7 +90,7 @@ PODS:
     - React-Core
     - React-CoreModules
     - React-RCTAppDelegate
-  - expo-dev-launcher/Unsafe (3.1.0):
+  - expo-dev-launcher/Unsafe (3.2.0):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -99,74 +99,74 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-RCTAppDelegate
-  - expo-dev-menu (4.1.0):
-    - expo-dev-menu/Main (= 4.1.0)
-    - expo-dev-menu/ReactNativeCompatibles (= 4.1.0)
+  - expo-dev-menu (4.2.0):
+    - expo-dev-menu/Main (= 4.2.0)
+    - expo-dev-menu/ReactNativeCompatibles (= 4.2.0)
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - expo-dev-menu-interface (1.4.0)
   - expo-dev-menu-interface/Tests (1.4.0):
     - Nimble
     - Quick
-  - expo-dev-menu/Main (4.1.0):
+  - expo-dev-menu/Main (4.2.0):
     - EXManifests
     - expo-dev-menu-interface
     - expo-dev-menu/Vendored
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - expo-dev-menu/ReactNativeCompatibles (4.1.0):
+  - expo-dev-menu/ReactNativeCompatibles (4.2.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - expo-dev-menu/SafeAreaView (4.1.0):
+  - expo-dev-menu/SafeAreaView (4.2.0):
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - expo-dev-menu/Tests (4.1.0):
+  - expo-dev-menu/Tests (4.2.0):
     - ExpoModulesTestCore
     - Nimble
     - Quick
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-CoreModules
-  - expo-dev-menu/UITests (4.1.0):
+  - expo-dev-menu/UITests (4.2.0):
     - RCT-Folly (= 2021.07.22.00)
     - React
     - React-Core
     - React-CoreModules
-  - expo-dev-menu/Vendored (4.1.0):
+  - expo-dev-menu/Vendored (4.2.0):
     - expo-dev-menu/SafeAreaView
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - ExpoAppleAuthentication (6.1.2):
     - ExpoModulesCore
-  - ExpoBackgroundFetch (11.5.0):
+  - ExpoBackgroundFetch (11.6.0):
     - ExpoModulesCore
   - ExpoBattery (7.5.0):
     - ExpoModulesCore
-  - ExpoBlur (12.6.0):
+  - ExpoBlur (12.7.0):
     - ExpoModulesCore
   - ExpoBrightness (11.6.0):
     - ExpoModulesCore
   - ExpoCellular (5.5.0):
     - ExpoModulesCore
-  - ExpoClipboard (4.5.0):
+  - ExpoClipboard (4.6.0):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (4.5.0):
+  - ExpoClipboard/Tests (4.6.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - ExpoCrypto (12.6.0):
     - ExpoModulesCore
-  - ExpoDevice (5.6.0):
+  - ExpoDevice (5.7.0):
     - ExpoModulesCore
   - ExpoDocumentPicker (11.7.0):
     - ExpoModulesCore
-  - ExpoFileSystem (15.6.0):
+  - ExpoFileSystem (15.7.0):
     - ExpoModulesCore
-  - ExpoFileSystem/Tests (15.6.0):
+  - ExpoFileSystem/Tests (15.7.0):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoGL (13.2.0):
+  - ExpoGL (13.3.0):
     - ExpoModulesCore
     - ReactCommon/turbomodule/core
   - ExpoHaptics (12.6.0):
@@ -185,7 +185,7 @@ PODS:
   - ExpoInsights (0.4.0):
     - EASClient
     - ExpoModulesCore
-  - ExpoKeepAwake (12.5.0):
+  - ExpoKeepAwake (12.6.0):
     - ExpoModulesCore
   - ExpoLinearGradient (12.5.0):
     - ExpoModulesCore
@@ -199,20 +199,20 @@ PODS:
     - ExpoModulesCore
     - GoogleMaps (= 7.3.0)
     - GooglePlaces (= 7.3.0)
-  - ExpoModulesCore (1.7.0):
+  - ExpoModulesCore (1.8.0):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesCore/Tests (1.7.0):
+  - ExpoModulesCore/Tests (1.8.0):
     - ExpoModulesTestCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
     - React-NativeModulesApple
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
-  - ExpoModulesTestCore (0.13.0):
+  - ExpoModulesTestCore (0.14.0):
     - ExpoModulesCore
     - Nimble (~> 9.2.0)
     - Quick (~> 5.0.0)
@@ -229,7 +229,7 @@ PODS:
     - React-Core
   - ExpoSecureStore (12.5.0):
     - ExpoModulesCore
-  - ExpoSensors (12.5.0):
+  - ExpoSensors (12.6.0):
     - ExpoModulesCore
   - ExpoSharing (11.7.0):
     - ExpoModulesCore
@@ -237,7 +237,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSpeech (11.5.0):
     - ExpoModulesCore
-  - ExpoSQLite (11.6.0):
+  - ExpoSQLite (11.7.0):
     - ExpoModulesCore
     - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.6.0):
@@ -248,20 +248,20 @@ PODS:
     - ExpoModulesCore
   - ExpoVideoThumbnails (7.6.0):
     - ExpoModulesCore
-  - ExpoWebBrowser (12.5.0):
+  - ExpoWebBrowser (12.6.0):
     - ExpoModulesCore
   - EXScreenCapture (5.5.0):
     - ExpoModulesCore
-  - EXSplashScreen (0.22.0):
+  - EXSplashScreen (0.23.0):
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - EXStructuredHeaders (3.4.0)
-  - EXStructuredHeaders/Tests (3.4.0)
+  - EXStructuredHeaders (3.5.0)
+  - EXStructuredHeaders/Tests (3.5.0)
   - EXTaskManager (11.5.0):
     - ExpoModulesCore
     - UMAppLoader
-  - EXUpdatesInterface (0.12.0)
+  - EXUpdatesInterface (0.13.0)
   - FBLazyVector (0.72.4)
   - FBReactNativeSpec (0.72.4):
     - RCT-Folly (= 2021.07.22.00)
@@ -1294,73 +1294,73 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
-  EASClient: f753a5789e9b41b9103eb508078bc3d03fdc5f7b
-  EXApplication: f0c9b72e41dab55921b3fe712d498f8fb5ecaed4
-  EXAV: 523cd6969ca53b3b2762f18fb5450b76f84df44f
+  EASClient: 549195cdf176ce848a155dbc1f0dfd1c200b9f87
+  EXApplication: 07130d1c32736b1c28b795366331755f723577fa
+  EXAV: d3419a360093a55581a0426f4c0090f34a392de4
   EXBarCodeScanner: 296dd50f6c03928d1d71d37ea17473b304cfdb00
   EXCalendar: f4dac0aa190d359f20652659707f5cc307656b6d
-  EXCamera: 2dc2bd2828bca4e283018a0b5a84aec6639ff0b4
-  EXConstants: f7ac442bf810dd8605f7eff9a44b2ff0d8a45b40
-  EXContacts: afd38f7adacef9a76d6d0bc479f30051736f068f
-  EXFont: 184302793457ce7c6a8260b729c408beb659c2cc
+  EXCamera: 3302fc0e5188a47a2272a439acef7d9a5248a67c
+  EXConstants: 2a5b45fc0f6eccd4351349eadb0c022b735329ae
+  EXContacts: 921cb74db0a191e931df4a3811bcce33820e5702
+  EXFont: b5d79c5341f45b55c362e323735fe658003afc7a
   EXImageLoader: 03063370bc06ea1825713d3f55fe0455f7c88d04
   EXInAppPurchases: 7cb409539cf093b0f5d266f9577c984003a15f72
-  EXJSONUtils: adddef895cae6148f1083c8a2a4b7300701ecc6b
+  EXJSONUtils: b82ded3f9fed1681638c772207bb2e35651478eb
   EXLocation: e5dd52bdf61ccb6153c9e46ad4cb2686c96a35f9
-  EXManifests: 1b13501056f121b014dde85a8d6d082468b28042
+  EXManifests: 3b001efa12886d0abc2b011bc32c4f3346b74256
   EXMediaLibrary: 802eee8ef888ee16ef80f1b79005d3d611793e14
-  EXNotifications: 40f334ce2b713e180e13beff9a16cab170a0c70c
+  EXNotifications: 91905ba30c801a44a1c8c5531b2870d3bec0fb41
   EXPermissions: 51c6115893689c3e9787f4819aa67ceeae601038
-  Expo: 64fd9c4f5aea10e4f326a3afc8e5b2af5e27bf7e
+  Expo: 0ccb4f7970a51de586683f48f2e738836f66aa94
   expo-dev-client: f150ac3b78ca158d2d12fafea8deb4dbe455db7e
-  expo-dev-launcher: 99aaf16e799e1639504fa05584a2f980836bf729
-  expo-dev-menu: 533fd5a1a9f9d717f193681afe0ffe91f4adef71
+  expo-dev-launcher: 8a9124854f5b57c9f15e12edea01f0a43f0197d7
+  expo-dev-menu: be0dd705a5f4f33f9ed5b048c1534fb6f97903ab
   expo-dev-menu-interface: 25a94ce9bead4668f624732d1f981b1791bbe8e2
   ExpoAppleAuthentication: 8c95178a99e7fdb8aea1e3f6385843708471c3df
-  ExpoBackgroundFetch: 7f3334150dd740923144fb0f1a4bf37df1f4dd0d
+  ExpoBackgroundFetch: fed277fbbb3ed9765c7a74e17c0f7fb23efda936
   ExpoBattery: 5f17ec31ec27b8a59f4c87ffe6e69fdbbf4a7cc0
-  ExpoBlur: 9e6da7c2bd4a0c5de7e57124694d0a380d7962f7
+  ExpoBlur: d43fee34125da1454e00044c5cee2dc7dc4e9efc
   ExpoBrightness: 6cdb6f59c20270048404443fbd5a65a2b6b5d9fb
   ExpoCellular: fcb9bc581cab254b63bfcffa60de0abd4e63550b
-  ExpoClipboard: d2f0e44d50e5ba07b02f5fb7bd280178b420e24e
+  ExpoClipboard: 6729cb7ff3f999bf555960a4f3b17dd6b0d919f2
   ExpoCrypto: 42485127a5968dda6f67ac5f2b42d3c0af31d7db
-  ExpoDevice: 4b9825263a3f996fd5a89ec26426e22e6cbc32d6
+  ExpoDevice: 3055a3229d414b8243323fddeb1ac2343548c2aa
   ExpoDocumentPicker: d3b6b0ed2dbbc2f05158e0294dd3f4673f386e5f
-  ExpoFileSystem: 50dfe9a70f6b6c0b7d1fca502a7ee0d8caf69883
-  ExpoGL: d41d4054d14289fb9f537b1203f23a845525c2dd
+  ExpoFileSystem: 62cf8d5681581de1fb43b8af8ea6d7604eb786a6
+  ExpoGL: 6aedfc52c13c1eea5728ec4504f96580bc4dee65
   ExpoHaptics: 604aca02e942d1d43c139cae7cf397b26f85476f
   ExpoImage: bbd451559f49f78d858592fe1d4d74aedb3d900b
   ExpoImageManipulator: 6d37f811d47a89afb34c0ec2521c6a6ea5f5a5be
   ExpoImagePicker: 9e5c745cb3e56ee00e1cfe5d6af59caab66ecf1a
   ExpoInsights: 13a962e646b6e5fd12b5251585f7f082331f9d83
-  ExpoKeepAwake: 3d88ab020efd9cd41988a00cfdf82a447e358b1b
+  ExpoKeepAwake: df1cf76de3171cd57e7cc8a2547401404fcc0b31
   ExpoLinearGradient: 5d18293f89c063036121281175c4653d6a7c34a2
   ExpoLocalAuthentication: 2fed4b25cf8e54d36d5d1ebc9917e8325b3b5911
   ExpoLocalization: 2d5f47577d67ce991ebdd951edf14fe1db85fa06
   ExpoMailComposer: f88bdf18939c94eb965db28c13ba2d85cba70112
   ExpoMaps: e513ba357e6d9fab2e21cd30f6800d89b051b431
-  ExpoModulesCore: a5a7e0dedd64bf0842e50c01e896fdcc47723411
-  ExpoModulesTestCore: e1bbe3bfa5ee4faa761ef255bafcb92383dcf86f
+  ExpoModulesCore: d8437d39da4407d3c6e7001535b9b6c940c62c1b
+  ExpoModulesTestCore: 0287488fb9c7f189fcecd8e46ef6b995091aa5a3
   ExpoNetwork: 1a591f426290be254a8ceaf56fd2a5b7c00111e1
   ExpoPrint: c048657854ad4315be943e1d6a5cf50d94df74f8
   ExpoRandom: ae54b3769440ee9dfefac777ce6263a9be10173b
   ExpoScreenOrientation: 0f0ebb2e4072c7cb2ec36e047f9d817bf428a812
   ExpoSecureStore: 5372610a4bbcf5e50fafbe6f38f8d9c22edf8253
-  ExpoSensors: 9cafd316a9e1ae5aabf70b35b12ef74cc6b1c99e
+  ExpoSensors: 50197fdd0fac79fc66a86885b5d4c975f5001c48
   ExpoSharing: 5366dab0e9a270a6da3acbb1e3471d5522044baf
   ExpoSMS: fbd73390bb7abf0388c8631d6b78186e1342049f
   ExpoSpeech: 8a73bb7e6e84a5b5b8dbaabd5b4f287bec39bf3b
-  ExpoSQLite: e297dec7ac1931a52fecbba77c84e20f473c0c29
+  ExpoSQLite: 1b715f89f306f0f9fe4f96d0e54cc3d058d5c578
   ExpoStoreReview: 6a63b9ae177bc6b46ec1679eb800ecc8a83a649a
   ExpoSystemUI: e4afa05539f42fe3be09d21a6498e5495019a5b2
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
   ExpoVideoThumbnails: d2ded9402b7f8ac10f148238e352eaa4026f2865
-  ExpoWebBrowser: b6e56949734089d75f758f21cfe93fad02bd828c
+  ExpoWebBrowser: 1ff7c5454410b9fbc55084bf298c5914608904d4
   EXScreenCapture: 6ba7b396fd8afd19cb9a5e0ac8820188baf5415e
-  EXSplashScreen: a906ff3babc76cad7ad7482255f043e9e5b9b5d4
-  EXStructuredHeaders: 8dd6bab97912194ee7641c329feca89321140318
+  EXSplashScreen: f464b6f673272b7e427d3816dd7ec07e943095b3
+  EXStructuredHeaders: b0591d7da7218124a950335b746366f0b2a90178
   EXTaskManager: aae3b3c8144af1e0bfdbe8a3cc19fb116a01368d
-  EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
+  EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 6a0e519257b285d77a669d6abe6636f9e6f64f2a
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -239,7 +239,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.6.0):
     - ExpoModulesCore
-    - sqlite3 (= 3.42.0)
+    - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.6.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.6.0):
@@ -1350,7 +1350,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 5366dab0e9a270a6da3acbb1e3471d5522044baf
   ExpoSMS: fbd73390bb7abf0388c8631d6b78186e1342049f
   ExpoSpeech: 8a73bb7e6e84a5b5b8dbaabd5b4f287bec39bf3b
-  ExpoSQLite: 9c22c140dc7c8afe3e8e27909392d5d1ade96d2f
+  ExpoSQLite: e297dec7ac1931a52fecbba77c84e20f473c0c29
   ExpoStoreReview: 6a63b9ae177bc6b46ec1679eb800ecc8a83a649a
   ExpoSystemUI: e4afa05539f42fe3be09d21a6498e5495019a5b2
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2327,7 +2327,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.7.0):
     - ExpoModulesCore
-    - sqlite3 (= 3.42.0)
+    - sqlite3 (~> 3.42.0)
   - ExpoStoreReview (6.6.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.6.0):
@@ -4967,6 +4967,7 @@ SPEC CHECKSUMS:
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   EXUpdates: f9a40063a208e21682ee174272b8d56defae6327
   EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
 ||||||| parent of c70391aaee ([ios][updates] bump sqlite version)
@@ -4976,6 +4977,11 @@ SPEC CHECKSUMS:
 =======
   EXUpdates: e00261ce6e9f030735a23712591dba9d94b77f0d
 >>>>>>> c6a37a4322 ([ios][updates] remove unneeded dep)
+||||||| parent of 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
+  EXUpdates: e00261ce6e9f030735a23712591dba9d94b77f0d
+=======
+  EXUpdates: 2ca83f3a1c21cf6bd22c7b71e157a7ece19c40aa
+>>>>>>> 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
   EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
 =======
 <<<<<<< HEAD

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2327,7 +2327,7 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (11.7.0):
     - ExpoModulesCore
-    - sqlite3 (= 3.39.2)
+    - sqlite3 (= 3.42.0)
   - ExpoStoreReview (6.6.0):
     - ExpoModulesCore
   - ExpoSystemUI (2.6.0):
@@ -3054,9 +3054,9 @@ PODS:
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
   - SocketRocket (0.6.1)
-  - sqlite3 (3.39.2):
-    - sqlite3/common (= 3.39.2)
-  - sqlite3/common (3.39.2)
+  - sqlite3 (3.42.0):
+    - sqlite3/common (= 3.42.0)
+  - sqlite3/common (3.42.0)
   - Stripe (23.8.0):
     - StripeApplePay (= 23.8.0)
     - StripeCore (= 23.8.0)
@@ -4964,8 +4964,24 @@ SPEC CHECKSUMS:
   EXSplashScreen: f464b6f673272b7e427d3816dd7ec07e943095b3
   EXStructuredHeaders: b0591d7da7218124a950335b746366f0b2a90178
   EXTaskManager: aae3b3c8144af1e0bfdbe8a3cc19fb116a01368d
+<<<<<<< HEAD
   EXUpdates: f9a40063a208e21682ee174272b8d56defae6327
   EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
+||||||| parent of c70391aaee ([ios][updates] bump sqlite version)
+  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
+  EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
+=======
+<<<<<<< HEAD
+  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
+  EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
+||||||| parent of b3a73bc072 ([ios][updates] bump sqlite version)
+  EXUpdates: 30c6c1eb2bb6fca39450260c4aeae9024c080c08
+  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
+=======
+  EXUpdates: 1d195e9306940cca4d95faa2bf205f9a94a80052
+  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
+>>>>>>> b3a73bc072 ([ios][updates] bump sqlite version)
+>>>>>>> c70391aaee ([ios][updates] bump sqlite version)
   FBAEMKit: af2972f39bb0f3f7c45998f435b007833c32ffb2
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
@@ -5057,7 +5073,7 @@ SPEC CHECKSUMS:
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: af09429398d99d524cae2fe00f6f0f6e491ed102
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  sqlite3: d115522c740c457b805c018b0296b5ba003da280
+  sqlite3: f163dbbb7aa3339ad8fc622782c2d9d7b72f7e9c
   Stripe: 5432fbab660595a3bee937235dd71a99028ac68c
   stripe-react-native: 096d83ad94da350f08f5cd48275e7f9645dde297
   StripeApplePay: 5e686f50ee07c439b79b907dffeb144135e601c9

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4965,6 +4965,7 @@ SPEC CHECKSUMS:
   EXStructuredHeaders: b0591d7da7218124a950335b746366f0b2a90178
   EXTaskManager: aae3b3c8144af1e0bfdbe8a3cc19fb116a01368d
 <<<<<<< HEAD
+<<<<<<< HEAD
   EXUpdates: f9a40063a208e21682ee174272b8d56defae6327
   EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
 ||||||| parent of c70391aaee ([ios][updates] bump sqlite version)
@@ -4973,7 +4974,14 @@ SPEC CHECKSUMS:
 =======
 <<<<<<< HEAD
   EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
+||||||| parent of 6101e3b405 ([ios][updates] fix podfile.lock)
+<<<<<<< HEAD
+  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
+=======
+  EXUpdates: 79bd417be2d521e99771df018258f9e76e030fd9
+>>>>>>> 6101e3b405 ([ios][updates] fix podfile.lock)
   EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
+<<<<<<< HEAD
 ||||||| parent of b3a73bc072 ([ios][updates] bump sqlite version)
   EXUpdates: 30c6c1eb2bb6fca39450260c4aeae9024c080c08
   EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
@@ -4982,6 +4990,16 @@ SPEC CHECKSUMS:
   EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
 >>>>>>> b3a73bc072 ([ios][updates] bump sqlite version)
 >>>>>>> c70391aaee ([ios][updates] bump sqlite version)
+||||||| parent of 6101e3b405 ([ios][updates] fix podfile.lock)
+||||||| parent of b3a73bc072 ([ios][updates] bump sqlite version)
+  EXUpdates: 30c6c1eb2bb6fca39450260c4aeae9024c080c08
+  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
+=======
+  EXUpdates: 1d195e9306940cca4d95faa2bf205f9a94a80052
+  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
+>>>>>>> b3a73bc072 ([ios][updates] bump sqlite version)
+=======
+>>>>>>> 6101e3b405 ([ios][updates] fix podfile.lock)
   FBAEMKit: af2972f39bb0f3f7c45998f435b007833c32ffb2
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2225,11 +2225,11 @@ PODS:
     - ExpoModulesCore
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - EXNotifications (0.24.0):
+  - EXNotifications (0.24.1):
     - ExpoModulesCore
   - EXPermissions (14.4.0):
     - ExpoModulesCore
-  - Expo (50.0.0-alpha.3):
+  - Expo (50.0.0-alpha.4):
     - ExpoModulesCore
   - ExpoAppleAuthentication (6.1.2):
     - ExpoModulesCore
@@ -2264,7 +2264,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - ExpoHaptics (12.6.0):
     - ExpoModulesCore
-  - ExpoHead (3.1.0):
+  - ExpoHead (3.1.1):
     - ExpoModulesCore
   - ExpoImage (1.5.1):
     - ExpoModulesCore
@@ -2358,6 +2358,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - ReachabilitySwift
     - React-Core
+    - sqlite3 (~> 3.42.0)
   - EXUpdates/Tests (0.21.0):
     - EASClient
     - EXManifests
@@ -2368,6 +2369,7 @@ PODS:
     - RCT-Folly (= 2021.07.22.00)
     - ReachabilitySwift
     - React-Core
+    - sqlite3 (~> 3.42.0)
   - EXUpdatesInterface (0.13.0)
   - FBAEMKit (16.1.3):
     - FBSDKCoreKit_Basics (= 16.1.3)
@@ -4918,9 +4920,9 @@ SPEC CHECKSUMS:
   EXLocation: e5dd52bdf61ccb6153c9e46ad4cb2686c96a35f9
   EXManifests: 3b001efa12886d0abc2b011bc32c4f3346b74256
   EXMediaLibrary: 802eee8ef888ee16ef80f1b79005d3d611793e14
-  EXNotifications: d563f36a0e2871596abe21277ed054af035eb15e
+  EXNotifications: 91905ba30c801a44a1c8c5531b2870d3bec0fb41
   EXPermissions: 51c6115893689c3e9787f4819aa67ceeae601038
-  Expo: ae76c5170af084275294c4e595aec6ef250ff90f
+  Expo: 0ccb4f7970a51de586683f48f2e738836f66aa94
   ExpoAppleAuthentication: 8c95178a99e7fdb8aea1e3f6385843708471c3df
   ExpoBackgroundFetch: fed277fbbb3ed9765c7a74e17c0f7fb23efda936
   ExpoBattery: 5f17ec31ec27b8a59f4c87ffe6e69fdbbf4a7cc0
@@ -4934,7 +4936,7 @@ SPEC CHECKSUMS:
   ExpoFileSystem: 62cf8d5681581de1fb43b8af8ea6d7604eb786a6
   ExpoGL: 6aedfc52c13c1eea5728ec4504f96580bc4dee65
   ExpoHaptics: 604aca02e942d1d43c139cae7cf397b26f85476f
-  ExpoHead: f77f5adeb4d1a76e912ad7303d96ca07e20ec506
+  ExpoHead: 57d01ae682309f5b6a293eb44343010c56d1bacc
   ExpoImage: bbd451559f49f78d858592fe1d4d74aedb3d900b
   ExpoImageManipulator: 6d37f811d47a89afb34c0ec2521c6a6ea5f5a5be
   ExpoImagePicker: 9e5c745cb3e56ee00e1cfe5d6af59caab66ecf1a
@@ -4954,7 +4956,7 @@ SPEC CHECKSUMS:
   ExpoSharing: 5366dab0e9a270a6da3acbb1e3471d5522044baf
   ExpoSMS: fbd73390bb7abf0388c8631d6b78186e1342049f
   ExpoSpeech: 8a73bb7e6e84a5b5b8dbaabd5b4f287bec39bf3b
-  ExpoSQLite: db24f4159b0b613d7c5b0d0857a33ace42df55d5
+  ExpoSQLite: 1b715f89f306f0f9fe4f96d0e54cc3d058d5c578
   ExpoStoreReview: 6a63b9ae177bc6b46ec1679eb800ecc8a83a649a
   ExpoSystemUI: e4afa05539f42fe3be09d21a6498e5495019a5b2
   ExpoTrackingTransparency: b14d3e7946b36962ee87c8656be540d60ff70c5d
@@ -4964,54 +4966,8 @@ SPEC CHECKSUMS:
   EXSplashScreen: f464b6f673272b7e427d3816dd7ec07e943095b3
   EXStructuredHeaders: b0591d7da7218124a950335b746366f0b2a90178
   EXTaskManager: aae3b3c8144af1e0bfdbe8a3cc19fb116a01368d
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-  EXUpdates: f9a40063a208e21682ee174272b8d56defae6327
+  EXUpdates: b6ffa480cd2539863f548f4b7e3c5a46d1fdfe72
   EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
-||||||| parent of c70391aaee ([ios][updates] bump sqlite version)
-  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
-||||||| parent of c6a37a4322 ([ios][updates] remove unneeded dep)
-  EXUpdates: 79bd417be2d521e99771df018258f9e76e030fd9
-=======
-  EXUpdates: e00261ce6e9f030735a23712591dba9d94b77f0d
->>>>>>> c6a37a4322 ([ios][updates] remove unneeded dep)
-||||||| parent of 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
-  EXUpdates: e00261ce6e9f030735a23712591dba9d94b77f0d
-=======
-  EXUpdates: 2ca83f3a1c21cf6bd22c7b71e157a7ece19c40aa
->>>>>>> 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
-  EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
-=======
-<<<<<<< HEAD
-  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
-||||||| parent of 6101e3b405 ([ios][updates] fix podfile.lock)
-<<<<<<< HEAD
-  EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
-=======
-  EXUpdates: 79bd417be2d521e99771df018258f9e76e030fd9
->>>>>>> 6101e3b405 ([ios][updates] fix podfile.lock)
-  EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
-<<<<<<< HEAD
-||||||| parent of b3a73bc072 ([ios][updates] bump sqlite version)
-  EXUpdates: 30c6c1eb2bb6fca39450260c4aeae9024c080c08
-  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
-=======
-  EXUpdates: 1d195e9306940cca4d95faa2bf205f9a94a80052
-  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
->>>>>>> b3a73bc072 ([ios][updates] bump sqlite version)
->>>>>>> c70391aaee ([ios][updates] bump sqlite version)
-||||||| parent of 6101e3b405 ([ios][updates] fix podfile.lock)
-||||||| parent of b3a73bc072 ([ios][updates] bump sqlite version)
-  EXUpdates: 30c6c1eb2bb6fca39450260c4aeae9024c080c08
-  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
-=======
-  EXUpdates: 1d195e9306940cca4d95faa2bf205f9a94a80052
-  EXUpdatesInterface: 1f9cdd9e1e1026de7488ac537e9c40bc6b6fb872
->>>>>>> b3a73bc072 ([ios][updates] bump sqlite version)
-=======
->>>>>>> 6101e3b405 ([ios][updates] fix podfile.lock)
   FBAEMKit: af2972f39bb0f3f7c45998f435b007833c32ffb2
   FBAudienceNetwork: 03e273f66b70756be7d060927111af97b7641b06
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4966,10 +4966,16 @@ SPEC CHECKSUMS:
   EXTaskManager: aae3b3c8144af1e0bfdbe8a3cc19fb116a01368d
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
   EXUpdates: f9a40063a208e21682ee174272b8d56defae6327
   EXUpdatesInterface: 98f69982f4b429eb62a1d99259bc980038240f27
 ||||||| parent of c70391aaee ([ios][updates] bump sqlite version)
   EXUpdates: 2a2b560639dbc2424bc13f4010b7212c82a2b63f
+||||||| parent of c6a37a4322 ([ios][updates] remove unneeded dep)
+  EXUpdates: 79bd417be2d521e99771df018258f9e76e030fd9
+=======
+  EXUpdates: e00261ce6e9f030735a23712591dba9d94b77f0d
+>>>>>>> c6a37a4322 ([ios][updates] remove unneeded dep)
   EXUpdatesInterface: 376edcf7e762dcf8f55552804944dac004fa3349
 =======
 <<<<<<< HEAD

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,18 +10,14 @@
 
 ### 💡 Others
 
-<<<<<<< HEAD
+- [iOS] Bump `SQLite`version to latest. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 11.7.0 — 2023-09-15
 
 ### 🐛 Bug fixes
 
 - [iOS] Fixed an issue with CRSQLite missing a minimum OS version on iOS, causing rejections on AppStore Connect submission. ([#24347](https://github.com/expo/expo/pull/24347) by [@derekstavis](https://github.com/derekstavis))
 
-||||||| parent of 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
-=======
-- [iOS] Bump `SQLite`version to latest. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))
-
->>>>>>> 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
 ## 11.3.3 — 2023-09-08
 
 ### 🎉 New features

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,12 +10,18 @@
 
 ### 💡 Others
 
+<<<<<<< HEAD
 ## 11.7.0 — 2023-09-15
 
 ### 🐛 Bug fixes
 
 - [iOS] Fixed an issue with CRSQLite missing a minimum OS version on iOS, causing rejections on AppStore Connect submission. ([#24347](https://github.com/expo/expo/pull/24347) by [@derekstavis](https://github.com/derekstavis))
 
+||||||| parent of 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
+=======
+- [iOS] Bump `SQLite`version to latest. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))
+
+>>>>>>> 44fc8dd96a ([ios][updates] loosen podspec constraint. Make call sites consistent)
 ## 11.3.3 — 2023-09-08
 
 ### 🎉 New features

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'ExpoModulesCore'
   # The builtin sqlite does not support extensions so we update it
-  s.dependency 'sqlite3', '3.42.0'
+  s.dependency 'sqlite3', '~> 3.42.0'
   
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
   s.dependency 'ExpoModulesCore'
   # The builtin sqlite does not support extensions so we update it
-  s.dependency 'sqlite3', '3.39.2'
+  s.dependency 'sqlite3', '3.42.0'
   
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -34,7 +34,6 @@
 - Update E2E test. ([#24272](https://github.com/expo/expo/pull/24272) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Disable packager and bundle JS when `EX_UPDATES_NATIVE_DEBUG` set. ([#24366](https://github.com/expo/expo/pull/24366) by [@douglowder](https://github.com/douglowder))
 - Add Apple TV to Updates E2E (build only). ([#24411](https://github.com/expo/expo/pull/24411) by [@douglowder](https://github.com/douglowder))
-- [iOS] Disable packager and bundle JS when EX_UPDATES_NATIVE_DEBUG set. ([#24366](https://github.com/expo/expo/pull/24366) by [@douglowder](https://github.com/douglowder))
 - Add `sqlite3` to the podspec to use newer version that the built in. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.20.0 — 2023-09-04

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -34,6 +34,8 @@
 - Update E2E test. ([#24272](https://github.com/expo/expo/pull/24272) by [@EvanBacon](https://github.com/EvanBacon))
 - [iOS] Disable packager and bundle JS when `EX_UPDATES_NATIVE_DEBUG` set. ([#24366](https://github.com/expo/expo/pull/24366) by [@douglowder](https://github.com/douglowder))
 - Add Apple TV to Updates E2E (build only). ([#24411](https://github.com/expo/expo/pull/24411) by [@douglowder](https://github.com/douglowder))
+- [iOS] Disable packager and bundle JS when EX_UPDATES_NATIVE_DEBUG set. ([#24366](https://github.com/expo/expo/pull/24366) by [@douglowder](https://github.com/douglowder))
+- Add `sqlite3` to the podspec to use newer version that the built in. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.20.0 — 2023-09-04
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -14,7 +14,6 @@ Pod::Spec.new do |s|
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
-  
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency 'EXStructuredHeaders'
@@ -22,7 +21,7 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
-  s.dependency 'sqlite3', '3.42.0'
+  s.dependency 'sqlite3', '~> 3.42.0'
 
   unless defined?(install_modules_dependencies)
     # `install_modules_dependencies` is defined from react_native_pods.rb.

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
+  s.dependency 'ASN1Decoder', '~> 1.8'
+  s.dependency 'sqlite3', '3.42.0'
 
   unless defined?(install_modules_dependencies)
     # `install_modules_dependencies` is defined from react_native_pods.rb.

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
-
+  
   s.dependency 'ExpoModulesCore'
   s.dependency 'React-Core'
   s.dependency 'EXStructuredHeaders'
@@ -22,7 +22,6 @@ Pod::Spec.new do |s|
   s.dependency 'EXManifests'
   s.dependency 'EASClient'
   s.dependency 'ReachabilitySwift'
-  s.dependency 'ASN1Decoder', '~> 1.8'
   s.dependency 'sqlite3', '3.42.0'
 
   unless defined?(install_modules_dependencies)

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal enum UpdatesDatabaseMigrationError: Error {
   case foreignKeysError

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration4To5.swift
@@ -3,7 +3,7 @@
 // swiftlint:disable line_length
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration4To5: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v4.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration5To6.swift
@@ -3,7 +3,7 @@
 // swiftlint:disable line_length
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration5To6: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v5.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration6To7.swift
@@ -3,7 +3,7 @@
 // swiftlint:disable line_length
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration6To7: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v6.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration7To8.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration7To8.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration7To8: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v7.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration8To9.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration8To9.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2021 650 Industries. All rights reserved.
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration8To9: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v8.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/Migrations/UpdatesDatabaseMigration9To10.swift
@@ -3,7 +3,7 @@
 // swiftlint:disable line_length
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal final class UpdatesDatabaseMigration9To10: UpdatesDatabaseMigration {
   private(set) var filename: String = "expo-v9.db"

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -10,7 +10,7 @@
 // swiftlint:disable file_length
 
 import Foundation
-import SQLite3
+import sqlite3
 import EXManifests
 
 internal enum UpdatesDatabaseError: Error {

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -6,7 +6,7 @@
 // swiftlint:disable force_unwrapping
 
 import Foundation
-import SQLite3
+import sqlite3
 
 enum UpdatesDatabaseInitializationError: Error {
   case migrateAndRemoveOldDatabaseFailure

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -195,7 +195,7 @@ internal final class UpdatesDatabaseInitialization {
     }
 
     var db: OpaquePointer?
-    if sqlite3_open(String(latestURL.absoluteString.utf8), &db) != SQLITE_OK {
+    if sqlite3_open(latestURL.path, &db) != SQLITE_OK {
       NSLog("Error opening migrated SQLite db: %@", [UpdatesDatabaseUtils.errorCodesAndMessage(fromSqlite: db!).message])
       sqlite3_close(db)
       return false

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseInitialization.swift
@@ -113,7 +113,7 @@ internal final class UpdatesDatabaseInitialization {
     }
 
     var dbInit: OpaquePointer?
-    let resultCode = sqlite3_open(String(dbUrl.path.utf8), &dbInit)
+    let resultCode = sqlite3_open(dbUrl.path, &dbInit)
 
     guard var db = dbInit else {
       throw UpdatesDatabaseInitializationError.openDatabaseFalure
@@ -134,7 +134,7 @@ internal final class UpdatesDatabaseInitialization {
 
         NSLog("Moved corrupt SQLite db to %@", archivedDbFilename)
         var dbInit2: OpaquePointer?
-        guard sqlite3_open(String(dbUrl.absoluteString.utf8), &dbInit2) == SQLITE_OK else {
+        guard sqlite3_open(dbUrl.path, &dbInit2) == SQLITE_OK else {
           throw UpdatesDatabaseInitializationError.openAfterMovingCorruptedDatabaseFailure
         }
 

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabaseUtils.swift
@@ -8,7 +8,7 @@
 // swiftlint:disable force_unwrapping
 
 import Foundation
-import SQLite3
+import sqlite3
 
 internal struct UpdatesDatabaseUtilsErrorInfo {
   let code: Int

--- a/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
+++ b/packages/expo-updates/ios/Tests/DatabaseInitializationSpec.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2020 650 Industries, Inc. All rights reserved.
 
 import ExpoModulesTestCore
-import SQLite3
+import sqlite3
 
 @testable import EXUpdates
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3996,7 +3996,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18", "@types/express-serve-static-core@^4.17.33":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.33":
   version "4.17.36"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
   integrity sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==


### PR DESCRIPTION
# Why
We need to update to the latest SQLite version for some features we are adding to `expo-sqlite`. 

# How
Adding `sqlite3` to the `expo-updates` podspec

# Test Plan
~~There is one failing native test `migrates 4 to 5`. For some reason, the migration isn't being run. Maybe someone more familiar can see why? The rest of the test suite is passing~~
All tests passing
