### PR TITLE
[docs] Update old forums link to Discord forums

### DIFF
--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -154,7 +154,7 @@ If you have followed the advice here, you're now in a good position to describe 
 
 ### How to ask a good question
 
-Join us on [Discord and Forums](https://chat.expo.dev) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/eas/enterprise-support). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
+Join us on [Discord and Forums](https://chat.expo.dev) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/support-terms#target-response-time-guidelines-for-subscriptions). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
 
 When you ask for troubleshooting help, be sure to share the following information:
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -61,7 +61,7 @@ It's important to note that with iOS builds the build details page only displays
 
 If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
-Armed with your error logs, you can often start to fix your build, or you can search the [forums](https://discord.gg/expo) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
+Armed with your error logs, you can often start to fix your build or search the [forums](https://chat.expo.dev/) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 
 <Collapsible summary="Are you using a monorepo?">
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -61,7 +61,7 @@ It's important to note that with iOS builds the build details page only displays
 
 If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
-Armed with your error logs, you can often start to fix your build, or you can search the [forums](https://forums.expo.dev) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
+Armed with your error logs, you can often start to fix your build, or you can search the [forums](https://discord.gg/expo) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 
 <Collapsible summary="Are you using a monorepo?">
 
@@ -154,7 +154,7 @@ If you have followed the advice here, you're now in a good position to describe 
 
 ### How to ask a good question
 
-Join us on [Discord](https://chat.expo.dev) or the [forums](https://forums.expo.dev) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/eas/enterprise-support). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
+Join us on [Discord](https://chat.expo.dev) or the [forums](https://discord.gg/expo) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/eas/enterprise-support). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
 
 When you ask for troubleshooting help, be sure to share the following information:
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -154,7 +154,7 @@ If you have followed the advice here, you're now in a good position to describe 
 
 ### How to ask a good question
 
-Join us on [Discord](https://chat.expo.dev) or the [forums](https://discord.gg/expo) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/eas/enterprise-support). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
+Join us on [Discord and Forums](https://chat.expo.dev) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/eas/enterprise-support). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
 
 When you ask for troubleshooting help, be sure to share the following information:
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -12,7 +12,7 @@ EAS Build allows you to build a ready-to-submit binary of your app for the Googl
 
 Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you toward resources that explain how to do that.
 
-For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on the [Expo forums](https://discord.gg/expo) or [Discord](https://chat.expo.dev/).
+For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on [Discord and Forums](https://chat.expo.dev/).
 
 ## Prerequisites
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -12,7 +12,7 @@ EAS Build allows you to build a ready-to-submit binary of your app for the Googl
 
 Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you toward resources that explain how to do that.
 
-For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on the [Expo forums](https://forums.expo.dev/) or [Discord](https://chat.expo.dev/).
+For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on the [Expo forums](https://discord.gg/expo) or [Discord](https://chat.expo.dev/).
 
 ## Prerequisites
 

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -31,7 +31,7 @@ This stack trace is **extremely valuable** since it gives you the location of th
 
 When you look at that file, on line 7, you will see that a variable called `renderDescription` is referenced. The error message describes that the variable is not found because the variable is not declared in **HomeScreen.js**. This is a typical example of how helpful error messages and stack traces can be if you take the time to decipher them.
 
-Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The **Expo community** and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the [forums](https://forums.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
+Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The **Expo community** and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the [forums](https://discord.gg/expo), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
 
 ## Next step
 

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -31,7 +31,7 @@ This stack trace is **extremely valuable** since it gives you the location of th
 
 When you look at that file, on line 7, you will see that a variable called `renderDescription` is referenced. The error message describes that the variable is not found because the variable is not declared in **HomeScreen.js**. This is a typical example of how helpful error messages and stack traces can be if you take the time to decipher them.
 
-Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The **Expo community** and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the [forums](https://discord.gg/expo), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
+Debugging errors is one of the most frustrating but satisfying parts of development. Remember that you're never alone. The **Expo community** and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into your exact error. Make sure to read the documentation, search the [forums](https://chat.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
 
 ## Next step
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -171,7 +171,7 @@ This might indicate that there is a performance issue. You likely need to run yo
 
 ## Stuck?
 
-The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://discord.gg/expo), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
+The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://chat.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
 
 ## Next step
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -171,7 +171,7 @@ This might indicate that there is a performance issue. You likely need to run yo
 
 ## Stuck?
 
-The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://forums.expo.dev/), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
+The Expo community and the React and React Native communities are great resources for help when you get stuck. There's a good chance someone else has run into the same error as you, so make sure to read the documentation, search the [forums](https://discord.gg/expo), [GitHub issues](https://github.com/expo/expo/issues/), and [Stack Overflow](https://stackoverflow.com/).
 
 ## Next step
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -11,7 +11,7 @@ import {
   BellRinging04Icon,
 } from '@expo/styleguide-icons';
 
-This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [ Forums](https://forums.expo.io) for more common questions.
+This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [Forums](https://discord.gg/expo) for more common questions.
 
 ## What is Expo used for?
 

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -11,7 +11,7 @@ import {
   BellRinging04Icon,
 } from '@expo/styleguide-icons';
 
-This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [Forums](https://discord.gg/expo) for more common questions.
+This page lists some of the common questions and answers about Expo and related services. If you have a question that is not answered here, see [Forums](https://chat.expo.dev/) for more common questions.
 
 ## What is Expo used for?
 

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -9,7 +9,6 @@ import {
   GithubIcon,
   Image03DuotoneIcon,
   Mail01Icon,
-  MessageDotsSquareDuotoneIcon,
   NotificationMessageDuotoneIcon,
   RedditIcon,
   XLogoIcon,

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -6,10 +6,10 @@ import {
   ArrowRightIcon,
   CameraPlusDuotoneIcon,
   DiscordIcon,
-  DiscourseIcon,
   GithubIcon,
   Image03DuotoneIcon,
   Mail01Icon,
+  MessageDotsSquareDuotoneIcon,
   NotificationMessageDuotoneIcon,
   RedditIcon,
   XLogoIcon,
@@ -293,8 +293,8 @@ export function JoinTheCommunity() {
           <CommunityGridCell
             title="Forums"
             description="Ask or answer a question on the forums."
-            link="https://forums.expo.dev/"
-            icon={<DiscourseIcon className="icon-lg text-palette-white" />}
+            link="https://discord.gg/expo"
+            icon={<MessageDotsSquareDuotoneIcon className="icon-lg text-palette-white" />}
           />
         </Row>
         <Row>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -275,7 +275,7 @@ export function JoinTheCommunity() {
           />
           <CommunityGridCell
             title="Discord and Forums"
-            description="Join our Discord to chat with Expo users or ask questions on the forums."
+            description="Join our Discord to chat with Expo users or ask questions."
             link="https://chat.expo.dev"
             icon={<DiscordIcon className="icon-lg text-palette-white" />}
             iconBackground="#3131E8"

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -275,8 +275,8 @@ export function JoinTheCommunity() {
             icon={<GithubIcon className="icon-lg text-palette-white" />}
           />
           <CommunityGridCell
-            title="Discord"
-            description="Join our Discord and chat with other Expo users."
+            title="Discord and Forums"
+            description="Join our Discord to chat with Expo users or ask questions on the forums."
             link="https://chat.expo.dev"
             icon={<DiscordIcon className="icon-lg text-palette-white" />}
             iconBackground="#3131E8"
@@ -291,10 +291,10 @@ export function JoinTheCommunity() {
             iconBackground="#000000"
           />
           <CommunityGridCell
-            title="Forums"
-            description="Ask or answer a question on the forums."
-            link="https://discord.gg/expo"
-            icon={<MessageDotsSquareDuotoneIcon className="icon-lg text-palette-white" />}
+            title="Newsletter"
+            description="Get the latest updates from monthly Expo newsletter."
+            link="http://eepurl.com/hk1tCn"
+            icon={<Mail01Icon className="icon-lg text-palette-white" />}
           />
         </Row>
         <Row>
@@ -304,12 +304,6 @@ export function JoinTheCommunity() {
             link="https://www.reddit.com/r/expo"
             icon={<RedditIcon className="icon-lg text-palette-white" />}
             iconBackground="#FC471E"
-          />
-          <CommunityGridCell
-            title="Newsletter"
-            description="Get the latest updates from monthly Expo newsletter."
-            link="http://eepurl.com/hk1tCn"
-            icon={<Mail01Icon className="icon-lg text-palette-white" />}
           />
         </Row>
       </CellContainer>

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -38,7 +38,7 @@ Run your app with `npx expo start` and press <kbd>i</kbd> from the command line.
 
 You may get a warning about needing to accept the Xcode license. Run the command that it suggests. Open your app again to see if it was successful. If not, check the [troubleshooting](#troubleshooting) tips below.
 
-If the troubleshooting tips are not helpful, ask a question in our [forums](https://discord.gg/expo), Stack Overflow, or Google.
+If the troubleshooting tips are not helpful, ask a question in our [forums](https://chat.expo.dev/), Stack Overflow, or Google.
 
 <Video file="open-in-ios-simulator.mp4" />
 

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -38,7 +38,7 @@ Run your app with `npx expo start` and press <kbd>i</kbd> from the command line.
 
 You may get a warning about needing to accept the Xcode license. Run the command that it suggests. Open your app again to see if it was successful. If not, check the [troubleshooting](#troubleshooting) tips below.
 
-If the troubleshooting tips are not helpful, seek help on [Expo Development Tools section of the forums](https://forums.expo.dev/c/expo-dev-tools), Stack Overflow, or Google.
+If the troubleshooting tips are not helpful, ask a question in our [forums](https://discord.gg/expo), Stack Overflow, or Google.
 
 <Video file="open-in-ios-simulator.mp4" />
 

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -24,7 +24,7 @@ export const IssuesLink = ({ title, repositoryUrl }: { title: string; repository
 export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: string }) =>
   isAPIPage ? (
     <LI>
-      <A isStyled openInNewTab href={`https://discord.gg/expo`} className={LINK_CLASSES}>
+      <A isStyled openInNewTab href="https://discord.gg/expo" className={LINK_CLASSES}>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums about {title}</CALLOUT>
       </A>

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -24,18 +24,14 @@ export const IssuesLink = ({ title, repositoryUrl }: { title: string; repository
 export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: string }) =>
   isAPIPage ? (
     <LI>
-      <A
-        isStyled
-        openInNewTab
-        href={`https://forums.expo.dev/tag/${title}`}
-        className={LINK_CLASSES}>
+      <A isStyled openInNewTab href={`https://discord.gg/expo`} className={LINK_CLASSES}>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums about {title}</CALLOUT>
       </A>
     </LI>
   ) : (
     <LI>
-      <A isStyled openInNewTab href="https://forums.expo.dev/" className={LINK_CLASSES}>
+      <A isStyled openInNewTab href="https://discord.gg/expo" className={LINK_CLASSES}>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums</CALLOUT>
       </A>

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -24,14 +24,14 @@ export const IssuesLink = ({ title, repositoryUrl }: { title: string; repository
 export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: string }) =>
   isAPIPage ? (
     <LI>
-      <A isStyled openInNewTab href="https://discord.gg/expo" className={LINK_CLASSES}>
+      <A isStyled openInNewTab href="https://chat.expo.dev/" className={LINK_CLASSES}>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums about {title}</CALLOUT>
       </A>
     </LI>
   ) : (
     <LI>
-      <A isStyled openInNewTab href="https://discord.gg/expo" className={LINK_CLASSES}>
+      <A isStyled openInNewTab href="https://chat.expo.dev/" className={LINK_CLASSES}>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums</CALLOUT>
       </A>

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -1,10 +1,5 @@
 import { SnackLogo } from '@expo/styleguide';
-import {
-  ChangelogIcon,
-  DiscordIcon,
-  Mail01Icon,
-  MessageDotsSquareIcon,
-} from '@expo/styleguide-icons';
+import { ChangelogIcon, DiscordIcon, Mail01Icon } from '@expo/styleguide-icons';
 import { useRouter } from 'next/compat/router';
 
 import { SidebarSingleEntry } from './SidebarSingleEntry';
@@ -34,15 +29,8 @@ export const SidebarFooter = () => {
       <SidebarSingleEntry
         secondary
         href="https://chat.expo.dev"
-        title="Discord"
+        title="Discord and Forums"
         Icon={DiscordIcon}
-        isExternal
-      />
-      <SidebarSingleEntry
-        secondary
-        href="https://discord.gg/expo"
-        title="Forums"
-        Icon={MessageDotsSquareIcon}
         isExternal
       />
       <SidebarSingleEntry

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -40,7 +40,7 @@ export const SidebarFooter = () => {
       />
       <SidebarSingleEntry
         secondary
-        href="https://forums.expo.dev"
+        href="https://discord.gg/expo"
         title="Forums"
         Icon={MessageDotsSquareIcon}
         isExternal


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove old forums links and replace them by discord forums & closes ENG-10240.

~~Also, updated the forums icon on the home page to use the same icon from the footer and sidebar footer.~~

**Update**:

After talking with Kim and Simek, we decided to use a link on the home page and footer sidebar for Discord and Forums.
<img width="1143" alt="CleanShot 2023-10-18 at 15 49 33@2x" src="https://github.com/expo/expo/assets/10234615/27e5f1a1-da08-473f-82f1-c9dd6d7013d4">




<img width="274" alt="CleanShot 2023-10-17 at 03 57 25@2x" src="https://github.com/expo/expo/assets/10234615/5d3f64b8-1112-41fd-98c5-895a3380fa01">


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally, visit a docs page and click the "Ask a question in the forums..." link from the footer of that page. It should redirect to Discord.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
