### PR TITLE
[docs] Add a section on Navigate to a screen in a nested navigator

### DIFF
--- a/docs/pages/router/advanced/nesting-navigators.mdx
+++ b/docs/pages/router/advanced/nesting-navigators.mdx
@@ -1,18 +1,19 @@
 ---
 title: Nesting navigators
 description: Learn how to nest navigators in Expo Router.
-hideTOC: true
 ---
 
 import { FileTree } from '~/ui/components/FileTree';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
 
-> This guide is an extension from [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router.
-
 > **warning** Navigation UI elements (Link, Tabs, Stack) may move out of the Expo Router library in the future.
 
-Consider the following file structure which is used as an example in this guide:
+Nesting navigators allow rendering a navigator inside the screen of another navigator. This guide is an extension of [React Navigation: Nesting navigators](https://reactnavigation.org/docs/nesting-navigators) to Expo Router. It provides an example of how nesting navigators work when using Expo Router.
+
+## Example
+
+Consider the following file structure which is used as an example:
 
 <FileTree
   files={[
@@ -28,18 +29,21 @@ In the above example, **app/home/feed.js** matches `/home/feed`, and **app/home/
 
 ```jsx app/_layout.js
 import { Stack } from 'expo-router';
+
 export default Stack;
 ```
 
-Both **app/home/_layout.js** and **app/index.js** below are nested in the **app/_layout.js** layout so that it will be rendered as a stack.
+Both **app/home/\_layout.js** and **app/index.js** below are nested in the **app/\_layout.js** layout so that it will be rendered as a stack.
 
 ```jsx app/home/_layout.js
 import { Tabs } from 'expo-router';
+
 export default Tabs;
 ```
 
 ```jsx app/index.js
 import { Link } from 'expo-router';
+
 export default function Root() {
   return <Link href="/home/messages">Navigate to nested route</Link>;
 }
@@ -49,6 +53,7 @@ Both **app/home/feed.js** and **app/home/messages.js** below are nested in the *
 
 ```jsx app/home/feed.js
 import { View, Text } from 'react-native';
+
 export default function Feed() {
   return (
     <View>
@@ -60,6 +65,7 @@ export default function Feed() {
 
 ```jsx app/home/messages.js
 import { View, Text } from 'react-native';
+
 export default function Messages() {
   return (
     <View>
@@ -67,6 +73,27 @@ export default function Messages() {
     </View>
   );
 }
+```
+
+## Navigate to a screen in a nested navigator
+
+In React Navigation, navigating to a specific nested screen can be controlled by passing the screen name in params. This renders the specified nested screen instead of the initial screen for that nested navigator.
+
+For example, from the initial screen inside the `root` navigator, you want to navigate to a screen called `media` inside `settings` (a nested navigator). In React Navigation, this is done as shown in the example below:
+
+```js React Navigation
+navigation.navigate('root', {
+  screen: 'settings',
+  params: {
+    screen: 'media',
+  },
+});
+```
+
+In Expo Router, you can use `router.push()` to achieve the same result. There is no need to pass the screen name in the params explicitly.
+
+```js Expo Router
+router.push('/root/settings/media');
 ```
 
 ## Next steps


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up on Expo Router sync to add info about Navigating to a screen inside a nested navigator using Expo Router in comparison to React Navigation.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a new section with a short example on how to achieve the functionality from React Navigation, with Expo Router

<img width="892" alt="CleanShot 2023-10-23 at 15 55 17@2x" src="https://github.com/expo/expo/assets/10234615/56c6cdfe-c9f8-4db7-be5b-0f665536e2e5">

- Improve the verbiage in the introduction section

<img width="863" alt="CleanShot 2023-10-23 at 15 55 12@2x" src="https://github.com/expo/expo/assets/10234615/a61732e4-a332-472a-8bd3-432e9a699efd">

- Remove `hideTOC` from frontmatter since this page has now two sections

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview or run docs locally and visit: http://localhost:3002/router/advanced/nesting-navigators/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
