### PR TITLE
[android][file-system] fix interceptor error

### DIFF
--- a/apps/test-suite/tests/FileSystem.js
+++ b/apps/test-suite/tests/FileSystem.js
@@ -112,7 +112,7 @@ export async function test({ describe, expect, it, ...t }) {
       } catch (e) {
         error = e;
       }
-      expect(error.message).toMatch(/not exist/);
+      expect(error.message).toMatch(/could not be deleted because it could not be found/);
     });
 
     it('download(md5, uri) -> read -> delete -> !exists -> read[error]', async () => {
@@ -465,7 +465,7 @@ export async function test({ describe, expect, it, ...t }) {
         const localUri = FS.documentDirectory + 'doesnt/exists/download1.png';
         await FS.downloadAsync(remoteUrl, localUri);
       } catch (err) {
-        expect(err.message).toMatch(/Directory '.*' does not exist/);
+        expect(err.message).toMatch(/exists before calling downloadAsync/);
       }
     }, 30000);
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, use `addInterceptor` instead of `addNetworkInterceptor` in `downloadResumableStartAsync`. ([#24702](https://github.com/expo/expo/pull/24702) by [@alanhughes](https://github.com/alanjhughes))
+
 ### 💡 Others
 
 ## 15.7.0 — 2023-09-15

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -643,7 +643,7 @@ open class FileSystemModule : Module() {
         }
       }
       val client = okHttpClient?.newBuilder()
-        ?.addNetworkInterceptor { chain ->
+        ?.addInterceptor { chain ->
           val originalResponse = chain.proceed(chain.request())
           originalResponse.newBuilder()
             .body(ProgressResponseBody(originalResponse.body, progressListener))


### PR DESCRIPTION
# Why
Closes #24239
Closes ENG-10261
We should be using an application-level interceptor instead of a network-level one.

# How
Switch from `addNetworkInterceptor` to `addInterceptor`

# Test Plan
bare-expo tests are passing. Also verified in the provided repro.
