### PR TITLE
Extract e2e auth app reducer to fix TS errors

### DIFF
--- a/apps/router-e2e/__e2e__/auth/useStorageState.ts
+++ b/apps/router-e2e/__e2e__/auth/useStorageState.ts
@@ -2,16 +2,19 @@ import * as SecureStore from 'expo-secure-store';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-type UseStateHook<T> = [[boolean, T | null], (value?: T | null) => void];
+type NullableValue<T> = T | null;
+type State<T> = [boolean, NullableValue<T>];
+type SetValue<T> = (value: NullableValue<T>) => void;
+type UseStateHook<T> = [State<T>, SetValue<T>];
 
-function useAsyncState<T>(initialValue?: [boolean, T | null]): UseStateHook<T> {
-  return React.useReducer(
-    (state: [boolean, T | null], action?: T | null) => [
-      false,
-      action === undefined ? null : action,
-    ],
-    initialValue ?? [true, undefined]
-  ) as UseStateHook<T>;
+function reducer<T>(state: State<T>, action?: NullableValue<T>): State<T> {
+  return [false, action === undefined ? null : action];
+}
+
+function useAsyncState<T>(
+  initialValue: State<T> = [true, null],
+): UseStateHook<T> {
+  return React.useReducer(reducer<T>, initialValue) as UseStateHook<T>;
 }
 
 export async function setStorageItemAsync(key: string, value: string | null) {

--- a/apps/router-e2e/__e2e__/auth/useStorageState.ts
+++ b/apps/router-e2e/__e2e__/auth/useStorageState.ts
@@ -19,11 +19,15 @@ function useAsyncState<T>(
 
 export async function setStorageItemAsync(key: string, value: string | null) {
   if (Platform.OS === 'web') {
-    if (value == null) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, value);
-    }
+    try {
+       if (value === null) {
+         localStorage.removeItem(key);
+       } else {
+         localStorage.setItem(key, value);
+       }
+     } catch (e) {
+       console.error('Local storage is unavailable:', e);
+     }
   } else {
     if (value == null) {
       await SecureStore.deleteItemAsync(key);
@@ -40,11 +44,15 @@ export function useStorageState(key: string): UseStateHook<string> {
   // Get
   React.useEffect(() => {
     if (Platform.OS === 'web') {
-      if (typeof localStorage !== 'undefined') {
-        setState(localStorage.getItem(key));
+      try {
+        if (typeof localStorage !== 'undefined') {
+          setState(localStorage.getItem(key));
+        }
+      } catch (e) {
+        console.error('Local storage is unavailable:', e);
       }
     } else {
-      SecureStore.getItemAsync(key).then((value) => {
+      SecureStore.getItemAsync(key).then(value => {
         setState(value);
       });
     }

--- a/apps/router-e2e/__e2e__/auth/useStorageState.ts
+++ b/apps/router-e2e/__e2e__/auth/useStorageState.ts
@@ -14,7 +14,7 @@ function reducer<T>(state: State<T>, action?: NullableValue<T>): State<T> {
 function useAsyncState<T>(
   initialValue: State<T> = [true, null],
 ): UseStateHook<T> {
-  return React.useReducer(reducer<T>, initialValue) as UseStateHook<T>;
+  return React.useReducer(reducer<T>, initialValue);
 }
 
 export async function setStorageItemAsync(key: string, value: string | null) {

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -102,7 +102,7 @@ function reducer<T>(state: State<T>, action?: NullableValue<T>): State<T> {
 function useAsyncState<T>(
   initialValue: State<T> = [true, null],
 ): UseStateHook<T> {
-  return React.useReducer(reducer<T>, initialValue) as UseStateHook<T>;
+  return React.useReducer(reducer<T>, initialValue);
 }
 
 export async function setStorageItemAsync(key: string, value: string | null) {

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -107,11 +107,15 @@ function useAsyncState<T>(
 
 export async function setStorageItemAsync(key: string, value: string | null) {
   if (Platform.OS === 'web') {
-    if (value == null) {
-      localStorage.removeItem(key);
-    } else {
-      localStorage.setItem(key, value);
-    }
+    try {
+       if (value === null) {
+         localStorage.removeItem(key);
+       } else {
+         localStorage.setItem(key, value);
+       }
+     } catch (e) {
+       console.error('Local storage is unavailable:', e);
+     }
   } else {
     if (value == null) {
       await SecureStore.deleteItemAsync(key);
@@ -128,11 +132,15 @@ export function useStorageState(key: string): UseStateHook<string> {
   // Get
   React.useEffect(() => {
     if (Platform.OS === 'web') {
-      if (typeof localStorage !== 'undefined') {
-        setState(localStorage.getItem(key));
+      try {
+        if (typeof localStorage !== 'undefined') {
+          setState(localStorage.getItem(key));
+        }
+      } catch (e) {
+        console.error('Local storage is unavailable:', e);
       }
     } else {
-      SecureStore.getItemAsync(key).then((value) => {
+      SecureStore.getItemAsync(key).then(value => {
         setState(value);
       });
     }

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -90,27 +90,27 @@ import * as SecureStore from 'expo-secure-store';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-type UseStateHook<T> = [[boolean, T | null], (value?: T | null) => void];
+type NullableValue<T> = T | null;
+type State<T> = [boolean, NullableValue<T>];
+type SetValue<T> = (value: NullableValue<T>) => void;
+type UseStateHook<T> = [State<T>, SetValue<T>];
+
+function reducer<T>(state: State<T>, action?: NullableValue<T>): State<T> {
+  return [false, action === undefined ? null : action];
+}
 
 function useAsyncState<T>(
-  initialValue: [boolean, T | null] = [true, undefined],
+  initialValue: State<T> = [true, null],
 ): UseStateHook<T> {
-  return React.useReducer(
-    (state: [boolean, T | null], action: T | null = null) => [false, action],
-    initialValue
-  ) as UseStateHook<T>;
+  return React.useReducer(reducer<T>, initialValue) as UseStateHook<T>;
 }
 
 export async function setStorageItemAsync(key: string, value: string | null) {
   if (Platform.OS === 'web') {
-    try {
-      if (value === null) {
-        localStorage.removeItem(key);
-      } else {
-        localStorage.setItem(key, value);
-      }
-    } catch (e) {
-      console.error('Local storage is unavailable:', e);
+    if (value == null) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, value);
     }
   } else {
     if (value == null) {
@@ -128,15 +128,11 @@ export function useStorageState(key: string): UseStateHook<string> {
   // Get
   React.useEffect(() => {
     if (Platform.OS === 'web') {
-      try {
-        if (typeof localStorage !== 'undefined') {
-          setState(localStorage.getItem(key));
-        }
-      } catch (e) {
-        console.error('Local storage is unavailable:', e);
+      if (typeof localStorage !== 'undefined') {
+        setState(localStorage.getItem(key));
       }
     } else {
-      SecureStore.getItemAsync(key).then(value => {
+      SecureStore.getItemAsync(key).then((value) => {
         setState(value);
       });
     }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Using this file in a newly created Expo app results in a TypeScript error when passing the `initialValue` argument into the call to `useReducer`: `Argument of type '[boolean, T | null]' is not assignable to parameter of type 'never'`.

Reading around, it seems that the reducer's return value should be explicitly typed: https://stackoverflow.com/a/55284031

# How

<!--
How did you build this feature or fix this bug and why?
-->

I experienced a TypeScript error when copy-pasting the suggested code snippet for `useStorageState.ts` from the documentation site. I noticed that the example e2e app deviated slightly from the documentation, and so that was also fixed.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

The existing tests should continue to cover this scenario.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
