### PR TITLE
[7/n][go][ios] Remove most stuff from EXEnvironment

### DIFF
--- a/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -188,9 +188,6 @@ NSString * const EXRuntimeErrorDomain = @"incompatible-runtime";
                                   // HACK: because `SecItemCopyMatching` doesn't work in older iOS (see EXApiUtil.m)
                                   ([UIDevice currentDevice].systemVersion.floatValue < 10) ||
                                   
-                                  // the developer disabled manifest verification
-                                  [EXEnvironment sharedEnvironment].isManifestVerificationBypassed ||
-                                  
                                   // we're using a copy that came with the NSBundle and was therefore already codesigned
                                   [self isUsingEmbeddedResource] ||
                                   

--- a/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -343,7 +343,7 @@ NS_ASSUME_NONNULL_BEGIN
     EXUpdatesConfig.EXUpdatesConfigScopeKeyKey: httpManifestUrl.absoluteString,
     EXUpdatesConfig.EXUpdatesConfigReleaseChannelKey: releaseChannel,
     EXUpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: @NO,
-    EXUpdatesConfig.EXUpdatesConfigEnabledKey: @([EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled),
+    EXUpdatesConfig.EXUpdatesConfigEnabledKey: @YES,
     EXUpdatesConfig.EXUpdatesConfigLaunchWaitMsKey: launchWaitMs,
     EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchKey: shouldCheckOnLaunch ? EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueAlways : EXUpdatesConfig.EXUpdatesConfigCheckOnLaunchValueNever,
     EXUpdatesConfig.EXUpdatesConfigExpectsSignedManifestKey: @YES,
@@ -384,11 +384,6 @@ NS_ASSUME_NONNULL_BEGIN
   updatesConfig[EXUpdatesConfig.EXUpdatesConfigEnableExpoUpdatesProtocolV0CompatibilityModeKey] = @YES;
 
   _config = [EXUpdatesConfig configFromDictionary:updatesConfig];
-
-  if (![EXEnvironment sharedEnvironment].areRemoteUpdatesEnabled) {
-    [self _launchWithNoDatabaseAndError:nil];
-    return;
-  }
 
   EXUpdatesDatabaseManager *updatesDatabaseManager = [EXKernel sharedInstance].serviceRegistry.updatesDatabaseManager;
 
@@ -527,7 +522,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // if the app bypassed verification or the manifest is scoped to a random anonymous
     // scope key, automatically verify it
-    if (![mutableManifest[@"isVerified"] boolValue] && (EXEnvironment.sharedEnvironment.isManifestVerificationBypassed || [EXAppLoaderExpoUpdates _isAnonymousExperience:manifest])) {
+    if (![mutableManifest[@"isVerified"] boolValue] && [EXAppLoaderExpoUpdates _isAnonymousExperience:manifest]) {
       mutableManifest[@"isVerified"] = @(YES);
     }
 

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.h
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.h
@@ -15,55 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL isDebugXCodeScheme;
 
 /**
- *  The custom url scheme for the standalone app (if isDetached == true).
- */
-@property (nonatomic, readonly, nullable) NSString *urlScheme;
-
-/**
- *  The release channel from which to fetch the standalone app (if isDetached == true).
- */
-@property (nonatomic, readonly, nonnull) NSString *releaseChannel;
-
-/**
- *  The `bundleUrl` given by the embedded manifest that shipped with this NSBundle, if any.
- */
-@property (nonatomic, readonly) NSString * _Nullable embeddedBundleUrl;
-
-/**
- *  May contain a local development url for a detached project.
- */
-@property (nonatomic, readonly, nonnull) NSArray *allManifestUrls;
-
-/**
- *  True by default in ExpoKit apps created with `expo eject`, because the owner of the app needs to
- *  manually modify their App Id to enable keychain sharing.
- */
-@property (nonatomic, readonly) BOOL isManifestVerificationBypassed;
-
-/**
- *  Whether remote updates are allowed at all for this standalone app.
- */
-@property (nonatomic, readonly) BOOL areRemoteUpdatesEnabled;
-
-/**
-*  Whether to check for updates to this app automatically on launch. Applies to standalone apps only.
-*/
-@property (nonatomic, readonly) BOOL updatesCheckAutomatically;
-
-/**
-*  Timeout when checking for updates on launch after which to fall back to cache. Applies to standalone apps only.
-*/
-@property (nonatomic, readonly) NSNumber *updatesFallbackToCacheTimeout;
-
-/**
  *  Whether the app is running in a test environment (local Xcode test target, CI, or not at all).
  */
 @property (nonatomic, assign) EXTestEnvironment testEnvironment;
-
-/**
- *  True if urlScheme is nonnull.
- */
-- (BOOL)hasUrlScheme;
 
 @end
 

--- a/ios/Exponent/Kernel/Environment/EXEnvironment.m
+++ b/ios/Exponent/Kernel/Environment/EXEnvironment.m
@@ -29,22 +29,11 @@
   return self;
 }
 
-- (BOOL)hasUrlScheme
-{
-  return (_urlScheme != nil);
-}
-
 #pragma mark - internal
 
 - (void)_reset
 {
-  _urlScheme = nil;
-  _areRemoteUpdatesEnabled = YES;
-  _updatesCheckAutomatically = YES;
-  _updatesFallbackToCacheTimeout = @(0);
-  _allManifestUrls = @[];
   _isDebugXCodeScheme = NO;
-  _releaseChannel = @"default";
 }
 
 - (void)_loadDefaultConfig

--- a/ios/Tests/Environment/EXEnvironmentTests.m
+++ b/ios/Tests/Environment/EXEnvironmentTests.m
@@ -22,20 +22,6 @@
   }
 }
 
-- (void)testIsAllManifestUrlsPropertyCorrect
-{
-  [EXEnvironmentMocks loadProdServiceConfig];
-  NSString *expectedProdUrl = [EXEnvironmentMocks shellConfig][@"manifestUrl"];
-  XCTAssert(_environment.allManifestUrls.count == 1, @"Service standalone app should only have one manifest url");
-  XCTAssert([_environment.allManifestUrls.firstObject isEqualToString:expectedProdUrl], @"Service standalone app's `allManifestUrls` should contain the prod manifest url");
-
-  [EXEnvironmentMocks loadDevDetachConfig];
-  NSString *expectedDevUrl = [EXEnvironmentMocks expoKitDevUrl];
-  XCTAssert(_environment.allManifestUrls.count == 2, @"Dev detached app should have one local, and one prod, manifest url");
-  XCTAssert([_environment.allManifestUrls containsObject:expectedProdUrl], @"Dev detached app's `allManifestUrls` should contain the prod manifest url");
-  XCTAssert([_environment.allManifestUrls containsObject:expectedDevUrl], @"Dev detached app's `allManifestUrls` should contain the dev manifest url");
-}
-
 - (void)testDoesDefaultConfigRespectXcodeScheme
 {
   [_environment _loadDefaultConfig];


### PR DESCRIPTION
# Why

Part 2 of https://github.com/expo/expo/pull/24814.

This propagates the unchanged/unread properties outwards.

# How

Find/delete

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
