### PR TITLE
[docs] Add docs for migrating from expo webpack to expo router

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -202,7 +202,10 @@ const general = [
       makePage('router/reference/troubleshooting.mdx'),
       makePage('router/reference/faq.mdx'),
     ]),
-    makeGroup('Migration', [makePage('router/migrate/from-react-navigation.mdx')]),
+    makeGroup('Migration', [
+      makePage('router/migrate/from-react-navigation.mdx'),
+      makePage('router/migrate/from-expo-webpack.mdx'),
+    ]),
   ]),
   makeSection(
     'Expo Modules API',

--- a/docs/pages/guides/customizing-webpack.mdx
+++ b/docs/pages/guides/customizing-webpack.mdx
@@ -45,39 +45,6 @@ module.exports = async function (env, argv) {
 };
 ```
 
-## Polyfills
-
-React Native for Web uses [some advanced browser features](https://github.com/necolas/react-native-web/blob/e4ed0fd3c863e6c61aa3ea8afeff79b7fa74b461/packages/docs/src/introduction.stories.mdx#install) that might not be available in every browser. Expo web tries to include these features with `@expo/webpack-config`.
-
-### `ResizeObserver`
-
-**TL;DR:** To fully support `onLayout` install `resize-observer-polyfill`.
-
-The `onLayout` prop that's used in all of the core primitives such as View, Image, Text, ScrollView, and so on, requires an API called [`ResizeObserver`](https://drafts.csswg.org/resize-observer-1/). This API isn't fully [supported across all browsers](https://caniuse.com/#feat=resizeobserver), for example, iOS Safari (in iOS 13). If the device doesn't support `ResizeObserver` then `react-native-web` will fallback on `window.onresize` and you'll see a warning in the logs:
-
-```
-onLayout relies on ResizeObserver which is not supported by your browser.
-Please include a polyfill, e.g., https://github.com/que-etc/resize-observer-polyfill.
-Falling back to window.onresize.
-```
-
-To get everything working properly, you'll want to install and include a global polyfill for `ResizeObserver`.
-
-### Adding `ResizeObserver`
-
-- Install the polyfill:
-  <Terminal cmd={['$ npx expo install resize-observer-polyfill']} />
-- Restart the project and `@expo/webpack-config` will automatically include the polyfill.
-
-The reason it automatically includes the polyfill is that `react-native-web` needs it included immediately. webpack can inject the polyfill before any of the application code has been executed. Alternatively, you can customize the webpack config and include the polyfill in the `entry` field yourself.
-
-### Testing the `ResizeObserver` polyfill
-
-- Open the running Expo project in iOS Safari.
-- Connect the device to an Apple computer.
-- Open Safari on the computer in go to `Develop > [YOUR DEVICE] > [YOUR HOST]`.
-- Ensure the logs don't have the `onLayout relies on ResizeObserver...` warning.
-
 ## Editing static files
 
 You can also use `npx expo customize` to generate the static project files: **index.html**, **serve.json**, and so on. These can be used to customize your project more familiarly.

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -1,0 +1,341 @@
+---
+title: Migrate from Expo Webpack
+sidebar_title: Expo Webpack
+description: Learn how to migrate a website using Expo Webpack to Expo Router.
+---
+
+import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
+import { Terminal } from '~/ui/components/Snippet';
+
+The original version of "Expo for web" was based on Webpack 4 and focused primarily on building single-page applications (SPAs). This approach was based on [Create React App](https://create-react-app.dev/) and enabled simple web apps to be built with Expo SDK and React Native for web.
+
+Expo Router is the new approach to building powerful universal apps that run on web and native. This guide will help you migrate your existing website to Expo Router.
+
+Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and many of the concepts are the same.
+
+## Pitch
+
+Unlike Expo Webpack, Expo Router supports [static rendering on web](/router/reference/static-rendering) which enables search engine optimization (SEO), social media previews, and faster loading times.
+
+Along with all the benefits of React Navigation, Expo Router also enables automatic deep linking, [type safety](/router/reference/typed-routes), [deferred bundling](/router/reference/async-routes), [modular HTML templates](/router/reference/static-rendering#root-html), [static rendering on web](/router/reference/static-rendering), and more.
+
+Expo Router is also designed to fix the main cross-platform issue with Expo Webpack; sharing navigation between web and native, without compromising on functionality or performance.
+
+## Anti-pitch
+
+Expo Router uses a custom bundler stack that is based on [Metro](https://facebook.github.io/metro/), which is the same bundler used by React Native. While this is great for ensuring maximum code reusability and solves many of the forked behavior issues that came from using different bundlers across platforms, this also means certain bundling features may not be available in Expo Router yet.
+
+Ultimately Expo Router, being a full universal framework, is a substantially more robust solution than `@expo/webpack-config`, a bundler integration, and should be used for all new projects Expo web projects.
+
+## Expo CLI
+
+Unlike `@expo/webpack-config`, Expo Router uses the same CLI commands and features for web and native. Refer to the table below for more information on the differences between Expo Router and `@expo/webpack-config`.
+
+| Feature           | Expo Router                          | `@expo/webpack-config` |
+| ----------------- | ------------------------------------ | ---------------------- |
+| Start command     | `npx expo start`                     | `npx expo start`       |
+| Bundle command    | `npx expo export`                    | `npx expo export:web`  |
+| Output folder     | **dist**                             | **web-build**          |
+| Static folder     | **public**                           | **web**                |
+| Config file       | **metro.config.js**                  | **webpack.config.js**  |
+| Default config    | `@expo/metro-config`                 | `@expo/webpack-config` |
+| Multi-platform    | <YesIcon />                          | <NoIcon />             |
+| Fast Refresh      | <YesIcon /> (`@expo/metro-runtime`)  | <NoIcon />             |
+| Error Overlay     | <YesIcon /> (`@expo/metro-runtime`)  | <NoIcon />             |
+| Deferred Bundling | <YesIcon /> (`@expo/metro-runtime`)  | <NoIcon />             |
+| CSS Modules       | <YesIcon /> (SDK 50)                 | <NoIcon />             |
+| Global CSS        | <YesIcon /> (SDK 50)                 | <YesIcon />            |
+| Bundle Splitting  | <YesIcon /> (pending native and web) | <YesIcon />            |
+
+## HTML template
+
+In `@expo/webpack-config` all routes shared a single HTML file. This file was based on the template in `web/index.html` which was then modified by the `@expo/webpack-config` to include the necessary scripts and stylesheets.
+
+In Expo Router there are two different rendering patterns:
+
+- Recommended: `web.output: "static"` which outputs a new HTML file for each route in the app. With this approach, you can dynamically generate the entire HTML template using the `app/+html.js` file. [Learn more](/router/reference/static-rendering#root-html).
+- Not recommended: `web.output: "single"` which outputs a single-page application. With this approach, you can use `public/index.html` as the template HTML file.
+
+## Static resources
+
+In `@expo/webpack-config` you could host static files in the `web` directory and they would be served from the root of the website. For example, `web/favicon.ico` would be served from `https://example.com/favicon.ico`.
+
+In Expo Router, you can use the `public` directory to host static files. For example, `public/favicon.ico` would be served from `https://example.com/favicon.ico`. Unlike Webpack, Expo Router's hosting works on native too, just ensure to host the files from a server before using them in production.
+
+## Bundling for production
+
+In `@expo/webpack-config` you could bundle your website for production using `npx expo export:web`. This would output a bundle to the `web-build` directory.
+
+In Expo Router, use the `npx expo export --platform web` command to export to the `dist` directory. You can generate sourcemaps with the `--dump-sourcemap` flag. On build, the contents of the `public` directory will be copied to the `dist` directory.
+
+## Babel configuration
+
+Just like before, the root `babel.config.js` file is used for both web and native. You can change the preset by using the `platform` property in the API caller:
+
+```js babel.config.js
+module.exports = api => {
+  // Get the platform from the API caller...
+  const platform = api.caller(caller => caller && caller.platform);
+
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      // Add a web-only plugin...
+      platform === 'web' && 'custom-web-only-plugin',
+    ].filter(Boolean),
+  };
+};
+```
+
+## Dev server
+
+In Expo Router, all platforms are hosted from the same dev server, on the same port. This is conveneient for emulating the production behavior of the app. All logs and hot module reloading goes through the same port as well.
+
+Due to limitations on native, hosting with fake https is not supported at the moment. This feature is less important now than it was in 2018 as you can test secure features like camera and location on localhost using Chrome now.
+
+## Expo constants
+
+The `expo-constants` library can be used to access the `app.json` in-app. Behind the scenes, this is accomplished by setting `process.env.APP_MANIFEST` with the stringified contents of the `app.json` file.
+
+In Expo Router, this is done using Babel with the `expo-router/babel` in SDK 49 and lower, and `babel-preset-expo` in SDK 50 and higher. If you modify the app.json, you will need to restart the Babel cache with `npx expo start --clear` in order to see the updates.
+
+## Base path and subpath hosting
+
+> Experimental functionality. It will be available from SDK 50.
+
+In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `homepage` field in the project's `package.json` file like so:
+
+```json package.json
+{
+  "homepage": "/evanbacon/my-website"
+}
+```
+
+In Expo Router, you can use the experimental `basePath` field in the project's `app.json` file like so:
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "basePath": "/evanbacon/my-website"
+    }
+  }
+}
+```
+
+Unlike the previous system, this will also update the routing to account for the base path. For example, if you have a route `/profile` and you set the base path to `/evanbacon/my-website`, then the route will be `/evanbacon/my-website/profile`.
+
+Learn more: [Hosting with sub-paths](/more/expo-cli#hosting-with-sub-paths).
+
+## Fast refresh
+
+In `@expo/webpack-config` you could install `@pmmmwh/react-refresh-webpack-plugin` and add this to the `webpack.config.js`:
+
+```js webpack.config.js
+const createExpoWebpackConfigAsync = require('@expo/webpack-config');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+
+module.exports = async function (env, argv) {
+  const config = await createExpoWebpackConfigAsync(env, argv);
+
+  // Use the React refresh plugin in development mode
+  if (env.mode === 'development') {
+    config.plugins.push(new ReactRefreshWebpackPlugin({ disableRefreshCheck: true }));
+  }
+
+  return config;
+};
+```
+
+In Expo Router, **Fast Refresh is enabled by default** using the official Fast Refresh implementation by Meta.
+
+## Favicons
+
+Just like `@expo/webpack-config`, Expo Router supports generating the favicon.ico file based on the `web.favicon` field in the `app.json`.
+
+## Service workers
+
+**Warning:** Be careful adding service workers as they are known to cause unexpected behavior on web. If you accidentally ship a service worker which aggressively caches your website, users will not be able to easily request updates. For the best offline mobile experience, create a native app with Expo. Unlike websites with service workers, native apps can be updated through the app store to clear the cached experience, this would be akin to resetting the user's native browser (which they may have to do if the service worker is aggressive enough). Learn more about [why service workers are suboptimal](https://github.com/facebook/create-react-app/issues/2398).
+
+Expo Webpack didn't have built-in service worker support, but you could add it yourself by using the `workbox-webpack-plugin` and adding it to the `webpack.config.js`.
+
+Workbox doesn't have a Metro integration, but because Workbox doesn't require one of the core features of a bundler (transformation, resolution, serialization), it can easily be used as a post-build step.
+
+Simply follow the [guide for using Workbox CLI](https://developer.chrome.com/docs/workbox/modules/workbox-cli/), and wherever it refers to a "build script" use `npx expo export -p web`.
+
+For example, here's a possible flow for setting up Workbox:
+
+- `bun create expo -t tabs my-app`
+- `cd my-app`
+
+Next, create a root HTML file for the app and add the service worker registration script:
+
+```js app/+html.tsx
+import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from 'react';
+
+// This file is web-only and used to configure the root HTML for every
+// web page during static rendering.
+// The contents of this function only run in Node.js environments and
+// do not have access to the DOM or browser APIs.
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+
+        {/* Bootstrap the service worker. */}
+        <script dangerouslySetInnerHTML={{ __html: sw }} />
+
+        {/*
+          This viewport disables scaling which makes the mobile website act more like a native app.
+          However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
+            <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        */}
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
+        />
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
+          However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
+        */}
+        <ScrollViewStyleReset />
+
+        {/* Add any additional <head> elements that you want globally available on web... */}
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+
+const sw = `
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').then(registration => {
+            console.log('Service Worker registered with scope:', registration.scope);
+        }).catch(error => {
+            console.error('Service Worker registration failed:', error);
+        });
+    });
+}
+`;
+```
+
+Now build the app before running the wizard:
+
+<Terminal cmd={['$ npx expo export -p web']} />
+
+Run the wizard command, selecting `dist` as the root of the app, and the defaults for everything else...
+
+<Terminal
+  cmd={[
+    '$ npx workbox-cli wizard',
+    '',
+    '$ ? What is the root of your web app (i.e. which directory do you deploy)? dist/',
+    '$ ? Which file types would you like to precache? js, html, ttf, ico, json',
+    '$ ? Where would you like your service worker file to be saved? dist/sw.js',
+    '$ ? Where would you like to save these configuration options? workbox-config.js',
+    "$ ? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+  ]}
+/>
+
+Finally, run `workbox generateSW workbox-config.js` to generate the service worker config.
+
+Going forward, you can add a build script to run both scripts in the correct order:
+
+```json package.json
+{
+  "scripts": {
+    "build:web": "expo export -p web && workbox generateSW workbox-config.js"
+  }
+}
+```
+
+## PWA manifests
+
+Unlike `@expo/webpack-config`, Expo Router does not automatically attempt to generate the PWA manifest configuration. You can create one in your `public/manifest.json`:
+
+```json
+{
+  "short_name": "Expo App",
+  "name": "Expo Router Sample",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "logo192.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "logo512.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}
+```
+
+You can link this in your HTML file using the `link` tag:
+
+```js app/+html.tsx
+import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from 'react';
+
+// This file is web-only and used to configure the root HTML for every
+// web page during static rendering.
+// The contents of this function only run in Node.js environments and
+// do not have access to the DOM or browser APIs.
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+
+        {/* Link the PWA manifest file. */}
+        <link rel="manifest" href="/manifest.json" />
+
+        {/*
+          This viewport disables scaling which makes the mobile website act more like a native app.
+          However this does reduce built-in accessibility. If you want to enable scaling, use this instead:
+            <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        */}
+        <meta
+          name="viewport"
+          content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1.00001,viewport-fit=cover"
+        />
+        {/*
+          Disable body scrolling on web. This makes ScrollView components work closer to how they do on native.
+          However, body scrolling is often nice to have for mobile web. If you want to enable it, remove this line.
+        */}
+        <ScrollViewStyleReset />
+
+        {/* Add any additional <head> elements that you want globally available on web... */}
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+## Bundler plugins
+
+If you were using custom bundler plugins, refer to the [Expo Metro config](/versions/latest/config/metro) to learn more about adding custom functionality to your bundler pipeline.
+
+## Navigation
+
+If you used React Navigation for navigating between screens in `@expo/webpack-config`, then refer to the migration guide for [React Navigation](/router/migrate/from-react-navigation).
+
+## Deployment
+
+Visit the [publishing websites documentation](/distribution/publishing-websites) and select "Expo Router" to learn how to deploy Expo Router websites to various hosting providers.

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -163,7 +163,7 @@ Workbox doesn't have a Metro integration, but because Workbox doesn't require on
 
 For example, here's a possible flow for setting up Workbox. Create a new project with the following command:
 
-<Terminal cmd={
+<Terminal cmd={[
   "$ bun create expo -t tabs my-app",
   "",
   "$ cd my-app",

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -103,7 +103,7 @@ In Expo Router, this is done using Babel with the `expo-router/babel` in SDK 49 
 
 > Experimental functionality. It will be available from SDK 50.
 
-In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `homepage` field in the project's `package.json` file like so:
+In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `PUBLIC_URL` environment variable, or the `homepage` field in the project's `package.json` file like so:
 
 ```json package.json
 {

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -7,27 +7,25 @@ description: Learn how to migrate a website using Expo Webpack to Expo Router.
 import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { Terminal } from '~/ui/components/Snippet';
 
-The original version of "Expo for web" was based on Webpack 4 and focused primarily on building single-page applications (SPAs). This approach was based on [Create React App](https://create-react-app.dev/) and enabled simple web apps to be built with Expo SDK and React Native for web.
+The original **Expo for web** version was based on Webpack 4 and focused primarily on building single-page applications (SPAs). This approach was based on [Create React App](https://create-react-app.dev/) and enabled building simple web apps with Expo SDK and React Native for web.
 
 Expo Router is the new approach to building powerful universal apps that run on web and native. This guide will help you migrate your existing website to Expo Router.
 
-Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and many of the concepts are the same.
+Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and has many shared concepts.
 
 ## Pitch
 
-> `@expo/webpack-config` is in maintenance-mode and not receiving any new feature updates.
+> **warning** `@expo/webpack-config` is in maintenance-mode and not receiving any new feature updates.
 
-Unlike Expo Webpack, Expo Router supports [static rendering on web](/router/reference/static-rendering) which enables search engine optimization (SEO), social media previews, and faster loading times.
+Expo Router supports [static rendering on web](/router/reference/static-rendering), which enables search engine optimization (SEO), social media previews, and faster loading times, unlike Expo Webpack. Along with the benefits of React Navigation, it enables automatic deep linking,  [type safety](/router/reference/typed-routes), [deferred bundling](/router/reference/async-routes), [modular HTML templates](/router/reference/static-rendering#root-html), [static rendering on web](/router/reference/static-rendering), and more.
 
-Along with all the benefits of React Navigation, Expo Router also enables automatic deep linking, [type safety](/router/reference/typed-routes), [deferred bundling](/router/reference/async-routes), [modular HTML templates](/router/reference/static-rendering#root-html), [static rendering on web](/router/reference/static-rendering), and more.
-
-Expo Router is also designed to fix the main cross-platform issue with Expo Webpack; sharing navigation between web and native, without compromising on functionality or performance.
+Expo Router is also designed to fix the main cross-platform issue with Expo Webpack by sharing navigation between web and native without compromising functionality or performance.
 
 ## Anti-pitch
 
-Expo Router uses a custom bundler stack that is based on [Metro](https://facebook.github.io/metro/), which is the same bundler used by React Native. While this is great for ensuring maximum code reusability and solves many of the forked behavior issues that came from using different bundlers across platforms, this also means certain bundling features may not be available in Expo Router yet.
+Expo Router uses a custom bundler stack based on [Metro](https://facebook.github.io/metro/). It is the same bundler used by React Native. While this is great for ensuring maximum code reusability and solves many forked behavior issues from using different bundlers across platforms. This also means certain bundling features may not be available in Expo Router yet.
 
-Ultimately Expo Router, being a full universal framework, is a substantially more robust solution than `@expo/webpack-config`, a bundler integration, and should be used for all new projects Expo web projects.
+Ultimately as a full universal framework, Expo Router is a substantially more robust solution than `@expo/webpack-config`, which is a bundler integration. It should be used for all new Expo web projects.
 
 ## Expo CLI
 
@@ -53,26 +51,26 @@ Unlike `@expo/webpack-config`, Expo Router uses the same CLI commands and featur
 
 In `@expo/webpack-config` all routes shared a single HTML file. This file was based on the template in `web/index.html` which was then modified by the `@expo/webpack-config` to include the necessary scripts and stylesheets.
 
-In Expo Router there are two different rendering patterns:
+In Expo Router, there are two different rendering patterns:
 
-- Recommended: `web.output: "static"` which outputs a new HTML file for each route in the app. With this approach, you can dynamically generate the entire HTML template using the `app/+html.js` file. [Learn more](/router/reference/static-rendering#root-html).
-- Not recommended: `web.output: "single"` which outputs a single-page application. With this approach, you can use `public/index.html` as the template HTML file.
+- **Recommended**: `web.output: "static"` which outputs a new HTML file for each route in the app. This approach lets you [dynamically generate the entire HTML template using the **app/+html.js** file](/router/reference/static-rendering#root-html).
+- **Not recommended**: `web.output: "single"` which outputs a single-page application. This approach lets you use `public/index.html` as the template HTML file.
 
 ## Static resources
 
-In `@expo/webpack-config` you could host static files in the `web` directory and they would be served from the root of the website. For example, `web/favicon.ico` would be served from `https://example.com/favicon.ico`.
+In `@expo/webpack-config`, you could host static files in the `web` directory, which would be served from the website's root. For example, `web/favicon.ico` was served from `https://example.com/favicon.ico`.
 
-In Expo Router, you can use the `public` directory to host static files. For example, `public/favicon.ico` would be served from `https://example.com/favicon.ico`. Unlike Webpack, Expo Router's hosting works on native too, just ensure to host the files from a server before using them in production.
+In Expo Router, you can use the **public** directory to host static files. For example, **public/favicon.ico** is served from `https://example.com/favicon.ico`. Unlike Webpack, Expo Router's hosting works on native too. Make sure to host the files from a server before using them in production.
 
 ## Bundling for production
 
-In `@expo/webpack-config` you could bundle your website for production using `npx expo export:web`. This would output a bundle to the `web-build` directory.
+In `@expo/webpack-config`, you could bundle your website for production using `npx expo export:web`. This would output a bundle to the **web-build** directory.
 
-In Expo Router, use the `npx expo export --platform web` command to export to the `dist` directory. You can generate sourcemaps with the `--dump-sourcemap` flag. On build, the contents of the `public` directory will be copied to the `dist` directory.
+In Expo Router, use the `npx expo export --platform web` command to export to the **dist** directory. You can generate sourcemaps with the `--dump-sourcemap` flag. On build, the contents of the **public** directory will be copied to the **dist** directory.
 
 ## Babel configuration
 
-Just like before, the root `babel.config.js` file is used for both web and native. You can change the preset by using the `platform` property in the API caller:
+Like before, the root **babel.config.js** file is used for both web and native. You can change the preset by using the `platform` property in the API caller:
 
 ```js babel.config.js
 module.exports = api => {
@@ -91,21 +89,21 @@ module.exports = api => {
 
 ## Dev server
 
-In Expo Router, all platforms are hosted from the same dev server, on the same port. This is conveneient for emulating the production behavior of the app. All logs and hot module reloading goes through the same port as well.
+In Expo Router, all platforms are hosted from the same dev server on the same port. This is convenient for emulating the production behavior of the app. All logs and hot module reloading go through the same port as well.
 
-Due to limitations on native, hosting with fake https is not supported at the moment. This feature is less important now than it was in 2018 as you can test secure features like camera and location on localhost using Chrome now.
+Due to limitations on native, hosting with fake HTTPS is not currently supported. This feature is less important now than in 2018, as you can test secure features such as camera and location on localhost using a web browser like Chrome.
 
 ## Expo constants
 
-The `expo-constants` library can be used to access the `app.json` in-app. Behind the scenes, this is accomplished by setting `process.env.APP_MANIFEST` with the stringified contents of the `app.json` file.
+The [`expo-constants`](/versions/latest/sdk/constants/) library can be used to access the **app.json** in-app. Behind the scenes, this is accomplished by setting `process.env.APP_MANIFEST` with the stringified contents of the **app.json** file.
 
-In Expo Router, this is done using Babel with the `expo-router/babel` in SDK 49 and lower, and `babel-preset-expo` in SDK 50 and higher. If you modify the app.json, you will need to restart the Babel cache with `npx expo start --clear` in order to see the updates.
+In Expo Router, this is done using Babel with the `expo-router/babel` in SDK 49 and lower and `babel-preset-expo` in SDK 50 and higher. If you modify the **app.json**, restart the Babel cache with `npx expo start --clear` to see the updates.
 
 ## Base path and subpath hosting
 
 > Experimental functionality. It will be available from SDK 50.
 
-In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `PUBLIC_URL` environment variable, or the `homepage` field in the project's `package.json` file like so:
+In `@expo/webpack-config`, you could bundle your website to be hosted from a subpath by using the `PUBLIC_URL` environment variable or the `homepage` field in the project's **package.json**:
 
 ```json package.json
 {
@@ -113,7 +111,7 @@ In `@expo/webpack-config`, you could bundle your website to be hosted from a sub
 }
 ```
 
-In Expo Router, you can use the experimental `basePath` field in the project's `app.json` file like so:
+In Expo Router, you can use the experimental `basePath` field in the project's **app.json**:
 
 ```json app.json
 {
@@ -127,11 +125,11 @@ In Expo Router, you can use the experimental `basePath` field in the project's `
 
 Unlike the previous system, this will also update the routing to account for the base path. For example, if you have a route `/profile` and you set the base path to `/evanbacon/my-website`, then the route will be `/evanbacon/my-website/profile`.
 
-Learn more: [Hosting with sub-paths](/more/expo-cli#hosting-with-sub-paths).
+See [hosting with sub-paths](/more/expo-cli#hosting-with-sub-paths) for more information.
 
 ## Fast refresh
 
-In `@expo/webpack-config` you could install `@pmmmwh/react-refresh-webpack-plugin` and add this to the `webpack.config.js`:
+In `@expo/webpack-config` you could install `@pmmmwh/react-refresh-webpack-plugin` and add the following to the **webpack.config.js**:
 
 ```js webpack.config.js
 const createExpoWebpackConfigAsync = require('@expo/webpack-config');
@@ -153,26 +151,27 @@ In Expo Router, **Fast Refresh is enabled by default** using the official Fast R
 
 ## Favicons
 
-Just like `@expo/webpack-config`, Expo Router supports generating the favicon.ico file based on the `web.favicon` field in the `app.json`.
+Like `@expo/webpack-config`, Expo Router supports generating the **favicon.ico** file based on the `web.favicon` field in the **app.json**.
 
 ## Service workers
 
-**Warning:** Be careful adding service workers as they are known to cause unexpected behavior on web. If you accidentally ship a service worker which aggressively caches your website, users will not be able to easily request updates. For the best offline mobile experience, create a native app with Expo. Unlike websites with service workers, native apps can be updated through the app store to clear the cached experience, this would be akin to resetting the user's native browser (which they may have to do if the service worker is aggressive enough). Learn more about [why service workers are suboptimal](https://github.com/facebook/create-react-app/issues/2398).
+> **warning:** Be careful adding service workers as they are known to cause unexpected behavior on web. If you accidentally ship a service worker who aggressively caches your website, users cannot request updates easily. For the best offline mobile experience, create a native app with Expo. Unlike websites with service workers, native apps can be updated through the app store to clear the cached experience. This would be similar to resetting the user's native browser (which they may have to do if the service worker is aggressive enough). See [why service workers are suboptimal](https://github.com/facebook/create-react-app/issues/2398) for more information.
 
-Expo Webpack didn't have built-in service worker support, but you could add it yourself by using the `workbox-webpack-plugin` and adding it to the `webpack.config.js`.
+Expo Webpack didn't have built-in service worker support. However, you could add it yourself by using the `workbox-webpack-plugin` and adding it to the **webpack.config.js**.
 
-Workbox doesn't have a Metro integration, but because Workbox doesn't require one of the core features of a bundler (transformation, resolution, serialization), it can easily be used as a post-build step.
+Workbox doesn't have a Metro integration, but because Workbox doesn't require one of the core features of a bundler (transformation, resolution, serialization), it can easily be used as a post-build step. Follow the guide for [using Workbox CLI](https://developer.chrome.com/docs/workbox/modules/workbox-cli/), and wherever it refers to a "build script" use `npx expo export -p web` instead.
 
-Simply follow the [guide for using Workbox CLI](https://developer.chrome.com/docs/workbox/modules/workbox-cli/), and wherever it refers to a "build script" use `npx expo export -p web`.
+For example, here's a possible flow for setting up Workbox. Create a new project with the following command:
 
-For example, here's a possible flow for setting up Workbox:
-
-- `bun create expo -t tabs my-app`
-- `cd my-app`
+<Terminal cmd={
+  "$ bun create expo -t tabs my-app",
+  "",
+  "$ cd my-app",
+]} cmdCopy="bun create expo -t tabs my-app && cd my-app" />
 
 Next, create a root HTML file for the app and add the service worker registration script:
 
-```js app/+html.tsx
+```tsx app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 
@@ -243,9 +242,7 @@ Run the wizard command, selecting `dist` as the root of the app, and the default
   ]}
 />
 
-Finally, run `workbox generateSW workbox-config.js` to generate the service worker config.
-
-Going forward, you can add a build script to run both scripts in the correct order:
+Finally, run `workbox generateSW workbox-config.js` to generate the service worker config. Going forward, you can add a build script in **package.json** to run both scripts in the correct order:
 
 ```json package.json
 {
@@ -257,7 +254,7 @@ Going forward, you can add a build script to run both scripts in the correct ord
 
 ## PWA manifests
 
-Unlike `@expo/webpack-config`, Expo Router does not automatically attempt to generate the PWA manifest configuration. You can create one in your `public/manifest.json`:
+Unlike `@expo/webpack-config`, Expo Router does not automatically attempt to generate the PWA manifest configuration. You can create one in **public/manifest.json**:
 
 ```json
 {
@@ -289,7 +286,7 @@ Unlike `@expo/webpack-config`, Expo Router does not automatically attempt to gen
 
 You can link this in your HTML file using the `link` tag:
 
-```js app/+html.tsx
+```tsx app/+html.tsx
 import { ScrollViewStyleReset } from 'expo-router/html';
 import type { PropsWithChildren } from 'react';
 
@@ -332,12 +329,12 @@ export default function Root({ children }: PropsWithChildren) {
 
 ## Bundler plugins
 
-If you were using custom bundler plugins, refer to the [Expo Metro config](/versions/latest/config/metro) to learn more about adding custom functionality to your bundler pipeline.
+If you were using custom bundler plugins, see [Expo Metro config](/versions/latest/config/metro) for adding custom functionality to your bundler pipeline.
 
 ## Navigation
 
-If you used React Navigation for navigating between screens in `@expo/webpack-config`, then refer to the migration guide for [React Navigation](/router/migrate/from-react-navigation).
+If you used React Navigation for navigating between screens in `@expo/webpack-config`, see the [migration guide for React Navigation](/router/migrate/from-react-navigation).
 
 ## Deployment
 
-Visit the [publishing websites documentation](/distribution/publishing-websites) and select "Expo Router" to learn how to deploy Expo Router websites to various hosting providers.
+See [publishing websites](/distribution/publishing-websites) and select "Expo Router" on how to deploy Expo Router websites to various hosting providers.

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -15,6 +15,8 @@ Both React Navigation and Expo Router are Expo frameworks for routing and naviga
 
 ## Pitch
 
+> `@expo/webpack-config` is in maintenance-mode and not receiving any new feature updates.
+
 Unlike Expo Webpack, Expo Router supports [static rendering on web](/router/reference/static-rendering) which enables search engine optimization (SEO), social media previews, and faster loading times.
 
 Along with all the benefits of React Navigation, Expo Router also enables automatic deep linking, [type safety](/router/reference/typed-routes), [deferred bundling](/router/reference/async-routes), [modular HTML templates](/router/reference/static-rendering#root-html), [static rendering on web](/router/reference/static-rendering), and more.


### PR DESCRIPTION
# Why

- Resolve ENG-9820
- Resolve ENG-9037
- Resolve ENG-8667

# How

Add a bunch of public resources for helping users understand the relationship between `@expo/webpack-config` and Expo Router.
