### PR TITLE
[expo-updates][android] Make scopekey only required when getting database entity

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix updates enabled defaulting on iOS. ([#24327](https://github.com/expo/expo/pull/24327) by [@wschurman](https://github.com/wschurman))
+- [Android] Make scopekey only required when getting database entity. ([#24466](https://github.com/expo/expo/pull/24466) by [@wschurman](https://github.com/wschurman))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/BareUpdateManifest.kt
@@ -22,13 +22,13 @@ import java.util.*
 class BareUpdateManifest private constructor(
   override val manifest: BareManifest,
   private val mId: UUID,
-  private val mScopeKey: String,
+  private val mScopeKey: String?,
   private val mCommitTime: Date,
   private val mRuntimeVersion: String,
   private val mAssets: JSONArray?
 ) : UpdateManifest {
   override val updateEntity: UpdateEntity by lazy {
-    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey, this@BareUpdateManifest.manifest.getRawJson()).apply {
+    UpdateEntity(mId, mCommitTime, mRuntimeVersion, mScopeKey!!, this@BareUpdateManifest.manifest.getRawJson()).apply {
       status = UpdateStatus.EMBEDDED
     }
   }
@@ -94,7 +94,7 @@ class BareUpdateManifest private constructor(
       return BareUpdateManifest(
         manifest,
         id,
-        configuration.scopeKey!!,
+        configuration.scopeKey,
         commitTime,
         runtimeVersion,
         assets


### PR DESCRIPTION
# Why

This brings the nullability semantics in-line with those on iOS (ish, though there's no exact parallel) in order to fix the issue: people are setting isEnabled to false but the system still expects a URL in order to generate a scopeKey in order to start the NoDatabaseLauncher.

Closes ENG-9880.

# How

This is the alternative to https://github.com/expo/expo/pull/24330. It is a far simpler solution but keeps us in the status quo of "it may throw later down the line in certain cases". Those cases are when this is used outside of NoDatabaseLoader, and there's little we can do to guarantee we don't accidentally write code that does this, hence the crashes our users are experiencing.

# Test Plan

```
et gba -n testwat13 expo-updates expo-manifests expo-updates-interface expo-constants
// set updates.enabled to false
npx expo prebuild
// build in release mode on android
// no longer see crash
```


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
