### PR TITLE
[expo-image] [android] fix crash when loading local files with no file extension

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### 🐛 Bug fixes
 
+- [Android] fix crash when loading local image files with no file extension ([#24201](https://github.com/expo/expo/pull/25032) by [@kadikraman](https://github.com/kadikraman))
+
+
 ### 💡 Others
 
 ## 1.6.0 — 2023-10-17

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -38,7 +38,14 @@ data class SourceMap(
 
   private fun isLocalFileUri() = parsedUri?.scheme?.startsWith("file") ?: false
 
-  private fun isSvg() = parsedUri?.toString()?.substring(parsedUri.toString().lastIndexOf('.'))?.startsWith(".svg") ?: false
+  private fun isSvg(): Boolean {
+    var lastDotIndex = parsedUri.toString().lastIndexOf('.');
+    // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
+    if (lastDotIndex == -1) {
+      return false
+    }
+    return parsedUri?.toString()?.substring(lastDotIndex)?.startsWith(".svg") ?: false
+  }
 
   fun isBlurhash() = parsedUri?.scheme?.startsWith("blurhash") ?: false
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -39,7 +39,7 @@ data class SourceMap(
   private fun isLocalFileUri() = parsedUri?.scheme?.startsWith("file") ?: false
 
   private fun isSvg(): Boolean {
-    var lastDotIndex = parsedUri.toString().lastIndexOf('.');
+    var lastDotIndex = parsedUri.toString().lastIndexOf('.')
     // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
     if (lastDotIndex == -1) {
       return false

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -39,9 +39,9 @@ data class SourceMap(
   private fun isLocalFileUri() = parsedUri?.scheme?.startsWith("file") ?: false
 
   private fun isSvg(): Boolean {
-    var lastDotIndex = parsedUri.toString().lastIndexOf('.')
+    var lastDotIndex = parsedUri?.toString()?.lastIndexOf('.')
     // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
-    if (lastDotIndex == -1) {
+    if (lastDotIndex == -1 || lastDotIndex == null) {
       return false
     }
     return parsedUri?.toString()?.substring(lastDotIndex)?.startsWith(".svg") ?: false


### PR DESCRIPTION
# Why

User reported this crash on Android.

<img width="1195" alt="Screenshot 2023-10-25 at 12 23 32" src="https://github.com/expo/expo/assets/6534400/2d990e47-4c44-4383-b7b4-13a0d94bcddf">

# How

It can be traced back to this line of code:
```kt
private fun isSvg() = parsedUri?.toString()?.substring(parsedUri.toString().lastIndexOf('.'))?.startsWith(".svg") ?: false
```
in particular if the uri has no `.` in it
```kt
parsedUri.toString().lastIndexOf('.')
```
then this would return `-1` and `parsedUri?.toString()?.substring(-1)` would throw.

This could happen when using local files with no file path, ie. `file://some/path`.

# Test Plan

I wasn't able to reproduce this on my emulator, so I tested it by copying the the `isSvg` function and calling this with `isSvgTest("file://path/to/file")` and verifying it does not crash.

```kt
  private fun isSvgTest(value: String): Boolean {
    var lastDotIndex = value.lastIndexOf('.');
    // if the path has no file extension and no . at all (e.g. file://path/to/file) return false
    if (lastDotIndex == -1) {
      return false
    }
    return value?.substring(lastDotIndex)?.startsWith(".svg") ?: false
  }
```

<img width="573" alt="Screenshot 2023-10-25 at 12 39 06" src="https://github.com/expo/expo/assets/6534400/71e027b4-3bf1-4459-96fa-7d70bcb89faf">


# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
