### PR TITLE
[docs] Adding small example how to edit Drawer

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -47,6 +47,33 @@ export default function Layout() {
 }
 ```
 
+To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
+
+```jsx app/_layout.js
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return ( 
+    <Drawer>
+      <Drawer.Screen
+        name="index" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: "Home",
+          title: "overview",
+        }}
+      />
+      <Drawer.Screen
+        name="user/[id]" // This is the name of the page and must match the url from root
+        options={{
+          drawerLabel: "User",
+          title: "overview",
+        }}
+      />
+    </Drawer>
+  )
+}
+```
+
 </Tab>
 
 <Tab label="SDK 50 and greater">
@@ -63,6 +90,36 @@ export default function Layout() {
       <Drawer />
     </GestureHandlerRootView>
   );
+}
+```
+
+To edit the drawer navigation menu labels, titles and screen options specific screens are required as follows:
+
+```jsx app/_layout.js
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { Drawer } from 'expo-router/drawer';
+
+export default function Layout() {
+  return ( 
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Drawer>
+        <Drawer.Screen
+          name="index" // This is the name of the page and must match the url from root
+          options={{
+            drawerLabel: "Home",
+            title: "overview",
+          }}
+        />
+        <Drawer.Screen
+          name="user/[id]" // This is the name of the page and must match the url from root
+          options={{
+            drawerLabel: "User",
+            title: "overview",
+          }}
+        />
+      </Drawer>
+    </GestureHandlerRootView>
+  )
 }
 ```
 


### PR DESCRIPTION
# Why

There was no info how to modify [expo-router Drawer](https://docs.expo.dev/router/advanced/drawer/) component. I found this snipped from [here](https://expo.github.io/router/docs/migration/react-navigation/drawer-navigator). Without this information I had no idea how to work with expo-router Drawer.

# How

-

# Test Plan

- 

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
