### PR TITLE
fix(cli): fallback to `xcrun devicectl` for iOS 17

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Ensure a unique static path is generated for each group during static extraction ([#24218](https://github.com/expo/expo/pull/24218) by [@marklawlor](https://github.com/marklawlor))
+- Fallback to `xcrun devicectl` for iOS 17 to launch the app.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - Ensure a unique static path is generated for each group during static extraction ([#24218](https://github.com/expo/expo/pull/24218) by [@marklawlor](https://github.com/marklawlor))
-- Fallback to `xcrun devicectl` for iOS 17 to launch the app.
+- Fallback to `xcrun devicectl` for iOS 17 to launch the app. ([#24635](https://github.com/expo/expo/pull/24635) by [@byCedric](https://github.com/byCedric))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -252,6 +252,6 @@ async function launchApp(
     clientManager.end();
 
     // Fallback to devicectl for iOS 17 support
-    return await launchAppWithDeviceCtl(clientManager.device.Properties.SerialNumber, bundleId);
+    return await launchAppWithDeviceCtl(deviceId, bundleId);
   }
 }

--- a/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/AppleDevice.ts
@@ -9,6 +9,7 @@ import { UsbmuxdClient } from './client/UsbmuxdClient';
 import { AFC_STATUS, AFCError } from './protocol/AFCProtocol';
 import { Log } from '../../../log';
 import { XcodeDeveloperDiskImagePrerequisite } from '../../../start/doctor/apple/XcodeDeveloperDiskImagePrerequisite';
+import { xcrunAsync } from '../../../start/platforms/ios/xcrun';
 import { delayAsync } from '../../../utils/delay';
 import { CommandError } from '../../../utils/errors';
 import { installExitHooks } from '../../../utils/exit';
@@ -122,8 +123,13 @@ export async function runOnDevice({
     if (appInfo) {
       // launch fails with EBusy or ENotFound if you try to launch immediately after install
       await delayAsync(200);
-      const debugServerClient = await launchApp(clientManager, { appInfo, detach: !waitForApp });
-      if (waitForApp) {
+      const debugServerClient = await launchApp(clientManager, {
+        bundleId,
+        appInfo,
+        detach: !waitForApp,
+      });
+
+      if (waitForApp && debugServerClient) {
         installExitHooks(async () => {
           // causes continue() to return
           debugServerClient.halt();
@@ -181,7 +187,7 @@ async function uploadApp(
   await afcClient.uploadDirectory(appBinaryPath, destinationPath);
 }
 
-async function launchApp(
+async function launchAppWithUsbmux(
   clientManager: ClientManager,
   { appInfo, detach }: { appInfo: IPLookupResult[string]; detach?: boolean }
 ) {
@@ -216,4 +222,36 @@ async function launchApp(
     }
   }
   throw new CommandError('Unable to launch app, number of tries exceeded');
+}
+
+async function launchAppWithDeviceCtl(deviceId: string, bundleId: string) {
+  await xcrunAsync(['devicectl', 'device', 'process', 'launch', '--device', deviceId, bundleId]);
+}
+
+/**
+ * iOS 17 introduces a new protocol called RemoteXPC.
+ * This is not yet implemented, so we fallback to devicectl.
+ *
+ * @see https://github.com/doronz88/pymobiledevice3/blob/master/misc/RemoteXPC.md#process-remoted
+ */
+async function launchApp(
+  clientManager: ClientManager,
+  {
+    bundleId,
+    appInfo,
+    detach,
+  }: { bundleId: string; appInfo: IPLookupResult[string]; detach?: boolean }
+) {
+  try {
+    return await launchAppWithUsbmux(clientManager, { appInfo, detach });
+  } catch (error) {
+    debug('Failed to launch app with Usbmuxd, falling back to xcrun...', error);
+
+    // Get the device UDID and close the connection, to allow `xcrun devicectl` to connect
+    const deviceId = clientManager.device.Properties.SerialNumber;
+    clientManager.end();
+
+    // Fallback to devicectl for iOS 17 support
+    return await launchAppWithDeviceCtl(clientManager.device.Properties.SerialNumber, bundleId);
+  }
 }


### PR DESCRIPTION
# Why

Works around issue #24615

This is a dirty workaround and needs further attention. If we want to keep the fast socket connections, we need to implement the new [Quic + XPC](https://github.com/doronz88/pymobiledevice3/blob/master/misc/RemoteXPC.md) protocol.

# How

- on iOS 17, there is a new protocol to connect to the device ([Quic + XPC](https://github.com/doronz88/pymobiledevice3/blob/master/misc/RemoteXPC.md)) 
- If the `com.apple.debugserver` service can't be launched, use the fallback option
- Fallback is just `xcrun devicectl`

# Test Plan

- `$ yarn create expo ./test-run -t tabs@49`
- `$ cd ./test-run`
- `$ yarn expo run:ios --device`
- Select an iOS 17 device (not simulator)
- Should install, and boot the app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
