### PR TITLE
[core][Android] Fix `null` or `undefined` wasn't converted to `JavaScriptValue`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
+- [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
-- [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`.
+- [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`. ([#24899](https://github.com/expo/expo/pull/24899) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JavaScriptValueTest.kt
@@ -89,4 +89,15 @@ class JavaScriptValueTest {
       Truth.assertThat(receivedObject!!.getProperty("expo").getInt()).isEqualTo(123)
     }
   }
+
+  @Test
+  fun null_should_be_pass_as_js_value() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("f") { a: JavaScriptValue -> a.isNull() }
+    }
+  ) {
+    val value = evaluateScript("expo.modules.TestModule.f(null)").getBool()
+    Truth.assertThat(value).isTrue()
+  }
 }

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -151,16 +151,15 @@ jobjectArray MethodMetadata::convertJSIArgsToJNI(
   for (size_t argIndex = 0; argIndex < count; argIndex++) {
     const jsi::Value &arg = getCurrentArg(argIndex);
     auto &type = argTypes[argIndex];
-    if (arg.isNull() || arg.isUndefined()) {
-      // If value is null or undefined, we just passes a null
-      // Kotlin code will check if expected type is nullable.
-      continue;
-    }
 
     if (type->converter->canConvert(rt, arg)) {
       auto converterValue = type->converter->convert(rt, env, moduleRegistry, arg);
       env->SetObjectArrayElement(argumentArray, argIndex, converterValue);
       env->DeleteLocalRef(converterValue);
+    } else if (arg.isNull() || arg.isUndefined()) {
+      // If value is null or undefined, we just passes a null
+      // Kotlin code will check if expected type is nullable.
+      continue;
     } else {
       auto stringRepresentation = arg.toString(rt).utf8(rt);
       throwNewJavaException(


### PR DESCRIPTION
# Why

Fixes `null` or `undefined` wasn't converted to `JavaScriptValue`

# Test Plan

- unit test ✅ 