### PR TITLE
[expo-updates][android] Fix instrumentation test for new module

### DIFF
--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/logging/UpdatesLoggingTest.kt
@@ -2,9 +2,9 @@ package expo.modules.updates.logging
 
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry
-import expo.modules.core.Promise
 import expo.modules.core.logging.LogType
 import expo.modules.core.logging.PersistentFileLog
+import expo.modules.updates.UpdatesModule
 import expo.modules.updates.logging.UpdatesLogger.Companion.EXPO_UPDATES_LOGGING_TAG
 import expo.modules.updates.logging.UpdatesLogger.Companion.MAX_FRAMES_IN_STACKTRACE
 import org.junit.Assert
@@ -125,79 +125,41 @@ class UpdatesLoggingTest {
     Assert.assertEquals("Message 2", UpdatesLogEntry.create(purgedLogs[0])?.message)
   }
 
-  // Commenting out the test below after Updates module conversion to new Expo modules API
-  // TODO: reenable this test
-  /*
   @Test
   fun testBridgeMethods() {
     val asyncTestUtil = AsyncTestUtil()
     val instrumentationContext = InstrumentationRegistry.getInstrumentation().context
     val logger = UpdatesLogger(instrumentationContext)
     logger.warn("Test message", UpdatesErrorCode.JSRuntimeError)
-    asyncTestUtil.waitForTimeout(500)
-    val updatesModule = UpdatesModule(instrumentationContext)
-    asyncTestUtil.asyncMethodRunning = true
-    var entries: List<Bundle>? = null
-    var rejected = false
-    updatesModule.readLogEntriesAsync(
+    val entries = UpdatesModule.readLogEntries(
+      instrumentationContext,
       1000L,
-      PromiseTestWrapper(
-        resolve = { result ->
-          entries = result as? List<Bundle>
-          asyncTestUtil.asyncMethodRunning = false
-        },
-        reject = { _, _, _ ->
-          rejected = true
-          asyncTestUtil.asyncMethodRunning = false
-        }
-      )
     )
-    asyncTestUtil.waitForAsyncMethodToFinish("readLogEntriesAsync timed out", 1000)
-    Assert.assertFalse(rejected)
     Assert.assertNotNull(entries)
-    Assert.assertEquals(1, entries?.size)
-    val bundle = entries?.get(0)
-    Assert.assertEquals("Test message", bundle?.get("message"))
+    Assert.assertEquals(1, entries.size)
+    val bundle = entries[0]
+    Assert.assertEquals("Test message", bundle.getString("message"))
 
-    rejected = false
+    var rejected = false
     asyncTestUtil.asyncMethodRunning = true
-    updatesModule.clearLogEntriesAsync(
-      PromiseTestWrapper(
-        resolve = {
-          asyncTestUtil.asyncMethodRunning = false
-        },
-        reject = { _, _, _ ->
-          rejected = true
-          asyncTestUtil.asyncMethodRunning = false
-        }
-      )
-    )
+    UpdatesModule.clearLogEntries(instrumentationContext) { error ->
+      if (error != null) {
+        rejected = true
+        asyncTestUtil.asyncMethodRunning = false
+      }
+      asyncTestUtil.asyncMethodRunning = false
+    }
     asyncTestUtil.waitForAsyncMethodToFinish("clearLogEntriesAsync timed out", 1000)
     Assert.assertFalse(rejected)
 
-    entries = null
-    rejected = false
-    asyncTestUtil.asyncMethodRunning = true
-    updatesModule.readLogEntriesAsync(
-      1000L,
-      PromiseTestWrapper(
-        resolve = { result ->
-          entries = result as? List<Bundle>
-          asyncTestUtil.asyncMethodRunning = false
-        },
-        reject = { _, _, _ ->
-          rejected = true
-          asyncTestUtil.asyncMethodRunning = false
-        }
-      )
+    val entries2 = UpdatesModule.readLogEntries(
+      instrumentationContext,
+      1000L
     )
     asyncTestUtil.waitForAsyncMethodToFinish("readLogEntriesAsync timed out", 1000000)
-    Assert.assertFalse(rejected)
-    Assert.assertNotNull(entries)
-    Assert.assertEquals(0, entries?.size)
+    Assert.assertNotNull(entries2)
+    Assert.assertEquals(0, entries2.size)
   }
-
-   */
 
   internal class AsyncTestUtil {
     var asyncMethodRunning = false
@@ -218,20 +180,6 @@ class UpdatesLoggingTest {
       while (System.currentTimeMillis() < end) {
         Thread.sleep(16)
       }
-    }
-  }
-
-  internal class PromiseTestWrapper(
-    private val resolve: (_: Any?) -> Unit,
-    private val reject: (code: String?, message: String?, e: Throwable?) -> Unit
-
-  ) : Promise {
-    override fun resolve(value: Any?) {
-      resolve.invoke(value)
-    }
-
-    override fun reject(code: String?, message: String?, e: Throwable?) {
-      reject.invoke(code, message, e)
     }
   }
 }


### PR DESCRIPTION
# Why

I broke the expo-updates instrumentation tests by converting the UpdatesModule to the new API in https://github.com/expo/expo/pull/24890.

# How

This fixes it by making the methods static and testing those.

There does exist a module test helper `ModuleMock.createMock`, but this seems to only be used for unit tests. When I try to add as a `androidTestImplementation` dependency it fails to compile with duplicate class errors.

# Test Plan

Run test.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
