### PR TITLE
[android][brightness] Fix: add event to module definition

### DIFF
--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, add event to prevent the `new NativeEventEmitter()` warning.
+
 ### 💡 Others
 
 ## 11.7.0 — 2023-10-17

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, add event to prevent the `new NativeEventEmitter()` warning.
+- On `Android`, add event to prevent the `new NativeEventEmitter()` warning. ([#24942](https://github.com/expo/expo/pull/24942) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -12,12 +12,16 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import kotlin.math.roundToInt
 
+const val brightnessChangeEvent = "Expo.brightnessDidChange"
+
 class BrightnessModule : Module() {
   private val currentActivity
     get() = appContext.currentActivity ?: throw Exceptions.MissingActivity()
 
   override fun definition() = ModuleDefinition {
     Name("ExpoBrightness")
+
+    Events(brightnessChangeEvent)
 
     AsyncFunction("requestPermissionsAsync") { promise: Promise ->
       Permissions.askForPermissionsWithPermissionsManager(appContext.permissions, promise, Manifest.permission.WRITE_SETTINGS)

--- a/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
+++ b/packages/expo-brightness/android/src/main/java/expo/modules/brightness/BrightnessModule.kt
@@ -21,6 +21,7 @@ class BrightnessModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExpoBrightness")
 
+    // This is unused on Android. It is only here to suppress the native event emitter warning
     Events(brightnessChangeEvent)
 
     AsyncFunction("requestPermissionsAsync") { promise: Promise ->


### PR DESCRIPTION
# Why
Same as #24943

# How
This module has an event that is only supported on `iOS` but it still needs to be added to the module definition on`Android` to prevent a warning.

# Test Plan
bare-expo. The warning is cleared
