### PR TITLE
[docs] Update last update date on infrastructure page

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import al from '@mdx-js/react';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **May 5, 2023**.
+> This document was last updated on **September 28, 2023**.
 
 ## Builder IP addresses
 


### PR DESCRIPTION
# Why
We just updated the iOS images for Xcode 15 (https://github.com/expo/expo/pull/24641), but the date didn't reflect that.

# How

Updated the date
