### PR TITLE
[av][Android] Use `ReadableArguments` instead of `Map<String,Any?>`

### DIFF
--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
@@ -25,52 +25,52 @@ class AVModule : Module() {
       avManager.setAudioIsEnabled(value)
     }
 
-    AsyncFunction("setAudioMode") { map: Map<String, Any?> ->
-      avManager.setAudioMode(map.toReadableArguments())
+    AsyncFunction("setAudioMode") { map: ReadableArguments ->
+      avManager.setAudioMode(map)
     }
 
-    AsyncFunction("loadForSound") { source: Map<String, Any?>, status: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.loadForSound(source.toReadableArguments(), status.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("loadForSound") { source: ReadableArguments, status: ReadableArguments, promise: KotlinPromise ->
+      avManager.loadForSound(source, status, promise.toLegacyPromise())
     }
 
     AsyncFunction("unloadForSound") { key: Int, promise: KotlinPromise ->
       avManager.unloadForSound(key, promise.toLegacyPromise())
     }
 
-    AsyncFunction("setStatusForSound") { key: Int, status: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.setStatusForSound(key, status.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("setStatusForSound") { key: Int, status: ReadableArguments, promise: KotlinPromise ->
+      avManager.setStatusForSound(key, status, promise.toLegacyPromise())
     }
 
-    AsyncFunction("replaySound") { key: Int, status: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.replaySound(key, status.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("replaySound") { key: Int, status: ReadableArguments, promise: KotlinPromise ->
+      avManager.replaySound(key, status, promise.toLegacyPromise())
     }
 
     AsyncFunction("getStatusForSound") { key: Int, promise: KotlinPromise ->
       avManager.getStatusForSound(key, promise.toLegacyPromise())
     }
 
-    AsyncFunction("loadForVideo") { tag: Int, source: Map<String, Any?>?, status: Map<String, Any?>?, promise: KotlinPromise ->
-      avManager.loadForVideo(tag, source?.toReadableArguments(), status?.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("loadForVideo") { tag: Int, source: ReadableArguments?, status: ReadableArguments?, promise: KotlinPromise ->
+      avManager.loadForVideo(tag, source, status, promise.toLegacyPromise())
     }
 
     AsyncFunction("unloadForVideo") { tag: Int, promise: KotlinPromise ->
       avManager.unloadForVideo(tag, promise.toLegacyPromise())
     }
 
-    AsyncFunction("setStatusForVideo") { tag: Int, status: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.setStatusForVideo(tag, status.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("setStatusForVideo") { tag: Int, status: ReadableArguments, promise: KotlinPromise ->
+      avManager.setStatusForVideo(tag, status, promise.toLegacyPromise())
     }
 
-    AsyncFunction("replayVideo") { tag: Int, status: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.replayVideo(tag, status.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("replayVideo") { tag: Int, status: ReadableArguments, promise: KotlinPromise ->
+      avManager.replayVideo(tag, status, promise.toLegacyPromise())
     }
 
     AsyncFunction("getStatusForVideo") { tag: Int, promise: KotlinPromise ->
       avManager.getStatusForVideo(tag, promise.toLegacyPromise())
     }
 
-    AsyncFunction("prepareAudioRecorder") { options: Map<String, Any?>, promise: KotlinPromise ->
-      avManager.prepareAudioRecorder(options.toReadableArguments(), promise.toLegacyPromise())
+    AsyncFunction("prepareAudioRecorder") { options: ReadableArguments, promise: KotlinPromise ->
+      avManager.prepareAudioRecorder(options, promise.toLegacyPromise())
     }
 
     AsyncFunction("getAvailableInputs") { promise: KotlinPromise ->
@@ -126,8 +126,4 @@ private fun KotlinPromise.toLegacyPromise(): LegacyPromise {
       newPromise.reject(c ?: "unknown", m, e)
     }
   }
-}
-
-private fun Map<String, Any?>.toReadableArguments(): ReadableArguments {
-  return MapArguments(this)
 }

--- a/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
+++ b/packages/expo-av/android/src/main/java/expo/modules/av/AVModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.av
 
 import android.Manifest
-import expo.modules.core.arguments.MapArguments
 import expo.modules.core.arguments.ReadableArguments
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.exception.CodedException


### PR DESCRIPTION
# Why

Uses `ReadableArguments` instead of the `Map<String, Any?>`. `ReadableArguments` will be removed in the future, but the underlying API uses it heavily for now. We have a converter, so I used it instead of manually converting the map. 

# Test Plan

- bare-expo ✅