### PR TITLE
[docs] ignore Prettier cache directory

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,3 +1,4 @@
+.cache
 .next
 node_modules
 out/


### PR DESCRIPTION
# Why

Refs #24996

# How

Add Puppeteer directory to `.gitignore` so it does not pollute repo with unversioned files.

# Test Plan

No unversioned files in repo anymore after running Link Tests locally.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
