### PR TITLE
[templates][android] update template to replace usesCleartextTraffic

### DIFF
--- a/templates/expo-template-bare-minimum/android/app/src/debug/AndroidManifest.xml
+++ b/templates/expo-template-bare-minimum/android/app/src/debug/AndroidManifest.xml
@@ -3,5 +3,5 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic" />
 </manifest>


### PR DESCRIPTION
# Why
Spoke to user on discord who had an issue when using the `usesCleartextTraffic` setting from `expo-build-properties`. If you set it to `false`, when running in `Debug` you will get an error about conflicting values because in the debug manifest `usesCleartextTraffic` is always true and in the app manifest it will be false. 

# How
Updated the template by adding `tools:replace="android:usesCleartextTraffic"` to the `Debug` manifest to override the value when running in debug

# Test Plan
Tested locally. The app now runs without issue in `Debug` using `usesCleartextTraffic=true` and in `Release` as whatever was provided to `expo-build-properties`.
