### PR TITLE
[ios][calendar] fix potential argument exception

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -13,6 +13,7 @@
 - On `iOS`, fix permissions error on `iOS 17`. ([#24545](https://github.com/expo/expo/pull/24545) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix url parsing when adding url in calendar event and reminder on iOS. ([#24102](https://github.com/expo/expo/pull/24102) by [@Thomas-Mollard](https://github.com/Thomas-Mollard))
 - On `iOS`, fix check that determines if the version of Xcode supports `iOS 17`. ([#24655](https://github.com/expo/expo/pull/24655) by [@alanjhughes](https://github.com/alanjhughes))
+- On `iOS`, validate calendars argument in `getRemindersAsync` before accessing `count`. ([#24677](https://github.com/expo/expo/pull/24677) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
@@ -498,7 +498,7 @@ EX_EXPORT_METHOD_AS(getRemindersAsync,
   NSDate *startDate = [EXUtilities NSDate:startDateStr];
   NSDate *endDate = [EXUtilities NSDate:endDateStr];
 
-  if (calendars.count) {
+  if (calendars && calendars.count) {
     reminderCalendars = [[NSMutableArray alloc] init];
     NSArray *deviceCalendars = [self.eventStore calendarsForEntityType:EKEntityTypeReminder];
 


### PR DESCRIPTION
# Why
I noticed this while doing some testing on the latest changes. We're not validating the `calendars` argument exists before accessing the count in `getRemindersAsync`. This will cause a crash on the native side.

# How
Check the array exists before accessing the `count`

# Test Plan
bare-expo 