### PR TITLE
refactor(expo-tools): use `bun run` for `expo-tools check-packages`

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -35,18 +35,26 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 100
+
+      - name: ⬢ Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.x
+
       - name: ⬇️ Fetch commits from base branch
         run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
           yarn-workspace: 'true'
-          yarn-tools: 'true'
+
       - name: 🧶 Install workspace node modules
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
+
       - name: 🧐 Check packages
         run: |
           echo "Checking packages according to the event name: ${{ github.event_name }}"
@@ -58,6 +66,7 @@ jobs:
             # In pull requests and workflow_dispatch events check all packages changed in the entire PR.
             bin/expotools check-packages --since ${{ github.event.before || github.base_ref || 'main' }}
           fi
+
       - name: 🔔 Notify on Slack
         uses: 8398a7/action-slack@v3
         if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/tools/src/check-packages/runPackageScriptAsync.ts
+++ b/tools/src/check-packages/runPackageScriptAsync.ts
@@ -19,12 +19,12 @@ export default async function runPackageScriptAsync(
     logger.debug(`🤷‍♂️ ${cyan(scriptName)} script not found`);
     return;
   }
-  const spawnArgs = [scriptName, ...args];
+  const spawnArgs = ['run', scriptName, ...args];
 
-  logger.log(`🏃‍♀️ Running ${cyan.italic(`yarn ${spawnArgs.join(' ')}`)}`);
+  logger.log(`🏃‍♀️ Running ${cyan.italic(`bun ${spawnArgs.join(' ')}`)}`);
 
   try {
-    await spawnAsync('yarn', spawnArgs, {
+    await spawnAsync('bun', spawnArgs, {
       stdio: 'pipe',
       cwd: pkg.path,
     });

--- a/tools/src/commands/CheckPackages.ts
+++ b/tools/src/commands/CheckPackages.ts
@@ -18,10 +18,10 @@ export default (program: Command) => {
       'main'
     )
     .option('-a, --all', 'Whether to check all packages and ignore `--since` option.', false)
-    .option('--no-build', 'Whether to skip `yarn build` check.', false)
-    .option('--no-test', 'Whether to skip `yarn test` check.', false)
-    .option('--no-lint', 'Whether to skip `yarn lint` check.', false)
-    .option('--fix-lint', 'Whether to run `yarn lint --fix` instead of `yarn lint`.', false)
+    .option('--no-build', 'Whether to skip `bun run build` check.', false)
+    .option('--no-test', 'Whether to skip `bun run test` check.', false)
+    .option('--no-lint', 'Whether to skip `bun run lint` check.', false)
+    .option('--fix-lint', 'Whether to run `bun run lint --fix` instead of `bun run lint`.', false)
     .option(
       '--no-uniformity-check',
       'Whether to check the uniformity of committed and generated build files.',


### PR DESCRIPTION
# Why

See main PR #24416

> This is an experiment to see if we can speed up `expo-tools` using Bun.

# How

- Moved `expo-tools` run commands from `yarn` to `bun`.
- Updated `sdk` workflow to use Bun

# Test Plan

CI should pass, and people should be able to use it locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
