### PR TITLE
[docs] install prettier with eslint

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -21,11 +21,11 @@ Install ESLint in your project.
 
 <Tabs>
     <Tab label="npm">
-        <Terminal cmd={['$ npm install eslint eslint-config-universe --save-dev']} />
+        <Terminal cmd={['$ npm install eslint prettier eslint-config-universe --save-dev']} />
     </Tab>
 
     <Tab label="yarn">
-        <Terminal cmd={['$ yarn add -D eslint eslint-config-universe']} />
+        <Terminal cmd={['$ yarn add -D eslint prettier eslint-config-universe']} />
     </Tab>
 
 </Tabs>


### PR DESCRIPTION
# Why

Docs page: https://docs.expo.dev/guides/using-eslint/

The "install eslint" step says to install `eslint-config-universe` which has a peer dependency on `prettier`. So unless you already have prettier installed, this will error.

<img width="1254" alt="Screenshot 2023-10-15 at 15 42 25" src="https://github.com/expo/expo/assets/6534400/0631981a-7813-47eb-9db2-ccd2b715009b">


# How

Add `prettier` to the install script.

# Test Plan

```sh
yarn create expo-app my-app
cd my-app
```

and follow the steps in the docs to install prettier.

Then run `yarn lint` and ensure it runs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
