### PR TITLE
[core][Android] Rework the `Either` type converter

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
 - [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`. ([#24899](https://github.com/expo/expo/pull/24899) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Fixed `Either` converter not working with types that have common representation in JavaScript.
+- [Android] Fixed `Either` converter not working with types that have common representation in JavaScript. ([#24903](https://github.com/expo/expo/pull/24903) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed typed arrays couldn't be returned from synchronous functions. ([#24744](https://github.com/expo/expo/pull/24744) by [@lukmccall](https://github.com/lukmccall))
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
 - [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`. ([#24899](https://github.com/expo/expo/pull/24899) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Fixed `Either` converter not working with types that have common representation in JavaScript.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/EitherTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/EitherTypeConversionTest.kt
@@ -1,0 +1,65 @@
+@file:OptIn(EitherType::class, ExperimentalCoroutinesApi::class)
+
+package expo.modules.kotlin.jni
+
+import com.google.common.truth.Truth
+import expo.modules.kotlin.apifeatures.EitherType
+import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import expo.modules.kotlin.types.Either
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.Test
+import java.net.URL
+
+class EitherTypeConversionTest {
+  @Test
+  fun either_should_be_convertible() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("eitherFirst") { either: Either<Int, String> ->
+        Truth.assertThat(either.`is`(Int::class)).isTrue()
+        Truth.assertThat(either.`is`(String::class)).isFalse()
+        either.get(Int::class)
+      }
+      Function("eitherSecond") { either: Either<Int, String> ->
+        Truth.assertThat(either.`is`(String::class)).isTrue()
+        Truth.assertThat(either.`is`(Int::class)).isFalse()
+        either.get(String::class)
+      }
+    }
+  ) {
+    val int = evaluateScript("expo.modules.TestModule.eitherFirst(123)").getInt()
+    val string = evaluateScript("expo.modules.TestModule.eitherSecond('expo')").getString()
+
+    Truth.assertThat(int).isEqualTo(123)
+    Truth.assertThat(string).isEqualTo("expo")
+  }
+
+  @Test
+  fun either_with_overlapping_types_should_be_convertible() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("either") { either: Either<URL, String> ->
+        Truth.assertThat(either.`is`(URL::class)).isTrue()
+        Truth.assertThat(either.`is`(String::class)).isTrue()
+
+        either.first()
+      }
+    }
+  ) {
+    val url = evaluateScript("expo.modules.TestModule.either('https://expo.dev/')").getString()
+
+    Truth.assertThat(url).isEqualTo("https://expo.dev/")
+  }
+
+  @Test(expected = JavaScriptEvaluateException::class)
+  fun convert_should_throw_when_conversion_is_impossible() = withJSIInterop(
+    inlineModule {
+      Name("TestModule")
+      Function("either") { _: Either<String, Map<String, Any>> ->
+        false
+      }
+    }
+  ) {
+    evaluateScript("expo.modules.TestModule.either(123)")
+  }
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -2,61 +2,119 @@
 
 package expo.modules.kotlin.types
 
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.apifeatures.EitherType
+import java.lang.ref.WeakReference
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+sealed class DeferredValue
+
+object IncompatibleValue : DeferredValue()
+
+class UnconvertedValue(
+  private val unconvertedValue: Any,
+  private val typeConverter: TypeConverter<*>,
+  context: AppContext?
+) : DeferredValue() {
+  private val contextHolder = WeakReference(context)
+
+  private var convertedValue: Any? = null
+
+  fun getConvertedValue(): Any {
+    if (convertedValue == null) {
+      convertedValue = typeConverter.convert(unconvertedValue, contextHolder.get())
+    }
+
+    return convertedValue!!
+  }
+}
+
+data class ConvertedValue(val convertedValue: Any) : DeferredValue()
 
 @EitherType
 open class Either<FirstType : Any, SecondType : Any>(
-  @PublishedApi
-  internal val value: Any
+  private val bareValue: Any,
+  private val deferredValue: MutableList<DeferredValue>,
+  private val types: List<KType>
+
 ) {
-  @JvmName("isFirstType")
-  fun `is`(type: KClass<FirstType>): Boolean {
-    return type.isInstance(value)
+  internal fun `is`(index: Int): Boolean {
+    return when (val value = deferredValue[index]) {
+      is ConvertedValue -> true
+      IncompatibleValue -> false
+      is UnconvertedValue -> {
+        try {
+          deferredValue[index] = ConvertedValue(value.getConvertedValue())
+          true
+        } catch (e: Throwable) {
+          deferredValue[index] = IncompatibleValue
+          false
+        }
+      }
+    }
   }
+
+  internal fun get(index: Int): Any {
+    return when (val value = deferredValue[index]) {
+      is ConvertedValue -> value.convertedValue
+      IncompatibleValue -> throw TypeCastException("Cannot cast '$bareValue' to '${types[index]}'")
+      is UnconvertedValue -> {
+        try {
+          val convertedValue = value.getConvertedValue()
+          deferredValue[index] = ConvertedValue(convertedValue)
+          convertedValue
+        } catch (e: Throwable) {
+          deferredValue[index] = IncompatibleValue
+          throw TypeCastException("Cannot cast '$bareValue' to '${types[index]}'")
+        }
+      }
+    }
+  }
+
+  @JvmName("isFirstType")
+  fun `is`(type: KClass<FirstType>): Boolean = `is`(0)
 
   @JvmName("isSecondType")
-  fun `is`(type: KClass<SecondType>): Boolean {
-    return type.isInstance(value)
-  }
+  fun `is`(type: KClass<SecondType>): Boolean = `is`(1)
 
   @JvmName("getFirstType")
-  fun get(type: KClass<FirstType>) = value as FirstType
+  fun get(type: KClass<FirstType>): FirstType = get(0) as FirstType
 
   @JvmName("getSecondType")
-  fun get(type: KClass<SecondType>) = value as SecondType
+  fun get(type: KClass<SecondType>): SecondType = get(1) as SecondType
 
-  fun first() = value as FirstType
+  fun first(): FirstType = get(0) as FirstType
 
-  fun second() = value as SecondType
+  fun second(): SecondType = get(1) as SecondType
 }
 
 @EitherType
 open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
-  value: Any
-) : Either<FirstType, SecondType>(value) {
+  bareValue: Any,
+  deferredValue: MutableList<DeferredValue>,
+  types: List<KType>
+) : Either<FirstType, SecondType>(bareValue, deferredValue, types) {
   @JvmName("isThirdType")
-  fun `is`(type: KClass<ThirdType>): Boolean {
-    return type.isInstance(value)
-  }
+  fun `is`(type: KClass<ThirdType>): Boolean = `is`(2)
 
   @JvmName("getThirdType")
-  fun get(type: KClass<ThirdType>) = value as ThirdType
+  fun get(type: KClass<ThirdType>) = get(3) as ThirdType
 
-  fun third() = value as ThirdType
+  fun third(): ThirdType = get(3) as ThirdType
 }
 
 @EitherType
 class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
-  value: Any
-) : EitherOfThree<FirstType, SecondType, ThirdType>(value) {
+  bareValue: Any,
+  deferredValue: MutableList<DeferredValue>,
+  types: List<KType>
+) : EitherOfThree<FirstType, SecondType, ThirdType>(bareValue, deferredValue, types) {
   @JvmName("isFourthType")
-  fun `is`(type: KClass<FourthType>): Boolean {
-    return type.isInstance(value)
-  }
+  fun `is`(type: KClass<FourthType>): Boolean = `is`(3)
 
   @JvmName("getFourthType")
-  fun get(type: KClass<FourthType>) = value as FourthType
+  fun get(type: KClass<FourthType>): FourthType = get(3) as FourthType
 
-  fun fourth() = value as FourthType
+  fun fourth(): FourthType = get(3) as FourthType
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -3,8 +3,63 @@ package expo.modules.kotlin.types
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.jni.ExpectedType
-import expo.modules.kotlin.jni.SingleType
 import kotlin.reflect.KType
+
+private fun createDeferredValue(
+  value: Any,
+  wasConverted: Boolean,
+  typeConverter: TypeConverter<*>,
+  expectedType: ExpectedType,
+  context: AppContext?
+): DeferredValue {
+  for (type in expectedType.getPossibleTypes()) {
+    if (type.expectedCppType.clazz.isInstance(value)) {
+      return if (wasConverted) {
+        UnconvertedValue(value, typeConverter, context)
+      } else {
+        val convertedValue = tryToConvert(typeConverter, value, context) ?: continue
+        ConvertedValue(convertedValue)
+      }
+    }
+  }
+
+  return IncompatibleValue
+}
+
+private fun tryToConvert(typeConverter: TypeConverter<*>, value: Any, context: AppContext?): Any? {
+  return try {
+    if (typeConverter.isTrivial()) {
+      value
+    } else {
+      typeConverter.convert(value, context)
+    }
+  } catch (e: Throwable) {
+    null
+  }
+}
+
+private fun createDeferredValues(
+  value: Any,
+  context: AppContext?,
+  list: List<Pair<ExpectedType, TypeConverter<*>>>,
+  typeList: List<KType>
+): List<DeferredValue> {
+  var wasConverted = false
+  val result = list.map { (expectedType, converter) ->
+    val deferredValue = createDeferredValue(value, wasConverted, converter, expectedType, context)
+    if (deferredValue is ConvertedValue) {
+      wasConverted = true
+    }
+
+    deferredValue
+  }
+
+  if (!wasConverted) {
+    throw TypeCastException("Cannot cast '$value' to 'Either<${typeList.joinToString(separator = ", ") { it.toString() }}>'")
+  }
+
+  return result
+}
 
 @EitherType
 class EitherTypeConverter<FirstType : Any, SecondType : Any>(
@@ -23,27 +78,23 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   private val secondType = secondTypeConverter.getCppRequiredTypes()
 
   override fun convertNonOptional(value: Any, context: AppContext?): Either<FirstType, SecondType> {
-    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
-      for (singleType in types) {
-        if (singleType.expectedCppType.clazz.isInstance(value)) {
-          return@Convert if (firstTypeConverter.isTrivial()) {
-            Either<FirstType, SecondType>(value)
-          } else {
-            Either(converter.convert(value)!!)
-          }
-        }
-      }
-      null
-    }
+    val typeList = listOf(firstJavaType, secondJavaType)
 
-    return convertValueIfNeeded(
-      firstType.getPossibleTypes(),
-      firstTypeConverter
-    ) ?: convertValueIfNeeded(
-      secondType.getPossibleTypes(),
-      secondTypeConverter
+    val deferredValues = createDeferredValues(
+      value,
+      context,
+      listOf(
+        firstType to firstTypeConverter,
+        secondType to secondTypeConverter
+      ),
+      typeList
     )
-      ?: throw TypeCastException("Cannot cast '$value' to 'Either<$firstJavaType, $secondJavaType>'")
+
+    return Either(
+      value,
+      deferredValues.toMutableList(),
+      typeList
+    )
   }
 
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType
@@ -73,30 +124,23 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
   private val thirdType = thirdTypeConverter.getCppRequiredTypes()
 
   override fun convertNonOptional(value: Any, context: AppContext?): EitherOfThree<FirstType, SecondType, ThirdType> {
-    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
-      for (singleType in types) {
-        if (singleType.expectedCppType.clazz.isInstance(value)) {
-          return@Convert if (firstTypeConverter.isTrivial()) {
-            EitherOfThree<FirstType, SecondType, ThirdType>(value)
-          } else {
-            EitherOfThree(converter.convert(value)!!)
-          }
-        }
-      }
-      null
-    }
-
-    return convertValueIfNeeded(
-      firstType.getPossibleTypes(),
-      firstTypeConverter
-    ) ?: convertValueIfNeeded(
-      secondType.getPossibleTypes(),
-      secondTypeConverter
-    ) ?: convertValueIfNeeded(
-      thirdType.getPossibleTypes(),
-      thirdTypeConverter
+    val typeList = listOf(firstJavaType, secondJavaType, thirdJavaType)
+    val deferredValues = createDeferredValues(
+      value,
+      context,
+      listOf(
+        firstType to firstTypeConverter,
+        secondType to secondTypeConverter,
+        thirdType to thirdTypeConverter
+      ),
+      typeList
     )
-      ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfThree<$firstJavaType, $secondJavaType, $thirdJavaType>'")
+
+    return EitherOfThree(
+      value,
+      deferredValues.toMutableList(),
+      typeList
+    )
   }
 
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType
@@ -129,33 +173,24 @@ class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : A
   private val fourthType = fourthTypeConverter.getCppRequiredTypes()
 
   override fun convertNonOptional(value: Any, context: AppContext?): EitherOfFour<FirstType, SecondType, ThirdType, FourthType> {
-    val convertValueIfNeeded = Convert@{ types: Array<out SingleType>, converter: TypeConverter<*> ->
-      for (singleType in types) {
-        if (singleType.expectedCppType.clazz.isInstance(value)) {
-          return@Convert if (firstTypeConverter.isTrivial()) {
-            EitherOfFour<FirstType, SecondType, ThirdType, FourthType>(value)
-          } else {
-            EitherOfFour(converter.convert(value)!!)
-          }
-        }
-      }
-      null
-    }
-
-    return convertValueIfNeeded(
-      firstType.getPossibleTypes(),
-      firstTypeConverter
-    ) ?: convertValueIfNeeded(
-      secondType.getPossibleTypes(),
-      secondTypeConverter
-    ) ?: convertValueIfNeeded(
-      thirdType.getPossibleTypes(),
-      thirdTypeConverter
-    ) ?: convertValueIfNeeded(
-      fourthType.getPossibleTypes(),
-      fourthTypeConverter
+    val typeList = listOf(firstJavaType, secondJavaType, thirdJavaType, fourthJavaType)
+    val deferredValues = createDeferredValues(
+      value,
+      context,
+      listOf(
+        firstType to firstTypeConverter,
+        secondType to secondTypeConverter,
+        thirdType to thirdTypeConverter,
+        fourthType to fourthTypeConverter
+      ),
+      listOf(firstJavaType, secondJavaType, thirdJavaType, fourthJavaType)
     )
-      ?: throw TypeCastException("Cannot cast '$value' to 'EitherOfFourth<$firstJavaType, $secondJavaType, $thirdJavaType, $fourthJavaType>'")
+
+    return EitherOfFour(
+      value,
+      deferredValues.toMutableList(),
+      typeList
+    )
   }
 
   override fun getCppRequiredTypes(): ExpectedType = firstType + secondType + thirdType


### PR DESCRIPTION
# Why

Rework the  `Either` type converter to make it more versatile. 

# How

Right now, when you want to use `Either<URL, String>`, it won't work correctly. That PR aims to solve problems with either when two types have a common part. 

# Test Plan

- unit tests ✅