### PR TITLE
[9/n][go][android] Remove more standalone constants

### DIFF
--- a/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
+++ b/android/app/src/main/java/host/exp/exponent/generated/AppConstants.java
@@ -13,32 +13,13 @@ import host.exp.exponent.Constants;
 public class AppConstants {
 
   public static final String VERSION_NAME = null;
-  public static final String RELEASE_CHANNEL = "default";
-  public static boolean ARE_REMOTE_UPDATES_ENABLED = true;
-  public static boolean UPDATES_CHECK_AUTOMATICALLY = true;
-  public static int UPDATES_FALLBACK_TO_CACHE_TIMEOUT = 0;
-  public static final List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
   public static boolean FCM_ENABLED = true;
   public static SplashScreenImageResizeMode SPLASH_SCREEN_IMAGE_RESIZE_MODE = SplashScreenImageResizeMode.CONTAIN;
-
-  static {
-    List<Constants.EmbeddedResponse> embeddedResponses = new ArrayList<>();
-
-    // ADD EMBEDDED RESPONSES HERE
-    // START EMBEDDED RESPONSES
-    // END EMBEDDED RESPONSES
-    EMBEDDED_RESPONSES = embeddedResponses;
-  }
 
   // Called from expoview/Constants
   public static Constants.ExpoViewAppConstants get() {
     Constants.ExpoViewAppConstants constants = new Constants.ExpoViewAppConstants();
     constants.VERSION_NAME = VERSION_NAME;
-    constants.RELEASE_CHANNEL = RELEASE_CHANNEL;
-    constants.ARE_REMOTE_UPDATES_ENABLED = ARE_REMOTE_UPDATES_ENABLED;
-    constants.UPDATES_CHECK_AUTOMATICALLY = UPDATES_CHECK_AUTOMATICALLY;
-    constants.UPDATES_FALLBACK_TO_CACHE_TIMEOUT = UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
-    constants.EMBEDDED_RESPONSES = EMBEDDED_RESPONSES;
     constants.ANDROID_VERSION_CODE = BuildConfig.VERSION_CODE;
     constants.FCM_ENABLED = FCM_ENABLED;
     constants.SPLASH_SCREEN_IMAGE_RESIZE_MODE = SPLASH_SCREEN_IMAGE_RESIZE_MODE;

--- a/android/expoview/src/main/java/host/exp/exponent/Constants.java
+++ b/android/expoview/src/main/java/host/exp/exponent/Constants.java
@@ -20,11 +20,6 @@ public class Constants {
 
   public static class ExpoViewAppConstants {
     public String VERSION_NAME;
-    public String RELEASE_CHANNEL;
-    public boolean ARE_REMOTE_UPDATES_ENABLED;
-    public boolean UPDATES_CHECK_AUTOMATICALLY;
-    public int UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
-    public List<Constants.EmbeddedResponse> EMBEDDED_RESPONSES;
     public int ANDROID_VERSION_CODE;
     public boolean FCM_ENABLED;
     public SplashScreenImageResizeMode SPLASH_SCREEN_IMAGE_RESIZE_MODE;
@@ -33,18 +28,12 @@ public class Constants {
   private static final String TAG = Constants.class.getSimpleName();
 
   public static String VERSION_NAME = null;
-  public static final String API_HOST = "https://exp.host";
   public static String ABI_VERSIONS;
   public static String SDK_VERSIONS;
   public static List<String> SDK_VERSIONS_LIST;
   public static final String TEMPORARY_ABI_VERSION = null;
   public static final String EMBEDDED_KERNEL_PATH = "assets://kernel.android.bundle";
-  public static List<EmbeddedResponse> EMBEDDED_RESPONSES;
   public static boolean DISABLE_NUX = false;
-  public static String RELEASE_CHANNEL = "default";
-  public static boolean ARE_REMOTE_UPDATES_ENABLED = true;
-  public static boolean UPDATES_CHECK_AUTOMATICALLY = true;
-  public static int UPDATES_FALLBACK_TO_CACHE_TIMEOUT = 0;
   public static int ANDROID_VERSION_CODE;
   public static boolean FCM_ENABLED;
   public static SplashScreenImageResizeMode SPLASH_SCREEN_IMAGE_RESIZE_MODE;
@@ -81,28 +70,12 @@ public class Constants {
 
     setSdkVersions(abiVersions);
 
-    List<EmbeddedResponse> embeddedResponses = new ArrayList<>();
-    // WHEN_PREPARING_SHELL_REMOVE_FROM_HERE
-    embeddedResponses.add(new EmbeddedResponse("https://exp.host/@exponent/home/bundle", EMBEDDED_KERNEL_PATH, "application/javascript"));
-    // WHEN_PREPARING_SHELL_REMOVE_TO_HERE
-
-    // ADD EMBEDDED RESPONSES HERE
-    // START EMBEDDED RESPONSES
-    // END EMBEDDED RESPONSES
-
     try {
       Class appConstantsClass = Class.forName("host.exp.exponent.generated.AppConstants");
       ExpoViewAppConstants appConstants = (ExpoViewAppConstants) appConstantsClass.getMethod("get").invoke(null);
       VERSION_NAME = appConstants.VERSION_NAME;
-      RELEASE_CHANNEL = appConstants.RELEASE_CHANNEL;
-      ARE_REMOTE_UPDATES_ENABLED = appConstants.ARE_REMOTE_UPDATES_ENABLED;
-      UPDATES_CHECK_AUTOMATICALLY = appConstants.UPDATES_CHECK_AUTOMATICALLY;
-      UPDATES_FALLBACK_TO_CACHE_TIMEOUT = appConstants.UPDATES_FALLBACK_TO_CACHE_TIMEOUT;
       ANDROID_VERSION_CODE = appConstants.ANDROID_VERSION_CODE;
       FCM_ENABLED = appConstants.FCM_ENABLED;
-
-      embeddedResponses.addAll(appConstants.EMBEDDED_RESPONSES);
-      EMBEDDED_RESPONSES = embeddedResponses;
       SPLASH_SCREEN_IMAGE_RESIZE_MODE = appConstants.SPLASH_SCREEN_IMAGE_RESIZE_MODE;
     } catch (ClassNotFoundException e) {
       e.printStackTrace();
@@ -121,18 +94,6 @@ public class Constants {
   public static final boolean ENABLE_LEAK_CANARY = false;
   public static final boolean WRITE_BUNDLE_TO_LOG = false;
   public static final boolean WAIT_FOR_DEBUGGER = false;
-
-  public static class EmbeddedResponse {
-    public final String url;
-    public final String responseFilePath;
-    public final String mediaType;
-
-    public EmbeddedResponse(final String url, final String responseFilePath, final String mediaType) {
-      this.url = url;
-      this.responseFilePath = responseFilePath;
-      this.mediaType = mediaType;
-    }
-  }
 
   public static String getVersionName(Context context) {
     if (VERSION_NAME != null) {

--- a/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -40,7 +40,6 @@ class ManifestException : ExponentException {
 
   override fun toString(): String {
     val extraMessage = if (ExpoViewBuildConfig.DEBUG) {
-      // This will get hit in a detached app.
       " Are you sure expo-cli is running?"
     } else {
       ""

--- a/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
+++ b/android/expoview/src/main/java/host/exp/exponent/kernel/DevMenuManager.kt
@@ -66,7 +66,7 @@ class DevMenuManager {
   }
 
   /**
-   * Shows dev menu in given experience activity. Ensures it never happens in standalone apps and is run on the UI thread.
+   * Shows dev menu in given experience activity. Ensures it is run on the UI thread.
    */
   @SuppressLint("SourceLockedOrientationActivity")
   fun showInActivity(activity: ExperienceActivity) {
@@ -94,7 +94,7 @@ class DevMenuManager {
   }
 
   /**
-   * Hides dev menu in given experience activity. Ensures it never happens in standalone apps and is run on the UI thread.
+   * Hides dev menu in given experience activity. Ensures it is run on the UI thread.
    */
   fun hideInActivity(activity: ExperienceActivity) {
     UiThreadUtil.runOnUiThread {

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentPackage.kt
@@ -116,7 +116,7 @@ class ExponentPackage : ReactPackage {
       // WHEN_VERSIONING_REMOVE_TO_HERE
     }
     if (!isKernel) {
-      // We need DevMenuModule only in non-home and non-standalone apps.
+      // We need DevMenuModule only in non-home apps.
       nativeModules.add(DevMenuModule(reactContext, experienceProperties, manifest))
     }
 

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/notifications/ScopedServerRegistrationModule.kt
@@ -15,9 +15,6 @@ class ScopedServerRegistrationModule : ServerRegistrationModule() {
     //   which has previously been run on an older SDK
     //   (where it persisted an installation ID in
     //   the legacy storage) or
-    // - we're in a standalone app after update
-    //   from SDK where installation ID has been
-    //   persisted in legacy storage
     // we let the migration do its job of moving
     // expo-notifications-specific installation ID
     // from scoped SharedPreferences to scoped noBackupDir


### PR DESCRIPTION
# Why

This is a second part of https://github.com/expo/expo/pull/24819 that removes more stuff only set by standalone/detach scripts.

# How

Remove constants, propagate outwards.

# Test Plan

Build versioned expo go.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
