### PR TITLE
Support mocking Node.js externals for client-side bundles.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Support mocking Node.js externals for client-side bundles.
+- Support mocking Node.js externals for client-side bundles. ([#24453](https://github.com/expo/expo/pull/24453) by [@EvanBacon](https://github.com/EvanBacon))
 - Add additional port check after build to ensure port is still available. ([#24315](https://github.com/expo/expo/pull/24315) by [@EvanBacon](https://github.com/EvanBacon))
 - Add support for bun as a package manager. ([#24344](https://github.com/expo/expo/pull/24344) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Support mocking Node.js externals for client-side bundles.
 - Add additional port check after build to ensure port is still available. ([#24315](https://github.com/expo/expo/pull/24315) by [@EvanBacon](https://github.com/EvanBacon))
 - Add support for bun as a package manager. ([#24344](https://github.com/expo/expo/pull/24344) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -162,7 +162,7 @@ export function formatUsingNodeStandardLibraryError(
       ].join('\n');
     } else {
       return [
-        `You attempted attempted to import the Node standard library module "${chalk.bold(
+        `You attempted to import the Node standard library module "${chalk.bold(
           targetModuleName
         )}" from "${chalk.bold(relativePath)}".`,
         `It failed because the native React runtime does not include the Node standard library.`,

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -170,7 +170,7 @@ describe(formatUsingNodeStandardLibraryError, () => {
       targetModuleName: 'path',
     } as any);
     expect(stripAnsi(format)).toMatchInlineSnapshot(`
-      "You attempted attempted to import the Node standard library module "path" from "App.js".
+      "You attempted to import the Node standard library module "path" from "App.js".
       It failed because the native React runtime does not include the Node standard library.
       Learn more: https://docs.expo.dev/workflow/using-libraries/#using-third-party-libraries"
     `);

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -316,7 +316,43 @@ export function withExtendedResolver(
         );
       }
 
+      if (
+        // is web
+        platform === 'web' &&
+        // Not server runtime
+        !isNode &&
+        // Is Node.js built-in
+        isNodeExternal(moduleName)
+      ) {
+        // Perform optional resolve first. If the module doesn't exist (no module in the node_modules)
+        // then we can mock the file to use an empty module.
+        result ??= optionalResolve(moduleName);
+
+        if (!result) {
+          // In this case, mock the file to use an empty module.
+          return {
+            type: 'empty',
+          };
+        }
+      }
+
       result ??= doResolve(moduleName);
+
+      if (
+        // No results
+        !result &&
+        // Not server runtime
+        !isNode &&
+        // is web
+        platform === 'web' &&
+        // Is Node.js external
+        isNodeExternal(moduleName)
+      ) {
+        // In this case, mock the file to use an empty module.
+        return {
+          type: 'empty',
+        };
+      }
 
       if (result) {
         // Replace the web resolver with the original one.

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -338,22 +338,6 @@ export function withExtendedResolver(
 
       result ??= doResolve(moduleName);
 
-      if (
-        // No results
-        !result &&
-        // Not server runtime
-        !isNode &&
-        // is web
-        platform === 'web' &&
-        // Is Node.js external
-        isNodeExternal(moduleName)
-      ) {
-        // In this case, mock the file to use an empty module.
-        return {
-          type: 'empty',
-        };
-      }
-
       if (result) {
         // Replace the web resolver with the original one.
         // This is basically an alias for web-only.


### PR DESCRIPTION
# Why

- Fix regression in https://github.com/expo/expo/pull/24199 which breaks all Metro web tests.
