### PR TITLE
[ENG-10374] [expo-go] update Expo Go dev menu UI

### DIFF
--- a/home/menu/DevMenuServerInfo.tsx
+++ b/home/menu/DevMenuServerInfo.tsx
@@ -1,8 +1,9 @@
 import Constants from 'expo-constants';
 import { Row, View, Text, Spacer } from 'expo-dev-client-components';
 import React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, TouchableOpacity, Clipboard } from 'react-native';
 
+import { ClipboardIcon } from './ClipboardIcon';
 import DevIndicator from '../components/DevIndicator';
 import FriendlyUrls from '../legacy/FriendlyUrls';
 
@@ -20,6 +21,13 @@ export function DevMenuServerInfo({ task }: Props) {
       ? manifest.extra.expoGo.developer.tool
       : null;
 
+  async function onCopyTaskUrl() {
+    const { manifestUrl } = task;
+
+    Clipboard.setString(manifestUrl);
+    alert(`Copied "${manifestUrl}" to the clipboard.`);
+  }
+
   return (
     <View bg="default" padding="medium">
       {devServerName ? (
@@ -30,14 +38,19 @@ export function DevMenuServerInfo({ task }: Props) {
           <Spacer.Vertical size="tiny" />
         </>
       ) : null}
-      <Row align="center">
-        {devServerName ? (
-          <DevIndicator style={styles.taskDevServerIndicator} isActive isNetworkAvailable />
-        ) : null}
-        <Text type="InterRegular" size="medium" numberOfLines={1}>
-          {taskUrl}
-        </Text>
-      </Row>
+      <TouchableOpacity onPress={onCopyTaskUrl}>
+        <Row align="center" justify="between" mx="2">
+          <Row align="center">
+            {devServerName ? (
+              <DevIndicator style={styles.taskDevServerIndicator} isActive isNetworkAvailable />
+            ) : null}
+            <Text type="InterRegular" size="medium" numberOfLines={1}>
+              {taskUrl}
+            </Text>
+          </Row>
+          <ClipboardIcon />
+        </Row>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/home/menu/DevMenuView.tsx
+++ b/home/menu/DevMenuView.tsx
@@ -121,6 +121,11 @@ export function DevMenuView({ uuid, task }: Props) {
     setIsLoaded(true);
   }
 
+  function onAppReload() {
+    collapse();
+    DevMenu.reloadAppAsync();
+  }
+
   function onGoToHome() {
     collapse();
     DevMenu.goToHomeAsync();
@@ -159,7 +164,7 @@ export function DevMenuView({ uuid, task }: Props) {
                 <DevMenuItem
                   buttonKey="reload"
                   label="Reload"
-                  onPress={onGoToHome}
+                  onPress={onAppReload}
                   icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
                 />
                 <Divider />

--- a/home/menu/DevMenuView.tsx
+++ b/home/menu/DevMenuView.tsx
@@ -1,14 +1,12 @@
 import { HomeFilledIcon, iconSize, RefreshIcon } from '@expo/styleguide-native';
 import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
-import { Divider, Row, Spacer, useExpoTheme, View } from 'expo-dev-client-components';
+import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import React, { Fragment, useContext, useEffect, useRef } from 'react';
 import { Clipboard } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { ClipboardIcon } from './ClipboardIcon';
 import DevMenuBottomSheetContext from './DevMenuBottomSheetContext';
-import { DevMenuButton } from './DevMenuButton';
 import { DevMenuCloseButton } from './DevMenuCloseButton';
 import { DevMenuItem } from './DevMenuItem';
 import * as DevMenu from './DevMenuModule';
@@ -24,12 +22,12 @@ type Props = {
 // These are defined in EXVersionManager.m in a dictionary, ordering needs to be
 // done here.
 const DEV_MENU_ORDER = [
-  'dev-live-reload',
-  'dev-hmr',
-  'dev-remote-debug',
-  'dev-reload',
   'dev-perf-monitor',
   'dev-inspector',
+  'dev-remote-debug',
+  'dev-live-reload',
+  'dev-hmr',
+  'dev-reload',
 ];
 
 function ThemedMaterialIcon({
@@ -170,32 +168,23 @@ export function DevMenuView({ uuid, task }: Props) {
           <View style={{ paddingBottom: insets.bottom }}>
             <DevMenuServerInfo task={task} />
             <Divider />
-            <Row align="center" padding="medium">
-              <DevMenuButton
-                buttonKey="reload"
-                label="Reload"
-                onPress={onAppReload}
-                icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
-              />
-              <Spacer.Horizontal size="medium" />
-              {task && task.manifestUrl && (
-                <>
-                  <DevMenuButton
-                    buttonKey="copy"
-                    label="Copy Link"
-                    onPress={onCopyTaskUrl}
-                    icon={<ClipboardIcon size={iconSize.regular} color={theme.icon.default} />}
-                  />
-                  <Spacer.Horizontal size="medium" />
-                </>
-              )}
-              <DevMenuButton
-                buttonKey="home"
-                label="Go Home"
-                onPress={onGoToHome}
-                icon={<HomeFilledIcon size={iconSize.regular} color={theme.icon.default} />}
-              />
-            </Row>
+            <View padding="medium">
+              <View bg="default" rounded="large">
+                <DevMenuItem
+                  buttonKey="reload"
+                  label="Reload"
+                  onPress={onGoToHome}
+                  icon={<RefreshIcon size={iconSize.small} color={theme.icon.default} />}
+                />
+                <Divider />
+                <DevMenuItem
+                  buttonKey="home"
+                  label="Go Home"
+                  onPress={onGoToHome}
+                  icon={<HomeFilledIcon size={iconSize.small} color={theme.icon.default} />}
+                />
+              </View>
+            </View>
             {enableDevMenuTools && devMenuItems && (
               <View padding="medium" style={{ paddingTop: 0 }}>
                 <View bg="default" rounded="large">

--- a/home/menu/DevMenuView.tsx
+++ b/home/menu/DevMenuView.tsx
@@ -3,7 +3,6 @@ import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIc
 import { Divider, useExpoTheme, View } from 'expo-dev-client-components';
 import * as Font from 'expo-font';
 import React, { Fragment, useContext, useEffect, useRef } from 'react';
-import { Clipboard } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import DevMenuBottomSheetContext from './DevMenuBottomSheetContext';
@@ -120,19 +119,6 @@ export function DevMenuView({ uuid, task }: Props) {
     setDevMenuItems(devMenuItems);
     setIsOnboardingFinished(isOnboardingFinished);
     setIsLoaded(true);
-  }
-
-  function onAppReload() {
-    collapse();
-    DevMenu.reloadAppAsync();
-  }
-
-  async function onCopyTaskUrl() {
-    const { manifestUrl } = task;
-
-    await collapseAndCloseDevMenuAsync();
-    Clipboard.setString(manifestUrl);
-    alert(`Copied "${manifestUrl}" to the clipboard!`);
   }
 
   function onGoToHome() {


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/23538

There is an inconsistency between the Expo Go dev menu and the regular dev menu: we're showing the same options, but in a different order.

| Expo Go      | Development Build |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 - 2023-10-18 at 16 38 11](https://github.com/expo/expo/assets/6534400/7b32fb9f-fc2c-4272-a4f3-4b301f0ad409)      | ![image](https://github.com/expo/expo/assets/6534400/dd3b3a29-40fa-4520-a8a1-7aed18fb825f)       |

# How

Update the Expo Go UI to match.

# Test Plan

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 - 2023-10-18 at 16 38 11](https://github.com/expo/expo/assets/6534400/7b32fb9f-fc2c-4272-a4f3-4b301f0ad409)       | ![Simulator Screenshot - iPhone 15 - 2023-10-18 at 17 42 24](https://github.com/expo/expo/assets/6534400/c4222ddc-c21a-4523-991e-a43c18703676)       |




# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
