### PR TITLE
Update react-native-maps to 1.8.0

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -144,7 +144,7 @@
     "react-native": "0.72.5",
     "react-native-dropdown-picker": "^5.3.0",
     "react-native-gesture-handler": "~2.12.0",
-    "react-native-maps": "1.7.1",
+    "react-native-maps": "1.8.0",
     "react-native-pager-view": "6.2.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.3.0",

--- a/home/package.json
+++ b/home/package.json
@@ -60,7 +60,7 @@
     "react-native-gesture-handler": "~2.12.0",
     "react-native-infinite-scroll-view": "^0.4.5",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-maps": "1.7.1",
+    "react-native-maps": "1.8.0",
     "react-native-paper": "^4.0.1",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -87,7 +87,7 @@
   "react-native-web": "~0.19.6",
   "react-native-gesture-handler": "~2.12.0",
   "react-native-get-random-values": "~1.8.0",
-  "react-native-maps": "1.7.1",
+  "react-native-maps": "1.8.0",
   "react-native-pager-view": "6.2.0",
   "react-native-reanimated": "~3.3.0",
   "react-native-screens": "~3.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16444,10 +16444,10 @@ react-native-keyboard-aware-scroll-view@^0.9.5:
     prop-types "^15.6.2"
     react-native-iphone-x-helper "^1.0.3"
 
-react-native-maps@1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.7.1.tgz#e0b9d68542b4b59b5ca3df375ada7c860fb41f2e"
-  integrity sha512-CHVLzL+Q2jiUGgbt4/vosxVI1SukWyaLGjD62VLgR/wZpnH4Umi9ql1bmKDPWcfj2C1QZwMU0Yc7rXTbvZUIiw==
+react-native-maps@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-1.8.0.tgz#1f2471dec6f406725d22f2545f326c6fb6d9abf9"
+  integrity sha512-KfVZ03L42+a22Fkcl2uDe5d+73BweTlcRUzm2G+aQUJ7fHrBxj7CuXWtKMSNpVDiO3YDCWcshiiyjSXxkd/qOw==
   dependencies:
     "@types/geojson" "^7946.0.10"
 


### PR DESCRIPTION
# Why

In order to upgrade react-native to 0.73 we will need to update some android libraries to ensure that a namespace is specified in their build.gradle as React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. (https://github.com/react-native-community/discussions-and-proposals/issues/671)

# How

`et uvm -m react-native-maps --commit "v1.8.0"`

# Test Plan
 

- [x] test using `bare-expo` Android + NCL  
- [x] test using `bare-expo` iOS + NCL  
- [x] test unversioned expo go ios + NCL  
- [x] test unversioned expo go android + NCL  


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
