### PR TITLE
chore(ci): temporarily disable web test suite due to `bare-expo` not supporting Metro web

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -25,41 +25,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  web:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: ⬢ Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          yarn-workspace: 'true'
-      - name: 🧶 Install node modules in root dir
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: 🧪 Run Web tests
-        run: yarn test:web
-        working-directory: apps/bare-expo
-        env:
-          EXPO_NO_TYPESCRIPT_SETUP: 1
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_web }}
-        with:
-          channel: '#expo-web'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (Web)
+  # Disabled due to Webpack being broken in `bare-expo`.
+  # TODO(cedric): re-enable the web tests once `bare-expo` supports Metro web.
+  # web:
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: 👀 Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #     - name: ⬢ Setup Node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 16
+  #     - name: ♻️ Restore caches
+  #       uses: ./.github/actions/expo-caches
+  #       id: expo-caches
+  #       with:
+  #         yarn-workspace: 'true'
+  #     - name: 🧶 Install node modules in root dir
+  #       if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+  #       run: yarn install --frozen-lockfile
+  #     - name: 🧪 Run Web tests
+  #       run: yarn test:web
+  #       working-directory: apps/bare-expo
+  #       env:
+  #         EXPO_NO_TYPESCRIPT_SETUP: 1
+  #     - name: 🔔 Notify on Slack
+  #       uses: 8398a7/action-slack@v3
+  #       if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_web }}
+  #       with:
+  #         channel: '#expo-web'
+  #         status: ${{ job.status }}
+  #         fields: job,message,ref,eventName,author,took
+  #         author_name: Test Suite (Web)
 
   ios:
     runs-on: macos-13


### PR DESCRIPTION
# Why

Expo's webpack support is currently sunset, and `bare-expo` does not play well with the Metro web bundler. To avoid spamming Slack, and other PRs, with unnecessary/expected failures, I disabled the web test suite.

We can re-enable this once `bare-expo` supports Metro web.

# How

- Commented out the workflow job

# Test Plan

No test plan is needed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
