### PR TITLE
[ENG-10384][docs] update Android images docs

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -9,7 +9,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import al from '@mdx-js/react';
 import { HardwareList, BuildResourceList } from '~/ui/components/utils/infrastructure';
 
-> This document was last updated on **October 18, 2023**.
+> This document was last updated on **October 24, 2023**.
 
 ## Builder IP addresses
 
@@ -65,7 +65,22 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Android server images
 
-#### `ubuntu-22.04-jdk-11-ndk-r21e` (alias `latest`)
+#### `ubuntu-22.04-jdk-17-ndk-r21e` (alias `latest`)
+
+<Collapsible summary="Details">
+
+- Docker image: `ubuntu:jammy-20220531`
+- NDK 21.4.7075529
+- Node.js 16.18.1
+- Bun 1.0.2
+- Yarn 1.22.17
+- pnpm 8.9.2
+- npm 8.19.2
+- Java 17
+
+</Collapsible>
+
+#### `ubuntu-22.04-jdk-11-ndk-r21e` (alias `default`)
 
 <Collapsible summary="Details">
 


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-10384/add-images-for-jdk-17-and-21

Update docs to reflect new infra changes regarding EAS Build Android images

# How

Mark the JDK 11 image as `default` (prev `latest`), mark the new JDK 17 image as `latest`, and add info about the new JDK 17 image

# Test Plan

Open docs website

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
