### PR TITLE
[hold] Try running test suite on ARM64

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,7 +64,7 @@ jobs:
   #         author_name: Test Suite (Web)
 
   ios:
-    runs-on: macos-13
+    runs-on: macos-13-xlarge # ARM64 https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
@@ -142,111 +142,111 @@ jobs:
           fields: job,message,ref,eventName,author,took
           author_name: Test Suite (iOS)
 
-  android-build:
-    runs-on: ubuntu-22.04
-    env:
-      ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
-    steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-        with:
-          submodules: true
-      - name: ⬢ Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - name: 🔨 Use JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-      - name: ➕ Add `bin` to GITHUB_PATH
-        run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: ♻️ Restore caches
-        uses: ./.github/actions/expo-caches
-        id: expo-caches
-        with:
-          gradle: 'true'
-          yarn-workspace: 'true'
-          yarn-tools: 'true'
-          react-native-gradle-downloads: 'true'
-      - name: 🧶 Install workspace node modules
-        if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
-        run: yarn install --frozen-lockfile
-      - name: ⚛️ Display React Native config
-        run: yarn react-native config
-        working-directory: apps/bare-expo
-      - name: 🛠️ Generate dynamic macros
-        run: expotools android-generate-dynamic-macros --configuration release --bare
-      - name: 🏗️ Build Android project
-        run: ./gradlew -DtestBuildType=release :app:assembleRelease :app:assembleAndroidTest --no-daemon
-        working-directory: apps/bare-expo/android
-        timeout-minutes: 35
-        env:
-          EXPO_DEBUG: 1
-          NODE_ENV: production
-      - name: 📸 Upload builds
-        uses: actions/upload-artifact@v3
-        with:
-          name: bare-expo-android-builds
-          path: apps/bare-expo/android/app/build/outputs/apk
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        with:
-          channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (Android)
+  # android-build:
+  #   runs-on: ubuntu-22.04
+  #   env:
+  #     ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
+  #     GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
+  #   steps:
+  #     - name: 👀 Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         submodules: true
+  #     - name: ⬢ Setup Node
+  #       uses: actions/setup-node@v3
+  #       with:
+  #         node-version: 16
+  #     - name: 🔨 Use JDK 11
+  #       uses: actions/setup-java@v3
+  #       with:
+  #         distribution: 'temurin'
+  #         java-version: '11'
+  #     - name: ➕ Add `bin` to GITHUB_PATH
+  #       run: echo "$(pwd)/bin" >> $GITHUB_PATH
+  #     - name: ♻️ Restore caches
+  #       uses: ./.github/actions/expo-caches
+  #       id: expo-caches
+  #       with:
+  #         gradle: 'true'
+  #         yarn-workspace: 'true'
+  #         yarn-tools: 'true'
+  #         react-native-gradle-downloads: 'true'
+  #     - name: 🧶 Install workspace node modules
+  #       if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
+  #       run: yarn install --frozen-lockfile
+  #     - name: ⚛️ Display React Native config
+  #       run: yarn react-native config
+  #       working-directory: apps/bare-expo
+  #     - name: 🛠️ Generate dynamic macros
+  #       run: expotools android-generate-dynamic-macros --configuration release --bare
+  #     - name: 🏗️ Build Android project
+  #       run: ./gradlew -DtestBuildType=release :app:assembleRelease :app:assembleAndroidTest --no-daemon
+  #       working-directory: apps/bare-expo/android
+  #       timeout-minutes: 35
+  #       env:
+  #         EXPO_DEBUG: 1
+  #         NODE_ENV: production
+  #     - name: 📸 Upload builds
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: bare-expo-android-builds
+  #         path: apps/bare-expo/android/app/build/outputs/apk
+  #     - name: 🔔 Notify on Slack
+  #       uses: 8398a7/action-slack@v3
+  #       if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+  #         MATRIX_CONTEXT: ${{ toJson(matrix) }}
+  #       with:
+  #         channel: '#expo-android'
+  #         status: ${{ job.status }}
+  #         fields: job,message,ref,eventName,author,took
+  #         author_name: Test Suite (Android)
 
-  android-test:
-    needs: android-build
-    runs-on: macos-13
-    strategy:
-      matrix:
-        api-level: [33]
-    steps:
-      - name: 👀 Checkout
-        uses: actions/checkout@v3
-      - name: 🌠 Download builds
-        uses: actions/download-artifact@v3
-        with:
-          name: bare-expo-android-builds
-          path: apps/bare-expo/android/app/build/outputs/apk
-      - name: 🧪 Run tests
-        uses: ./.github/actions/use-android-emulator
-        with:
-          avd-api: ${{ matrix.api-level }}
-          avd-name: avd-${{ matrix.api-level }}
-          script: |
-            mkdir artifacts || true
-            adb logcat -d > artifacts/emulator.log
-            adb logcat -c || true
-            adb shell screencap -p /data/local/tmp/bareexpo.png && adb pull /data/local/tmp/bareexpo.png artifacts/beforeTests.png
-            ./scripts/start-android-e2e-test.sh
-            adb shell screencap -p /data/local/tmp/bareexpo.png && adb pull /data/local/tmp/bareexpo.png artifacts/afterTests.png
-            adb logcat -d > artifacts/adb.log
-          working-directory: ./apps/bare-expo
-      - name: 📸 Store images of test failures
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: bare-expo-artifacts
-          path: apps/bare-expo/artifacts
-      - name: 🔔 Notify on Slack
-        uses: 8398a7/action-slack@v3
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-        with:
-          channel: '#expo-android'
-          status: ${{ job.status }}
-          fields: job,message,ref,eventName,author,took
-          author_name: Test Suite (Android)
+  # android-test:
+  #   needs: android-build
+  #   runs-on: macos-13
+  #   strategy:
+  #     matrix:
+  #       api-level: [33]
+  #   steps:
+  #     - name: 👀 Checkout
+  #       uses: actions/checkout@v3
+  #     - name: 🌠 Download builds
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: bare-expo-android-builds
+  #         path: apps/bare-expo/android/app/build/outputs/apk
+  #     - name: 🧪 Run tests
+  #       uses: ./.github/actions/use-android-emulator
+  #       with:
+  #         avd-api: ${{ matrix.api-level }}
+  #         avd-name: avd-${{ matrix.api-level }}
+  #         script: |
+  #           mkdir artifacts || true
+  #           adb logcat -d > artifacts/emulator.log
+  #           adb logcat -c || true
+  #           adb shell screencap -p /data/local/tmp/bareexpo.png && adb pull /data/local/tmp/bareexpo.png artifacts/beforeTests.png
+  #           ./scripts/start-android-e2e-test.sh
+  #           adb shell screencap -p /data/local/tmp/bareexpo.png && adb pull /data/local/tmp/bareexpo.png artifacts/afterTests.png
+  #           adb logcat -d > artifacts/adb.log
+  #         working-directory: ./apps/bare-expo
+  #     - name: 📸 Store images of test failures
+  #       if: always()
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: bare-expo-artifacts
+  #         path: apps/bare-expo/artifacts
+  #     - name: 🔔 Notify on Slack
+  #       uses: 8398a7/action-slack@v3
+  #       if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_android }}
+  #         MATRIX_CONTEXT: ${{ toJson(matrix) }}
+  #       with:
+  #         channel: '#expo-android'
+  #         status: ${{ job.status }}
+  #         fields: job,message,ref,eventName,author,took
+  #         author_name: Test Suite (Android)


### PR DESCRIPTION
# Why

I want to see if Github Actions suffer from the same problems as I have experienced.

# How

Used the xlarge worker which is ARM64.

# Test Plan

This _is_ the test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
