### PR TITLE
[docs] Unify vscode extension name

### DIFF
--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -84,7 +84,7 @@ const { /* @hide ...*//* @end */ } = require('@expo/config-plugins');
 
 ### Tooling
 
-We highly recommend installing the [Expo Tools VS Code plugin][vscode-expo]
+We highly recommend installing the [Expo Tools VS Code extension][vscode-expo]
 as this will perform automatic validation on the plugins and surface error information along with other quality of life improvements for Config Plugin development.
 
 ### Setup up a playground environment

--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -17,7 +17,7 @@ When submitting your app to app stores, you need to provide metadata. This proce
 
 EAS Metadata is available starting from EAS CLI >= 0.54.0, and currently **only supports the Apple App Store**.
 
-> Using VS Code? Install the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
+> Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
 
 ## Create a store config
 

--- a/docs/pages/develop/project-structure.mdx
+++ b/docs/pages/develop/project-structure.mdx
@@ -17,7 +17,7 @@ The **App.js** file is the default screen of your project. It is the root file t
 
 The **app.json** file contains [configuration options](/versions/latest/config/app) for the project. These options change the behavior of your project while developing, in addition to while building, submitting, and updating our app.
 
-> Install our [Expo for VS Code](https://github.com/expo/vscode-expo) extension to get intellisense.
+> Install our [VS Code Expo Tools](https://github.com/expo/vscode-expo) extension to get intellisense.
 
 ## assets folder
 

--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -20,7 +20,7 @@ The code snippet below shows an example store config with basic App Store inform
 
 You can find all configuration options in the [store config schema](./schema.mdx).
 
-> If you have the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) installed, you get auto-complete, suggestions, and warnings for **store.config.json** files.
+> If you have the [VS Code Expo Tools extension](https://github.com/expo/vscode-expo#readme) installed, you get auto-complete, suggestions, and warnings for **store.config.json** files.
 
 ```json store.config.json
 {

--- a/docs/pages/eas/metadata/faq.mdx
+++ b/docs/pages/eas/metadata/faq.mdx
@@ -22,7 +22,7 @@ Before pushing the changes to the app stores, EAS Metadata looks for common pitf
 
 EAS Metadata comes with built-in validation, even before anything is sent to the app stores. This validation helps you iterate faster over the information without starting a review. Instead, you can begin the review process when everything is provided, and no issues are detected.
 
-> Make sure to install the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) to get auto-complete, suggestions, and warnings for **store.config.json** files.
+> Make sure to install the [VS Code Expo Tools extension](https://github.com/expo/vscode-expo#readme) to get auto-complete, suggestions, and warnings for **store.config.json** files.
 
 ### Extensible with dynamic store config
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -15,7 +15,7 @@ EAS Metadata enables you to automate and maintain your app store presence from t
 
 EAS Metadata is available starting from EAS CLI >= 0.54.0, and _currently_ only supports the Apple App Store.
 
-> Using VS Code? Install the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
+> Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
 
 ## Create the store config
 

--- a/docs/pages/eas/metadata/index.mdx
+++ b/docs/pages/eas/metadata/index.mdx
@@ -22,7 +22,7 @@ EAS Metadata can also instantly identify known app store restrictions that could
 
 Adding the store config file to your repository enables you to collaborate with other team members to prepare the app submission.
 
-> Using VS Code? Install the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
+> Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
 
 ## Get started
 

--- a/docs/pages/eas/metadata/schema.mdx
+++ b/docs/pages/eas/metadata/schema.mdx
@@ -14,7 +14,7 @@ import { MetadataTable, MetadataSubcategories } from '~/components/plugins/EasMe
 The store config in EAS Metadata contains information that otherwise would be provided manually through the app store dashboards.
 This document outlines the structure of the object in your store config.
 
-> If you use the [VS Code Expo plugin](https://github.com/expo/vscode-expo#readme), you get all this information through auto-complete, suggestions, and warnings in your editor.
+> If you use the [VS Code Expo Tools extension](https://github.com/expo/vscode-expo#readme), you get all this information through auto-complete, suggestions, and warnings in your editor.
 
 ## Config schema
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -350,7 +350,7 @@ Traditionally, apps for Android and iOS are updated by submitting an updated bin
 
 ### VS Code Expo
 
-The VS Code extension for improving the developer experience of working with app config files. This extension provides autocomplete and intellisense for the [app config](#app-config), [Store Config](#store-config), [Expo Module Config](#expo-module-config), and [EAS Config](#eas-config). For more information, see the [VS Code Expo extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools).
+The VS Code extension for improving the developer experience of working with app config files. This extension provides autocomplete and intellisense for the [app config](#app-config), [Store Config](#store-config), [Expo Module Config](#expo-module-config), and [EAS Config](#eas-config). For more information, see the [VS Code Expo Tools extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools).
 
 ### Watchman
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -27,7 +27,7 @@ Most configuration from the app config is accessible at runtime from the JavaScr
 
 The app config configures many things such as app name, icon, splash screen, deep linking scheme, API keys to use for some services and so on. For a complete list of available properties, see [app.json/app.config.js reference](/versions/latest/config/app/).
 
-> **info** Do you use Visual Studio Code? If so, we recommend that you install the [vscode-expo](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) extension to get auto-completion of properties in **app.json** files.
+> **info** Do you use Visual Studio Code? If so, we recommend that you install the [Expo Tools](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) extension to get auto-completion of properties in **app.json** files.
 
 ## Extending configuration
 


### PR DESCRIPTION
# Why

The Expo Tools extension is sometimes referred to as plugin, sometimes extension or vscode-expo, Expo for VSCode etc. This PR unifies all occurences to be "Expo Tools extension" 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
