### PR TITLE
[dev-launcher] Fix config plugin undefined props

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Add support for skipping the launcher screen and launching directly into a previously opened project. ([#24614](https://github.com/expo/expo/pull/24614) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for skipping the launcher screen and launching directly into a previously opened project. ([#24614](https://github.com/expo/expo/pull/24614), [#24646](https://github.com/expo/expo/pull/24646) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -3,8 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
-exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props) => {
-    (0, pluginConfig_1.validateConfig)(props || {});
+exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
+    (0, pluginConfig_1.validateConfig)(props);
     if (props.ios?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
             config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = true;

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -10,8 +10,8 @@ import { PluginConfigType, validateConfig } from './pluginConfig';
 const pkg = require('expo-dev-launcher/package.json');
 
 export default createRunOncePlugin<PluginConfigType>(
-  (config, props) => {
-    validateConfig(props || {});
+  (config, props = {}) => {
+    validateConfig(props);
 
     if (props.ios?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
       config = withInfoPlist(config, (config) => {


### PR DESCRIPTION
# Why

Updates E2E tests are currently broken due to it not specifying any configurations to the dev launcher plugin, causing 
the prebuild step to fail with a `Cannot read properties of undefined` error. The dev launcher plugin should not require users to set any props 

# How

Update `withDevLauncher` plugin to use `{}` as the default props, thus preventing any `Cannot read properties of undefined` errors 

# Test Plan

Add dev-client to sandbox and run `npx expo prebuild` with no errors

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
