### PR TITLE
[expo-image] [ENG-10268] support tintColor for SVGs on Android (part 2)

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,7 +9,8 @@
 ### 🎉 New features
 
 - Added support for the `headers` key in the `source` object on web. ([#24447](https://github.com/expo/expo/pull/24447) by [@aleqsio](https://github.com/aleqsio))
-- Add support for setting `tintColor` on SVGs on Android ([#24733](https://github.com/expo/expo/pull/24733) by [@alanjhughes](https://github.com/alanjhughes) and [@kadikraman](https://github.com/kadikraman))
+- Add support for setting `tintColor` on SVGs on Android (part 1) ([#24733](https://github.com/expo/expo/pull/24733) by [@alanjhughes](https://github.com/alanjhughes) and [@kadikraman](https://github.com/kadikraman))
+- Add support for setting `tintColor` on SVGs on Android (part 2) ([#24888](https://github.com/expo/expo/pull/24888) by [@kadikraman](https://github.com/kadikraman))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -38,6 +38,8 @@ data class SourceMap(
 
   private fun isLocalFileUri() = parsedUri?.scheme?.startsWith("file") ?: false
 
+  private fun isSvg() = parsedUri?.toString()?.substring(parsedUri.toString().lastIndexOf('.'))?.startsWith(".svg") ?: false
+
   fun isBlurhash() = parsedUri?.scheme?.startsWith("blurhash") ?: false
 
   fun isThumbhash() = parsedUri?.scheme?.startsWith("thumbhash") ?: false
@@ -100,9 +102,9 @@ data class SourceMap(
           parsedUri = computeUri(context)
         }
 
-        // Override the size for local assets. This ensures that
+        // Override the size for local assets (apart from SVGs). This ensures that
         // resizeMode "center" displays the image in the correct size.
-        if (width != 0 && height != 0) {
+        if (width != 0 && height != 0 && !isSvg()) {
           override((width * scale).toInt(), (height * scale).toInt())
         }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDecoder.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/svg/SVGDecoder.kt
@@ -23,6 +23,8 @@ class SVGDecoder : ResourceDecoder<InputStream, SVG> {
   override fun decode(source: InputStream, width: Int, height: Int, options: Options): Resource<SVG>? {
     return try {
       val svg: SVG = SVG.getFromInputStream(source)
+      svg.documentWidth = width.toFloat()
+      svg.documentHeight = height.toFloat()
       SimpleResource(svg)
     } catch (ex: SVGParseException) {
       throw IOException("Cannot load SVG from stream", ex)


### PR DESCRIPTION
# Why

Follows up from https://github.com/expo/expo/pull/24733
Fixes https://github.com/expo/expo/issues/24511#issuecomment-1745337004

As part of the above PR, we removed these lines:

```kotlin
svg.documentWidth = width.toFloat()
svg.documentHeight = height.toFloat()
```

This meant that all svgs will be created at 512x512 regardless of actual rendered size.

# How

We are overriding the image size in `SourceMap.kt`, so we can opt out of this in case of SVGs.

# Test Plan

It's easiest to test it by running locally with breakpoints:

### The dimensions of `expo.svg` currently
<img width="890" alt="Screenshot 2023-10-16 at 16 22 49" src="https://github.com/expo/expo/assets/6534400/8a63c0a1-a536-46ca-8cc2-6ffcce8bfcf4">

### The dimensions is we re-add the `svg.documentWidth` lines with no other changes (this is what makes the svg look blurry)
<img width="873" alt="Screenshot 2023-10-16 at 16 25 24" src="https://github.com/expo/expo/assets/6534400/e725d79c-b222-4f8f-b97f-d186c6ff6206">

### The dimensions after this PR ✅ 
<img width="896" alt="Screenshot 2023-10-16 at 16 13 30" src="https://github.com/expo/expo/assets/6534400/330e4c5f-17e3-439e-b4e5-97e8ff00a14f">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
