### PR TITLE
[docs] expo-router authentication fix ts props

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -60,7 +60,7 @@ export function useSession() {
   return value;
 }
 
-export function SessionProvider(props) {
+export function SessionProvider(props: React.PropsWithChildren) {
   const [[isLoading, session], setSession] = useStorageState('session');
 
   return (


### PR DESCRIPTION
# Why

When copy/pasting `ctx.tsx` from the auth guide
https://docs.expo.dev/router/reference/authentication/

TypeScript raises an error with:
```typescript
export function SessionProvider(props)
```


# Solution

**before**
![image](https://github.com/expo/expo/assets/360936/92602e65-82b9-4a7e-9eef-0ac398b77508)

**after**
adding `React.PropsWithChildren` do not raise and error 
![image](https://github.com/expo/expo/assets/360936/8729ec59-8c64-4a42-9adf-002ccb58c063)


# Test Plan

Done locally on VSCode

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
