### PR TITLE
Fix secure store module constraint mapping

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' constraint being incorrectly mapped wrong secure store accessible ([#24831](https://github.com/expo/expo/pull/24831) by [@mmmguitar](https://github.com/mmmguitar))
+- Fixed the 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' constraint being incorrectly mapped to wrong secure store accessible ([#24831](https://github.com/expo/expo/pull/24831) by [@mmmguitar](https://github.com/mmmguitar))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed the 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' constraint being incorrectly mapped wrong secure store accessible
+- Fixed the 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' constraint being incorrectly mapped wrong secure store accessible ([#24831](https://github.com/expo/expo/pull/24831) by [@mmmguitar](https://github.com/mmmguitar))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the 'WHEN_UNLOCKED_THIS_DEVICE_ONLY' constraint being incorrectly mapped wrong secure store accessible
+
 ### 💡 Others
 
 ## 12.5.0 — 2023-09-04

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -13,7 +13,7 @@ public final class SecureStoreModule: Module {
       "WHEN_PASSCODE_SET_THIS_DEVICE_ONLY": SecureStoreAccessible.whenPasscodeSetThisDeviceOnly.rawValue,
       "ALWAYS_THIS_DEVICE_ONLY": SecureStoreAccessible.alwaysThisDeviceOnly.rawValue,
       "WHEN_UNLOCKED": SecureStoreAccessible.whenUnlocked.rawValue,
-      "WHEN_UNLOCKED_THIS_DEVICE_ONLY": SecureStoreAccessible.whenPasscodeSetThisDeviceOnly.rawValue
+      "WHEN_UNLOCKED_THIS_DEVICE_ONLY": SecureStoreAccessible.whenUnlockedThisDeviceOnly.rawValue
     ])
 
     AsyncFunction("getValueWithKeyAsync") { (key: String, options: SecureStoreOptions) -> String? in


### PR DESCRIPTION
# Why
Closes #24829
We are experiencing issues with the secure store constraints after updating from expo 48 to 49.  

I raised an issue https://github.com/expo/expo/issues/24829 that details it further but long story short, there is a constraints map that maps constraint -> secure store accessible and there is an incorrect mapping.

# How

Its a simple mapping issue on an enum, I just quickly edited the file.  I have no means to build + test this given the docs for that seem to be mac specific (I'm using linux) and I just don't have time so would hope this fix is simple enough any CI should "just work" or hope someone else in the community that has the dev env already setup could quickly check this out and test it builds.

# Test Plan

I have no test plan given I can't build it locally and I don't really have the time to fathom this on linux.  The change is rather simple and I would hope CI / building is enough if not I would hope someone else in the community that has the dev env already setup could test this works.  It requires testing on a real iphone as well (details on the bug report) and I don't even have one of those...

To test this, I have snack code in the issue I raised that replicates the issue on a real device.  A version of the that app just needs to be run on an IOS device without a passcode/biometrics and the secure store save / get not error.

# Checklist

- [✓] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md)
-- there is no documentation changes needed as this is a bug fix (apart from the changelog)

- [✓] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
-- I made no real changed, just changed the use of an enum value to the right enum value
- [✓] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
-- assuming I copied and pasted the enum value correctly... I really didnt change much
