### PR TITLE
[expo-dev-client] Add possibility to disable the generated default `exp+slug` scheme

### DIFF
--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add possibility to disable the generated `exp+slug` scheme. ([#24976](https://github.com/expo/expo/pull/24976) by [@sync](https://github.com/sync))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-client/plugin/build/withDevClient.js
+++ b/packages/expo-dev-client/plugin/build/withDevClient.js
@@ -12,10 +12,13 @@ const withGeneratedAndroidScheme_1 = require("./withGeneratedAndroidScheme");
 const withGeneratedIosScheme_1 = require("./withGeneratedIosScheme");
 const pkg = require('expo-dev-client/package.json');
 function withDevClient(config, props) {
+    const { generatedSchemeEnabled = true } = props;
     config = (0, app_plugin_2.default)(config);
     config = (0, app_plugin_1.default)(config, props);
-    config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
-    config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
+    if (generatedSchemeEnabled) {
+        config = (0, withGeneratedAndroidScheme_1.withGeneratedAndroidScheme)(config);
+        config = (0, withGeneratedIosScheme_1.withGeneratedIosScheme)(config);
+    }
     return config;
 }
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withDevClient, pkg.name, pkg.version);

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -12,10 +12,14 @@ import { withGeneratedIosScheme } from './withGeneratedIosScheme';
 const pkg = require('expo-dev-client/package.json');
 
 function withDevClient(config: ExpoConfig, props: PluginConfigType) {
+  const { generatedSchemeEnabled = true } = props;
+
   config = withDevMenu(config);
   config = withDevLauncher(config, props);
-  config = withGeneratedAndroidScheme(config);
-  config = withGeneratedIosScheme(config);
+  if (generatedSchemeEnabled) {
+    config = withGeneratedAndroidScheme(config);
+    config = withGeneratedIosScheme(config);
+  }
   return config;
 }
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add possibility to disable the generated `exp+slug` scheme. ([#24976](https://github.com/expo/expo/pull/24976) by [@sync](https://github.com/sync))
+
 ### 🐛 Bug fixes
 
 - [iOS] Prevent React Native Dev Menu from showing up on launcher screen. ([#28936](https://github.com/expo/expo/pull/28936) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -36,6 +36,11 @@ export type PluginConfigOptions = {
      * @deprecated use the `launchMode` property instead
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
+    /**
+     * Determines whether to add the generated default `exp+slug` URL scheme or not.
+     * @default 'true'
+     */
+    generatedSchemeEnabled?: boolean;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -18,6 +18,10 @@ const schema = {
             enum: ['most-recent', 'launcher'],
             nullable: true,
         },
+        generatedSchemeEnabled: {
+            type: 'boolean',
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
@@ -29,6 +33,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                generatedSchemeEnabled: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },
@@ -45,6 +53,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                generatedSchemeEnabled: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -40,6 +40,11 @@ export type PluginConfigOptions = {
    * @deprecated use the `launchMode` property instead
    */
   launchModeExperimental?: 'most-recent' | 'launcher';
+  /**
+   * Determines whether to add the generated default `exp+slug` URL scheme or not.
+   * @default 'true'
+   */
+  generatedSchemeEnabled?: boolean;
 };
 
 const schema: JSONSchemaType<PluginConfigType> = {
@@ -55,6 +60,10 @@ const schema: JSONSchemaType<PluginConfigType> = {
       enum: ['most-recent', 'launcher'],
       nullable: true,
     },
+    generatedSchemeEnabled: {
+      type: 'boolean',
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
@@ -66,6 +75,10 @@ const schema: JSONSchemaType<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        generatedSchemeEnabled: {
+          type: 'boolean',
           nullable: true,
         },
       },
@@ -82,6 +95,10 @@ const schema: JSONSchemaType<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        generatedSchemeEnabled: {
+          type: 'boolean',
           nullable: true,
         },
       },


### PR DESCRIPTION
# Why

If you possess two apps with identical expo configurations and slugs but distinct bundle identifiers, installing the expo-dev-client will cause both to adopt the same supplementary scheme, such as exp+slug (e.g., exp+form-duo). This results in a conflict between the two apps. 

 It's preferable to activate the scheme only for the app that has the development client enabled.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Introduce an additional flag in the `expo-dev-client` plugin configuration, allowing adjustments within your `app.config.js`:
```
[
  'expo-dev-client',
  {
      generatedSchemeEnabled: process.env.ENV !== 'production',
  },
]
```

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Implement this solution for our production (with schemeEnabled: false) and preproduction (with schemeEnabled: true) builds. After installing both apps on a device, ensure that only the preproduction app launches when scanning a QR code containing the expo+slug.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
