### PR TITLE
[expo-updates][android][1/n] Refactor responsibility

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Android: Stub expo-updates in Expo Go and remove service pattern. ([#24890](https://github.com/expo/expo/pull/24890) by [@wschurman](https://github.com/wschurman))
 - iOS: Refactor responsibility of app controller. ([#24934](https://github.com/expo/expo/pull/24934), [#24949](https://github.com/expo/expo/pull/24949) by [@wschurman](https://github.com/wschurman))
+- Android: Refactor responsibility of app controller. ([#24954](https://github.com/expo/expo/pull/24954) by [@wschurman](https://github.com/wschurman))
 
 ## 0.22.0 — 2023-10-17
 


### PR DESCRIPTION
# Why

Similar to https://github.com/expo/expo/pull/24934 but we're not quite in a position to make a lot of the controller fields private yet (compared to iOS). Think I need to backport the expo go versioned module stuff to older SDKs.

# How

Similar strategy to https://github.com/expo/expo/pull/24934: move methods into the controller to start to centralize logic so that hopefully we can combine the logic and better reason about state machine updates.

# Test Plan

Wait for CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
