### PR TITLE
[docs] Add newsletter links to sidebar footer and Home page

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -7,9 +7,9 @@ import {
   DiscordIcon,
   DiscourseIcon,
   GithubIcon,
+  Mail01Icon,
   RedditIcon,
   TwitterIcon,
-  Mail01DuotoneIcon,
 } from '@expo/styleguide-icons';
 import type { PropsWithChildren } from 'react';
 import { Row, ScreenClassProvider } from 'react-grid-system';
@@ -302,7 +302,7 @@ export function JoinTheCommunity() {
             title="Newsletter"
             description="Get the latest updates from monthly Expo newsletter."
             link="http://eepurl.com/hk1tCn"
-            icon={<Mail01DuotoneIcon className="icon-lg text-palette-white" />}
+            icon={<Mail01Icon className="icon-lg text-palette-white" />}
           />
         </Row>
       </CellContainer>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   GithubIcon,
   RedditIcon,
   TwitterIcon,
+  Mail01DuotoneIcon,
 } from '@expo/styleguide-icons';
 import type { PropsWithChildren } from 'react';
 import { Row, ScreenClassProvider } from 'react-grid-system';
@@ -296,6 +297,12 @@ export function JoinTheCommunity() {
             link="https://www.reddit.com/r/expo"
             icon={<RedditIcon className="icon-lg text-palette-white" />}
             iconBackground="#FC471E"
+          />
+          <CommunityGridCell
+            title="Newsletter"
+            description="Get the latest updates from monthly Expo newsletter."
+            link="http://eepurl.com/hk1tCn"
+            icon={<Mail01DuotoneIcon className="icon-lg text-palette-white" />}
           />
         </Row>
       </CellContainer>

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -2,7 +2,7 @@ import { SnackLogo } from '@expo/styleguide';
 import {
   ChangelogIcon,
   DiscordIcon,
-  Mail01DuotoneIcon,
+  Mail01Icon,
   MessageDotsSquareIcon,
 } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
@@ -56,7 +56,7 @@ export const SidebarFooter = () => {
         secondary
         href="http://eepurl.com/hk1tCn"
         title="Newsletter"
-        Icon={Mail01DuotoneIcon}
+        Icon={Mail01Icon}
         isExternal
       />
     </div>

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -1,5 +1,10 @@
 import { SnackLogo } from '@expo/styleguide';
-import { ChangelogIcon, DiscordIcon, MessageDotsSquareIcon } from '@expo/styleguide-icons';
+import {
+  ChangelogIcon,
+  DiscordIcon,
+  Mail01DuotoneIcon,
+  MessageDotsSquareIcon,
+} from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { SidebarSingleEntry } from './SidebarSingleEntry';
@@ -45,6 +50,13 @@ export const SidebarFooter = () => {
         href="https://expo.dev/changelog"
         title="Changelog"
         Icon={ChangelogIcon}
+        isExternal
+      />
+      <SidebarSingleEntry
+        secondary
+        href="http://eepurl.com/hk1tCn"
+        title="Newsletter"
+        Icon={Mail01DuotoneIcon}
         isExternal
       />
     </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We increasing the visibility of the monthly Expo newsletter. Currently, on Docs, we do not mention about the newseltter.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Adds the monthly newsletter link in the Sidebar footer

<img width="275" alt="CleanShot 2023-09-17 at 15 49 56@2x" src="https://github.com/expo/expo/assets/10234615/63e49e19-3536-40a1-8afc-6f20ec6856cf">

- Adds the monthly newsletter link in "Join the community" section

<img width="1153" alt="CleanShot 2023-09-17 at 15 52 13@2x" src="https://github.com/expo/expo/assets/10234615/8f992074-b602-43ef-9aa7-03f44689c308">

- Uses Duotone icon variant of `Mail01`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit: http://localhost:3002/ and then look at Join the community section on Home page and sidebar footer for newsletter links.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
