### PR TITLE
chore(template): fix rehydration errors in tabs template

### DIFF
--- a/templates/expo-template-tabs/app/(tabs)/_layout.tsx
+++ b/templates/expo-template-tabs/app/(tabs)/_layout.tsx
@@ -1,12 +1,13 @@
+import React from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
 import { Link, Tabs } from 'expo-router';
-import { Pressable, useColorScheme } from 'react-native';
+import { Pressable } from 'react-native';
 
 import Colors from '@/constants/Colors';
+import { useColorScheme } from '@/components/useColorScheme';
+import { useClientOnlyValue } from '@/components/useClientOnlyValue';
 
-/**
- * You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
- */
+// You can explore the built-in icon families and icons on the web at https://icons.expo.fyi/
 function TabBarIcon(props: {
   name: React.ComponentProps<typeof FontAwesome>['name'];
   color: string;
@@ -21,6 +22,9 @@ export default function TabLayout() {
     <Tabs
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+        // Disable the static render of the header on web
+        // to prevent a hydration error in React Navigation v6.
+        headerShown: useClientOnlyValue(false, true),
       }}>
       <Tabs.Screen
         name="index"

--- a/templates/expo-template-tabs/app/_layout.tsx
+++ b/templates/expo-template-tabs/app/_layout.tsx
@@ -3,7 +3,8 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { useFonts } from 'expo-font';
 import { SplashScreen, Stack } from 'expo-router';
 import { useEffect } from 'react';
-import { useColorScheme } from 'react-native';
+
+import { useColorScheme } from '@/components/useColorScheme';
 
 export {
   // Catch any errors thrown by the Layout component.

--- a/templates/expo-template-tabs/components/Themed.tsx
+++ b/templates/expo-template-tabs/components/Themed.tsx
@@ -3,9 +3,10 @@
  * https://docs.expo.io/guides/color-schemes/
  */
 
-import { Text as DefaultText, useColorScheme, View as DefaultView } from 'react-native';
+import { Text as DefaultText, View as DefaultView } from 'react-native';
 
 import Colors from '@/constants/Colors';
+import { useColorScheme } from './useColorScheme';
 
 type ThemeProps = {
   lightColor?: string;

--- a/templates/expo-template-tabs/components/useClientOnlyValue.ts
+++ b/templates/expo-template-tabs/components/useClientOnlyValue.ts
@@ -1,0 +1,4 @@
+// This function is web-only as native doesn't currently support server (or build-time) rendering.
+export function useClientOnlyValue<S, C>(server: S, client: C): S | C {
+  return client;
+}

--- a/templates/expo-template-tabs/components/useClientOnlyValue.web.ts
+++ b/templates/expo-template-tabs/components/useClientOnlyValue.web.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+// `useEffect` is not invoked during server rendering, meaning
+// we can use this to determine if we're on the server or not.
+export function useClientOnlyValue<S, C>(server: S, client: C): S | C {
+  const [value, setValue] = React.useState<S | C>(server);
+  React.useEffect(() => {
+    setValue(client);
+  }, [client]);
+
+  return value;
+}

--- a/templates/expo-template-tabs/components/useColorScheme.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.ts
@@ -1,0 +1,1 @@
+export { useColorScheme } from 'react-native';

--- a/templates/expo-template-tabs/components/useColorScheme.web.ts
+++ b/templates/expo-template-tabs/components/useColorScheme.web.ts
@@ -1,0 +1,8 @@
+// NOTE: The default React Native styling doesn't support server rendering.
+// Server rendered styles should not change between the first render of the HTML
+// and the first render on the client. Typically, web developers will use CSS media queries
+// to render different styles on the client and server, these aren't directly supported in React Native
+// but can be achieved using a styling library like Nativewind.
+export function useColorScheme() {
+  return 'light';
+}


### PR DESCRIPTION
# Why

- This change ensures there are no hydration errors in the tabs template when using Expo Router v3.
- I considered using some web-only CSS modules but that wouldn't work with React Navigation's theme provider.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Disable appearance-based styles on web.
- Disable the React Navigation header for the initial render on web.
- Annotate the changes.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Open on web and force reload each page to ensure no errors are thrown. Inspecting the page source should show most of the HTML is rendered ahead of time.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
