### PR TITLE
[expo-updates][ios][2/n] Refactor AppController callback types for JS methods

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### 💡 Others
 
 - Android: Stub expo-updates in Expo Go and remove service pattern. ([#24890](https://github.com/expo/expo/pull/24890) by [@wschurman](https://github.com/wschurman))
-- iOS: Refactor responsibility of app controller. ([#24934](https://github.com/expo/expo/pull/24934) by [@wschurman](https://github.com/wschurman))
+- iOS: Refactor responsibility of app controller. ([#24934](https://github.com/expo/expo/pull/24934), [#24949](https://github.com/expo/expo/pull/24949) by [@wschurman](https://github.com/wschurman))
 
 ## 0.22.0 — 2023-10-17
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -390,7 +390,7 @@ public final class AppLoaderTask: NSObject {
             self.delegateQueue.async {
               swiftDelegate.appLoaderTask(
                 self, didFinishCheckingForRemoteUpdateWithRemoteCheckResult: RemoteCheckResult.rollBackToEmbedded(
-                  commitTime: RollBackToEmbeddedUpdateDirective.rollbackCommitTime(rollBackUpdateDirective)
+                  commitTime: rollBackUpdateDirective.commitTime
                 )
               )
             }

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/UpdateResponse.swift
@@ -63,11 +63,6 @@ public final class RollBackToEmbeddedUpdateDirective: UpdateDirective {
     self.commitTime = commitTime
     super.init(signingInfo: signingInfo)
   }
-
-  // Extract commit time from an UpdateDirective
-  internal static func rollbackCommitTime(_ updateDirective: RollBackToEmbeddedUpdateDirective) -> Date {
-    return updateDirective.commitTime
-  }
 }
 
 public class UpdateResponsePart {}


### PR DESCRIPTION
# Why

As mentioned in https://github.com/expo/expo/pull/24934 as a follow-up, this "Change[s] result types of JS API methods in the app controller to have more concrete types rather than a non-strictly-keyed dictionary."

The reason for doing this is to make refactors of code internal to the library safer (no chance of messing up keys).

# How

Do the translation at the JS module layer rather than in the controller. Previously this was done in UpdatesUtils but now the sole concern of the UpdatesModule is to translate internal concrete data structures into loosely-typed maps that can be sent over the bride and match the types in JS.

# Test Plan

Build. wait for CI tests.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
