### PR TITLE
[core] Fix deallocating core module definition on iOS

### DIFF
--- a/packages/expo-modules-core/ios/AppContext.swift
+++ b/packages/expo-modules-core/ios/AppContext.swift
@@ -81,6 +81,11 @@ public final class AppContext: NSObject {
   internal private(set) lazy var coreModule = CoreModule(appContext: self)
 
   /**
+   The module holder for the core module.
+   */
+  internal private(set) lazy var coreModuleHolder = ModuleHolder(appContext: self, module: coreModule)
+
+  /**
    Designated initializer without modules provider.
    */
   public init(config: AppContextConfig = .default) {
@@ -362,7 +367,7 @@ public final class AppContext: NSObject {
 
   internal func prepareRuntime() throws {
     let runtime = try runtime
-    let coreObject = try coreModule.definition().build(appContext: self)
+    let coreObject = try coreModuleHolder.definition.build(appContext: self)
 
     // Initialize `global.expo`.
     try runtime.initializeCoreObject(coreObject)


### PR DESCRIPTION
# Why

Fixes an issue found in #25017, when the core module definition elements were being deallocated

# How

Added a ModuleHolder for the core module, which holds the module definition in memory

# Test Plan

Some tests from #25017 are passing now