### PR TITLE
[docs] fixed casing in ios build command

### DIFF
--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -193,7 +193,7 @@ To build your project locally you can use compile commands from Expo CLI which g
     '# Build native Android project',
     '$ npx expo run:android',
     '# Build native iOS project',
-    '$ npx expo run:iOS',
+    '$ npx expo run:ios',
   ]}
 />
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Running the ios build command as it is in the documentation right now gives me "Invalid project root" message, the command works just fine when iOS is written all in lower-case.
