### PR TITLE
[expo-updates][android][5/n] Further privatize updates controller

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - Android: Stub expo-updates in Expo Go and remove service pattern. ([#24890](https://github.com/expo/expo/pull/24890) by [@wschurman](https://github.com/wschurman))
 - iOS: Refactor responsibility of app controller. ([#24934](https://github.com/expo/expo/pull/24934), [#24949](https://github.com/expo/expo/pull/24949) by [@wschurman](https://github.com/wschurman))
-- Android: Refactor responsibility of app controller. ([#24954](https://github.com/expo/expo/pull/24954), [#24975](https://github.com/expo/expo/pull/24975) by [@wschurman](https://github.com/wschurman))
+- Android: Refactor responsibility of app controller. ([#24954](https://github.com/expo/expo/pull/24954), [#24975](https://github.com/expo/expo/pull/24975), [#25043](https://github.com/expo/expo/pull/25043) by [@wschurman](https://github.com/wschurman))
 - Android: Backport ExpoGoUpdatesModule to SDK 49. ([#24974](https://github.com/expo/expo/pull/24974) by [@wschurman](https://github.com/wschurman))
 - Remove unused `storedUpdateIdsWithConfiguration` method. ([#25194](https://github.com/expo/expo/pull/25194) by [@wschurman](https://github.com/wschurman))
 - Remove ability for embedded manifests to be legacy manifests. ([#25195](https://github.com/expo/expo/pull/25195) by [@wschurman](https://github.com/wschurman))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -19,11 +19,13 @@ class UpdatesStateMachine(
    * The current state
    */
   var state: UpdatesStateValue = UpdatesStateValue.Idle
+    private set
 
   /**
    * The context
    */
   var context: UpdatesStateContext = UpdatesStateContext()
+    private set
 
   /**
    Called after the app restarts (reloadAsync()) to reset the machine to its


### PR DESCRIPTION
# Why

This brings the android implementation up-to-date with iOS once more. Essentially making as many of the fields of the controller private. This is to make subsequent refactors safer and easier to reason about.

The first refactor I'm thinking of doing will be having a controller interface (not an exported service "interface" which was a concrete class like we used to have) and extracting the "is enabled" logic into a "disabled controller" and "enabled controller" so that we don't have a ton of `isEnabled` stuff all over the place and can better guarantee scope key nullability. This will hopefully fix the issue we had a while back.

# How

Make fields private, add public getters to match iOS.

# Test Plan

Build.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
