### PR TITLE
[docs] Fix FAQ about custom entry point in build migration guide

### DIFF
--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -35,9 +35,9 @@ The tradeoff when migrating from `expo build` is that you need to be careful whe
 
 If you use environment variables in your **app.config.js** or in your app source code (for example, with `babel-plugin-inline-dotenv`), you need to define these variables for your build profiles or in secrets, as described in [Environment variables and secrets](/build-reference/variables).
 
-### Custom `"main"` entry point in package.json is not supported
+### Custom `"main"` entry point in package.json is not supported for SDK 48 and below
 
-If your app depends on a custom `"main"` entry point, remove it from **package.json**. Then, create **index.js** at the root of your project and use [`registerRootComponent`](/versions/latest/sdk/register-root-component) to register your root component.
+If your app uses SDK 48 or below and depends on a custom `"main"` entry point, remove it from **package.json**. Then, create **index.js** at the root of your project and use [`registerRootComponent`](/versions/latest/sdk/register-root-component) to register your root component.
 
 For example, if your app's root component lives in **src/App.tsx**, the **index.js** should look like the following:
 

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -48,6 +48,8 @@ import App from './src/App';
 registerRootComponent(App);
 ```
 
+> **Note:** For SDK 49 and above, see [how to rename the main app file](/versions/latest/sdk/register-root-component/#what-if-i-want-to-name-my-main-app-file-something-other-than-appjs).
+
 ### The `--config` flag is not supported
 
 If you are using `expo build:[ios|android] --config app.production.json` to switch app configuration files used by your project, you'll have to migrate to an alternative since this is not supported in EAS Build. For more information, see [Migrating away from the `--config` flag in Expo CLI](https://expo.fyi/config-flag-migration).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The Custom Entry Point FAQ in the build migration doc is outdated. Caught by @wodin (thank you!). For complete context, check [Slack](https://exponent-internal.slack.com/archives/CP8BDK9F1/p1694674505705699).

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the FAQ to explicitly mention that this instruction is valid if using SDK 48 or below. Also, add a note about SDK 49 and above to redirect to the `registerRootComponent` doc.

**Preview of changes**

![CleanShot 2023-09-14 at 21 36 01](https://github.com/expo/expo/assets/10234615/3471a4e4-797a-4697-a99f-167154ef6897)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/build-reference/migrating/#custom-main-entry-point-in-packagejson-is-not-supported-for-sdk-48-and-below

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
