### PR TITLE
[docs] Fix header, outdated and duplicated info in Deep Linking on Android

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -24,6 +24,7 @@ exceptions:
   - Android Studio
   - APNs
   - App
+  - App Links
   - AppDelegate
   - App Store Connect
   - Apple

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -219,16 +219,16 @@ Implementing deep links on Android (without a custom URL scheme) is somewhat sim
 }
 ```
 
-### Android Asset Links
+### Android App Links
 
 It may be desirable for links to your domain to always open your app (without presenting the user a dialog where they can choose the browser or a different handler). You can implement this with Android App Links, which use a similar verification process as Universal Links on iOS.
 
 Create a JSON file for the website verification (a.k.a. [digital asset links](https://developers.google.com/digital-asset-links/v1/getting-started) file) at **public/.well-known/assetlinks.json** (or **web/.well-known/assetlinks.json** for legacy Expo webpack websites), and collect the following information:
 
 - `package_name`: The Android [application ID](/versions/latest/config/app/#package) of your app (for example, `com.bacon.app`). This can be found in the **app.json** file under `expo.android.package`.
-- `sha256_cert_fingerprints`: The SHA256 fingerprints of your app’s signing certificate. This can be obtained in one of two ways:
+- `sha256_cert_fingerprints`: The SHA256 fingerprints of your app's signing certificate. This can be obtained in one of two ways:
   1. After building an Android app with EAS Build, run `eas credentials -p android` and select the profile you wish to obtain the fingerprint for. The fingerprint will be listed under `SHA256 Fingerprint`.
-  2. By visiting the [Play Console](https://play.google.com/console/) developer account under **Release > Setup > App Integrity > App Signing**. If you do, then you'll also find the correct Digital Asset Links JSON snippet for your app on the same page. The value will look like `14:6D:E9:83...`
+  2. By visiting the [Play Console](https://play.google.com/console/) developer account under **Release > Setup > App Signing**. If you do, then you'll also find the correct Digital Asset Links JSON snippet for your app on the same page. The value will look like `14:6D:E9:83...`
 
 ```json public/.well-known/assetlinks.json
 [
@@ -250,11 +250,9 @@ Installing the native app on a device will trigger the [Android app verification
 
 <ConfigReactNative title="Manual native configuration">
 
-If you're not using EAS to manage code signing, you can find the **sha256_cert_fingerprints** by building and submitting your app manually, then visiting the [Google Play Console](https://play.google.com/console/) developer account under **Release > Setup > App Integrity > App Signing**; if you do, then you'll also find the correct **Digital Asset Links JSON** snippet for your app on the same page. The value will look like `14:6D:E9:83...`. Copy this value into your `public/.well-known/assetlinks.json` file.
+If you're not using EAS to manage code signing, you can find the **sha256_cert_fingerprints** by building and submitting your app manually, then visiting the [Google Play Console](https://play.google.com/console/) developer account under **Release > Setup > App Signing**; if you do, then you'll also find the correct **Digital Asset Links JSON** snippet for your app on the same page. The value will look like `14:6D:E9:83...`. Copy this value into your `public/.well-known/assetlinks.json` file.
 
 </ConfigReactNative>
-
-It may be desirable for links to your domain to always open your app (without presenting the user a dialog where they can choose the browser or a different handler). You can implement this with Android App Links, which use a similar verification process as Universal Links on iOS.
 
 <Collapsible summary={<>Handle App Links on Android for <CODE>expo-dev-client</CODE> version 1.2.1 and below</>}>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1697565560362869)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By fixing the title of the sub section
- Remove duplicated paragraph
- Update outdated Play console settings path
- Also, update Vale heading case rule to add App Links (its the convention used in Android docs too so let's keep the same casing for this terminology)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/deep-linking/#deep-links-on-android

**Preview**

<img width="891" alt="CleanShot 2023-10-18 at 01 54 44@2x" src="https://github.com/expo/expo/assets/10234615/fd0a20a5-ea0e-481d-a4e4-0228f0b7307c">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
