### PR TITLE
[dev-launcher][ios] Fix Cmd+D opening React Native Debug Menu on launcher

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix Cmd+D opening React Native Debug Menu on launcher screen.
+- [iOS] Fix Cmd+D opening React Native Debug Menu on launcher screen. ([#24580](https://github.com/expo/expo/pull/24580) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fixed app launch when using multiple scenes. ([#24565](https://github.com/expo/expo/pull/24565) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fetch dev sessions whenever navigating to the launcher home screen. ([#24378](https://github.com/expo/expo/pull/24378), [#24502](https://github.com/expo/expo/pull/24502) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### 🐛 Bug fixes
 
-- Fixed app launch when using multiple scenes. ([#24565](https://github.com/expo/expo/pull/24565) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fix Cmd+D opening React Native Debug Menu on launcher screen.
+- [iOS] Fixed app launch when using multiple scenes. ([#24565](https://github.com/expo/expo/pull/24565) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fetch dev sessions whenever navigating to the launcher home screen. ([#24378](https://github.com/expo/expo/pull/24378), [#24502](https://github.com/expo/expo/pull/24502) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -309,6 +309,8 @@
   if (url != nil) {
     // Connect to the websocket
     [[RCTPackagerConnection sharedPackagerConnection] setSocketConnectionURL:url];
+  } else {
+    [self _addInitModuleObserver];
   }
 #endif
 


### PR DESCRIPTION
# Why

Close ENG-10142

# How

To prevent the React Native Debug Menu from being displayed on the launcher screen we must unregister the KeyCommand from react-native. We were already doing that inside [_initAppWithUrl](https://github.com/expo/expo/blob/015c884fae8544ddd4e99e96387d0437fa609857/packages/expo-dev-launcher/ios/EXDevLauncherController.m#L515) but that only affects new react-native instances and not the dev-launcher itself. To fix that this PR updates the `navigateToLauncher` function to also init the module observer. I decided to not unregister cmd+d when `EX_DEV_LAUNCHER_URL` is present to facilitate local development when working with dev-launcher

# Test Plan

Run dev-client through bare-expo with and without EX_DEV_LAUNCHER_URL

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
