### PR TITLE
[dev-launcher][android] Fix Fast Refresh being disabled by default

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed Fast Refresh being disabled by default ([#24643](https://github.com/expo/expo/pull/24643) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Drop support for configuring SDK 44 and below with Prebuild. ([#24504](https://github.com/expo/expo/pull/24504) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
+++ b/packages/expo-dev-menu/android/src/main/java/com/facebook/react/devsupport/DevMenuReactInternalSettings.kt
@@ -69,5 +69,12 @@ internal class DevMenuInternalSettingsWrapper(private val devSettings: DevIntern
     set(value) {
       devSettings.isRemoteJSDebugEnabled = value
     }
+
+  var isJSDevModeEnabled: Boolean
+    get() = devSettings.isJSDevModeEnabled
+    set(value) {
+      devSettings.isJSDevModeEnabled = value
+    }
+
   val packagerConnectionSettings: PackagerConnectionSettings = devSettings.packagerConnectionSettings
 }

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -34,7 +34,7 @@ class DevMenuDevToolsDelegate(
   internal val devInternalSettings: DevMenuInternalSettingsWrapper?
     get() {
       val devSettings = this.devSettings ?: return null
-      return if (devSettings.javaClass.canonicalName == "com.facebook.react.DevInternalSettings") DevMenuInternalSettingsWrapper(devSettings) else null
+      return if (devSettings.javaClass.canonicalName == "com.facebook.react.devsupport.DevLauncherInternalSettings") DevMenuInternalSettingsWrapper(devSettings) else null
     }
 
   val reactContext

--- a/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
+++ b/packages/expo-dev-menu/android/src/main/java/expo/modules/devmenu/extensions/DevMenuExtension.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import android.view.KeyEvent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.devsupport.HMRClient
 import expo.interfaces.devmenu.DevMenuExtensionInterface
 import expo.interfaces.devmenu.DevMenuExtensionSettingsInterface
 import expo.interfaces.devmenu.items.DevMenuDataSourceInterface
@@ -87,7 +88,20 @@ class DevMenuExtension(reactContext: ReactApplicationContext) :
       }
 
       val fastRefreshAction = {
-        devInternalSettings.isHotModuleReplacementEnabled = !devInternalSettings.isHotModuleReplacementEnabled
+        val nextEnabled = !devInternalSettings.isHotModuleReplacementEnabled
+        devInternalSettings.isHotModuleReplacementEnabled = nextEnabled
+
+       if (reactApplicationContext != null) {
+         if (nextEnabled) {
+           reactApplicationContext.getJSModule(HMRClient::class.java).enable()
+         } else {
+           reactApplicationContext.getJSModule(HMRClient::class.java).disable()
+         }
+       }
+       if (nextEnabled && !devInternalSettings.isJSDevModeEnabled) {
+         devInternalSettings.isJSDevModeEnabled = true
+         reactDevManager.handleReloadJS()
+       }
       }
 
       action("fast-refresh", fastRefreshAction) {


### PR DESCRIPTION
# Why

Closes ENG-10237

While working on the refactoring of react-native core to be a monorepo Meta moved the class DevInternalSettings on Android to a new package, `com.facebook.react.devsupport.DevInternalSettings` (https://github.com/facebook/react-native/commit/714b502b0c7a5f897432dbad388c02d3b75b4689#diff-7a91ed9253e9f152486ddfdaa764f83d1163fdc325f5925e3a4bdff6689e802b)

This change ended up breaking our canonicalName check inside DevMenuDevToolsDelegate.kt on all projects running on react-native 0.72

# How

- Update the `canonicalName` check to reference to "com.facebook.react.devsupport.DevLauncherInternalSettings"
- Expose `isJSDevModeEnabled` in DevMenuReactInternalSettings
- Update DevMenuExtension `fastRefreshAction` to enable/disable HMRClient when triggered, removing the need to reload the bundle (based on https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java#L434-L450)

# Test Plan

Run dev-client through bare-expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
