### PR TITLE
[android][barcode-scanner] fix: displayValue is incomplete

### DIFF
--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, use `rawValue` in the case of scanning a contact card to return complete information.
+- On `Android`, use `rawValue` in the case of scanning a contact card to return complete information. ([#24791](https://github.com/expo/expo/pull/24791) by [@alanhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-barcode-scanner/CHANGELOG.md
+++ b/packages/expo-barcode-scanner/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, use `rawValue` in the case of scanning a contact card to return complete information.
+
 ### 💡 Others
 
 ## 12.7.0 — 2023-09-04


### PR DESCRIPTION
# Why
Closes #24444
In certain cases, the `displayValue` will not return complete information. ie a contact card. 

# How
Check the `valueType` and return the raw value in the case of a contact card. `MLKit` returns more complex data types than  `play-services-vision` which we had been using. Ideally, we would parse all of these and return an appropriate object. 

# Test Plan
bare-expo