### PR TITLE
[home] Fix apollo auth link spread ordering

### DIFF
--- a/home/api/ApolloClient.ts
+++ b/home/api/ApolloClient.ts
@@ -25,8 +25,8 @@ const authMiddlewareLink = setContext((_request, previousContext): any => {
     return {
       ...previousContext,
       headers: {
-        ...previousContext.headers,
         'expo-session': sessionSecret,
+        ...previousContext.headers,
       },
     };
   }


### PR DESCRIPTION
# Why

The ordering matters when there is still a session in the store (and in local storage), especially when the context is trying to be overridden at the query callsite:
https://github.com/expo/expo/blob/main/home/screens/AccountModal/LoggedOutAccountView.tsx#L121
https://github.com/expo/expo/blob/main/home/HomeApp.tsx#L108

The history and blame trail here is as follows:
- We first experienced this issue on the website where writes to local storage aren't immediately visible on old iOS OS's. To solve this, we added this `prevContext` pattern in https://github.com/expo/universe/pull/12959
- https://github.com/expo/expo/pull/22863 tried to fix the issue of the async thunk dispatch to store and save the session not having been completed before a call to do a fetch in the same way as that website PR. I don't believe it was sufficient.
- https://github.com/expo/expo/pull/23946 tried a second fix but got the ordering of the inbound context spread incorrect for the edge case of invalid sessions (though it's tough to really know what the correct ordering is, traditional middleware chains take precedence from the current middleware layer being evaluated over previous middleware). So this PR is the blame.

# How

The problem was that in the following code, any existing sessionSecret (valid or invalid) would override any provided in `previousContext`. When a query is made that tries to override context, that comes in via `previousContext`. So the old session secret (that was invalidated via log out of all) was being given preference over the manual override.
```typescript
const authMiddlewareLink = setContext((_request, previousContext): any => {
  const { sessionSecret } = Store.getState().session;

  if (sessionSecret) {
    return {
      ...previousContext,
      headers: {
        ...previousContext.headers,
        'expo-session': sessionSecret,
      },
    };
  }

  return previousContext;
});
```

The fix is to reverse the preference order.

As mentioned above though, this isn't without its own potential issues. If we were to add another middleware link that mutated headers,  we'd actually want to not use this reversed preference order as it could potentially overwrite a valid session.

I think this pattern is decently confusing, but it's what we have. I'll make the same fix on the website.

# Test Plan

Running expo go locally and locally-running go packager:

1. sign in in expo go
2. go to website, press "log out of other sessions"
3. close expo go. reopen it
4. try to log in again, see it works with the fix

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
