### PR TITLE
[document-picker] Set default mimetype for unknown extensions

### DIFF
--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Added default mimetype (`application/octet-stream`) to avoid quiet failure when mimetype is null on iOS ([#24764](https://github.com/expo/expo/pull/24764) by [@OzymandiasTheGreat](https://github.com/OzymandiasTheGreat))
+
 ### 💡 Others
 
 ## 11.7.0 — 2023-09-04

--- a/packages/expo-document-picker/ios/DocumentPickerModule.swift
+++ b/packages/expo-document-picker/ios/DocumentPickerModule.swift
@@ -130,7 +130,7 @@ public class DocumentPickerModule: Module, PickingResultHandler {
       try FileManager.default.copyItem(at: documentUrl, to: newUrl)
     }
 
-    let mimeType = self.getMimeType(from: documentUrl.pathExtension)
+    let mimeType = self.getMimeType(from: documentUrl.pathExtension) ?? "application/octet-stream"
 
     return DocumentInfo(
       uri: newUrl.absoluteString,


### PR DESCRIPTION
# Why
Currently picking a file with unknown file extension results in quiet failure on iOS.
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How
If `getMimeType()` returns nil, set mimetype to `application/octet-stream`, which is default mimetype for unknown files, at least on the web.
This small change allows to successfully pick any file on iOS. Android doesn't seem to have this issue.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan
In a test application I was able to pick "unknown" files, like `map.gpx`.
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
