### PR TITLE
[docs] Remove unwanted comment in the example of Expo Router auth guide

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -366,7 +366,6 @@ export default function RootLayout() {
 ```js app/(app)/_layout.js
 export default function RootLayout() {
   React.useEffect(() => {
-    // This navigation event will trigger the error above.
     router.push('/about');
   }, []);
 


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The After example has a comment from the previous (before) example which became the point of confusion. Refs: https://github.com/expo/expo/pull/24185#discussion_r1324578086

This PR fixes this by removing that comment.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
