### PR TITLE
[docs] Update private npm packages doc

### DIFF
--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -73,7 +73,7 @@ registry=https://registry.johndoe.com/
 
 ## Both private npm packages and private registry
 
-> **info** This is an advanced example.
+> This is an advanced example.
 
 Private npm packages are always [scoped](https://docs.npmjs.com/about-scopes#scopes-and-package-visibility). For example, if your npm username is `johndoe`, the private self-hosted registry URL is `https://registry.johndoe.com/`. If you want to install dependencies from both sources, create a **.npmrc** in your project's root directory with the following:
 

--- a/docs/pages/build-reference/private-npm-packages.mdx
+++ b/docs/pages/build-reference/private-npm-packages.mdx
@@ -13,13 +13,13 @@ Before starting the build, you will need to configure your project to provide EA
 
 By default, EAS Build uses a self-hosted npm cache that speeds up installing dependencies for all builds. Every EAS Build builder is configured with a **.npmrc** file for each platform:
 
-#### Android
+### Android
 
 ```ini
 registry=http://npm-cache-service.worker-infra-production.svc.cluster.local:4873
 ```
 
-#### iOS
+### iOS
 
 ```ini
 registry=http://10.254.24.8:4873
@@ -73,7 +73,9 @@ registry=https://registry.johndoe.com/
 
 ## Both private npm packages and private registry
 
-This is an advanced example, and you will probably never use it. Private npm packages are always [scoped](https://docs.npmjs.com/about-scopes#scopes-and-package-visibility). For example, if your npm username is `johndoe`, private self-hosted registry URL is `https://registry.johndoe.com/`. If you want to install dependencies from both sources, create a **.npmrc** in your project's root directory with the following:
+> **info** This is an advanced example.
+
+Private npm packages are always [scoped](https://docs.npmjs.com/about-scopes#scopes-and-package-visibility). For example, if your npm username is `johndoe`, the private self-hosted registry URL is `https://registry.johndoe.com/`. If you want to install dependencies from both sources, create a **.npmrc** in your project's root directory with the following:
 
 ```ini .npmrc
 //registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Updating verbiage "probably never use it". We make this assumption but at times it could have a negative effect on someone going through the docs. This recently came up in support inbox rotation where a developer had to go through the doc twice to see we already cover this information. People often skim through instead.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Use callout to mark the paragraph as an advance example
- Remove the negative phrasing
- Fix header hierarchy usage

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/build-reference/private-npm-packages/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
