### PR TITLE
Update @react-native-picker/picker to 2.5.1

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/picker/ReactPickerManager.java
@@ -297,6 +297,10 @@ public abstract class ReactPickerManager extends BaseViewManager<ReactPicker, Re
         textView.setTextColor(item.getInt("color"));
       }
 
+      if (item.hasKey("contentDescription") && !item.isNull("contentDescription")) {
+        textView.setContentDescription(item.getString("contentDescription"));
+      }
+
       if (item.hasKey("fontFamily") && !item.isNull("fontFamily")) {
         Typeface face = Typeface.create(item.getString("fontFamily"), Typeface.NORMAL);
         textView.setTypeface(face);

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -750,7 +750,7 @@ PODS:
     - React-Core
   - RNCMaskedView (0.2.9):
     - React-Core
-  - RNCPicker (2.4.10):
+  - RNCPicker (2.5.1):
     - React-Core
   - RNDateTimePicker (7.2.0):
     - React-Core
@@ -1417,7 +1417,7 @@ SPEC CHECKSUMS:
   ReactCommon: 91ece8350ebb3dd2be9cef662abd78b6948233c0
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNCMaskedView: 949696f25ec596bfc697fc88e6f95cf0c79669b6
-  RNCPicker: 0bc2f0a29abcca7b7ed44a2d036aac9ab6d25700
+  RNCPicker: 529d564911e93598cc399b56cc0769ce3675f8c8
   RNDateTimePicker: 3942382593f104af226ad9c56e16166960c7ae30
   RNFlashList: ade81b4e928ebd585dd492014d40fb8d0e848aab
   RNGestureHandler: dec4645026e7401a0899f2846d864403478ff6a5

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -66,7 +66,7 @@
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.9",
-    "@react-native-picker/picker": "2.4.10",
+    "@react-native-picker/picker": "2.5.1",
     "@react-native-segmented-control/segmented-control": "2.4.1",
     "@shopify/flash-list": "1.4.3",
     "expo": "~50.0.0-alpha.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -48,7 +48,7 @@
     "@react-native-community/netinfo": "9.3.10",
     "@react-native-community/slider": "4.4.2",
     "@react-native-masked-view/masked-view": "0.2.9",
-    "@react-native-picker/picker": "2.4.10",
+    "@react-native-picker/picker": "2.5.1",
     "@react-native-segmented-control/segmented-control": "2.4.1",
     "@react-navigation/bottom-tabs": "~6.4.0",
     "@react-navigation/drawer": "6.5.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -6,7 +6,7 @@
   "@react-native-community/netinfo": "9.3.10",
   "@react-native-community/slider": "4.4.2",
   "@react-native-community/viewpager": "5.0.11",
-  "@react-native-picker/picker": "2.4.10",
+  "@react-native-picker/picker": "2.5.1",
   "@react-native-segmented-control/segmented-control": "2.4.1",
   "@stripe/stripe-react-native": "0.28.0",
   "expo-analytics-amplitude": "~11.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,10 +3290,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.2.9.tgz#723a7a076d56b8f5f3fda076eaa5b6b82988e854"
   integrity sha512-Hs4vKBKj+15VxHZHFtMaFWSBxXoOE5Ea8saoigWhahp8Mepssm0ezU+2pTl7DK9z8Y9s5uOl/aPb4QmBZ3R3Zw==
 
-"@react-native-picker/picker@2.4.10":
-  version "2.4.10"
-  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.4.10.tgz#339c7bfc6e1d9a5e934122eaaa7767dc1c5fb725"
-  integrity sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==
+"@react-native-picker/picker@2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.5.1.tgz#dfa13d5b97bfbedf1f7e7c608181a82f1d58b351"
+  integrity sha512-/sADUfQsosMRYtrqqL3ZYZSECRygj0fXtpRLqxJfwuMEoqfvfn40756R6B1alzusVvDRZFI0ari0iQid56hA/Q==
 
 "@react-native-segmented-control/segmented-control@2.4.1":
   version "2.4.1"


### PR DESCRIPTION
# Why

In order to upgrade react-native to 0.73 we will need to update some android libraries to ensure that a namespace is specified in their build.gradle as React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. (https://github.com/react-native-community/discussions-and-proposals/issues/671)

# How

`et uvm -m @react-native-picker/picker --commit "v2.5.1"`

# Test Plan
 

- [x] test using `bare-expo` Android + NCL  
- [x] test using `bare-expo` iOS + NCL  
- [x] test unversioned expo go ios + NCL  
- [x] test unversioned expo go android + NCL  

# Checklist
 

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
