### PR TITLE
fix(cli): Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers.
+- Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers.
+
 ### 💡 Others
 
 ## 0.14.0 — 2023-10-17

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -108,6 +108,7 @@ export async function loadMetroConfigAsync(
     isTsconfigPathsEnabled: exp.experiments?.tsconfigPaths ?? true,
     webOutput: exp.web?.output ?? 'single',
     isFastResolverEnabled: env.EXPO_USE_FAST_RESOLVER,
+    isExporting,
   });
 
   logEventAsync('metro config', getMetroProperties(projectRoot, exp, config));
@@ -182,7 +183,7 @@ export async function instantiateMetroAsync(
     hmrEnabled: true,
     // @ts-expect-error: Inconsistent `websocketEndpoints` type between metro and @react-native-community/cli-server-api
     websocketEndpoints,
-    watch: isWatchEnabled(),
+    watch: !isExporting && isWatchEnabled(),
   });
 
   prependMiddleware(middleware, (req: ServerRequest, res: ServerResponse, next: ServerNext) => {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -97,7 +97,7 @@ export function withExtendedResolver(
     platforms,
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
-    isExporting
+    isExporting,
   }: {
     projectRoot: string;
     tsconfig: TsConfigPaths | null;
@@ -167,36 +167,36 @@ export function withExtendedResolver(
       })
     : null;
 
-    if (!isExporting && isInteractive()) {
-      if (isTsconfigPathsEnabled) {
-        // TODO: We should track all the files that used imports and invalidate them
-        // currently the user will need to save all the files that use imports to
-        // use the new aliases.
-        const configWatcher = new FileNotifier(projectRoot, ['./tsconfig.json', './jsconfig.json']);
-        configWatcher.startObserving(() => {
-          debug('Reloading tsconfig.json');
-          loadTsConfigPathsAsync(projectRoot).then((tsConfigPaths) => {
-            if (tsConfigPaths?.paths && !!Object.keys(tsConfigPaths.paths).length) {
-              debug('Enabling tsconfig.json paths support');
-              tsConfigResolve = resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
-                paths: tsConfigPaths.paths ?? {},
-                baseUrl: tsConfigPaths.baseUrl,
-              });
-            } else {
-              debug('Disabling tsconfig.json paths support');
-              tsConfigResolve = null;
-            }
-          });
+  if (!isExporting && isInteractive()) {
+    if (isTsconfigPathsEnabled) {
+      // TODO: We should track all the files that used imports and invalidate them
+      // currently the user will need to save all the files that use imports to
+      // use the new aliases.
+      const configWatcher = new FileNotifier(projectRoot, ['./tsconfig.json', './jsconfig.json']);
+      configWatcher.startObserving(() => {
+        debug('Reloading tsconfig.json');
+        loadTsConfigPathsAsync(projectRoot).then((tsConfigPaths) => {
+          if (tsConfigPaths?.paths && !!Object.keys(tsConfigPaths.paths).length) {
+            debug('Enabling tsconfig.json paths support');
+            tsConfigResolve = resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
+              paths: tsConfigPaths.paths ?? {},
+              baseUrl: tsConfigPaths.baseUrl,
+            });
+          } else {
+            debug('Disabling tsconfig.json paths support');
+            tsConfigResolve = null;
+          }
         });
-    
-        // TODO: This probably prevents the process from exiting.
-        installExitHooks(() => {
-          configWatcher.stopObserving();
-        });
-      } else {
-        debug('Skipping tsconfig.json paths support');
-      }
+      });
+
+      // TODO: This probably prevents the process from exiting.
+      installExitHooks(() => {
+        configWatcher.stopObserving();
+      });
+    } else {
+      debug('Skipping tsconfig.json paths support');
     }
+  }
 
   let nodejsSourceExtensions: string[] | null = null;
 
@@ -484,7 +484,7 @@ export async function withMetroMultiPlatformAsync(
     tsconfig,
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
-    isExporting
+    isExporting,
   });
 }
 
@@ -496,7 +496,7 @@ function withMetroMultiPlatform(
     isTsconfigPathsEnabled,
     tsconfig,
     isFastResolverEnabled,
-    isExporting
+    isExporting,
   }: {
     config: ConfigT;
     isTsconfigPathsEnabled: boolean;

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -97,12 +97,14 @@ export function withExtendedResolver(
     platforms,
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
+    isExporting
   }: {
     projectRoot: string;
     tsconfig: TsConfigPaths | null;
     platforms: string[];
     isTsconfigPathsEnabled?: boolean;
     isFastResolverEnabled?: boolean;
+    isExporting?: boolean;
   }
 ) {
   if (isFastResolverEnabled) {
@@ -165,34 +167,36 @@ export function withExtendedResolver(
       })
     : null;
 
-  if (isTsconfigPathsEnabled && isInteractive()) {
-    // TODO: We should track all the files that used imports and invalidate them
-    // currently the user will need to save all the files that use imports to
-    // use the new aliases.
-    const configWatcher = new FileNotifier(projectRoot, ['./tsconfig.json', './jsconfig.json']);
-    configWatcher.startObserving(() => {
-      debug('Reloading tsconfig.json');
-      loadTsConfigPathsAsync(projectRoot).then((tsConfigPaths) => {
-        if (tsConfigPaths?.paths && !!Object.keys(tsConfigPaths.paths).length) {
-          debug('Enabling tsconfig.json paths support');
-          tsConfigResolve = resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
-            paths: tsConfigPaths.paths ?? {},
-            baseUrl: tsConfigPaths.baseUrl,
+    if (!isExporting && isInteractive()) {
+      if (isTsconfigPathsEnabled) {
+        // TODO: We should track all the files that used imports and invalidate them
+        // currently the user will need to save all the files that use imports to
+        // use the new aliases.
+        const configWatcher = new FileNotifier(projectRoot, ['./tsconfig.json', './jsconfig.json']);
+        configWatcher.startObserving(() => {
+          debug('Reloading tsconfig.json');
+          loadTsConfigPathsAsync(projectRoot).then((tsConfigPaths) => {
+            if (tsConfigPaths?.paths && !!Object.keys(tsConfigPaths.paths).length) {
+              debug('Enabling tsconfig.json paths support');
+              tsConfigResolve = resolveWithTsConfigPaths.bind(resolveWithTsConfigPaths, {
+                paths: tsConfigPaths.paths ?? {},
+                baseUrl: tsConfigPaths.baseUrl,
+              });
+            } else {
+              debug('Disabling tsconfig.json paths support');
+              tsConfigResolve = null;
+            }
           });
-        } else {
-          debug('Disabling tsconfig.json paths support');
-          tsConfigResolve = null;
-        }
-      });
-    });
-
-    // TODO: This probably prevents the process from exiting.
-    installExitHooks(() => {
-      configWatcher.stopObserving();
-    });
-  } else {
-    debug('Skipping tsconfig.json paths support');
-  }
+        });
+    
+        // TODO: This probably prevents the process from exiting.
+        installExitHooks(() => {
+          configWatcher.stopObserving();
+        });
+      } else {
+        debug('Skipping tsconfig.json paths support');
+      }
+    }
 
   let nodejsSourceExtensions: string[] | null = null;
 
@@ -433,6 +437,7 @@ export async function withMetroMultiPlatformAsync(
     webOutput,
     routerDirectory,
     isFastResolverEnabled,
+    isExporting,
   }: {
     config: ConfigT;
     isTsconfigPathsEnabled: boolean;
@@ -440,6 +445,7 @@ export async function withMetroMultiPlatformAsync(
     webOutput?: 'single' | 'static' | 'server';
     routerDirectory: string;
     isFastResolverEnabled?: boolean;
+    isExporting?: boolean;
   }
 ) {
   // Auto pick app entry for router.
@@ -478,6 +484,7 @@ export async function withMetroMultiPlatformAsync(
     tsconfig,
     isTsconfigPathsEnabled,
     isFastResolverEnabled,
+    isExporting
   });
 }
 
@@ -489,12 +496,14 @@ function withMetroMultiPlatform(
     isTsconfigPathsEnabled,
     tsconfig,
     isFastResolverEnabled,
+    isExporting
   }: {
     config: ConfigT;
     isTsconfigPathsEnabled: boolean;
     platformBundlers: PlatformBundlers;
     tsconfig: TsConfigPaths | null;
     isFastResolverEnabled?: boolean;
+    isExporting?: boolean;
   }
 ) {
   let expoConfigPlatforms = Object.entries(platformBundlers)
@@ -515,6 +524,7 @@ function withMetroMultiPlatform(
   return withExtendedResolver(config, {
     projectRoot,
     tsconfig,
+    isExporting,
     isTsconfigPathsEnabled,
     platforms: expoConfigPlatforms,
     isFastResolverEnabled,


### PR DESCRIPTION


# Why

The CLI process is hanging because the tsconfig files are being watched during an export build. This PR ensures the watchers are all disabled when we are bundling for export.
