### PR TITLE
[docs][EAS Build] remove Intel resource class related docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -256,7 +256,7 @@ iOS builder VMs run on Mac Mini hosts in an isolated environment. Every build ge
 
 </Collapsible>
 
-#### `macos-monterey-12.6-xcode-14.1` (`default` for Intel builders)
+#### `macos-monterey-12.6-xcode-14.1`
 
 <Collapsible summary="Details">
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import al from '@mdx-js/react';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **September 28, 2023**.
+> This document was last updated on **October 18, 2023**.
 
 ## Builder IP addresses
 

--- a/docs/public/static/resource-specs.json
+++ b/docs/public/static/resource-specs.json
@@ -12,12 +12,6 @@
             "memory": "32 GB RAM",
             "description": "n2-standard-8 Google Cloud machine type"
         },
-        "apple-intel": {
-            "name": "Apple Intel",
-            "cpu": "Intel(R) Core(TM) i7-8700B CPU",
-            "memory": "64 GB RAM",
-            "description": "6 cores/12 threads"
-        },
         "apple-m1": {
             "name": "Apple M1",
             "cpu": "M1 3.2GHz 8-Core",
@@ -57,16 +51,6 @@
     },
     "resources": {
         "ios": {
-            "intel-medium": {
-                "name": "Intel Medium",
-                "symbol": "intel-medium",
-                "hardware": {
-                    "apple-intel": {
-                        "vm": "apple-0",
-                        "extra": "2 builder VMs per host"
-                    }
-                }
-            },
             "medium": {
                 "name": "Medium",
                 "symbol": "m-medium",

--- a/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-ios-schema.js
@@ -47,8 +47,8 @@ export default [
     enum: ['default', 'medium', ...iosResourceClasses],
     description: [
       'The iOS-specific resource class that will be used to run this build.',
-      '- For SDK version >= 45 or React Native version >= 0.71.0 `default` maps to `m-medium`, otherwise it maps to `intel-medium`',
-      '- For SDK version >= 45 or React Native version >= 0.71.0 `medium` maps to `m-medium`, otherwise it maps to `intel-medium`',
+      '`m-medium`',
+      '`m-medium`',
       '',
       'Build resources:',
       ...iosResourcesList,


### PR DESCRIPTION
# Why

Intel resource class is no longer available

# How

Clean up the Intel resource class related docs

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
