### PR TITLE
test(pkg-manager): typo in bun test description

### DIFF
--- a/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
+++ b/packages/create-expo/src/__tests__/resolvePackageManager.test.ts
@@ -25,7 +25,7 @@ describe(resolvePackageManager, () => {
     process.env.npm_config_user_agent = 'pnpm';
     expect(resolvePackageManager()).toBe('pnpm');
   });
-  it('should use pnpm due to the user agent', () => {
+  it('should use bun due to the user agent', () => {
     process.env.npm_config_user_agent = 'bun';
     expect(resolvePackageManager()).toBe('bun');
   });


### PR DESCRIPTION
# Why

<!-- 

!! NOTICE !! The global Expo CLI (`packages/expo-cli`) is deprecated in favor of the new versioned CLI `npx expo`:

Open Expo CLI changes here -> https://github.com/expo/expo/tree/main/packages/@expo/cli

...

Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

Just updating a copy/paste typo for in the `resolvePackageManager.test.ts` test description for new `bun` package manager.

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

Fixed the typo.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Same tests, just update the description.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
