### PR TITLE
split create-expo tests out of Expo CLI tests

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -60,12 +60,6 @@ jobs:
       - name: E2E Test @expo/fingerprint
         run: yarn test:e2e
         working-directory: packages/@expo/fingerprint
-      - name: 🛠 Build create-expo
-        run: yarn prepare
-        working-directory: packages/create-expo
-      - name: E2E Test create-expo
-        run: yarn test:e2e
-        working-directory: packages/create-expo
       # - name: 🔔 Notify on Slack
       #   uses: 8398a7/action-slack@v3
       #   if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -1,0 +1,46 @@
+name: Create Expo App
+
+on:
+  push:
+    branches: [main, 'sdk-*']
+    paths:
+      - .github/workflows/create-expo-app.yml
+      - packages/create-expo/**
+      - yarn.lock
+  pull_request:
+    paths:
+      - .github/workflows/create-expo-app.yml
+      - packages/create-expo/**
+      - yarn.lock
+  schedule:
+    - cron: 0 14 * * *
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+      - name: ⬇️ Fetch commits from base branch
+        run: git fetch origin ${{ github.event.before || github.base_ref || 'main' }}:${{ github.event.before || github.base_ref || 'main' }} --depth 100
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          yarn-workspace: 'true'
+      - name: 🧶 Install node modules in root dir
+        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+        run: yarn install --frozen-lockfile
+      - name: 🛠 Build create-expo
+        run: yarn prepare
+        working-directory: packages/create-expo
+      - name: E2E Test create-expo
+        run: yarn test:e2e
+        working-directory: packages/create-expo


### PR DESCRIPTION
# Why

Keep the Expo CLI tests fast