### PR TITLE
[location][android] Update `play-services-location`, update usage of deprecated APIs

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 📚 3rd party library updates
 
-- Updated `com.google.android.gms:play-services-location` to `21.0.1`.
+- Updated `com.google.android.gms:play-services-location` to `21.0.1`. ([#25028](https://github.com/expo/expo/pull/25028) by [@behenate](https://github.com/behenate))
 
 ## 16.4.0 — 2023-10-17
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - [Android] Moved to the new Modules API. ([#24737](https://github.com/expo/expo/pull/24737) by [@behenate](https://github.com/behenate))
 
+### 📚 3rd party library updates
+
+- Updated `com.google.android.gms:play-services-location` to `21.0.1`.
+
 ## 16.4.0 — 2023-10-17
 
 ### 🛠 Breaking changes

--- a/packages/expo-location/android/build.gradle
+++ b/packages/expo-location/android/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   }
 
-  api 'com.google.android.gms:play-services-location:20.0.0'
+  api 'com.google.android.gms:play-services-location:21.0.1'
 
   api('io.nlopez.smartlocation:library:3.3.3') {
     transitive = false

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationHelpers.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.location.CurrentLocationRequest
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.Granularity
 import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.Priority
 import expo.modules.interfaces.permissions.Permissions
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
@@ -47,13 +48,12 @@ class LocationHelpers {
     internal fun prepareLocationRequest(options: LocationOptions): LocationRequest {
       val locationParams = mapOptionsToLocationParams(options)
 
-      return LocationRequest.create().apply {
-        fastestInterval = locationParams.interval
-        interval = locationParams.interval
-        maxWaitTime = locationParams.interval
-        smallestDisplacement = locationParams.distance
-        priority = mapAccuracyToPriority(options.accuracy)
-      }
+      return LocationRequest.Builder(locationParams.interval)
+        .setMinUpdateIntervalMillis(locationParams.interval)
+        .setMaxUpdateDelayMillis(locationParams.interval)
+        .setMinUpdateDistanceMeters(locationParams.distance)
+        .setPriority(mapAccuracyToPriority(options.accuracy))
+        .build()
     }
 
     internal fun prepareCurrentLocationRequest(options: LocationOptions): CurrentLocationRequest {
@@ -119,10 +119,10 @@ class LocationHelpers {
 
     private fun mapAccuracyToPriority(accuracy: Int): Int {
       return when (accuracy) {
-        LocationModule.ACCURACY_BEST_FOR_NAVIGATION, LocationModule.ACCURACY_HIGHEST, LocationModule.ACCURACY_HIGH -> LocationRequest.PRIORITY_HIGH_ACCURACY
-        LocationModule.ACCURACY_BALANCED, LocationModule.ACCURACY_LOW -> LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY
-        LocationModule.ACCURACY_LOWEST -> LocationRequest.PRIORITY_LOW_POWER
-        else -> LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY
+        LocationModule.ACCURACY_BEST_FOR_NAVIGATION, LocationModule.ACCURACY_HIGHEST, LocationModule.ACCURACY_HIGH -> Priority.PRIORITY_HIGH_ACCURACY
+        LocationModule.ACCURACY_BALANCED, LocationModule.ACCURACY_LOW -> Priority.PRIORITY_BALANCED_POWER_ACCURACY
+        LocationModule.ACCURACY_LOWEST -> Priority.PRIORITY_LOW_POWER
+        else -> Priority.PRIORITY_BALANCED_POWER_ACCURACY
       }
     }
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -82,9 +82,6 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
   private var mLastUpdate: Long = 0
   private var mGeocoderPaused = false
 
-  private val DEGREE_DELTA = 0.0355 // in radians, about 2 degrees
-  private val TIME_DELTA = 50f // in milliseconds
-
   override fun definition() = ModuleDefinition {
     Name("ExpoLocation")
 
@@ -776,6 +773,9 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
 
     const val GEOFENCING_EVENT_ENTER = 1
     const val GEOFENCING_EVENT_EXIT = 2
+
+    const val DEGREE_DELTA = 0.0355 // in radians, about 2 degrees
+    const val TIME_DELTA = 50f // in milliseconds
   }
 
   override fun onHostResume() {


### PR DESCRIPTION
# Why

We are using outdated `play-services-location` and some deprecated APIs. This PR is restores some of the changes made in https://github.com/expo/expo/pull/22653 and https://github.com/expo/expo/pull/22468, which had to be reverted because of conflicts with `play-services-location` from `react-native-maps`.

# How

Bumped `play-services-location`, updated usage of deprecated Apis

# Test Plan

Passed NCL location tests in BareExpo

