### PR TITLE
[ci] Fix react-native nightly pod install

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -55,6 +55,9 @@ jobs:
       - name: 🌳 Display pod environment
         run: pod env
         working-directory: apps/bare-expo/ios
+      - name: 🥥 Update boost, RCT-Folly and SocketRocket pods in apps/bare-expo/ios
+        run: pod update boost RCT-Folly SocketRocket --no-repo-update
+        working-directory: apps/bare-expo/ios
       - name: 🥥 Install pods in apps/bare-expo/ios
         run: npx pod-install
         working-directory: apps/bare-expo/ios

--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -229,6 +229,20 @@ async function updateBareExpoAsync(nightlyVersion: string) {
       find: /(platform :ios, )['"]13\.0['"]/g,
       replaceWith: "$1'13.4'",
     },
+    {
+      // __apply_Xcode_12_5_M1_post_install_workaround was removed in 0.73
+      find: '__apply_Xcode_12_5_M1_post_install_workaround(installer)',
+      replaceWith: '',
+    },
+    {
+      // Flipper was removed in 0.74
+      find: `flipper_config = ENV['NO_FLIPPER'] == "1" || ENV['CI'] ? FlipperConfiguration.disabled : FlipperConfiguration.enabled`,
+      replaceWith: '',
+    },
+    {
+      find: /:flipper_configuration => FlipperConfiguration.disabled,/g,
+      replaceWith: '',
+    },
   ]);
 
   // flipper-integration


### PR DESCRIPTION
# Why

the iOS Test Suite on React Native nightly build workflow is currently failing due to CocoaPods not being able to find compatible versions for "RCT-Folly", "boost" and "SocketRocket"

<img width="849" alt="image" src="https://github.com/expo/expo/assets/11707729/fd6e6f3d-0c8b-4c61-9355-76d4e6f2bef1">


# How

Manually update RCT-Folly", "boost" and "SocketRocket" pods before running `npx pod-install` (this should only be necessary until we update the repo to rn-0.73)

Also update SetupReactNativeNightly to remove mentions of `__apply_Xcode_12_5_M1_post_install_workaround` and `Flipper` as both were removed in 0.73 and  0.74 respectively

# Test Plan

Run Test Suite on React Native nightly on CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
