### PR TITLE
[docs][modules] fix import references to config plugins in native module tutorial

### DIFF
--- a/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
+++ b/docs/pages/modules/config-plugin-and-native-module-tutorial.mdx
@@ -154,7 +154,7 @@ Let's start by creating our plugin with this minimal boilerplate. This will crea
 2. Create a **plugin/src/index.ts** file for our plugin:
 
    ```typescript plugin/src/index.ts
-   import { ConfigPlugin } from 'expo/config-plugins';
+   import { ConfigPlugin } from '@expo/config-plugins';
 
    const withMyApiKey: ConfigPlugin = config => {
      console.log('my custom plugin');
@@ -185,7 +185,7 @@ Now when running `npx expo prebuild` inside our **example** folder we should see
 
 <Terminal cmd={['$ cd example', '$ npx expo prebuild --clean']} />
 
-To inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper [`mods` provided by `expo/config-plugins`](/config-plugins/plugins-and-mods/#what-are-mods), which makes it easy to modify native files. In our example, we will use two of them, `withAndroidManifest` and `withInfoPlist`.
+To inject our custom API keys into **AndroidManifest.xml** and **Info.plist** we can use a few helper [`mods` provided by `@expo/config-plugins`](/config-plugins/plugins-and-mods/#what-are-mods), which makes it easy to modify native files. In our example, we will use two of them, `withAndroidManifest` and `withInfoPlist`.
 
 As the name suggests, `withInfoPlist` allows us to read and modify **Info.plist** values. Using the `modResults` property, we can add custom values as demonstrated in the code snippet below:
 
@@ -227,7 +227,7 @@ import {
   withAndroidManifest,
   AndroidConfig,
   ConfigPlugin,
-} from 'expo/config-plugins';
+} from '@expo/config-plugins';
 
 const withMyApiKey: ConfigPlugin<{ apiKey: string }> = (config, { apiKey }) => {
   config = withInfoPlist(config, config => {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

https://discord.com/channels/695411232856997968/1009056414028812299/1156993204718141521

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the references to the config plugins imports

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
