### PR TITLE
[expo-insights][iOS] put launch code in dispatch queue

### DIFF
--- a/packages/expo-insights/ios/InsightsModule.swift
+++ b/packages/expo-insights/ios/InsightsModule.swift
@@ -11,13 +11,15 @@ public final class InsightsModule: Module {
     Name("ExpoInsights")
 
     OnCreate {
-      // The app launch event should be sent only during the first launch
-      // which means that we need to prevent dispatching them on app reload.
-      if !wasAppLaunchEventDispatched {
-        wasAppLaunchEventDispatched = true
+      DispatchQueue.main.async {
+        // The app launch event should be sent only during the first launch
+        // which means that we need to prevent dispatching them on app reload.
+        if !wasAppLaunchEventDispatched {
+          wasAppLaunchEventDispatched = true
 
-        Task {
-          try await dispatchLaunchEvent()
+          Task {
+            try await self.dispatchLaunchEvent()
+          }
         }
       }
     }
@@ -38,70 +40,70 @@ public final class InsightsModule: Module {
     let data = getLaunchEventData(projectId: projectId)
     try await dispatchEvent(projectId: projectId, eventName: "APP_LAUNCH", data: data)
   }
-}
 
-/**
- Sends an event with the given name and data.
- */
-private func dispatchEvent(projectId: String, eventName: String, data: [String: String?]) async throws {
-  let endpointUrl = "https://i.expo.dev/v1/c/\(projectId)"
+  /**
+   Sends an event with the given name and data.
+   */
+  private func dispatchEvent(projectId: String, eventName: String, data: [String: String?]) async throws {
+    let endpointUrl = "https://i.expo.dev/v1/c/\(projectId)"
 
-  guard var urlComponents = URLComponents(string: endpointUrl) else {
-    log.warn("Insights: The URL for the HTTP endpoint is invalid: \(endpointUrl)")
-    return
+    guard var urlComponents = URLComponents(string: endpointUrl) else {
+      log.warn("Insights: The URL for the HTTP endpoint is invalid: \(endpointUrl)")
+      return
+    }
+    var queryItems: [URLQueryItem] = []
+
+    for (key, value) in data {
+      queryItems.append(
+        URLQueryItem(name: key, value: value)
+      )
+    }
+
+    urlComponents.queryItems = queryItems
+
+    guard let url = urlComponents.url else {
+      log.warn("Insights: Cannot create an URL instance from the given query: \(urlComponents.query ?? "Null query")")
+      return
+    }
+    var request = URLRequest(url: url)
+
+    request.httpMethod = "GET"
+
+    let (_, response) = try await URLSession.shared.data(for: request)
+
+    guard let response = response as? HTTPURLResponse else {
+      log.warn("Insights: Unexpectedly the response is not of HTTPURLResponse type")
+      return
+    }
+    guard (200...299).contains(response.statusCode) else {
+      log.warn("Insights: Server responded with status code \(response.statusCode) for event \(eventName)")
+      return
+    }
   }
-  var queryItems: [URLQueryItem] = []
 
-  for (key, value) in data {
-    queryItems.append(
-      URLQueryItem(name: key, value: value)
-    )
+  /**
+   Gets the project ID from the manifest.
+   */
+  private func getProjectId(manifest: [String: Any]) -> String? {
+    let extra = manifest["extra"] as? [String: Any]
+    let eas = extra?["eas"] as? [String: Any]
+
+    return eas?["projectId"] as? String
   }
 
-  urlComponents.queryItems = queryItems
+  /**
+   Returns the data necessary for `APP_LAUNCH` event.
+   */
+  private func getLaunchEventData(projectId: String) -> [String: String?] {
+    let info = Bundle.main.infoDictionary
 
-  guard let url = urlComponents.url else {
-    log.warn("Insights: Cannot create an URL instance from the given query: \(urlComponents.query)")
-    return
+    return [
+      "event_name": "APP_LAUNCH",
+      "eas_client_id": EASClientID.uuid().uuidString,
+      "project_id": projectId,
+      "app_version": info?["CFBundleShortVersionString"] as? String,
+      "platform": "iOS",
+      "os_version": UIDevice.current.systemVersion
+    ]
   }
-  var request = URLRequest(url: url)
-
-  request.httpMethod = "GET"
-
-  let (_, response) = try await URLSession.shared.data(for: request)
-
-  guard let response = response as? HTTPURLResponse else {
-    log.warn("Insights: Unexpectedly the response is not of HTTPURLResponse type")
-    return
-  }
-  guard (200...299).contains(response.statusCode) else {
-    log.warn("Insights: Server responded with status code \(response.statusCode) for event \(eventName)")
-    return
-  }
-}
-
-/**
- Gets the project ID from the manifest.
- */
-private func getProjectId(manifest: [String: Any]) -> String? {
-  let extra = manifest["extra"] as? [String: Any]
-  let eas = extra?["eas"] as? [String: Any]
-
-  return eas?["projectId"] as? String
-}
-
-/**
- Returns the data necessary for `APP_LAUNCH` event.
- */
-private func getLaunchEventData(projectId: String) -> [String: String?] {
-  let info = Bundle.main.infoDictionary
-
-  return [
-    "event_name": "APP_LAUNCH",
-    "eas_client_id": EASClientID.uuid().uuidString,
-    "project_id": projectId,
-    "app_version": info?["CFBundleShortVersionString"] as? String,
-    "platform": "iOS",
-    "os_version": UIDevice.current.systemVersion
-  ]
 }


### PR DESCRIPTION
# Why

When both `expo-updates` and `expo-insights` are running in an iOS app, there is an occasional issue happening on app startup, where `expo-updates` becomes disabled. This was seen in #21885 where the `useFonts()` hook broke, since asset paths depend on updates being present.

# How

`expo-insights` initialization is creating a `Task` and waiting for a response from an Expo service. This apparently can lead to a race condition with `expo-updates` initialization.

If the code is placed in an async block in the main dispatch queue, the problem seems to be avoided.

I also found that some methods that appeared intended to be part of the `InsightsModule` class were actually standalone code outside the class block -- I put them in the class.

# Test Plan

- Test on real iOS device
- Before the above fix, the problem occurred every 1 in 5 or 10 starts.
- After the above fix, I no longer see the problem occurring.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
