### PR TITLE
[android][ios] Upgrade react-native-webview to 13.6.2

### DIFF
--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebChromeClient.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebChromeClient.java
@@ -16,6 +16,7 @@ import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 
 import androidx.annotation.RequiresApi;
@@ -29,6 +30,7 @@ import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.react.uimanager.UIManagerHelper;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopLoadingProgressEvent;
+import versioned.host.exp.exponent.modules.api.components.webview.events.TopOpenWindowEvent;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -77,6 +79,8 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
     protected RNCWebView.ProgressChangedFilter progressChangedFilter = null;
     protected boolean mAllowsProtectedMedia = false;
 
+    protected boolean mHasOnOpenWindowEvent = false;
+
     public RNCWebChromeClient(RNCWebView webView) {
         this.mWebView = webView;
     }
@@ -85,6 +89,24 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
     public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
 
         final WebView newWebView = new WebView(view.getContext());
+
+        if(mHasOnOpenWindowEvent) {
+            newWebView.setWebViewClient(new WebViewClient(){
+            @Override
+            public boolean shouldOverrideUrlLoading (WebView subview, String url) {
+                WritableMap event = Arguments.createMap();
+                event.putString("targetUrl", url);
+
+                ((RNCWebView) view).dispatchEvent(
+                    view,
+                    new TopOpenWindowEvent(RNCWebViewWrapper.getReactTagFromWebView(view), event)
+                );
+
+                return true;
+            }
+            });
+        }
+
         final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
         transport.setWebView(newWebView);
         resultMsg.sendToTarget();
@@ -108,15 +130,15 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
         if (progressChangedFilter.isWaitingForCommandLoadUrl()) {
             return;
         }
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
         WritableMap event = Arguments.createMap();
-        event.putDouble("target", webView.getId());
+        event.putDouble("target", reactTag);
         event.putString("title", webView.getTitle());
         event.putString("url", url);
         event.putBoolean("canGoBack", webView.canGoBack());
         event.putBoolean("canGoForward", webView.canGoForward());
         event.putDouble("progress", (float) newProgress / 100);
 
-        int reactTag = webView.getId();
         UIManagerHelper.getEventDispatcherForReactTag(this.mWebView.getThemedReactContext(), reactTag).dispatchEvent(new TopLoadingProgressEvent(reactTag, event));
     }
 
@@ -342,5 +364,9 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
      */
     public void setAllowsProtectedMedia(boolean enabled) {
       mAllowsProtectedMedia = enabled;
+    }
+
+    public void setHasOnOpenWindowEvent(boolean hasEvent) {
+      mHasOnOpenWindowEvent = hasEvent;
     }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewClient.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewClient.java
@@ -71,7 +71,7 @@ public class RNCWebViewClient extends WebViewClient {
       ((RNCWebView) webView).dispatchEvent(
         webView,
         new TopLoadingStartEvent(
-          webView.getId(),
+          RNCWebViewWrapper.getReactTagFromWebView(webView),
           createWebViewEvent(webView, url)));
     }
 
@@ -125,7 +125,7 @@ public class RNCWebViewClient extends WebViewClient {
             FLog.w(TAG, "Couldn't use blocking synchronous call for onShouldStartLoadWithRequest due to debugging or missing Catalyst instance, falling back to old event-and-load.");
             progressChangedFilter.setWaitingForCommandLoadUrl(true);
 
-            int reactTag = view.getId();
+            int reactTag = RNCWebViewWrapper.getReactTagFromWebView(view);
             UIManagerHelper.getEventDispatcherForReactTag((ReactContext) view.getContext(), reactTag).dispatchEvent(new TopShouldStartLoadWithRequestEvent(
                     reactTag,
                     createWebViewEvent(view, url)));
@@ -240,8 +240,8 @@ public class RNCWebViewClient extends WebViewClient {
         eventData.putDouble("code", errorCode);
         eventData.putString("description", description);
 
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(webView.getId(), eventData));
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingErrorEvent(reactTag, eventData));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
@@ -257,8 +257,8 @@ public class RNCWebViewClient extends WebViewClient {
             eventData.putInt("statusCode", errorResponse.getStatusCode());
             eventData.putString("description", errorResponse.getReasonPhrase());
 
-            int reactTag = webView.getId();
-            UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopHttpErrorEvent(webView.getId(), eventData));
+            int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
+            UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopHttpErrorEvent(reactTag, eventData));
         }
     }
 
@@ -287,21 +287,21 @@ public class RNCWebViewClient extends WebViewClient {
 
         WritableMap event = createWebViewEvent(webView, webView.getUrl());
         event.putBoolean("didCrash", detail.didCrash());
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopRenderProcessGoneEvent(webView.getId(), event));
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopRenderProcessGoneEvent(reactTag, event));
 
         // returning false would crash the app.
         return true;
     }
 
     protected void emitFinishEvent(WebView webView, String url) {
-        int reactTag = webView.getId();
-        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingFinishEvent(webView.getId(), createWebViewEvent(webView, url)));
+        int reactTag = RNCWebViewWrapper.getReactTagFromWebView(webView);
+        UIManagerHelper.getEventDispatcherForReactTag((ReactContext) webView.getContext(), reactTag).dispatchEvent(new TopLoadingFinishEvent(reactTag, createWebViewEvent(webView, url)));
     }
 
     protected WritableMap createWebViewEvent(WebView webView, String url) {
         WritableMap event = Arguments.createMap();
-        event.putDouble("target", webView.getId());
+        event.putDouble("target", RNCWebViewWrapper.getReactTagFromWebView(webView));
         // Don't use webView.getUrl() here, the URL isn't updated to the new value yet in callbacks
         // like onPageFinished
         event.putString("url", url);

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManager.java
@@ -6,11 +6,9 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.module.annotations.ReactModule;
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.views.scroll.ScrollEventType;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopCustomMenuSelectionEvent;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopHttpErrorEvent;
@@ -19,18 +17,13 @@ import versioned.host.exp.exponent.modules.api.components.webview.events.TopLoad
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopLoadingProgressEvent;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopLoadingStartEvent;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopMessageEvent;
+import versioned.host.exp.exponent.modules.api.components.webview.events.TopOpenWindowEvent;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopRenderProcessGoneEvent;
 import versioned.host.exp.exponent.modules.api.components.webview.events.TopShouldStartLoadWithRequestEvent;
 
-import android.graphics.Color;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.Map;
-import java.util.HashMap;
 
-public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
+public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
 
     private final RNCWebViewManagerImpl mRNCWebViewManagerImpl;
 
@@ -44,236 +37,246 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @Override
-    public RNCWebView createViewInstance(ThemedReactContext context) {
+    public RNCWebViewWrapper createViewInstance(ThemedReactContext context) {
         return mRNCWebViewManagerImpl.createViewInstance(context);
     }
 
-    public RNCWebView createViewInstance(ThemedReactContext context, RNCWebView webView) {
-      return mRNCWebViewManagerImpl.createViewInstance(context, webView);
+    public RNCWebViewWrapper createViewInstance(ThemedReactContext context, RNCWebViewWrapper view) {
+      return mRNCWebViewManagerImpl.createViewInstance(context, view.getWebView());
     }
 
     @ReactProp(name = "allowFileAccess")
-    public void setAllowFileAccess(RNCWebView view, boolean value) {
+    public void setAllowFileAccess(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccess(view, value);
     }
 
     @ReactProp(name = "allowFileAccessFromFileURLs")
-    public void setAllowFileAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowFileAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowFileAccessFromFileURLs(view, value);
 
     }
 
     @ReactProp(name = "allowUniversalAccessFromFileURLs")
-    public void setAllowUniversalAccessFromFileURLs(RNCWebView view, boolean value) {
+    public void setAllowUniversalAccessFromFileURLs(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowUniversalAccessFromFileURLs(view, value);
     }
 
     @ReactProp(name = "allowsFullscreenVideo")
-    public void setAllowsFullscreenVideo(RNCWebView view, boolean value) {
+    public void setAllowsFullscreenVideo(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsFullscreenVideo(view, value);
     }
 
     @ReactProp(name = "allowsProtectedMedia")
-    public void setAllowsProtectedMedia(RNCWebView view, boolean value) {
+    public void setAllowsProtectedMedia(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setAllowsProtectedMedia(view, value);
     }
 
     @ReactProp(name = "androidLayerType")
-    public void setAndroidLayerType(RNCWebView view, @Nullable String value) {
+    public void setAndroidLayerType(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setAndroidLayerType(view, value);
     }
 
     @ReactProp(name = "applicationNameForUserAgent")
-    public void setApplicationNameForUserAgent(RNCWebView view, @Nullable String value) {
+    public void setApplicationNameForUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setApplicationNameForUserAgent(view, value);
     }
 
     @ReactProp(name = "basicAuthCredential")
-    public void setBasicAuthCredential(RNCWebView view, @Nullable ReadableMap value) {
+    public void setBasicAuthCredential(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setBasicAuthCredential(view, value);
     }
 
     @ReactProp(name = "cacheEnabled")
-    public void setCacheEnabled(RNCWebView view, boolean value) {
+    public void setCacheEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setCacheEnabled(view, value);
     }
 
     @ReactProp(name = "cacheMode")
-    public void setCacheMode(RNCWebView view, @Nullable String value) {
+    public void setCacheMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setCacheMode(view, value);
     }
 
     @ReactProp(name = "domStorageEnabled")
-    public void setDomStorageEnabled(RNCWebView view, boolean value) {
+    public void setDomStorageEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setDomStorageEnabled(view, value);
     }
 
     @ReactProp(name = "downloadingMessage")
-    public void setDownloadingMessage(RNCWebView view, @Nullable String value) {
+    public void setDownloadingMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setDownloadingMessage(value);
     }
 
     @ReactProp(name = "forceDarkOn")
-    public void setForceDarkOn(RNCWebView view, boolean value) {
+    public void setForceDarkOn(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setForceDarkOn(view, value);
     }
 
     @ReactProp(name = "geolocationEnabled")
-    public void setGeolocationEnabled(RNCWebView view, boolean value) {
+    public void setGeolocationEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setGeolocationEnabled(view, value);
     }
 
     @ReactProp(name = "hasOnScroll")
-    public void setHasOnScroll(RNCWebView view, boolean hasScrollEvent) {
+    public void setHasOnScroll(RNCWebViewWrapper view, boolean hasScrollEvent) {
         mRNCWebViewManagerImpl.setHasOnScroll(view, hasScrollEvent);
     }
 
     @ReactProp(name = "incognito")
-    public void setIncognito(RNCWebView view, boolean value) {
+    public void setIncognito(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setIncognito(view, value);
     }
 
     @ReactProp(name = "injectedJavaScript")
-    public void setInjectedJavaScript(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScript(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScript(view, value);
     }
 
     @ReactProp(name = "injectedJavaScriptBeforeContentLoaded")
-    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebView view, @Nullable String value) {
+    public void setInjectedJavaScriptBeforeContentLoaded(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoaded(view, value);
     }
 
     @ReactProp(name = "injectedJavaScriptForMainFrameOnly")
-    public void setInjectedJavaScriptForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptForMainFrameOnly(view, value);
 
     }
 
     @ReactProp(name = "injectedJavaScriptBeforeContentLoadedForMainFrameOnly")
-    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebView view, boolean value) {
+    public void setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(view, value);
 
     }
 
+    @ReactProp(name = "injectedJavaScriptObject")
+    public void setInjectedJavaScriptObject(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setInjectedJavaScriptObject(view, value);
+    }
+
     @ReactProp(name = "javaScriptCanOpenWindowsAutomatically")
-    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebView view, boolean value) {
+    public void setJavaScriptCanOpenWindowsAutomatically(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setJavaScriptCanOpenWindowsAutomatically(view, value);
     }
 
     @ReactProp(name = "javaScriptEnabled")
-    public void setJavaScriptEnabled(RNCWebView view, boolean enabled) {
+    public void setJavaScriptEnabled(RNCWebViewWrapper view, boolean enabled) {
         mRNCWebViewManagerImpl.setJavaScriptEnabled(view, enabled);
     }
 
     @ReactProp(name = "lackPermissionToDownloadMessage")
-    public void setLackPermissionToDownloadMessage(RNCWebView view, @Nullable String value) {
+    public void setLackPermissionToDownloadMessage(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setLackPermissionToDownloadMessage(value);
     }
 
+    @ReactProp(name = "hasOnOpenWindowEvent")
+    public void setHasOnOpenWindowEvent(RNCWebViewWrapper view, boolean hasEvent) {
+        mRNCWebViewManagerImpl.setHasOnOpenWindowEvent(view, hasEvent);
+    }
+
     @ReactProp(name = "mediaPlaybackRequiresUserAction")
-    public void setMediaPlaybackRequiresUserAction(RNCWebView view, boolean value) {
+    public void setMediaPlaybackRequiresUserAction(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMediaPlaybackRequiresUserAction(view, value);
     }
 
     @ReactProp(name = "messagingEnabled")
-    public void setMessagingEnabled(RNCWebView view, boolean value) {
+    public void setMessagingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setMessagingEnabled(view, value);
     }
 
     @ReactProp(name = "menuItems")
-    public void setMenuCustomItems(RNCWebView view, @Nullable ReadableArray items) {
+    public void setMenuCustomItems(RNCWebViewWrapper view, @Nullable ReadableArray items) {
         mRNCWebViewManagerImpl.setMenuCustomItems(view, items);
     }
 
     @ReactProp(name = "messagingModuleName")
-    public void setMessagingModuleName(RNCWebView view, @Nullable String value) {
+    public void setMessagingModuleName(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMessagingModuleName(view, value);
     }
 
     @ReactProp(name = "minimumFontSize")
-    public void setMinimumFontSize(RNCWebView view, int value) {
+    public void setMinimumFontSize(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setMinimumFontSize(view, value);
     }
 
     @ReactProp(name = "mixedContentMode")
-    public void setMixedContentMode(RNCWebView view, @Nullable String value) {
+    public void setMixedContentMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setMixedContentMode(view, value);
     }
 
     @ReactProp(name = "nestedScrollEnabled")
-    public void setNestedScrollEnabled(RNCWebView view, boolean value) {
+    public void setNestedScrollEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setNestedScrollEnabled(view, value);
     }
 
     @ReactProp(name = "overScrollMode")
-    public void setOverScrollMode(RNCWebView view, @Nullable String value) {
+    public void setOverScrollMode(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setOverScrollMode(view, value);
     }
 
     @ReactProp(name = "saveFormDataDisabled")
-    public void setSaveFormDataDisabled(RNCWebView view, boolean value) {
+    public void setSaveFormDataDisabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSaveFormDataDisabled(view, value);
     }
 
     @ReactProp(name = "scalesPageToFit")
-    public void setScalesPageToFit(RNCWebView view, boolean value) {
+    public void setScalesPageToFit(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setScalesPageToFit(view, value);
     }
 
     @ReactProp(name = "setBuiltInZoomControls")
-    public void setSetBuiltInZoomControls(RNCWebView view, boolean value) {
+    public void setSetBuiltInZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetBuiltInZoomControls(view, value);
     }
 
     @ReactProp(name = "setDisplayZoomControls")
-    public void setSetDisplayZoomControls(RNCWebView view, boolean value) {
+    public void setSetDisplayZoomControls(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetDisplayZoomControls(view, value);
     }
 
     @ReactProp(name = "setSupportMultipleWindows")
-    public void setSetSupportMultipleWindows(RNCWebView view, boolean value) {
+    public void setSetSupportMultipleWindows(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setSetSupportMultipleWindows(view, value);
     }
 
     @ReactProp(name = "showsHorizontalScrollIndicator")
-    public void setShowsHorizontalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsHorizontalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsHorizontalScrollIndicator(view, value);
     }
 
     @ReactProp(name = "showsVerticalScrollIndicator")
-    public void setShowsVerticalScrollIndicator(RNCWebView view, boolean value) {
+    public void setShowsVerticalScrollIndicator(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setShowsVerticalScrollIndicator(view, value);
     }
 
     @ReactProp(name = "source")
-    public void setSource(RNCWebView view, @Nullable ReadableMap value) {
+    public void setSource(RNCWebViewWrapper view, @Nullable ReadableMap value) {
         mRNCWebViewManagerImpl.setSource(view, value, false);
     }
 
     @ReactProp(name = "textZoom")
-    public void setTextZoom(RNCWebView view, int value) {
+    public void setTextZoom(RNCWebViewWrapper view, int value) {
         mRNCWebViewManagerImpl.setTextZoom(view, value);
     }
 
     @ReactProp(name = "thirdPartyCookiesEnabled")
-    public void setThirdPartyCookiesEnabled(RNCWebView view, boolean value) {
+    public void setThirdPartyCookiesEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setThirdPartyCookiesEnabled(view, value);
     }
 
     @ReactProp(name = "webviewDebuggingEnabled")
-    public void setWebviewDebuggingEnabled(RNCWebView view, boolean value) {
+    public void setWebviewDebuggingEnabled(RNCWebViewWrapper view, boolean value) {
         mRNCWebViewManagerImpl.setWebviewDebuggingEnabled(view, value);
     }
 
     @ReactProp(name = "userAgent")
-    public void setUserAgent(RNCWebView view, @Nullable String value) {
+    public void setUserAgent(RNCWebViewWrapper view, @Nullable String value) {
         mRNCWebViewManagerImpl.setUserAgent(view, value);
     }
 
     @Override
-    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebView view) {
+    protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
         // Do not register default touch emitter and let WebView implementation handle touches
-        view.setWebViewClient(new RNCWebViewClient());
+        viewWrapper.getWebView().setWebViewClient(new RNCWebViewClient());
     }
 
     @Override
@@ -295,6 +298,7 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
         export.put(TopHttpErrorEvent.EVENT_NAME, MapBuilder.of("registrationName", "onHttpError"));
         export.put(TopRenderProcessGoneEvent.EVENT_NAME, MapBuilder.of("registrationName", "onRenderProcessGone"));
         export.put(TopCustomMenuSelectionEvent.EVENT_NAME, MapBuilder.of("registrationName", "onCustomMenuSelection"));
+        export.put(TopOpenWindowEvent.EVENT_NAME, MapBuilder.of("registrationName", "onOpenWindow"));
         return export;
     }
 
@@ -305,13 +309,13 @@ public class RNCWebViewManager extends SimpleViewManager<RNCWebView> {
     }
 
     @Override
-    public void receiveCommand(@NonNull RNCWebView reactWebView, String commandId, @Nullable ReadableArray args) {
+    public void receiveCommand(@NonNull RNCWebViewWrapper reactWebView, String commandId, @Nullable ReadableArray args) {
         mRNCWebViewManagerImpl.receiveCommand(reactWebView, commandId, args);
         super.receiveCommand(reactWebView, commandId, args);
     }
 
     @Override
-    public void onDropViewInstance(@NonNull RNCWebView view) {
+    public void onDropViewInstance(@NonNull RNCWebViewWrapper view) {
         mRNCWebViewManagerImpl.onDropViewInstance(view);
         super.onDropViewInstance(view);
     }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManagerImpl.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewManagerImpl.kt
@@ -27,7 +27,7 @@ import org.json.JSONObject
 import java.io.UnsupportedEncodingException
 import java.net.MalformedURLException
 import java.net.URL
-import java.util.*
+import java.util.Locale
 
 val invalidCharRegex = "[\\\\/%\"]".toRegex()
 
@@ -42,6 +42,7 @@ class RNCWebViewManagerImpl {
     private var mAllowsProtectedMedia = false
     private var mDownloadingMessage: String? = null
     private var mLackPermissionToDownloadMessage: String? = null
+    private var mHasOnOpenWindowEvent = false
 
     private var mUserAgent: String? = null
     private var mUserAgentWithApplicationName: String? = null
@@ -61,12 +62,12 @@ class RNCWebViewManagerImpl {
         return RNCWebView(context)
     }
 
-    fun createViewInstance(context: ThemedReactContext): RNCWebView {
+    fun createViewInstance(context: ThemedReactContext): RNCWebViewWrapper {
       val webView = createRNCWebViewInstance(context)
       return createViewInstance(context, webView);
     }
 
-    fun createViewInstance(context: ThemedReactContext, webView: RNCWebView): RNCWebView {
+    fun createViewInstance(context: ThemedReactContext, webView: RNCWebView): RNCWebViewWrapper {
         setupWebChromeClient(webView)
         context.addLifecycleEventListener(webView)
         mWebViewConfig.configWebView(webView)
@@ -78,8 +79,8 @@ class RNCWebViewManagerImpl {
         settings.allowFileAccess = false
         settings.allowContentAccess = false
         settings.allowFileAccessFromFileURLs = false
-        setAllowUniversalAccessFromFileURLs(webView, false)
-        setMixedContentMode(webView, "never")
+        settings.allowUniversalAccessFromFileURLs = false
+        settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
 
         // Fixes broken full-screen modals/galleries due to body height being 0.
         webView.layoutParams = ViewGroup.LayoutParams(
@@ -134,7 +135,7 @@ class RNCWebViewManagerImpl {
                 )
             }
         })
-        return webView
+        return RNCWebViewWrapper(context, webView)
     }
 
     private fun setupWebChromeClient(
@@ -206,6 +207,7 @@ class RNCWebViewManagerImpl {
                     }
                 }
             webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
+            webChromeClient.setHasOnOpenWindowEvent(mHasOnOpenWindowEvent);
             webView.webChromeClient = webChromeClient
         } else {
             var webChromeClient = webView.webChromeClient as RNCWebChromeClient?
@@ -216,29 +218,31 @@ class RNCWebViewManagerImpl {
                 }
             }
             webChromeClient.setAllowsProtectedMedia(mAllowsProtectedMedia);
+            webChromeClient.setHasOnOpenWindowEvent(mHasOnOpenWindowEvent);
             webView.webChromeClient = webChromeClient
         }
     }
 
-    fun setUserAgent(view: WebView, userAgent: String?) {
+    fun setUserAgent(viewWrapper: RNCWebViewWrapper, userAgent: String?) {
         mUserAgent = userAgent
-        setUserAgentString(view)
+        setUserAgentString(viewWrapper)
     }
 
-    fun setApplicationNameForUserAgent(view: WebView, applicationName: String?) {
+    fun setApplicationNameForUserAgent(viewWrapper: RNCWebViewWrapper, applicationName: String?) {
         when {
             applicationName != null -> {
-                val defaultUserAgent = WebSettings.getDefaultUserAgent(view.context)
+                val defaultUserAgent = WebSettings.getDefaultUserAgent(viewWrapper.webView.context)
                 mUserAgentWithApplicationName = "$defaultUserAgent $applicationName"
             }
             else -> {
                 mUserAgentWithApplicationName = null
             }
         }
-        setUserAgentString(view)
+        setUserAgentString(viewWrapper)
     }
 
-    private fun setUserAgentString(view: WebView) {
+    private fun setUserAgentString(viewWrapper: RNCWebViewWrapper) {
+        val view = viewWrapper.webView
         when {
             mUserAgent != null -> {
                 view.settings.userAgentString = mUserAgent
@@ -252,7 +256,7 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setBasicAuthCredential(view: WebView, credential: ReadableMap?) {
+    fun setBasicAuthCredential(viewWrapper: RNCWebViewWrapper, credential: ReadableMap?) {
         var basicAuthCredential: RNCBasicAuthCredential? = null
         if (credential != null) {
             if (credential.hasKey("username") && credential.hasKey("password")) {
@@ -261,10 +265,11 @@ class RNCWebViewManagerImpl {
                 basicAuthCredential = RNCBasicAuthCredential(username, password)
             }
         }
-        (view as RNCWebView).setBasicAuthCredential(basicAuthCredential)
+        viewWrapper.webView.setBasicAuthCredential(basicAuthCredential)
     }
 
-    fun onDropViewInstance(webView: RNCWebView) {
+    fun onDropViewInstance(viewWrapper: RNCWebViewWrapper) {
+        val webView = viewWrapper.webView
         webView.themedReactContext.removeLifecycleEventListener(webView)
         webView.cleanupCallbacksAndDestroy()
         webView.mWebChromeClient = null
@@ -300,7 +305,8 @@ class RNCWebViewManagerImpl {
         .build()
     }
 
-    fun receiveCommand(webView: RNCWebView, commandId: String, args: ReadableArray) {
+    fun receiveCommand(viewWrapper: RNCWebViewWrapper, commandId: String, args: ReadableArray) {
+      val webView = viewWrapper.webView
       when (commandId) {
         "goBack" -> webView.goBack()
         "goForward" -> webView.goForward()
@@ -343,7 +349,8 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMixedContentMode(view: WebView, mixedContentMode: String?) {
+    fun setMixedContentMode(viewWrapper: RNCWebViewWrapper, mixedContentMode: String?) {
+        val view = viewWrapper.webView
         if (mixedContentMode == null || "never" == mixedContentMode) {
             view.settings.mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
         } else if ("always" == mixedContentMode) {
@@ -353,8 +360,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setAllowUniversalAccessFromFileURLs(view: WebView, allow: Boolean) {
-        view.settings.allowUniversalAccessFromFileURLs = allow
+    fun setAllowUniversalAccessFromFileURLs(viewWrapper: RNCWebViewWrapper, allow: Boolean) {
+        viewWrapper.webView.settings.allowUniversalAccessFromFileURLs = allow
     }
 
     private fun getDownloadingMessageOrDefault(): String? {
@@ -366,7 +373,8 @@ class RNCWebViewManagerImpl {
             ?: DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE
     }
 
-    fun setSource(view: RNCWebView, source: ReadableMap?, newArch: Boolean = true) {
+    fun setSource(viewWrapper: RNCWebViewWrapper, source: ReadableMap?, newArch: Boolean = true) {
+        val view = viewWrapper.webView
         if (source != null) {
             if (source.hasKey("html")) {
                 val html = source.getString("html")
@@ -439,15 +447,18 @@ class RNCWebViewManagerImpl {
         view.loadUrl(BLANK_URL)
     }
 
-    fun setMessagingModuleName(view: RNCWebView, value: String?) {
+    fun setMessagingModuleName(viewWrapper: RNCWebViewWrapper, value: String?) {
+        val view = viewWrapper.webView
         view.messagingModuleName = value
     }
 
-    fun setCacheEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setCacheEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+      val view = viewWrapper.webView
       view.settings.cacheMode = if (enabled) WebSettings.LOAD_DEFAULT else WebSettings.LOAD_NO_CACHE
     }
 
-    fun setIncognito(view: RNCWebView, enabled: Boolean) {
+    fun setIncognito(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         // Don't do anything when incognito is disabled
         if (!enabled) {
             return;
@@ -467,64 +478,84 @@ class RNCWebViewManagerImpl {
         view.settings.saveFormData = false;
     }
 
-    fun setInjectedJavaScript(view: RNCWebView, injectedJavaScript: String?) {
+    fun setInjectedJavaScript(viewWrapper: RNCWebViewWrapper, injectedJavaScript: String?) {
+        val view = viewWrapper.webView
         view.injectedJS = injectedJavaScript
     }
 
-    fun setInjectedJavaScriptBeforeContentLoaded(view: RNCWebView, value: String?) {
+    fun setInjectedJavaScriptBeforeContentLoaded(viewWrapper: RNCWebViewWrapper, value: String?) {
+        val view = viewWrapper.webView
         view.injectedJSBeforeContentLoaded = value
     }
 
-    fun setInjectedJavaScriptForMainFrameOnly(view: RNCWebView, value: Boolean) {
+    fun setInjectedJavaScriptForMainFrameOnly(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.injectedJavaScriptForMainFrameOnly = value
     }
 
-    fun setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(view: RNCWebView, value: Boolean) {
+    fun setInjectedJavaScriptBeforeContentLoadedForMainFrameOnly(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.injectedJavaScriptBeforeContentLoadedForMainFrameOnly = value
     }
 
-    fun setJavaScriptCanOpenWindowsAutomatically(view: RNCWebView, value: Boolean) {
+    fun setInjectedJavaScriptObject(viewWrapper: RNCWebViewWrapper, value: String?) {
+        val view = viewWrapper.webView
+        view.setInjectedJavaScriptObject(value)
+    }
+
+    fun setJavaScriptCanOpenWindowsAutomatically(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.javaScriptCanOpenWindowsAutomatically = value
     }
 
-    fun setShowsVerticalScrollIndicator(view: RNCWebView, value: Boolean) {
+    fun setShowsVerticalScrollIndicator(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.isVerticalScrollBarEnabled = value
     }
 
-    fun setShowsHorizontalScrollIndicator(view: RNCWebView, value: Boolean) {
+    fun setShowsHorizontalScrollIndicator(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.isHorizontalScrollBarEnabled = value
     }
 
-    fun setMessagingEnabled(view: RNCWebView, value: Boolean) {
+    fun setMessagingEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.setMessagingEnabled(value)
     }
 
-    fun setMediaPlaybackRequiresUserAction(view: RNCWebView, value: Boolean) {
+    fun setMediaPlaybackRequiresUserAction(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.mediaPlaybackRequiresUserGesture = value
     }
 
-    fun setHasOnScroll(view: RNCWebView, value: Boolean) {
+    fun setHasOnScroll(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.setHasScrollEvent(value)
     }
 
-    fun setJavaScriptEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setJavaScriptEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         view.settings.javaScriptEnabled = enabled
     }
 
-    fun setAllowFileAccess(view: RNCWebView, allowFileAccess: Boolean) {
+    fun setAllowFileAccess(viewWrapper: RNCWebViewWrapper, allowFileAccess: Boolean) {
+        val view = viewWrapper.webView
         view.settings.allowFileAccess = allowFileAccess;
     }
 
-    fun setAllowFileAccessFromFileURLs(view: RNCWebView, value: Boolean) {
+    fun setAllowFileAccessFromFileURLs(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.allowFileAccessFromFileURLs = value;
     }
 
-    fun setAllowsFullscreenVideo(view: RNCWebView, value: Boolean) {
+    fun setAllowsFullscreenVideo(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         mAllowsFullscreenVideo = value
         setupWebChromeClient(view)
     }
 
-    fun setAndroidLayerType(view: RNCWebView, layerTypeString: String?) {
+    fun setAndroidLayerType(viewWrapper: RNCWebViewWrapper, layerTypeString: String?) {
+        val view = viewWrapper.webView
         val layerType = when (layerTypeString) {
             "hardware" -> View.LAYER_TYPE_HARDWARE
             "software" -> View.LAYER_TYPE_SOFTWARE
@@ -533,7 +564,8 @@ class RNCWebViewManagerImpl {
         view.setLayerType(layerType, null)
     }
 
-    fun setCacheMode(view: RNCWebView, cacheModeString: String?) {
+    fun setCacheMode(viewWrapper: RNCWebViewWrapper, cacheModeString: String?) {
+        val view = viewWrapper.webView
         view.settings.cacheMode = when (cacheModeString) {
             "LOAD_CACHE_ONLY" -> WebSettings.LOAD_CACHE_ONLY
             "LOAD_CACHE_ELSE_NETWORK" -> WebSettings.LOAD_CACHE_ELSE_NETWORK
@@ -543,7 +575,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setDomStorageEnabled(view: RNCWebView, value: Boolean) {
+    fun setDomStorageEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.domStorageEnabled = value
     }
 
@@ -551,7 +584,8 @@ class RNCWebViewManagerImpl {
         mDownloadingMessage = value
     }
 
-    fun setForceDarkOn(view: RNCWebView, enabled: Boolean) {
+    fun setForceDarkOn(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         // Only Android 10+ support dark mode
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
@@ -574,7 +608,8 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setGeolocationEnabled(view: RNCWebView, value: Boolean) {
+    fun setGeolocationEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.setGeolocationEnabled(value)
     }
 
@@ -582,11 +617,19 @@ class RNCWebViewManagerImpl {
         mLackPermissionToDownloadMessage = value
     }
 
-    fun setMinimumFontSize(view: RNCWebView, value: Int) {
+    fun setHasOnOpenWindowEvent(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
+        mHasOnOpenWindowEvent = value
+        setupWebChromeClient(view)
+    }
+
+    fun setMinimumFontSize(viewWrapper: RNCWebViewWrapper, value: Int) {
+        val view = viewWrapper.webView
         view.settings.minimumFontSize = value
     }
 
-    fun setAllowsProtectedMedia(view: RNCWebView, enabled: Boolean) {
+    fun setAllowsProtectedMedia(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+      val view = viewWrapper.webView
       // This variable is used to keep consistency
       // in case a new WebChromeClient is created
       // (eg. when mAllowsFullScreenVideo changes)
@@ -599,15 +642,18 @@ class RNCWebViewManagerImpl {
       }
     }
 
-    fun setMenuCustomItems(view: RNCWebView, value: ReadableArray) {
+    fun setMenuCustomItems(viewWrapper: RNCWebViewWrapper, value: ReadableArray) {
+        val view = viewWrapper.webView
         view.setMenuCustomItems(value.toArrayList() as List<Map<String, String>>)
     }
 
-    fun setNestedScrollEnabled(view: RNCWebView, value: Boolean) {
+    fun setNestedScrollEnabled(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.nestedScrollEnabled = value
     }
 
-    fun setOverScrollMode(view: RNCWebView, overScrollModeString: String?) {
+    fun setOverScrollMode(viewWrapper: RNCWebViewWrapper, overScrollModeString: String?) {
+        val view = viewWrapper.webView
         view.overScrollMode = when (overScrollModeString) {
             "never" -> View.OVER_SCROLL_NEVER
             "content" -> View.OVER_SCROLL_IF_CONTENT_SCROLLS
@@ -616,37 +662,44 @@ class RNCWebViewManagerImpl {
         }
     }
 
-    fun setSaveFormDataDisabled(view: RNCWebView, disabled: Boolean) {
+    fun setSaveFormDataDisabled(viewWrapper: RNCWebViewWrapper, disabled: Boolean) {
+        val view = viewWrapper.webView
         view.settings.saveFormData = !disabled
     }
 
-    fun setScalesPageToFit(view: RNCWebView, value: Boolean) {
+    fun setScalesPageToFit(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.loadWithOverviewMode = value
         view.settings.useWideViewPort = value
     }
 
-    fun setSetBuiltInZoomControls(view: RNCWebView, value: Boolean) {
+    fun setSetBuiltInZoomControls(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.builtInZoomControls = value
     }
 
-    fun setSetDisplayZoomControls(view: RNCWebView, value: Boolean) {
+    fun setSetDisplayZoomControls(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.displayZoomControls = value
 
     }
 
-    fun setSetSupportMultipleWindows(view: RNCWebView, value: Boolean) {
+    fun setSetSupportMultipleWindows(viewWrapper: RNCWebViewWrapper, value: Boolean) {
+        val view = viewWrapper.webView
         view.settings.setSupportMultipleWindows(value)
     }
 
-    fun setTextZoom(view: RNCWebView, value: Int) {
+    fun setTextZoom(viewWrapper: RNCWebViewWrapper, value: Int) {
+        val view = viewWrapper.webView
         view.settings.textZoom = value
     }
 
-    fun setThirdPartyCookiesEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setThirdPartyCookiesEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
         CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled)
     }
 
-    fun setWebviewDebuggingEnabled(view: RNCWebView, enabled: Boolean) {
+    fun setWebviewDebuggingEnabled(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
         RNCWebView.setWebContentsDebuggingEnabled(enabled)
     }
 }

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewWrapper.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/RNCWebViewWrapper.kt
@@ -1,0 +1,39 @@
+package versioned.host.exp.exponent.modules.api.components.webview
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+import android.webkit.WebView
+import android.widget.FrameLayout
+
+/**
+ * A [FrameLayout] container to hold the [RNCWebView].
+ * We need this to prevent WebView crash when the WebView is out of viewport and
+ * [com.facebook.react.views.view.ReactViewGroup] clips the canvas.
+ * The WebView will then create an empty offscreen surface and NPE.
+ */
+class RNCWebViewWrapper(context: Context, webView: RNCWebView) : FrameLayout(context) {
+  init {
+    // We make the WebView as transparent on top of the container,
+    // and let React Native sets background color for the container.
+    webView.setBackgroundColor(Color.TRANSPARENT)
+    addView(webView)
+  }
+
+  val webView: RNCWebView = getChildAt(0) as RNCWebView
+
+  companion object {
+    /**
+     * A helper to get react tag id by given WebView
+     */
+    @JvmStatic
+    fun getReactTagFromWebView(webView: WebView): Int {
+      // It is expected that the webView is enclosed by [RNCWebViewWrapper] as the first child.
+      // Therefore, it must have a parent, and the parent ID is the reactTag.
+      // In exceptional cases, such as receiving WebView messaging after the view has been unmounted,
+      // the WebView will not have a parent.
+      // In this case, we simply return -1 to indicate that it was not found.
+      return (webView.parent as? View)?.id ?: -1
+    }
+  }
+}

--- a/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopNewWindowEvent.kt
+++ b/android/expoview/src/main/java/versioned/host/exp/exponent/modules/api/components/webview/events/TopNewWindowEvent.kt
@@ -1,0 +1,25 @@
+package versioned.host.exp.exponent.modules.api.components.webview.events
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+/**
+ * Event emitted when the WebView opens a new Window (i.e: target=_blank)
+ */
+class TopOpenWindowEvent(viewId: Int, private val mEventData: WritableMap) :
+  Event<TopOpenWindowEvent>(viewId) {
+  companion object {
+    const val EVENT_NAME = "topOpenWindow"
+  }
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun canCoalesce(): Boolean = false
+
+  override fun getCoalescingKey(): Short = 0
+
+  override fun dispatch(rctEventEmitter: RCTEventEmitter) =
+    rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
+}

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -634,7 +634,7 @@ PODS:
     - React-Core
   - react-native-view-shot (3.7.0):
     - React-Core
-  - react-native-webview (13.2.2):
+  - react-native-webview (13.6.2):
     - React-Core
   - React-NativeModulesApple (0.72.5):
     - hermes-engine
@@ -1323,7 +1323,7 @@ SPEC CHECKSUMS:
   ExpoCellular: fcb9bc581cab254b63bfcffa60de0abd4e63550b
   ExpoClipboard: 6729cb7ff3f999bf555960a4f3b17dd6b0d919f2
   ExpoCrypto: 42485127a5968dda6f67ac5f2b42d3c0af31d7db
-  ExpoDevice: 3055a3229d414b8243323fddeb1ac2343548c2aa
+  ExpoDevice: 2b9831d480aaf5f361998dbed4ede8cd70bac245
   ExpoDocumentPicker: d3b6b0ed2dbbc2f05158e0294dd3f4673f386e5f
   ExpoFileSystem: 62cf8d5681581de1fb43b8af8ea6d7604eb786a6
   ExpoGL: 6aedfc52c13c1eea5728ec4504f96580bc4dee65
@@ -1335,7 +1335,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: df1cf76de3171cd57e7cc8a2547401404fcc0b31
   ExpoLinearGradient: 5d18293f89c063036121281175c4653d6a7c34a2
   ExpoLocalAuthentication: 2fed4b25cf8e54d36d5d1ebc9917e8325b3b5911
-  ExpoLocalization: 2d5f47577d67ce991ebdd951edf14fe1db85fa06
+  ExpoLocalization: ed5b03c44592ae8aa7c9103882082612f63c2aff
   ExpoMailComposer: f88bdf18939c94eb965db28c13ba2d85cba70112
   ExpoMaps: e513ba357e6d9fab2e21cd30f6800d89b051b431
   ExpoModulesCore: d8437d39da4407d3c6e7001535b9b6c940c62c1b
@@ -1397,7 +1397,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
   react-native-view-shot: f5507655f122e6b104888a11130f267a427f0d57
-  react-native-webview: b8ec89966713985111a14d6e4bf98d8b54bced0d
+  react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
   React-NativeModulesApple: 797bc6078d566eef3fb3f74127e6e1d2e945a15f
   React-perflogger: cd8886513f68e1c135a1e79d20575c6489641597
   React-RCTActionSheet: 726d2615ca62a77ce3e2c13d87f65379cdc73498

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -90,7 +90,7 @@
     "react-native-screens": "~3.22.0",
     "react-native-svg": "13.9.0",
     "react-native-view-shot": "3.7.0",
-    "react-native-webview": "13.2.2",
+    "react-native-webview": "13.6.2",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -153,7 +153,7 @@
     "react-native-svg": "13.9.0",
     "react-native-view-shot": "3.7.0",
     "react-native-web": "~0.19.6",
-    "react-native-webview": "13.2.2",
+    "react-native-webview": "13.6.2",
     "react-navigation": "^4.4.0",
     "regl": "^1.3.0",
     "three": "^0.137.4",

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2885,7 +2885,7 @@ PODS:
     - React-Core
   - react-native-slider (4.4.2):
     - React-Core
-  - react-native-webview (13.2.2):
+  - react-native-webview (13.6.2):
     - React-Core
   - React-NativeModulesApple (0.72.5):
     - hermes-engine
@@ -4930,7 +4930,7 @@ SPEC CHECKSUMS:
   ExpoCellular: fcb9bc581cab254b63bfcffa60de0abd4e63550b
   ExpoClipboard: 6729cb7ff3f999bf555960a4f3b17dd6b0d919f2
   ExpoCrypto: 42485127a5968dda6f67ac5f2b42d3c0af31d7db
-  ExpoDevice: 3055a3229d414b8243323fddeb1ac2343548c2aa
+  ExpoDevice: 2b9831d480aaf5f361998dbed4ede8cd70bac245
   ExpoDocumentPicker: d3b6b0ed2dbbc2f05158e0294dd3f4673f386e5f
   ExpoFileSystem: 62cf8d5681581de1fb43b8af8ea6d7604eb786a6
   ExpoGL: 6aedfc52c13c1eea5728ec4504f96580bc4dee65
@@ -4942,7 +4942,7 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: df1cf76de3171cd57e7cc8a2547401404fcc0b31
   ExpoLinearGradient: 5d18293f89c063036121281175c4653d6a7c34a2
   ExpoLocalAuthentication: 2fed4b25cf8e54d36d5d1ebc9917e8325b3b5911
-  ExpoLocalization: 2d5f47577d67ce991ebdd951edf14fe1db85fa06
+  ExpoLocalization: ed5b03c44592ae8aa7c9103882082612f63c2aff
   ExpoMailComposer: f88bdf18939c94eb965db28c13ba2d85cba70112
   ExpoModulesCore: d8437d39da4407d3c6e7001535b9b6c940c62c1b
   ExpoModulesTestCore: 0287488fb9c7f189fcecd8e46ef6b995091aa5a3
@@ -5030,7 +5030,7 @@ SPEC CHECKSUMS:
   react-native-segmented-control: 0e4b5d93911e2234f110057df2b41738b326ab3e
   react-native-skia: 4753a9e236c5dfc73cfb98dccfff3496f12fd877
   react-native-slider: 33b8d190b59d4f67a541061bb91775d53d617d9d
-  react-native-webview: b8ec89966713985111a14d6e4bf98d8b54bced0d
+  react-native-webview: 8fc09f66a1a5b16bbe37c3878fda27d5982bb776
   React-NativeModulesApple: 797bc6078d566eef3fb3f74127e6e1d2e945a15f
   React-perflogger: cd8886513f68e1c135a1e79d20575c6489641597
   React-RCTActionSheet: 726d2615ca62a77ce3e2c13d87f65379cdc73498

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.mm
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebView.mm
@@ -374,6 +374,15 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
         }
         [_view setMenuItems:newMenuItems];
     }
+    if(oldViewProps.suppressMenuItems != newViewProps.suppressMenuItems) {
+        NSMutableArray *suppressMenuItems = [NSMutableArray array];
+
+        for (const auto &menuItem: newViewProps.suppressMenuItems) {
+            [suppressMenuItems addObject: RCTNSStringFromString(menuItem)];
+        }
+        
+        [_view setSuppressMenuItems:suppressMenuItems];
+    }
     if (oldViewProps.hasOnFileDownload != newViewProps.hasOnFileDownload) {
         if (newViewProps.hasOnFileDownload) {
             _view.onFileDownload = [self](NSDictionary* dictionary) {
@@ -387,6 +396,21 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
             };
         } else {
             _view.onFileDownload = nil;        
+        }
+    }
+    if (oldViewProps.hasOnOpenWindowEvent != newViewProps.hasOnOpenWindowEvent) {
+        if (newViewProps.hasOnOpenWindowEvent) {
+            _view.onOpenWindow = [self](NSDictionary* dictionary) {
+                if (_eventEmitter) {
+                    auto webViewEventEmitter = std::static_pointer_cast<RNCWebViewEventEmitter const>(_eventEmitter);
+                    facebook::react::RNCWebViewEventEmitter::OnOpenWindow data = {
+                        .targetUrl = std::string([[dictionary valueForKey:@"targetUrl"] UTF8String])
+                    };
+                    webViewEventEmitter->onOpenWindow(data);
+                }
+            };
+        } else {
+            _view.onOpenWindow = nil;
         }
     }
 //

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewImpl.h
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewImpl.h
@@ -56,6 +56,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, copy) RCTDirectEventBlock onMessage;
 @property (nonatomic, copy) RCTDirectEventBlock onScroll;
 @property (nonatomic, copy) RCTDirectEventBlock onContentProcessDidTerminate;
+@property (nonatomic, copy) RCTDirectEventBlock onOpenWindow;
 
 
 @property (nonatomic, weak) id<RNCWebViewDelegate> _Nullable delegate;
@@ -99,6 +100,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL enableApplePay;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
+@property (nonatomic, copy) NSArray<NSString *> * _Nullable suppressMenuItems;
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
 #if !TARGET_OS_OSX
 @property (nonatomic, assign) WKDataDetectorTypes dataDetectorTypes;
@@ -135,6 +137,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 - (void)reload;
 - (void)stopLoading;
 - (void)requestFocus;
+- (void)clearCache:(BOOL)includeDiskFiles;
 #ifdef RCT_NEW_ARCH_ENABLED
 - (void)destroyWebView;
 #endif

--- a/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.mm
+++ b/ios/vendored/unversioned/react-native-webview/apple/RNCWebViewManager.mm
@@ -74,6 +74,7 @@ RCT_EXPORT_VIEW_PROPERTY(onLoadingProgress, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onHttpError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onShouldStartLoadWithRequest, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onContentProcessDidTerminate, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onOpenWindow, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScript, NSString)
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScriptBeforeContentLoaded, NSString)
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScriptForMainFrameOnly, BOOL)
@@ -135,8 +136,12 @@ RCT_EXPORT_VIEW_PROPERTY(onMessage, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(enableApplePay, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(menuItems, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(suppressMenuItems, NSArray);
+
 // New arch only
 RCT_CUSTOM_VIEW_PROPERTY(hasOnFileDownload, BOOL, RNCWebViewImpl) {}
+RCT_CUSTOM_VIEW_PROPERTY(hasOnOpenWindowEvent, BOOL, RNCWebViewImpl) {}
+
 RCT_EXPORT_VIEW_PROPERTY(onCustomMenuSelection, RCTDirectEventBlock)
 RCT_CUSTOM_VIEW_PROPERTY(pullToRefreshEnabled, BOOL, RNCWebViewImpl) {
   view.pullToRefreshEnabled = json == nil ? false : [RCTConvert BOOL: json];
@@ -223,6 +228,7 @@ QUICK_RCT_EXPORT_COMMAND_METHOD(requestFocus)
 
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(postMessage, message:(NSString *)message, message)
 QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(injectJavaScript, script:(NSString *)script, script)
+QUICK_RCT_EXPORT_COMMAND_METHOD_PARAMS(clearCache, includeDiskFiles:(BOOL)includeDiskFiles, includeDiskFiles)
 
 RCT_EXPORT_METHOD(shouldStartLoadWithLockIdentifier:(BOOL)shouldStart
                                         lockIdentifier:(double)lockIdentifier)

--- a/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
+++ b/ios/vendored/unversioned/react-native-webview/react-native-webview.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-webview",
-  "version": "13.2.2",
+  "version": "13.6.2",
   "summary": "React Native WebView component for iOS, Android, macOS, and Windows",
   "license": "MIT",
   "authors": "Jamon Holmgren <jamon@infinite.red>",
@@ -11,7 +11,7 @@
   },
   "source": {
     "git": "https://github.com/react-native-webview/react-native-webview.git",
-    "tag": "v13.2.2"
+    "tag": "v13.6.2"
   },
   "source_files": "apple/**/*.{h,m,mm,swift}",
   "dependencies": {

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -94,7 +94,7 @@
   "react-native-safe-area-context": "4.6.3",
   "react-native-svg": "13.9.0",
   "react-native-view-shot": "3.7.0",
-  "react-native-webview": "13.2.2",
+  "react-native-webview": "13.6.2",
   "sentry-expo": "~7.0.0",
   "unimodules-app-loader": "~4.3.0",
   "unimodules-image-loader-interface": "~6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16550,10 +16550,10 @@ react-native-web@~0.19.6:
     postcss-value-parser "^4.2.0"
     styleq "^0.1.3"
 
-react-native-webview@13.2.2:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.2.2.tgz#06b04db8e1f4ed57a9dc92f4094aa0e41271b89b"
-  integrity sha512-uT70y2GUqQzaj2RwRb/QuKRdXeDjXM6oN3DdPqYQlOOMFTCT8r62fybyjVVRoik8io+KLa5KnmuSoS5B2O1BmA==
+react-native-webview@13.6.2:
+  version "13.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.6.2.tgz#0a9b18793e915add5b5dbdbf32509d7751b49167"
+  integrity sha512-QzhQ5JCU+Nf2W285DtvCZOVQy/MkJXMwNDYPZvOWQbAOgxJMSSO+BtqXTMA1UPugDsko6PxJ0TxSlUwIwJijDg==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"


### PR DESCRIPTION
# Why

In order to upgrade react-native to 0.73 we will need to update some android libraries to ensure that a namespace is specified in their build.gradle as React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. (https://github.com/react-native-community/discussions-and-proposals/issues/671)

# How

`et uvm -m react-native-webview --commit "v13.6.2"`

# Test Plan
 

- [x] test using `bare-expo` Android + NCL  
- [x] test using `bare-expo` iOS + NCL  
- [x] test unversioned expo go ios + NCL  
- [x] test unversioned expo go android + NCL  

# Checklist
 

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
