### PR TITLE
[@expo/cli] Apple TV support 3: EXPO_TV for prebuild

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- New env EXPO_TV allows switching to TV template. ([#24485](https://github.com/expo/expo/pull/24485) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/src/prebuild/__tests__/clearNativeFolder-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/clearNativeFolder-test.ts
@@ -1,3 +1,4 @@
+import { PackageJSONConfig } from '@expo/config';
 import { vol } from 'memfs';
 
 import rnFixture from './fixtures/react-native-project';
@@ -127,6 +128,48 @@ describe(getMalformedNativeProjectsAsync, () => {
     const projectRoot = '/';
     vol.fromJSON({}, projectRoot);
     const malformed = await getMalformedNativeProjectsAsync(projectRoot, ['ios', 'android']);
+    expect(malformed).toStrictEqual([]);
+  });
+
+  it(`finds both platforms if EXPO_TV is set`, async () => {
+    const projectRoot = '/';
+    const pkg: PackageJSONConfig = {
+      dependencies: {
+        'react-native': '0.72.4',
+      },
+    };
+    // mock out some non-empty ios and android folders.
+    vol.fromJSON(
+      {
+        'android/foobar': 'x',
+        'ios/Info.plist': 'xx',
+        'ios/another/file': 'xx',
+      },
+      '/'
+    );
+    const malformed = await getMalformedNativeProjectsAsync(
+      projectRoot,
+      ['android', 'ios'],
+      pkg,
+      true
+    );
+    expect(malformed).toStrictEqual(['android', 'ios']);
+  });
+  it(`finds no platforms if EXPO_TV is set and folders are empty`, async () => {
+    const projectRoot = '/';
+    const pkg: PackageJSONConfig = {
+      dependencies: {
+        'react-native': '0.72.4',
+      },
+    };
+    // mock out some non-empty ios and android folders.
+    vol.fromJSON({}, '/');
+    const malformed = await getMalformedNativeProjectsAsync(
+      projectRoot,
+      ['android', 'ios'],
+      pkg,
+      true
+    );
     expect(malformed).toStrictEqual([]);
   });
 });

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -2,7 +2,11 @@ import chalk from 'chalk';
 
 import * as Log from '../../log';
 import { isModuleSymlinked } from '../../utils/isModuleSymlinked';
-import { hashForDependencyMap, updatePkgDependencies } from '../updatePackageJson';
+import {
+  hashForDependencyMap,
+  updatePkgDependencies,
+  needsReactNativeDependencyChangedForTV,
+} from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
 jest.mock('../../log');
@@ -149,5 +153,19 @@ describe(updatePkgDependencies, () => {
           .join(', ')}`
       )
     );
+  });
+  test('needsReactNativeDependencyChangedForTV', () => {
+    // If no react-native dependency, should always return true (the RN dependency should be added)
+    const depsWithoutRN = {};
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: false })).toBe(true);
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: true })).toBe(true);
+    // If core react-native dependency and isTV is true, return true
+    const depsWithRNCore = { 'react-native': '0.72' };
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: false })).toBe(false);
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: true })).toBe(true);
+    // If TV react-native dependency and isTV is false, return true
+    const depsWithRNTV = { 'react-native': 'npm:react-native-tvos@0.72' };
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: false })).toBe(true);
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: true })).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -155,17 +155,17 @@ describe(updatePkgDependencies, () => {
     );
   });
   test('needsReactNativeDependencyChangedForTV', () => {
-    // If no react-native dependency, should always return true (the RN dependency should be added)
+    // If no react-native dependency, we are ok with phone or TV (template will add the right one)
     const depsWithoutRN = {};
-    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: false })).toBe(true);
-    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: true })).toBe(true);
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: false })).toBe(false);
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: true })).toBe(false);
     // If core react-native dependency and isTV is true, return true
     const depsWithRNCore = { 'react-native': '0.72' };
     expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: false })).toBe(false);
     expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: true })).toBe(true);
-    // If TV react-native dependency and isTV is false, return true
+    // If TV react-native dependency, we are ok with phone or TV
     const depsWithRNTV = { 'react-native': 'npm:react-native-tvos@0.72' };
-    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: false })).toBe(true);
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: false })).toBe(false);
     expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: true })).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -2,11 +2,7 @@ import chalk from 'chalk';
 
 import * as Log from '../../log';
 import { isModuleSymlinked } from '../../utils/isModuleSymlinked';
-import {
-  hashForDependencyMap,
-  updatePkgDependencies,
-  needsReactNativeDependencyChangedForTV,
-} from '../updatePackageJson';
+import { hashForDependencyMap, updatePkgDependencies } from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
 jest.mock('../../log');
@@ -153,19 +149,5 @@ describe(updatePkgDependencies, () => {
           .join(', ')}`
       )
     );
-  });
-  test('needsReactNativeDependencyChangedForTV', () => {
-    // If no react-native dependency, we are ok with phone or TV (template will add the right one)
-    const depsWithoutRN = {};
-    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: false })).toBe(false);
-    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: true })).toBe(false);
-    // If core react-native dependency and isTV is true, return true
-    const depsWithRNCore = { 'react-native': '0.72' };
-    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: false })).toBe(false);
-    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: true })).toBe(true);
-    // If TV react-native dependency, we are ok with phone or TV
-    const depsWithRNTV = { 'react-native': 'npm:react-native-tvos@0.72' };
-    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: false })).toBe(false);
-    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: true })).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -70,9 +70,6 @@ export async function prebuildAsync(
     }
     // Clear the native folders before syncing
     await clearNativeFolder(projectRoot, options.platforms);
-  } else {
-    // Check if the existing project folders are malformed.
-    await promptToClearMalformedNativeProjectsAsync(projectRoot, options.platforms);
   }
 
   // Warn if the project is attempting to prebuild an unsupported platform (iOS on Windows).
@@ -82,6 +79,17 @@ export async function prebuildAsync(
 
   // Get the Expo config, create it if missing.
   const { exp, pkg } = await ensureConfigAsync(projectRoot, { platforms: options.platforms });
+
+  // Check for malformed native folders
+  if (!options.clean) {
+    // Check if the existing project folders are malformed.
+    await promptToClearMalformedNativeProjectsAsync(
+      projectRoot,
+      options.platforms,
+      pkg,
+      env.EXPO_TV
+    );
+  }
 
   // Create native projects from template.
   const { hasNewProjectFiles, needsPodInstall, hasNewDependencies } = await updateFromTemplateAsync(

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -83,12 +83,7 @@ export async function prebuildAsync(
   // Check for malformed native folders
   if (!options.clean) {
     // Check if the existing project folders are malformed.
-    await promptToClearMalformedNativeProjectsAsync(
-      projectRoot,
-      options.platforms,
-      pkg,
-      env.EXPO_TV
-    );
+    await promptToClearMalformedNativeProjectsAsync(projectRoot, options.platforms, env.EXPO_TV);
   }
 
   // Create native projects from template.

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -299,7 +299,7 @@ function versionRangesIntersect(rangeA: string | SemverRange, rangeB: string | S
  */
 export function needsReactNativeDependencyChangedForTV(
   dependencies: any,
-  params: { isTV: boolean }
+  params?: { isTV?: boolean }
 ) {
   const rnVersion: string | undefined = dependencies['react-native'];
   // If the package currently has no react-native dependency, prebuild should add
@@ -309,5 +309,5 @@ export function needsReactNativeDependencyChangedForTV(
   }
   const rnVersionIsTV = (rnVersion?.indexOf('npm:react-native-tvos') ?? -1) === 0;
   // Return true if the existing version is not TV, and the template is TV, or vice versa
-  return params.isTV !== rnVersionIsTV;
+  return (params?.isTV ?? false) !== rnVersionIsTV;
 }

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -9,6 +9,7 @@ import * as Log from '../log';
 import { env } from '../utils/env';
 import { isModuleSymlinked } from '../utils/isModuleSymlinked';
 import { logNewSection } from '../utils/ora';
+import { needsReactNativeDependencyChangedForTV } from '../utils/tv';
 
 export type DependenciesMap = { [key: string]: string | number };
 
@@ -290,25 +291,4 @@ function versionRangesIntersect(rangeA: string | SemverRange, rangeB: string | S
   } catch {
     return false;
   }
-}
-
-/**
- * Determine if the react-native dependency in the project needs to be replaced
- * when prebuilding and the EXPO_TV environment variable is set
- */
-export function needsReactNativeDependencyChangedForTV(
-  dependencies: any,
-  params?: { isTV?: boolean }
-) {
-  const rnVersion: string | undefined = dependencies['react-native'];
-  if (!params?.isTV) {
-    return false;
-  }
-  // If the package currently has no react-native dependency, prebuild will add
-  // the template version anyway
-  if (rnVersion === undefined) {
-    return false;
-  }
-  // Return true if the existing version is not the TV fork
-  return (rnVersion?.indexOf('npm:react-native-tvos') ?? -1) !== 0;
 }

--- a/packages/@expo/cli/src/utils/__tests__/tv-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/tv-test.ts
@@ -1,0 +1,18 @@
+import { needsReactNativeDependencyChangedForTV } from '../tv';
+
+describe('tv-test', () => {
+  test('needsReactNativeDependencyChangedForTV', () => {
+    // If no react-native dependency, we are ok with phone or TV (template will add the right one)
+    const depsWithoutRN = {};
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: false })).toBe(false);
+    expect(needsReactNativeDependencyChangedForTV(depsWithoutRN, { isTV: true })).toBe(false);
+    // If core react-native dependency and isTV is true, return true
+    const depsWithRNCore = { 'react-native': '0.72' };
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: false })).toBe(false);
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNCore, { isTV: true })).toBe(true);
+    // If TV react-native dependency, we are ok with phone or TV
+    const depsWithRNTV = { 'react-native': 'npm:react-native-tvos@0.72' };
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: false })).toBe(false);
+    expect(needsReactNativeDependencyChangedForTV(depsWithRNTV, { isTV: true })).toBe(false);
+  });
+});

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -35,6 +35,11 @@ class Env {
     return boolish('EXPO_LOCAL', false);
   }
 
+  /** Enable prebuild with TV template */
+  get EXPO_TV() {
+    return boolish('EXPO_TV', false);
+  }
+
   /** Is running in non-interactive CI mode */
   get CI() {
     return boolish('CI', false);

--- a/packages/@expo/cli/src/utils/tv.ts
+++ b/packages/@expo/cli/src/utils/tv.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ *
+ * @param dependencies The project package.json dependencies.
+ * @param params isTV is true if we are building for TV.
+ * @returns true if isTV is true, and the react-native dependency is not the TV fork.
+ */
+export function needsReactNativeDependencyChangedForTV(
+  dependencies: any,
+  params?: { isTV?: boolean }
+) {
+  const rnVersion: string | undefined = dependencies['react-native'];
+  if (!params?.isTV) {
+    return false;
+  }
+  // If the package currently has no react-native dependency, prebuild will add
+  // the template version anyway
+  if (rnVersion === undefined) {
+    return false;
+  }
+  // Return true if the existing version is not the TV fork
+  return (rnVersion?.indexOf('npm:react-native-tvos') ?? -1) !== 0;
+}
+
+/**
+ *
+ * @param projectRoot The project root path.
+ * @param params isTV is true if we are building for TV.
+ * @returns true if we are building for TV, but there is an existing Podfile configured for phone, or vice versa.
+ */
+export function needsIosProjectChangedForTV(projectRoot: string, params?: { isTV?: boolean }) {
+  const podFilePath = path.join(projectRoot, 'ios', 'Podfile');
+  if (!fs.existsSync(podFilePath)) {
+    return false;
+  }
+  const podFileText = fs.readFileSync(podFilePath, { encoding: 'utf-8' });
+  const podFileConfiguredForTV = podFileText.indexOf(':tvos') !== -1;
+  return (params?.isTV ?? false) !== podFileConfiguredForTV;
+}


### PR DESCRIPTION
# Why

Starting with a managed Expo project (no `ios` or `android` folders) created with blank or blank-typescript template, a developer should be able to cause prebuild to create the correct native files for TV.

With this change, a developer could create such a project, and have multiple EAS build profiles, some targeted for phone and some targeted for TV (both Apple TV and Android TV).

This requires that the `react-native` dependency be changed to use the TV fork (which supports both phone and TV builds):

```
"react-native": "npm:react-native-tvos@0.72.4-0",
```

We should think about whether this technique could be extended to other non-phone platforms (e.g. desktop).

# How

- New environment variable `EXPO_TV`
- When enabled, use `expo-template-tv` instead of `expo-template-bare-minimum` for prebuild
- Enabling `EXPO_TV` requires that TV fork be used. If `EXPO_TV` is enabled and the `react-native` dependency is not correct, prebuild throws an error and exits
- If value of `EXPO_TV` is changed, and ios or android folder exists, prompt to clean existing ios or android folder

# Test Plan

- Tested with a blank-typescript project
- Unit test for the new TV method to detect when react-native dependency is incorrect

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
