### PR TITLE
[docs] Fix missing images in Location

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -182,16 +182,6 @@ const styles = StyleSheet.create({
 
 ## Enable Emulator Location
 
-### iOS Simulator
-
-With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
-
-<ImageSpotlight
-  alt="Location settings in iOS simulator."
-  src="/static/images/sdk/location/ios-simulator-location.png"
-  style={{ maxWidth: 480 }}
-/>
-
 ### Android Emulator
 
 Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
@@ -205,6 +195,16 @@ Open Android Studio, and launch the Android Emulator. Inside it, go to **Setting
 If you don't receive the locations in the emulator, you may have to turn off the **Improve Location Accuracy** setting. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 
 For Android 12 and higher, go to **Settings** > **Location** > **Location Services** > **Google Location Accuracy**, and turn off **Improve Location Accuracy**. For Android 11 and lower, go to **Settings** > **Location** > **Advanced** > **Google Location Accuracy**, and turn off **Google Location Accuracy**.
+
+### iOS Simulator
+
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
+
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ## API
 

--- a/docs/pages/versions/v46.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/location.mdx
@@ -141,15 +141,23 @@ const styles = StyleSheet.create({
 
 ### iOS Simulator
 
-With Simulator open, go to Debug > Location and choose any option besides "None" (obviously).
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
 
-![iOS Simulator location](/static/images/ios-simulator-location.png)
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ### Android Emulator
 
-Open Android Studio, and launch your AVD in the emulator. Then, on the options bar for your device, click the icon for "More" and navigate to the "Location" tab.
+Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
 
-![Android Simulator location](/static/images/android-emulator-location.png)
+<ImageSpotlight
+  alt="Location settings in Android Emulator for versions 12 and higher"
+  src="/static/images/sdk/location/enable-android-emulator-location.png"
+  style={{ maxWidth: 360 }}
+/>
 
 If you don't receive the locations in the emulator, you may have to turn off "Improve Location Accuracy" in Settings - Location in the emulator. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 

--- a/docs/pages/versions/v46.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/location.mdx
@@ -10,6 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { AndroidPermissions } from '~/components/plugins/permissions';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -139,16 +140,6 @@ const styles = StyleSheet.create({
 
 ## Enabling Emulator Location
 
-### iOS Simulator
-
-With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
-
-<ImageSpotlight
-  alt="Location settings in iOS simulator."
-  src="/static/images/sdk/location/ios-simulator-location.png"
-  style={{ maxWidth: 480 }}
-/>
-
 ### Android Emulator
 
 Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
@@ -160,6 +151,16 @@ Open Android Studio, and launch the Android Emulator. Inside it, go to **Setting
 />
 
 If you don't receive the locations in the emulator, you may have to turn off "Improve Location Accuracy" in Settings - Location in the emulator. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
+
+### iOS Simulator
+
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
+
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ## API
 

--- a/docs/pages/versions/v47.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/location.mdx
@@ -141,15 +141,23 @@ const styles = StyleSheet.create({
 
 ### iOS Simulator
 
-With Simulator open, go to Debug > Location and choose any option besides "None" (obviously).
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
 
-![iOS Simulator location](/static/images/ios-simulator-location.png)
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ### Android Emulator
 
-Open Android Studio, and launch your AVD in the emulator. Then, on the options bar for your device, click the icon for "More" and navigate to the "Location" tab.
+Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
 
-![Android Simulator location](/static/images/android-emulator-location.png)
+<ImageSpotlight
+  alt="Location settings in Android Emulator for versions 12 and higher"
+  src="/static/images/sdk/location/enable-android-emulator-location.png"
+  style={{ maxWidth: 360 }}
+/>
 
 If you don't receive the locations in the emulator, you may have to turn off "Improve Location Accuracy" in Settings - Location in the emulator. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 

--- a/docs/pages/versions/v47.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/location.mdx
@@ -10,6 +10,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import PlatformsSection from '~/components/plugins/PlatformsSection';
 import { SnackInline } from '~/ui/components/Snippet';
 import { AndroidPermissions } from '~/components/plugins/permissions';
+import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 
 `expo-location` allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.
 
@@ -139,16 +140,6 @@ const styles = StyleSheet.create({
 
 ## Enabling Emulator Location
 
-### iOS Simulator
-
-With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
-
-<ImageSpotlight
-  alt="Location settings in iOS simulator."
-  src="/static/images/sdk/location/ios-simulator-location.png"
-  style={{ maxWidth: 480 }}
-/>
-
 ### Android Emulator
 
 Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
@@ -160,6 +151,16 @@ Open Android Studio, and launch the Android Emulator. Inside it, go to **Setting
 />
 
 If you don't receive the locations in the emulator, you may have to turn off "Improve Location Accuracy" in Settings - Location in the emulator. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
+
+### iOS Simulator
+
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
+
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ## API
 

--- a/docs/pages/versions/v48.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/location.mdx
@@ -182,16 +182,6 @@ const styles = StyleSheet.create({
 
 ## Enable Emulator Location
 
-### iOS Simulator
-
-With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
-
-<ImageSpotlight
-  alt="Location settings in iOS simulator."
-  src="/static/images/sdk/location/ios-simulator-location.png"
-  style={{ maxWidth: 480 }}
-/>
-
 ### Android Emulator
 
 Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
@@ -205,6 +195,16 @@ Open Android Studio, and launch the Android Emulator. Inside it, go to **Setting
 If you don't receive the locations in the emulator, you may have to turn off the **Improve Location Accuracy** setting. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 
 For Android 12 and higher, go to **Settings** > **Location** > **Location Services** > **Google Location Accuracy**, and turn off **Improve Location Accuracy**. For Android 11 and lower, go to **Settings** > **Location** > **Advanced** > **Google Location Accuracy**, and turn off **Google Location Accuracy**.
+
+### iOS Simulator
+
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
+
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ## API
 

--- a/docs/pages/versions/v49.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/location.mdx
@@ -182,16 +182,6 @@ const styles = StyleSheet.create({
 
 ## Enable Emulator Location
 
-### iOS Simulator
-
-With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
-
-<ImageSpotlight
-  alt="Location settings in iOS simulator."
-  src="/static/images/sdk/location/ios-simulator-location.png"
-  style={{ maxWidth: 480 }}
-/>
-
 ### Android Emulator
 
 Open Android Studio, and launch the Android Emulator. Inside it, go to **Settings** > **Location** and enable **Use location**.
@@ -205,6 +195,16 @@ Open Android Studio, and launch the Android Emulator. Inside it, go to **Setting
 If you don't receive the locations in the emulator, you may have to turn off the **Improve Location Accuracy** setting. This will turn off Wi-Fi location and only use GPS. Then you can manipulate the location with GPS data through the emulator.
 
 For Android 12 and higher, go to **Settings** > **Location** > **Location Services** > **Google Location Accuracy**, and turn off **Improve Location Accuracy**. For Android 11 and lower, go to **Settings** > **Location** > **Advanced** > **Google Location Accuracy**, and turn off **Google Location Accuracy**.
+
+### iOS Simulator
+
+With Simulator open, go to **Features** > **Location** and choose any option besides **None**.
+
+<ImageSpotlight
+  alt="Location settings in iOS simulator."
+  src="/static/images/sdk/location/ios-simulator-location.png"
+  style={{ maxWidth: 480 }}
+/>
 
 ## API
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Image path missing for Android and iOS in enable emulator location section.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix missing image path for SDK 47 and 46
- Fix platform order reference in all SDK and unversioned docs

**Preview**

<img width="1512" alt="CleanShot 2023-09-12 at 17 33 58@2x" src="https://github.com/expo/expo/assets/10234615/9c41ea85-285e-42f7-be4b-946dffda45dd">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/versions/v47.0.0/sdk/location/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
