### PR TITLE
docs: add analytics tool

### DIFF
--- a/docs/pages/guides/using-analytics.mdx
+++ b/docs/pages/guides/using-analytics.mdx
@@ -47,3 +47,9 @@ The following list provides common analytics providers that are available in the
   description="Learn how to integrate Aptabase Analytics in your project. Works with Expo Go."
   href="https://aptabase.com/for-react-native"
 />
+
+<BoxLink
+  title="Astrolytics"
+  description="Learn how to integrate Astrolytics in your project. Works with Expo Go."
+  href="https://www.astrolytics.io/react-native"
+/>


### PR DESCRIPTION
Hi all, it'd be awesome if we can add a link to our react native analytics solution in your docs. Thanks 🙏 

# Why

We have a React Native SDK for our [analytics tool](https://astrolytics.io/react-native). I want to add it to the analytics guide.

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
