### PR TITLE
fix(router): Ignore root HTML automatically in the context module.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 💡 Others
 
+- Ignore root HTML automatically in the context module.
 - Compile to cjs to support running directly in Node.js. ([#24349](https://github.com/expo/expo/pull/24349) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build. ([#24309](https://github.com/expo/expo/pull/24309) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 💡 Others
 
-- Ignore root HTML automatically in the context module.
+- Ignore root HTML automatically in the context module. ([#24388](https://github.com/expo/expo/pull/24388) by [@EvanBacon](https://github.com/EvanBacon))
 - Compile to cjs to support running directly in Node.js. ([#24349](https://github.com/expo/expo/pull/24349) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix build. ([#24309](https://github.com/expo/expo/pull/24309) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/expo-router/_ctx.android.js
+++ b/packages/expo-router/_ctx.android.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /.*/,
+  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_ANDROID
 );

--- a/packages/expo-router/_ctx.android.js
+++ b/packages/expo-router/_ctx.android.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
+  /^(?:\.\/)(?!(?:(?:(?:.*\+api)|(?:\+html)))\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_ANDROID
 );

--- a/packages/expo-router/_ctx.ios.js
+++ b/packages/expo-router/_ctx.ios.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /.*/,
+  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_IOS
 );

--- a/packages/expo-router/_ctx.ios.js
+++ b/packages/expo-router/_ctx.ios.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
+  /^(?:\.\/)(?!(?:(?:(?:.*\+api)|(?:\+html)))\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_IOS
 );

--- a/packages/expo-router/_ctx.js
+++ b/packages/expo-router/_ctx.js
@@ -2,5 +2,5 @@ export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
   // Ignore root `./+html.js` and API route files `./generate+api.tsx`.
-  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/
+  /^(?:\.\/)(?!(?:(?:(?:.*\+api)|(?:\+html)))\.[tj]sx?$).*\.[tj]sx?$/
 );

--- a/packages/expo-router/_ctx.js
+++ b/packages/expo-router/_ctx.js
@@ -1,1 +1,6 @@
-export const ctx = require.context(process.env.EXPO_ROUTER_APP_ROOT, true, /.*/);
+export const ctx = require.context(
+  process.env.EXPO_ROUTER_APP_ROOT,
+  true,
+  // Ignore root `./+html.js` and API route files `./generate+api.tsx`.
+  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/
+);

--- a/packages/expo-router/_ctx.web.js
+++ b/packages/expo-router/_ctx.web.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /.*/,
+  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_WEB
 );

--- a/packages/expo-router/_ctx.web.js
+++ b/packages/expo-router/_ctx.web.js
@@ -1,6 +1,6 @@
 export const ctx = require.context(
   process.env.EXPO_ROUTER_APP_ROOT,
   true,
-  /^(?:\.\/)(?!(.*\+api)|\+html\.[tj]sx?$).*\.[tj]sx?$/,
+  /^(?:\.\/)(?!(?:(?:(?:.*\+api)|(?:\+html)))\.[tj]sx?$).*\.[tj]sx?$/,
   process.env.EXPO_ROUTER_IMPORT_MODE_WEB
 );


### PR DESCRIPTION
# Why

- Update the regex in context modules to prevent importing HTML wrappers and API routes. This will cut down on resolution nominally, and decrease the chance that a user will break the transformer that strips API code.
