### PR TITLE
[ci] Re-enable updates E2E test on iOS

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
   pull_request:
     paths:
-      - .github/workflows/updates-e2e-basic.yml
+      - .github/workflows/updates-e2e.yml
       - packages/@expo/cli/**
       - packages/@expo/config-plugins/**
       - packages/@expo/config-types/**
@@ -20,7 +20,7 @@ on:
   push:
     branches: [main, 'sdk-*']
     paths:
-      - .github/workflows/updates-e2e-basic.yml
+      - .github/workflows/updates-e2e.yml
       - packages/@expo/cli/**
       - packages/@expo/config-plugins/**
       - packages/@expo/config-types/**
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [android, tvos]
+        platform: [ios, android, tvos]
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     env:


### PR DESCRIPTION
# Why

This was removed in https://github.com/expo/expo/pull/24549. Missing context on why in the PR, but we should have this enabled before landing more iOS refactors. I had erroneously assumed this was passing.

Edit: found context in slack: https://exponent-internal.slack.com/archives/C013ZK4SA12/p1696479316190969?thread_ts=1696471352.398469&cid=C013ZK4SA12

We definitely need to get this passing before 50 cut. Should probably also get the tvos one passing?

# How

Re-enable. This also fixes the workflow file to run the workflow when the workflow file is changed.

# Test Plan

Wait for CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
