### PR TITLE
[expo-updates][Android] embedded loader should load images at all scales

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ios, android, tvos]
+        platform: [android, tvos]
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     env:

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Add missing export in checkForUpdateAsync result. (by [@douglowder](https://github.com/douglowder)) ([#24503](https://github.com/expo/expo/pull/24503) by [@douglowder](https://github.com/douglowder))
+- [Android] embedded loader should load images at all scales. ([#24549](https://github.com/expo/expo/pull/24549) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -106,7 +106,7 @@ class EmbeddedLoaderTest {
   @Throws(JSONException::class, IOException::class, NoSuchAlgorithmException::class)
   fun testEmbeddedLoader_MultipleScales() {
     val multipleScalesManifest: UpdateManifest = BareUpdateManifest.fromBareManifest(
-      BareManifest(JSONObject("{\"id\":\"d26d7f92-c7a6-4c44-9ada-4804eda7e6e2\",\"commitTime\":1630435460610,\"assets\":[{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":1,\"packagerHash\":\"54da1e9816c77e30ebc5920e256736f2\",\"subdirectory\":\"/assets\",\"scales\":[1,2],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"},{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":2,\"packagerHash\":\"4ecff55cf37460b7f768dc7b72bcea6b\",\"subdirectory\":\"/assets\",\"scales\":[1,2],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"}]}")),
+      BareManifest(JSONObject("{\"id\":\"d26d7f92-c7a6-4c44-9ada-4804eda7e6e2\",\"commitTime\":1630435460610,\"assets\":[{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":1,\"packagerHash\":\"54da1e9816c77e30ebc5920e256736f2\",\"subdirectory\":\"/assets\",\"scales\":[1,2,3],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"},{\"name\":\"robot-dev\",\"type\":\"png\",\"scale\":2,\"packagerHash\":\"4ecff55cf37460b7f768dc7b72bcea6b\",\"subdirectory\":\"/assets\",\"scales\":[1,2,3],\"resourcesFilename\":\"robotdev\",\"resourcesFolder\":\"drawable\"}]}")),
       configuration
     )
 
@@ -116,14 +116,14 @@ class EmbeddedLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
+    verify(exactly = 3) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
-    Assert.assertEquals(2, assets.size.toLong())
+    Assert.assertEquals(3, assets.size.toLong())
   }
 
   @Test
@@ -140,14 +140,14 @@ class EmbeddedLoaderTest {
 
     verify { mockCallback.onSuccess(any()) }
     verify(exactly = 0) { mockCallback.onFailure(any()) }
-    verify(exactly = 2) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
+    verify(exactly = 3) { mockLoaderFiles.copyAssetAndGetHash(any(), any(), any()) }
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
-    Assert.assertEquals(2, assets.size.toLong())
+    Assert.assertEquals(3, assets.size.toLong())
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -120,7 +120,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(3, assets.size.toLong())
@@ -144,7 +144,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(3, assets.size.toLong())
@@ -172,7 +172,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(2, assets.size.toLong())

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -120,7 +120,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(3, assets.size.toLong())
@@ -144,7 +144,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(3, assets.size.toLong())
@@ -172,7 +172,7 @@ class EmbeddedLoaderTest {
 
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
-    Assert.assertEquals(UpdateStatus.EMBEDDED, updates[0].status)
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
 
     val assets = db.assetDao().loadAllAssets()
     Assert.assertEquals(2, assets.size.toLong())

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -90,11 +90,11 @@ abstract class UpdateDao {
   abstract fun _setUpdateCommitTime(id: UUID, commitTime: Date)
 
   @Transaction
-  open fun markUpdateFinished(update: UpdateEntity, isEmbedded: Boolean) {
+  open fun markUpdateFinished(update: UpdateEntity, hasSkippedEmbeddedAssets: Boolean) {
     var statusToMark = UpdateStatus.READY
     if (update.status === UpdateStatus.DEVELOPMENT) {
       statusToMark = UpdateStatus.DEVELOPMENT
-    } else if (isEmbedded) {
+    } else if (hasSkippedEmbeddedAssets) {
       statusToMark = UpdateStatus.EMBEDDED
     }
     _markUpdateWithStatus(statusToMark, update.id)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/UpdateDao.kt
@@ -90,11 +90,11 @@ abstract class UpdateDao {
   abstract fun _setUpdateCommitTime(id: UUID, commitTime: Date)
 
   @Transaction
-  open fun markUpdateFinished(update: UpdateEntity, hasSkippedEmbeddedAssets: Boolean) {
+  open fun markUpdateFinished(update: UpdateEntity, isEmbedded: Boolean) {
     var statusToMark = UpdateStatus.READY
     if (update.status === UpdateStatus.DEVELOPMENT) {
       statusToMark = UpdateStatus.DEVELOPMENT
-    } else if (hasSkippedEmbeddedAssets) {
+    } else if (isEmbedded) {
       statusToMark = UpdateStatus.EMBEDDED
     }
     _markUpdateWithStatus(statusToMark, update.id)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -22,11 +22,6 @@ import java.util.*
  * update. The benefits of this include (a) a single code path for launching most updates and (b)
  * assets included in embedded updates and copied into the cache in this way do not need to be
  * redownloaded if included in future updates.
- *
- * However, if a visual asset is included at multiple scales in an embedded update, we don't have
- * access to and must skip copying scales that don't match the resolution of the current device. In
- * this case, we cannot fully copy the embedded update, and instead launch it from the original
- * location. We still copy the assets we can so they don't need to be redownloaded in the future.
  */
 class EmbeddedLoader internal constructor(
   private val context: Context,
@@ -37,7 +32,6 @@ class EmbeddedLoader internal constructor(
 ) : Loader(
   context, configuration, database, updatesDirectory, loaderFiles
 ) {
-  private val pixelDensity = context.resources.displayMetrics.density
 
   constructor(
     context: Context,
@@ -99,26 +93,7 @@ class EmbeddedLoader internal constructor(
   }
 
   override fun shouldSkipAsset(assetEntity: AssetEntity): Boolean {
-    return if (assetEntity.scales == null || assetEntity.scale == null) {
-      false
-    } else pickClosestScale(assetEntity.scales!!) != assetEntity.scale
-  }
-
-  // https://developer.android.com/guide/topics/resources/providing-resources.html#BestMatch
-  // If a perfect match is not available, the OS will pick the next largest scale.
-  // If only smaller scales are available, the OS will choose the largest available one.
-  private fun pickClosestScale(scales: Array<Float>): Float {
-    var closestScale = Float.MAX_VALUE
-    var largestScale = 0f
-    for (scale in scales) {
-      if (scale >= pixelDensity && scale < closestScale) {
-        closestScale = scale
-      }
-      if (scale > largestScale) {
-        largestScale = scale
-      }
-    }
-    return if (closestScale < Float.MAX_VALUE) closestScale else largestScale
+    return false
   }
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -30,7 +30,7 @@ class EmbeddedLoader internal constructor(
   updatesDirectory: File?,
   private val loaderFiles: LoaderFiles
 ) : Loader(
-  context, configuration, database, updatesDirectory, loaderFiles, isEmbedded = true
+  context, configuration, database, updatesDirectory, loaderFiles
 ) {
 
   constructor(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -30,7 +30,7 @@ class EmbeddedLoader internal constructor(
   updatesDirectory: File?,
   private val loaderFiles: LoaderFiles
 ) : Loader(
-  context, configuration, database, updatesDirectory, loaderFiles
+  context, configuration, database, updatesDirectory, loaderFiles, isEmbedded = true
 ) {
 
   constructor(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/EmbeddedLoader.kt
@@ -92,10 +92,6 @@ class EmbeddedLoader internal constructor(
     }
   }
 
-  override fun shouldSkipAsset(assetEntity: AssetEntity): Boolean {
-    return false
-  }
-
   companion object {
     private val TAG = EmbeddedLoader::class.java.simpleName
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -34,7 +34,6 @@ abstract class Loader protected constructor(
   private var callback: LoaderCallback? = null
   private var assetTotal = 0
   private var erroredAssetList = mutableListOf<AssetEntity>()
-  private var skippedAssetList = mutableListOf<AssetEntity>()
   private var existingAssetList = mutableListOf<AssetEntity>()
   private var finishedAssetList = mutableListOf<AssetEntity>()
 
@@ -89,8 +88,6 @@ abstract class Loader protected constructor(
     callback: AssetDownloadCallback
   )
 
-  protected abstract fun shouldSkipAsset(assetEntity: AssetEntity): Boolean
-
   // lifecycle methods for class
   fun start(callback: LoaderCallback) {
     if (this.callback != null) {
@@ -129,7 +126,6 @@ abstract class Loader protected constructor(
     callback = null
     assetTotal = 0
     erroredAssetList = mutableListOf()
-    skippedAssetList = mutableListOf()
     existingAssetList = mutableListOf()
     finishedAssetList = mutableListOf()
   }
@@ -219,17 +215,13 @@ abstract class Loader protected constructor(
   }
 
   private enum class AssetLoadResult {
-    FINISHED, ALREADY_EXISTS, ERRORED, SKIPPED
+    FINISHED, ALREADY_EXISTS, ERRORED
   }
 
   private fun downloadAllAssets(assetList: List<AssetEntity>) {
     assetTotal = assetList.size
     for (assetEntityCur in assetList) {
       var assetEntity = assetEntityCur
-      if (shouldSkipAsset(assetEntity)) {
-        handleAssetDownloadCompleted(assetEntity, AssetLoadResult.SKIPPED)
-        continue
-      }
 
       val matchingDbEntry = database.assetDao().loadAssetWithKey(assetEntity.key)
       if (matchingDbEntry != null) {
@@ -279,7 +271,6 @@ abstract class Loader protected constructor(
       AssetLoadResult.FINISHED -> finishedAssetList.add(assetEntity)
       AssetLoadResult.ALREADY_EXISTS -> existingAssetList.add(assetEntity)
       AssetLoadResult.ERRORED -> erroredAssetList.add(assetEntity)
-      AssetLoadResult.SKIPPED -> skippedAssetList.add(assetEntity)
       else -> throw AssertionError("Missing implementation for AssetLoadResult value")
     }
 
@@ -290,7 +281,7 @@ abstract class Loader protected constructor(
       assetTotal
     )
 
-    if (finishedAssetList.size + erroredAssetList.size + existingAssetList.size + skippedAssetList.size == assetTotal) {
+    if (finishedAssetList.size + erroredAssetList.size + existingAssetList.size == assetTotal) {
       try {
         for (asset in existingAssetList) {
           val existingAssetFound = database.assetDao()
@@ -313,7 +304,7 @@ abstract class Loader protected constructor(
         database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
 
         if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!, skippedAssetList.size != 0)
+          database.updateDao().markUpdateFinished(updateEntity!!, false)
         }
       } catch (e: Exception) {
         finishWithError("Error while adding new update to database", e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -27,8 +27,7 @@ abstract class Loader protected constructor(
   private val configuration: UpdatesConfiguration,
   private val database: UpdatesDatabase,
   private val updatesDirectory: File?,
-  private val loaderFiles: LoaderFiles,
-  private val isEmbedded: Boolean
+  private val loaderFiles: LoaderFiles
 ) {
   private var updateResponse: UpdateResponse? = null
   private var updateEntity: UpdateEntity? = null
@@ -305,7 +304,7 @@ abstract class Loader protected constructor(
         database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
 
         if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!, isEmbedded)
+          database.updateDao().markUpdateFinished(updateEntity!!, false)
         }
       } catch (e: Exception) {
         finishWithError("Error while adding new update to database", e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -27,7 +27,8 @@ abstract class Loader protected constructor(
   private val configuration: UpdatesConfiguration,
   private val database: UpdatesDatabase,
   private val updatesDirectory: File?,
-  private val loaderFiles: LoaderFiles
+  private val loaderFiles: LoaderFiles,
+  private val isEmbedded: Boolean
 ) {
   private var updateResponse: UpdateResponse? = null
   private var updateEntity: UpdateEntity? = null
@@ -304,7 +305,7 @@ abstract class Loader protected constructor(
         database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
 
         if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!, false)
+          database.updateDao().markUpdateFinished(updateEntity!!, isEmbedded)
         }
       } catch (e: Exception) {
         finishWithError("Error while adding new update to database", e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -304,7 +304,7 @@ abstract class Loader protected constructor(
         database.assetDao().insertAssets(finishedAssetList, updateEntity!!)
 
         if (erroredAssetList.size == 0) {
-          database.updateDao().markUpdateFinished(updateEntity!!, false)
+          database.updateDao().markUpdateFinished(updateEntity!!)
         }
       } catch (e: Exception) {
         finishWithError("Error while adding new update to database", e)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -59,10 +59,6 @@ class RemoteLoader internal constructor(
     mFileDownloader.downloadAsset(assetEntity, updatesDirectory, configuration, context, callback)
   }
 
-  override fun shouldSkipAsset(assetEntity: AssetEntity): Boolean {
-    return false
-  }
-
   companion object {
     private val TAG = RemoteLoader::class.java.simpleName
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -28,14 +28,14 @@ class RemoteLoader internal constructor(
   updatesDirectory: File?,
   private val launchedUpdate: UpdateEntity?,
   private val loaderFiles: LoaderFiles
-) : Loader(context, configuration, database, updatesDirectory, loaderFiles) {
+) : Loader(context, configuration, database, updatesDirectory, loaderFiles, isEmbedded = false) {
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
     database: UpdatesDatabase,
     fileDownloader: FileDownloader,
     updatesDirectory: File?,
-    launchedUpdate: UpdateEntity?
+    launchedUpdate: UpdateEntity?,
   ) : this(context, configuration, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
   override fun loadRemoteUpdate(

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/RemoteLoader.kt
@@ -28,14 +28,14 @@ class RemoteLoader internal constructor(
   updatesDirectory: File?,
   private val launchedUpdate: UpdateEntity?,
   private val loaderFiles: LoaderFiles
-) : Loader(context, configuration, database, updatesDirectory, loaderFiles, isEmbedded = false) {
+) : Loader(context, configuration, database, updatesDirectory, loaderFiles) {
   constructor(
     context: Context,
     configuration: UpdatesConfiguration,
     database: UpdatesDatabase,
     fileDownloader: FileDownloader,
     updatesDirectory: File?,
-    launchedUpdate: UpdateEntity?,
+    launchedUpdate: UpdateEntity?
   ) : this(context, configuration, database, fileDownloader, updatesDirectory, launchedUpdate, LoaderFiles())
 
   override fun loadRemoteUpdate(

--- a/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
@@ -35,7 +35,7 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 14"
+        "type": "iPhone 15"
       }
     },
     "emulator": {


### PR DESCRIPTION
# Why

Customers building Android apps are seeing image assets downloaded on the first update after app installation, even though the image assets are already part of the installed application resources.

This is happening because `EmbeddedLoader.kt` checks the asset's scale value for compatibility with the device pixel density, and skips the asset if the image is not the right scale for the device.  Unfortunately, these images must still be downloaded from the update server if the app is updated, because the update manifests are not scale-aware and require that all assets be present.

It seems better to go ahead and copy all assets from the embedded application, if possible, so that the app does not have to download them from the network later.

# How

Align `EmbeddedLoader.kt` and `RemoteLoader.kt` so that they both load all assets.

# Test Plan

- Test on real devices to ensure that there are no issues with attempting to read resources with a scale not appropriate for the device.
- Document this feature of updates that is specific to Android.

TBD: Look for a way to detect specifically if there is a problem reading the resource for the asset, and skip the asset if we see that the asset has non-null scale values

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
