### PR TITLE
[core][Android] `Any` converter doesn't use `ReadableMap` or `ReadableList` anymore

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -29,7 +29,7 @@
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
 - [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`. ([#24899](https://github.com/expo/expo/pull/24899) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `Either` converter not working with types that have common representation in JavaScript. ([#24903](https://github.com/expo/expo/pull/24903) by [@lukmccall](https://github.com/lukmccall))
-- [Android] `Any` converter doesn't use `ReadableMap` or `ReadableList` anymore. Objects and arrays are converted to Kotlin's primitives.
+- [Android] `Any` converter doesn't use `ReadableMap` or `ReadableList` anymore. Objects and arrays are converted to Kotlin's primitives. ([#24963](https://github.com/expo/expo/pull/24963) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [iOS] Fixed exception when deallocating shared objects. ([#24836](https://github.com/expo/expo/pull/24836) by [@kudo](https://github.com/kudo))
 - [Android] Fixed `null` or `undefined` wasn't converted to `JavaScriptValue`. ([#24899](https://github.com/expo/expo/pull/24899) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Fixed `Either` converter not working with types that have common representation in JavaScript. ([#24903](https://github.com/expo/expo/pull/24903) by [@lukmccall](https://github.com/lukmccall))
+- [Android] `Any` converter doesn't use `ReadableMap` or `ReadableList` anymore. Objects and arrays are converted to Kotlin's primitives.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/CppType.h
@@ -25,6 +25,7 @@ enum CppType {
   MAP = 1 << 13,
   VIEW_TAG = 1 << 14,
   SHARED_OBJECT_ID = 1 << 15,
-  JS_FUNCTION = 1 << 16
+  JS_FUNCTION = 1 << 16,
+  ANY = 1 << 17
 };
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -545,11 +545,6 @@ jobject AnyFrontendConvert::convert(
     for (size_t i = 0; i < size; i++) {
       auto jsValue = jsArray.getValueAtIndex(rt, i);
 
-      if (jsValue.isNull() || jsValue.isUndefined()) {
-        arrayList->add(nullptr);
-        continue;
-      }
-
       auto convertedElement = this->convert(
         rt, env, moduleRegistry, jsValue
       );
@@ -570,13 +565,6 @@ jobject AnyFrontendConvert::convert(
     auto jsValue = obj.getProperty(rt, key);
 
     auto convertedKey = env->NewStringUTF(key.utf8(rt).c_str());
-
-    // TODO(@lukmccall): pass information to CPP if the underlying type is nullable or not.
-    if (jsValue.isNull() || jsValue.isUndefined()) {
-      map->put(convertedKey, nullptr);
-      continue;
-    }
-
     auto convertedValue = this->convert(
       rt, env, moduleRegistry, jsValue
     );

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -508,4 +508,89 @@ jobject SharedObjectIdConverter::convert(jsi::Runtime &rt, JNIEnv *env,
 bool SharedObjectIdConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
   return value.isObject() && value.getObject(rt).hasProperty(rt, "__expo_shared_object_id__");
 }
+
+jobject AnyFrontendConvert::convert(
+  jsi::Runtime &rt,
+  JNIEnv *env,
+  JSIInteropModuleRegistry *moduleRegistry,
+  const jsi::Value &value
+) const {
+  if (value.isUndefined() || value.isNull()) {
+    return nullptr;
+  }
+
+  if (booleanConverter.canConvert(rt, value)) {
+    return booleanConverter.convert(rt, env, moduleRegistry, value);
+  }
+
+  if (doubleConverter.canConvert(rt, value)) {
+    return doubleConverter.convert(rt, env, moduleRegistry, value);
+  }
+
+  if (stringConverter.canConvert(rt, value)) {
+    return stringConverter.convert(rt, env, moduleRegistry, value);
+  }
+
+  if (!value.isObject()) {
+    return nullptr;
+  }
+
+  const jsi::Object &obj = value.asObject(rt);
+
+  if (obj.isArray(rt)) {
+    const jsi::Array &jsArray = obj.asArray(rt);
+    size_t size = jsArray.size(rt);
+
+    auto arrayList = java::ArrayList<jobject>::create(size);
+    for (size_t i = 0; i < size; i++) {
+      auto jsValue = jsArray.getValueAtIndex(rt, i);
+
+      if (jsValue.isNull() || jsValue.isUndefined()) {
+        arrayList->add(nullptr);
+        continue;
+      }
+
+      auto convertedElement = this->convert(
+        rt, env, moduleRegistry, jsValue
+      );
+      arrayList->add(convertedElement);
+      env->DeleteLocalRef(convertedElement);
+    }
+
+    return arrayList.release();
+  }
+
+  // it's object, so we're going to convert it to LinkedHashMap
+  auto propertyNames = obj.getPropertyNames(rt);
+  size_t size = propertyNames.size(rt);
+  auto map = java::LinkedHashMap<jobject, jobject>::create(size);
+
+  for (size_t i = 0; i < size; i++) {
+    auto key = propertyNames.getValueAtIndex(rt, i).getString(rt);
+    auto jsValue = obj.getProperty(rt, key);
+
+    auto convertedKey = env->NewStringUTF(key.utf8(rt).c_str());
+
+    // TODO(@lukmccall): pass information to CPP if the underlying type is nullable or not.
+    if (jsValue.isNull() || jsValue.isUndefined()) {
+      map->put(convertedKey, nullptr);
+      continue;
+    }
+
+    auto convertedValue = this->convert(
+      rt, env, moduleRegistry, jsValue
+    );
+
+    map->put(convertedKey, convertedValue);
+
+    env->DeleteLocalRef(convertedKey);
+    env->DeleteLocalRef(convertedValue);
+  }
+
+  return map.release();
+}
+
+bool AnyFrontendConvert::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
+  return true;
+}
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -370,4 +370,24 @@ private:
    */
   std::shared_ptr<FrontendConverter> valueConverter;
 };
+
+/**
+ * Converter from js object to [kotlin.Any] (Boolean, Double, String, Map<Any>, List<Any>).
+ */
+class AnyFrontendConvert : public FrontendConverter {
+public:
+  jobject convert(
+    jsi::Runtime &rt,
+    JNIEnv *env,
+    JSIInteropModuleRegistry *moduleRegistry,
+    const jsi::Value &value
+  ) const override;
+
+  bool canConvert(jsi::Runtime &rt, const jsi::Value &value) const override;
+
+private:
+  BooleanFrontendConverter booleanConverter;
+  DoubleFrontendConverter doubleConverter;
+  StringFrontendConverter stringConverter;
+};
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.cpp
@@ -25,6 +25,7 @@ void FrontendConverterProvider::createConverters() {
   RegisterConverter(CppType::READABLE_ARRAY, ReadableNativeArrayFrontendConverter);
   RegisterConverter(CppType::VIEW_TAG, ViewTagFrontendConverter);
   RegisterConverter(CppType::SHARED_OBJECT_ID, SharedObjectIdConverter);
+  RegisterConverter(CppType::ANY, AnyFrontendConvert);
 #undef RegisterConverter
 
   auto registerPolyConverter = [this](const std::vector<CppType> &types) {
@@ -41,16 +42,6 @@ void FrontendConverterProvider::createConverters() {
 
   // Enums
   registerPolyConverter({CppType::STRING, CppType::INT});
-
-  // Any
-  // We are not using all types here to provide a similar behaviour to the bridge implementation
-  registerPolyConverter({
-                          CppType::DOUBLE,
-                          CppType::READABLE_MAP,
-                          CppType::READABLE_ARRAY,
-                          CppType::STRING,
-                          CppType::BOOLEAN
-                        });
 }
 
 std::shared_ptr<FrontendConverter> FrontendConverterProvider::obtainConverter(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/CppType.kt
@@ -30,5 +30,6 @@ enum class CppType(val clazz: KClass<*>, val value: Int = nextValue()) {
   MAP(Map::class),
   VIEW_TAG(Int::class),
   SHARED_OBJECT_ID(Int::class),
-  JS_FUNCTION(JavaScriptFunction::class);
+  JS_FUNCTION(JavaScriptFunction::class),
+  ANY(Any::class);
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -75,15 +75,6 @@ class ExpectedType(
       SingleType(CppType.PRIMITIVE_ARRAY, arrayOf(parameterType))
     )
 
-    // We are not using all types here to provide a similar behaviour to the bridge implementation
-    fun forAny() = ExpectedType(
-      CppType.READABLE_MAP,
-      CppType.READABLE_ARRAY,
-      CppType.STRING,
-      CppType.BOOLEAN,
-      CppType.DOUBLE
-    )
-
     fun forEnum() = ExpectedType(
       CppType.STRING,
       CppType.INT

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeConverter.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.types
 
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
+import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 /**
@@ -16,13 +17,13 @@ class AnyTypeConverter(isOptional: Boolean) : DynamicAwareTypeConverters<Any>(is
       ReadableType.Boolean -> value.asBoolean()
       ReadableType.Number -> value.asDouble()
       ReadableType.String -> value.asString()
-      ReadableType.Map -> value.asMap()
-      ReadableType.Array -> value.asArray()
+      ReadableType.Map -> value.asMap().toHashMap()
+      ReadableType.Array -> value.asArray().toArrayList()
       else -> error("Unknown dynamic type: ${value.type}")
     }
   }
 
   override fun convertFromAny(value: Any): Any = value
 
-  override fun getCppRequiredTypes(): ExpectedType = ExpectedType.forAny()
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.NullArgumentException
 import expo.modules.kotlin.exception.UnsupportedClass
+import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 
 /**
@@ -22,7 +23,7 @@ abstract class TypeConverter<Type : Any> {
    * For instance js object can be pass as [Map] or [expo.modules.kotlin.jni.JavaScriptObject].
    * This value tells us which one we should choose.
    */
-  open fun getCppRequiredTypes(): ExpectedType = ExpectedType.forAny()
+  open fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.ANY)
 
   /**
    * Checks if the current converter is a trivial one.


### PR DESCRIPTION
# Why

Changes how conversion to `kotlin.Any` is working. Currently, when converting arrays or objects to kotlin any type, those values will be represented as `ReadableMap` or `ReadableArray`, which is not very useful.  I think it will be better to convert those to kotlin `Map`/`List` 

# How

Add `AnyFrontendConverter`.

# Test Plan

- unit tests ✅
- contact modules ✅