### PR TITLE
chore(cli) amend the --dev flag description

### DIFF
--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -42,7 +42,7 @@ export const expoExport: Command = async (argv) => {
       chalk`npx expo export {dim <dir>}`,
       [
         chalk`<dir>                      Directory of the Expo project. {dim Default: Current working directory}`,
-        `--dev                      Generates a development bundle`,
+        `--dev                      Bundles JavaScript files in development mode`,
         chalk`--output-dir <dir>         The directory to export the static files to. {dim Default: dist}`,
         `--max-workers <number>     Maximum number of tasks to allow the bundler to spawn`,
         `--dump-assetmap            Dump the asset map for further processing`,

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -42,7 +42,7 @@ export const expoExport: Command = async (argv) => {
       chalk`npx expo export {dim <dir>}`,
       [
         chalk`<dir>                      Directory of the Expo project. {dim Default: Current working directory}`,
-        `--dev                      Configure static files for developing locally using a non-https server`,
+        `--dev                      Generates a development bundle`,
         chalk`--output-dir <dir>         The directory to export the static files to. {dim Default: dist}`,
         `--max-workers <number>     Maximum number of tasks to allow the bundler to spawn`,
         `--dump-assetmap            Dump the asset map for further processing`,


### PR DESCRIPTION
# Why

The legacy `expo-cli` exposed the `export` command that did [extra actions](https://github.com/expo/expo-cli/blob/main/packages/expo-cli/src/commands/export/exportAsync.ts#L59) with the `--dev` flag, but the current cli appears to only pass the flag off to metro to [generate a development bundle](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/export/exportApp.ts#L79) and set node env to 'development'. 

# How

Amend the documentation to reflect what `--dev` does

# Test Plan

- [ ] tests still pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
