### PR TITLE
[docs] Add pending web in Metro vs webpack table for bundle splitting

### DIFF
--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -295,23 +295,23 @@ Learn once, bundle everywhere!
 
 Universal Expo Metro is designed to be fully universal, meaning any web bundling features should also work on native too. Because of this, we make some breaking changes between the two bundler implementations, carefully check the difference if you're moving from webpack to Metro.
 
-| Feature           | Metro                               | webpack                |
-| ----------------- | ----------------------------------- | ---------------------- |
-| Start command     | `npx expo start`                    | `npx expo start`       |
-| Bundle command    | `npx expo export`                   | `npx expo export:web`  |
-| Output folder     | **dist**                            | **web-build**          |
-| Static folder     | **public**                          | **web**                |
-| Config file       | **metro.config.js**                 | **webpack.config.js**  |
-| Default config    | `@expo/metro-config`                | `@expo/webpack-config` |
-| Multi-platform    | <YesIcon />                         | <NoIcon />             |
-| Fast Refresh      | <YesIcon /> (`@expo/metro-runtime`) | <NoIcon />             |
-| Error Overlay     | <YesIcon /> (`@expo/metro-runtime`) | <NoIcon />             |
-| Deferred Bundling | <YesIcon /> (`@expo/metro-runtime`) | <NoIcon />             |
-| Global CSS        | <PendingIcon /> (Beta • SDK 49)     | <YesIcon />            |
-| CSS Modules       | <PendingIcon /> (Beta • SDK 49)     | <NoIcon />             |
-| Bundle Splitting  | <PendingIcon /> (pending native)    | <YesIcon />            |
-| Tree Shaking      | <NoIcon />                          | <YesIcon />            |
-| Asset Manifests   | <NoIcon />                          | <YesIcon />            |
+| Feature           | Metro                                    | webpack                |
+| ----------------- | ---------------------------------------- | ---------------------- |
+| Start command     | `npx expo start`                         | `npx expo start`       |
+| Bundle command    | `npx expo export`                        | `npx expo export:web`  |
+| Output folder     | **dist**                                 | **web-build**          |
+| Static folder     | **public**                               | **web**                |
+| Config file       | **metro.config.js**                      | **webpack.config.js**  |
+| Default config    | `@expo/metro-config`                     | `@expo/webpack-config` |
+| Multi-platform    | <YesIcon />                              | <NoIcon />             |
+| Fast Refresh      | <YesIcon /> (`@expo/metro-runtime`)      | <NoIcon />             |
+| Error Overlay     | <YesIcon /> (`@expo/metro-runtime`)      | <NoIcon />             |
+| Deferred Bundling | <YesIcon /> (`@expo/metro-runtime`)      | <NoIcon />             |
+| Global CSS        | <PendingIcon /> (Beta • SDK 49)          | <YesIcon />            |
+| CSS Modules       | <PendingIcon /> (Beta • SDK 49)          | <NoIcon />             |
+| Bundle Splitting  | <PendingIcon /> (pending native and web) | <YesIcon />            |
+| Tree Shaking      | <NoIcon />                               | <YesIcon />            |
+| Asset Manifests   | <NoIcon />                               | <YesIcon />            |
 
 Note that aliases, resolution, and other bundler features are now universal across platforms as well!
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in Expo Router sync where Evan suggested we should update the info Bundle splitting in Metro vs Webpack that it also pending for web.

This PR fixes that.

# Test Plan

Run docs locally and visit http://localhost:3002/guides/customizing-metro/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
