### PR TITLE
[dev-launcher] rename tryToLaunchLastOpenedBundle config plugin option to launchModeExperimental

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Improve 'Development servers' and 'Recently opened' UX. ([#24665](https://github.com/expo/expo/pull/24665) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add support for skipping the launcher screen and launching directly into a previously opened project. ([#24614](https://github.com/expo/expo/pull/24614), [#24646](https://github.com/expo/expo/pull/24646) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for skipping the launcher screen and launching directly into a previously opened project. ([#24614](https://github.com/expo/expo/pull/24614), [#24646](https://github.com/expo/expo/pull/24646), [#24758](https://github.com/expo/expo/pull/24758) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -22,10 +22,16 @@ export type PluginConfigOptionsByPlatform = {
  */
 export type PluginConfigOptions = {
     /**
-     * Attempts to launch directly into a previously opened project. If unable to connect,
+     * **Experimental:** Determines whether to launch the most recently opened project or navigate to the launcher screen.
+     *
+     * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
      * fall back to the launcher screen.
+     *
+     * - `'launcher'` - Opens the launcher screen.
+     *
+     * @default 'launcher'
      */
-    tryToLaunchLastOpenedBundle?: boolean;
+    launchModeExperimental?: 'most-recent' | 'launcher';
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -8,18 +8,30 @@ const ajv_1 = __importDefault(require("ajv"));
 const schema = {
     type: 'object',
     properties: {
-        tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+        launchModeExperimental: {
+            type: 'string',
+            enum: ['most-recent', 'launcher'],
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
-                tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+                launchModeExperimental: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
             },
             nullable: true,
         },
         ios: {
             type: 'object',
             properties: {
-                tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+                launchModeExperimental: {
+                    type: 'string',
+                    enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
             },
             nullable: true,
         },

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -5,13 +5,13 @@ const pluginConfig_1 = require("./pluginConfig");
 const pkg = require('expo-dev-launcher/package.json');
 exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {}) => {
     (0, pluginConfig_1.validateConfig)(props);
-    if (props.ios?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
+    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
             config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = true;
             return config;
         });
     }
-    if (props.android?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
+    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', true?.toString());

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -26,27 +26,45 @@ export type PluginConfigOptionsByPlatform = {
  */
 export type PluginConfigOptions = {
   /**
-   * Attempts to launch directly into a previously opened project. If unable to connect,
+   * **Experimental:** Determines whether to launch the most recently opened project or navigate to the launcher screen.
+   *
+   * - `'most-recent'` - Attempt to launch directly into a previously opened project and if unable to connect,
    * fall back to the launcher screen.
+   *
+   * - `'launcher'` - Opens the launcher screen.
+   *
+   * @default 'launcher'
    */
-  tryToLaunchLastOpenedBundle?: boolean;
+  launchModeExperimental?: 'most-recent' | 'launcher';
 };
 
 const schema: JSONSchemaType<PluginConfigType> = {
   type: 'object',
   properties: {
-    tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+    launchModeExperimental: {
+      type: 'string',
+      enum: ['most-recent', 'launcher'],
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
-        tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+        launchModeExperimental: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
       },
       nullable: true,
     },
     ios: {
       type: 'object',
       properties: {
-        tryToLaunchLastOpenedBundle: { type: 'boolean', nullable: true },
+        launchModeExperimental: {
+          type: 'string',
+          enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
       },
       nullable: true,
     },

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -13,14 +13,14 @@ export default createRunOncePlugin<PluginConfigType>(
   (config, props = {}) => {
     validateConfig(props);
 
-    if (props.ios?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
+    if ((props.ios?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
       config = withInfoPlist(config, (config) => {
         config.modResults['DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE'] = true;
         return config;
       });
     }
 
-    if (props.android?.tryToLaunchLastOpenedBundle ?? props.tryToLaunchLastOpenedBundle) {
+    if ((props.android?.launchModeExperimental || props.launchModeExperimental) === 'most-recent') {
       config = withAndroidManifest(config, (config) => {
         const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/expo/pull/24614#discussion_r1346530165

# How

Rename `expo-dev-client` config plugin `tryToLaunchLastOpenedBundle` option to include the `experimental` suffix and to be a String union instead of a boolean 

# Test Plan

Add `expo-dev-client` to apps/sandbox, configure the config-plugin and run `npx expo prebuild --clean`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
