### PR TITLE
[tools] Add publish-prod-home command

### DIFF
--- a/home/app.json
+++ b/home/app.json
@@ -22,22 +22,15 @@
     "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "host.exp.exponent",
-      "publishBundlePath": "../ios/Exponent/Supporting/kernel.ios.bundle"
+      "bundleIdentifier": "host.exp.exponent"
     },
     "android": {
-      "package": "host.exp.exponent",
-      "publishBundlePath": "../android/app/src/main/assets/kernel.android.bundle"
+      "package": "host.exp.exponent"
     },
     "androidStatusBar": {
       "barStyle": "dark-content"
     },
     "scheme": "exp",
-    "isKernel": true,
-    "kernel": {
-      "iosManifestPath": "../ios/Exponent/Supporting/kernel-manifest.json",
-      "androidManifestPath": "../android/app/src/main/assets/kernel-manifest.json"
-    },
     "jsEngine": "hermes",
     "extra": {
       "eas": {
@@ -45,7 +38,7 @@
       }
     },
     "runtimeVersion": {
-      "policy": "appVersion"
+      "policy": "sdkVersion"
     }
   }
 }

--- a/tools/src/EASUpdate.ts
+++ b/tools/src/EASUpdate.ts
@@ -10,13 +10,14 @@ type Options = {
     username: string;
     password: string;
   };
+  branch: string;
   message: string;
 };
 
 /**
  * Uses the installed version of `eas-cli` to publish a project.
  */
-export async function publishProjectWithEasCliAsync(
+export async function setAuthAndPublishProjectWithEasCliAsync(
   projectRoot: string,
   options: Options
 ): Promise<{ createdUpdateGroupId: string }> {
@@ -37,10 +38,20 @@ export async function publishProjectWithEasCliAsync(
     }
   }
 
+  return await publishProjectWithEasCliAsync(projectRoot, options);
+}
+
+export async function publishProjectWithEasCliAsync(
+  projectRoot: string,
+  options: {
+    branch: string;
+    message: string;
+  }
+): Promise<{ createdUpdateGroupId: string }> {
   Log.collapsed('Publishing...');
   const publishedUpdatesJSONString = await EASCLI.runEASCliAsync(
     'update',
-    ['--non-interactive', '--json', '--branch', 'development', '--message', options.message],
+    ['--non-interactive', '--json', '--branch', options.branch, '--message', options.message],
     {
       cwd: projectRoot,
     }

--- a/tools/src/commands/PublishDevExpoHomeCommand.ts
+++ b/tools/src/commands/PublishDevExpoHomeCommand.ts
@@ -85,34 +85,9 @@ async function setExpoCliStateAsync(newState: object): Promise<void> {
 }
 
 /**
- * Deletes kernel fields that needs to be removed from published manifest.
- */
-function deleteKernelFields(appJson: AppConfig): void {
-  console.log(`Deleting kernel-related fields...`);
-
-  // @tsapeta: Using `delete` keyword here would change the order of keys in app.json.
-  appJson.expo.kernel = undefined;
-  appJson.expo.isKernel = undefined;
-  appJson.expo.ios.publishBundlePath = undefined;
-  appJson.expo.android.publishBundlePath = undefined;
-}
-
-/**
- * Restores kernel fields that have been removed in previous steps - we don't want them to be present in published manifest.
- */
-function restoreKernelFields(appJson: AppConfig, appJsonBackup: AppConfig): void {
-  console.log('Restoring kernel-related fields...');
-
-  appJson.expo.kernel = appJsonBackup.expo.kernel;
-  appJson.expo.isKernel = appJsonBackup.expo.isKernel;
-  appJson.expo.ios.publishBundlePath = appJsonBackup.expo.ios.publishBundlePath;
-  appJson.expo.android.publishBundlePath = appJsonBackup.expo.android.publishBundlePath;
-}
-
-/**
  * Publishes dev home app on EAS Update.
  */
-async function publishAppAsync({
+async function publishAppOnDevelopmentBranchAsync({
   slug,
   message,
 }: {
@@ -121,11 +96,12 @@ async function publishAppAsync({
 }): Promise<{ createdUpdateGroupId: string }> {
   console.log(`Publishing ${chalk.green(slug)}...`);
 
-  const result = await EASUpdate.publishProjectWithEasCliAsync(EXPO_HOME_PATH, {
+  const result = await EASUpdate.setAuthAndPublishProjectWithEasCliAsync(EXPO_HOME_PATH, {
     userpass: {
       username: EXPO_HOME_DEV_ACCOUNT_USERNAME!,
       password: EXPO_HOME_DEV_ACCOUNT_PASSWORD!,
     },
+    branch: 'development',
     message,
   });
 
@@ -189,8 +165,6 @@ async function action(options: ActionOptions): Promise<void> {
   console.log(`Modifying home's slug to ${chalk.green(slug)}...`);
   appJson.expo.slug = slug;
 
-  deleteKernelFields(appJson);
-
   // Save the modified `appJson` to the file so it'll be used as a manifest.
   await appJsonFile.writeAsync(appJson);
 
@@ -203,10 +177,9 @@ async function action(options: ActionOptions): Promise<void> {
     });
   }
 
-  const createdUpdateGroupId = (await publishAppAsync({ slug, message: expoHomeHashNode.hash }))
-    .createdUpdateGroupId;
-
-  restoreKernelFields(appJson, appJsonBackup);
+  const createdUpdateGroupId = (
+    await publishAppOnDevelopmentBranchAsync({ slug, message: expoHomeHashNode.hash })
+  ).createdUpdateGroupId;
 
   console.log(`Restoring home's slug to ${chalk.green(appJsonBackup.expo.slug)}...`);
   appJson.expo.slug = appJsonBackup.expo.slug;

--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -1,0 +1,222 @@
+import { Command } from '@expo/commander';
+import JsonFile from '@expo/json-file';
+import {
+  isMultipartPartWithName,
+  parseMultipartMixedResponseAsync,
+} from '@expo/multipart-body-parser';
+import chalk from 'chalk';
+import fs from 'fs/promises';
+import fetch, { Response } from 'node-fetch';
+import nullthrows from 'nullthrows';
+import os from 'os';
+import path from 'path';
+
+import { deepCloneObject } from '../Utils';
+import { Directories, EASUpdate } from '../expotools';
+import AppConfig from '../typings/AppConfig';
+
+type ExpoCliStateObject = {
+  auth?: {
+    username?: string;
+  };
+};
+
+const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
+
+const iosPublishBundlePath = '../ios/Exponent/Supporting/kernel.ios.bundle';
+const androidPublishBundlePath = '../android/app/src/main/assets/kernel.android.bundle';
+const iosManifestPath = '../ios/Exponent/Supporting/kernel-manifest.json';
+const androidManifestPath = '../android/app/src/main/assets/kernel-manifest.json';
+
+/**
+ * Returns path to production's expo-cli state file.
+ */
+function getExpoCliStatePath(): string {
+  return path.join(os.homedir(), '.expo/state.json');
+}
+
+/**
+ * Reads expo-cli state file which contains, among other things, session credentials to the account that you're logged in.
+ */
+async function getExpoCliStateAsync(): Promise<ExpoCliStateObject> {
+  return JsonFile.readAsync<ExpoCliStateObject>(getExpoCliStatePath());
+}
+
+/**
+ * Publishes @exponent/home app on EAS Update.
+ */
+async function publishAppAsync({
+  slug,
+  message,
+}: {
+  slug: string;
+  message: string;
+}): Promise<{ createdUpdateGroupId: string }> {
+  console.log(`Publishing ${chalk.green(slug)}...`);
+
+  const result = await EASUpdate.publishProjectWithEasCliAsync(EXPO_HOME_PATH, {
+    branch: 'production',
+    message,
+  });
+
+  console.log(
+    `Done publishing ${chalk.green(slug)}. Update Group ID is: ${chalk.blue(
+      result.createdUpdateGroupId
+    )}`
+  );
+
+  return result;
+}
+
+interface Manifest {
+  id: string;
+  launchAsset: {
+    key: string;
+    url: string;
+  };
+}
+
+type AssetRequestHeaders = { authorization: string };
+type Extensions = { assetRequestHeaders: { [key: string]: AssetRequestHeaders } };
+
+async function getManifestAndExtensionsAsync(response: Response): Promise<{
+  manifest: Manifest;
+  extensions: Extensions;
+}> {
+  const contentType = response.headers.get('content-type');
+  if (!contentType) {
+    throw new Error('The multipart manifest response is missing the content-type header');
+  }
+
+  const bodyBuffer = await response.arrayBuffer();
+  const multipartParts = await parseMultipartMixedResponseAsync(
+    contentType,
+    Buffer.from(bodyBuffer)
+  );
+
+  const manifestPart = multipartParts.find((part) => isMultipartPartWithName(part, 'manifest'));
+  if (!manifestPart) {
+    throw new Error('The multipart manifest response is missing the manifest part');
+  }
+  const manifest: Manifest = JSON.parse(manifestPart.body);
+
+  const extensionsPart = multipartParts.find((part) => isMultipartPartWithName(part, 'extensions'));
+  if (!extensionsPart) {
+    throw new Error('The multipart manifest response is missing the extensions part');
+  }
+  const extensions: Extensions = JSON.parse(extensionsPart.body);
+
+  return { manifest, extensions };
+}
+
+async function fetchManifestAndBundleAsync(
+  projectRoot: string,
+  projectId: string,
+  groupId: string,
+  platform: 'ios' | 'android'
+): Promise<void> {
+  const manifestUrl = `https://staging-u.expo.dev/${projectId}/group/${groupId}`;
+  const manifestResponse = await fetch(manifestUrl, {
+    method: 'GET',
+    headers: {
+      accept: 'multipart/mixed',
+      'expo-platform': platform,
+    },
+  });
+  const { manifest, extensions } = await getManifestAndExtensionsAsync(manifestResponse);
+
+  const bundleUrl = manifest.launchAsset.url;
+  const bundleRequestHeaders = nullthrows(
+    extensions?.assetRequestHeaders[manifest.launchAsset.key]
+  );
+
+  const bundleResponse = await fetch(bundleUrl, {
+    method: 'GET',
+    headers: {
+      ...bundleRequestHeaders,
+    },
+  });
+
+  const manifestPath = platform === 'ios' ? iosManifestPath : androidManifestPath;
+  await fs.writeFile(path.resolve(projectRoot, manifestPath), JSON.stringify(manifest));
+
+  const bundlePath = platform === 'ios' ? iosPublishBundlePath : androidPublishBundlePath;
+  await fs.writeFile(path.resolve(projectRoot, bundlePath), await bundleResponse.buffer());
+}
+
+/**
+ * Main action that runs once the command is invoked.
+ */
+async function action(): Promise<void> {
+  console.log('Getting expo-cli state of the current session...');
+  const cliState = await getExpoCliStateAsync();
+  const cliUsername = cliState?.auth?.username;
+  if (cliUsername !== 'exponent') {
+    throw new Error('Must be logged in as `exponent` account to publish');
+  }
+
+  const appJsonFilePath = path.join(EXPO_HOME_PATH, 'app.json');
+
+  const slug = 'home';
+  const owner = 'exponent';
+  const easProjectId = '6b6c6660-df76-11e6-b9b4-59d1587e6774';
+  const easUpdateURL = `https://u.expo.dev/${easProjectId}`;
+
+  const appJsonFile = new JsonFile<AppConfig>(appJsonFilePath);
+  const appJson = await appJsonFile.readAsync();
+
+  if (!appJson.expo.owner) {
+    throw new Error('app.json missing owner');
+  }
+  if (!appJson.expo.extra || !appJson.expo.extra.eas || !appJson.expo.extra.eas.projectId) {
+    throw new Error('app.json missing extra.eas.projectId');
+  }
+  if (!appJson.expo.updates || !appJson.expo.updates.url) {
+    throw new Error('app.json missing updates.url');
+  }
+
+  console.log(`Creating backup of ${chalk.magenta('app.json')} file...`);
+  const appJsonBackup = deepCloneObject<AppConfig>(appJson);
+
+  console.log(`Modifying home's slug to ${chalk.green(slug)}...`);
+  appJson.expo.slug = slug;
+
+  console.log(`Modifying home's owner to ${chalk.green(owner)}...`);
+  appJson.expo.owner = owner;
+
+  console.log(`Modifying home's EAS project ID to ${chalk.green(easProjectId)}...`);
+  appJson.expo.extra.eas.projectId = easProjectId;
+
+  console.log(`Modifying home's update URL to ${chalk.green(easUpdateURL)}...`);
+  appJson.expo.updates.url = easUpdateURL;
+
+  // Save the modified `appJson` to the file so it'll be used as a manifest.
+  await appJsonFile.writeAsync(appJson);
+
+  const createdUpdateGroupId = (
+    await publishAppAsync({ slug, message: `Publish ${appJson.expo.sdkVersion}` })
+  ).createdUpdateGroupId;
+
+  console.log(`Restoring ${chalk.magenta('app.json')} file...`);
+  await appJsonFile.writeAsync(appJsonBackup);
+
+  console.log(`Downloading published manifests and bundles...`);
+  await Promise.all([
+    fetchManifestAndBundleAsync(EXPO_HOME_PATH, easProjectId, createdUpdateGroupId, 'ios'),
+    fetchManifestAndBundleAsync(EXPO_HOME_PATH, easProjectId, createdUpdateGroupId, 'android'),
+  ]);
+
+  console.log(
+    chalk.yellow(
+      `Finished publishing. Remember to commit changes of the embedded manifests and bundles.`
+    )
+  );
+}
+
+export default (program: Command) => {
+  program
+    .command('publish-prod-home')
+    .alias('pph')
+    .description(`Publishes home app for production on EAS Update.`)
+    .asyncAction(action);
+};

--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -11,6 +11,7 @@ import nullthrows from 'nullthrows';
 import os from 'os';
 import path from 'path';
 
+import { ANDROID_DIR, IOS_DIR } from '../Constants';
 import { deepCloneObject } from '../Utils';
 import { Directories, EASUpdate } from '../expotools';
 import AppConfig from '../typings/AppConfig';
@@ -23,10 +24,24 @@ type ExpoCliStateObject = {
 
 const EXPO_HOME_PATH = Directories.getExpoHomeJSDir();
 
-const iosPublishBundlePath = '../ios/Exponent/Supporting/kernel.ios.bundle';
-const androidPublishBundlePath = '../android/app/src/main/assets/kernel.android.bundle';
-const iosManifestPath = '../ios/Exponent/Supporting/kernel-manifest.json';
-const androidManifestPath = '../android/app/src/main/assets/kernel-manifest.json';
+const iosPublishBundlePath = path.join(IOS_DIR, 'Exponent', 'Supporting', 'kernel.ios.bundle');
+const androidPublishBundlePath = path.join(
+  ANDROID_DIR,
+  'app',
+  'src',
+  'main',
+  'assets',
+  'kernel.android.bundle'
+);
+const iosManifestPath = path.join(IOS_DIR, 'Exponent', 'Supporting', 'kernel-manifest.json');
+const androidManifestPath = path.join(
+  ANDROID_DIR,
+  'app',
+  'src',
+  'main',
+  'assets',
+  'kernel-manifest.json'
+);
 
 /**
  * Returns path to production's expo-cli state file.
@@ -110,7 +125,6 @@ async function getManifestAndExtensionsAsync(response: Response): Promise<{
 }
 
 async function fetchManifestAndBundleAsync(
-  projectRoot: string,
   projectId: string,
   groupId: string,
   platform: 'ios' | 'android'
@@ -138,10 +152,10 @@ async function fetchManifestAndBundleAsync(
   });
 
   const manifestPath = platform === 'ios' ? iosManifestPath : androidManifestPath;
-  await fs.writeFile(path.resolve(projectRoot, manifestPath), JSON.stringify(manifest));
+  await fs.writeFile(path.resolve(manifestPath), JSON.stringify(manifest));
 
   const bundlePath = platform === 'ios' ? iosPublishBundlePath : androidPublishBundlePath;
-  await fs.writeFile(path.resolve(projectRoot, bundlePath), await bundleResponse.buffer());
+  await fs.writeFile(path.resolve(bundlePath), await bundleResponse.buffer());
 }
 
 /**
@@ -202,8 +216,8 @@ async function action(): Promise<void> {
 
   console.log(`Downloading published manifests and bundles...`);
   await Promise.all([
-    fetchManifestAndBundleAsync(EXPO_HOME_PATH, easProjectId, createdUpdateGroupId, 'ios'),
-    fetchManifestAndBundleAsync(EXPO_HOME_PATH, easProjectId, createdUpdateGroupId, 'android'),
+    fetchManifestAndBundleAsync(easProjectId, createdUpdateGroupId, 'ios'),
+    fetchManifestAndBundleAsync(easProjectId, createdUpdateGroupId, 'android'),
   ]);
 
   console.log(
@@ -217,6 +231,6 @@ export default (program: Command) => {
   program
     .command('publish-prod-home')
     .alias('pph')
-    .description(`Publishes home app for production on EAS Update.`)
+    .description('Publishes home app for production on EAS Update.')
     .asyncAction(action);
 };

--- a/tools/src/typings/AppConfig.ts
+++ b/tools/src/typings/AppConfig.ts
@@ -32,8 +32,12 @@ export default interface AppConfig extends JSONObject {
 
     extra?: {
       eas?: {
-        projectId: string;
+        projectId?: string;
       };
+    };
+
+    updates?: {
+      url?: string;
     };
   };
 }


### PR DESCRIPTION
# Why

Second part of https://github.com/expo/expo/pull/24412 is to change the embedded manifest and bundle to use a published EAS Update. This PR adds a `et publish-prod-home` command.

Closes ENG-10024.

# How

The command does the following:
1. Requires being logged into `exponent` account
2. Updates fields in app.json since the ones committed are dev home I think
3. Publishes with EAS update
4. Downloads manifests and bundles from publish to predefined files, like XDL used to do for classic publishing (https://github.com/expo/expo-cli/blob/af2874cf685e6562c74ab597cdb099750c84a3fd/packages/xdl/src/project/publishAsync.ts#L252). Note that this means we can get rid of the kernel fields from the app.json which had warnings anyways.

# Test Plan

1. Apply the following patch:
```patch
diff --git a/tools/src/commands/PublishProdExpoHomeCommand.ts b/tools/src/commands/PublishProdExpoHomeCommand.ts
index 6e390c2b0a..299e35f08a 100644
--- a/tools/src/commands/PublishProdExpoHomeCommand.ts
+++ b/tools/src/commands/PublishProdExpoHomeCommand.ts
@@ -32,7 +32,7 @@ const androidManifestPath = '../android/app/src/main/assets/kernel-manifest.json
  * Returns path to production's expo-cli state file.
  */
 function getExpoCliStatePath(): string {
-  return path.join(os.homedir(), '.expo/state.json');
+  return path.join(os.homedir(), '.expo-staging/state.json');
 }

 /**
@@ -159,8 +159,8 @@ async function action(): Promise<void> {

   const slug = 'home';
   const owner = 'exponent';
-  const easProjectId = '6b6c6660-df76-11e6-b9b4-59d1587e6774';
-  const easUpdateURL = `https://u.expo.dev/${easProjectId}`;
+  const easProjectId = '78ca5ae1-95d9-4332-94b0-d390cff20d12'; // '6b6c6660-df76-11e6-b9b4-59d1587e6774';
+  const easUpdateURL = `https://staging-u.expo.dev/${easProjectId}`;

   const appJsonFile = new JsonFile<AppConfig>(appJsonFilePath);
   const appJson = await appJsonFile.readAsync();
```
6. `export EXPO_STAGING=1`
7. Log in to `exponent` staging account with creds from 1p
8. `et pph`
9. Verify that the embeded manifest and bundles are modified.
10. Build and run the iOS and android expo go release apps (including https://github.com/expo/expo/pull/24412 which reads from the embedded bundles). Breakpoint to ensure they load the manifest and bundle correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
