### PR TITLE
[docs] Move API Routes guide under Preview

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -191,7 +191,6 @@ const general = [
       makePage('router/reference/search-parameters.mdx'),
       makePage('router/reference/redirects.mdx'),
       makePage('router/reference/static-rendering.mdx'),
-      makePage('router/reference/api-routes.mdx'),
       makePage('router/reference/async-routes.mdx'),
       makePage('router/reference/sitemap.mdx'),
       makePage('router/reference/typed-routes.mdx'),
@@ -451,6 +450,7 @@ const preview = [
     makePage('preview/introduction.mdx'),
     makePage('preview/support.mdx'),
     { expanded: true },
+    makeSection('Expo Router', [makePage('preview/api-routes.mdx')]),
   ]),
 ];
 

--- a/docs/pages/preview/api-routes.mdx
+++ b/docs/pages/preview/api-routes.mdx
@@ -1,7 +1,6 @@
 ---
 title: API Routes
 description: Learn how to create server functions with Expo Router.
-hidden: true
 ---
 
 > **warning** This feature is still experimental. Available from Expo SDK 50 and Expo Router v3.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After discussing with Evan, we decided to move API Routes guide under Preview so it is not indexed by search engines at the moment.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update `navigation.js` and file location under `preview`. Before it was only hidden in the sidebar navigation.

**Preview**
![CleanShot 2023-09-19 at 01 19 02](https://github.com/expo/expo/assets/10234615/1c6ecdce-83d3-4e2c-addb-095a4ffd13a9)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/preview/api-routes/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
