### PR TITLE
refactor(cli): skip loading the telemetry client when disabled

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Remove `isCSSEnabled` flag from e2e tests ([#24489](https://github.com/expo/expo/pull/24489) by [@marklawlor](https://github.com/marklawlor))
 - Use Metro and web TypeScript types from `expo` instead of `expo-router`. ([#24255](https://github.com/expo/expo/pull/24255) by [@marklawlor](https://github.com/marklawlor))
 - Speed up Metro tests with new resolver. ([#24616](https://github.com/expo/expo/pull/24616) by [@EvanBacon](https://github.com/EvanBacon))
+- Skip loading the telemetry client when disabled.
 
 ## 0.10.13 — 2023-09-27
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Remove `isCSSEnabled` flag from e2e tests ([#24489](https://github.com/expo/expo/pull/24489) by [@marklawlor](https://github.com/marklawlor))
 - Use Metro and web TypeScript types from `expo` instead of `expo-router`. ([#24255](https://github.com/expo/expo/pull/24255) by [@marklawlor](https://github.com/marklawlor))
 - Speed up Metro tests with new resolver. ([#24616](https://github.com/expo/expo/pull/24616) by [@EvanBacon](https://github.com/EvanBacon))
-- Skip loading the telemetry client when disabled.
+- Skip loading the telemetry client when disabled. ([#24841](https://github.com/expo/expo/pull/24841) by [@byCedric](https://github.com/byCedric))
 
 ## 0.10.13 — 2023-09-27
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -2,11 +2,10 @@
 import arg from 'arg';
 import chalk from 'chalk';
 import Debug from 'debug';
-
-import { env } from '../src/utils/env';
+import { boolish } from 'getenv';
 
 // Setup before requiring `debug`.
-if (env.EXPO_DEBUG) {
+if (boolish('EXPO_DEBUG', false)) {
   Debug.enable('expo:*');
 } else if (Debug.enabled('expo:')) {
   process.env.EXPO_DEBUG = '1';
@@ -195,7 +194,7 @@ process.on('SIGTERM', () => process.exit(0));
 commands[command]().then((exec) => {
   exec(commandArgs);
 
-  if (!env.EXPO_NO_TELEMETRY) {
+  if (!boolish('EXPO_NO_TELEMETRY', false)) {
     // NOTE(EvanBacon): Track some basic telemetry events indicating the command
     // that was run. This can be disabled with the $EXPO_NO_TELEMETRY environment variable.
     // We do this to determine how well deprecations are going before removing a command.

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -2,10 +2,11 @@
 import arg from 'arg';
 import chalk from 'chalk';
 import Debug from 'debug';
-import { boolish } from 'getenv';
+
+import { env } from '../src/utils/env';
 
 // Setup before requiring `debug`.
-if (boolish('EXPO_DEBUG', false)) {
+if (env.EXPO_DEBUG) {
   Debug.enable('expo:*');
 } else if (Debug.enabled('expo:')) {
   process.env.EXPO_DEBUG = '1';
@@ -194,14 +195,16 @@ process.on('SIGTERM', () => process.exit(0));
 commands[command]().then((exec) => {
   exec(commandArgs);
 
-  // NOTE(EvanBacon): Track some basic telemetry events indicating the command
-  // that was run. This can be disabled with the $EXPO_NO_TELEMETRY environment variable.
-  // We do this to determine how well deprecations are going before removing a command.
-  const { logEventAsync } =
-    require('../src/utils/analytics/rudderstackClient') as typeof import('../src/utils/analytics/rudderstackClient');
-  logEventAsync('action', {
-    action: `expo ${command}`,
-    source: 'expo/cli',
-    source_version: process.env.__EXPO_VERSION,
-  });
+  if (!env.EXPO_NO_TELEMETRY) {
+    // NOTE(EvanBacon): Track some basic telemetry events indicating the command
+    // that was run. This can be disabled with the $EXPO_NO_TELEMETRY environment variable.
+    // We do this to determine how well deprecations are going before removing a command.
+    const { logEventAsync } =
+      require('../src/utils/analytics/rudderstackClient') as typeof import('../src/utils/analytics/rudderstackClient');
+    logEventAsync('action', {
+      action: `expo ${command}`,
+      source: 'expo/cli',
+      source_version: process.env.__EXPO_VERSION,
+    });
+  }
 });


### PR DESCRIPTION
# Why

When the telemetry client is not enabled, we don't have to load it. This does exactly that, mostly for commands that should execute pretty much instantly (like `npx expo config`).

# How

- Added check before loading the telemetry client in `bin/cli.ts`

# Test Plan

You can test the performance increase in a project using hyperfine:

<img width="891" alt="image" src="https://github.com/expo/expo/assets/1203991/a892cc19-cad0-4f35-b687-31e2ada29147">

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
