### PR TITLE
[docs] Fix typo in "Create a development build"

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -98,7 +98,7 @@ Then, run the following command to create the development build on an iOS Simula
 
 <Terminal cmd={['$ eas build --profile development-simulator --platform ios']} />
 
-After the build is complete, the CLI will prompt you to automatically download and install the it on the iOS Simulator. When prompted, press <kbd>Y</kbd> to directly install it on the simulator.
+After the build is complete, the CLI will prompt you to automatically download and install it on the iOS Simulator. When prompted, press <kbd>Y</kbd> to directly install it on the simulator.
 
 See [Installing build on the simulator](/build-reference/simulators/#installing-build-on-the-simulator) for more information.
 


### PR DESCRIPTION
# Why

Simply polish up the documentation by fixing a typo.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
