### PR TITLE
[ios][barcode-scanner] fix: handling nil barcode types

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - On `Android`, use `rawValue` in the case of scanning a contact card to return complete information. ([#24791](https://github.com/expo/expo/pull/24791) by [@alanhughes](https://github.com/alanjhughes))
+- On `iOS`, correctly handle when unsupported barcode types are passed to the `barCodeTypes` prop. ([#24784](https://github.com/expo/expo/pull/24784) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/BarCodeScannerModule.swift
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/BarCodeScannerModule.swift
@@ -79,8 +79,10 @@ public final class BarCodeScannerModule: Module {
         }
       }
 
-      Prop("barCodeTypes") { (view, barcodeTypes: [String]) in
-        view.barCodeTypes = barcodeTypes
+      Prop("barCodeTypes") { (view, barcodeTypes: [String?]) in
+        view.barCodeTypes = barcodeTypes.compactMap {
+          $0
+        }
       }
     }
   }

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -305,6 +305,8 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 
   if (result) {
     completion(result, error);
+  } else {
+    completion(nil, error);
   }
 }
 

--- a/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
+++ b/packages/expo-barcode-scanner/ios/EXBarCodeScanner/EXBarCodeScanner.m
@@ -305,8 +305,6 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 
   if (result) {
     completion(result, error);
-  } else {
-    completion(nil, error);
   }
 }
 


### PR DESCRIPTION
# Why
Fixes an issue where if an unsupported barcode type is passed to the `barCodeTypes` prop, parsing it fails silently and the prop is ignored. This is because the closure parameters were 
```swift
  Prop("barCodeTypes") { (view, barcodeTypes: [String]) in
```
and should have been 
```swift
  Prop("barCodeTypes") { (view, barcodeTypes: [String?]) in
```

# How
Changed the closure parameters and used `compactMap` to filter out any `nil` values.

# Test Plan
bare-expo using a provided image and setup from the report.