### PR TITLE
[docs] Clarify that Expo Router typed routes require TypeScript and may already be configured in your project

### DIFF
--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -14,7 +14,7 @@ Expo Router supports generating TypeScript types automatically with Expo CLI. Th
 ## Get started
 
 ### Quick start
-If you created your project using the [Expo Router quick start guide](/routing/installation/#quick-start) then your project is already configured to use typed routes. The Expo CLI will generate the needed type file the first time you run `npx expo start`. Then you can use autocomplete for `href` props whenever you use an Expo Router `<Link>` component in a **.tsx** file.
+If you created your project using the [Expo Router quick start guide](/routing/installation/#quick-start) then your project is already configured to use typed routes. The Expo CLI will generate the required type file the first time you run `npx expo start`. Then, you can use autocomplete for `href` props whenever you use an Expo Router `<Link>` component in a **.tsx** file.
 
 ### Manual configuration
 

--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -13,6 +13,11 @@ Expo Router supports generating TypeScript types automatically with Expo CLI. Th
 
 ## Get started
 
+### Quick start
+If you created your project using the template from our [Expo Router quick start guide](/routing/installation/#quick-start), then your project is already configured to use typed routes. Run `npx expo start` and you can start using autocomplete in the Expo Router `<Link>` component's `href` prop in your **.tsx** files.
+
+### Manual configuration
+
 While the feature is in beta, you can enable it by setting `experiments.typedRoutes` to `true` in your **app.json**:
 
 ```json app.json
@@ -37,7 +42,7 @@ If you find yourself in a situation where you need to generate these types witho
 
 ## Statically typed routes
 
-Components and functions that use `Href<T>` will now by statically typed and have a much stricter definition. For example:
+Components and functions that use `Href<T>` will now be statically typed and have a much stricter definition. For example:
 
 ```tsx
 ✅ <Link href="/about" />
@@ -75,18 +80,18 @@ You can leverage the `useSegments()` hooks from `expo-router` to create complex 
 
 <FileTree
   files={[
-    'app/(feed)/_layout.js',
-    'app/(feed)/feed.js',
-    'app/(feed)/search.js',
-    'app/(feed)/profile.js',
-    'app/(search)/profile.js',
-    'components/button.js',
+    'app/(feed)/_layout.tsx',
+    'app/(feed)/feed.tsx',
+    'app/(feed)/search.tsx',
+    'app/(feed)/profile.tsx',
+    'app/(search)/profile.tsx',
+    'components/button.tsx',
   ]}
 />
 
 You can ensure that you push to the same tab by using the `useSegments()` hook to get the first segment of the current route.
 
-```tsx button.js
+```tsx button.tsx
 import { Link, useSegments } from 'expo-router';
 
 export function Button() {

--- a/docs/pages/router/reference/typed-routes.mdx
+++ b/docs/pages/router/reference/typed-routes.mdx
@@ -7,14 +7,14 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 import { FileTree } from '~/ui/components/FileTree';
 
-> Available from Expo SDK 49 and Expo Router v2. Expo Router supports standard TypeScript out of the box. See the [TypeScript](/guides/typescript/) guide for more information on how to set it up.
+> Available from Expo SDK 49 and Expo Router v2 when using TypeScript. Expo Router supports standard TypeScript out of the box. See the [TypeScript](/guides/typescript/) guide for more information on how to set it up.
 
 Expo Router supports generating TypeScript types automatically with Expo CLI. This enables `<Link>`, and the [hooks API](/router/reference/hooks) to be statically typed. This feature is currently in beta and is not enabled by default.
 
 ## Get started
 
 ### Quick start
-If you created your project using the template from our [Expo Router quick start guide](/routing/installation/#quick-start), then your project is already configured to use typed routes. Run `npx expo start` and you can start using autocomplete in the Expo Router `<Link>` component's `href` prop in your **.tsx** files.
+If you created your project using the [Expo Router quick start guide](/routing/installation/#quick-start) then your project is already configured to use typed routes. The Expo CLI will generate the needed type file the first time you run `npx expo start`. Then you can use autocomplete for `href` props whenever you use an Expo Router `<Link>` component in a **.tsx** file.
 
 ### Manual configuration
 
@@ -104,7 +104,7 @@ export function Button() {
 }
 ```
 
-Now, you can leverage `<Button />` from both **app/(feed)/feed.js** and **app/(search)/search.js** to push `./profile` while preserving the current tab.
+Now, you can leverage `<Button />` from both **app/(feed)/feed.tsx** and **app/(search)/search.tsx** to push `./profile` while preserving the current tab.
 
 ## Imperative navigation
 


### PR DESCRIPTION
# Why
Some ideas to make typed routes a little more inviting, especially for non-TS users...

If you followed the quick start guide for Expo Router as of SDK 49 / v2, you already have typed routes - so lets let folks know they may not have to sweat the extra configuration.

Also, it wasn't quite clear that you need to use TypeScript files to use typed routes. I'm sure this is obvious for TS regulars, but Visual Studio Code does attempt some TS-based Intellisense in JS files, so it can be confusing where that boundary is if you default to JS. AFAIK, the `href` autocomplete doesn't work in a JS file, as I just tried it on a new project and it didn't. If this is not expected behavior, let me know!

# How
- Noted the scenario where typed routes are already setup
- Changed example files to .tsx
- Added a note to the effect of "you gotta use TS to get this"

