### PR TITLE
[core][iOS] Fix AppContextConfig initialization

### DIFF
--- a/packages/expo-modules-core/ios/AppContext.swift
+++ b/packages/expo-modules-core/ios/AppContext.swift
@@ -91,7 +91,7 @@ public final class AppContext: NSObject {
   }
 
   public convenience init(legacyModulesProxy: Any, legacyModuleRegistry: Any, config: AppContextConfig = .default) {
-    self.init()
+    self.init(config: config)
     self.legacyModulesProxy = legacyModulesProxy as? LegacyNativeModulesProxy
     self.legacyModuleRegistry = legacyModuleRegistry as? EXModuleRegistry
   }


### PR DESCRIPTION
# Why

Expo Go is unable to load assets and throws an error stating that `File 'XYZ' is not writable`. This is happening because it's trying to use the wrong File System directory given that the `AppContextConfig` is not being provided.

# How

Add missing `config` parameter to `self.init` inside `AppContext.swift`


# Test Plan

Run Expo Go unversioned and ensure assets are being loaded 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
