### PR TITLE
[docs] Update notifications registration example to call `setNotificationChannelAsync` before `requestPermissionsAsync` for Android 13

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -80,6 +80,18 @@ async function sendPushNotification(expoPushToken) {
 
 async function registerForPushNotificationsAsync() {
   let token;
+
+  /* @info On Android, you need to specify a channel. */
+  if (Platform.OS === 'android') {
+    Notifications.setNotificationChannelAsync('default', {
+      name: 'default',
+      importance: Notifications.AndroidImportance.MAX,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#FF231F7C',
+    });
+  }
+  /* @end */
+
   /* @info You should make sure the app is running on a physical device since push notifications don't work on an emulator/simulator. */
   if (Device.isDevice) {
     /* @end */
@@ -102,17 +114,6 @@ async function registerForPushNotificationsAsync() {
   } else {
     alert('Must use physical device for Push Notifications');
   }
-
-  /* @info On Android, you need to specify a channel. */
-  if (Platform.OS === 'android') {
-    Notifications.setNotificationChannelAsync('default', {
-      name: 'default',
-      importance: Notifications.AndroidImportance.MAX,
-      vibrationPattern: [0, 250, 250, 250],
-      lightColor: '#FF231F7C',
-    });
-  }
-  /* @end */
 
   return token;
 }


### PR DESCRIPTION
On android, `setNotificationChannelAsync` must be called before `requestPermissionsAsync`, because a opaque side effect of that function call is necessary for the premission request will work.

If this mistake is made, not only must the order be fixed, *the entire expo go app needs to have the storage cleared, and be reinstalled.*

https://stackoverflow.com/questions/75544314/receiving-error-while-reqeusting-notification-permission-on-expo-app

# Why

The example is incorrect, and the repurcussions are major as it requires an entire app clear and reinstall.

# How

I encountered an obscure error:

```
Error: Encountered an exception while calling native method: Exception occurred while executing exported method requestPermissionsAsync on module ExpoNotificationPermissionsModule: String resource ID #0xffffffff
```

I found [this post](https://stackoverflow.com/questions/75544314/receiving-error-while-reqeusting-notification-permission-on-expo-app) with a solution.

I fixed the order and tried again, but still had the error. I followed the rest of the instructions and cleared storage and reinstalled the app and it worked.

# Test Plan

I tested this on my local machine. The issue can be reproduced by running the code in the example. The issue can be fixed by clearing the expo go storage, reinstalling, and running the corrected code in this PR.

# Checklist

- [X] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
