### PR TITLE
Use iPhone 15 for expo-updates e2e tests

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
+++ b/packages/expo-updates/e2e/fixtures/project_files/.detoxrc.json
@@ -35,7 +35,7 @@
     "simulator": {
       "type": "ios.simulator",
       "device": {
-        "type": "iPhone 14"
+        "type": "iPhone 15"
       }
     },
     "emulator": {


### PR DESCRIPTION
# Why

The latest image on EAS Build now uses Xcode 15, which doesn't include simulators for iPhone 14.

# How

Changed the simulator to `iPhone 15`

# Test Plan

