### PR TITLE
fix(asset): URL encode asset paths defined as query parameter

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- URL encode asset paths defined as query parameter.
+- URL encode asset paths defined as query parameter. ([#24562](https://github.com/expo/expo/pull/24562) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- URL encode asset paths defined as query parameter.
+
 ### 💡 Others
 
 ## 8.12.1 — 2023-09-16

--- a/packages/expo-asset/tools/hashAssetFiles.js
+++ b/packages/expo-asset/tools/hashAssetFiles.js
@@ -15,6 +15,19 @@ module.exports = function hashAssetFiles(asset) {
         .replace(/\.\.\//g, '_');
     }
 
+    // URL encode asset paths defined as `?export_path` or `?unstable_path` query parameters.
+    // Decoding should be done automatically when parsing the URL through Node or the browser.
+    const assetPathQueryParameter = asset.httpServerLocation.match(
+      /\?(export_path|unstable_path)=(.*)/
+    );
+    if (assetPathQueryParameter && assetPathQueryParameter[2]) {
+      const assetPath = assetPathQueryParameter[2];
+      asset.httpServerLocation = asset.httpServerLocation.replace(
+        assetPath,
+        encodeURIComponent(assetPath)
+      );
+    }
+
     return asset;
   });
 };


### PR DESCRIPTION
# Why

Package folders may contain a `+` symbol when using isolated modules by supported package managers. This happens for `@expo/vector-icons` and pnpm, for example:

<img width="1351" alt="image" src="https://github.com/expo/expo/assets/1203991/f8c226ce-ba62-4b5a-bc30-422669845771">

While the path _is_ valid, the `+` is [interpreted as a special character (space)](https://datatracker.ietf.org/doc/html/rfc1738#section-2.2) because it's not URL encoded.

# How

- Escape asset path (in `asset.httpServerLocation`) when defined as ?export_path` or `?unstable_path` query parameter.

# Test Plan

- Create a tabs pnpm project (see #24561)
- `$ pnpm expo start`
- Vector icons should work on both Android and iOS
- No warning in terminal must be logged:
    <img width="839" alt="image" src="https://github.com/expo/expo/assets/1203991/9e7e9b4c-44fd-4dc4-979f-6eccb17d5278">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
