### PR TITLE
[av][ios] Fix audio recording resetting when receiving a phone call

### DIFF
--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix audio recording resetting when receiving a phone call.
+- Fix audio recording resetting when receiving a phone call. ([#25054](https://github.com/expo/expo/pull/25054) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix audio recording resetting when receiving a phone call.
+
 ### 💡 Others
 
 - Use `pointerEvent` style instead of prop for video component on web. ([#24931](https://github.com/expo/expo/pull/24931) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-av/ios/EXAV/EXAV.m
+++ b/packages/expo-av/ios/EXAV/EXAV.m
@@ -429,6 +429,9 @@ EX_EXPORT_MODULE(ExponentAV);
 {
   NSNumber *interruptionType = [[notification userInfo] objectForKey:AVAudioSessionInterruptionTypeKey];
   if (interruptionType.unsignedIntegerValue == AVAudioSessionInterruptionTypeBegan) {
+    if (_audioRecorder && [_audioRecorder isRecording]) {
+      [self _deactivateAudioSession];
+    }
     _currentAudioSessionMode = EXAVAudioSessionModeInactive;
   }
   


### PR DESCRIPTION
# Why

We don't pause the recording correctly when receiving an interrupt, which causes iOS to stop the recording completely
Fixes https://github.com/expo/expo/issues/24922

# How

When receiving an interrupt while recording pause the recording

# Test Plan

Tested in Bare Expo on iOS 17 device
