### PR TITLE
[sqlite][ios] fix issues for sqlite/next

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix some issues for `sqlite/next`. ([#25022](https://github.com/expo/expo/pull/25022) by [@kudo](https://github.com/kudo))
+
 ### 💡 Others
 
 ## 11.8.0 — 2023-10-17

--- a/packages/expo-sqlite/ios/Exceptions.swift
+++ b/packages/expo-sqlite/ios/Exceptions.swift
@@ -61,3 +61,6 @@ internal class SQLiteErrorException: GenericException<String> {
     "\(param)"
   }
 }
+
+internal class InvalidConvertibleException: GenericException<String> {
+}

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -54,7 +54,7 @@ public final class SQLiteModuleNext: Module {
         }
 
         // Try to find opened database for fast refresh
-        for database in cachedDatabases where database.dbName == dbName && database.openOptions == options {
+        for database in cachedDatabases where database.dbName == dbName && database.openOptions == options && !options.useNewConnection {
           return database
         }
 

--- a/packages/expo-sqlite/ios/SQLiteModuleNext.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleNext.swift
@@ -237,7 +237,7 @@ public final class SQLiteModuleNext: Module {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     return [
-      "lastID": Int(sqlite3_last_insert_rowid(database.pointer)),
+      "lastInsertRowid": Int(sqlite3_last_insert_rowid(database.pointer)),
       "changes": Int(sqlite3_changes(database.pointer))
     ]
   }
@@ -377,7 +377,7 @@ public final class SQLiteModuleNext: Module {
     let contextPair = Unmanaged.passRetained(((self, database) as AnyObject))
     contextPairs.append(contextPair)
     // swiftlint:disable:next multiline_arguments
-    sqlite3_update_hook(database.pointer, { obj, action, _, tableName, rowId in
+    sqlite3_update_hook(database.pointer, { obj, action, dbName, tableName, rowId in
       guard let obj,
         let tableName,
         let pair = Unmanaged<AnyObject>.fromOpaque(obj).takeUnretainedValue() as? (SQLiteModuleNext, NativeDatabase) else {
@@ -385,9 +385,11 @@ public final class SQLiteModuleNext: Module {
       }
       let selfInstance = pair.0
       let database = pair.1
-      if selfInstance.hasListeners {
+      let dbFilePath = sqlite3_db_filename(database.pointer, dbName)
+      if selfInstance.hasListeners, let dbName, let dbFilePath {
         selfInstance.sendEvent("onDatabaseChange", [
-          "dbName": database.dbName,
+          "dbName": String(cString: UnsafePointer(dbName)),
+          "dbFilePath": String(cString: UnsafePointer(dbFilePath)),
           "tableName": String(cString: UnsafePointer(tableName)),
           "rowId": rowId,
           "typeId": SQLAction.fromCode(value: action)
@@ -418,19 +420,19 @@ public final class SQLiteModuleNext: Module {
       return sqlite3_column_double(instance, index)
     case SQLITE_TEXT:
       guard let text = sqlite3_column_text(instance, index) else {
-        throw Exception(name: "InvalidConvertibleException", description: "Null text")
+        throw InvalidConvertibleException("Null text")
       }
       return String(cString: text)
     case SQLITE_BLOB:
       guard let blob = sqlite3_column_blob(instance, index) else {
-        throw Exception(name: "InvalidConvertibleException", description: "Null blob")
+        throw InvalidConvertibleException("Null blob")
       }
       let size = sqlite3_column_bytes(instance, index)
       return Data(bytes: blob, count: Int(size))
     case SQLITE_NULL:
       return NSNull()
     default:
-      throw Exception(name: "InvalidConvertibleException", description: "Unsupported column type: \(type)")
+      throw InvalidConvertibleException("Unsupported column type: \(type)")
     }
   }
 
@@ -454,7 +456,7 @@ public final class SQLiteModuleNext: Module {
     case let param as Bool:
       sqlite3_bind_int(instance, index, param ? 1 : 0)
     default:
-      throw Exception(name: "InvalidConvertibleException", description: "Unsupported parameter type: \(type(of: param))")
+      throw InvalidConvertibleException("Unsupported parameter type: \(type(of: param))")
     }
   }
 }


### PR DESCRIPTION
# Why

fix some issues for sqlite/next on ios

# How

1. fix `lastInsertRowid` name from returned runAsync/runSync calls
2. add dedicated `InvalidConvertibleException`
3. update `addDatabaseChangeListener` arguments to return correct `dbName` and `dbFilePath`
4. align the `useNewConnection` logic with android

# Test Plan

test-suite SQLiteNext passed on ios

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
