### PR TITLE
[docs] Add capability to add caption under an image

### DIFF
--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -11,19 +11,17 @@ type Props = {
 
 export default function ImageSpotlight({ alt, src, style, containerStyle, caption }: Props) {
   return (
-    <figure>
-      <div
-        style={{
-          textAlign: 'center',
-          backgroundColor: theme.background.subtle,
-          paddingTop: 10,
-          paddingBottom: 10,
-          marginTop: 20,
-          marginBottom: 20,
-          ...containerStyle,
-        }}>
-        <img src={src} alt={alt} style={style} className="inline" />
-      </div>
+    <figure
+      style={{
+        textAlign: 'center',
+        backgroundColor: theme.background.subtle,
+        paddingTop: 10,
+        paddingBottom: 10,
+        marginTop: 20,
+        marginBottom: 20,
+        ...containerStyle,
+      }}>
+      <img src={src} alt={alt} style={style} className="inline" />
       {caption && (
         <figcaption
           style={{
@@ -31,7 +29,6 @@ export default function ImageSpotlight({ alt, src, style, containerStyle, captio
             fontSize: 14,
             color: theme.text.secondary,
             textAlign: 'center',
-            marginBottom: 20,
           }}>
           {caption}
         </figcaption>

--- a/docs/components/plugins/ImageSpotlight.tsx
+++ b/docs/components/plugins/ImageSpotlight.tsx
@@ -6,21 +6,36 @@ type Props = {
   style?: CSSProperties;
   containerStyle?: CSSProperties;
   src: string;
+  caption?: string;
 };
 
-export default function ImageSpotlight({ alt, src, style, containerStyle }: Props) {
+export default function ImageSpotlight({ alt, src, style, containerStyle, caption }: Props) {
   return (
-    <div
-      style={{
-        textAlign: 'center',
-        backgroundColor: theme.background.subtle,
-        paddingTop: 10,
-        paddingBottom: 10,
-        marginTop: 20,
-        marginBottom: 20,
-        ...containerStyle,
-      }}>
-      <img src={src} alt={alt} style={style} className="inline" />
-    </div>
+    <figure>
+      <div
+        style={{
+          textAlign: 'center',
+          backgroundColor: theme.background.subtle,
+          paddingTop: 10,
+          paddingBottom: 10,
+          marginTop: 20,
+          marginBottom: 20,
+          ...containerStyle,
+        }}>
+        <img src={src} alt={alt} style={style} className="inline" />
+      </div>
+      {caption && (
+        <figcaption
+          style={{
+            marginTop: 14,
+            fontSize: 14,
+            color: theme.text.secondary,
+            textAlign: 'center',
+            marginBottom: 20,
+          }}>
+          {caption}
+        </figcaption>
+      )}
+    </figure>
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10260

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Updated the ImageSpotlight component to add the capability of adding a `caption` under any image. Right now, this prop is optional. We can also use `alt` instead of `caption` here (just a suggestion). Instead of making too many changes in our docs for adding caption, I wanted to make sure the modifications in the PR are acceptable in terms of design.



# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs locally
- Go to a doc that uses `ImageSpotlight` and a `caption` prop to it. Value of this prop is a meaningful string that describes the contents of the image.

**Preview**

Here is an example of how adding caption to the `ImageSpotlight` will look. For this example, I used [Account Types](http://localhost:3002/accounts/account-types/) since that guide has a significant amount of images.

<img width="958" alt="CleanShot 2023-09-29 at 22 40 48@2x" src="https://github.com/expo/expo/assets/10234615/5fcf3ce7-23ec-4c26-a5d0-b86b20858d7f">

![CleanShot 2023-09-29 at 22 41 14@2x](https://github.com/expo/expo/assets/10234615/aae74fc2-ad4c-40a0-986b-0a70a97da801)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
