### PR TITLE
chore(expo-tools): fix linting issues related to eslint upgrade

### DIFF
--- a/tools/src/android-update-native-dependencies/androidProjectReports.ts
+++ b/tools/src/android-update-native-dependencies/androidProjectReports.ts
@@ -4,19 +4,19 @@ import glob from 'glob-promise';
 import ora from 'ora';
 import * as path from 'path';
 
-import * as Directories from '../Directories';
-import logger from '../Logger';
-import { spawnAsync, SpawnResult } from '../Utils';
 import {
   AndroidProjectReport,
   GradleDependency,
   RawGradleDependency,
   RawGradleReport,
 } from './types';
+import * as Directories from '../Directories';
+import logger from '../Logger';
+import { spawnAsync, SpawnResult } from '../Utils';
 
 export const REVISIONS = ['release', 'milestone', 'integration'] as const;
 
-export type Revision = typeof REVISIONS[number];
+export type Revision = (typeof REVISIONS)[number];
 
 export interface GradleTaskOptions {
   revision: Revision;

--- a/tools/src/android-update-native-dependencies/index.ts
+++ b/tools/src/android-update-native-dependencies/index.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
 
-import logger from '../Logger';
 import { getAndroidProjectReports, Revision } from './androidProjectReports';
 import { promptForNativeDependenciesUpdates, promptForAndroidProjectsSelection } from './prompts';
 import { AndroidProjectReport, GradleDependency } from './types';
 import { addChangelogEntries } from './updateChangelogFiles';
 import { updateGradleDependencies } from './updateGradleFiles';
 import { addColorBasedOnSemverDiff, calculateSemverDiff, getChangelogLink } from './utils';
+import logger from '../Logger';
 
 async function printAvailableUpdates(reports: AndroidProjectReport[]) {
   const printDependency = (dependency: GradleDependency) => {

--- a/tools/src/android-update-native-dependencies/prompts.ts
+++ b/tools/src/android-update-native-dependencies/prompts.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import inquirer from 'inquirer';
 import stripAnsi from 'strip-ansi';
 
-import logger from '../Logger';
 import {
   AndroidProjectDependenciesUpdates,
   AndroidProjectReport,
@@ -15,6 +14,7 @@ import {
   getChangelogLink,
   SemverDiff,
 } from './utils';
+import logger from '../Logger';
 
 function generateAndroidProjectsSelectionChoice({
   projectName,

--- a/tools/src/android-update-native-dependencies/updateChangelogFiles.ts
+++ b/tools/src/android-update-native-dependencies/updateChangelogFiles.ts
@@ -1,6 +1,6 @@
+import { AndroidProjectDependenciesUpdates } from './types';
 import * as Changelogs from '../Changelogs';
 import dependenciesChangelogs from '../data/androidDependenciesChangelogs.json';
-import { AndroidProjectDependenciesUpdates } from './types';
 
 function maybeWrapInChangelogLink(text: string, dependencyName: string) {
   const changelog = dependenciesChangelogs[dependencyName];

--- a/tools/src/android-update-native-dependencies/updateGradleFiles.ts
+++ b/tools/src/android-update-native-dependencies/updateGradleFiles.ts
@@ -3,10 +3,10 @@ import { readFile, writeFile } from 'fs-extra';
 import * as path from 'path';
 import terminalLink from 'terminal-link';
 
-import { EXPO_DIR } from '../Constants';
-import logger from '../Logger';
 import { AndroidProjectDependenciesUpdates } from './types';
 import { addColorBasedOnSemverDiff, calculateSemverDiff } from './utils';
+import { EXPO_DIR } from '../Constants';
+import logger from '../Logger';
 
 function replaceVersionInGradleFile(
   body: string,

--- a/tools/src/check-packages/checkPackageAsync.ts
+++ b/tools/src/check-packages/checkPackageAsync.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
-import logger from '../Logger';
-import { Package } from '../Packages';
 import checkUniformityAsync from './checkUniformityAsync';
 import runPackageScriptAsync from './runPackageScriptAsync';
 import { ActionOptions } from './types';
+import logger from '../Logger';
+import { Package } from '../Packages';
 
 const { green } = chalk;
 

--- a/tools/src/check-packages/getPackagesToCheckAsync.ts
+++ b/tools/src/check-packages/getPackagesToCheckAsync.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
+import { ActionOptions } from './types';
 import { formatCommitHash } from '../Formatter';
 import Git from '../Git';
 import logger from '../Logger';
 import { getListOfPackagesAsync } from '../Packages';
-import { ActionOptions } from './types';
 
 const { yellow } = chalk;
 

--- a/tools/src/client-build/AndroidClientBuilder.ts
+++ b/tools/src/client-build/AndroidClientBuilder.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra';
 import path from 'path';
 
+import { ClientBuilder, ClientBuildFlavor, Platform, S3Client } from './types';
 import { ANDROID_DIR } from '../Constants';
 import logger from '../Logger';
 import { androidAppVersionAsync } from '../ProjectVersions';
 import { spawnAsync } from '../Utils';
-import { ClientBuilder, ClientBuildFlavor, Platform, S3Client } from './types';
 
 export default class AndroidClientBuilder implements ClientBuilder {
   platform: Platform = 'android';

--- a/tools/src/client-build/IosClientBuilder.ts
+++ b/tools/src/client-build/IosClientBuilder.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra';
 import path from 'path';
 
+import { ClientBuilder, ClientBuildFlavor, Platform } from './types';
 import { podInstallAsync } from '../CocoaPods';
 import { EXPO_DIR, IOS_DIR } from '../Constants';
 import { iosAppVersionAsync } from '../ProjectVersions';
 import { spawnAsync } from '../Utils';
-import { ClientBuilder, ClientBuildFlavor, Platform } from './types';
 
 export default class IosClientBuilder implements ClientBuilder {
   platform: Platform = 'ios';

--- a/tools/src/code-review/index.ts
+++ b/tools/src/code-review/index.ts
@@ -1,8 +1,5 @@
 import chalk from 'chalk';
 
-import Git from '../Git';
-import * as GitHub from '../GitHub';
-import logger from '../Logger';
 import { COMMENT_HEADER, generateReportFromOutputs } from './reports';
 import checkMissingChangelogs from './reviewers/checkMissingChangelogs';
 import lintSwiftFiles from './reviewers/lintSwiftFiles';
@@ -16,6 +13,9 @@ import {
   ReviewStatus,
   Reviewer,
 } from './types';
+import Git from '../Git';
+import * as GitHub from '../GitHub';
+import logger from '../Logger';
 
 /**
  * An array with functions whose purpose is to check and review the diff.

--- a/tools/src/dynamic-macros/generateDynamicMacros.ts
+++ b/tools/src/dynamic-macros/generateDynamicMacros.ts
@@ -3,10 +3,10 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { Directories } from '../expotools';
 import AndroidMacrosGenerator from './AndroidMacrosGenerator';
 import IosMacrosGenerator from './IosMacrosGenerator';
 import macros from './macros';
+import { Directories } from '../expotools';
 
 const EXPO_DIR = Directories.getExpoRepositoryRootDir();
 

--- a/tools/src/generate-module/generateModuleAsync.ts
+++ b/tools/src/generate-module/generateModuleAsync.ts
@@ -2,10 +2,10 @@ import chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 
-import { PACKAGES_DIR, EXPO_DIR } from '../Constants';
 import configureModule from './configureModule';
 import fetchTemplate from './fetchTemplate';
 import promptQuestionsAsync from './promptQuestionsAsync';
+import { PACKAGES_DIR, EXPO_DIR } from '../Constants';
 
 const TEMPLATE_PACKAGE_NAME = 'expo-module-template';
 

--- a/tools/src/packages-graph/PackagesGraph.ts
+++ b/tools/src/packages-graph/PackagesGraph.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
 
+import PackagesGraphEdge from './PackagesGraphEdge';
+import PackagesGraphNode from './PackagesGraphNode';
 import {
   DefaultDependencyKind,
   DependencyKind,
   getListOfPackagesAsync,
   Package,
 } from '../Packages';
-import PackagesGraphEdge from './PackagesGraphEdge';
-import PackagesGraphNode from './PackagesGraphNode';
 
 type PackagesMap = Map<string, PackagesGraphNode>;
 

--- a/tools/src/packages-graph/PackagesGraphEdge.ts
+++ b/tools/src/packages-graph/PackagesGraphEdge.ts
@@ -1,5 +1,5 @@
-import { DependencyKind } from '../Packages';
 import PackagesGraphNode from './PackagesGraphNode';
+import { DependencyKind } from '../Packages';
 
 /**
  * A graph edge that refers to the relation between two packages.

--- a/tools/src/packages-graph/PackagesGraphNode.ts
+++ b/tools/src/packages-graph/PackagesGraphNode.ts
@@ -1,5 +1,5 @@
-import { DefaultDependencyKind, DependencyKind, Package } from '../Packages';
 import PackagesGraphEdge from './PackagesGraphEdge';
+import { DefaultDependencyKind, DependencyKind, Package } from '../Packages';
 
 /**
  * A graph node that refers to the single package.

--- a/tools/src/packages-graph/PackagesGraphUtils.ts
+++ b/tools/src/packages-graph/PackagesGraphUtils.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 import { EOL } from 'os';
 
-import { DefaultDependencyKind, DependencyKind } from '../Packages';
 import PackagesGraph from './PackagesGraph';
 import PackagesGraphEdge from './PackagesGraphEdge';
 import PackagesGraphNode from './PackagesGraphNode';
+import { DefaultDependencyKind, DependencyKind } from '../Packages';
 
 type NodeVisitingData = {
   visited: Record<string, boolean>;

--- a/tools/src/prebuilds/Prebuilder.ts
+++ b/tools/src/prebuilds/Prebuilder.ts
@@ -3,10 +3,6 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
-import { Podspec } from '../CocoaPods';
-import { IOS_DIR } from '../Constants';
-import logger from '../Logger';
-import { Package } from '../Packages';
 import {
   createSpecFromPodspecAsync,
   generateXcodeProjectAsync,
@@ -14,6 +10,10 @@ import {
 } from './XcodeGen';
 import XcodeProject from './XcodeProject';
 import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
+import { Podspec } from '../CocoaPods';
+import { IOS_DIR } from '../Constants';
+import logger from '../Logger';
+import { Package } from '../Packages';
 
 const PODS_DIR = path.join(IOS_DIR, 'Pods');
 

--- a/tools/src/prebuilds/XcodeGen.ts
+++ b/tools/src/prebuilds/XcodeGen.ts
@@ -2,15 +2,15 @@ import fs from 'fs-extra';
 import path from 'path';
 import semver from 'semver';
 
-import { Podspec } from '../CocoaPods';
-import { EXPOTOOLS_DIR, IOS_DIR } from '../Constants';
-import { arrayize, spawnAsync } from '../Utils';
 import {
   ProjectSpec,
   ProjectSpecDependency,
   ProjectSpecPlatform,
   XcodeConfig,
 } from './XcodeGen.types';
+import { Podspec } from '../CocoaPods';
+import { EXPOTOOLS_DIR, IOS_DIR } from '../Constants';
+import { arrayize, spawnAsync } from '../Utils';
 
 const PODS_DIR = path.join(IOS_DIR, 'Pods');
 const PODS_PUBLIC_HEADERS_DIR = path.join(PODS_DIR, 'Headers', 'Public');

--- a/tools/src/prebuilds/XcodeProject.ts
+++ b/tools/src/prebuilds/XcodeProject.ts
@@ -2,11 +2,11 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
-import { formatXcodeBuildOutput } from '../Formatter';
-import { spawnAsync } from '../Utils';
 import { generateXcodeProjectAsync } from './XcodeGen';
 import { ProjectSpec } from './XcodeGen.types';
 import { Flavor, Framework, XcodebuildSettings } from './XcodeProject.types';
+import { formatXcodeBuildOutput } from '../Formatter';
+import { spawnAsync } from '../Utils';
 
 /**
  * Path to the shared derived data directory.

--- a/tools/src/promote-packages/helpers.ts
+++ b/tools/src/promote-packages/helpers.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
+import { Parcel } from './types';
 import * as Changelogs from '../Changelogs';
 import { GitDirectory } from '../Git';
 import logger from '../Logger';
 import { Package } from '../Packages';
-import { Parcel } from './types';
 
 const { cyan, green, magenta, red, gray } = chalk;
 

--- a/tools/src/promote-packages/tasks/listPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/listPackagesToPromote.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 
+import { findPackagesToPromote } from './findPackagesToPromote';
+import { prepareParcels } from './prepareParcels';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { printPackagesToPromote } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { findPackagesToPromote } from './findPackagesToPromote';
-import { prepareParcels } from './prepareParcels';
 
 const { yellow } = chalk;
 

--- a/tools/src/promote-packages/tasks/promotePackages.ts
+++ b/tools/src/promote-packages/tasks/promotePackages.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
 
+import { findPackagesToPromote } from './findPackagesToPromote';
+import { prepareParcels } from './prepareParcels';
+import { selectPackagesToPromote } from './selectPackagesToPromote';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { formatVersionChange } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { findPackagesToPromote } from './findPackagesToPromote';
-import { prepareParcels } from './prepareParcels';
-import { selectPackagesToPromote } from './selectPackagesToPromote';
 
 const { yellow, red, green, cyan } = chalk;
 

--- a/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
+++ b/tools/src/promote-packages/tasks/selectPackagesToPromote.ts
@@ -3,11 +3,11 @@ import inquirer from 'inquirer';
 import readline from 'readline';
 import stripAnsi from 'strip-ansi';
 
+import { findPackagesToPromote } from './findPackagesToPromote';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { formatVersionChange } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { findPackagesToPromote } from './findPackagesToPromote';
 
 const { green, red } = chalk;
 

--- a/tools/src/publish-packages/constants.ts
+++ b/tools/src/publish-packages/constants.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import { EXPOTOOLS_DIR } from '../Constants';
 import { ReleaseType } from './types';
+import { EXPOTOOLS_DIR } from '../Constants';
 
 /**
  * File name of the backup file.

--- a/tools/src/publish-packages/helpers.ts
+++ b/tools/src/publish-packages/helpers.ts
@@ -4,17 +4,17 @@ import pick from 'lodash/pick';
 import npmPacklist from 'npm-packlist';
 import semver from 'semver';
 
-import * as Changelogs from '../Changelogs';
-import * as Formatter from '../Formatter';
-import { GitDirectory, GitFileLog, GitFileStatus } from '../Git';
-import logger from '../Logger';
-import { Package } from '../Packages';
 import {
   BACKUPABLE_OPTIONS_FIELDS,
   NATIVE_DIRECTORIES,
   RELEASE_TYPES_ASC_ORDER,
 } from './constants';
 import { BackupableOptions, CommandOptions, PackageGitLogs, Parcel, ReleaseType } from './types';
+import * as Changelogs from '../Changelogs';
+import * as Formatter from '../Formatter';
+import { GitDirectory, GitFileLog, GitFileStatus } from '../Git';
+import logger from '../Logger';
+import { Package } from '../Packages';
 
 const { green, cyan, magenta, gray, red } = chalk;
 

--- a/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
+++ b/tools/src/publish-packages/tasks/addPublishedLabelToPullRequests.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
 import { link } from '../../Formatter';
 import * as GitHub from '../../GitHub';
@@ -8,7 +9,6 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 // https://github.com/expo/expo/pulls?q=label:published
 const PUBLISHED_LABEL_NAME = 'published';

--- a/tools/src/publish-packages/tasks/checkPackagesIntegrity.ts
+++ b/tools/src/publish-packages/tasks/checkPackagesIntegrity.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 
+import { loadRequestedParcels } from './loadRequestedParcels';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { loadRequestedParcels } from './loadRequestedParcels';
 
 const { green, cyan, blue, yellow } = chalk;
 

--- a/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
+++ b/tools/src/publish-packages/tasks/commentOnIssuesTask.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { ChangelogEntry, UNPUBLISHED_VERSION_NAME } from '../../Changelogs';
 import { EXPO_DIR } from '../../Constants';
 import { link } from '../../Formatter';
@@ -11,7 +12,6 @@ import { Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { CommentatorPayload } from '../../commands/CommentatorCommand';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 type CommentRowObject = {
   pkg: Package;

--- a/tools/src/publish-packages/tasks/commitStagedChanges.ts
+++ b/tools/src/publish-packages/tasks/commitStagedChanges.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { blue } = chalk;
 

--- a/tools/src/publish-packages/tasks/cutOffChangelogs.ts
+++ b/tools/src/publish-packages/tasks/cutOffChangelogs.ts
@@ -1,9 +1,9 @@
 import chalk from 'chalk';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { green, gray } = chalk;
 

--- a/tools/src/publish-packages/tasks/grantTeamAccessToPackages.ts
+++ b/tools/src/publish-packages/tasks/grantTeamAccessToPackages.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk';
 
+import { loadRequestedParcels } from './loadRequestedParcels';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { loadRequestedParcels } from './loadRequestedParcels';
 
 const { green } = chalk;
 

--- a/tools/src/publish-packages/tasks/listUnpublished.ts
+++ b/tools/src/publish-packages/tasks/listUnpublished.ts
@@ -1,8 +1,8 @@
+import { loadRequestedParcels } from './loadRequestedParcels';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { isParcelUnpublished, printPackageParcel } from '../helpers';
 import { Parcel, TaskArgs } from '../types';
-import { loadRequestedParcels } from './loadRequestedParcels';
 
 /**
  * Lists packages that have any unpublished changes.

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -2,12 +2,12 @@ import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import Git from '../../Git';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { green, cyan, yellow } = chalk;
 

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -1,8 +1,5 @@
 import chalk from 'chalk';
 
-import logger from '../../Logger';
-import { Task } from '../../TasksRunner';
-import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
@@ -21,6 +18,9 @@ import { updateIosProjects } from './updateIosProjects';
 import { updateModuleTemplate } from './updateModuleTemplate';
 import { updatePackageVersions } from './updatePackageVersions';
 import { updateWorkspaceProjects } from './updateWorkspaceProjects';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 const { cyan, yellow } = chalk;
 

--- a/tools/src/publish-packages/tasks/pushCommittedChanges.ts
+++ b/tools/src/publish-packages/tasks/pushCommittedChanges.ts
@@ -1,8 +1,8 @@
+import { commitStagedChanges } from './commitStagedChanges';
 import Git from '../../Git';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import { commitStagedChanges } from './commitStagedChanges';
 
 /**
  * Pushes committed changes to remote repo.

--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -1,6 +1,11 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 
+import {
+  createParcelsForDependenciesOf,
+  createParcelsForGraphNodes,
+  loadRequestedParcels,
+} from './loadRequestedParcels';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
@@ -13,11 +18,6 @@ import {
   validateVersion,
 } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
-import {
-  createParcelsForDependenciesOf,
-  createParcelsForGraphNodes,
-  loadRequestedParcels,
-} from './loadRequestedParcels';
 
 const { green, cyan } = chalk;
 

--- a/tools/src/publish-packages/tasks/updateAndroidProjects.ts
+++ b/tools/src/publish-packages/tasks/updateAndroidProjects.ts
@@ -2,12 +2,12 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { transformFileAsync } from '../../Transforms';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { yellow, magenta } = chalk;
 

--- a/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
+++ b/tools/src/publish-packages/tasks/updateBundledNativeModulesFile.ts
@@ -2,11 +2,11 @@ import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { magenta, green, gray, cyan } = chalk;
 

--- a/tools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/src/publish-packages/tasks/updateIosProjects.ts
@@ -1,13 +1,13 @@
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { podInstallAsync } from '../../CocoaPods';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { filterAsync } from '../../Utils';
 import * as Workspace from '../../Workspace';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { green } = chalk;
 

--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -2,11 +2,11 @@ import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { getPackageByName, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { cyan, green } = chalk;
 const MODULE_TEMPLATE_PKG_NAME = 'expo-module-template';

--- a/tools/src/publish-packages/tasks/updatePackageVersions.ts
+++ b/tools/src/publish-packages/tasks/updatePackageVersions.ts
@@ -2,10 +2,10 @@ import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
 import path from 'path';
 
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { Parcel, TaskArgs } from '../types';
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 const { magenta, cyan, green } = chalk;
 

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -1,9 +1,9 @@
+import { BACKUPABLE_OPTIONS_FIELDS } from './constants';
 import { Changelog, ChangelogChanges } from '../Changelogs';
 import { GitLog, GitFileLog, GitDirectory } from '../Git';
 import { PackageViewType } from '../Npm';
 import { Package } from '../Packages';
 import { PackagesGraphNode } from '../packages-graph';
-import { BACKUPABLE_OPTIONS_FIELDS } from './constants';
 
 /**
  * Command's options.
@@ -28,7 +28,7 @@ export type CommandOptions = {
 /**
  * CommandOptions without options that aren't backupable or just don't matter when restoring a backup.
  */
-export type BackupableOptions = Pick<CommandOptions, typeof BACKUPABLE_OPTIONS_FIELDS[number]>;
+export type BackupableOptions = Pick<CommandOptions, (typeof BACKUPABLE_OPTIONS_FIELDS)[number]>;
 
 /**
  * Represents command's backup data.

--- a/tools/src/vendoring/AndroidVendoring.ts
+++ b/tools/src/vendoring/AndroidVendoring.ts
@@ -1,6 +1,6 @@
-import { searchFilesAsync } from '../Utils';
 import { copyVendoredFilesAsync } from './common';
 import { VendoringModuleConfig } from './types';
+import { searchFilesAsync } from '../Utils';
 
 export async function vendorAsync(
   sourceDirectory: string,

--- a/tools/src/vendoring/IosVendoring.ts
+++ b/tools/src/vendoring/IosVendoring.ts
@@ -4,12 +4,12 @@ import glob from 'glob-promise';
 import inquirer from 'inquirer';
 import path from 'path';
 
+import { copyVendoredFilesAsync } from './common';
+import { VendoringModuleConfig } from './types';
 import { podInstallAsync, Podspec, readPodspecAsync } from '../CocoaPods';
 import { IOS_DIR } from '../Constants';
 import logger from '../Logger';
 import { arrayize, searchFilesAsync } from '../Utils';
-import { copyVendoredFilesAsync } from './common';
-import { VendoringModuleConfig } from './types';
 
 export async function vendorAsync(
   sourceDirectory: string,

--- a/tools/src/vendoring/devmenu/Pipe.ts
+++ b/tools/src/vendoring/devmenu/Pipe.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 
-import logger from '../../Logger';
 import { Task } from './steps/Task';
+import logger from '../../Logger';
 
 export type Platform = 'ios' | 'android' | 'all';
 

--- a/tools/src/vendoring/devmenu/steps/Append.ts
+++ b/tools/src/vendoring/devmenu/steps/Append.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import { findFiles } from '../utils';
 import { Task } from './Task';
+import { findFiles } from '../utils';
 
 export type AppendSettings = {
   source?: string;

--- a/tools/src/vendoring/devmenu/steps/CopyFiles.ts
+++ b/tools/src/vendoring/devmenu/steps/CopyFiles.ts
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { toRepoPath, findFiles } from '../utils';
 import { Task } from './Task';
+import { toRepoPath, findFiles } from '../utils';
 
 export type CopyFilesSettings = {
   from?: string;

--- a/tools/src/vendoring/devmenu/steps/GenerateJsonFromPodspec.ts
+++ b/tools/src/vendoring/devmenu/steps/GenerateJsonFromPodspec.ts
@@ -2,9 +2,9 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { Task } from './Task';
 import { readPodspecAsync } from '../../../CocoaPods';
 import { toRepoPath } from '../utils';
-import { Task } from './Task';
 
 type GenerateJsonFromPodspecSettings = {
   from: string;

--- a/tools/src/vendoring/devmenu/steps/PrefixHeaders.ts
+++ b/tools/src/vendoring/devmenu/steps/PrefixHeaders.ts
@@ -1,8 +1,8 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import { findFiles } from '../utils';
 import { Task } from './Task';
+import { findFiles } from '../utils';
 
 export type PrefixHeadersSettings = {
   source?: string;

--- a/tools/src/vendoring/devmenu/steps/RemoveFiles.ts
+++ b/tools/src/vendoring/devmenu/steps/RemoveFiles.ts
@@ -1,8 +1,8 @@
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
-import { findFiles } from '../utils';
 import { Task } from './Task';
+import { findFiles } from '../utils';
 
 export type RemoveFilesSettings = {
   source?: string;

--- a/tools/src/vendoring/devmenu/steps/TransformFilesContent.ts
+++ b/tools/src/vendoring/devmenu/steps/TransformFilesContent.ts
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { findFiles } from '../utils';
 import { Task } from './Task';
+import { findFiles } from '../utils';
 
 export type FileContentTransformStepSettings = {
   source?: string;

--- a/tools/src/vendoring/devmenu/steps/TransformFilesName.ts
+++ b/tools/src/vendoring/devmenu/steps/TransformFilesName.ts
@@ -2,8 +2,8 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { findFiles } from '../utils';
 import { TransformFilesContent } from './TransformFilesContent';
+import { findFiles } from '../utils';
 
 export class TransformFilesName extends TransformFilesContent {
   async execute() {

--- a/tools/src/vendoring/index.ts
+++ b/tools/src/vendoring/index.ts
@@ -2,15 +2,15 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import semver from 'semver';
 
-import { link } from '../Formatter';
-import logger from '../Logger';
-import * as Npm from '../Npm';
-import { getBundledVersionsAsync } from '../ProjectVersions';
 import {
   VendoringModulePlatformConfig,
   VendoringProvider,
   VendoringTargetModulesConfig,
 } from './types';
+import { link } from '../Formatter';
+import logger from '../Logger';
+import * as Npm from '../Npm';
+import { getBundledVersionsAsync } from '../ProjectVersions';
 
 const VENDORING_PROVIDERS: Record<string, () => VendoringProvider> = {
   ios: () => require('../vendoring/IosVendoring'),

--- a/tools/src/versioning/android/copyExpoview.ts
+++ b/tools/src/versioning/android/copyExpoview.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 import path from 'path';
 
+import { expoviewTransforms } from './transforms/expoviewTransforms';
 import { copyFileWithTransformsAsync } from '../../Transforms';
 import { searchFilesAsync } from '../../Utils';
-import { expoviewTransforms } from './transforms/expoviewTransforms';
 
 export async function copyExpoviewAsync(sdkVersion: string, androidDir: string): Promise<void> {
   const abiVersion = `abi${sdkVersion.replace(/\./g, '_')}`;

--- a/tools/src/versioning/android/expoModulesTransforms.ts
+++ b/tools/src/versioning/android/expoModulesTransforms.ts
@@ -1,9 +1,9 @@
 import escapeRegExp from 'lodash/escapeRegExp';
 
-import type { Package } from '../../Packages';
-import { FileTransforms } from '../../Transforms.types';
 import { packagesToKeep, packagesToRename } from './packagesConfig';
 import { deleteLinesBetweenTags } from './utils';
+import type { Package } from '../../Packages';
+import { FileTransforms } from '../../Transforms.types';
 
 function expoModulesBaseTransforms(pkg: Package, abiVersion: string): FileTransforms {
   return {

--- a/tools/src/versioning/android/index.ts
+++ b/tools/src/versioning/android/index.ts
@@ -6,10 +6,6 @@ import minimatch from 'minimatch';
 import path from 'path';
 import semver from 'semver';
 
-import * as Directories from '../../Directories';
-import { getListOfPackagesAsync } from '../../Packages';
-import { copyFileWithTransformsAsync } from '../../Transforms';
-import { searchFilesAsync } from '../../Utils';
 import { copyExpoviewAsync } from './copyExpoview';
 import { expoModulesTransforms } from './expoModulesTransforms';
 import { buildManifestMergerJarAsync } from './jarFiles';
@@ -17,6 +13,10 @@ import { packagesToKeep } from './packagesConfig';
 import { versionCxxExpoModulesAsync } from './versionCxx';
 import { updateVersionedReactNativeAsync } from './versionReactNative';
 import { removeVersionedVendoredModulesAsync } from './versionVendoredModules';
+import * as Directories from '../../Directories';
+import { getListOfPackagesAsync } from '../../Packages';
+import { copyFileWithTransformsAsync } from '../../Transforms';
+import { searchFilesAsync } from '../../Utils';
 
 export { versionVendoredModulesAsync } from './versionVendoredModules';
 

--- a/tools/src/versioning/android/reactNativeTransforms.ts
+++ b/tools/src/versioning/android/reactNativeTransforms.ts
@@ -1,11 +1,11 @@
 import escapeRegExp from 'lodash/escapeRegExp';
 import path from 'path';
 
-import { transformString } from '../../Transforms';
-import { FileTransform, FileTransforms, StringTransform } from '../../Transforms.types';
 import { baseCmakeTransforms } from './cmakeTransforms';
 import { JniLibNames } from './libraries';
 import { packagesToRename } from './packagesConfig';
+import { transformString } from '../../Transforms';
+import { FileTransform, FileTransforms, StringTransform } from '../../Transforms.types';
 
 function pathFromPkg(pkg: string): string {
   return pkg.replace(/\./g, '/');

--- a/tools/src/versioning/android/versionReactNative.ts
+++ b/tools/src/versioning/android/versionReactNative.ts
@@ -2,15 +2,15 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs-extra';
 import path from 'path';
 
-import { runReactNativeCodegenAsync } from '../../Codegen';
-import { REACT_NATIVE_SUBMODULE_DIR, REACT_NATIVE_SUBMODULE_MONOREPO_ROOT } from '../../Constants';
-import { copyFileWithTransformsAsync, transformFileAsync } from '../../Transforms';
-import { searchFilesAsync } from '../../Utils';
 import {
   codegenTransforms,
   hermesTransforms,
   reactNativeTransforms,
 } from './reactNativeTransforms';
+import { runReactNativeCodegenAsync } from '../../Codegen';
+import { REACT_NATIVE_SUBMODULE_DIR, REACT_NATIVE_SUBMODULE_MONOREPO_ROOT } from '../../Constants';
+import { copyFileWithTransformsAsync, transformFileAsync } from '../../Transforms';
+import { searchFilesAsync } from '../../Utils';
 
 export async function updateVersionedReactNativeAsync(
   androidDir: string,

--- a/tools/src/versioning/android/versionVendoredModules.ts
+++ b/tools/src/versioning/android/versionVendoredModules.ts
@@ -5,15 +5,15 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
+import {
+  exponentPackageTransforms,
+  vendoredModulesTransforms,
+} from './transforms/vendoredModulesTransforms';
 import { ANDROID_DIR, ANDROID_VENDORED_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { copyFileWithTransformsAsync, transformFilesAsync } from '../../Transforms';
 import { FileTransforms } from '../../Transforms.types';
 import { searchFilesAsync } from '../../Utils';
-import {
-  exponentPackageTransforms,
-  vendoredModulesTransforms,
-} from './transforms/vendoredModulesTransforms';
 
 /**
  * Versions Android vendored modules.

--- a/tools/src/versioning/ios/index.ts
+++ b/tools/src/versioning/ios/index.ts
@@ -8,19 +8,6 @@ import inquirer from 'inquirer';
 import path from 'path';
 import semver from 'semver';
 
-import { runReactNativeCodegenAsync } from '../../Codegen';
-import {
-  EXPO_DIR,
-  IOS_DIR,
-  REACT_NATIVE_SUBMODULE_DIR,
-  REACT_NATIVE_SUBMODULE_MONOREPO_ROOT,
-  VERSIONED_RN_IOS_DIR,
-} from '../../Constants';
-import logger from '../../Logger';
-import { getListOfPackagesAsync, Package } from '../../Packages';
-import { copyFileWithTransformsAsync } from '../../Transforms';
-import type { FileTransforms, StringTransform } from '../../Transforms.types';
-import { renderExpoKitPodspecAsync } from '../../dynamic-macros/IosMacrosGenerator';
 import { runTransformPipelineAsync } from './transforms';
 import { injectMacros } from './transforms/injectMacros';
 import { kernelFilesTransforms } from './transforms/kernelFilesTransforms';
@@ -37,6 +24,19 @@ import {
   versionVendoredModulesAsync,
   removeVersionedVendoredModulesAsync,
 } from './versionVendoredModules';
+import { runReactNativeCodegenAsync } from '../../Codegen';
+import {
+  EXPO_DIR,
+  IOS_DIR,
+  REACT_NATIVE_SUBMODULE_DIR,
+  REACT_NATIVE_SUBMODULE_MONOREPO_ROOT,
+  VERSIONED_RN_IOS_DIR,
+} from '../../Constants';
+import logger from '../../Logger';
+import { getListOfPackagesAsync, Package } from '../../Packages';
+import { copyFileWithTransformsAsync } from '../../Transforms';
+import type { FileTransforms, StringTransform } from '../../Transforms.types';
+import { renderExpoKitPodspecAsync } from '../../dynamic-macros/IosMacrosGenerator';
 
 export { versionVendoredModulesAsync, versionExpoModulesAsync };
 

--- a/tools/src/versioning/ios/versionExpoModules.ts
+++ b/tools/src/versioning/ios/versionExpoModules.ts
@@ -4,17 +4,17 @@ import fs from 'fs-extra';
 import os from 'os';
 import path from 'path';
 
-import { Podspec } from '../../CocoaPods';
-import logger from '../../Logger';
-import { Package } from '../../Packages';
-import { FileTransforms, copyFileWithTransformsAsync } from '../../Transforms';
-import { arrayize, searchFilesAsync } from '../../Utils';
 import {
   getCommonExpoModulesTransforms,
   getVersioningExpoModuleConfig,
 } from './transforms/expoModulesTransforms';
 import { VersioningModuleConfig } from './types';
 import { getVersionPrefix, getVersionedDirectory } from './utils';
+import { Podspec } from '../../CocoaPods';
+import logger from '../../Logger';
+import { Package } from '../../Packages';
+import { FileTransforms, copyFileWithTransformsAsync } from '../../Transforms';
+import { arrayize, searchFilesAsync } from '../../Utils';
 
 // Label of the console's timer used during versioning
 const TIMER_LABEL = 'Versioning expo modules finished in';

--- a/tools/src/versioning/ios/versionExpoModulesProvider.ts
+++ b/tools/src/versioning/ios/versionExpoModulesProvider.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra';
 import path from 'path';
 
+import { getVersionedDirectory, getVersionPrefix } from './utils';
 import { IOS_DIR } from '../../Constants';
 import { copyFileWithTransformsAsync } from '../../Transforms';
 import { execAll } from '../../Utils';
-import { getVersionedDirectory, getVersionPrefix } from './utils';
 
 // Name of the pod containing versioned modules provider.
 export const MODULES_PROVIDER_POD_NAME = 'ExpoModulesProvider';

--- a/tools/src/versioning/ios/versionVendoredModules.ts
+++ b/tools/src/versioning/ios/versionVendoredModules.ts
@@ -4,12 +4,12 @@ import fs from 'fs-extra';
 import glob from 'glob-promise';
 import path from 'path';
 
+import vendoredModulesTransforms from './transforms/vendoredModulesTransforms';
 import { IOS_VENDORED_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { copyFileWithTransformsAsync } from '../../Transforms';
 import { FileTransforms } from '../../Transforms.types';
 import { searchFilesAsync } from '../../Utils';
-import vendoredModulesTransforms from './transforms/vendoredModulesTransforms';
 
 /**
  * Versions iOS vendored modules.


### PR DESCRIPTION
# Why

Due to swapping yarn for bun, some of the ESLint packages are upgraded. Resulting in some new listing issues.

# How

- Ran `bun run lint --fix`

# Test Plan

See if CI passes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
