### PR TITLE
[docs] Remove duplicated link in Local app development guide

### DIFF
--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -201,9 +201,16 @@ The above commands compile your project, using your locally installed Android SD
 
 - These compilation commands initially run `npx expo prebuild` to generate native directories (**android** and **ios**) before building, if they do not exist yet. If they already exist, this will be skipped.
 - You can also add the `--device` flag to select a device to run the app on — you can select a physically connected device or emulator/simulators.
-- You can pass in `--variant release` (Android) or `--configuration Release` (iOS) to build a production version of your app. [Learn more about production builds](/deploy/build-project/).
+- You can pass in `--variant release` (Android) or `--configuration Release` (iOS) to build a production version of your app.
 
-To modify your project's configuration or native code after the first build, you will have to rebuild your project. Running `npx expo prebuild` again layers the changes on the top of existing files. It may also produce different results after the build.
+<BoxLink
+  title="Production builds locally"
+  description="Learn how to create a production build for your app that is ready to be submitted to app stores."
+  href="/deploy/build-project/#production-builds-locally"
+  Icon={BookOpen02Icon}
+/>
+
+To modify your project's configuration or native code after the first build, you will have to rebuild your project. Running `npx expo prebuild` again layers the changes on top of existing files. It may also produce different results after the build.
 
 To avoid this, add native directories to the project's **.gitignore** and use `npx expo prebuild --clean` command. This ensures that the project is always managed, and the [`--clean` flag](/workflow/prebuild/#clean) will delete existing directories before regenerating them. You can use [app config](/workflow/configuration/) or create a [config plugin](/config-plugins/introduction/) to modify your project's configuration or code inside the native directories.
 
@@ -240,13 +247,4 @@ To learn more about how compilation and prebuild works, see the following guides
   }
   href="/build-reference/local-builds"
   Icon={BuildIcon}
-/>
-
-## Next steps
-
-<BoxLink
-  title="Production builds locally"
-  description="Learn how to create a production build for your app that is ready to be submitted to app stores."
-  href="/deploy/build-project/#production-builds-locally"
-  Icon={BookOpen02Icon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Remove duplicated link to production builds doc
- Also, update the link to create production builds locally to the specific section
- Fix typo

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit http://localhost:3002/guides/local-app-development/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
