### PR TITLE
[expo-updates][Android] Replace renameTo() with copyTo() when downloading assets

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -54,7 +54,7 @@ jobs:
       - name: ⬢ Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(yarn global bin)" >> $GITHUB_PATH
       - name: ♻️ Restore caches

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -512,7 +512,7 @@ async function initAsync(
       CI: '1',
     },
     cwd: projectRoot,
-    stdio: 'ignore',
+    stdio: 'inherit',
   });
 
   // We are done with template tarball


### PR DESCRIPTION
# Why

On Android, errors are sometimes occurring when renaming downloaded assets to their permanent location after verifying checksums.

# How

Replace the renameTo() call with a copyTo() that checks for the various possible exceptions that could occur, followed by a delete of the original file.

# Test Plan

- E2E should pass
- Test with real apps where this problem occurs

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
