### PR TITLE
[docs] Update ESLint guide to include info about Prettier and minor fixes

### DIFF
--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -1,13 +1,15 @@
 ---
-title: Use ESLint
-description: A guide on configuring ESLint to format Expo apps.
+title: Use ESLint and Prettier
+description: A guide on configuring ESLint and Prettier to format Expo apps.
 ---
 
+import { BoxLink } from '~/ui/components/BoxLink';
+import { CODE } from '~/ui/components/Text';
 import { Collapsible } from '~/ui/components/Collapsible';
-import { Terminal } from '~/ui/components/Snippet';
 import { FileTree } from '~/ui/components/FileTree';
-import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
 import { Step } from '~/ui/components/Step';
+import { Tabs, Tab, TabsGroup } from '~/ui/components/Tabs';
+import { Terminal } from '~/ui/components/Snippet';
 
 <TabsGroup>
 
@@ -17,7 +19,7 @@ import { Step } from '~/ui/components/Step';
 
 <Step label="1">
 
-Install ESLint in your project.
+Install ESLint, Prettier, and [`eslint-config-universe`](https://github.com/expo/expo/tree/main/packages/eslint-config-universe#eslint-config-universe) in your project.
 
 <Tabs>
     <Tab label="npm">
@@ -29,6 +31,8 @@ Install ESLint in your project.
     </Tab>
 
 </Tabs>
+
+The `eslint-config-universe` library provides shared ESLint configurations for Node.js, web and universal Expo apps.
 
 </Step>
 
@@ -67,7 +71,7 @@ You can replace the `.` with specific directories or files to lint. For example,
 
 ## Usage
 
-You can lint your code manually from the command-line with the script:
+You can lint your code manually from the command line with the script:
 
 <Tabs>
     <Tab label="npm">
@@ -84,7 +88,7 @@ You can lint your code manually from the command-line with the script:
 
 ## Environment configuration
 
-ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **app/index.js** can be run in Hermes, Node.js, or the web browser.
+ESLint is generally configured for a single environment. However, the source code is written in JavaScript in an Expo app that runs in multiple different environments. For example, the **app.config.js**, **metro.config.js**, **babel.config.js**, and **app/+html.tsx** files are run in a Node.js environment. It means they have access to the global `__dirname` variable and can use Node.js modules such as `path`. Standard Expo project files like **app/index.js** can be run in Hermes, Node.js, or the web browser.
 
 You can add the `eslint-env` comment directive to the top of a file to tell ESLint which environment the file is running in. For example, to tell ESLint that a file is run in Node.js, add the following comment to the top of the file:
 
@@ -99,6 +103,16 @@ const config = getDefaultConfig(
 
 module.exports = config;
 ```
+
+## Prettier
+
+[Prettier](https://prettier.io/docs/en/) is a code formatter that ensures that all the code files follow a consistent styling. To customize its settings, create a **.prettierrc** file at the root of your project and add the configuration.
+
+<BoxLink
+  title="Custom Prettier configuration"
+  description="Learn more about customizing Prettier configuration."
+  href="https://github.com/expo/expo/tree/main/packages/eslint-config-universe#customizing-prettier"
+/>
 
 ## Troubleshooting
 
@@ -118,3 +132,15 @@ node_modules
 ```
 
 </TabsGroup>
+
+## Next step
+
+<BoxLink
+  title={
+    <>
+      <CODE>eslint-config-universe</CODE>
+    </>
+  }
+  description="Learn more about shared ESLint configurations for Node.js, web and universal Expo apps."
+  href="https://github.com/expo/expo/tree/main/packages/eslint-config-universe"
+/>

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -13,7 +13,9 @@ import { Terminal } from '~/ui/components/Snippet';
 
 <TabsGroup>
 
-[ESLint](https://eslint.org/) is a JavaScript linter that helps you find and fix errors in your code. It's a great tool to help you write better code and catch mistakes before they make it to production.
+[ESLint](https://eslint.org/) is a JavaScript linter that helps you find and fix errors in your code. It's a great tool to help you write better code and catch mistakes before they make it to production. In conjunction, you can use [Prettier](https://prettier.io/docs/en/), a code formatter that ensures all the code files follow a consistent styling.
+
+This guide provides steps to set up and configure ESLint and Prettier.
 
 ## Setup
 
@@ -106,7 +108,7 @@ module.exports = config;
 
 ## Prettier
 
-[Prettier](https://prettier.io/docs/en/) is a code formatter that ensures that all the code files follow a consistent styling. To customize its settings, create a **.prettierrc** file at the root of your project and add the configuration.
+To customize its settings, create a **.prettierrc** file at the root of your project and add the configuration.
 
 <BoxLink
   title="Custom Prettier configuration"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

- Context [Twitter](https://twitter.com/dimaportenko/status/1716165366991225304)
- Prettier is also a common term searched in Algolia. Below is an example from last week's report. It gets filtered out because we do not have anything to provide info about it in our docs.

<img width="653" alt="CleanShot 2023-10-23 at 11 22 13@2x" src="https://github.com/expo/expo/assets/10234615/6edbd5a0-fe25-4c43-9fab-029295c42b1c">

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update page title and description. We can make use of the searched term here and also guide and provide info about Prettier at the same time.
- Improve Step 1 to describe what libraries one has to install.
- Use BoxLink to provide links to the `eslint-config-universe` doc
- Add a section about prettier and provide a link on how to customize the config

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/guides/using-eslint/ or see the preview link: /guides/using-eslint/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).