### PR TITLE
[expo-image][iOS] Fix compilation on tvOS

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] fix crash when loading local image files with no file extension ([#24201](https://github.com/expo/expo/pull/25032) by [@kadikraman](https://github.com/kadikraman))
-
+- [iOS] Fix compilation on tvOS. ([#25010](https://github.com/expo/expo/pull/25010) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ExpoImage.podspec
+++ b/packages/expo-image/ios/ExpoImage.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platforms       = { :ios => '13.0', :tvos => '13.0'}
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -70,7 +70,9 @@ public final class ImageModule: Module {
       }
 
       Prop("enableLiveTextInteraction") { (view, enableLiveTextInteraction: Bool?) in
+        #if !os(tvOS)
         view.enableLiveTextInteraction = enableLiveTextInteraction ?? false
+        #endif
       }
 
       Prop("accessible") { (view, accessible: Bool?) in

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -111,7 +111,7 @@ public final class ImageModule: Module {
   }
 
   static func registerCoders() {
-    if #available(iOS 14.0, *) {
+    if #available(iOS 14.0, tvOS 14.0, *) {
       // By default Animated WebP is not supported
       SDImageCodersManager.shared.addCoder(SDImageAWebPCoder.shared)
     } else {

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -2,9 +2,6 @@
 
 import SDWebImage
 import ExpoModulesCore
-#if !os(tvOS)
-import VisionKit
-#endif
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
 
@@ -378,9 +375,11 @@ public final class ImageView: ExpoView {
       sdImageView.image = image
     }
 
+    #if !os(tvOS)
     if enableLiveTextInteraction {
       analyzeImage()
     }
+    #endif
   }
 
   // MARK: - Helpers
@@ -420,10 +419,7 @@ public final class ImageView: ExpoView {
   }
 
   // MARK: - Live Text Interaction
-  #if os(tvOS)
-  private func analyzeImage() {}
-  var enableLiveTextInteraction = false
-  #else
+  #if !os(tvOS)
   @available(iOS 16.0, macCatalyst 17.0, *)
   static let imageAnalyzer = ImageAnalyzer.isSupported ? ImageAnalyzer() : nil
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -2,7 +2,9 @@
 
 import SDWebImage
 import ExpoModulesCore
+#if !os(tvOS)
 import VisionKit
+#endif
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
 
@@ -418,7 +420,10 @@ public final class ImageView: ExpoView {
   }
 
   // MARK: - Live Text Interaction
-
+  #if os(tvOS)
+  private func analyzeImage() {}
+  var enableLiveTextInteraction = false
+  #else
   @available(iOS 16.0, macCatalyst 17.0, *)
   static let imageAnalyzer = ImageAnalyzer.isSupported ? ImageAnalyzer() : nil
 
@@ -468,4 +473,5 @@ public final class ImageView: ExpoView {
     }
     return interaction as? ImageAnalysisInteraction
   }
+  #endif
 }

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -2,6 +2,9 @@
 
 import SDWebImage
 import ExpoModulesCore
+#if !os(tvOS)
+import VisionKit
+#endif
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
 

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -80,9 +80,8 @@ private func isPhotoLibraryStatusAuthorized() -> Bool {
   if #available(iOS 14, tvOS 14, *) {
     let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     return status == .authorized || status == .limited
-  } else {
-    return PHPhotoLibrary.authorizationStatus() == .authorized
   }
+  return PHPhotoLibrary.authorizationStatus() == .authorized
 }
 
 /**

--- a/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
+++ b/packages/expo-image/ios/Loaders/PhotoLibraryAssetLoader.swift
@@ -77,7 +77,7 @@ private func assetLocalIdentifier(fromUrl url: URL) -> String? {
  Checks whether the app is authorized to read the Photo Library.
  */
 private func isPhotoLibraryStatusAuthorized() -> Bool {
-  if #available(iOS 14, *) {
+  if #available(iOS 14, tvOS 14, *) {
     let status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     return status == .authorized || status == .limited
   } else {

--- a/packages/expo-image/ios/Thumbhash.swift
+++ b/packages/expo-image/ios/Thumbhash.swift
@@ -456,7 +456,7 @@ func thumbHashToApproximateAspectRatio(hash: Data) -> Float32 {
   return Float32(lx) / Float32(ly)
 }
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
 import UIKit
 
 func thumbHash(fromImage: UIImage) -> Data {

--- a/packages/expo-image/ios/ThumbhashLoader.swift
+++ b/packages/expo-image/ios/ThumbhashLoader.swift
@@ -20,7 +20,6 @@ class ThumbhashLoader: NSObject, SDImageLoader {
       completedBlock?(nil, nil, error, false)
       return nil
     }
-
     // The URI looks like this: thumbhash:/3OcRJYB4d3h\iIeHeEh3eIhw+j2w
     // ThumbHash may include slashes which could break the structure of the URL, so we replace them
     // with backslashes on the JS side and revert them back to slashes here, before generating the image.

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -18,6 +18,7 @@ const expoDependencyNames = [
   'expo-eas-client',
   'expo-file-system',
   'expo-font',
+  'expo-image',
   'expo-json-utils',
   'expo-keep-awake',
   'expo-localization',


### PR DESCRIPTION
# Why

expo-image can work on tvOS with only a few changes. The only feature not supported is text recognition with VisionKit, which does not exist on tvOS.

# How

- Add tvOS in the Podfile
- Make required code changes

# Test Plan

- Add expo-image to the updates tvOS CI to test that compilation succeeds

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
