### PR TITLE
[docs] Add canonical URL to `Head`

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -120,9 +120,7 @@ export default function DocumentationPage(props: Props) {
       <Head
         title={props.title}
         description={props.description}
-        canonicalUrl={
-          version !== 'latest' && version !== 'unversioned' ? getCanonicalUrl(pathname) : undefined
-        }>
+        canonicalUrl={version !== 'unversioned' ? getCanonicalUrl(pathname) : undefined}>
         {props.hideFromSearch !== true && (
           <meta
             name="docsearch:version"

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -117,7 +117,12 @@ export default function DocumentationPage(props: Props) {
       isMobileMenuVisible={isMobileMenuVisible}
       onContentScroll={handleContentScroll}
       sidebarScrollPosition={sidebarScrollPosition}>
-      <Head title={props.title} description={props.description}>
+      <Head
+        title={props.title}
+        description={props.description}
+        canonicalUrl={
+          version !== 'latest' && version !== 'unversioned' ? getCanonicalUrl(pathname) : ''
+        }>
         {props.hideFromSearch !== true && (
           <meta
             name="docsearch:version"
@@ -127,9 +132,6 @@ export default function DocumentationPage(props: Props) {
         {(version === 'unversioned' ||
           RoutesUtils.isPreviewPath(pathname) ||
           RoutesUtils.isArchivePath(pathname)) && <meta name="robots" content="noindex" />}
-        {version !== 'latest' && version !== 'unversioned' && (
-          <link rel="canonical" href={getCanonicalUrl(pathname)} />
-        )}
       </Head>
       <div css={STYLES_DOCUMENT}>
         {props.title && (

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -121,7 +121,7 @@ export default function DocumentationPage(props: Props) {
         title={props.title}
         description={props.description}
         canonicalUrl={
-          version !== 'latest' && version !== 'unversioned' ? getCanonicalUrl(pathname) : ''
+          version !== 'latest' && version !== 'unversioned' ? getCanonicalUrl(pathname) : undefined
         }>
         {props.hideFromSearch !== true && (
           <meta

--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -1,18 +1,19 @@
 import NextHead from 'next/head';
 import type { PropsWithChildren } from 'react';
 
-type HeadProps = PropsWithChildren<{ title?: string; description?: string }>;
+type HeadProps = PropsWithChildren<{ title?: string; description?: string; canonicalUrl?: string }>;
 
 const BASE_TITLE = 'Expo Documentation';
 const BASE_DESCRIPTION = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
 
-const Head = ({ title, description, children }: HeadProps) => (
+const Head = ({ title, description, canonicalUrl, children }: HeadProps) => (
   <NextHead>
     <title>{title ? `${title} - ${BASE_TITLE}` : BASE_TITLE}</title>
     <meta charSet="utf-8" />
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/static/images/favicon.ico" sizes="32x32" />
+    <link rel="canonical" href={canonicalUrl} />
 
     <meta name="description" content={description === '' ? BASE_DESCRIPTION : description} />
     <meta property="og:title" content={title} />

--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -13,7 +13,7 @@ const Head = ({ title, description, canonicalUrl, children }: HeadProps) => (
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/static/images/favicon.ico" sizes="32x32" />
-    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+    <link rel="canonical" href={canonicalUrl} />
 
     <meta name="description" content={description === '' ? BASE_DESCRIPTION : description} />
     <meta property="og:title" content={title} />

--- a/docs/components/Head.tsx
+++ b/docs/components/Head.tsx
@@ -13,7 +13,7 @@ const Head = ({ title, description, canonicalUrl, children }: HeadProps) => (
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/static/images/favicon.ico" sizes="32x32" />
-    <link rel="canonical" href={canonicalUrl} />
+    {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
 
     <meta name="description" content={description === '' ? BASE_DESCRIPTION : description} />
     <meta property="og:title" content={title} />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10174

# How

<!--
How did you build this feature or fix this bug and why?
-->

- This PR adds referencing canonical URLs for all docs pages by adding it to the `Head`.
- It follows the same pattern (as before) and eliminates referencing `/latest` or `/unversioned` API docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally and visit a docs page
- Inspect element in your browser and search for `link` tag with `rel="canonical"`

For example:

<img width="687" alt="CleanShot 2023-09-26 at 15 51 22@2x" src="https://github.com/expo/expo/assets/10234615/bd9bb82d-9dec-4f1d-9f87-0d78923d472e">

Alternatively, can use the Detailed SEO extension and it should show the "Canonical" URL (ignore the red cross mark since you're running a development server - on production, it will be a green check mark since it will be self-referencing)

<img width="680" alt="CleanShot 2023-09-26 at 15 52 18@2x" src="https://github.com/expo/expo/assets/10234615/61cc504c-b917-44ae-af8b-f816b4996b3b">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
