### PR TITLE
fix(cli): rework typed routes exclusion regex (remove 404, api)

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Prevent log-spew when running prebuild in debug mode. ([#25434](https://github.com/expo/expo/pull/25434) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix @react-native/dev-middleware types for react-native 0.73. ([#25513](https://github.com/expo/expo/pull/25513) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Only use `bundledNativeModules.json` for dependencies validation when using canary versions. ([#25600](https://github.com/expo/expo/pull/25600) by [@byCedric](https://github.com/byCedric))
+- Remove the 404 route from typed routes
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix @react-native/dev-middleware types for react-native 0.73. ([#25513](https://github.com/expo/expo/pull/25513) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Only use `bundledNativeModules.json` for dependencies validation when using canary versions. ([#25600](https://github.com/expo/expo/pull/25600) by [@byCedric](https://github.com/byCedric))
 - Remove the 404 route from typed routes
+- Remove the 404 route from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Only use `bundledNativeModules.json` for dependencies validation when using canary versions. ([#25600](https://github.com/expo/expo/pull/25600) by [@byCedric](https://github.com/byCedric))
 - Remove the 404 route from typed routes
 - Remove the 404 route from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
+- Exclude `+not-found` and `*+api` routes from typed routes ([#24496](https://github.com/expo/expo/pull/24496) by [@marklawlor](https://github.com/marklawlor))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -122,16 +122,9 @@ describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
     expect('/folder/route+anything.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 
-  it('will match 404 pages', () => {
-    expect('404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-    expect('[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-    expect('[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-  });
-
-  it('will match nested 404 pages', () => {
-    expect('/folder/404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-    expect('/folder/[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-    expect('/folder/[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  it('will match +not_found', () => {
+    expect('+not_found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/+not_found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 });
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -104,7 +104,7 @@ describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
     expect('/route/_layout.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 
-  it.only('will match +html files', () => {
+  it('will match +html files', () => {
     expect('+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
     expect('/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
     expect('/route/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
@@ -122,9 +122,9 @@ describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
     expect('/folder/route+anything.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 
-  it('will match +not_found', () => {
-    expect('+not_found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
-    expect('/folder/+not_found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  it('will match +not+found', () => {
+    expect('+not+found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/+not+found.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 });
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -6,6 +6,7 @@ import {
   CAPTURE_GROUP_REGEX,
   ARRAY_GROUP_REGEX,
   getTypedRoutesUtils,
+  TYPED_ROUTES_EXCLUSION_REGEX,
 } from '../routes';
 
 describe(`${CAPTURE_DYNAMIC_PARAMS}`, () => {
@@ -82,6 +83,55 @@ describe(`${CAPTURE_GROUP_REGEX}`, () => {
     expect([...matches[0]]).toStrictEqual(['(   group1  ', 'group1']);
     expect([...matches[1]]).toStrictEqual([', my group', 'my group']);
     expect([...matches[2]]).toStrictEqual([', my other   group  ', 'my other   group']);
+  });
+});
+
+describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
+  it('will not match standard routes', () => {
+    expect('/route.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/route.js'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/route.jsx'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/route.tsx'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+
+    expect('/folder/html.tsx'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/folder/api.tsx'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/folder/layout.tsx'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+  });
+
+  it('will match _layout files', () => {
+    expect('_layout.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/_layout.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/route/_layout.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  });
+
+  it('will match +html files', () => {
+    expect('+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/route/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  });
+
+  it('will match API routes', () => {
+    expect('route+api.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/route+api.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/route+api.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  });
+
+  it('will match any +filename', () => {
+    expect('route+anything.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/route+anything.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/route+anything.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  });
+
+  it('will match 404 pages', () => {
+    expect('404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+  });
+
+  it('will NOT match nested 404 pages', () => {
+    expect('/folder/404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/folder/[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+    expect('/folder/[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
   });
 });
 

--- a/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__tests__/routes.test.ts
@@ -104,7 +104,7 @@ describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
     expect('/route/_layout.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 
-  it('will match +html files', () => {
+  it.only('will match +html files', () => {
     expect('+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
     expect('/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
     expect('/route/+html.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
@@ -128,10 +128,10 @@ describe(`${TYPED_ROUTES_EXCLUSION_REGEX}`, () => {
     expect('[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 
-  it('will NOT match nested 404 pages', () => {
-    expect('/folder/404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
-    expect('/folder/[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
-    expect('/folder/[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeNull();
+  it('will match nested 404 pages', () => {
+    expect('/folder/404.ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/[404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
+    expect('/folder/[...404].ts'.match(TYPED_ROUTES_EXCLUSION_REGEX)).toBeTruthy();
   });
 });
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -22,11 +22,10 @@ export const CAPTURE_GROUP_REGEX = /[\\(,]\s*(\w[\w\s]*?)\s*(?=[,\\)])/g;
  * Match:
  *  - _layout files
  *  - filenames that take the form of `+${string}`, including +html, and API routes
- *    - Routes can still use `+`, but it cannot be in the last segment.
+ *  - Routes can still use `+`, but it cannot be in the last segment.
  *  - All variations of 404 files, 404.ts, [404].ts, [...404].ts
- *    - Only matches 404 on the top level, nested 404 files are allowed
  */
-export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout|\+[^/]+|^404|^\[(\.\.\.)?404\])\.[tj]sx?$/;
+export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout|404|\[(\.\.\.)?404\]|\+[^/]+)\.[tj]sx?$/;
 
 export interface SetupTypedRoutesOptions {
   server?: ServerLike;

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -20,10 +20,10 @@ export const ARRAY_GROUP_REGEX = /\(\s*\w[\w\s]*?,.*?\)/g;
 export const CAPTURE_GROUP_REGEX = /[\\(,]\s*(\w[\w\s]*?)\s*(?=[,\\)])/g;
 /**
  * Match:
- *  - _layout files, +html, +not_found, string+api, etc
+ *  - _layout files, +html, +not-found, string+api, etc
  *  - Routes can still use `+`, but it cannot be in the last segment.
  */
-export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout||\+[^/]+)\.[tj]sx?$/;
+export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout|[^/]*?\+[^/]*?)\.[tj]sx?$/;
 
 export interface SetupTypedRoutesOptions {
   server?: ServerLike;

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -18,6 +18,15 @@ export const SLUG = /\[.+?\]/g;
 export const ARRAY_GROUP_REGEX = /\(\s*\w[\w\s]*?,.*?\)/g;
 // /(group1,group2,group3)/test - captures ["group1", "group2", "group3"]
 export const CAPTURE_GROUP_REGEX = /[\\(,]\s*(\w[\w\s]*?)\s*(?=[,\\)])/g;
+/**
+ * Match:
+ *  - _layout files
+ *  - filenames that take the form of `+${string}`, including +html, and API routes
+ *    - Routes can still use `+`, but it cannot be in the last segment.
+ *  - All variations of 404 files, 404.ts, [404].ts, [...404].ts
+ *    - Only matches 404 on the top level, nested 404 files are allowed
+ */
+export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout|\+[^/]+|^404|^\[(\.\.\.)?404\])\.[tj]sx?$/;
 
 export interface SetupTypedRoutesOptions {
   server?: ServerLike;
@@ -162,8 +171,7 @@ export function getTypedRoutesUtils(appRoot: string, filePathSeperator = path.se
   };
 
   const isRouteFile = (filePath: string) => {
-    // Layout and filenames starting with `+` are not routes
-    if (filePath.match(/_layout\.[tj]sx?$/) || filePath.match(/\/\+/)) {
+    if (filePath.match(TYPED_ROUTES_EXCLUSION_REGEX)) {
       return false;
     }
 

--- a/packages/@expo/cli/src/start/server/type-generation/routes.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/routes.ts
@@ -20,12 +20,10 @@ export const ARRAY_GROUP_REGEX = /\(\s*\w[\w\s]*?,.*?\)/g;
 export const CAPTURE_GROUP_REGEX = /[\\(,]\s*(\w[\w\s]*?)\s*(?=[,\\)])/g;
 /**
  * Match:
- *  - _layout files
- *  - filenames that take the form of `+${string}`, including +html, and API routes
+ *  - _layout files, +html, +not_found, string+api, etc
  *  - Routes can still use `+`, but it cannot be in the last segment.
- *  - All variations of 404 files, 404.ts, [404].ts, [...404].ts
  */
-export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout|404|\[(\.\.\.)?404\]|\+[^/]+)\.[tj]sx?$/;
+export const TYPED_ROUTES_EXCLUSION_REGEX = /(_layout||\+[^/]+)\.[tj]sx?$/;
 
 export interface SetupTypedRoutesOptions {
   server?: ServerLike;


### PR DESCRIPTION
# Why

 Rework typed routes exclusion regex (remove 404, +api). This regex also needed better unit testings.

It now excludes:

- `_layout`
- Any file that is `+{string}.{extension}`
  - This coverers `+html`/`my-route+api.ts`
  - `+` can still be part of the path, it just cannot be in the last segment
- All variations of 404 pages  

ENG-10141
ENG-10074

# How

Reworked the Route exclusion regex.

# Test Plan

Exported the regex and wrote new tests for `_layout`/`+html`/`+api`/`404`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
