### PR TITLE
[docs] Add `"distribution": "internal"` to list of configurations that create an `.apk`

### DIFF
--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -12,8 +12,8 @@ The default file format used when building Android apps with EAS Build is an [An
 
 To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding one of the following properties in a build profile:
 
-- `distribution` to `internal`
 - `developmentClient` to `true` (**default**)
+- `distribution` to `internal`
 - `android.buildType` to `apk`
 - `android.gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces **.apk**
 

--- a/docs/pages/build-reference/apk.mdx
+++ b/docs/pages/build-reference/apk.mdx
@@ -12,6 +12,7 @@ The default file format used when building Android apps with EAS Build is an [An
 
 To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding one of the following properties in a build profile:
 
+- `distribution` to `internal`
 - `developmentClient` to `true` (**default**)
 - `android.buildType` to `apk`
 - `android.gradleCommand` to `:app:assembleRelease`, `:app:assembleDebug` or any other gradle command that produces **.apk**
@@ -32,6 +33,9 @@ To generate an **.apk**, modify the [**eas.json**](/build/eas-json) by adding on
     "preview3": {
       "developmentClient": true
     },
+    "preview4": {
+      "distribution": "internal"
+    }
     "production": {}
   }
 }


### PR DESCRIPTION
# Why

For some time, I wondered why one of the default `eas.json` build configurations, `preview`, seemed [not to fulfill any of the requirements for generating an `.apk`](https://docs.expo.dev/build-reference/apk/#configuring-a-profile-to-build-apks) yet also was not targeted to publish to the store. It seems from the [description of `distribution`](https://docs.expo.dev/eas/json/#distribution) that this is pointless and does not create anything functional. However, then I just went ahead and tried it, and it seems from my testing that setting `distribution` to `internal` is sufficient to configure a build to create an `.apk`, not an `.aab`. As such, I decided to update the documentation for others to enjoy.

# How

I added a line to the section explaining how to configure to build an `.apk`.

# Test Plan

N/A

# Checklist

N/A

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

Thanks for all the hard work on this awesome library!
