### PR TITLE
[docs] Add info about `reset` action and accessing `navigation.navigate` prop in React Navigation migration guide

### DIFF
--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -198,7 +198,7 @@ export default function Page({
 }
 ```
 
-Similarly, migrate from the `route` prop to the `useLocalSearchParams` hooks.
+Similarly, migrate from the `route` prop to the [`useLocalSearchParams`](/router/reference/hooks/#uselocalsearchparams) hook.
 
 ```diff
 + import { useLocalSearchParams } from 'expo-router';
@@ -442,7 +442,7 @@ Expo Router wraps `expo-splash-screen` and adds special handling to ensure it's 
 
 ### Navigation state observation
 
-If you're observing the navigation state directly, consider migrating to the `usePathname`, `useSegments`, and `useGlobalSearchParams` hooks.
+If you're observing the navigation state directly, migrate to the [`usePathname`](/router/reference/hooks/#usepathname), [`useSegments`](/router/reference/hooks/#usesegments), and [`useGlobalSearchParams`](/router/reference/hooks/#useglobalsearchparams) hooks.
 
 ### Pass params to nested screens
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -467,7 +467,7 @@ In React Navigation, you can use the `initialRouteName` property of the linking 
 
 You can use the [`reset`](https://reactnavigation.org/docs/navigation-actions/#reset) action from the React Navigation library to reset the navigation state. It is dispatched using the [`useNavigation`](/router/reference/hooks/#usenavigation) hook from Expo Router to access the `navigation` prop.
 
-In the below example, the `navigation` prop is accessible from the `useNavigation` hook and the `CommonActions.reset` action from `@react-navigation/native`.
+In the below example, the `navigation` prop is accessible from the `useNavigation` hook and the `CommonActions.reset` action from `@react-navigation/native`. The object specified in the `reset` action replaces the existing navigation state with the new one.
 
 {/* prettier-ignore */}
 ```jsx app/screen.js

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -212,6 +212,8 @@ export default function Page({
 }
 ```
 
+The [`navigate`](https://reactnavigation.org/docs/navigation-prop/#navigate) prop is accessible using [`useNavigation`](/router/reference/hooks/#usenavigation) hook.
+
 ### Migrate the Link component
 
 React Navigation and Expo Router both provide Link components. However, Expo's Link component uses `href` instead of [`to`](https://reactnavigation.org/docs/use-link-props#to).

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -499,8 +499,8 @@ export default function Screen() {
 
   return (
     <>
-    /* @hide ... */ /* @end */
-    <Button title='Reset' onPress={handleResetAction}>
+      /* @hide ... */ /* @end */
+      <Button title='Reset' onPress={handleResetAction}>
     </>
   )
 }

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -25,7 +25,7 @@ We recommend making the following modifications to your codebase before beginnin
 
 - Split React Navigation screen components into individual files. For example, if you have `<Stack.Screen component={HomeScreen} />`, then ensure the `HomeScreen` class is in its own file.
 - Convert the project to [TypeScript](/guides/typescript#path-aliases). This will make it easier to spot errors that may occur during the migration.
-- Convert relative imports to [typed aliases](/guides/typescript#path-aliases), for example `../../components/button.tsx` to `@/components/button`, before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
+- Convert relative imports to [typed aliases](/guides/typescript#path-aliases). For example, **../../components/button.tsx** to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
 - Migrate away from `resetRoot`. This is used to "restart" the app while running. This is generally considered bad practice, and you should restructure your app's navigation so this never needs to happen.
 - Rename the initial route to `index`. Expo Router considers the route that is opened on launch to match `/`, React Navigation users will generally use something such as "Home" for the initial route.
 
@@ -80,7 +80,7 @@ export default function App() {
 }
 ```
 
-### Copying screens to the app directory
+### Copy screens to the app directory
 
 Create an **app** directory at the root of your repo, or in a root **src** directory.
 
@@ -179,9 +179,9 @@ export default function HomeLayout() {
 }
 ```
 
-### Using Expo Router hooks
+### Use Expo Router hooks
 
-React Navigation v6 and lower will pass the props `{ navigation, route }` to every screen. This pattern is going away in React Navigation, but we never introduced it to the Expo Router.
+React Navigation v6 and lower will pass the props `{ navigation, route }` to every screen. This pattern is going away in React Navigation, and we never introduced it to the Expo Router.
 
 Instead, migrate `navigation` to the `useRouter` hook.
 
@@ -212,7 +212,7 @@ export default function Page({
 }
 ```
 
-### Migrating the Link component
+### Migrate the Link component
 
 React Navigation and Expo Router both provide Link components. However, Expo's Link component uses `href` instead of [`to`](https://reactnavigation.org/docs/use-link-props#to).
 
@@ -226,7 +226,7 @@ React Navigation and Expo Router both provide Link components. However, Expo's L
 
 React Navigation users will often create a custom Link component with the `useLinkProps` hook to control the child component. This isn't necessary in Expo Router, instead, use the `asChild` prop.
 
-### Sharing screens across navigators
+### Share screens across navigators
 
 It's common for React Navigation apps to reuse a set of routes across multiple navigators. This is generally used with tabs to ensure each tab can push any screen.
 
@@ -234,15 +234,15 @@ In Expo Router, you can either migrate to [shared routes](/router/advanced/share
 
 When you use groups or shared routes, you can navigate to specific tabs by using the fully qualified route name, for example, `/(home)/settings` instead of `/settings`.
 
-### Migrating screen tracking events
+### Migrate screen tracking events
 
 You may have your screen tracking setup according to our [React Navigation screen tracking guide](https://reactnavigation.org/docs/screen-tracking/), update it according to the [Expo Router screen tracking guide](/router/reference/screen-tracking).
 
-### Using platform-specific components for screens
+### Use platform-specific components for screens
 
 Refer to the [platform-specific modules](/router/advanced/platform-specific-modules) guide for info on switching UI based on the platform.
 
-### Replacing the NavigationContainer
+### Replace the `NavigationContainer`
 
 The global React Navigation [`<NavigationContainer />`](https://reactnavigation.org/docs/navigation-container/) is completely managed in Expo Router. Expo Router provides systems for achieving the same functionality as the `NavigationContainer` without needing to use it directly.
 
@@ -373,7 +373,7 @@ Use the `useRootNavigation()` hook instead.
 
 </Collapsible>
 
-### Rewriting custom navigators
+### Rewrite custom navigators
 
 If your project has a custom navigator, you can rewrite this or port it to Expo Router.
 
@@ -440,11 +440,11 @@ function Header() {
 
 Expo Router wraps `expo-splash-screen` and adds special handling to ensure it's hidden after the navigation mounts, and whenever an unexpected error is caught. Simply migrate from importing `expo-splash-screen` to importing `SplashScreen` from `expo-router`.
 
-### Observing the navigation state
+### Navigation state observation
 
 If you're observing the navigation state directly, consider migrating to the `usePathname`, `useSegments`, and `useGlobalSearchParams` hooks.
 
-### Passing params to nested screens
+### Pass params to nested screens
 
 Instead of using the [nested screen navigation events](https://reactnavigation.org/docs/params/#passing-params-to-nested-navigators), use a qualified href:
 
@@ -459,7 +459,7 @@ navigation.navigate('Account', {
 router.push({ pathname: '/account/settings', params: { user: 'jane' } });
 ```
 
-### Setting initial routes for deep linking and server navigation
+### Set initial routes for deep linking and server navigation
 
 In React Navigation, you can use the `initialRouteName` property of the linking configuration. In Expo Router, use [layout settings](/router/advanced/router-settings).
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -463,6 +463,35 @@ router.push({ pathname: '/account/settings', params: { user: 'jane' } });
 
 In React Navigation, you can use the `initialRouteName` property of the linking configuration. In Expo Router, use [layout settings](/router/advanced/router-settings).
 
+### Reset navigation state
+
+You can use the [`reset`](https://reactnavigation.org/docs/navigation-actions/#reset) action from the React Navigation library to reset the navigation state. It is dispatched using the [`useNavigation`](/router/reference/hooks/#usenavigation) hook from Expo Router to access the `navigation` prop.
+
+In the below example, the `navigation` prop is accessible from the `useNavigation` hook and the `CommonActions.reset` action from `@react-navigation/native`.
+
+{/* prettier-ignore */}
+```jsx app/screen.js
+import { useNavigation } from 'expo-router'
+import { CommonActions } from '@react-navigation/native'
+
+export default function Screen() {
+  const navigation = useNavigation();
+
+  const handleResetAction = () => {
+    navigation.dispatch(CommonActions.reset({
+      routes: [{key: "(tabs)", name: "(tabs)"}]
+    }))
+  }
+
+  return (
+    <>
+    /* @hide ... */ /* @end */
+    <Button title='Reset' onPress={handleResetAction}>
+    </>
+  )
+}
+```
+
 ### Migrating TypeScript types
 
 Expo Router can automatically generate [statically typed routes](/router/reference/typed-routes), this will ensure you can only navigate to valid routes.

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -25,7 +25,7 @@ We recommend making the following modifications to your codebase before beginnin
 
 - Split React Navigation screen components into individual files. For example, if you have `<Stack.Screen component={HomeScreen} />`, then ensure the `HomeScreen` class is in its own file.
 - Convert the project to [TypeScript](/guides/typescript#path-aliases). This will make it easier to spot errors that may occur during the migration.
-- Convert relative imports to [typed aliases](/guides/typescript#path-aliases). For example, **../../components/button.tsx** to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
+- Convert relative imports to [typed aliases](/guides/typescript#path-aliases). For example, `../../components/button.tsx` to `@/components/button` before starting the migration. This makes it easier to move screens around the filesystem without having to update the relative paths.
 - Migrate away from `resetRoot`. This is used to "restart" the app while running. This is generally considered bad practice, and you should restructure your app's navigation so this never needs to happen.
 - Rename the initial route to `index`. Expo Router considers the route that is opened on launch to match `/`, React Navigation users will generally use something such as "Home" for the initial route.
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -189,12 +189,12 @@ Instead, migrate `navigation` to the `useRouter` hook.
 + import { useRouter } from 'expo-router';
 
 export default function Page({
--    navigation
+-  navigation
 }) {
--    navigation.push('User', { user: 'bacon' });
+-  navigation.push('User', { user: 'bacon' });
 
-+    const router = useRouter();
-+    router.push('/users/bacon');
++  const router = useRouter();
++  router.push('/users/bacon');
 }
 ```
 
@@ -204,11 +204,11 @@ Similarly, migrate from the `route` prop to the [`useLocalSearchParams`](/router
 + import { useLocalSearchParams } from 'expo-router';
 
 export default function Page({
--    route
+-  route
 }) {
--    const user = route?.params?.user;
+-  const user = route?.params?.user;
 
-+    const { user } = useLocalSearchParams();
++  const { user } = useLocalSearchParams();
 }
 ```
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -212,7 +212,19 @@ export default function Page({
 }
 ```
 
-The [`navigate`](https://reactnavigation.org/docs/navigation-prop/#navigate) prop is accessible using [`useNavigation`](/router/reference/hooks/#usenavigation) hook.
+To access the [`navigation.navigate`](https://reactnavigation.org/docs/navigation-prop/#navigate), import the `navigation` prop from [`useNavigation`](/router/reference/hooks/#usenavigation) hook.
+
+```diff
++ import { useNavigation } from 'expo-router';
+
+export default function Page({
++  const navigation = useNavigation();
+
+  return (
+    <Button onPress={navigation.navigate('screenName')}>
+  )
+})
+```
 
 ### Migrate the Link component
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -492,6 +492,6 @@ export default function Screen() {
 }
 ```
 
-### Migrating TypeScript types
+### Migrate TypeScript types
 
 Expo Router can automatically generate [statically typed routes](/router/reference/typed-routes), this will ensure you can only navigate to valid routes.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In React Navigation migration guide, we do not cover the following:
- `reset` navigation state
- access `navigation.navigate` prop

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR:
- Adds info on accessing `navigation` prop using `useNavigation` hook under the Use Expo Router hooks section with an example

**Preview**
<img width="918" alt="CleanShot 2023-09-27 at 19 22 00@2x" src="https://github.com/expo/expo/assets/10234615/d009d276-7724-4b0c-b950-5bbc4b674802">

- Adds a section on resetting navigation state with an example

**Preview**
<img width="903" alt="CleanShot 2023-09-27 at 19 17 00@2x" src="https://github.com/expo/expo/assets/10234615/f9de31d2-92e6-41ff-9ef1-47e0ddff2a5a">

- Fixes section titles to use short form verbs instead of gerunds


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit:
- http://localhost:3002/router/migrate/from-react-navigation/#use-expo-router-hooks
- http://localhost:3002/router/migrate/from-react-navigation/#reset-navigation-state

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
