### PR TITLE
[expo-image] [ENG-10268] support tintColor for SVGs on Android

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Added support for the `headers` key in the `source` object on web. ([#24447](https://github.com/expo/expo/pull/24447) by [@aleqsio](https://github.com/aleqsio))
+- Add support for setting `tintColor` on SVGs on Android ([#24733](https://github.com/expo/expo/pull/24733) by [@alanjhughes](https://github.com/alanjhughes) and [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDecoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDecoder.kt
@@ -4,7 +4,6 @@ import com.bumptech.glide.load.Options
 import com.bumptech.glide.load.ResourceDecoder
 import com.bumptech.glide.load.engine.Resource
 import com.bumptech.glide.load.resource.SimpleResource
-import com.bumptech.glide.request.target.Target.SIZE_ORIGINAL
 import com.caverock.androidsvg.SVG
 import com.caverock.androidsvg.SVGParseException
 import java.io.IOException
@@ -24,12 +23,6 @@ class SVGDecoder : ResourceDecoder<InputStream, SVG> {
   override fun decode(source: InputStream, width: Int, height: Int, options: Options): Resource<SVG>? {
     return try {
       val svg: SVG = SVG.getFromInputStream(source)
-      if (width != SIZE_ORIGINAL) {
-        svg.documentWidth = width.toFloat()
-      }
-      if (height != SIZE_ORIGINAL) {
-        svg.documentHeight = height.toFloat()
-      }
       SimpleResource(svg)
     } catch (ex: SVGParseException) {
       throw IOException("Cannot load SVG from stream", ex)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDrawableTranscoder.kt
@@ -1,6 +1,10 @@
 package expo.modules.image.svg
 
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Picture
+import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.PictureDrawable
 import com.bumptech.glide.load.Options
@@ -15,10 +19,19 @@ import com.caverock.androidsvg.SVG
  * Copied from https://github.com/bumptech/glide/blob/10acc31a16b4c1b5684f69e8de3117371dfa77a8/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgDrawableTranscoder.java
  * and rewritten to Kotlin.
  */
-class SVGDrawableTranscoder : ResourceTranscoder<SVG?, Drawable> {
+class SVGDrawableTranscoder(val context: Context) : ResourceTranscoder<SVG?, Drawable> {
   override fun transcode(toTranscode: Resource<SVG?>, options: Options): Resource<Drawable> {
     val picture = toTranscode.get().renderToPicture()
-    val drawable: Drawable = PictureDrawable(picture)
-    return SimpleResource(drawable)
+    val drawable = PictureDrawable(picture)
+    val width = drawable.intrinsicWidth
+    val height = drawable.intrinsicHeight
+
+    val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val canvas = Canvas(bitmap)
+    drawable.setBounds(0, 0, canvas.width, canvas.height)
+    drawable.draw(canvas)
+
+    val newDrawable = BitmapDrawable(context.resources, bitmap)
+    return SimpleResource(newDrawable)
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGModule.kt
@@ -21,6 +21,6 @@ class SVGModule : LibraryGlideModule() {
     super.registerComponents(context, glide, registry)
     registry
       .append(InputStream::class.java, SVG::class.java, SVGDecoder())
-      .register(SVG::class.java, Drawable::class.java, SVGDrawableTranscoder())
+      .register(SVG::class.java, Drawable::class.java, SVGDrawableTranscoder(context))
   }
 }


### PR DESCRIPTION
# Why

This is actually a new feature. We've not supported `tintColor` on SVGs before, but iOS support was added [recently](https://github.com/expo/expo/pull/23418). This will add Android support. 

# How

SVG on Android needs to be converted into a format that supports `tintColor`.

# Test Plan

Test on Bare Expo.

| Before      | After |
| ----------- | ----------- |
| <img width="419" alt="Screenshot 2023-10-04 at 15 28 43" src="https://github.com/expo/expo/assets/6534400/4dce40df-8b38-4b0a-9c58-3efa4b09805b"> | <img width="419" alt="Screenshot 2023-10-04 at 15 56 01" src="https://github.com/expo/expo/assets/6534400/b2e1ffb1-f0ab-4647-aac6-af2717e64561"> |

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
