### PR TITLE
[go][ios][1/n] Remove EXEnvironment.isDetached

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
+++ b/ios/Exponent/Kernel/AppLoader/AppFetcher/EXAppFetcher.m
@@ -45,11 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
   jsResource.requestTimeoutInterval = timeoutInterval;
 
   EXCachedResourceBehavior behavior = cacheBehavior;
-  // if we've disabled updates, ignore all other settings and only use the cache
-  if ([EXEnvironment sharedEnvironment].isDetached && ![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    behavior = EXCachedResourceOnlyCache;
-  }
-
+  
   if ([self.dataSource appFetcherShouldInvalidateBundleCache:self]) {
     [jsResource removeCache];
   }

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXJavaScriptResource.m
@@ -89,24 +89,13 @@
 
 - (BOOL)isUsingEmbeddedResource
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    // if the URL of our request matches the remote URL of the embedded JS bundle,
-    // skip checking any caches and just immediately open the NSBundle copy
-    if ([EXEnvironment sharedEnvironment].embeddedBundleUrl &&
-        [self.remoteUrl isEqual:[EXApiUtil encodedUrlFromString:[EXEnvironment sharedEnvironment].embeddedBundleUrl]]) {
-      return YES;
-    } else {
-      return NO;
-    }
-  } else {
 #if DEBUG
-    return NO;
+  return NO;
 #else
-    // we only need this because the bundle URL of prod home never changes, so we need
-    // to use the legacy logic and load embedded home if and only if a cached copy doesn't exist.
-    return [super isUsingEmbeddedResource];
+  // we only need this because the bundle URL of prod home never changes, so we need
+  // to use the legacy logic and load embedded home if and only if a cached copy doesn't exist.
+  return [super isUsingEmbeddedResource];
 #endif
-  }
 }
 
 - (NSError *)_validateResponseData:(NSData *)data response:(NSURLResponse *)response

--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -34,16 +34,7 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
   _originalUrl = originalUrl;
   _canBeWrittenToCache = NO;
   
-  NSString *resourceName;
-  if ([EXEnvironment sharedEnvironment].isDetached && [originalUrl.absoluteString isEqual:[EXEnvironment sharedEnvironment].standaloneManifestUrl]) {
-    resourceName = kEXEmbeddedManifestResourceName;
-    if ([EXEnvironment sharedEnvironment].releaseChannel){
-      self.releaseChannel = [EXEnvironment sharedEnvironment].releaseChannel;
-    }
-    NSLog(@"EXManifestResource: Standalone manifest remote url is %@ (%@)", url, originalUrl);
-  } else {
-    resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
-  }
+  NSString *resourceName = [EXKernelLinkingManager linkingUriForExperienceUri:url useLegacy:YES];
   
   if (self = [super initWithResourceName:resourceName resourceType:@"json" remoteUrl:url cachePath:[[self class] cachePath]]) {
     self.shouldVersionCache = NO;

--- a/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXDevelopmentHomeLoader.m
@@ -323,14 +323,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)_clientEnvironment
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return @"STANDALONE";
-  } else {
-    return @"EXPO_DEVICE";
+  return @"EXPO_DEVICE";
 #if TARGET_IPHONE_SIMULATOR
-    return @"EXPO_SIMULATOR";
+  return @"EXPO_SIMULATOR";
 #endif
-  }
 }
 
 - (NSString *)_sdkVersions

--- a/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
+++ b/ios/Exponent/Kernel/AppLoader/EXFileDownloader.m
@@ -90,14 +90,10 @@ NSTimeInterval const EXFileDownloaderDefaultTimeoutInterval = 60;
     releaseChannel = @"default";
   }
   NSString *clientEnvironment;
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    clientEnvironment = @"STANDALONE";
-  } else {
-    clientEnvironment = @"EXPO_DEVICE";
+  clientEnvironment = @"EXPO_DEVICE";
 #if TARGET_IPHONE_SIMULATOR
-    clientEnvironment = @"EXPO_SIMULATOR";
+  clientEnvironment = @"EXPO_SIMULATOR";
 #endif
-  }
   
   [request setValue:releaseChannel forHTTPHeaderField:@"Expo-Release-Channel"];
   [request setValue:@"true" forHTTPHeaderField:@"Expo-JSON-Error"];

--- a/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
+++ b/ios/Exponent/Kernel/Core/EXKernelAppRegistry.m
@@ -77,15 +77,6 @@
 
 - (EXKernelAppRecord *)standaloneAppRecord
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    for (NSString *recordId in self.appEnumerator) {
-      EXKernelAppRecord *record = [self recordForId:recordId];
-      if (record.appLoader.manifestUrl
-          && [record.appLoader.manifestUrl.absoluteString isEqualToString:[EXEnvironment sharedEnvironment].standaloneManifestUrl]) {
-        return record;
-      }
-    }
-  }
   return nil;
 }
 

--- a/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
+++ b/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m
@@ -248,11 +248,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
 
 - (void)_handleMenuCommand
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
-  } else {
-    [[EXKernel sharedInstance] switchTasks];
-  }
+  [[EXKernel sharedInstance] switchTasks];
 }
 
 - (void)_handleRefreshCommand

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -13,11 +13,6 @@ FOUNDATION_EXPORT NSString * const kEXEmbeddedManifestResourceName;
 + (instancetype)sharedEnvironment;
 
 /**
- *  Whether the app is running as a detached/standalone app (true) or as Expo Go (false).
- */
-@property (nonatomic, readonly) BOOL isDetached;
-
-/**
  *  Whether the app was built with a Debug configuration.
  */
 @property (nonatomic, readonly) BOOL isDebugXCodeScheme;

--- a/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -156,7 +156,7 @@
 - (NSDictionary *)extraParams
 {
   // we allow the vanilla RN dev menu in some circumstances.
-  BOOL isStandardDevMenuAllowed = [EXEnvironment sharedEnvironment].isDetached;
+  BOOL isStandardDevMenuAllowed = false;
   NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
     @"manifest": _appRecord.appLoader.manifest.rawManifestJSON,
     @"constants": @{
@@ -270,12 +270,7 @@
 
 - (NSString *)bundleResourceNameForAppFetcher:(EXAppFetcher *)appFetcher withManifest:(nonnull EXManifestsManifest *)manifest
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    NSLog(@"Standalone bundle remote url is %@", [EXEnvironment sharedEnvironment].standaloneManifestUrl);
-    return kEXEmbeddedBundleResourceName;
-  } else {
-    return manifest.legacyId;
-  }
+  return manifest.legacyId;
 }
 
 - (BOOL)appFetcherShouldInvalidateBundleCache:(EXAppFetcher *)appFetcher
@@ -540,11 +535,7 @@
 
 - (void)toggleDevMenu
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    [[EXKernel sharedInstance].visibleApp.appManager showDevMenu];
-  } else {
-    [[EXKernel sharedInstance] switchTasks];
-  }
+  [[EXKernel sharedInstance] switchTasks];
 }
 
 - (void)setupWebSocketControls
@@ -630,18 +621,11 @@
 
 - (NSDictionary *)launchOptionsForBridge
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    // pass the native app's launch options to standalone bridge.
-    return [ExpoKit sharedInstance].launchOptions;
-  }
   return @{};
 }
 
 - (Class)moduleRegistryDelegateClass
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return [ExpoKit sharedInstance].moduleRegistryDelegateClass;
-  }
   return nil;
 }
 
@@ -717,11 +701,7 @@
 
 - (NSString *)_executionEnvironment
 {
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return EXConstantsExecutionEnvironmentStandalone;
-  } else {
-    return EXConstantsExecutionEnvironmentStoreClient;
-  }
+  return EXConstantsExecutionEnvironmentStoreClient;
 }
 
 - (NSString *)scopedDocumentDirectory

--- a/ios/Exponent/Kernel/Services/EXPermissionsManager.m
+++ b/ios/Exponent/Kernel/Services/EXPermissionsManager.m
@@ -50,11 +50,7 @@ EX_REGISTER_SINGLETON_MODULE(Permissions)
 }
 
 - (BOOL)hasGrantedPermission:(NSString *)permission forExperience:(NSString *)scopeKey
-{
-  if ([EXEnvironment sharedEnvironment].isDetached) {
-    return YES;
-  }
-  
+{  
   return [self getPermission:[EXPermissionsManager mapPermissionType:permission] forExperience:scopeKey] == EXPermissionStatusGranted;
 }
 

--- a/ios/Exponent/Kernel/Views/EXAppViewController.m
+++ b/ios/Exponent/Kernel/Views/EXAppViewController.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
   if (self = [super init]) {
     _appRecord = record;
-    _isStandalone = [EXEnvironment sharedEnvironment].isDetached;
+    _isStandalone = false;
     // For iPads traitCollectionDidChange will not be called (it's always in the same size class). It is necessary
     // to init it in here, so it's possible to return it in the didUpdateDimensionsEvent of the module
     if (ScreenOrientationRegistry.shared.currentTraitCollection == nil) {
@@ -229,14 +229,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSAssert(NO, @"AppViewController error handler was called on an object that isn't an NSError");
 #endif
     return;
-  }
-
-  // we don't ever want to show any Expo UI in a production standalone app, so hard crash
-  if ([EXEnvironment sharedEnvironment].isDetached && ![_appRecord.appManager enablesDeveloperTools]) {
-    NSException *e = [NSException exceptionWithName:@"ExpoFatalError"
-                                             reason:[NSString stringWithFormat:@"Expo encountered a fatal error: %@", [error localizedDescription]]
-                                           userInfo:@{NSUnderlyingErrorKey: error}];
-    @throw e;
   }
 
   NSString *domain = (error && error.domain) ? error.domain : @"";

--- a/ios/Exponent/Kernel/Views/EXErrorView.m
+++ b/ios/Exponent/Kernel/Views/EXErrorView.m
@@ -157,7 +157,7 @@
 {
   EXKernelAppRecord *homeRecord = [EXKernel sharedInstance].appRegistry.homeAppRecord;
   _btnBack.hidden = (!homeRecord || _appRecord == homeRecord);
-  _lblUrl.hidden = (!homeRecord && ![self _isDevDetached]);
+  _lblUrl.hidden = !homeRecord;
   _lblUrl.text = _appRecord.appLoader.manifestUrl.absoluteString;
   // TODO: maybe hide retry (see BrowserErrorView)
   [self setNeedsLayout];
@@ -187,11 +187,6 @@
       [url rangeOfString:@"172."].length > 0
     )
   );
-}
-
-- (BOOL)_isDevDetached
-{
-  return [EXEnvironment sharedEnvironment].isDetached && [EXEnvironment sharedEnvironment].isDebugXCodeScheme;
 }
 
 // for creating a filled button background in iOS < 15

--- a/ios/Tests/Environment/EXEnvironment+Tests.h
+++ b/ios/Tests/Environment/EXEnvironment+Tests.h
@@ -7,9 +7,7 @@
            withInfoPlist:(NSDictionary *)infoPlist
        withExpoKitDevUrl:(NSString *)expoKitDevelopmentUrl
     withEmbeddedManifest:(NSDictionary *)embeddedManifest
-              isDetached:(BOOL)isDetached
-      isDebugXCodeScheme:(BOOL)isDebugScheme
-            isUserDetach:(BOOL)isUserDetach;
+      isDebugXCodeScheme:(BOOL)isDebugScheme;
 
 - (void)_loadDefaultConfig;
 

--- a/ios/Tests/Environment/EXEnvironmentTests.m
+++ b/ios/Tests/Environment/EXEnvironmentTests.m
@@ -22,32 +22,6 @@
   }
 }
 
-- (void)testIsServiceConfigRespected
-{
-  [EXEnvironmentMocks loadProdServiceConfig];
-  NSDictionary *expectedShellConfig = [EXEnvironmentMocks shellConfig];
-  NSString *expectedUrlScheme = [EXEnvironmentMocks prodUrlScheme];
-  NSDictionary *expectedEmbeddedManifest = [EXEnvironmentMocks embeddedManifest];
-  XCTAssert(_environment.isDetached, @"EXEnvironment should indicate isDetached == true when a valid standalone config is provided");
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedShellConfig[@"manifestUrl"]], @"EXEnvironment should adopt the manifest url specified in the config");
-  XCTAssert([_environment.releaseChannel isEqualToString:@"default"], @"EXEnvironment should use default release channel when none is specified");
-  XCTAssert([_environment.urlScheme isEqualToString:expectedUrlScheme], @"EXEnvironment should adopt url scheme %@ when configured", expectedUrlScheme);
-  XCTAssert([_environment.embeddedBundleUrl isEqualToString:expectedEmbeddedManifest[@"bundleUrl"]], @"EXEnvironment should adopt the bundle url specified in the embedded manifest");
-}
-
-- (void)testIsDevDetachConfigRespected
-{
-  [EXEnvironmentMocks loadDevDetachConfig];
-  NSString *expectedUrl = [EXEnvironmentMocks expoKitDevUrl];
-  NSString *expectedUrlScheme = [EXEnvironmentMocks prodUrlScheme];
-  NSDictionary *expectedEmbeddedManifest = [EXEnvironmentMocks embeddedManifest];
-  XCTAssert(_environment.isDetached, @"EXEnvironment should indicate isDetached == true when a dev detach config is provided");
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedUrl], @"EXEnvironment should adopt the local dev url when a dev detach config is provided");
-  XCTAssert([_environment.releaseChannel isEqualToString:@"default"], @"EXEnvironment should use default release channel when a dev detach config is provided");
-  XCTAssert([_environment.urlScheme isEqualToString:expectedUrlScheme], @"EXEnvironment should adopt url scheme %@ when configured", expectedUrlScheme);
-  XCTAssert([_environment.embeddedBundleUrl isEqualToString:expectedEmbeddedManifest[@"bundleUrl"]], @"EXEnvironment should adopt the bundle url specified in the embedded manifest");
-}
-
 - (void)testIsAllManifestUrlsPropertyCorrect
 {
   [EXEnvironmentMocks loadProdServiceConfig];
@@ -60,33 +34,6 @@
   XCTAssert(_environment.allManifestUrls.count == 2, @"Dev detached app should have one local, and one prod, manifest url");
   XCTAssert([_environment.allManifestUrls containsObject:expectedProdUrl], @"Dev detached app's `allManifestUrls` should contain the prod manifest url");
   XCTAssert([_environment.allManifestUrls containsObject:expectedDevUrl], @"Dev detached app's `allManifestUrls` should contain the dev manifest url");
-}
-
-- (void)testDoesMissingDevDetachUrlThrow
-{
-  // local dev detach with nil dev url
-  XCTAssertThrows(
-                  [_environment _loadShellConfig:[EXEnvironmentMocks shellConfig]
-                                   withInfoPlist:[EXEnvironmentMocks infoPlist]
-                               withExpoKitDevUrl:nil
-                            withEmbeddedManifest:[EXEnvironmentMocks embeddedManifest]
-                                      isDetached:YES
-                              isDebugXCodeScheme:YES
-                                    isUserDetach:YES]
-                  , @"Configuring EXEnvironment as a local detached project in Debug mode should throw if no development url is provided");
-}
-
-- (void)testDoesProdDetachUseProdUrl
-{
-  NSDictionary *expectedShellConfig = [EXEnvironmentMocks shellConfig];
-  [_environment _loadShellConfig:expectedShellConfig
-                   withInfoPlist:[EXEnvironmentMocks infoPlist]
-               withExpoKitDevUrl:[EXEnvironmentMocks expoKitDevUrl]
-            withEmbeddedManifest:[EXEnvironmentMocks embeddedManifest]
-                      isDetached:YES
-              isDebugXCodeScheme:NO
-                    isUserDetach:YES];
-  XCTAssert([_environment.standaloneManifestUrl isEqualToString:expectedShellConfig[@"manifestUrl"]], @"EXEnvironment should ignore the ExpoKit dev url when using a prod build scheme");
 }
 
 - (void)testDoesDefaultConfigRespectXcodeScheme


### PR DESCRIPTION
# Why

This is no longer used since we removed classic builds and this detached/standalone builds. This 

# How

Remove, build.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
