### PR TITLE
[docs] Fix link for install app variants guide

### DIFF
--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -40,7 +40,7 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
 ## Next steps
 
 <BoxLink
-  title="Install app variants on the same device"
+  title="Install multiple app variants on the same device"
   description={
     <>
       Learn how to install multiple variants (development, preview, production) of an app on the
@@ -49,9 +49,6 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
     </>
   }
   href="/build-reference/variants/"
-  title="Parallel installation"
-  description="Learn about having a development build and a production build installed on the same device."
-  href="/develop/development-builds/parallel-installation"
   Icon={BookOpen02Icon}
 />
 
@@ -66,4 +63,5 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
   title="Tools, workflows and extensions"
   description="Learn more about different tools, workflows and extensions available when working with development builds."
   href="/develop/development-builds/development-workflows/"
+  Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/share-with-your-team.mdx
+++ b/docs/pages/develop/development-builds/share-with-your-team.mdx
@@ -45,7 +45,7 @@ You can use `eas build:resign` to codesign an existing **.ipa** for iOS to a new
     <>
       Learn how to install multiple variants (development, preview, production) of an app on the
       same device side by side by converting <CODE>app.json</CODE> to <CODE>app.config.js</CODE> and
-      additional configuration is required to start the development server for each variant.
+      additional configuration that is required to start the development server for each variant.
     </>
   }
   href="/build-reference/variants/"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10091 #24404

# How

<!--
How did you build this feature or fix this bug and why?
-->

The `BoxLink` was not up to date with the multiple app variant guide and was pointing towards the removed doc.
This PR fixes that, and also adds the missing icon in the third `BoxLink`.

**Preview**

<img width="893" alt="CleanShot 2023-09-13 at 13 17 39@2x" src="https://github.com/expo/expo/assets/10234615/e14186ed-8577-411c-842d-c138b7ecc05b">

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/develop/development-builds/share-with-your-team/#next-steps

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
