### PR TITLE
[sqlite] fix load extension test

### DIFF
--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -661,7 +661,7 @@ export function test(t) {
         const db = SQLite.openDatabase('test.db');
         await db.transactionAsync(async (tx) => {
           await tx.executeSqlAsync('DROP TABLE IF EXISTS foo;', []);
-          await tx.executeSqlAsync('create table foo (a primary key, b);', []);
+          await tx.executeSqlAsync('create table foo (a primary key, b INTEGER);', []);
           await tx.executeSqlAsync('select crsql_as_crr("foo");', []);
           await tx.executeSqlAsync('insert into foo (a,b) values (?, ?);', [1, 2]);
           await tx.executeSqlAsync('insert into foo (a,b) values (?, ?);', [3, 4]);

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix broken JS test. ([#24498](https://github.com/expo/expo/pull/24498) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 - [iOS] Bump `SQLite`version to latest. ([#24375](https://github.com/expo/expo/pull/24375) by [@alanjhughes](https://github.com/alanjhughes))


### PR DESCRIPTION
# Why
Fix the date type of the `b` column in the test that loads the `crsqlite` extension.

# How
Added the `INTEGER` type.

# Test Plan
Tests are passing with the correct values now