### PR TITLE
[docs] Fix keyboard shortcut representation in Profiling JavaScript section

### DIFF
--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -82,7 +82,10 @@ You can enable the **JavaScript Profiler tab** within Chrome DevTools to record 
 
 <Collapsible summary="Screenshot of the Chrome DevTools command palette">
 
-![Screenshot of the Chrome DevTools](/static/images/debugging/profiling-enable.png)
+<ImageSpotlight
+  alt="Chrome DevTools showing the command paletter."
+  src="/static/images/debugging/profiling-enable.png"
+/>
 
 </Collapsible>
 
@@ -95,7 +98,10 @@ You can enable the **JavaScript Profiler tab** within Chrome DevTools to record 
 
 <Collapsible summary="Screenshot of the Chrome DevTools with the JavaScript Profiler tab open">
 
-![Screenshot of Chrome DevTools](/static/images/debugging/profiling-start.png)
+<ImageSpotlight
+  alt="JavaScript Profiler tab opened in the Chrome DevTools."
+  src="/static/images/debugging/profiling-start.png"
+/>
 
 </Collapsible>
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -77,8 +77,8 @@ You can enable the **JavaScript Profiler tab** within Chrome DevTools to record 
 
 ### Enable the JavaScript Profiler within Chrome DevTools
 
-- Press <kbd>⌘ + shift + p</kbd> (Mac) or <kbd>ctrl + shift + p</kbd> (Windows, Linux) to open the command palette.
-- Type 'javascript' and select 'Show JavaScript Profiler'.
+- Press <kbd>⌘ cmd</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> (Mac) or <kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>p</kbd> (Windows, Linux) to open the command palette.
+- Type **javascript** and select **Show JavaScript Profiler**.
 
 <Collapsible summary="Screenshot of the Chrome DevTools command palette">
 


### PR DESCRIPTION
# Why & how

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Currently, the keyboard shortcut provided doesn't follow our writing style guide format. This PR fixes that.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and visit: http://localhost:3002/debugging/tools/#profiling-javascript-performance

**Preview**

![CleanShot 2023-10-25 at 20 07 16](https://github.com/expo/expo/assets/10234615/4f7f6d3b-d0b5-4209-af4b-67b1074c1120)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
