### PR TITLE
[actions] remove 'need review' label if an issue is accepted

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -97,9 +97,21 @@ jobs:
               However, we can’t promise any sort of timeline for resolution. We prioritize issues based on severity, breadth of impact, and alignment with our roadmap. If you’d like to help move it more quickly, you can continue to investigate it more deeply and/or you can open a pull request that fixes the cause.
             `})
       - name: Remove "Needs Review" label
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: 'needs review'
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: ['needs review']
+              })
+            } catch (e) {
+              if (e.status != 404) {
+                throw e;
+              }
+            }
       - name: 👀 Checkout
         uses: actions/checkout@v3
       - name: ➕ Add `bin` to GITHUB_PATH

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -79,6 +79,8 @@ jobs:
 
   issue-accepted:
     runs-on: ubuntu-22.04
+    permissions:
+      issues: write
     if: github.event.label.name == 'issue accepted'
     steps:
       - name: Comment on issue
@@ -94,6 +96,10 @@ jobs:
               This comment acknowledges we believe this may be a bug and there’s enough information to investigate it.
               However, we can’t promise any sort of timeline for resolution. We prioritize issues based on severity, breadth of impact, and alignment with our roadmap. If you’d like to help move it more quickly, you can continue to investigate it more deeply and/or you can open a pull request that fixes the cause.
             `})
+      - name: Remove "Needs Review" label
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'needs review'
       - name: 👀 Checkout
         uses: actions/checkout@v3
       - name: ➕ Add `bin` to GITHUB_PATH


### PR DESCRIPTION
# Why

When we accept the an issue, the "needs review" label should be automatically removed. This makes it easier to filter new issues that need review.

# How

Add a step to remove the "needs review" label in the "issue-triage" action.

# Test Plan

Tested in isolation in a separate repo:

### Code tested:

```yml issue-triage.yml
name: Issue Triage
on:
  issues:
    types: [labeled]

jobs:
  issue-accepted:
    runs-on: ubuntu-22.04
    permissions:
      issues: write
    if: github.event.label.name == 'issue accepted'
    steps:
      - name: Remove "Needs Review" label
        uses: actions/github-script@v6
        with:
          script: |
            try {
              await github.rest.issues.removeLabel({
                issue_number: context.issue.number,
                owner: context.repo.owner,
                repo: context.repo.repo,
                name: ['needs review']
              })
            } catch (e) {
              if (e.status != 404) {
                throw e;
              }
            }
```

### Result:
<img width="944" alt="Screenshot 2023-10-13 at 10 58 53" src="https://github.com/expo/expo/assets/6534400/1f2a7f4f-bcd2-41b4-bb90-7ff845aeb500">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
