### PR TITLE
[docs] Improve description for local builds doc

### DIFF
--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -17,14 +17,14 @@ You can run the same build process that we run on the EAS Build servers directly
 
 You need to be authenticated with Expo:
 
-- Run `eas login`,
-- or set `EXPO_TOKEN` ([learn more about token-based authentication](/accounts/programmatic-access)).
+- Run `eas login`
+- Alternatively, set `EXPO_TOKEN` [using token-based authentication](/accounts/programmatic-access)
 
 ## Use cases for local builds
 
 - Company policies that restrict the use of third-party CI/CD services. With local builds, the entire process runs on your infrastructure and the only communication with EAS servers is:
   - to make sure project `@account/slug` exists
-  - if you are using managed credentials to download them.
+  - if you are using managed credentials to download them
 - [Debugging](#using-local-builds-for-debugging) build failures on EAS servers.
 
 ## Use local builds for debugging

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -32,7 +32,7 @@ You need to be authenticated with Expo:
 If you encounter build failures on EAS servers and you're unable to determine the cause from inspecting the logs, you may find it helpful to debug the issue locally. To simplify that process we support several environment variables to configure the local build process.
 
 - `EAS_LOCAL_BUILD_SKIP_CLEANUP=1` - Set this to disable cleaning up the working directory after the build process is finished.
-- `EAS_LOCAL_BUILD_WORKINGDIR` - Specify the working directory for the build process, by default it's somewhere (it's platform dependent) in `/tmp` folder.
+- `EAS_LOCAL_BUILD_WORKINGDIR` - Specify the working directory for the build process, by default it's somewhere (it's platform dependent) in **/tmp** directory.
 - `EAS_LOCAL_BUILD_ARTIFACTS_DIR` - The directory where artifacts are copied after a successful build. By default these files are copied to the current directory, which may be undesirable if you are running many consecutive builds.
 
 ## Limitations

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -1,6 +1,6 @@
 ---
 title: Run builds on your own infrastructure
-description: Learn how to run EAS Build on your own custom infrastructure.
+description: Learn how to use EAS Build locally on your machine or a custom infrastructure using the --local flag.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -11,14 +11,14 @@ You can run the same build process that we run on the EAS Build servers directly
   cmd={['eas build --platform android --local', '# or', 'eas build --platform ios --local']}
 />
 
-> Note: if you use [Continuous Native Generation](/workflow/continuous-native-generation.mdx), you can run [prebuild](/workflow/prebuild.mdx) to generate your **android** and **ios** directories and then proceed open the projects in the respective IDEs and build them just like any native project. It's not necessary to run `eas build --local`, but it handles more of the build process for you — see ["Use cases for local builds"](#use-cases-for-local-builds).
+> **Note:** If you use [Continuous Native Generation](/workflow/continuous-native-generation), you can run [prebuild](/workflow/prebuild) to generate your **android** and **ios** directories and then proceed to open the projects in the respective IDEs. Further, you can build them just like any native project. It's not necessary to run `eas build --local`. However, it handles more of the build process for you &mdash; see [Use cases for local builds](#use-cases-for-local-builds).
 
 ## Prerequisites
 
 You need to be authenticated with Expo:
 
 - Run `eas login`,
-- or set `EXPO_TOKEN` ([learn more about token-based authentication](/accounts/programmatic-access.mdx)).
+- or set `EXPO_TOKEN` ([learn more about token-based authentication](/accounts/programmatic-access)).
 
 ## Use cases for local builds
 
@@ -27,9 +27,9 @@ You need to be authenticated with Expo:
   - if you are using managed credentials to download them.
 - [Debugging](#using-local-builds-for-debugging) build failures on EAS servers.
 
-## Using local builds for debugging
+## Use local builds for debugging
 
-If you encounter build failures on EAS servers and you're unable to determine the cause from inspecting the logs, you may find it helpful to debug the issue locally. To simplify that process we support a number of environment variables to configure the local build process.
+If you encounter build failures on EAS servers and you're unable to determine the cause from inspecting the logs, you may find it helpful to debug the issue locally. To simplify that process we support several environment variables to configure the local build process.
 
 - `EAS_LOCAL_BUILD_SKIP_CLEANUP=1` - Set this to disable cleaning up the working directory after the build process is finished.
 - `EAS_LOCAL_BUILD_WORKINGDIR` - Specify the working directory for the build process, by default it's somewhere (it's platform dependent) in `/tmp` folder.
@@ -44,7 +44,7 @@ Some of the options available for cloud builds are not available locally. Limita
 - Caching is not supported.
 - EAS Secrets are not supported (set them in your environment locally instead).
 - You are responsible for making sure that the environment has all the necessary tools installed:
-  - Node.js/yarn/npm
+  - Node.js/Yarn/npm
   - fastlane (iOS only)
   - CocoaPods (iOS only)
   - Android SDK and NDK


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context: [Slack](https://exponent-internal.slack.com/archives/C1QMWQ1P0/p1697842848419499)

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Improve doc's description
- Fix verbiage issues

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/build-reference/local-builds/

**Preview**

![CleanShot 2023-10-22 at 12 46 15](https://github.com/expo/expo/assets/10234615/5da06f03-e6ec-48ff-8eba-946b5d04179a)


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
