### PR TITLE
[docs] Update av.mdx

### DIFF
--- a/docs/pages/versions/unversioned/sdk/av.mdx
+++ b/docs/pages/versions/unversioned/sdk/av.mdx
@@ -194,7 +194,7 @@ import { Audio, Video } from 'expo-av';
 
 You must add the following permissions to your **app.json** inside the [`expo.android.permissions`](/versions/latest/config/app/#permissions) array.
 
-<AndroidPermissions permissions={['RECORD_AUDIO']} />
+<AndroidPermissions permissions={['RECORD_AUDIO', 'WRITE_EXTERNAL_STORAGE', 'READ_EXTERNAL_STORAGE']} />
 
 ### iOS
 


### PR DESCRIPTION


# Why

For me dev client was working perfectly, but when creating releases for play store I was not able to record even with permissions given by the user. Error from adb logs is 
ReactNativeJS:
'Failed to start recording
{ [Error: Call to function
'ExponentAV .prepareAudioRecorder' has been rejected.] }

After adding these permisions it was finally able to record
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
