### PR TITLE
[docs] Update stack.mdx with alternative to Stack.Screen

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -112,6 +112,26 @@ export default function Details() {
 }
 ```
 
+It's sometimes useful to configure options using `navigation.setOptions()`, as an alternative to the `<Stack.Screen>` component.
+
+```jsx app/home.js
+import { Stack, useNavigation } from 'expo-router';
+import { Text, View } from 'react-native';
+
+export default function Home() {
+  const navigation = useNavigation();
+
+  React.useEffect(() => {
+    navigation.setOptions({ headerShown: false });
+  }, [navigation]);
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Home Screen</Text>
+    </View>
+  );
+}
+```
+
 ## Header buttons
 
 With the following file structure:

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -112,7 +112,7 @@ export default function Details() {
 }
 ```
 
-It's sometimes useful to configure options using `navigation.setOptions()`, as an alternative to the `<Stack.Screen>` component.
+As an alternative to the `<Stack.Screen>` component, you can use [`navigation.setOptions()`](https://reactnavigation.org/docs/navigation-prop/#setoptions) to configure screen options from within the component.
 
 ```jsx app/home.js
 import { Stack, useNavigation } from 'expo-router';
@@ -124,6 +124,7 @@ export default function Home() {
   React.useEffect(() => {
     navigation.setOptions({ headerShown: false });
   }, [navigation]);
+  
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Home Screen</Text>


### PR DESCRIPTION
Adds section to stack.mdx showing alternative method to configure screen options from route, via imperative API

# Why


Clarifying feature options following discussion in this issue: https://github.com/expo/router/issues/834#issuecomment-1740464993

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
