### PR TITLE
[core][Android] Fix typed arrays couldn't be returned from synchronous functions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed typed arrays couldn't be returned from synchronous functions.
+- Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed typed arrays couldn't be returned from synchronous functions.
+
 ### 💡 Others
 
 - Improve tracking on Android. ([#24625](https://github.com/expo/expo/pull/24625) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.typedarray.Float32Array
 import expo.modules.kotlin.typedarray.Int32Array
 import expo.modules.kotlin.typedarray.Int8Array
+import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -339,6 +340,25 @@ class JSIFunctionsTest {
     }
   ) {
     evaluateScript("expo.modules.TestModule.f(new Int32Array([1,2,3]), new Float32Array([1.0,2.0,3.0]), new Int8Array([1,2,3]))")
+  }
+
+  @Test
+  fun typed_arrays_should_be_returnable() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("genericTypedArray") { typedArray: TypedArray ->
+        typedArray
+      }
+      Function("intTypedArray") { typedArray: Int32Array ->
+        typedArray
+      }
+    }
+  ) {
+    val isArray = evaluateScript("expo.modules.TestModule.genericTypedArray(new Int32Array([1,2,3]))").isTypedArray()
+    val isArray2 = evaluateScript("expo.modules.TestModule.intTypedArray(new Int32Array([1,2,3]))").isTypedArray()
+
+    Truth.assertThat(isArray).isTrue()
+    Truth.assertThat(isArray2).isTrue()
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.cpp
@@ -83,7 +83,7 @@ jsi::Value convert(
   }
   if (env->IsInstanceOf(
     unpackedValue,
-    JavaReferencesCache::instance()->getJClass(
+    cache->getJClass(
       "expo/modules/kotlin/sharedobjects/SharedObject").clazz
   )) {
     auto jsObject = std::make_shared<jsi::Object>(jsi::Object(rt));
@@ -94,6 +94,14 @@ jsi::Value convert(
     );
     moduleRegistry->registerSharedObject(jni::make_local(unpackedValue), jsObjectRef);
     return jsi::Value(rt, *jsObject);
+  }
+  if (env->IsInstanceOf(
+    unpackedValue,
+    cache->getJClass("expo/modules/kotlin/jni/JavaScriptTypedArray").clazz
+  )) {
+    auto typedArray = jni::static_ref_cast<JavaScriptTypedArray::javaobject>(value);
+    auto jsTypedArray = typedArray->cthis()->get();
+    return jsi::Value(rt, *jsTypedArray);
   }
 
   return jsi::Value::undefined();

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/typedarray/ConcreteTypedArrays.kt
@@ -9,8 +9,12 @@ private inline fun TypedArray.checkIfInRange(index: Int) {
   }
 }
 
-class Int8Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Byte> {
+interface RawTypedArrayHolder {
+  val rawArray: JavaScriptTypedArray
+}
+
+class Int8Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Byte>, RawTypedArrayHolder {
   override operator fun get(index: Int): Byte {
     checkIfInRange(index)
     return readByte(index * Byte.SIZE_BYTES)
@@ -22,8 +26,8 @@ class Int8Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Int16Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Short> {
+class Int16Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Short>, RawTypedArrayHolder {
   override operator fun get(index: Int): Short {
     checkIfInRange(index)
     return read2Byte(index * Short.SIZE_BYTES)
@@ -35,8 +39,8 @@ class Int16Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Int32Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Int> {
+class Int32Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Int>, RawTypedArrayHolder {
   override operator fun get(index: Int): Int {
     checkIfInRange(index)
     return read4Byte(index * Int.SIZE_BYTES)
@@ -48,8 +52,8 @@ class Int32Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Uint8Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<UByte> {
+class Uint8Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<UByte>, RawTypedArrayHolder {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index * UByte.SIZE_BYTES).toUByte()
@@ -61,8 +65,8 @@ class Uint8Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<UByte> {
+class Uint8ClampedArray(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<UByte>, RawTypedArrayHolder {
   override operator fun get(index: Int): UByte {
     checkIfInRange(index)
     return readByte(index * UByte.SIZE_BYTES).toUByte()
@@ -74,8 +78,8 @@ class Uint8ClampedArray(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Uint16Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<UShort> {
+class Uint16Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<UShort>, RawTypedArrayHolder {
   override operator fun get(index: Int): UShort {
     checkIfInRange(index)
     return read2Byte(index * UShort.SIZE_BYTES).toUShort()
@@ -87,8 +91,8 @@ class Uint16Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Uint32Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<UInt> {
+class Uint32Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<UInt>, RawTypedArrayHolder {
   override operator fun get(index: Int): UInt {
     checkIfInRange(index)
     return read4Byte(index * UInt.SIZE_BYTES).toUInt()
@@ -100,8 +104,8 @@ class Uint32Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Float32Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Float> {
+class Float32Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Float>, RawTypedArrayHolder {
   override operator fun get(index: Int): Float {
     checkIfInRange(index)
     return readFloat(index * Float.SIZE_BYTES)
@@ -113,8 +117,8 @@ class Float32Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class Float64Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Double> {
+class Float64Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Double>, RawTypedArrayHolder {
 
   override operator fun get(index: Int): Double {
     checkIfInRange(index)
@@ -127,8 +131,8 @@ class Float64Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<Long> {
+class BigInt64Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<Long>, RawTypedArrayHolder {
   override operator fun get(index: Int): Long {
     checkIfInRange(index)
     return read8Byte(index * Long.SIZE_BYTES)
@@ -140,8 +144,8 @@ class BigInt64Array(private val rawArray: JavaScriptTypedArray) :
   }
 }
 
-class BigUint64Array(private val rawArray: JavaScriptTypedArray) :
-  TypedArray by rawArray, GenericTypedArray<ULong> {
+class BigUint64Array(override val rawArray: JavaScriptTypedArray) :
+  TypedArray by rawArray, GenericTypedArray<ULong>, RawTypedArrayHolder {
   override operator fun get(index: Int): ULong {
     checkIfInRange(index)
     return read8Byte(index * ULong.SIZE_BYTES).toULong()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.typedarray.RawTypedArrayHolder
 import java.io.File
 import java.net.URI
 import java.net.URL
@@ -25,7 +26,6 @@ object JSTypeConverter {
     return when (value) {
       null, is Unit -> null
       is Bundle -> value.toJSValue(containerProvider)
-      is Iterable<*> -> value.toJSValue(containerProvider)
       is Array<*> -> value.toJSValue(containerProvider)
       is IntArray -> value.toJSValue(containerProvider)
       is FloatArray -> value.toJSValue(containerProvider)
@@ -40,6 +40,8 @@ object JSTypeConverter {
       is File -> value.toJSValue()
       is Pair<*, *> -> value.toJSValue(containerProvider)
       is Long -> value.toDouble()
+      is RawTypedArrayHolder -> value.rawArray
+      is Iterable<*> -> value.toJSValue(containerProvider)
       else -> value
     }
   }


### PR DESCRIPTION
# Why

Add the ability to return typed arrays from sync functions. So code like this:
![image](https://github.com/expo/expo/assets/9578601/973bdf49-9936-4d42-9d83-338958ece44a)
should work. 

# How 

Add missing conversion. 

# Test Plan

- e2e tests ✅