### PR TITLE
[docs] Upgrade PNPM on Android workers to latest 8.7.5

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -87,7 +87,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 8.7.5
+- pnpm 7.0.0
 - npm 8.19.2
 - Java 8
 
@@ -101,7 +101,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 8.7.5
+- pnpm 7.0.0
 - npm 8.19.2
 - Java 11
 
@@ -115,7 +115,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 8.7.5
+- pnpm 7.0.0
 - npm 8.19.2
 - Java 8
 
@@ -129,7 +129,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 19.2.5345600
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 8.7.5
+- pnpm 7.0.0
 - npm 8.19.2
 - Java 11
 
@@ -143,7 +143,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 19.2.5345600
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 8.7.5
+- pnpm 7.0.0
 - npm 8.19.2
 - Java 8
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -73,7 +73,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 11
 
@@ -87,7 +87,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 8
 
@@ -101,7 +101,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 11
 
@@ -115,7 +115,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 21.4.7075529
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 8
 
@@ -129,7 +129,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 19.2.5345600
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 11
 
@@ -143,7 +143,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 - NDK 19.2.5345600
 - Node.js 16.18.1
 - Yarn 1.22.17
-- pnpm 7.0.0
+- pnpm 8.7.5
 - npm 8.19.2
 - Java 8
 


### PR DESCRIPTION
# Why

Update docs to reflect current situation. See https://github.com/expo/turtle-v2/pull/1428.

# How

Found the page, updated the version.

# Test Plan

None.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
