### PR TITLE
[docs] Fix Deep Linking typo 

### DIFF
--- a/docs/pages/guides/deep-linking.mdx
+++ b/docs/pages/guides/deep-linking.mdx
@@ -79,7 +79,7 @@ If you're using [Expo Router](/routing/introduction/) to build your website (or 
         // Example: "QQ57RJ5UTD.com.acme.myapp"
         "appID": "{APPLE_TEAM_ID}.{BUNDLE_ID}",
         // All paths that should support redirecting
-        "paths": ["*"]
+        "paths": ["/records/*"]
       }
     ]
   },


### PR DESCRIPTION
# Why

In the Deep Linking docs, in the iOS section, it reads:

> "This snippet tells iOS that any links to https://www.myapp.io/records/* (with wildcard matching for the record ID) should be opened directly by the app with a matching bundle identifier."

This is incorrect, currently, the snippet tells iOS to open any link to https://www.myapp.io/*. See [Apple Documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html)

<img width="897" alt="image" src="https://github.com/expo/expo/assets/34781348/e756851c-aec6-4ff6-b1ae-ff1cdaaa437e">

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Fix the code snippet to actually mean `https://www.myapp.io/records/*` by changing `"paths": ["*"]` to `"paths": ["/records/*"]`. This is more informative to the user than changing the text to say "any links to `https://www.myapp.io/*`", as it shows how to manage routes.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Typo fix, no testing.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
