### PR TITLE
[dev-launcher][ios] Fix app launch when using multiple scenes

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed app launch when using multiple scenes. ([#24565](https://github.com/expo/expo/pull/24565) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fetch dev sessions whenever navigating to the launcher home screen. ([#24378](https://github.com/expo/expo/pull/24378), [#24502](https://github.com/expo/expo/pull/24502) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
@@ -8,7 +8,7 @@ public class ExpoDevLauncherAppDelegateSubscriber: ExpoAppDelegateSubscriber {
       return false
     }
 
-    guard let window = UIApplication.shared.delegate?.window ?? UIApplication.shared.windows.filter {$0.isKeyWindow}.first else {
+    guard let window = UIApplication.shared.delegate?.window ?? UIApplication.shared.windows.filter { $0.isKeyWindow }.first else {
       fatalError("Cannot find the keyWindow. Make sure to call `window.makeKeyAndVisible()`.")
     }
     EXDevLauncherController.sharedInstance().autoSetupStart(window)

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift
@@ -8,7 +8,7 @@ public class ExpoDevLauncherAppDelegateSubscriber: ExpoAppDelegateSubscriber {
       return false
     }
 
-    guard let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first else {
+    guard let window = UIApplication.shared.delegate?.window ?? UIApplication.shared.windows.filter {$0.isKeyWindow}.first else {
       fatalError("Cannot find the keyWindow. Make sure to call `window.makeKeyAndVisible()`.")
     }
     EXDevLauncherController.sharedInstance().autoSetupStart(window)


### PR DESCRIPTION
# Why


When configuring an app that uses `UIApplicationSupportsMultipleScenes`, UIApplication.shared.windows is unable to find any UIWindow causing ExpoDevLauncherAppDelegateSubscriber to fail to start
https://github.com/expo/expo/blob/284bb8887638b6c52273aea5d234288478ffff66/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherAppDelegateSubscriber.swift#L12 


Closes https://github.com/expo/expo/issues/23536
Closes ENG-9926

# How

This PR updates AppDelegateSubscriber to attempt to get a window from `UIApplication.shared.delegate?.window` and then falls back to `UIApplication.shared.windows` if a window is not located. I also tried using `UIApplication.shared.connectedScenes` but returns an empty array 

# Test Plan

Run dev-client through Bare Expo 

<img width="400" alt="image" src="https://github.com/expo/expo/assets/11707729/9988ab96-c920-4afd-a1a8-201c13c047da">


Run an [example project](https://github.com/banesp/expo-dev-launcher-keywindow-bug-demo/tree/bare-with-scene-delegates) using Carplay
<img width="1069" alt="image" src="https://github.com/expo/expo/assets/11707729/8c3089f3-5842-4658-8ffc-5e1e38277e97">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
