### PR TITLE
docs: remove unnecessary import from docs

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -185,8 +185,7 @@ export default function Root() {
 Create a nested [Layout route](/routing/layouts) that checks whether users are authenticated before rendering the child route components. This layout route redirects users to the sign-in screen if they are not authenticated.
 
 ```jsx app/(app)/_layout.js
-import { Link, Redirect, Stack } from 'expo-router';
-import { Text, View } from 'react-native';
+import { Redirect, Stack } from 'expo-router';
 
 import { useSession } from '../../ctx';
 


### PR DESCRIPTION
# Why

I just removed unnecessary imports from the doc


- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
