### PR TITLE
[go] Load embedded bundle and manifest in release builds

### DIFF
--- a/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExpoApplication.kt
@@ -29,7 +29,7 @@ abstract class ExpoApplication : MultiDexApplication() {
     super.onCreate()
 
     ExpoViewBuildConfig.DEBUG = isDebug
-    ExpoViewBuildConfig.USE_INTERNET_KERNEL = shouldUseInternetKernel()
+    ExpoViewBuildConfig.USE_EMBEDDED_KERNEL = shouldUseEmbeddedKernel()
 
     if (ExpoViewBuildConfig.DEBUG && Constants.WAIT_FOR_DEBUGGER) {
       Debug.waitForDebugger()
@@ -85,7 +85,7 @@ abstract class ExpoApplication : MultiDexApplication() {
 
   // we're leaving this stub in here so that if people don't modify their MainApplication to
   // remove the override of shouldUseInternetKernel() their project will still build without errors
-  fun shouldUseInternetKernel(): Boolean {
+  fun shouldUseEmbeddedKernel(): Boolean {
     return !isDebug
   }
 

--- a/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/ExponentManifest.kt
@@ -161,7 +161,7 @@ class ExponentManifest @Inject constructor(
     throw RuntimeException("Can't get local manifest: $e")
   }
 
-  private fun getRemoteKernelManifest(): Manifest? = try {
+  private fun getEmbeddedKernelManifest(): Manifest? = try {
     val inputStream = context.assets.open(EMBEDDED_KERNEL_MANIFEST_ASSET)
     val jsonString = IOUtils.toString(inputStream)
     val manifest = JSONObject(jsonString)
@@ -175,9 +175,9 @@ class ExponentManifest @Inject constructor(
   fun getKernelManifestAndAssetRequestHeaders(): ManifestAndAssetRequestHeaders {
     val manifestAndAssetRequestHeaders: ManifestAndAssetRequestHeaders
     val log: String
-    if (exponentSharedPreferences.shouldUseInternetKernel()) {
-      log = "Using remote Expo kernel manifest"
-      manifestAndAssetRequestHeaders = ManifestAndAssetRequestHeaders(getRemoteKernelManifest()!!, JSONObject())
+    if (exponentSharedPreferences.shouldUseEmbeddedKernel()) {
+      log = "Using embedded Expo kernel manifest"
+      manifestAndAssetRequestHeaders = ManifestAndAssetRequestHeaders(getEmbeddedKernelManifest()!!, JSONObject())
     } else {
       log = "Using local Expo kernel manifest"
       manifestAndAssetRequestHeaders = getLocalKernelManifestAndAssetRequestHeaders()

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -173,7 +173,7 @@ class Kernel : KernelInterface() {
       isStarted = true
     }
     hasError = false
-    if (!exponentSharedPreferences.shouldUseInternetKernel()) {
+    if (!exponentSharedPreferences.shouldUseEmbeddedKernel()) {
       try {
         // Make sure we can get the manifest successfully. This can fail in dev mode
         // if the kernel packager is not running.
@@ -198,37 +198,8 @@ class Kernel : KernelInterface() {
     // On first run use the embedded kernel js but fire off a request for the new js in the background.
     val bundleUrlToLoad =
       bundleUrl + (if (ExpoViewBuildConfig.DEBUG) "" else "?versionName=" + ExpoViewKernel.instance.versionName)
-    if (exponentSharedPreferences.shouldUseInternetKernel() &&
-      exponentSharedPreferences.getBoolean(ExponentSharedPreferences.ExponentSharedPreferencesKey.IS_FIRST_KERNEL_RUN_KEY)
-    ) {
+    if (exponentSharedPreferences.shouldUseEmbeddedKernel()) {
       kernelBundleListener().onBundleLoaded(Constants.EMBEDDED_KERNEL_PATH)
-
-      // Now preload bundle for next run
-      Handler().postDelayed(
-        {
-          Exponent.instance.loadJSBundle(
-            null,
-            bundleUrlToLoad,
-            bundleAssetRequestHeaders,
-            KernelConstants.KERNEL_BUNDLE_ID,
-            RNObject.UNVERSIONED,
-            object : BundleListener {
-              override fun onBundleLoaded(localBundlePath: String) {
-                exponentSharedPreferences.setBoolean(
-                  ExponentSharedPreferences.ExponentSharedPreferencesKey.IS_FIRST_KERNEL_RUN_KEY,
-                  false
-                )
-                EXL.d(TAG, "Successfully preloaded kernel bundle")
-              }
-
-              override fun onError(e: Exception) {
-                EXL.e(TAG, "Error preloading kernel bundle: $e")
-              }
-            }
-          )
-        },
-        KernelConstants.DELAY_TO_PRELOAD_KERNEL_JS
-      )
     } else {
       var shouldNotUseKernelCache =
         exponentSharedPreferences.getBoolean(ExponentSharedPreferences.ExponentSharedPreferencesKey.SHOULD_NOT_USE_KERNEL_CACHE)

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -13,7 +13,6 @@ import android.net.Uri
 import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Bundle
-import android.os.Handler
 import android.util.Log
 import android.widget.Toast
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/KernelConstants.kt
@@ -28,7 +28,6 @@ object KernelConstants {
   const val OPEN_EXPERIENCE_ACTIVITY_KEY = "openExperienceActivity"
   const val LOAD_BUNDLE_FOR_EXPERIENCE_ACTIVITY_KEY = "loadBundleForExperienceActivity"
   const val EXPERIENCE_ID_SET_FOR_ACTIVITY_KEY = "experienceIdSetForActivity"
-  const val DELAY_TO_PRELOAD_KERNEL_JS: Long = 5000
   const val HTTP_NOT_MODIFIED = 304
   const val OVERLAY_PERMISSION_REQUEST_CODE = 123
   const val DEFAULT_APPLICATION_KEY = "main"

--- a/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/storage/ExponentSharedPreferences.kt
@@ -59,8 +59,8 @@ class ExponentSharedPreferences constructor(val context: Context) {
     sharedPreferences.edit().remove(key.preferenceKey).apply()
   }
 
-  fun shouldUseInternetKernel(): Boolean {
-    return getBoolean(ExponentSharedPreferencesKey.USE_INTERNET_KERNEL_KEY)
+  fun shouldUseEmbeddedKernel(): Boolean {
+    return getBoolean(ExponentSharedPreferencesKey.USE_EMBEDDED_KERNEL_KEY)
   }
 
   fun getUUID(): String? {
@@ -128,8 +128,7 @@ class ExponentSharedPreferences constructor(val context: Context) {
     const val EXPERIENCE_METADATA_NOTIFICATION_CHANNELS = "notificationChannels"
 
     private val DEFAULT_VALUES = mutableMapOf(
-      ExponentSharedPreferencesKey.USE_INTERNET_KERNEL_KEY to ExpoViewBuildConfig.USE_INTERNET_KERNEL,
-      ExponentSharedPreferencesKey.IS_FIRST_KERNEL_RUN_KEY to true,
+      ExponentSharedPreferencesKey.USE_EMBEDDED_KERNEL_KEY to ExpoViewBuildConfig.USE_EMBEDDED_KERNEL,
       ExponentSharedPreferencesKey.IS_ONBOARDING_FINISHED_KEY to false,
       ExponentSharedPreferencesKey.NUX_HAS_FINISHED_FIRST_RUN_KEY to false,
       ExponentSharedPreferencesKey.SHOULD_NOT_USE_KERNEL_CACHE to false
@@ -146,10 +145,9 @@ class ExponentSharedPreferences constructor(val context: Context) {
 
   enum class ExponentSharedPreferencesKey(val preferenceKey: String) {
     // Dev options
-    USE_INTERNET_KERNEL_KEY("use_internet_kernel"),
+    USE_EMBEDDED_KERNEL_KEY("use_embedded_kernel"),
 
     // Other
-    IS_FIRST_KERNEL_RUN_KEY("is_first_kernel_run"),
     FCM_TOKEN_KEY("fcm_token"),
     REFERRER_KEY("referrer"),
     NUX_HAS_FINISHED_FIRST_RUN_KEY("nux_has_finished_first_run"),

--- a/android/expoview/src/main/java/host/exp/expoview/ExpoViewBuildConfig.kt
+++ b/android/expoview/src/main/java/host/exp/expoview/ExpoViewBuildConfig.kt
@@ -2,6 +2,6 @@
 package host.exp.expoview
 
 object ExpoViewBuildConfig {
-  @JvmStatic var USE_INTERNET_KERNEL = true
+  @JvmStatic var USE_EMBEDDED_KERNEL = true
   @JvmStatic var DEBUG = false
 }

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -252,7 +252,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 - Make sure to run `yarn` in `home`.
 - Publish dev home first by running `et publish-dev-home`. Commit the change to `dev-home-config.json`; do not commit any other changes from the script (in particular, if it changes `home/app.json`, do not commit those changes).
 - Run a debug build of both the iOS and Android versions of Expo Go to smoke test the newly published dev home.
-- To publish production home, log into expo-cli with the `exponent` account (credentials in 1P). Then publish home with `EXPO_NO_DOCTOR=true expo publish`. This will publish home to production (making it available as an OTA update for the SDK version in `app.json`) and write changes to two manifests and bundles (one each for iOS and Android) in the repo. Commit these changes.
+- To publish production home, log into eas-cli with the `exponent` account (credentials in 1P). Then publish home with `et publish-prod-home`. This will publish home to production (unused) and write to two manifests and bundles (one each for iOS and Android) in the repo. Commit these changes.
 
 ## 3.2. Build and submit
 

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -252,7 +252,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 - Make sure to run `yarn` in `home`.
 - Publish dev home first by running `et publish-dev-home`. Commit the change to `dev-home-config.json`; do not commit any other changes from the script (in particular, if it changes `home/app.json`, do not commit those changes).
 - Run a debug build of both the iOS and Android versions of Expo Go to smoke test the newly published dev home.
-- To publish production home, log into eas-cli with the `exponent` account (credentials in 1P). Then publish home with `et publish-prod-home`. This will publish home to production (unused) and write to two manifests and bundles (one each for iOS and Android) in the repo. Commit these changes.
+- To publish production home, log into eas-cli with the `exponent` account (credentials in 1P). Then publish home with `et publish-prod-home`. This will publish home to production (update is unused in production) and write to two manifests and bundles (one each for iOS and Android) in the repo to be embedded in builds of Expo Go. Commit these changes.
 
 ## 3.2. Build and submit
 

--- a/ios/Client/EXHomeAppManager.h
+++ b/ios/Client/EXHomeAppManager.h
@@ -2,12 +2,7 @@
 
 @class EXManifestAndAssetRequestHeaders;
 
-FOUNDATION_EXPORT NSString *kEXHomeBundleResourceName;
-FOUNDATION_EXPORT NSString *kEXHomeManifestResourceName;
-
 @interface EXHomeAppManager : EXReactAppManager
-
-+ (EXManifestAndAssetRequestHeaders *)bundledHomeManifestAndAssetRequestHeaders;
 
 #pragma mark - interfacing with home JS
 

--- a/ios/Client/EXHomeAppManager.m
+++ b/ios/Client/EXHomeAppManager.m
@@ -13,6 +13,7 @@
 #import "EXReactAppManager+Private.h"
 #import "EXVersionManagerObjC.h"
 #import "EXVersions.h"
+#import "EXEmbeddedHomeLoader.h"
 
 #import <EXConstants/EXConstantsService.h>
 
@@ -31,8 +32,6 @@
 @import EXUpdates;
 
 NSString * const kEXHomeLaunchUrlDefaultsKey = @"EXKernelLaunchUrlDefaultsKey";
-NSString *kEXHomeBundleResourceName = @"kernel.ios";
-NSString *kEXHomeManifestResourceName = @"kernel-manifest";
 
 @implementation EXHomeAppManager
 
@@ -168,47 +167,6 @@ NSString *kEXHomeManifestResourceName = @"kernel-manifest";
     initialHomeUrl = [EXKernelLinkingManager initialUrlFromLaunchOptions:[self launchOptionsForBridge]];
   }
   return initialHomeUrl;
-}
-
-+ (EXManifestAndAssetRequestHeaders * _Nullable)bundledHomeManifestAndAssetRequestHeaders
-{
-  NSString *manifestAndAssetRequestHeadersJson = nil;
-  BOOL usesNSBundleManifest = NO;
-
-  // if developing, use development manifest from EXBuildConstants
-  if ([EXBuildConstants sharedInstance].isDevKernel) {
-    manifestAndAssetRequestHeadersJson = [EXBuildConstants sharedInstance].kernelManifestAndAssetRequestHeadersJsonString;
-  }
-
-  // otherwise use published manifest
-  if (!manifestAndAssetRequestHeadersJson) {
-    NSString *manifestPath = [[NSBundle mainBundle] pathForResource:kEXHomeManifestResourceName ofType:@"json"];
-    if (manifestPath) {
-      NSError *error;
-      usesNSBundleManifest = YES;
-      NSString *manifestJson = [NSString stringWithContentsOfFile:manifestPath encoding:NSUTF8StringEncoding error:&error];
-      if (!error) {
-        manifestAndAssetRequestHeadersJson = [NSString stringWithFormat:@"{\"manifest\": %@, \"assetRequestHeaders\":{}}", manifestJson];
-      }
-    }
-  }
-
-  if (manifestAndAssetRequestHeadersJson) {
-    id manifestAndAssetRequestHeaders = RCTJSONParse(manifestAndAssetRequestHeadersJson, nil);
-    if ([manifestAndAssetRequestHeaders isKindOfClass:[NSDictionary class]]) {
-      id manifest = manifestAndAssetRequestHeaders[@"manifest"];
-      id assetRequestHeaders = manifestAndAssetRequestHeaders[@"assetRequestHeaders"];
-      if ([manifest isKindOfClass:[NSDictionary class]]) {
-        if (usesNSBundleManifest && !([manifest[@"id"] isEqualToString:@"@exponent/home"])) {
-          DDLogError(@"Bundled kernel manifest was published with an id other than @exponent/home");
-        }
-        return [[EXManifestAndAssetRequestHeaders alloc] initWithManifest:[EXManifestsManifestFactory manifestForManifestJSON:manifest]
-                                                      assetRequestHeaders:assetRequestHeaders];
-      }
-    }
-  }
-
-  return nil;
 }
 
 - (BOOL)requiresValidManifests

--- a/ios/Client/EXRootViewController.m
+++ b/ios/Client/EXRootViewController.m
@@ -7,13 +7,15 @@
 #import "EXAppViewController.h"
 #import "EXHomeAppManager.h"
 #import "EXKernel.h"
-#import "EXHomeLoader.h"
+#import "EXDevelopmentHomeLoader.h"
 #import "EXKernelAppRecord.h"
 #import "EXKernelAppRegistry.h"
 #import "EXKernelLinkingManager.h"
 #import "EXKernelServiceRegistry.h"
 #import "EXRootViewController.h"
 #import "EXDevMenuManager.h"
+#import "EXEmbeddedHomeLoader.h"
+#import "EXBuildConstants.h"
 
 @import ExpoScreenOrientation;
 
@@ -74,7 +76,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)createRootAppAndMakeVisible
 {
   EXHomeAppManager *homeAppManager = [[EXHomeAppManager alloc] init];
-  EXHomeLoader *homeAppLoader = [[EXHomeLoader alloc] initWithManifestAndAssetRequestHeaders:[EXHomeAppManager bundledHomeManifestAndAssetRequestHeaders]];
+
+  // if developing, use development manifest from EXBuildConstants
+  EXAbstractLoader *homeAppLoader;
+  if ([EXBuildConstants sharedInstance].isDevKernel) {
+    homeAppLoader = [[EXDevelopmentHomeLoader alloc] init];
+  } else {
+    homeAppLoader = [[EXEmbeddedHomeLoader alloc] init];
+  }
+
   EXKernelAppRecord *homeAppRecord = [[EXKernelAppRecord alloc] initWithAppLoader:homeAppLoader appManager:homeAppManager];
   [[EXKernel sharedInstance].appRegistry registerHomeAppRecord:homeAppRecord];
   [self moveAppToVisible:homeAppRecord];

--- a/ios/Exponent.xcodeproj/project.pbxproj
+++ b/ios/Exponent.xcodeproj/project.pbxproj
@@ -30,8 +30,8 @@
 		2596F06B22201A9500DEEFF9 /* EXScopedFileSystemModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 2596F06A22201A9400DEEFF9 /* EXScopedFileSystemModule.m */; };
 		28F885A428FEC26000CFD75C /* EXTextDirectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F885A328FEC26000CFD75C /* EXTextDirectionController.swift */; };
 		2D27CAA71656C7458DE5E8BA /* libPods-ExponentIntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 36E1417121838E61F500BA69 /* libPods-ExponentIntegrationTests.a */; };
-		2D5265EB294998B5001BB2BB /* EXHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXHomeLoader.m */; };
-		2D5265EC294998B5001BB2BB /* EXHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXHomeLoader.m */; };
+		2D5265EB294998B5001BB2BB /* EXDevelopmentHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXDevelopmentHomeLoader.m */; };
+		2D5265EC294998B5001BB2BB /* EXDevelopmentHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D5265EA294998B5001BB2BB /* EXDevelopmentHomeLoader.m */; };
 		2E2E55ADAE3243799CC2CDFE /* RNCPicker.m in Sources */ = {isa = PBXBuildFile; fileRef = A60CC11587F645D0BF1C832F /* RNCPicker.m */; settings = {COMPILER_FLAGS = "-w"; }; };
 		312D2ED2234DF2DC002F4049 /* EXScopedFacebook.m in Sources */ = {isa = PBXBuildFile; fileRef = 312D2ED1234DF2DC002F4049 /* EXScopedFacebook.m */; };
 		31361A5A2260B2F600662769 /* EXScopedSecureStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 31361A592260B2F600662769 /* EXScopedSecureStore.m */; };
@@ -144,6 +144,8 @@
 		B22BB0342366F3F400EE04EC /* EXScopedErrorRecoveryModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B22BB0322366F3F400EE04EC /* EXScopedErrorRecoveryModule.m */; };
 		B236C4F324740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */; };
 		B23D9AA324758C6600D09AC8 /* EXScopedNotificationPresentationModule.m in Sources */ = {isa = PBXBuildFile; fileRef = B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */; };
+		B2641CB52AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B2641CB42AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m */; };
+		B2641CB62AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = B2641CB42AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m */; };
 		B26DF25628048DB80071B0CD /* EXAppLoaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */; };
 		B26DF25728048EBB0071B0CD /* EXAppLoaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */; };
 		B287BB2427DD909C008DA282 /* expo-root.pem in Resources */ = {isa = PBXBuildFile; fileRef = B287BB2327DD909B008DA282 /* expo-root.pem */; };
@@ -538,8 +540,8 @@
 		2596F06A22201A9400DEEFF9 /* EXScopedFileSystemModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedFileSystemModule.m; sourceTree = "<group>"; };
 		28F885A328FEC26000CFD75C /* EXTextDirectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXTextDirectionController.swift; sourceTree = "<group>"; };
 		2A9DD7D91B97F78E98C01A4A /* Pods-Expo Go-Expo Go (versioned).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Expo Go-Expo Go (versioned).debug.xcconfig"; path = "Target Support Files/Pods-Expo Go-Expo Go (versioned)/Pods-Expo Go-Expo Go (versioned).debug.xcconfig"; sourceTree = "<group>"; };
-		2D5265E9294998B5001BB2BB /* EXHomeLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXHomeLoader.h; sourceTree = "<group>"; };
-		2D5265EA294998B5001BB2BB /* EXHomeLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXHomeLoader.m; sourceTree = "<group>"; };
+		2D5265E9294998B5001BB2BB /* EXDevelopmentHomeLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXDevelopmentHomeLoader.h; sourceTree = "<group>"; };
+		2D5265EA294998B5001BB2BB /* EXDevelopmentHomeLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXDevelopmentHomeLoader.m; sourceTree = "<group>"; };
 		312D2ED1234DF2DC002F4049 /* EXScopedFacebook.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedFacebook.m; sourceTree = "<group>"; };
 		312D2ED3234DF2F6002F4049 /* EXScopedFacebook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedFacebook.h; sourceTree = "<group>"; };
 		31361A582260B2F600662769 /* EXScopedSecureStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedSecureStore.h; sourceTree = "<group>"; };
@@ -747,6 +749,8 @@
 		B236C4F224740C1E00D0CB66 /* EXScopedNotificationSchedulerModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationSchedulerModule.m; sourceTree = "<group>"; };
 		B23D9AA124758C6600D09AC8 /* EXScopedNotificationPresentationModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXScopedNotificationPresentationModule.h; sourceTree = "<group>"; };
 		B23D9AA224758C6600D09AC8 /* EXScopedNotificationPresentationModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXScopedNotificationPresentationModule.m; sourceTree = "<group>"; };
+		B2641CB32AB0E8B100ACB763 /* EXEmbeddedHomeLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EXEmbeddedHomeLoader.h; sourceTree = "<group>"; };
+		B2641CB42AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EXEmbeddedHomeLoader.m; sourceTree = "<group>"; };
 		B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EXAppLoaderHelpers.swift; sourceTree = "<group>"; };
 		B287BB2327DD909B008DA282 /* expo-root.pem */ = {isa = PBXFileReference; lastKnownFileType = text; name = "expo-root.pem"; path = "Exponent/Supporting/expo-root.pem"; sourceTree = "<group>"; };
 		B287BB2527DD90AF008DA282 /* expo-root.pem */ = {isa = PBXFileReference; lastKnownFileType = text; name = "expo-root.pem"; path = "Exponent/Supporting/expo-root.pem"; sourceTree = "<group>"; };
@@ -1576,9 +1580,11 @@
 				B5A72C2320A0D1BF00974CCE /* AppFetcher */,
 				B5A72C1920A0D13E00974CCE /* CachedResource */,
 				B26DF25528048DB80071B0CD /* EXAppLoaderHelpers.swift */,
-				2D5265E9294998B5001BB2BB /* EXHomeLoader.h */,
-				2D5265EA294998B5001BB2BB /* EXHomeLoader.m */,
+				2D5265E9294998B5001BB2BB /* EXDevelopmentHomeLoader.h */,
+				2D5265EA294998B5001BB2BB /* EXDevelopmentHomeLoader.m */,
 				B216039B2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift */,
+				B2641CB32AB0E8B100ACB763 /* EXEmbeddedHomeLoader.h */,
+				B2641CB42AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m */,
 			);
 			path = AppLoader;
 			sourceTree = "<group>";
@@ -2614,6 +2620,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2641CB52AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m in Sources */,
 				31AD9A382285B53100F19090 /* AIRMapPolygon.m in Sources */,
 				B5A72C2120A0D13E00974CCE /* EXCachedResource.m in Sources */,
 				BBE8539422B98829001FF9C2 /* EXScopedFontLoader.m in Sources */,
@@ -2780,7 +2787,7 @@
 				31AD99DF2285B51100F19090 /* AIRGoogleMapCalloutSubview.m in Sources */,
 				B2E2CCC72AA7D33E00E2260C /* HomeAppLoader.swift in Sources */,
 				B5AC39B11E95A90B00540AA7 /* EXRemoteNotificationManager.m in Sources */,
-				2D5265EB294998B5001BB2BB /* EXHomeLoader.m in Sources */,
+				2D5265EB294998B5001BB2BB /* EXDevelopmentHomeLoader.m in Sources */,
 				07295CD920559E7300ED42D4 /* EXUpdatesManager.m in Sources */,
 				25742BE72174B8BE003E7453 /* EXExpoUserNotificationCenterProxy.m in Sources */,
 				8767F5B824D177AD009F9372 /* EXManagedAppSplashScreenConfigurationBuilder.m in Sources */,
@@ -2840,6 +2847,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2641CB62AB0E8DD00ACB763 /* EXEmbeddedHomeLoader.m in Sources */,
 				F14217DF262CB68600BB97E6 /* AIRMapPolygon.m in Sources */,
 				F14217E0262CB68600BB97E6 /* EXCachedResource.m in Sources */,
 				8215F58228F08D1900D66BE5 /* RNDateTimePickerShadowView.m in Sources */,
@@ -2978,7 +2986,7 @@
 				F14218B1262CB68600BB97E6 /* EXKernelDevKeyCommands.m in Sources */,
 				F14218B2262CB68600BB97E6 /* AIRMapUrlTileManager.m in Sources */,
 				837A38262A20D7090046BD8E /* EXVersionedNetworkInterceptor.m in Sources */,
-				2D5265EC294998B5001BB2BB /* EXHomeLoader.m in Sources */,
+				2D5265EC294998B5001BB2BB /* EXDevelopmentHomeLoader.m in Sources */,
 				F14218B3262CB68600BB97E6 /* EXKernelAppRegistry.m in Sources */,
 				F14218B4262CB68600BB97E6 /* EXErrorRecoveryManager.m in Sources */,
 				B216039D2A017E490003168A /* EXExpoGoLauncherSelectionPolicyFilterAware.swift in Sources */,

--- a/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.h
@@ -2,18 +2,16 @@
 
 #import "EXAbstractLoader.h"
 
-@class EXManifestAndAssetRequestHeaders;
-
 @protocol EXHomeAppLoaderTaskDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- Subclass of EXAbstractLoader, specifically for loading the home app.
+ Subclass of EXAbstractLoader, specifically for loading the home app in development (published dev home or locally running home bundler).
  */
-@interface EXHomeLoader : EXAbstractLoader <EXHomeAppLoaderTaskDelegate>
+@interface EXDevelopmentHomeLoader : EXAbstractLoader <EXHomeAppLoaderTaskDelegate>
 
-- (instancetype)initWithManifestAndAssetRequestHeaders:(EXManifestAndAssetRequestHeaders *)manifestAndAssetRequestHeaders;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithManifestUrl:(NSURL *)url NS_UNAVAILABLE;
 - (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest NS_UNAVAILABLE;
 

--- a/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.h
+++ b/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.h
@@ -1,0 +1,22 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#import "EXAbstractLoader.h"
+
+@class EXManifestAndAssetRequestHeaders;
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSString *kEXHomeBundleResourceName;
+
+/**
+ Subclass of EXAbstractLoader, specifically for loading the embedded home app bundle and manifest in production.
+ */
+@interface EXEmbeddedHomeLoader : EXAbstractLoader
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithManifestUrl:(NSURL *)url NS_UNAVAILABLE;
+- (instancetype)initWithLocalManifest:(EXManifestsManifest *)manifest NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.m
@@ -29,16 +29,13 @@ typedef NS_ENUM(NSInteger, EXEmbeddedHomeLoaderErrorCode) {
 
 @implementation EXEmbeddedHomeLoader
 
+- (nonnull instancetype)init {
+  return self = [super init];
+}
+
 @synthesize manifest = _manifest;
 @synthesize bundle = _bundle;
 @synthesize isUpToDate = _isUpToDate;
-
-- (instancetype)init {
-  if (self = [super init]) {
-
-  }
-  return self;
-}
 
 #pragma mark - getters and lifecycle
 

--- a/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXEmbeddedHomeLoader.m
@@ -1,0 +1,154 @@
+// Copyright 2020-present 650 Industries. All rights reserved.
+
+#import "EXEmbeddedHomeLoader.h"
+#import "EXKernel.h"
+
+#import <React/RCTUtils.h>
+
+@import EXManifests;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NSString * const EXEmbeddedHomeLoaderErrorDomain = @"embedded-home-loader";
+
+NSString *kEXHomeBundleResourceName = @"kernel.ios";
+NSString *kEXHomeManifestResourceName = @"kernel-manifest";
+
+typedef NS_ENUM(NSInteger, EXEmbeddedHomeLoaderErrorCode) {
+  EXEmbeddedHomeLoaderErrorCodeUnableToLoadEmbeddedManifest,
+  EXEmbeddedHomeLoaderErrorCodeUnableToLoadEmbeddedBundle,
+};
+
+@interface EXEmbeddedHomeLoader ()
+
+@property (nonatomic, strong, nullable) EXManifestsManifest *manifest;
+@property (nonatomic, strong, nullable) NSData *bundle;
+@property (nonatomic, assign) BOOL isUpToDate;
+
+@end
+
+@implementation EXEmbeddedHomeLoader
+
+@synthesize manifest = _manifest;
+@synthesize bundle = _bundle;
+@synthesize isUpToDate = _isUpToDate;
+
+- (instancetype)init {
+  if (self = [super init]) {
+
+  }
+  return self;
+}
+
+#pragma mark - getters and lifecycle
+
+- (void)_reset
+{
+  _manifest = nil;
+  _bundle = nil;
+}
+
+- (EXAppLoaderStatus)status
+{
+  if (_bundle) {
+    return kEXAppLoaderStatusHasManifestAndBundle;
+  } else if (_manifest) {
+    return kEXAppLoaderStatusHasManifest;
+  }
+  return kEXAppLoaderStatusNew;
+}
+
+- (nullable EXManifestsManifest *)manifest
+{
+  return _manifest;
+}
+
+- (nullable NSData *)bundle
+{
+  return _bundle;
+}
+
+- (BOOL)supportsBundleReload
+{
+  return NO;
+}
+
+#pragma mark - public
+
+- (void)request
+{
+  [self _reset];
+  [self _beginRequest];
+}
+
+- (void)requestFromCache
+{
+  [self request];
+}
+
+#pragma mark - internal
+
+- (void)_beginRequest
+{
+  NSString *manifestPath = [[NSBundle mainBundle] pathForResource:kEXHomeManifestResourceName ofType:@"json"];
+  if (!manifestPath) {
+    NSError *error = [NSError errorWithDomain:EXEmbeddedHomeLoaderErrorDomain code:EXEmbeddedHomeLoaderErrorCodeUnableToLoadEmbeddedManifest userInfo:@{
+      NSLocalizedDescriptionKey: @"Could not load embedded manifest"
+    }];
+    [self.delegate appLoader:self didFailWithError:error];
+    return;
+  }
+
+  NSError *stringReadError;
+  NSString *manifestJson = [NSString stringWithContentsOfFile:manifestPath encoding:NSUTF8StringEncoding error:&stringReadError];
+  if (stringReadError) {
+    [self.delegate appLoader:self didFailWithError:stringReadError];
+    return;
+  }
+
+  id manifest = RCTJSONParse(manifestJson, nil);
+  if (![manifest isKindOfClass:[NSDictionary class]]) {
+    NSError *error = [NSError errorWithDomain:EXEmbeddedHomeLoaderErrorDomain code:EXEmbeddedHomeLoaderErrorCodeUnableToLoadEmbeddedManifest userInfo:@{
+      NSLocalizedDescriptionKey: @"Embedded manifest not valid JSON"
+    }];
+    [self.delegate appLoader:self didFailWithError:error];
+    return;
+  }
+
+  if (!([manifest[@"id"] isEqualToString:@"@exponent/home"])) {
+    DDLogError(@"Bundled kernel manifest was published with an id other than @exponent/home");
+  }
+
+  _manifest = [EXManifestsManifestFactory manifestForManifestJSON:manifest];
+  if (self.delegate) {
+    [self.delegate appLoader:self didLoadOptimisticManifest:_manifest];
+  }
+
+  _isUpToDate = true;
+
+  NSString *bundlePath = [[NSBundle mainBundle] pathForResource:kEXHomeBundleResourceName ofType:@"bundle"];
+  if (!bundlePath) {
+    NSError *error = [NSError errorWithDomain:EXEmbeddedHomeLoaderErrorDomain code:EXEmbeddedHomeLoaderErrorCodeUnableToLoadEmbeddedManifest userInfo:@{
+      NSLocalizedDescriptionKey: @"Could not load embedded bundle"
+    }];
+    [self.delegate appLoader:self didFailWithError:error];
+    return;
+  }
+
+  NSError *dataReadError;
+  NSData *bundleData = [NSData dataWithContentsOfFile:bundlePath options:0 error:&dataReadError];
+  if (dataReadError) {
+    [self.delegate appLoader:self didFailWithError:dataReadError];
+    return;
+  }
+
+  _bundle = bundleData;
+
+  if (self.delegate) {
+    [self.delegate appLoader:self didFinishLoadingManifest:_manifest bundle:_bundle];
+  }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/Tests/AppLoader/EXAppLoader+Tests.h
+++ b/ios/Tests/AppLoader/EXAppLoader+Tests.h
@@ -1,10 +1,10 @@
-#import "EXHomeLoader.h"
+#import "EXDevelopmentHomeLoader.h"
 
 @class EXManifestsManifest;
 
 #pragma mark - private/internal methods in App Loader & App Fetchers
 
-@interface EXHomeLoader (EXAppLoaderTests)
+@interface EXDevelopmentHomeLoader (EXAppLoaderTests)
 
 @property (nonatomic, readonly) EXAppFetcher * _Nullable appFetcher;
 

--- a/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
+++ b/ios/Tests/AppLoader/EXAppLoaderConfigurationTests.m
@@ -31,7 +31,7 @@
 - (void)testIsDefaultUpdatesConfigUsed
 {
   NSDictionary *manifest = @{};
-  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXDevelopmentHomeLoader *appLoader = [[EXDevelopmentHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should choose to use AppFetcherWithTimeout when fetching remotely");
   XCTAssert([(EXAppFetcherWithTimeout *)appLoader.appFetcher timeout] == kEXAppLoaderDefaultTimeout, @"AppFetcherWithTimeout should have the correct user-specified timeout length");
@@ -44,7 +44,7 @@
       @"fallbackToCacheTimeout": @1000,
     }
   };
-  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXDevelopmentHomeLoader *appLoader = [[EXDevelopmentHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should choose to use AppFetcherWithTimeout when fetching remotely");
   XCTAssert([(EXAppFetcherWithTimeout *)appLoader.appFetcher timeout] == 1.0f, @"AppFetcherWithTimeout should have the correct user-specified timeout length");
@@ -57,7 +57,7 @@
       @"checkAutomatically": @"ON_ERROR_RECOVERY"
     }
   };
-  EXHomeLoader *appLoader = [[EXHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
+  EXDevelopmentHomeLoader *appLoader = [[EXDevelopmentHomeLoader alloc] initWithManifestUrl:[NSURL URLWithString:@"exp://exp.host/@esamelson/test-fetch-update"]];
   [appLoader _fetchBundleWithManifest:manifest];
   XCTAssert([appLoader.appFetcher isKindOfClass:[EXAppFetcherWithTimeout class]], @"AppLoader should ignore ON_ERROR_RECOVERY in Expo Go");
 }

--- a/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.h
+++ b/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.h
@@ -11,6 +11,6 @@
                expectToFail:(XCTestExpectation *)expectToFail;
 - (void)request;
 
-@property (nonatomic, readonly) EXHomeLoader *appLoader;
+@property (nonatomic, readonly) EXDevelopmentHomeLoader *appLoader;
 
 @end

--- a/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.m
+++ b/ios/Tests/AppLoader/EXAppLoaderRequestExpectation.m
@@ -9,7 +9,7 @@
 @property (nonatomic, strong) NSURL *url;
 @property (nonatomic, strong) XCTestExpectation *expectToSucceed;
 @property (nonatomic, strong) XCTestExpectation *expectToFail;
-@property (nonatomic, strong) EXHomeLoader *appLoader;
+@property (nonatomic, strong) EXDevelopmentHomeLoader *appLoader;
 
 @end
 
@@ -21,7 +21,7 @@
     _url = url;
     _expectToSucceed = expectToSucceed;
     _expectToFail = expectToFail;
-    _appLoader = [[EXHomeLoader alloc] initWithManifestUrl:_url];
+    _appLoader = [[EXDevelopmentHomeLoader alloc] initWithManifestUrl:_url];
     _appLoader.delegate = self;
   }
   return self;
@@ -34,27 +34,27 @@
 
 #pragma mark - AppLoaderDelegate
 
-- (void)appLoader:(EXHomeLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
+- (void)appLoader:(EXDevelopmentHomeLoader *)appLoader didLoadOptimisticManifest:(NSDictionary *)manifest
 {
   
 }
 
-- (void)appLoader:(EXHomeLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
+- (void)appLoader:(EXDevelopmentHomeLoader *)appLoader didLoadBundleWithProgress:(EXLoadingProgress *)progress
 {
 
 }
 
-- (void)appLoader:(EXHomeLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
+- (void)appLoader:(EXDevelopmentHomeLoader *)appLoader didFinishLoadingManifest:(NSDictionary *)manifest bundle:(NSData *)data
 {
   [_expectToSucceed fulfill];
 }
 
-- (void)appLoader:(EXHomeLoader *)appLoader didFailWithError:(NSError *)error
+- (void)appLoader:(EXDevelopmentHomeLoader *)appLoader didFailWithError:(NSError *)error
 {
   [_expectToFail fulfill];
 }
 
-- (void)appLoader:(EXHomeLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
+- (void)appLoader:(EXDevelopmentHomeLoader *)appLoader didResolveUpdatedBundleWithManifest:(NSDictionary * _Nullable)manifest isFromCache:(BOOL)isFromCache error:(NSError * _Nullable)error
 {
   
 }


### PR DESCRIPTION
# Why

We need to convert the `expo publish` step of the SDK release to `eas update`. This is a follow-up to #24216 which switch the dev home publish to EAS Update.

The key though is that EAS update assets access is protected by a required header that is short-lived (the asset can only be requested for a short amount of time after the URL is generated). So this works decently for development home as the manifest is requested during macro generation and the bundle is hopefully downloaded shortly afterwards by `EXDevelopmentHomeLoader`. But this doesn't work for the embedded manifest since that is generated long before the bundle was downloaded.

So the solution is to stop downloading the bundle in release builds, and just use the embedded bundle. I don't have the full context to know why we weren't doing this anyways.

This also updates the SDK release instructions to allude to a new command, `et publish-production-home` which will take care of publishing the home bundle and re-downloading it back into the repo like https://github.com/expo/expo-cli/blob/af2874cf685e6562c74ab597cdb099750c84a3fd/packages/xdl/src/project/publishAsync.ts#L252 did for classic publishing in the past. Note that this PR doesn't add this command yet as it is distinct enough to merit its own PR.

Closes ENG-7462.

# How

On android, remove the code that preloads the bundle from the embedded manifest in release builds. Instead, just load the embedded bundle only.

On iOS, more was needed as it appeared that we always downloaded the bundle. So a new loader implementation was added, `EXEmbeddedHomeLoader`, and used in all release builds. This loader just reads the embedded manifest and bundle.

# Test Plan

Build a release build of both iOS and Android and ensure they use the embedded bundle.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
