### PR TITLE
[android][splashscreen] remove isClickable  from splashscreen view

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On Android, remove `isClickable` on `SplashScreenView` that caused incorrect behaviour with `TalkBack`. ([#24601](https://github.com/expo/expo/pull/24601) by [@alanhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 0.23.1 — 2023-09-18

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenView.kt
@@ -24,7 +24,6 @@ class SplashScreenView(
 
   init {
     layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
-    isClickable = true
 
     addView(imageView)
   }


### PR DESCRIPTION
# Why
Closes ENG-10216
Closes #24544

# How
Remove `isClickable` from the `SplashScreenView`

# Test Plan
Tested in bare-expo with `TalkBack` on. The incorrect announcement doesn't occur. 
