### PR TITLE
[ios][calendar] fix: add os check

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -46,8 +46,6 @@ PODS:
     - React-Core
   - EXNotifications (0.24.2):
     - ExpoModulesCore
-  - EXPermissions (14.4.0):
-    - ExpoModulesCore
   - Expo (50.0.0-alpha.5):
     - ExpoModulesCore
   - expo-dev-client (3.1.1):
@@ -839,7 +837,6 @@ DEPENDENCIES:
   - EXManifests/Tests (from `../../../packages/expo-manifests/ios`)
   - EXMediaLibrary (from `../../../packages/expo-media-library/ios`)
   - EXNotifications (from `../../../packages/expo-notifications/ios`)
-  - EXPermissions (from `../../../packages/expo-permissions/ios`)
   - Expo (from `../../../packages/expo`)
   - expo-dev-client (from `../../../packages/expo-dev-client/ios`)
   - expo-dev-launcher (from `../../../packages/expo-dev-launcher`)
@@ -1030,9 +1027,6 @@ EXTERNAL SOURCES:
   EXNotifications:
     inhibit_warnings: false
     :path: "../../../packages/expo-notifications/ios"
-  EXPermissions:
-    inhibit_warnings: false
-    :path: "../../../packages/expo-permissions/ios"
   Expo:
     inhibit_warnings: false
     :path: "../../../packages/expo"
@@ -1316,7 +1310,6 @@ SPEC CHECKSUMS:
   EXManifests: 3b001efa12886d0abc2b011bc32c4f3346b74256
   EXMediaLibrary: 802eee8ef888ee16ef80f1b79005d3d611793e14
   EXNotifications: f6ae23a3d89a1e2236bca9861dc9bd36b4544cda
-  EXPermissions: 51c6115893689c3e9787f4819aa67ceeae601038
   Expo: 001317580dc33f3a8bdcebd50adaf7f58cc9e303
   expo-dev-client: 9249b1dc8236038479779b7ea56f5c8c5472616e
   expo-dev-launcher: bd6cc619cf034fd6fc1cb331ad30cbe2d5f0a773

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - On `iOS`, fix permissions error on `iOS 17`. ([#24545](https://github.com/expo/expo/pull/24545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix url parsing when adding url in calendar event and reminder on iOS. ([#24102](https://github.com/expo/expo/pull/24102) by [@Thomas-Mollard](https://github.com/Thomas-Mollard))
+- On `iOS`, fix check that determines if the version of Xcode supports `iOS 17`. ([#24655](https://github.com/expo/expo/pull/24655) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendarPermissionRequester.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendarPermissionRequester.m
@@ -53,7 +53,8 @@
 {
   EKEventStore *eventStore = [[EKEventStore alloc] init];
   EX_WEAKIFY(self)
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 170000
+#if defined(__IPHONE_17_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >=__IPHONE_17_0 
+  if (@available(iOS 17.0, *)) {
     [eventStore requestFullAccessToEventsWithCompletion:^(BOOL granted, NSError * _Nullable error) {
       EX_STRONGIFY(self)
       if (error && error.code != 100) {
@@ -62,6 +63,17 @@
         resolve([self getPermissions]);
       }
     }];
+  } else {
+    [eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
+      EX_STRONGIFY(self)
+      // Error code 100 is a when the user denies permission; in that case we don't want to reject.
+      if (error && error.code != 100) {
+        reject(@"E_CALENDAR_ERROR_UNKNOWN", error.localizedDescription, error);
+      } else {
+        resolve([self getPermissions]);
+      }
+    }];
+  }
 #else
     [eventStore requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
       EX_STRONGIFY(self)

--- a/packages/expo-calendar/ios/EXCalendar/EXRemindersPermissionRequester.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXRemindersPermissionRequester.m
@@ -53,15 +53,27 @@
 {
   EKEventStore *eventStore = [[EKEventStore alloc] init];
   EX_WEAKIFY(self)
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 170000
-  [eventStore requestFullAccessToRemindersWithCompletion:^(BOOL granted, NSError * _Nullable error) {
-    EX_STRONGIFY(self)
-    if (error && error.code != 100) {
-      reject(@"E_CALENDAR_ERROR_UNKNOWN", error.localizedDescription, error);
-    } else {
-      resolve([self getPermissions]);
-    }
-  }];
+#if defined(__IPHONE_17_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_17_0
+  if (@available(iOS 17.0, *)) {
+    [eventStore requestFullAccessToRemindersWithCompletion:^(BOOL granted, NSError * _Nullable error) {
+      EX_STRONGIFY(self)
+      if (error && error.code != 100) {
+        reject(@"E_CALENDAR_ERROR_UNKNOWN", error.localizedDescription, error);
+      } else {
+        resolve([self getPermissions]);
+      }
+    }];
+  } else {
+    [eventStore requestAccessToEntityType:EKEntityTypeReminder completion:^(BOOL granted, NSError *error) {
+      EX_STRONGIFY(self)
+      // Error code 100 is a when the user denies permission; in that case we don't want to reject.
+      if (error && error.code != 100) {
+        reject(@"E_REMINDERS_ERROR_UNKNOWN", error.localizedDescription, error);
+      } else {
+        resolve([self getPermissions]);
+      }
+    }];
+  }
 #else
   [eventStore requestAccessToEntityType:EKEntityTypeReminder completion:^(BOOL granted, NSError *error) {
     EX_STRONGIFY(self)


### PR DESCRIPTION
# Why
The check for the Xcode version wasn't correct. `__IPHONE_OS_VERSION_MIN_REQUIRED` returns the minimum supported deployment target. The new check is correct. We also need another check for iOS 17 availability once we have determined we are on a supported version of Xcode.

# How
Add the check for the OS version after determining the version of Xcode with `#if defined(__IPHONE_17_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >=__IPHONE_17_0 `

# Test Plan
This should have failed initially in bare-expo but didn't. Tested in a new local project on Xcode 14 and 15 and now works correctly. Also, the workaround for Xcode 14 that RN deployed is not working. I had to remove the added linker flags `-Wl -ld_classic` to get the project to build on Xcode 14.
