### PR TITLE
[docs] Add the video tutorial for debugging using adb logcat and Console app

### DIFF
--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -9,6 +9,7 @@ import { Step } from '~/ui/components/Step';
 import { Terminal } from '~/ui/components/Snippet';
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
+import Video from '~/components/plugins/Video';
 
 Whether you're developing your app locally, sending it out to select beta testers, or launching your app live to the app stores, you'll always find yourself debugging issues. It's useful to split errors into two categories:
 
@@ -161,6 +162,12 @@ This will open the console app for you to view logs from your device or simulato
 </Step>
 
 For more information, see Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
+
+### Video walkthrough
+
+Watch the tutorial on how to use `adb logcat` for Android and Console app from Xcode for iOS.
+
+<Video url="https://www.youtube.com/watch?v=LvCci4Bwmpc" />
 
 ### App crashes on certain (older) devices
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -115,7 +115,9 @@ Errors or bugs in your production app can be much harder to solve, mainly becaus
 
 It can be a frustrating scenario when a production app crashes. There is very little information to look into when it happens. It's important to reproduce the issue, and even if you can't do that, to find any related crash reports.
 
-Start by reproducing the crash using your production app and then **find an associated crash report**.
+Start by reproducing the crash using your production app and then **find an associated crash report**. For Android, you can use `adb logcat` and for iOS you can use the Console app in Xcode.
+
+<Video url="https://www.youtube.com/watch?v=LvCci4Bwmpc" />
 
 #### Crash reports using adb logcat
 
@@ -162,12 +164,6 @@ This will open the console app for you to view logs from your device or simulato
 </Step>
 
 For more information, see Apple's [Diagnosing Issues Using Crash Reports and Device Logs](https://developer.apple.com/documentation/xcode/diagnosing-issues-using-crash-reports-and-device-logs) guide.
-
-### Video walkthrough
-
-Watch the tutorial on how to use `adb logcat` for Android and Console app from Xcode for iOS.
-
-<Video url="https://www.youtube.com/watch?v=LvCci4Bwmpc" />
 
 ### App crashes on certain (older) devices
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Keith's tutorial on debugging with adb logcat and console app got published.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add the video tutorial in debugging runtime issues guide under Production errors section.

**Preview**
<img width="903" alt="CleanShot 2023-09-28 at 18 25 52@2x" src="https://github.com/expo/expo/assets/10234615/684a4547-2f72-4121-8b6e-7f96418df592">

Also, add more context in the introduction about tools to use in case a production app is crashing.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/debugging/runtime-issues/#production-app-is-crashing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
