### PR TITLE
[ios][file-system] throw correct error

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Migrated to Swift and Expo Modules API on iOS. ([#23943](https://github.com/expo/expo/pull/23943) by [@tsapeta](https://github.com/tsapeta))
+- Throw the correct error when we can't find the permissions modules. ([#24464](https://github.com/expo/expo/pull/24464) by [@alanhughes](https://github.com/alanjhughes))
 
 ## 15.6.0 — 2023-09-04
 

--- a/packages/expo-file-system/ios/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/FileSystemHelpers.swift
@@ -58,7 +58,7 @@ internal func getResourceValues(from directory: URL?, forKeys: Set<URLResourceKe
 
 internal func ensurePathPermission(_ appContext: AppContext?, path: String, flag: EXFileSystemPermissionFlags) throws {
   guard let permissionsManager: EXFilePermissionModuleInterface = appContext?.legacyModule(implementing: EXFilePermissionModuleInterface.self) else {
-    throw Exceptions.FileSystemModuleNotFound()
+    throw Exceptions.PermissionsModuleNotFound()
   }
   guard permissionsManager.getPathPermissions(path).contains(flag) else {
     throw flag == .read ? FileNotReadableException(path) : FileNotWritableException(path)


### PR DESCRIPTION
# Why
Just noticed this while adding some tests. We're throwing the wrong error when not finding the permissions module.

# How
Throw the correct error

# Test Plan

