### PR TITLE
[docs] Fix link to JavaScriptCore Engine

### DIFF
--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -209,7 +209,7 @@ The operating system used on iPhone, iPad, and Apple TV. [Expo Go](#expo-go) cur
 
 ### JavaScript Engine
 
-A native package that can evaluate JavaScript on-device. In React Native we often use [JavaScriptCore](#javascript-engine). Other options include [Hermes](#hermes-engine) by [Meta](#meta), and V8 by Google.
+A native package that can evaluate JavaScript on-device. In React Native we often use [JavaScriptCore](#javascriptcore-engine). Other options include [Hermes](#hermes-engine) by [Meta](#meta), and V8 by Google.
 
 ### JavaScriptCore Engine
 


### PR DESCRIPTION
# Why

I noticed that the "JavaScript Engine" part links back to itself but it should link to the "JavaScriptCore Engine" instead.

# How

I saw that other parts of the file that have a link on `[JavaScriptCore]` also link to `#javascriptcore-engine`.

# Test Plan

I clicked the link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
