### PR TITLE
[docs] Fix Duplicate meta description tags and add any missing description

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Additional resources
+description: A reference of resources that are useful to learn about Expo tooling and services.
 ---
 
 import { Row } from 'react-grid-system';
-
 import { chunkArray } from '~/common/utilities';
 import TALKS from '~/public/static/talks';
 import { TalkGridCell, CellContainer } from '~/ui/components/Home';
@@ -34,7 +34,7 @@ The following resources are useful for learning about Expo tooling and services.
 
 ## React Native
 
-- [React Native Express](http://www.reactnativeexpress.com/) - The best way to get started with React Native! It's a walkthrough the building blocks of React and React Native.
+- [React Native Express](http://www.reactnativeexpress.com/) - The best way to get started with React Native! It's a walkthrough of the building blocks of React and React Native.
 - [Intermediate React Native](https://frontendmasters.com/courses/intermediate-react-native/) - Paid course by Frontend Masters.
 
 ## Animation and gestures

--- a/docs/pages/bare/error-recovery.mdx
+++ b/docs/pages/bare/error-recovery.mdx
@@ -1,5 +1,6 @@
 ---
 title: Error recovery
+description: Learn how to take advantage of using built-in error recovery when using expo-updates library.
 ---
 
 import { Tab, Tabs } from '~/ui/components/Tabs';

--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -1,6 +1,6 @@
 ---
 title: App stores metadata
-description: Learn how to automate and maintain your app store presence from the command line with EAS Metadata.
+description: A brief overview of how to use EAS Metadata to automate and maintain your app store presence.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -9,7 +9,7 @@ import { EasMetadataIcon, LayersTwo02Icon } from '@expo/styleguide-icons';
 
 > **warning** EAS Metadata is in beta and subject to breaking changes.
 
-When submitting your app to app stores, you need to provide metadata. This process is lengthy and is about often about complex topics that don't apply to your app. After the information you provide gets reviewed and if there is any issue with it, you need to restart this process.
+When submitting your app to app stores, you need to provide metadata. This process is lengthy and is often about complex topics that don't apply to your app. After the information you provide gets reviewed and if there is any issue with it, you need to restart this process.
 
 **EAS Metadata** enables you to automate and maintain this information from the command line instead of going through multiple forms in the app store dashboards. It can also instantly identify well-known app store restrictions that could trigger a rejection after a lengthy review queue. This guide shows how to use EAS Metadata to automate and maintain your app store presence.
 

--- a/docs/pages/develop/development-builds/next-steps.mdx
+++ b/docs/pages/develop/development-builds/next-steps.mdx
@@ -1,12 +1,11 @@
 ---
 title: Next steps
-description:
+description: A list of useful resources to learn more about developments or EAS Build.
+hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BuildIcon, BookOpen02Icon } from '@expo/styleguide-icons';
-
-The following resources are useful when learning more about development builds or EAS Build:
 
 <BoxLink
   title="Configuring EAS Build with eas.json"

--- a/docs/pages/develop/user-interface/next-steps.mdx
+++ b/docs/pages/develop/user-interface/next-steps.mdx
@@ -1,12 +1,11 @@
 ---
 title: Next steps
+description: A list of useful resources to learn more about UI.
 hideTOC: true
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Brush01Icon, Settings02Icon, TableIcon } from '@expo/styleguide-icons';
-
-The following resources are useful when learning more about User Interface.
 
 <BoxLink
   title="UI programming"

--- a/docs/pages/routing/next-steps.mdx
+++ b/docs/pages/routing/next-steps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Expo Router - Next steps
-description: The following resources are some of the hand-picked guides that will help you learn more about Expo Router.
+description: A list of hand-picked guides that will help you learn more about Expo Router.
 hideTOC: true
 sidebar_title: Next steps
 ---

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -1,5 +1,6 @@
 ---
 title: Build a screen
+description: In this tutorial, learn how to use React Native components such as Image, Pressable, and Vector icons to build a screen.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/tutorial/configuration.mdx
+++ b/docs/pages/tutorial/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure status bar, splash screen and app icon
+description: In this tutorial, learn the basics of how to configure a status bar, splash screen and app icon.
 ---
 
 import ImageSpotlight from '~/components/plugins/ImageSpotlight';

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create a modal
+description: In this tutorial, learn how to create a modal from React Native to select an image.
 ---
 
 import { SnackInline } from '~/ui/components/Snippet';

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -1,5 +1,6 @@
 ---
 title: Create your first app
+description: In this tutorial, learn how to create a new Expo project.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -1,5 +1,6 @@
 ---
 title: Learn more
+description: A list of resources to learn more about Expo and React Native.
 ---
 
 Now that the doing is done, let's fill in the gaps on the concepts that we applied.
@@ -26,11 +27,11 @@ We used Flexbox to layout our components. Check out the following recommendation
 - [Height and Width](https://reactnative.dev/docs/height-and-width)
 - [Layout with Flexbox](https://reactnative.dev/docs/flexbox)
 
-## Configuring your app with app.json
+## Configure your app with app.json
 
 You can learn more about customizing your [app icon](/develop/user-interface/app-icons/) and [splash screen](/develop/user-interface/splash-screen/) in our guides. Also, look through the [**app.json** app config reference](/workflow/configuration) for properties you can configure in this file.
 
-## Building your project into an app
+## Build your project into an app
 
 Once we've built a project we're ready to share with users, we can build it into an app. Read more about [distributing your app to stores](/deploy/build-project/) and [deploying websites](/distribution/publishing-websites).
 

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add gestures
+description: In this tutorial, learn how to implement gestures from React Native Gesture Handler and Reanimated libraries.
 ---
 
 import { SnackInline, Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -1,5 +1,6 @@
 ---
 title: Use an image picker
+description: In this tutorial, learn how to use Expo Image Picker.
 ---
 
 import { SnackInline, Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/tutorial/introduction.mdx
+++ b/docs/pages/tutorial/introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Tutorial: Introduction'
 sidebar_title: Introduction
+description: An introduction to a tutorial on how to build a universal app that runs on Android, iOS and the web using Expo.
 ---
 
 import Highlight from '~/components/plugins/Highlight';

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -1,5 +1,6 @@
 ---
 title: Handle platform differences
+description: In this tutorial, learn how to handle platform differences between native and web when creating a universal app.
 ---
 
 import { SnackInline, Terminal } from '~/ui/components/Snippet';
@@ -9,7 +10,7 @@ import { Step } from '~/ui/components/Step';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
 
-Android, iOS, and the web have different capabilities. In our case, Android and iOS both are able to capture a screenshot with the `react-native-view-shot` library, however web browsers cannot.
+Android, iOS, and the web have different capabilities. In our case, both Android and iOS can capture a screenshot with the `react-native-view-shot` library, however, web browsers cannot.
 
 In this chapter, let's learn how to make an exception for web browsers to get the same functionality on all platforms.
 

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -1,5 +1,6 @@
 ---
 title: Take a screenshot
+description: In this tutorial, learn how to capture a screenshot using a third-party library and Expo Media Library.
 ---
 
 import { SnackInline, Terminal } from '~/ui/components/Snippet';

--- a/docs/pages/versions/unversioned/config/app.mdx
+++ b/docs/pages/versions/unversioned/config/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: app.json / app.config.js
+description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+description: A reference of available configurations in Metro.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -210,7 +211,7 @@ To setup, install the `sass` package in your project:
 
 <Terminal cmd={['$ yarn add -D sass']} />
 
-Then, ensure [CSS is setup](#css) in the `metro.config.js` file.
+Then, ensure [CSS is setup](#css) in the **metro.config.js** file.
 
 - When `sass` is installed, then modules without extensions will be resolved in the following order: `scss`, `sass`, `css`.
 - Only use the intended syntax with `sass` files.
@@ -371,9 +372,9 @@ Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure nativ
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 
-### `metro.config.js`
+### metro.config.js
 
-Ensure the `metro.config.js` extends `expo/metro-config`:
+Ensure the **metro.config.js** extends `expo/metro-config`:
 
 ```js
 const { getDefaultConfig } = require('expo/metro-config');

--- a/docs/pages/versions/v46.0.0/config/app.mdx
+++ b/docs/pages/versions/v46.0.0/config/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: app.json / app.config.js
+description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 

--- a/docs/pages/versions/v46.0.0/config/metro.mdx
+++ b/docs/pages/versions/v46.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+description: A reference of available configurations in Metro.
 hideTOC: true
 ---
 

--- a/docs/pages/versions/v47.0.0/config/app.mdx
+++ b/docs/pages/versions/v47.0.0/config/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: app.json / app.config.js
+description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 

--- a/docs/pages/versions/v47.0.0/config/metro.mdx
+++ b/docs/pages/versions/v47.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+description: A reference of available configurations in Metro.
 hideTOC: true
 ---
 

--- a/docs/pages/versions/v48.0.0/config/app.mdx
+++ b/docs/pages/versions/v48.0.0/config/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: app.json / app.config.js
+description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 

--- a/docs/pages/versions/v48.0.0/config/metro.mdx
+++ b/docs/pages/versions/v48.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+description: A reference of available configurations in Metro.
 hideTOC: true
 ---
 

--- a/docs/pages/versions/v49.0.0/config/app.mdx
+++ b/docs/pages/versions/v49.0.0/config/app.mdx
@@ -1,5 +1,6 @@
 ---
 title: app.json / app.config.js
+description: A reference of available properties in Expo app config.
 maxHeadingDepth: 5
 ---
 

--- a/docs/pages/versions/v49.0.0/config/metro.mdx
+++ b/docs/pages/versions/v49.0.0/config/metro.mdx
@@ -1,5 +1,6 @@
 ---
 title: metro.config.js
+description: A reference of available configurations in Metro.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -54,7 +55,7 @@ For security purposes, client environment variables are inlined in the bundle, w
 
 > **info** CSS support is under development and currently only works on web.
 
-Expo supports CSS in your project. You can import CSS files from any component. CSS Modules are also supported. To enable CSS, configure your `metro.config.js` as follows, setting `isCSSEnabled` to `true`:
+Expo supports CSS in your project. You can import CSS files from any component. CSS Modules are also supported. To enable CSS, configure your **metro.config.js** as follows, setting `isCSSEnabled` to `true`:
 
 ```js metro.config.js
 const { getDefaultConfig } = require('expo/metro-config');
@@ -198,7 +199,7 @@ To setup, install the `sass` package in your project:
 
 <Terminal cmd={['$ yarn add -D sass']} />
 
-Then, ensure [CSS is setup](#css) in the `metro.config.js` file.
+Then, ensure [CSS is setup](#css) in the **metro.config.js** file.
 
 - When `sass` is installed, then modules without extensions will be resolved in the following order: `scss`, `sass`, `css`.
 - Only use the intended syntax with `sass` files.
@@ -340,9 +341,9 @@ Projects that don't use [Expo Prebuild](/workflow/prebuild) must configure nativ
 
 These modifications are meant to replace `npx react-native bundle` and `npx react-native start` with `npx expo export:embed` and `npx expo start` respectively.
 
-### `metro.config.js`
+### metro.config.js
 
-Ensure the `metro.config.js` extends `expo/metro-config`:
+Ensure the **metro.config.js** extends `expo/metro-config`:
 
 ```js
 const { getDefaultConfig } = require('expo/metro-config');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Closes ENG-10170

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fixed missing description tags form app config reference, metro config reference, tutorial pages, and other docs.
- Fixed typos and grammatical errors wherever necessary.
- Fixed gerunds usage in section titles for Learn more page under Tutorial

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
