### PR TITLE
Fix API Routes not updating in `src/app` directory.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix API Routes not updating in `src/app` directory.
+- Fix API Routes not updating in `src/app` directory. ([#24968](https://github.com/expo/expo/pull/24968) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix API Routes not updating in `src/app` directory.
 - Prevent `npx expo export` and `npx expo export:embed` from hanging with file watchers. ([#24952](https://github.com/expo/expo/pull/24952) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -450,7 +450,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         if (exp.web?.output === 'server') {
           // Cache observation for API Routes...
           observeApiRouteChanges(
-            this.projectRoot,
+            appDir,
             {
               metro,
               server,

--- a/packages/@expo/cli/src/start/server/metro/bundleApiRoutes.ts
+++ b/packages/@expo/cli/src/start/server/metro/bundleApiRoutes.ts
@@ -8,7 +8,7 @@
 import { logMetroErrorAsync } from './metroErrorInterface';
 import { requireFileContentsWithMetro } from '../getStaticRenderFunctions';
 
-const debug = require('debug')('expo:server-routes') as typeof console.log;
+const debug = require('debug')('expo:api-routes') as typeof console.log;
 
 const pendingRouteOperations = new Map<string, Promise<string | null>>();
 
@@ -33,7 +33,7 @@ export async function bundleApiRoute(
 
   async function bundleAsync() {
     try {
-      debug('Check API route:', options.appDir, filepath);
+      debug('Bundle API route:', options.appDir, filepath);
 
       const middleware = await requireFileContentsWithMetro(projectRoot, devServerUrl, filepath, {
         minify: options.mode === 'production',

--- a/packages/@expo/cli/src/start/server/metro/waitForMetroToObserveTypeScriptFile.ts
+++ b/packages/@expo/cli/src/start/server/metro/waitForMetroToObserveTypeScriptFile.ts
@@ -9,7 +9,7 @@ const debug = require('debug')('expo:start:server:metro:waitForTypescript') as t
  * TypeScript file is added to the project during development.
  */
 export function observeApiRouteChanges(
-  projectRoot: string,
+  appDir: string,
   runner: {
     metro: import('metro').Server;
     server: ServerLike;
@@ -18,7 +18,6 @@ export function observeApiRouteChanges(
 ): () => void {
   const watcher = runner.metro.getBundler().getBundler().getWatcher();
 
-  const appDir = path.join(projectRoot, 'app');
   const listener = ({
     eventsQueue,
   }: {


### PR DESCRIPTION
# Why

- Split out of https://github.com/expo/expo/pull/24937
