### PR TITLE
Shim `react-native-web` BackHandler to remove excessive error message.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Automatically optimize transformations based on Hermes usage. ([#24672](https://github.com/expo/expo/pull/24672) by [@EvanBacon](https://github.com/EvanBacon))
+- Shim `react-native-web` BackHandler to remove excessive error message.
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Automatically optimize transformations based on Hermes usage. ([#24672](https://github.com/expo/expo/pull/24672) by [@EvanBacon](https://github.com/EvanBacon))
-- Shim `react-native-web` BackHandler to remove excessive error message.
+- Shim `react-native-web` BackHandler to remove excessive error message. ([#24726](https://github.com/expo/expo/pull/24726) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -196,6 +196,8 @@ export function withExtendedResolver(
 
   let nodejsSourceExtensions: string[] | null = null;
 
+  const shimsFolder = path.join(require.resolve('@expo/cli/package.json'), '..', 'static/shims');
+
   return withMetroResolvers(config, projectRoot, [
     // Add a resolver to alias the web asset resolver.
     (immutableContext: ResolutionContext, moduleName: string, platform: string | null) => {
@@ -372,6 +374,23 @@ export function withExtendedResolver(
         ) {
           // @ts-expect-error: `readonly` for some reason.
           result.filePath = reactNativeWebAppContainer;
+        } else if (platform === 'web' && result.filePath.includes('node_modules')) {
+          // Replace with static shims
+
+          let normalName = normalizeSlashes(result.filePath);
+          // Drop everything up until the `node_modules` folder.
+          normalName = normalName.replace(/.*node_modules\//, '');
+
+          const shimPath = path.join(shimsFolder, normalName);
+          // console.log('normal:', normalName);
+          if (fs.existsSync(shimPath)) {
+            console.log('Using shim for:', result.filePath);
+            // @ts-expect-error: `readonly` for some reason.
+            result.filePath = shimPath;
+          }
+          if (normalName.includes('BackHandler')) {
+            console.log('shim', shimPath, normalName, result.filePath);
+          }
         }
       }
       return result;

--- a/packages/@expo/cli/static/shims/react-native-web/dist/cjs/exports/BackHandler/index.js
+++ b/packages/@expo/cli/static/shims/react-native-web/dist/cjs/exports/BackHandler/index.js
@@ -1,0 +1,10 @@
+'use strict';
+function emptyFunction() {}
+(exports.__esModule = !0), (exports.default = void 0);
+var BackHandler = {
+    exitApp: emptyFunction,
+    addEventListener: () => ({ remove: emptyFunction }),
+    removeEventListener: emptyFunction,
+  },
+  _default = BackHandler;
+(exports.default = _default), (module.exports = exports.default);

--- a/packages/@expo/cli/static/shims/react-native-web/dist/exports/BackHandler/index.js
+++ b/packages/@expo/cli/static/shims/react-native-web/dist/exports/BackHandler/index.js
@@ -1,0 +1,7 @@
+function emptyFunction() {}
+var BackHandler = {
+  exitApp: emptyFunction,
+  addEventListener: () => ({ remove: emptyFunction }),
+  removeEventListener: emptyFunction,
+};
+export default BackHandler;


### PR DESCRIPTION
# Why

- The `BackHandler is deprecated` error message is not helpful and shows up in every project. This change will shim the file to prevent the error from showing.
