### PR TITLE
[docs] Add description tag to pages where it is missing

### DIFF
--- a/docs/pages/regulatory-compliance/data-and-privacy-protection.mdx
+++ b/docs/pages/regulatory-compliance/data-and-privacy-protection.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data and Privacy protection
+description: An overview of data and privacy protection policies that Expo offers.
 hideTOC: true
 ---
 

--- a/docs/pages/regulatory-compliance/gdpr.mdx
+++ b/docs/pages/regulatory-compliance/gdpr.mdx
@@ -1,5 +1,6 @@
 ---
 title: GDPR compliance and Expo
+description: Learn about how applications built with Expo can be GDPR compliant.
 sidebar_title: GDPR compliance
 hideTOC: true
 ---

--- a/docs/pages/regulatory-compliance/hipaa.mdx
+++ b/docs/pages/regulatory-compliance/hipaa.mdx
@@ -2,6 +2,7 @@
 title: HIPAA compliance and Expo
 sidebar_title: HIPAA compliance
 hideTOC: true
+description: Learn about how applications built with Expo can be HIPAA compliant.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';

--- a/docs/pages/regulatory-compliance/privacy-shield.mdx
+++ b/docs/pages/regulatory-compliance/privacy-shield.mdx
@@ -1,5 +1,6 @@
 ---
 title: Privacy Shield and Expo
+description: Expo is Privacy Shield certified and learn about your rights as a user when using Expo.
 sidebar_title: Privacy Shield
 hideTOC: true
 ---
@@ -8,7 +9,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 ## Is Expo Privacy Shield certified?
 
-**Yes! [Here](https://www.privacyshield.gov/participant?id=a2zt00000004ooyAAA&status=Active) is our Privacy Shield participant page**
+**Yes! [Here](https://www.privacyshield.gov/participant?id=a2zt00000004ooyAAA&status=Active) is our Privacy Shield participant page**.
 
 Because we are Privacy Shield certified, all of our users have the right to obtain our confirmation of whether we maintain personal information relating to you, and the right to access, correct, amend, or delete that data. Any requests for alteration of data should be sent to secure@expo.dev, and all requests **must come from the email associated with that Expo account**.
 

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -1,5 +1,6 @@
 ---
 title: '"Application has not been registered" error'
+description: Learn about what the Application has not been registered error means and measures you can take to resolve it when using Expo.
 ---
 
 When developing an Expo or React Native app, it's not uncommon to run into an error that looks like:

--- a/docs/pages/troubleshooting/application-has-not-been-registered.mdx
+++ b/docs/pages/troubleshooting/application-has-not-been-registered.mdx
@@ -1,21 +1,21 @@
 ---
 title: '"Application has not been registered" error'
-description: Learn about what the Application has not been registered error means and measures you can take to resolve it when using Expo.
+description: Learn about what the Application has not been registered error means and how to resolve it in an Expo or React Native app.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 When developing an Expo or React Native app, it's not uncommon to run into an error that looks like:
 
-```
-Application "main" has not been registered.
-```
+<Terminal
+  cmd={[
+    'Application "main" has not been registered.',
+    '# Or',
+    'Invariant Violation: "main" has not been registered.',
+  ]}
+/>
 
-or
-
-```
-Invariant Violation: "main" has not been registered.
-```
-
-Where "main" can be any string.
+In this particular error, `"main"` can be any string.
 
 ## What this error means
 
@@ -34,7 +34,7 @@ Look at your logs before this error message to see what may have caused it. A fr
 
 Another possibility is that there is a mismatch between the `AppKey` being provided to [`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent), and the `AppKey` being registered on the native iOS or Android side.
 
-In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for your automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, please refer to the [registerRootComponent](/versions/latest/sdk/register-root-component.mdx) API reference.
+In managed projects, the default behavior is to use "main" as the `AppKey`. This is handled for you automatically, and as long as you don't change the `"main"` field in your **package.json** from the default value then this will just work. If you want to customize the app entry point, please refer to the [registerRootComponent](/versions/latest/sdk/register-root-component) API reference.
 
 In projects with native code, you will see something like this in your **index.js** by default:
 
@@ -67,7 +67,7 @@ protected String getMainComponentName() {
 }
 ```
 
-By default, "main" is consistently used throughout the project. If you're running into this error, it's likely that something has been changed and these values no longer coincide. Ensure that the names you are registering on the JavaScript side are the ones expected on the native side (if you're using Expo's `registerRootComponent` function, that would be "main").
+By default, "main" is consistently used throughout the project. If you're running into this error, something has likely changed and these values no longer coincide. Ensure that the names you are registering on the JavaScript side are the ones expected on the native side (if you're using Expo's `registerRootComponent` function, that would be "main").
 
 ## Other considerations
 

--- a/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
+++ b/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
@@ -1,5 +1,6 @@
 ---
 title: Clearing bundler caches on macOS and Linux
+description: Learn about the measures you can take to clear bundler caches on macOS and Linux when using Expo.
 ---
 
 > Need to clear development caches on Windows? [Find the relevant commands here.](clear-cache-windows.mdx)

--- a/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
+++ b/docs/pages/troubleshooting/clear-cache-macos-linux.mdx
@@ -1,7 +1,9 @@
 ---
-title: Clearing bundler caches on macOS and Linux
-description: Learn about the measures you can take to clear bundler caches on macOS and Linux when using Expo.
+title: Clear bundler caches on macOS and Linux
+description: Learn how to clear the bundler when using Yarn or npm with Expo CLI or React Native CLI on macOS and Linux.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 > Need to clear development caches on Windows? [Find the relevant commands here.](clear-cache-windows.mdx)
 
@@ -9,55 +11,87 @@ There are a number of different caches associated with your project that can pre
 
 To clear the various caches, run:
 
-### Expo CLI and Yarn
+## Expo CLI and Yarn
 
-```sh
-rm -rf node_modules # With Yarn workspaces, you may need to
-                    # delete node_modules in each workspace
-yarn cache clean
-yarn
-watchman watch-del-all
-rm -fr $TMPDIR/haste-map-*
-rm -rf $TMPDIR/metro-cache
-expo start --clear
-```
+<Terminal
+  cmd={[
+    '# With Yarn workspaces, you may need to delete node_modules in each workspace',
+    '$ rm -rf node_modules',
+    '',
+    '$ yarn cache clean',
+    '',
+    '$ yarn',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ rm -fr $TMPDIR/haste-map-*',
+    '',
+    '$ rm -rf $TMPDIR/metro-cache',
+    '',
+    '$ npx expo start --clear',
+  ]}
+/>
 
-### Expo CLI and npm
+## Expo CLI and npm
 
-```sh
-rm -rf node_modules
-npm cache clean --force
-npm install
-watchman watch-del-all
-rm -fr $TMPDIR/haste-map-*
-rm -rf $TMPDIR/metro-cache
-expo start --clear
-```
+<Terminal
+  cmd={[
+    '$ rm -rf node_modules',
+    '',
+    '$ npm cache clean --force',
+    '',
+    '$ npm install',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ rm -fr $TMPDIR/haste-map-*',
+    '',
+    '$ rm -rf $TMPDIR/metro-cache',
+    '',
+    '$ npx expo start --clear',
+  ]}
+/>
 
-### React Native CLI and Yarn
+## React Native CLI and Yarn
 
-```sh
-rm -rf node_modules # With Yarn workspaces, you may need to
-                    # delete node_modules in each workspace
-yarn cache clean
-yarn
-watchman watch-del-all
-rm -fr $TMPDIR/haste-map-*
-rm -rf $TMPDIR/metro-cache
-yarn start -- --reset-cache
-```
+<Terminal
+  cmd={[
+    '# With Yarn workspaces, you may need to delete node_modules in each workspace',
+    '$ rm -rf node_modules',
+    '',
+    '$ yarn cache clean',
+    '',
+    '$ yarn',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ rm -fr $TMPDIR/haste-map-*',
+    '',
+    '$ rm -rf $TMPDIR/metro-cache',
+    '',
+    '$ yarn start -- --reset-cache',
+  ]}
+/>
 
-### React Native CLI and npm
+## React Native CLI and npm
 
-```sh
-rm -rf node_modules
-npm cache clean --force
-npm install
-watchman watch-del-all
-rm -fr $TMPDIR/haste-map-*
-rm -rf $TMPDIR/metro-cache
-npm start -- --reset-cache
-```
+<Terminal
+  cmd={[
+    '$ rm -rf node_modules',
+    '',
+    '$ npm cache clean --force',
+    '',
+    '$ npm install',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ rm -fr $TMPDIR/haste-map-*',
+    '',
+    '$ rm -rf $TMPDIR/metro-cache',
+    '',
+    '$ npm start -- --reset-cache',
+  ]}
+/>
 
 ## What these commands are doing
 

--- a/docs/pages/troubleshooting/clear-cache-windows.mdx
+++ b/docs/pages/troubleshooting/clear-cache-windows.mdx
@@ -1,5 +1,6 @@
 ---
 title: Clearing bundler caches on Windows
+description: Learn about the measures you can take to clear bundler caches on Windows when using Expo.
 ---
 
 > Need to clear development caches on macOS or Linux? [Find the relevant commands here.](clear-cache-macos-linux.mdx)

--- a/docs/pages/troubleshooting/clear-cache-windows.mdx
+++ b/docs/pages/troubleshooting/clear-cache-windows.mdx
@@ -1,61 +1,99 @@
 ---
-title: Clearing bundler caches on Windows
-description: Learn about the measures you can take to clear bundler caches on Windows when using Expo.
+title: Clear bundler caches on Windows
+description: Learn how to create the bundler cache when using Yarn or npm with Expo CLI or React Native CLI on Windows.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 > Need to clear development caches on macOS or Linux? [Find the relevant commands here.](clear-cache-macos-linux.mdx)
 
 There are a number of different caches associated with your project that can prevent your project from running as intended. Clearing a cache sometimes can help you work around issues related to stale or corrupt data and is often useful when troubleshooting and debugging.
 
-### Expo CLI and Yarn
+## Expo CLI and Yarn
 
-```
-del node_modules &:: With Yarn workspaces, you may need to
-                 &:: delete node_modules in each workspace
-yarn cache clean
-yarn
-watchman watch-del-all
-del %localappdata%\Temp\haste-map-*
-del %localappdata%\Temp\metro-cache
-expo start --clear
-```
+{/* prettier-ignore */}
+<Terminal
+  cmd={[
+    '# With Yarn workspaces, you may need to delete node_modules in each workspace',
+    '$ rm -rf node_modules',
+    '',
+    '$ yarn cache clean',
+    '',
+    '$ yarn',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ del %localappdata%\Temp\haste-map-*',
+    '',
+    '$ del %localappdata%\Temp\metro-cache',
+    '',
+    '$ npx expo start --clear',
+  ]}
+/>
 
-### Expo CLI and npm
+## Expo CLI and npm
 
-```
-del node_modules
-npm cache clean --force
-npm install
-watchman watch-del-all
-del %localappdata%\Temp\haste-map-*
-del %localappdata%\Temp\metro-cache
-expo start --clear
-```
+{/* prettier-ignore */}
+<Terminal
+  cmd={[
+    '$ rm -rf node_modules',
+    '',
+    '$ npm cache clean --force',
+    '',
+    '$ npm install',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ del %localappdata%\Temp\haste-map-*',
+    '',
+    '$ del %localappdata%\Temp\metro-cache',
+    '',
+    '$ npx expo start --clear',
+  ]}
+/>
 
-### React Native CLI and Yarn
+## React Native CLI and Yarn
 
-```
-del node_modules &:: With Yarn workspaces, you may need to
-                 &:: delete node_modules in each workspace
-yarn cache clean
-yarn
-watchman watch-del-all
-del %localappdata%\Temp\haste-map-*
-del %localappdata%\Temp\metro-cache
-yarn start -- --reset-cache
-```
+{/* prettier-ignore */}
+<Terminal
+  cmd={[
+    '# With Yarn workspaces, you may need to delete node_modules in each workspace',
+    '$ rm -rf node_modules',
+    '',
+    '$ yarn cache clean',
+    '',
+    '$ yarn',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ del %localappdata%\Temp\haste-map-*',
+    '',
+    '$ del %localappdata%\Temp\metro-cache',
+    '',
+    '$ yarn start -- --reset-cache',
+  ]}
+/>
 
-### React Native CLI and npm
+## React Native CLI and npm
 
-```
-del node_modules
-npm cache clean --force
-npm install
-watchman watch-del-all
-del %localappdata%\Temp\haste-map-*
-del %localappdata%\Temp\metro-cache
-npm start -- --reset-cache
-```
+{/* prettier-ignore */}
+<Terminal
+  cmd={[
+    '$ rm -rf node_modules',
+    '',
+    '$ npm cache clean --force',
+    '',
+    '$ npm install',
+    '',
+    '$ watchman watch-del-all',
+    '',
+    '$ del %localappdata%\Temp\haste-map-*',
+    '',
+    '$ del %localappdata%\Temp\metro-cache',
+    '',
+    '$ npm start -- --reset-cache',
+  ]}
+/>
 
 ## What these commands are doing
 

--- a/docs/pages/troubleshooting/react-native-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.mdx
@@ -1,22 +1,26 @@
 ---
 title: '"React Native version mismatch" errors'
-description: Learn about what React Native version mismatch means and measures you can take to resolve it when using Expo.
+description: Learn about what React Native version mismatch means and how to resolve it in an Expo or React Native app.
 ---
+
+import { Terminal } from '~/ui/components/Snippet';
 
 When developing an Expo or React Native app, it's not uncommon to run into an error that looks like:
 
-```
-React Native version mismatch.
-
-JavaScript version: X.XX.X
-Native version: X.XX.X
-
-Make sure you have rebuilt the native code...
-```
+<Terminal
+  cmd={[
+    'React Native version mismatch.',
+    '',
+    'JavaScript version: X.XX.X',
+    'Native version: X.XX.X',
+    '',
+    'Make sure you have rebuilt the native code...',
+  ]}
+/>
 
 ## What this error means
 
-The bundler that you're running in your terminal (via `npx expo start`) is using a different JavaScript version of `react-native` than the native app on your device or emulator. This can happen after upgrading your React Native or Expo SDK version, _or_ when connecting to the wrong local development server.
+The bundler that you're running in your terminal (using `npx expo start`) is using a different JavaScript version of `react-native` than the native app on your device or emulator. This can happen after upgrading your React Native or Expo SDK version, _or_ when connecting to the wrong local development server.
 
 ## How to fix it
 
@@ -24,7 +28,7 @@ The bundler that you're running in your terminal (via `npx expo start`) is using
 
 - If this is a managed workflow project, either remove the `sdkVersion` field from your **app.json** file, or make sure it matches the value of the `expo` dependency in your **package.json** file.
 
-- If this is a managed workflow project, you should make sure your `react-native` version is correct. Run `expo-cli doctor` will show a warning where the `react-native` version you should install. If you did upgrade to newer SDK, make sure to run `expo-cli upgrade` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
+- If this is a managed workflow project, you should make sure your `react-native` version is correct. Run `npx expo-doctor` will show a warning where the `react-native` version you should install. If you did upgrade to a newer SDK, make sure to run `expo-cli upgrade` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
 
 - If this is a bare workflow project, and this error is occurring right after upgrading your React Native version, you should double-check that you've performed each of the upgrade steps correctly.
 

--- a/docs/pages/troubleshooting/react-native-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.mdx
@@ -1,5 +1,6 @@
 ---
 title: '"React Native version mismatch" errors'
+description: Learn about what React Native version mismatch means and measures you can take to resolve it when using Expo.
 ---
 
 When developing an Expo or React Native app, it's not uncommon to run into an error that looks like:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow up to #24669 (Initially, I left out these pages as I wasn't sure if we should keep them or remove them, but let's add the description tag for now)

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add missing description tags.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, go to pages individually and look for the `description` meta tag.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
