### PR TITLE
[docs] Add a section for creating production builds locally

### DIFF
--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -94,6 +94,26 @@ By default, the `eas build` command will wait for your build to complete, but yo
 
 If you are a member of an organization and your build is on its behalf, you will find the build details on [the build dashboard for that account](https://expo.dev/accounts/[account]/builds).
 
+## Production builds locally
+
+To create a production build locally, see the following React Native guides for more information on the necessary steps that are required for Android and iOS.
+
+> **Note**: Following the guide below, in step four, when you build the release **.aab** for Android, use `npx expo run:android --variant release` command instead of `npx react-native build-android --mode=release`.
+
+<BoxLink
+  title="Publishing to Google Play Store"
+  description="Learn how to publish an app to Google Play Store by following the necessary steps manually."
+  Icon={BookOpen02Icon}
+  href="https://reactnative.dev/docs/signed-apk-android"
+/>
+
+<BoxLink
+  title="Publishing to Apple App Store"
+  description="Learn how to publish an app to Apple App Store by following the necessary steps manually."
+  Icon={BookOpen02Icon}
+  href="https://reactnative.dev/docs/publishing-to-app-store"
+/>
+
 ## Next steps
 
 <BoxLink

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -16,7 +16,7 @@ Whether you have built a native app binary using [EAS](/build/setup/) or [locall
 
 Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight.
 
-## Production builds for EAS
+## Production builds using EAS
 
 Production builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -12,11 +12,13 @@ import { BuildIcon, EasSubmitIcon, EasMetadataIcon, BookOpen02Icon } from '@expo
 
 Whether you have built a native app binary using [EAS](/build/setup/) or [locally](/guides/local-app-development/), the next step in your app development journey is to submit your app to the stores. To do so, you need to create a **production build**.
 
-## Production builds
+## What is a production build
 
 Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight.
 
-These builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
+## Production builds for EAS
+
+Production builds must be installed through their respective app stores. They cannot be installed directly on your Android Emulator or device, or iOS Simulator or device. The only exception to this is if you explicitly set `"buildType": "apk"` for Android on your build profile. However, it is recommended to use **aab** when submitting to stores, and this is the default configuration.
 
 ### `eas.json` configuration
 
@@ -77,12 +79,12 @@ Whether you have experience with generating app signing credentials or not, EAS 
 ### Android app signing credentials
 
 - If you have not yet generated a keystore for your app, you can let EAS CLI take care of that for you by selecting `Generate new keystore`, and then you are done. The keystore is stored securely on EAS servers.
-- If you want to manually generate your keystore, please see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
+- If you want to manually generate your keystore, see the [manual Android credentials guide](/app-signing/local-credentials#android-credentials) for more information.
 
 ### iOS app signing credentials
 
 - If you have not generated a provisioning profile and/or distribution certificate yet, you can let EAS CLI take care of that for you by signing into your Apple Developer Program account and following the prompts.
-- If you want to rather manually generate your credentials, refer to the [manual iOS credentials guide](/app-signing/local-credentials#ios-credentials) for more information.
+- If you want to manually generate your credentials, see the [manual iOS credentials guide](/app-signing/local-credentials#ios-credentials) for more information.
 
 ## Wait for the build to complete
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -12,9 +12,7 @@ import { BuildIcon, EasSubmitIcon, EasMetadataIcon, BookOpen02Icon } from '@expo
 
 Whether you have built a native app binary using [EAS](/build/setup/) or [locally](/guides/local-app-development/), the next step in your app development journey is to submit your app to the stores. To do so, you need to create a **production build**.
 
-## What is a production build
-
-Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight.
+Production builds are submitted to app stores for release to the general public or as part of a store-facilitated testing process such as TestFlight. This guide explains how to create production builds with [EAS](#production-builds-using-eas) and [locally](#production-builds-locally). It is also possible to create production builds for Expo apps with any CI service capable of compiling Android and iOS apps.
 
 ## Production builds using EAS
 
@@ -97,6 +95,8 @@ If you are a member of an organization and your build is on its behalf, you will
 ## Production builds locally
 
 To create a production build locally, see the following React Native guides for more information on the necessary steps that are required for Android and iOS.
+
+These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate them before following these guides.
 
 > **Note**: Following the guide below, in step four, when you build the release **.aab** for Android, use `npx expo run:android --variant release` command instead of `npx react-native build-android --mode=release`.
 

--- a/docs/pages/deploy/build-project.mdx
+++ b/docs/pages/deploy/build-project.mdx
@@ -96,7 +96,7 @@ If you are a member of an organization and your build is on its behalf, you will
 
 To create a production build locally, see the following React Native guides for more information on the necessary steps that are required for Android and iOS.
 
-These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate them before following these guides.
+These guides assume your project has **android** and/or **ios** directories containing the respective native projects. If you use [Continuous Native Generation](/workflow/continuous-native-generation) then you will need to run [prebuild](/workflow/prebuild) to generate the directories before following the guides.
 
 > **Note**: Following the guide below, in step four, when you build the release **.aab** for Android, use `npx expo run:android --variant release` command instead of `npx react-native build-android --mode=release`.
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -241,8 +241,8 @@ To learn more about how compilation and prebuild works, see the following guides
 ## Next steps
 
 <BoxLink
-  title="Production builds"
+  title="Production builds locally"
   description="Learn how to create a production build for your app that is ready to be submitted to app stores."
-  href="/deploy/build-project/"
+  href="/deploy/build-project/#production-builds-locally"
   Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, in the Production build guide, we do not share info on how to generate production builds locally.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR
- Adds a new section on how to create a production build locally and provide links to React Native docs for both Android and iOS.
- Also, splits the first section into two: What is a  production build and Production builds using EAS
- Fix verbiage issues as per our writing style guide
- Update BoxLink in Local app development guide to redirect to Production build locally section

**Preview**

![CleanShot 2023-10-04 at 01 39 40](https://github.com/expo/expo/assets/10234615/11b94512-2d70-405e-9c09-edbb8bac4b18)


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/deploy/build-project/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
