### PR TITLE
[docs] Fix contraction usage issues

### DIFF
--- a/docs/pages/app-signing/app-credentials.mdx
+++ b/docs/pages/app-signing/app-credentials.mdx
@@ -51,7 +51,7 @@ Your application's keystore should be kept private. **Under no circumstances sho
 <Step label="2">
 ### Export keystore to `pem` format
 
-Once you've downloaded your credentials and the keystore, export it to the `pem` format so that you can submit it to Google:
+Once you have downloaded your credentials and the keystore, export it to the `pem` format so that you can submit it to Google:
 
 1. Find the key alias in your **credentials.json** file under the `keyAlias` key.
 2. Use `keytool` to export the certificate:

--- a/docs/pages/app-signing/local-credentials.mdx
+++ b/docs/pages/app-signing/local-credentials.mdx
@@ -57,7 +57,7 @@ If you want to build an Android app binary you'll need to have a keystore. If yo
   cmdCopy='keytool -genkey -v -storetype JKS -keyalg RSA -keysize 2048 -validity 10000 -storepass KEYSTORE_PASSWORD -keypass KEY_PASSWORD -alias KEY_ALIAS -keystore release.keystore -dname "CN=com.expo.your.android.package,OU=,O=,L=,S=,C=US"'
 />
 
-Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the `android/keystores` directory. **Remember to git-ignore all your release keystores!** If you've run the above keytool command and placed the keystore at `android/keystores/release.keystore`, you can ignore that file by adding the following line to `.gitignore`:
+Once you have the keystore file on your computer, you should move it to the appropriate directory. We recommend you keep your keystores in the `android/keystores` directory. **Remember to git-ignore all your release keystores!** If you have run the above keytool command and placed the keystore at `android/keystores/release.keystore`, you can ignore that file by adding the following line to `.gitignore`:
 
 ```sh .gitignore
 android/keystores/release.keystore
@@ -83,9 +83,9 @@ Create **credentials.json** and configure it with the credentials:
 ```
 
 - `keystorePath` points to where the keystore is located on your computer. Both relative (to the project root) and absolute paths are supported.
-- `keystorePassword` is the keystore password. If you've followed the previous steps it's the value of `KEYSTORE_PASSWORD`.
-- `keyAlias` is the key alias. If you've followed the previous steps it's the value of `KEY_ALIAS`.
-- `keyPassword` is the key password. If you've followed the previous steps it's the value of `KEY_PASSWORD`.
+- `keystorePassword` is the keystore password. If you have followed the previous steps it's the value of `KEYSTORE_PASSWORD`.
+- `keyAlias` is the key alias. If you have followed the previous steps it's the value of `KEY_ALIAS`.
+- `keyPassword` is the key password. If you have followed the previous steps it's the value of `KEY_PASSWORD`.
 
 ### iOS credentials
 
@@ -95,7 +95,7 @@ Once you have the Distribution Certificate and Provisioning Profile on your comp
 
 > Remember to add directory with your credentials to **.gitignore**, so you don't accidentally commit them to the repository and potentially leak your secrets.
 
-If you've placed the credentials in the suggested directory, you can ignore those files by adding the following line to **.gitignore**:
+If you have placed the credentials in the suggested directory, you can ignore those files by adding the following line to **.gitignore**:
 
 ```sh .gitignore
 ios/certs/*

--- a/docs/pages/archive/classic-updates/building-standalone-apps.mdx
+++ b/docs/pages/archive/classic-updates/building-standalone-apps.mdx
@@ -10,7 +10,7 @@ Classic Build service allows you to create standalone binaries for the Expo app 
 
 An Apple Developer account is required to build a standalone iOS app, but a Google Play Developer account is not required to build the standalone Android app. To submit to either app store, you need a developer account on that store.
 
-> We recommend that you read the [best practices about app stores](/distribution/app-stores) to ensure your app gets accepted into the Apple and Google stores. Once you've created an amazing app, EAS Build can help you build it and then submit it to the app stores.
+> We recommend that you read the [best practices about app stores](/distribution/app-stores) to ensure your app gets accepted into the Apple and Google stores. Once you have created an amazing app, EAS Build can help you build it and then submit it to the app stores.
 
 ## 1. Install Expo CLI
 
@@ -213,7 +213,7 @@ When the build process finishes, you will get a URL to your app file - an **.apk
 ### iOS
 
 - **To run it on your iOS Simulator**, first build your project with the simulator flag by running `expo build:ios -t simulator`, then download the artifact with the link printed when your build completes. To install the resulting **tar.gz** file, unzip it and drag and drop it into your iOS Simulator. If you'd like to install it from the command line, run `tar -xvzf your-app.tar.gz` to unpack the file, open a simulator, then run `xcrun simctl install booted <path to .app>`.
-- **To test a device build with Apple TestFlight**, download the **.ipa** file to your local machine. Within [App Store Connect](https://appstoreconnect.apple.com/apps), click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you've placed in **app.json**. Now, you need to use Xcode or [Transporter](https://apps.apple.com/app/transporter/id1450874784) (previously known as Application Loader) to upload the **.ipa** you got from `expo build:ios`. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
+- **To test a device build with Apple TestFlight**, download the **.ipa** file to your local machine. Within [App Store Connect](https://appstoreconnect.apple.com/apps), click the plus icon and create a New App. Make sure your `bundleIdentifier` matches what you have placed in **app.json**. Now, you need to use Xcode or [Transporter](https://apps.apple.com/app/transporter/id1450874784) (previously known as Application Loader) to upload the **.ipa** you got from `expo build:ios`. Once you do that, you can check the status of your build under `Activity`. Processing an app can take 10-15 minutes before it shows up under available builds.
 
 ## 6. Submit it to the appropriate store
 

--- a/docs/pages/archive/classic-updates/hosting-your-app.mdx
+++ b/docs/pages/archive/classic-updates/hosting-your-app.mdx
@@ -7,13 +7,13 @@ import { FileTree } from '~/ui/components/FileTree';
 
 > This doc was archived in August 2022 and will not receive any further updates. Please use EAS Update instead. [Learn more](/eas-update/introduction)
 
-Normally, when updates are enabled, your app will fetch updates comprising JavaScript bundles and assets from Expo’s CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, updates are slow or unusable in countries that have blocked Expo’s CDN providers on AWS and Google Cloud. In these cases, you can host your updates on your own servers to better suit your use cases.
+Normally, when updates are enabled, your app will fetch updates comprising JavaScript bundles and assets from Expo's CDN. However, there will be situations when you will want to host your JS bundles and assets on your own servers. For example, updates are slow or unusable in countries that have blocked Expo's CDN providers on AWS and Google Cloud. In these cases, you can host your updates on your own servers to better suit your use cases.
 
 For simplicity, the rest of this article will refer to hosting an update for the Android platform, but you could swap out Android for iOS at any point and everything would still be true.
 
 ## Exporting the update
 
-First, you’ll need to export all the static files of your update so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app’s static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the MD5 hash of their content. Your output directory should look something like this now:
+First, you'll need to export all the static files of your update so they can be served from your CDN. To do this, run `expo export --public-url <server-endpoint>` in your project directory and it will output all your app's static files to a directory named `dist`. In this guide, we will use `https://expo.github.io/self-hosting-example` as our example server endpoint. Asset and bundle files are named by the MD5 hash of their content. Your output directory should look something like this now:
 
 <FileTree
   files={[
@@ -27,7 +27,7 @@ First, you’ll need to export all the static files of your update so they can b
 
 ## Hosting your static files
 
-Once you've exported your update's static files, you can host the contents on your own server. For example, in your `dist` output directory, an easy way to host your own files is to push the contents to GitHub. You can enable [GitHub Pages](https://pages.github.com/) to make your app available at a base URL like https://username.github.io/project-name. To host your files on GitHub, you'd do something like this:
+Once you have exported your update's static files, you can host the contents on your own server. For example, in your `dist` output directory, an easy way to host your own files is to push the contents to GitHub. You can enable [GitHub Pages](https://pages.github.com/) to make your app available at a base URL like https://username.github.io/project-name. To host your files on GitHub, you'd do something like this:
 
 <Terminal
   cmd={[

--- a/docs/pages/archive/managed-vs-bare.mdx
+++ b/docs/pages/archive/managed-vs-bare.mdx
@@ -11,7 +11,7 @@ The two approaches to building applications with Expo tools are called the **man
 - With the _managed workflow_ you only write JavaScript/TypeScript and Expo tools and services take care of everything else for you.
 - In the _bare workflow_ you can use any Expo library and service, and you are responsible for the native Android and iOS projects.
 
-> **If you've used React Native without any Expo tools** then you have used the "bare workflow", however, the name probably doesn't sound familiar. It's easier to talk about something when it has a name, so we call this "bare" &mdash; somewhat in jest, and because of the existing term "bare metal". If you have direct access to the native code it's a _bare_ project. You can use any Expo tools and EAS services in a bare React Native project.
+> **If you have used React Native without any Expo tools** then you have used the "bare workflow", however, the name probably doesn't sound familiar. It's easier to talk about something when it has a name, so we call this "bare" &mdash; somewhat in jest, and because of the existing term "bare metal". If you have direct access to the native code it's a _bare_ project. You can use any Expo tools and EAS services in a bare React Native project.
 
 ## Managed workflow
 

--- a/docs/pages/archive/notification-channels.mdx
+++ b/docs/pages/archive/notification-channels.mdx
@@ -62,7 +62,7 @@ To do this, first make sure you are using the latest minor update of `expo` for 
 
 Next, plan out the notification channels your app will need. These may correspond to the different permutations of the `sound`, `vibrate` and `priority` settings you used on individual notifications.
 
-Once you've decided on a set of channels, you need to add logic to your app to create them. We recommend simply creating all channels in `componentDidMount` of your app's root component; this way all users will be sure to get all channels and not miss any notifications.
+Once you have decided on a set of channels, you need to add logic to your app to create them. We recommend simply creating all channels in `componentDidMount` of your app's root component; this way all users will be sure to get all channels and not miss any notifications.
 
 For example, if this is your code before:
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -59,7 +59,7 @@ It's important to note that with iOS builds the build details page only displays
 
 {/* TODO: native and js build phases should be separate in eas build logs, this is too much work for people to figure out */}
 
-If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you've added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
+If you are working on a managed app and the build error is a native error rather than a JavaScript error, this is likely due to a [config plugin](/config-plugins/introduction/) or a dependency in your project. Keep an eye out in the logs for any new packages that you have added since your previous successful build. Run `npx expo-doctor` to determine that the versions of Expo SDK dependencies in your project are compatible with your Expo SDK version.
 
 Armed with your error logs, you can often start to fix your build or search the [forums](https://chat.expo.dev/) and GitHub issues for related packages to dig deeper. Some common sources of problems are listed below.
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -16,7 +16,7 @@ To have multiple variants of an app installed on your device, each variant must 
 
 ## Configure development and production variants
 
-You've created a project using Expo tooling, and now you want to create a development and a production build. Your project's **app.json** may have the following configuration:
+You have created a project using Expo tooling, and now you want to create a development and a production build. Your project's **app.json** may have the following configuration:
 
 ```json app.json
 {

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -71,8 +71,7 @@ page](https://expo.dev/accounts/[account]/projects/[projectName]/github).
 
 ## Trigger a build from GitHub
 
-Once you've configured your app for GitHub, you can trigger a build from GitHub by using the UI on
-your project's build list page or by labels on your GitHub PRs.
+Once you have configured your app for GitHub, you can trigger a build from GitHub by using the UI on your project's build list page or by labels on your GitHub PRs.
 
 ### Build using the Expo website
 

--- a/docs/pages/debugging/errors-and-warnings.mdx
+++ b/docs/pages/debugging/errors-and-warnings.mdx
@@ -19,7 +19,7 @@ You can also create warnings and errors on your own with `console.warn("Warning 
 
 ## Stack traces
 
-When you encounter an error during development, you'll see the error message and a **stack trace**, which is a report of the recent calls your application made when it crashed. This stack trace is shown both in your terminal and the Expo Go app or if you've created a development build.
+When you encounter an error during development, you'll see the error message and a **stack trace**, which is a report of the recent calls your application made when it crashed. This stack trace is shown both in your terminal and the Expo Go app or if you have created a development build.
 
 This stack trace is **extremely valuable** since it gives you the location of the error's occurrence. For example, in the following image, the error comes from the file **HomeScreen.js** and is caused on line 7 in that file.
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -141,7 +141,7 @@ Open Xcode app, and then open **Devices and Simulators** window by pressing <kbd
 
 <Step label="2">
 
-If you've connected a physical device, select it under **Devices**. Otherwise, if you are using a simulator, select it under **Simulators**.
+If you have connected a physical device, select it under **Devices**. Otherwise, if you are using a simulator, select it under **Simulators**.
 
 <ImageSpotlight
   alt="Devices and Simulators window in Xcode."

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -214,6 +214,6 @@ There are however [some limitations](https://github.com/jhen0409/react-native-de
 
 ## Debugging production apps with Sentry
 
-In a perfect world, your app would ship without any bugs. However, that's usually not the case. So, it's a good idea to implement a crash and bug reporting system into your app. This way, if any user experiences a fatal JS error (or any event that you've configured to notify Sentry) you can see the details in your Sentry dashboard.
+In a perfect world, your app would ship without any bugs. However, that's usually not the case. So, it's a good idea to implement a crash and bug reporting system into your app. This way, if any user experiences a fatal JS error (or any event that you have configured to notify Sentry) you can see the details in your Sentry dashboard.
 
 Expo provides a wrapper called [`sentry-expo`](/guides/using-sentry) which allows you to get as much information as possible from crashes and other events. Plus, when running in the managed workflow, you can configure sourcemaps so that the stracktraces you see in Sentry will look much more like the code in your editor.

--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -33,7 +33,7 @@ Create a new **store.config.json** file at the root of your project directory as
       "en-US": {
         "title": "Awesome App",
         "subtitle": "Your self-made awesome app",
-        "description": "The most awesome app you've ever seen",
+        "description": "The most awesome app you have ever seen",
         "keywords": ["awesome", "app"],
         "marketingUrl": "https://example.com/en/promo",
         "supportUrl": "https://example.com/en/support",

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -44,7 +44,7 @@ If you launch the development build from your device's Home screen, you will see
   style={{ maxWidth: 600 }}
 />
 
-If a bundler is detected on your local network, or if you've signed in to an Expo account in both Expo CLI and your development build, you can connect to it directly from this screen. Otherwise, you can connect by scanning the QR code displayed by the Expo CLI.
+If a bundler is detected on your local network, or if you have signed in to an Expo account in both Expo CLI and your development build, you can connect to it directly from this screen. Otherwise, you can connect by scanning the QR code displayed by the Expo CLI.
 
 ## Rebuild a development build
 

--- a/docs/pages/eas-update/updating-your-app.mdx
+++ b/docs/pages/eas-update/updating-your-app.mdx
@@ -88,7 +88,7 @@ Inside **Expo.plist**, you'll see the following additions:
 
 The `EXUpdatesURL` value should contain your project's ID.
 
-Once you've built your project into a build, the `expo-updates` library will make requests for manifests with the native configuration defined above, along with the channel specified in **eas.json**.
+Once you have built your project into a build, the `expo-updates` library will make requests for manifests with the native configuration defined above, along with the channel specified in **eas.json**.
 
 ## Configuring the channel manually
 

--- a/docs/pages/eas/metadata/config.mdx
+++ b/docs/pages/eas/metadata/config.mdx
@@ -30,7 +30,7 @@ You can find all configuration options in the [store config schema](./schema.mdx
       "en-US": {
         "title": "Awesome App",
         "subtitle": "Your self-made awesome app",
-        "description": "The most awesome app you've ever seen",
+        "description": "The most awesome app you have ever seen",
         "keywords": ["awesome", "app"],
         "marketingUrl": "https://example.com/en/promo",
         "supportUrl": "https://example.com/en/support",

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -35,7 +35,7 @@ If you don't have an app in the stores yet, EAS Metadata can't generate the stor
       "en-US": {
         "title": "Awesome App",
         "subtitle": "Your self-made awesome app",
-        "description": "The most awesome app you've ever seen",
+        "description": "The most awesome app you have ever seen",
         "keywords": ["awesome", "app"],
         "marketingUrl": "https://example.com/en/promo",
         "supportUrl": "https://example.com/en/support",

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -149,7 +149,7 @@ For more information on what current limitations exist with EAS, see the followi
 
 Similar to [development builds](/develop/development-builds/introduction/), the bare workflow also provides access to the underlying native projects and any native code. It's a "bare" native project where you can make direct changes to the project's native **android** and **ios** directories rather than continuously generating them on demand using the [app config and prebuild](/workflow/prebuild).
 
-EAS Build is compatible with bare workflow projects if you check in the native directories, but no longer runs prebuild, as that could overwrite any manual customizations you've made to the native project files. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
+EAS Build is compatible with bare workflow projects if you check in the native directories, but no longer runs prebuild, as that could overwrite any manual customizations you have made to the native project files. You'll have to configure the native directories on your own with native tools such as Android Studio or Xcode.
 
 ### Expo Go
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -38,7 +38,7 @@ import App from './App';
 
 ## Prebuild
 
-> **warning** Make sure you've committed your changes in case you want to revert, the command will warn you about this too!
+> **warning** Make sure you have committed your changes in case you want to revert, the command will warn you about this too!
 
 If you're migrating an existing project, then you may want to refer to [**migrating native customizations**](#migrating-native-customizations) first.
 

--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -13,12 +13,12 @@ Universal links are different from standard deep links as they use regular HTTPS
 
 > Deferred deep links can be implemented with [`react-native-branch`](https://github.com/expo/config-plugins/tree/main/packages/react-native-branch).
 
-Before you can use an app/universal links, you've to setup the two-way association between the website and app for both Android and iOS:
+Before you can use an app/universal links, you have to setup the two-way association between the website and app for both Android and iOS:
 
 1. **Native app verification:** This requires some form of code signing that references the target website domain (URL).
 2. **Website verification:** This requires a file to be hosted on the target website in the **/.well-known** directory.
 
-After the two-way association is setup, you've to setup the runtime routing of the link in your app. This is done in JavaScript and must be configured for every route, then coordinated between web and native. Expo offers a fully automated solution for this called [Expo Router](/routing/introduction/).
+After the two-way association is setup, you have to setup the runtime routing of the link in your app. This is done in JavaScript and must be configured for every route, then coordinated between web and native. Expo offers a fully automated solution for this called [Expo Router](/routing/introduction/).
 
 > Universal links cannot be tested in the Expo Go app. You need to create a [development build](/develop/development-builds/introduction).
 
@@ -63,7 +63,7 @@ If you enable through the [Apple Developer Console](/build-reference/ios-capabil
 
 ### AASA configuration
 
-On the web-side, you've to host a config file from **/.well-known/apple-app-site-association** (with no extension). This file JSON specifies your Apple Developer Team ID, Bundler ID, and a list of supported paths to redirect to the native app.
+On the web-side, you have to host a config file from **/.well-known/apple-app-site-association** (with no extension). This file JSON specifies your Apple Developer Team ID, Bundler ID, and a list of supported paths to redirect to the native app.
 
 > You can run the **experimental** CLI command `npx setup-safari` to automatically register a bundle identifier to your Apple account, assign entitlements to the ID, and create an iTunes app entry in the store. The local setup will be printed and you can skip most the following. This is the easiest way to get started with universal links on iOS.
 
@@ -98,7 +98,7 @@ This snippet tells iOS that any links to `https://www.myapp.io/records/*` (with 
 
 > The `activitycontinuation` and `webcredentials` objects are optional, but recommended.
 
-After you've setup the AASA file, deploy your website to a server that supports HTTPS (most modern web hosts).
+After you have setup the AASA file, deploy your website to a server that supports HTTPS (most modern web hosts).
 
 See [Apple's documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html) for further details on the format of the AASA. Branch provides an [AASA validator](https://branch.io/resources/aasa-validator/) which can help you confirm that your AASA is correctly deployed and has a valid format.
 
@@ -152,7 +152,7 @@ To support all iOS versions, you can provide both the above formats in your `det
 
 Note that iOS will download your AASA when your app is first installed and when updates are installed from the App Store, but it will not refresh any more frequently. If you wish to change the paths in your AASA for a production app, you will need to issue a full update via the App Store so that all of your users' apps re-fetch your AASA and recognize the new paths.
 
-Now, a link to your website on your mobile device should open your app. If it doesn't, re-check the previous steps to ensure that your AASA is valid, the path is specified in the AASA, and you have correctly configured your App ID in the [Apple Developer Console](https://developer.apple.com/account/resources/identifiers/list). Once you've got your app opened, move to the [Handling links into your app](/guides/linking/#handling-links) section for details on how to handle the inbound link and show the user the content they requested.
+Now, a link to your website on your mobile device should open your app. If it doesn't, re-check the previous steps to ensure that your AASA is valid, the path is specified in the AASA, and you have correctly configured your App ID in the [Apple Developer Console](https://developer.apple.com/account/resources/identifiers/list). Once you have got your app opened, move to the [Handling links into your app](/guides/linking/#handling-links) section for details on how to handle the inbound link and show the user the content they requested.
 
 ### Apple Smart Banner
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -40,7 +40,7 @@ We recommend uploading the app to the Google Play Store if your app still needs 
   href="https://expo.fyi/first-android-submission"
 />
 
-Once you've uploaded your app, you can provide an SHA-1 certificate fingerprint value when asked while configuring the Google project. There are two values that you can provide from:
+Once you have uploaded your app, you can provide an SHA-1 certificate fingerprint value when asked while configuring the Google project. There are two values that you can provide from:
 
 - Fingerprint of the **.apk** you built (on your machine or using EAS Build). You can find the SHA-1 certificate fingerprint in the Google Play Console under **Release** > **Setup** > **App Integrity** > **Upload key certificate**.
 - Fingerprint of a **production app** downloaded from the play store. You can find the SHA-1 certificate fingerprint in the Google Play Console under **Release** > **Setup** > **App Integrity** > **App signing key certificate**.

--- a/docs/pages/guides/using-sentry.mdx
+++ b/docs/pages/guides/using-sentry.mdx
@@ -35,7 +35,7 @@ It notifies you of exceptions or errors that your users run into while using you
 
 ### Sign up for a Sentry account and create a project
 
-Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you've created a Sentry project. Here's how to do that:
+Before getting real-time updates on errors and making your app generally incredible, you'll need to make sure you have created a Sentry project. Here's how to do that:
 
 <Step label="1.1">
 

--- a/docs/pages/modules/get-started.mdx
+++ b/docs/pages/modules/get-started.mdx
@@ -146,7 +146,7 @@ Rebuild the app and you should see your change.
 </Step>
 ## Next steps
 
-Now that you've learned how to initialize a module and make simple changes to it, you can continue to a tutorial or dive right into the API reference.
+Now that you have learned how to initialize a module and make simple changes to it, you can continue to a tutorial or dive right into the API reference.
 
 <BoxLink
   title="Create your first native module"

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -333,7 +333,7 @@ To make sure your app builds successfully on both platforms, rerun the build com
 
 ## Next steps
 
-Congratulations! You've created your first simple wrapper around two separate third-party native libraries using Expo Modules!
+Congratulations! You have created your first simple wrapper around two separate third-party native libraries using Expo Modules!
 
 <BoxLink
   href="/modules/native-module-tutorial/"

--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -9,7 +9,7 @@ Expo Router relies on your file system, which can present challenges when settin
 
 ## Configuration
 
-Before you proceed, ensure you've set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started).
+Before you proceed, ensure you have set up `jest-expo` according to the [Unit Testing](/develop/unit-testing/) and [`@testing-library/react-native`](https://callstack.github.io/react-native-testing-library/docs/getting-started).
 
 ## `renderRouter`
 

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -96,10 +96,10 @@ If you ever need to submit your build without going through EAS Submit, for exam
 
 Start by creating an app profile in App Store Connect, if you haven't already:
 
-1. Go to [App Store Connect][asc] and sign in. Make sure you've accepted any legal notices or terms at the top of the page.
+1. Go to [App Store Connect][asc] and sign in. Make sure you have accepted any legal notices or terms at the top of the page.
 2. Click the blue plus button by the Apps header, then click **New App**.
 3. Add your app's name, language, bundle identifier, and SKU (this isn't seen by end users, it can be any unique string. A common choice is your app's bundle identifier, for example, "com.company.my-app").
-4. Click **Create**. If this succeeds, then you've created your application record.
+4. Click **Create**. If this succeeds, then you have created your application record.
 
 #### Uploading with Transporter
 

--- a/docs/pages/troubleshooting/react-native-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/react-native-version-mismatch.mdx
@@ -30,7 +30,7 @@ The bundler that you're running in your terminal (using `npx expo start`) is usi
 
 - If this is a managed workflow project, you should make sure your `react-native` version is correct. Run `npx expo-doctor` will show a warning where the `react-native` version you should install. If you did upgrade to a newer SDK, make sure to run `expo-cli upgrade` and follow the prompts. Expo CLI will make sure that your dependency versions for packages like `expo` and `react-native` are aligned.
 
-- If this is a bare workflow project, and this error is occurring right after upgrading your React Native version, you should double-check that you've performed each of the upgrade steps correctly.
+- If this is a bare workflow project, and this error is occurring right after upgrading your React Native version, you should double-check that you have performed each of the upgrade steps correctly.
 
 - Finally:
   - Clear your bundler caches by running `rm -rf node_modules && npm cache clean --force && npm install && watchman watch-del-all && rm -rf $TMPDIR/haste-map-* && rm -rf $TMPDIR/metro-cache && expo start --clear`

--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for Android
@@ -117,7 +117,7 @@ const styles = StyleSheet.create({
 
 ### iOS
 
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for iOS

--- a/docs/pages/versions/v46.0.0/sdk/apple-authentication.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/apple-authentication.mdx
@@ -31,7 +31,7 @@ This guide assumes [auto capability sync](../../../build-reference/ios-capabilit
 
 #### Bare workflow
 
-1. Ensure you've added enabled the Apple Sign In capability, either through the Xcode:
+1. Ensure you have added enabled the Apple Sign In capability, either through the Xcode:
 
 - Signing & Capabilities > + Capability > Sign in with Apple
 - Or by adding the entitlement to your `ios/[app]/[app].entitlements` file

--- a/docs/pages/versions/v46.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v46.0.0/sdk/map-view.mdx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for Android
@@ -117,7 +117,7 @@ const styles = StyleSheet.create({
 
 ### iOS
 
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for iOS

--- a/docs/pages/versions/v47.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v47.0.0/sdk/map-view.mdx
@@ -60,7 +60,7 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for Android
@@ -118,7 +118,7 @@ const styles = StyleSheet.create({
 
 ### iOS
 
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for iOS

--- a/docs/pages/versions/v48.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v48.0.0/sdk/map-view.mdx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for Android
@@ -117,7 +117,7 @@ const styles = StyleSheet.create({
 
 ### iOS
 
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for iOS

--- a/docs/pages/versions/v49.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v49.0.0/sdk/map-view.mdx
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
 
 ### Android
 
-> If you've already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
+> If you have already registered a project for another Google service on Android, such as Google Sign In, you enable the **Maps SDK for Android** on your project and jump to step 4.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for Android
@@ -117,7 +117,7 @@ const styles = StyleSheet.create({
 
 ### iOS
 
-> If you've already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
+> If you have already registered a project for another Google service on iOS, such as Google Sign In, you enable the **Maps SDK for iOS** on your project and jump to step 3.
 
 <Step label="1">
 #### Register a Google Cloud API project and enable the Maps SDK for iOS


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

As mentioned in #24877, using `you've` as a contract for `you have` have slipped multiple times in our documentation. Generally, we try to avoid using contractions in our documentation. This PR fixes that.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
