### PR TITLE
[core][iOS] Fix the object identifier for shared object types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed the object identifier for shared object types.
+- [iOS] Fixed the object identifier for shared object types. ([#25060](https://github.com/expo/expo/pull/25060) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the object identifier for shared object types.
+
 ### 💡 Others
 
 ## 1.9.0 — 2023-10-17

--- a/packages/expo-modules-core/ios/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/DynamicTypes/DynamicSharedObjectType.swift
@@ -9,11 +9,12 @@ internal struct DynamicSharedObjectType: AnyDynamicType {
   /**
    A unique identifier of the wrapped type.
    */
-  let typeIdentifier: ObjectIdentifier
+  var typeIdentifier: ObjectIdentifier {
+    return ObjectIdentifier(innerType)
+  }
 
-  init<SharedObjectType: SharedObject>(innerType: SharedObjectType.Type) {
+  init(innerType: SharedObject.Type) {
     self.innerType = innerType
-    self.typeIdentifier = ObjectIdentifier(SharedObjectType.self)
   }
 
   func wraps<InnerType>(_ type: InnerType.Type) -> Bool {


### PR DESCRIPTION
# Why

I found out that `ObjectIdentifier(SharedObjectType.self)` may return unexpected id since the generic type can be just a `SharedObject`, thus multiple classes could have the same id.

# How

Calculate the object identifier based on the given argument instead of the generic type.

# Test Plan

Object ids are now unique per type