### PR TITLE
[expo-intent-launcher] [Android] Fix the crash on fulfilled promises when ActivityNotFoundException is thrown

### DIFF
--- a/packages/expo-intent-launcher/CHANGELOG.md
+++ b/packages/expo-intent-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed errors in debug and crashes in production when an intent is launched without found activities. ([#24481](https://github.com/expo/expo/pull/24481) by [@robertying](https://github.com/robertying))
+
 ### 💡 Others
 
 ## 10.9.0 — 2023-09-04

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -9,6 +9,7 @@ import androidx.core.os.bundleOf
 import expo.modules.intentlauncher.exceptions.ActivityAlreadyStartedException
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -61,8 +61,7 @@ class IntentLauncherModule : Module() {
       try {
         currentActivity.startActivityForResult(intent, REQUEST_CODE)
         pendingPromise = promise
-      }
-      catch (e: Throwable) {
+      } catch (e: Throwable) {
         promise.reject(e.toCodedException())
       }
     }

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherModule.kt
@@ -58,8 +58,13 @@ class IntentLauncherModule : Module() {
       params.flags?.let { intent.addFlags(it) }
       params.category?.let { intent.addCategory(it) }
 
-      pendingPromise = promise
-      currentActivity.startActivityForResult(intent, REQUEST_CODE)
+      try {
+        currentActivity.startActivityForResult(intent, REQUEST_CODE)
+        pendingPromise = promise
+      }
+      catch (e: Throwable) {
+        promise.reject(e.toCodedException())
+      }
     }
 
     OnActivityResult { _, payload ->


### PR DESCRIPTION
# Why

The PR #23571 improved error handling on promises, which unfortunately also causes crashes when using `expo-intent-launcher` on Android.

When `currentActivity.startActivityForResult(intent, REQUEST_CODE)` throws, for example when we open a file with it but there's no supported app for the file type, an error occurs "Promised pass to 'ExpoIntentLauncher.startActivity' was already settled. It will lead to a crash in the production environment!" in debug and crashes the app in production.

# How

When `startActivityForResult` throws, the associated promise is **resolved**. `OnActivityResult` still gets called and tries to resolve the promise again with `pendingPromise?.resolve(response)`, which causes resolving an already settled promise.

The fix is to either make sure `OnActivityResult` does not resolve the promise on error, or simply make sure `OnActivityResult` is not called.

I propose to handle the `startActivityForResult` thrown error directly.

# Test Plan

With the file opening example:

```ts
export const openFile = async (uri: string, type?: string | null) => {
  const contentUri = await ExpoFileSystem.getContentUriAsync(uri);
  await IntentLauncher.startActivityAsync('android.intent.action.VIEW', {
    type: (type && mime.lookup(type)) || 'text/plain',
    data: contentUri,
    flags: 1,
  });
};
```

When we call `openFile` with an XLS file for example on a clean emulator, the error "Promised pass to 'ExpoIntentLauncher.startActivity' was already settled" shows up in debug before the fix.

After the fix, the error won't occur and the promise is correctly rejected. We get this nice error on the JS side:

```
[Error: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=content://com.x.y.z.FileSystemFileProvider/... typ=application/vnd.ms-excel flg=0x1 }]
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
