### PR TITLE
feat(cli): reduce static group routes

### DIFF
--- a/apps/router-e2e/__e2e__/server/app/(alpha)/beta.tsx
+++ b/apps/router-e2e/__e2e__/server/app/(alpha)/beta.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div data-testid="alpha-beta-text">Beta</div>;
+}

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Skip extraneous static HTML export in server mode.
+
 ## 0.13.2 — 2023-09-18
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Skip extraneous static HTML export in server mode.
+- Skip extraneous static HTML export in server mode. ([#24529](https://github.com/expo/expo/pull/24529) by [@EvanBacon](https://github.com/EvanBacon))
 
 ## 0.13.2 — 2023-09-18
 

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -225,6 +225,10 @@ describe('server-output', () => {
       // TODO: We shouldn't export this
       expect(files).toContain('_expo/functions/api/empty+api.js');
 
+      // Has single variation of group file
+      expect(files).toContain('(alpha)/beta.html');
+      expect(files).not.toContain('beta.html');
+
       // Injected by framework
       expect(files).toContain('_sitemap.html');
       expect(files).toContain('[...404].html');

--- a/packages/@expo/cli/e2e/__tests__/export/server.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server.test.ts
@@ -77,6 +77,16 @@ describe('server-output', () => {
         /<div id="root">/
       );
     });
+
+    it(`can serve up group routes`, async () => {
+      // Can access the same route from different paths
+      expect(await fetch('http://localhost:3000/beta').then((res) => res.text())).toMatch(
+        /<div data-testid="alpha-beta-text">/
+      );
+      expect(await fetch('http://localhost:3000/(alpha)/beta').then((res) => res.text())).toMatch(
+        /<div data-testid="alpha-beta-text">/
+      );
+    });
     it(`can serve up dynamic html routes`, async () => {
       expect(await fetch('http://localhost:3000/blog/123').then((res) => res.text())).toMatch(
         /\[post\]/

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -111,6 +111,7 @@ describe(getHtmlFiles, () => {
   it(`should get html files`, () => {
     expect(
       getHtmlFiles({
+        includeGroupVariations: true,
         manifest: {
           initialRouteName: undefined,
           screens: {
@@ -148,6 +149,7 @@ describe(getHtmlFiles, () => {
   it(`should get html files 2`, () => {
     expect(
       getHtmlFiles({
+        includeGroupVariations: true,
         manifest: {
           initialRouteName: undefined,
           screens: {
@@ -184,6 +186,70 @@ describe(getHtmlFiles, () => {
       '(root)/(index)/notifications.html',
     ]);
   });
+  it(`should get html files without group variation`, () => {
+    expect(
+      getHtmlFiles({
+        includeGroupVariations: false,
+        manifest: {
+          initialRouteName: undefined,
+          screens: {
+            '(root)': {
+              path: '(root)',
+              screens: {
+                '(index)': {
+                  path: '(index)',
+                  screens: {
+                    '[...missing]': '*missing',
+                    index: '',
+                    notifications: 'notifications',
+                  },
+                  initialRouteName: 'index',
+                },
+              },
+              initialRouteName: '(index)',
+            },
+          },
+        },
+      }).sort((a, b) => a.length - b.length)
+    ).toEqual([
+      '(root)/(index)/index.html',
+      '(root)/(index)/[...missing].html',
+      '(root)/(index)/notifications.html',
+    ]);
+
+    expect(
+      getHtmlFiles({
+        includeGroupVariations: false,
+        manifest: {
+          initialRouteName: undefined,
+          screens: {
+            alpha: {
+              path: 'alpha',
+              screens: { index: '', second: 'second' },
+              initialRouteName: 'index',
+            },
+            '(app)': {
+              path: '(app)',
+              screens: { compose: 'compose', index: '', 'note/[note]': 'note/:note' },
+              initialRouteName: 'index',
+            },
+            '(auth)/sign-in': '(auth)/sign-in',
+            _sitemap: '_sitemap',
+            '[...404]': '*404',
+          },
+        },
+      }).sort((a, b) => a.length - b.length)
+    ).toEqual([
+      '_sitemap.html',
+      '[...404].html',
+      'alpha/index.html',
+      '(app)/index.html',
+      'alpha/second.html',
+      '(app)/compose.html',
+      '(auth)/sign-in.html',
+      '(app)/note/[note].html',
+    ]);
+  });
 });
 
 describe(getFilesToExportFromServerAsync, () => {
@@ -191,6 +257,7 @@ describe(getFilesToExportFromServerAsync, () => {
     const renderAsync = jest.fn(async () => '');
     expect(
       await getFilesToExportFromServerAsync('/', {
+        includeGroupVariations: true,
         manifest: {
           initialRouteName: undefined,
           screens: {


### PR DESCRIPTION
# Why

- In server mode, we don't need to export every group variation because the server can automatically delegate all matchable paths to the single group file.
- This change only exports one static HTML file for a given group route when server mode is used in export, this can drastically reduce the amount of output files.


# Test Plan

- Added an e2e test to ensure the path variation is served as expected.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
