### PR TITLE
[android][screen-orientation] Fix: add event to module definition

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- On `Android`, add event to module definition to prevent `new NativeEventEmitter()` warning.
+
 ### 💡 Others
 
 ## 6.3.0 — 2023-10-17

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- On `Android`, add event to module definition to prevent `new NativeEventEmitter()` warning.
+- On `Android`, add event to module definition to prevent `new NativeEventEmitter()` warning. ([#24943](https://github.com/expo/expo/pull/24943) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -32,6 +32,7 @@ class ScreenOrientationModule : Module(), LifecycleEventListener {
   override fun definition() = ModuleDefinition {
     Name("ExpoScreenOrientation")
 
+    // This is unused on Android. It is only here to suppress the native event emitter warning
     Events("expoDidUpdateDimensions")
 
     AsyncFunction("lockAsync") { orientationLock: OrientationLock ->

--- a/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
+++ b/packages/expo-screen-orientation/android/src/main/java/expo/modules/screenorientation/ScreenOrientationModule.kt
@@ -32,6 +32,8 @@ class ScreenOrientationModule : Module(), LifecycleEventListener {
   override fun definition() = ModuleDefinition {
     Name("ExpoScreenOrientation")
 
+    Events("expoDidUpdateDimensions")
+
     AsyncFunction("lockAsync") { orientationLock: OrientationLock ->
       try {
         currentActivity.requestedOrientation = orientationLock.toPlatformInt()


### PR DESCRIPTION
# Why
Closes #23392

# How
Add the event to module definition on `Android` to prevent the native event emitter warning. The event is supported on both platforms but doesn't use the emitter from native on `Android`.

# Test Plan
bare-expo. Warning is cleared