### PR TITLE
[docs] add check/install step before running Docs Puppeteer test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,6 +56,7 @@ jobs:
       #   run: yarn lint-links --quiet
       - name: ✅ Test links (legacy)
         run: |
+          node node_modules/puppeteer/install.mjs &
           yarn export-server &
           while ! nc -z localhost 8000; do
             sleep 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,7 +56,6 @@ jobs:
       #   run: yarn lint-links --quiet
       - name: ✅ Test links (legacy)
         run: |
-          node node_modules/puppeteer/install.mjs &
           yarn export-server &
           while ! nc -z localhost 8000; do
             sleep 1

--- a/docs/.puppeteerrc.cjs
+++ b/docs/.puppeteerrc.cjs
@@ -1,0 +1,8 @@
+const { join } = require('path');
+
+/**
+ * @type {import("puppeteer").Configuration}
+ */
+module.exports = {
+  cacheDirectory: join(__dirname, '.cache', 'puppeteer'),
+};

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
     "export": "yarn generate-static-resoures production && yarn run build && next export && yarn run export-issue-404",
     "export-issue-404": "echo \"🛠  Patching https://github.com/vercel/next.js/issues/16528\"; cp out/404/index.html out/404.html",
     "export-server": "http-server out -p 8000",
-    "test-links": "node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
+    "test-links": "node node_modules/puppeteer/install.mjs && node --async-stack-traces --unhandled-rejections=strict ./scripts/test-links.js",
     "prettier": "prettier --write **/*.{md,mdx}",
     "lint": "tsc --noEmit && eslint .",
     "lint-links": "remark -u validate-links ./pages",

--- a/docs/scripts/test-links.js
+++ b/docs/scripts/test-links.js
@@ -27,7 +27,9 @@ const externalLinks = [
     const notFound = [];
     const redirectsFailed = [];
 
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({
+      headless: 'new',
+    });
     const page = await browser.newPage();
 
     for (const link of externalLinks) {


### PR DESCRIPTION
# Why

Make sure the on the CI Puppeteer have the wanted Chrome version installed.

The problematic step seems to work correctly locally.

# How

Add the `install` script to "Test Links" job, it should download the wanted Chrome, and if correct version is already installed it just outputs the confirmation, skipping the download.

# Test Plan

Run the CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
