### PR TITLE
fix(cli): improve browser shims

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Resolve browser shims with mismatched extensions.
+- Resolve browser shims with mismatched extensions. ([#24671](https://github.com/expo/expo/pull/24671) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure a unique static path is generated for each group during static extraction ([#24218](https://github.com/expo/expo/pull/24218) by [@marklawlor](https://github.com/marklawlor))
 - Fallback to `xcrun devicectl` for iOS 17 to launch the app. ([#24635](https://github.com/expo/expo/pull/24635) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve browser shims with mismatched extensions.
 - Ensure a unique static path is generated for each group during static extraction ([#24218](https://github.com/expo/expo/pull/24218) by [@marklawlor](https://github.com/marklawlor))
 - Fallback to `xcrun devicectl` for iOS 17 to launch the app. ([#24635](https://github.com/expo/expo/pull/24635) by [@byCedric](https://github.com/byCedric))
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/createExpoMetroResolver.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/createExpoMetroResolver.test.ts
@@ -128,6 +128,35 @@ describe(createFastResolver, () => {
         type: 'sourceFile',
       });
     });
+    it('resolves module with browser shims with non-matching extensions', () => {
+      const resolver = createFastResolver({ preserveSymlinks: false });
+      const context = createContext({
+        platform,
+        origin: path.join(originProjectRoot, 'index.js'),
+      });
+      const results = resolver(context, 'uuid/v4', platform);
+      expect(results).toEqual({
+        filePath: expect.stringMatching(/\/uuid\/v4.js$/),
+        type: 'sourceFile',
+      });
+
+      assert(results.type === 'sourceFile');
+
+      // Browser shims are applied on native.
+      expect(
+        resolver(
+          createContext({
+            platform,
+            origin: results.filePath,
+          }),
+          './lib/rng',
+          platform
+        )
+      ).toEqual({
+        filePath: expect.stringMatching(/node_modules\/uuid\/lib\/rng-browser\.js/),
+        type: 'sourceFile',
+      });
+    });
     it('resolves an asset', () => {
       const resolver = createFastResolver({ preserveSymlinks: false });
       const context = createContext({

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -139,7 +139,9 @@ export function createFastResolver({ preserveSymlinks }: { preserveSymlinks: boo
                 return '';
               }
 
-              const mappedPath = replacements[relativePath];
+              // TODO: Probably use a better extension matching system here.
+              // This was added for `uuid/v4` -> `./lib/rng` -> `./lib/rng-browser.js`
+              const mappedPath = replacements[relativePath] ?? replacements[relativePath + ".js"];
               if (mappedPath === false) {
                 throw new ShimModuleError();
               }

--- a/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoMetroResolver.ts
@@ -141,7 +141,7 @@ export function createFastResolver({ preserveSymlinks }: { preserveSymlinks: boo
 
               // TODO: Probably use a better extension matching system here.
               // This was added for `uuid/v4` -> `./lib/rng` -> `./lib/rng-browser.js`
-              const mappedPath = replacements[relativePath] ?? replacements[relativePath + ".js"];
+              const mappedPath = replacements[relativePath] ?? replacements[relativePath + '.js'];
               if (mappedPath === false) {
                 throw new ShimModuleError();
               }


### PR DESCRIPTION
# Why


If a browser shim has a mismatched extension to what is being imported, then it won't be resolved correctly. This change fixes that.