### PR TITLE
[docs] Add missing `description` for docs under Guides

### DIFF
--- a/docs/pages/distribution/custom-updates-server.mdx
+++ b/docs/pages/distribution/custom-updates-server.mdx
@@ -1,8 +1,9 @@
 ---
 title: Use expo-updates with a custom updates server
+description: Learn how to self-host a custom Expo Updates server using the expo-updates library.
 hideTOC: true
 ---
 
-EAS (Expo Application Services) is the Expo team's cloud service that can host and serve updates for a React Native app using the `expo-updates` library. In some cases, you may prefer to use your servers and control how updates are sent to your app. To accomplish this, it's possible to implement your own custom Expo Updates server that will provide update manifests and assets to your end-users' apps.
+EAS (Expo Application Services) is the Expo team's cloud service that can host and serve updates for a React Native app using the `expo-updates` library. In some cases, you may prefer to use your servers and control how updates are sent to your app. To accomplish this, it's possible to implement your own custom Expo Updates server that will provide update manifests and assets to your end-user's apps.
 
 The only requirement is that your custom server adheres to the [Expo Updates Protocol](/technical-specs/expo-updates-1). To help get you started, we created a demo repo that implements the protocol that you could deploy and test: [Custom Expo Updates Server](https://github.com/expo/custom-expo-updates-server).

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authentication with OAuth or OpenID providers
+description: Learn how to utilize the expo-auth-session library to implement authentication with OAuth or OpenID providers.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';
@@ -11,10 +12,10 @@ Expo can be used to login to many popular providers on Android, iOS, and web. Mo
 Here are some **important rules** that apply to all authentication providers:
 
 - Use `WebBrowser.maybeCompleteAuthSession()` to dismiss the web popup. If you forget to add this then the popup window will not close.
-- Create redirects with `AuthSession.makeRedirectUri()` this does a lot of the heavy lifting involved with universal platform support. Behind the scenes it uses `expo-linking`.
+- Create redirects with `AuthSession.makeRedirectUri()` this does a lot of the heavy lifting involved with universal platform support. Behind the scenes, it uses `expo-linking`.
 - Build requests using `AuthSession.useAuthRequest()`, the hook allows for async setup which means mobile browsers won't block the authentication.
 - Be sure to disable the prompt until `request` is defined.
-- You can only invoke `promptAsync` in a user-interaction on web.
+- You can only invoke `promptAsync` in user interaction on the web.
 
 ## Guides
 

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -1,5 +1,6 @@
 ---
 title: Icons
+description: Learn how to use various types of icons in your Expo app, including vector icons, custom icon fonts, icon images, and icon buttons.
 ---
 
 import { SnackInline } from '~/ui/components/Snippet';

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Progressive Web Apps
-desscription: Learn how to build a progressive web app with Expo.
+description: Learn how to build a progressive web app with Expo.
 ---
 
 import { CODE } from '~/ui/components/Text';

--- a/docs/pages/guides/sharing-preview-releases.mdx
+++ b/docs/pages/guides/sharing-preview-releases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Share pre-release versions of your app
+description: Learn about various methods to share pre-release versions of your app for internal distribution and TestFlight.
 sidebar_title: Share preview releases
 ---
 

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use ESLint
-description: How to configure ESLint for formatting Expo apps.
+description: A guide on configuring ESLint to format Expo apps.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -1,7 +1,7 @@
 ---
 title: Authentication in Expo Router
 sidebar_title: Authentication
-description: How to protect routes with Expo Router.
+description: How to implement authentication and protect routes with Expo Router.
 ---
 
 import { Lock01Icon, LockUnlocked01Icon } from '@expo/styleguide-icons';

--- a/docs/pages/router/reference/faq.mdx
+++ b/docs/pages/router/reference/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expo Router FAQs
+description: A list of common questions about Expo Router.
 sidebar_title: FAQ
 ---
 
@@ -32,20 +33,20 @@ Yes, Expo Router is the framework for universal React Native apps. Due to the de
 5. Async Routes (bundle splitting) improve development speed, especially in larger projects. They also make upgrades easier as errors are isolated to a single route, meaning you can incrementally update or refactor your app page-by-page rather than all at once (traditional React Native).
 6. Deep links always work, for every page. This makes it possible to share links to any content in the app, which is great for promoting your app, collecting bug reports, E2E testing, automating screenshots, and so on.
 7. Expo Head uses automatic links to enable deep-native integration. Features like Quick Notes, Handoff, Siri context, and universal links only require configuration setup, no code changes. This enables perfect vertical integration with the entire ecosystem of smart devices that a user has, leading to the types of user experiences that are only possible with universal apps (web ⇄ native).
-8. Expo Router has the ability to statically render each page automatically on web, enabling real SEO and full discoverability of your app's content. This is only possible because the file-based convention.
+8. Expo Router has the ability to statically render each page automatically on the web, enabling real SEO and full discoverability of your app's content. This is only possible because of the file-based convention.
 9. **Expo CLI** can infer a lot of information about your application when it follows a known convention. For example, we could implement automatic bundle splitting per route, or automatically generate a sitemap for your website. This is impossible when your app only has a single entry point.
-10. Re-engagment features like notifications and homescreen widgets are easier to integrate as you can simply intercept the launch and deep link, with query parameters, to anywhere in the app.
+10. Re-engagement features like notifications and home screen widgets are easier to integrate as you can simply intercept the launch and deep link, with query parameters, anywhere in the app.
 11. Like on the web, analytics and error reporting can easily be configured to automatically include the route name, which is useful for debugging and understanding user behavior.
 
 ## Why should I use Expo Router over React Navigation?
 
 Expo Router and React Navigation are both libraries from the Expo team. We built Expo Router on top of React Navigation to enable the benefits of file-based routing. Expo Router is a superset of React Navigation, meaning you can use any React Navigation components and APIs with Expo Router.
 
-If file-based routing isn't right for your project, you can drop down to React Navigation and setup routes, types, and links manually.
+If file-based routing isn't right for your project, you can drop down to React Navigation and set up routes, types, and links manually.
 
 ## How do I server-render my Expo Router website?
 
-Basic static rendering (SSG) is supported in Expo Router v2. Server-side rendering currently requires custom infrastructure to setup.
+Basic static rendering (SSG) is supported in Expo Router v2. Server-side rendering currently requires custom infrastructure to set up.
 
 ## Can I use React Navigation?
 

--- a/docs/pages/router/reference/screen-tracking.mdx
+++ b/docs/pages/router/reference/screen-tracking.mdx
@@ -1,5 +1,6 @@
 ---
 title: Screen tracking for analytics
+description: Learn how to enable screen tracking for analytic when using Expo Router.
 hideTOC: true
 ---
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some of docs under Guides are missing `description`. This is not good for SEO and also makes them a bit hard to search.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added missing description.
- Fixed misspelled description in PWA guide
- Fix minor grammatical errors Expo Router FAQ

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit guides such as https://docs.expo.dev/guides/progressive-web-apps/, https://docs.expo.dev/router/reference/faq/, https://docs.expo.dev/distribution/custom-updates-server/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
