### PR TITLE
[expo-image][iOS] ImageView - check macCatalyst support to use ImageAnalyzer

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Remove `GlideWebpDecoder` until they update their `libwebp` dependency. ([#24656](https://github.com/expo/expo/pull/24656) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Fix content fit not being applied correctly when using hash placeholders. ([#24542](https://github.com/expo/expo/pull/24542) by [@aleqsio](https://github.com/aleqsio))
+- [macCatalyst] Fix build with `ImageAnalyzer` on macCatalyst below 17.0. ([#24880](https://github.com/expo/expo/pull/24880) by [@kesha-antonov](https://github.com/kesha-antonov))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -417,12 +417,12 @@ public final class ImageView: ExpoView {
 
   // MARK: - Live Text Interaction
 
-  @available(iOS 16.0, *)
+  @available(iOS 16.0, macCatalyst 17.0, *)
   static let imageAnalyzer = ImageAnalyzer.isSupported ? ImageAnalyzer() : nil
 
   var enableLiveTextInteraction: Bool = false {
     didSet {
-      guard #available(iOS 16.0, *), oldValue != enableLiveTextInteraction, ImageAnalyzer.isSupported else {
+      guard #available(iOS 16.0, macCatalyst 17.0, *), oldValue != enableLiveTextInteraction, ImageAnalyzer.isSupported else {
         return
       }
       if enableLiveTextInteraction {
@@ -435,7 +435,7 @@ public final class ImageView: ExpoView {
   }
 
   private func analyzeImage() {
-    guard #available(iOS 16.0, *), ImageAnalyzer.isSupported, let image = sdImageView.image else {
+    guard #available(iOS 16.0, macCatalyst 17.0, *), ImageAnalyzer.isSupported, let image = sdImageView.image else {
       return
     }
 
@@ -459,7 +459,7 @@ public final class ImageView: ExpoView {
     }
   }
 
-  @available(iOS 16.0, *)
+  @available(iOS 16.0, macCatalyst 17.0, *)
   private func findImageAnalysisInteraction() -> ImageAnalysisInteraction? {
     let interaction = sdImageView.interactions.first {
       return $0 is ImageAnalysisInteraction


### PR DESCRIPTION
Hi

ImageAnalyzer is available only on Mac Catalyst 17.0+ as stated here:

https://developer.apple.com/documentation/visionkit/imageanalyzer

Fixes https://github.com/expo/expo/issues/23354

# Why

Fixes build expo-image with macCatalyst below 17.0

# How

Adds check to macCatalyst ImageAnalyzer availability

# Test Plan

Build macCatalyst app

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
