### PR TITLE
[menu][Android] Fix task ':packageReleaseAssets' uses this output of task ':copyAssets without declaring dependency

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed task ':expo-dev-menu:packageReleaseAssets' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency on Android.
+
 ### 💡 Others
 
 ## 4.1.0 — 2023-09-04

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed task ':expo-dev-menu:packageReleaseAssets' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency on Android.
+- Fixed task ':expo-dev-menu:packageReleaseAssets' uses this output of task ':expo-dev-menu:copyAssets' without declaring an explicit or implicit dependency on Android. ([#24393](https://github.com/expo/expo/pull/24393) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/.gitignore
+++ b/packages/expo-dev-menu/android/.gitignore
@@ -261,3 +261,4 @@ gradle-app.setting
 # End of https://www.gitignore.io/api/java,maven,gradle,android,intellij,androidstudio
 
 src/main/assets/
+src/debug/assets/

--- a/packages/expo-dev-menu/android/build.gradle
+++ b/packages/expo-dev-menu/android/build.gradle
@@ -112,11 +112,20 @@ android {
   }
 }
 
+task clenupAssets(type: Delete) {
+  // In the past, assets were placed in the `main` directory.
+  // However, this is no longer the case. To ensure a smooth transition,
+  // we’re also removing assets from the old location.
+  delete files("src/main/assets")
+}
+
 task copyAssets(type: Copy) {
+  dependsOn(clenupAssets)
+
   from('../assets') {
     exclude "*.ios.*"
   }
-  into 'src/main/assets'
+  into 'src/debug/assets'
 }
 
 project.afterEvaluate {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/24389.

# How

Make sure that the release task doesn't use the output of the `copyAssets`.

# Test Plan

- `npx expo prebuild --clean -p android && cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release`