### PR TITLE
[docs] Add info about `popToTop` action in Expo Router Stack navigation guide

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -218,7 +218,7 @@ For example, a stack has three screens &mdash; `home`, `details`, and `settings`
 
 The `home` screen is the first screen, and the `settings` is the last. To go from `settings` to `home` screen you'll have to go back to `details`. However, using the `popToTop` action, you can go from `settings` to `home` and dismiss any screen in between.
 
-It is accessed through [`StackActions`](https://reactnavigation.org/docs/stack-actions) from the React Navigation library and is dispatched using [`navigation`](/router/reference/hooks/#usenavigation) prop.
+It is accessible through [`StackActions`](https://reactnavigation.org/docs/stack-actions) from the React Navigation library and dispatched using [`navigation`](/router/reference/hooks/#usenavigation) prop.
 
 {/* prettier-ignore */}
 ```jsx app/settings.js

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -210,7 +210,7 @@ export default function Layout() {
 
 ## `popToTop` action
 
-By default, the screens in a `Stack` are pushed or popped to the next or the previous screen as per the order defined within the stack. To go back to the first screen in the existing stack, the [`popToTop`](https://reactnavigation.org/docs/stack-actions/#poptotop) stack action can be used from any screen.
+By default, the screens in a `Stack` are pushed or popped to the next or the previous screen. To return to the first screen in the existing stack, the [`popToTop`](https://reactnavigation.org/docs/stack-actions/#poptotop) stack action can be used from any screen.
 
 For example, a stack has three screens &mdash; `home`, `details`, and `settings`. The following layout describes the order of the screens in a stack.
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -208,6 +208,47 @@ export default function Layout() {
 }
 ```
 
+## `popToTop` action
+
+By default, the screens in a `Stack` are pushed or popped to the next or the previous screen as per the order defined within the stack. To go back to the first screen in the existing stack, the [`popToTop`](https://reactnavigation.org/docs/stack-actions/#poptotop) stack action can be used from any screen.
+
+For example, a stack has three screens &mdash; `home`, `details`, and `settings`. The following layout describes the order of the screens in a stack.
+
+<FileTree files={['app/_layout.js', 'app/home.js', 'app/details.js', 'app/settings.js']} />
+
+The `home` screen is the first screen, and the `settings` is the last. To go from `settings` to `home` screen you'll have to go back to `details`. However, using the `popToTop` action, you can go from `settings` to `home` and dismiss any screen in between.
+
+It is accessed through [`StackActions`](https://reactnavigation.org/docs/stack-actions) from the React Navigation library and is dispatched using [`navigation`](/router/reference/hooks/#usenavigation) prop.
+
+{/* prettier-ignore */}
+```jsx app/settings.js
+import { Button, View, Text } from "react-native";
+/* @info Import useNavigation from Expo Router and StackActions from React Navigation library. */
+import { useNavigation } from "expo-router";
+import { StackActions } from "@react-navigation/native";
+/* @end */
+
+export default function Settings() {
+  /* @info Access the underlying navigation prop from useNavigation hook. */
+  const navigation = useNavigation();
+  /* @end */
+
+  const handlePopToTop = () => {
+    /* @info In handle method, dispatch the Stack popToTop() to go back to the first screen in a stack. */
+    navigation.dispatch(StackActions.popToTop());
+    /* @end */
+  };
+
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+      /* @info Trigger the handler method on a touchable/button component */
+      <Button title="Go to first screen" onPress={handlePopToTop} />
+      /* @end */
+    </View>
+  );
+}
+```
+
 ## Next steps
 
 <BoxLink


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This was discussed on Expo Router sync to document [`popToTop` ](https://reactnavigation.org/docs/stack-actions/#poptotop)action from React Navigation so that developers do not have trouble guessing how to use an action like this when using Expo Router.

# How

<!--
How did you build this feature or fix this bug and why?
-->

In Expo Router > Advanced > Stack, add a new section called `popToTop` action with an example.

**Preview**

<img width="913" alt="CleanShot 2023-09-27 at 17 11 41@2x" src="https://github.com/expo/expo/assets/10234615/93b2d32f-43ad-4613-aa2a-0394608a9f7e">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/router/advanced/stack/#poptotop-action

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
