### PR TITLE
Fix findViewTag to work correctly with node handles

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
+- Fixed UIView arguments not being resolved correctly when passed in with findNodeHandle ([#24703](https://github.com/expo/expo/pull/24703) by [@javache](https://github.com/javache))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicViewType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicViewType.swift
@@ -46,11 +46,14 @@ internal struct DynamicViewType: AnyDynamicType {
 }
 
 private func findViewTag(_ value: JavaScriptValue) -> Int? {
-  if let viewTag = value as? Int {
-    return viewTag
+  if value.isNumber() {
+    return value.getInt()
   }
-  if let value = value as? JavaScriptValue, value.isObject() {
-    return value.getObject().getProperty("nativeTag").getInt()
+  if value.isObject() {
+    let nativeTag = value.getObject().getProperty("nativeTag");
+    if nativeTag.isNumber() {
+      return nativeTag.getInt()
+    }
   }
   return nil
 }

--- a/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicViewType.swift
+++ b/packages/expo-modules-core/ios/Swift/DynamicTypes/DynamicViewType.swift
@@ -50,7 +50,7 @@ private func findViewTag(_ value: JavaScriptValue) -> Int? {
     return value.getInt()
   }
   if value.isObject() {
-    let nativeTag = value.getObject().getProperty("nativeTag");
+    let nativeTag = value.getObject().getProperty("nativeTag")
     if nativeTag.isNumber() {
       return nativeTag.getInt()
     }


### PR DESCRIPTION
# Why

I was playing around with the Expo Modules API to call a native method with a view as parameter. The auto conversion didn't seem to work when `findNodeHandle` was used to pass in the integer tag representing the View in React.

# How

Fix the type-casting done in `DynamicViewType` (haven't done much Swift, but I don't think `JavaScriptValue` could ever  be `Int`?

# Test Plan

Apply changes locally, verify method with a View as parameter works correctly.

```
  AsyncFunction("destroyWindow") { (element: UIView) in
    let session = element.window?.windowScene?.session
    UIApplication.shared.requestSceneSessionDestruction(session!, options: nil)
  }.runOnQueue(DispatchQueue.main)
```

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
