### PR TITLE
[expo-calendar] [iOS] Fix unnecessary permission check for calendars when calling `saveCalendarAsync` with `entityType` `"reminder"`

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix unnecessary permission check for calendars when calling `saveCalendarAsync` with `entityType` `"reminder"` ([#24967](https://github.com/expo/expo/pull/24967) by [@robertying](https://github.com/robertying))
+
 ### 💡 Others
 
 ## 12.1.0 — 2023-10-17

--- a/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
+++ b/packages/expo-calendar/ios/EXCalendar/EXCalendar.m
@@ -121,7 +121,11 @@ EX_EXPORT_METHOD_AS(saveCalendarAsync,
                     resolver:(EXPromiseResolveBlock)resolve
                     rejecter:(EXPromiseRejectBlock)reject)
 {
-  if (![self _checkCalendarPermissions:reject]) {
+  NSString *type = details[@"entityType"];
+  if ([type isEqualToString:@"event"] && ![self _checkCalendarPermissions:reject]) {
+    return;
+  }
+  if ([type isEqualToString:@"reminder"] && ![self _checkRemindersPermissions:reject]) {
     return;
   }
 
@@ -129,7 +133,6 @@ EX_EXPORT_METHOD_AS(saveCalendarAsync,
   NSString *title = details[@"title"];
   NSNumber *color = details[@"color"];
   NSString *sourceId = details[@"sourceId"];
-  NSString *type = details[@"entityType"];
   NSString *calendarId = details[@"id"];
 
   if (calendarId) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`saveCalendarAsync` in Expo Calendar checks the permission for calendars even if the passed entity is of type Reminders; it also doesn't check for reminders permissions in this case.

# How

Check respective permissions based on `entityType` in the calendar details payload.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. With an app set with no calendar permission and only reminders permission, we can't create a reminder list in the Reminders app, getting the error of missing calendar permission.
2. Apply the fix.
3. Now if we are only creating a reminder list without any calendar permission, it can go through without an issue. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
