### PR TITLE
[expo] Add example VS Code debugger configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ xcuserdata
 
 # VSCode
 .history/
+/vscode/launch.json
 
 # Android
 *.apk

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,55 +1,55 @@
-/** HOW TO USE THIS FILE:
-    1) Copy this file to .vscode/launch.json (remove the .example extension)
-    2) Replace path names based on your local file structure
-    3) Launch the debugger by clicking the "Debug" icon in the sidebar and selecting the config you want to run
-**/
+/*
+  HOW TO USE THIS FILE:
+  1) Copy this file to .vscode/launch.json (remove the .example extension).
+  2) Replace path names based on your local file structure.
+  3) Launch the debugger by clicking the "Debug" icon in the sidebar and selecting the config you want to run.
+*/
 {
   "configurations": [
-  {
-    // Debug the currently-open Jest test file
-    "name": "Launch Jest for Current File",
-    "request": "launch",
-    "runtimeExecutable": "yarn",
-    "runtimeArgs": [
-      // args to pass to yarn, e.g., `yarn jest --runInBand`
-      "jest",
-      "--runInBand",
-      /** Filter tests run by filename
-          ${fileBasenameNoExtension} will filter by the name of the file in the current tab
-          change this to a hardcoded name to always filter by a specific file, or remove to run all tests
+    {
+      // Debug the currently-open Jest test file
+      "name": "Launch Jest for Current File",
+      "request": "launch",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        // args to pass to yarn, e.g., `yarn jest --runInBand`
+        "jest",
+        "--runInBand",
+        /*
+        Filter tests run by filename
+        ${fileBasenameNoExtension} will filter by the name of the file in the current tab
+        change this to a hardcoded name to always filter by a specific file, or remove to run all tests
       */
-      "${fileBasenameNoExtension}"
-    ],
-    "skipFiles": [
-      "<node_internals>/**"
-    ],
-    "type": "node",
-    // replace with the path to the Expo CLI package in your local checkout
-    "cwd" : "/Users/username/path-to/expo/packages/@expo/cli",
-    "console": "integratedTerminal"
-  },
-  {
-    /** Debug the Expo CLI when it is running against a test project.
-        Starting the debugger with this config will start your locally-built Expo CLI
-        but with it's CWD as a test project of your choice.
-        Be sure to run `yarn build` in expo/packages/@expo/cli first
+        "${fileBasenameNoExtension}"
+      ],
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      // replace with the path to the Expo CLI package in your local checkout
+      "cwd": "/Users/username/path-to/expo/packages/@expo/cli",
+      "console": "integratedTerminal"
+    },
+    {
+      /*
+      Debug the Expo CLI when it is running against a test project.
+      Starting the debugger with this config will start your locally-built Expo CLI,
+      but with it's CWD as a test project of your choice.
+      Be sure to run `yarn build` in expo/packages/@expo/cli first.
     */
-    "name": "Launch Expo CLI",
-    "request": "launch",
-    "args":[
-      /** Replace with the command args you want to pass to the Expo CLI
-          e.g., `start` will run the equivablent of `npx expo start`
+      "name": "Launch Expo CLI",
+      "request": "launch",
+      "args": [
+        /*
+        Replace with the command args you want to pass to the Expo CLI,
+        e.g., `start` will run the equivablent of `npx expo start`
       */
-      "start"
-    ],
-    "program": "${workspaceFolder}/packages/@expo/cli/build/bin/cli",
-    "skipFiles": [
-      "<node_internals>/**"
-    ],
-    "type": "node",
-    // Replace with the root directory of your test project you want to run the Expo CLI against.
-    "cwd" : "/Users/username/path-to/test-project",
-    "console": "integratedTerminal"
-  },
+        "start"
+      ],
+      "program": "${workspaceFolder}/packages/@expo/cli/build/bin/cli",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node",
+      // Replace with the root directory of your test project you want to run the Expo CLI against.
+      "cwd": "/Users/username/path-to/test-project",
+      "console": "integratedTerminal"
+    }
   ]
 }

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -32,7 +32,7 @@
     /** Debug the Expo CLI when it is running against a test project.
         Starting the debugger with this config will start your locally-built Expo CLI
         but with it's CWD as a test project of your choice.
-        Be sure to run `yarn build -w` in expo/packages/@expo/cli first
+        Be sure to run `yarn build` in expo/packages/@expo/cli first
     */
     "name": "Launch Expo CLI",
     "request": "launch",

--- a/.vscode/launch.json.example
+++ b/.vscode/launch.json.example
@@ -1,0 +1,55 @@
+/** HOW TO USE THIS FILE:
+    1) Copy this file to .vscode/launch.json (remove the .example extension)
+    2) Replace path names based on your local file structure
+    3) Launch the debugger by clicking the "Debug" icon in the sidebar and selecting the config you want to run
+**/
+{
+  "configurations": [
+  {
+    // Debug the currently-open Jest test file
+    "name": "Launch Jest for Current File",
+    "request": "launch",
+    "runtimeExecutable": "yarn",
+    "runtimeArgs": [
+      // args to pass to yarn, e.g., `yarn jest --runInBand`
+      "jest",
+      "--runInBand",
+      /** Filter tests run by filename
+          ${fileBasenameNoExtension} will filter by the name of the file in the current tab
+          change this to a hardcoded name to always filter by a specific file, or remove to run all tests
+      */
+      "${fileBasenameNoExtension}"
+    ],
+    "skipFiles": [
+      "<node_internals>/**"
+    ],
+    "type": "node",
+    // replace with the path to the Expo CLI package in your local checkout
+    "cwd" : "/Users/username/path-to/expo/packages/@expo/cli",
+    "console": "integratedTerminal"
+  },
+  {
+    /** Debug the Expo CLI when it is running against a test project.
+        Starting the debugger with this config will start your locally-built Expo CLI
+        but with it's CWD as a test project of your choice.
+        Be sure to run `yarn build -w` in expo/packages/@expo/cli first
+    */
+    "name": "Launch Expo CLI",
+    "request": "launch",
+    "args":[
+      /** Replace with the command args you want to pass to the Expo CLI
+          e.g., `start` will run the equivablent of `npx expo start`
+      */
+      "start"
+    ],
+    "program": "${workspaceFolder}/packages/@expo/cli/build/bin/cli",
+    "skipFiles": [
+      "<node_internals>/**"
+    ],
+    "type": "node",
+    // Replace with the root directory of your test project you want to run the Expo CLI against.
+    "cwd" : "/Users/username/path-to/test-project",
+    "console": "integratedTerminal"
+  },
+  ]
+}


### PR DESCRIPTION
# Why
VS Code integrated debugger launch configs have to be tweaked based on your local setup, what exactly you want to test. So, you can't check in a single config that works everywhere. But, we can provide an example file with the most useful configs and gitignore the **launch.json** file itself, so you can easily copy the configs, tweak them as needed, and not worry about accidentally committing them.

# How
Added configs for debugging a Jest test and debugging the Expo CLI against a test project to a **launch.json.example** file, and gitignored **launch.json**. Added comments to describe what the values do and what must be changed for each user.

# Test Plan
- [x] Use these configs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
