### PR TITLE
[docs] Fix section headers and usage of product/service in Use Bun guide

### DIFF
--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -83,9 +83,9 @@ Then, remove your lockfile and re-install the dependencies:
 
 <Terminal cmd={['$ rm -rf node_modules', '$ rm bun.lockb', '$ bun install']} />
 
-## Common Errors
+## Common errors
 
-### EAS build fails when using Sentry and Bun
+### EAS Build fails when using Sentry and Bun
 
 If you're using `sentry-expo` or `@sentry/react-native`, these depend on `@sentry/cli`, which updates source maps to Sentry during your build. The `@sentry/cli` package has a `postinstall` script which needs to run for the "upload source maps" script to become available.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up to #24710 as I missed a couple: sentence case in a section title and usage of service.

# How

<!--
How did you build this feature or fix this bug and why?
-->

This PR fixes the above mentioned issues.

**Preview**

![CleanShot 2023-10-04 at 03 20 57](https://github.com/expo/expo/assets/10234615/d20f71e3-4d84-4748-9da1-b8c36c647302)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/using-bun/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
