### PR TITLE
[core][iOS] Using shared ref as a prop

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Remove `deprecate` utility function. ([#24298](https://github.com/expo/expo/pull/24298) by [@EvanBacon](https://github.com/EvanBacon))
 - Deprecate `SyntheticPlatformEmitter` in favor of `DeviceEventEmitter`. ([#24298](https://github.com/expo/expo/pull/24298) by [@EvanBacon](https://github.com/EvanBacon))
 - Introduced an AppContext config to provide things like documents and caches directories for the modules. ([#24292](https://github.com/expo/expo/pull/24292) by [@tsapeta](https://github.com/tsapeta))
+- Converting shared object id passed as a prop to the associated native object. ([#24431](https://github.com/expo/expo/pull/24431) by [@tsapeta](https://github.com/tsapeta))
 
 ## 1.7.0 — 2023-09-04
 

--- a/packages/expo-modules-core/ios/Swift/SharedObjects/SharedRef.swift
+++ b/packages/expo-modules-core/ios/Swift/SharedObjects/SharedRef.swift
@@ -5,7 +5,7 @@
 open class SharedRef<PointerType>: SharedObject {
   public let pointer: PointerType
 
-  init(_ pointer: PointerType) {
+  public init(_ pointer: PointerType) {
     self.pointer = pointer
     super.init()
   }


### PR DESCRIPTION
# Why

Necessary for #24428 

# How

- Made SharedRef initializer public 🙈 
- Converting shared object id passed as a prop to the associated native object

# Test Plan

Works fine in #24428 