### PR TITLE
[@expo/cli] export only selected assets

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enable package exports for server bundling. ([#24937](https://github.com/expo/expo/pull/24937) by [@EvanBacon](https://github.com/EvanBacon))
 - Include static routes from `generateStaticParams` in server manifest. ([#25003](https://github.com/expo/expo/pull/25003) by [@EvanBacon](https://github.com/EvanBacon))
 - Added Expo CLI devtools plugins support. ([#24650](https://github.com/expo/expo/pull/24650) by [@kudo](https://github.com/kudo))
+- Optionally export only selected assets. ([#25065](https://github.com/expo/expo/pull/25065) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
@@ -46,4 +46,28 @@ describe(createMetadataJson, () => {
       version: expect.any(Number),
     });
   });
+  it(`writes metadata manifest with excluded assets`, async () => {
+    const metadata = await createMetadataJson({
+      fileNames: {
+        ios: 'ios-xxfooxxbarxx.js',
+      },
+      bundles: {
+        ios: {
+          assets: [{ hash: 'foo', type: 'image', fileHashes: ['foobar', 'other'] } as any],
+        },
+      },
+      embeddedHashSet: new Set(['foo']),
+    });
+
+    expect(metadata).toStrictEqual({
+      bundler: expect.any(String),
+      fileMetadata: {
+        ios: {
+          assets: [],
+          bundle: 'bundles/ios-xxfooxxbarxx.js',
+        },
+      },
+      version: expect.any(Number),
+    });
+  });
 });

--- a/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
@@ -1,61 +1,60 @@
-import { resolveAssetBundlePatternsAsync } from '../exportAssets';
+import { resolveAssetPatternsToBeBundledAsync } from '../exportAssets';
 
-describe(resolveAssetBundlePatternsAsync, () => {
+describe(resolveAssetPatternsToBeBundledAsync, () => {
   it(`does nothing with empty bundle patterns`, async () => {
-    expect(
-      await resolveAssetBundlePatternsAsync(
-        '/',
-        {
-          assetBundlePatterns: [],
-        },
-        []
-      )
-    ).toEqual({});
+    const exp = {
+      name: 'Foo',
+      slug: 'Foo',
+    };
+    expect(await resolveAssetPatternsToBeBundledAsync('/', exp, [])).toEqual({
+      name: 'Foo',
+      slug: 'Foo',
+    });
   });
   it(`expands bundle patterns`, async () => {
-    expect(
-      await resolveAssetBundlePatternsAsync(
-        '/',
-        {
-          assetBundlePatterns: ['**/*'],
-        },
-        [
-          {
-            __packager_asset: true,
-            files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
-            hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
-            name: 'icon',
-            type: 'png',
-            fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
-          },
-          {
-            __packager_asset: true,
-            files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
-            hash: 'foobar',
-            name: 'somn',
-            fileHashes: [
-              'foobar',
-              'foobar2',
-              // duplicates are stripped
-              'foobar2',
-            ],
-          },
-          {
-            // Wont match
-            __packager_asset: false,
-            files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
-            hash: 'foobar',
-            name: 'somn',
-            fileHashes: ['foobar3'],
-          },
-        ]
-      )
-    ).toEqual({
-      bundledAssets: [
-        'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',
-        'asset_foobar',
-        'asset_foobar2',
-      ],
-    });
+    const exp: any = {
+      name: 'Foo',
+      slug: 'Foo',
+      extra: {
+        assetPatternsToBeBundled: ['**/*'],
+      },
+    };
+    await resolveAssetPatternsToBeBundledAsync('/', exp, [
+      {
+        __packager_asset: true,
+        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
+        hash: '4e3f888fc8475f69fd5fa32f1ad5216a',
+        name: 'icon',
+        type: 'png',
+        fileHashes: ['4e3f888fc8475f69fd5fa32f1ad5216a'],
+      },
+      {
+        __packager_asset: true,
+        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+        hash: 'foobar',
+        name: 'somn',
+        fileHashes: [
+          'foobar',
+          'foobar2',
+          // duplicates are stripped
+          'foobar2',
+        ],
+      },
+      {
+        // Wont match
+        __packager_asset: false,
+        files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/somn'],
+        hash: 'foobar',
+        name: 'somn',
+        fileHashes: ['foobar3'],
+      },
+    ]);
+    const result = [...exp.bundledAssets];
+    result.sort();
+    expect(result).toEqual([
+      'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',
+      'asset_foobar',
+      'asset_foobar2',
+    ]);
   });
 });

--- a/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
@@ -1,17 +1,15 @@
-import { resolveAssetPatternsToBeBundledAsync } from '../exportAssets';
+import { resolveAssetPatternsToBeBundled } from '../exportAssets';
 
-describe(resolveAssetPatternsToBeBundledAsync, () => {
-  it(`does nothing with empty bundle patterns`, async () => {
+describe(resolveAssetPatternsToBeBundled, () => {
+  it(`does nothing with empty bundle patterns`, () => {
     const exp = {
       name: 'Foo',
       slug: 'Foo',
     };
-    expect(await resolveAssetPatternsToBeBundledAsync('/', exp, [])).toEqual({
-      name: 'Foo',
-      slug: 'Foo',
-    });
+    const assetPatterns = resolveAssetPatternsToBeBundled('/', exp, []);
+    expect(assetPatterns).toBeUndefined();
   });
-  it(`expands bundle patterns`, async () => {
+  it(`expands bundle patterns`, () => {
     const exp: any = {
       name: 'Foo',
       slug: 'Foo',
@@ -19,7 +17,7 @@ describe(resolveAssetPatternsToBeBundledAsync, () => {
         assetPatternsToBeBundled: ['**/*'],
       },
     };
-    await resolveAssetPatternsToBeBundledAsync('/', exp, [
+    const resultSet = resolveAssetPatternsToBeBundled('/', exp, [
       {
         __packager_asset: true,
         files: ['/Users/evanbacon/Documents/GitHub/lab/yolo87/assets/icon.png'],
@@ -49,7 +47,7 @@ describe(resolveAssetPatternsToBeBundledAsync, () => {
         fileHashes: ['foobar3'],
       },
     ]);
-    const result = [...exp.bundledAssets];
+    const result = [...(resultSet ?? new Set())];
     result.sort();
     expect(result).toEqual([
       'asset_4e3f888fc8475f69fd5fa32f1ad5216a.png',

--- a/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportAssets-test.ts
@@ -14,7 +14,9 @@ describe(resolveAssetPatternsToBeBundled, () => {
       name: 'Foo',
       slug: 'Foo',
       extra: {
-        assetPatternsToBeBundled: ['**/*'],
+        updates: {
+          assetPatternsToBeBundled: ['**/*'],
+        },
       },
     };
     const resultSet = resolveAssetPatternsToBeBundled('/', exp, [

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -38,10 +38,11 @@ export function createMetadataJson({
             bundle: path.join('bundles', fileNames[platform]!),
             // Collect all of the assets and convert them to the serial format.
             assets: bundle.assets
+              .filter((asset: any) => !asset.embedded)
               .map(
-                (asset) =>
+                (asset: any) =>
                   // Each asset has multiple hashes which we convert and then flatten.
-                  asset.fileHashes?.map((hash) => ({
+                  asset.fileHashes?.map((hash: string) => ({
                     path: path.join('assets', hash),
                     ext: asset.type,
                   }))

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -38,11 +38,11 @@ export function createMetadataJson({
             bundle: path.join('bundles', fileNames[platform]!),
             // Collect all of the assets and convert them to the serial format.
             assets: bundle.assets
-              .filter((asset: any) => !asset.embedded)
+              .filter((asset) => !asset.embedded)
               .map(
-                (asset: any) =>
+                (asset) =>
                   // Each asset has multiple hashes which we convert and then flatten.
-                  asset.fileHashes?.map((hash: string) => ({
+                  asset.fileHashes?.map((hash) => ({
                     path: path.join('assets', hash),
                     ext: asset.type,
                   }))

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -15,9 +15,11 @@ type FileMetadata = {
 export function createMetadataJson({
   bundles,
   fileNames,
+  embeddedHashSet,
 }: {
   bundles: Partial<Record<BundlePlatform, Pick<BundleOutput, 'assets'>>>;
   fileNames: Record<string, string | undefined>;
+  embeddedHashSet?: Set<string>;
 }): {
   version: 0;
   bundler: 'metro';
@@ -38,7 +40,7 @@ export function createMetadataJson({
             bundle: path.join('bundles', fileNames[platform]!),
             // Collect all of the assets and convert them to the serial format.
             assets: bundle.assets
-              .filter((asset) => !asset.embedded)
+              .filter((asset) => !embeddedHashSet || !embeddedHashSet.has(asset.hash))
               .map(
                 (asset) =>
                   // Each asset has multiple hashes which we convert and then flatten.

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -180,7 +180,7 @@ export async function exportAppAsync(
   // Can be empty during web-only SSG.
   // TODO: Use same asset system across platforms again.
   if (Object.keys(fileNames).length) {
-    const { assets } = await exportAssetsAsync(projectRoot, {
+    const { assets, embeddedHashSet } = await exportAssetsAsync(projectRoot, {
       exp,
       outputDir: staticFolder,
       bundles,
@@ -210,7 +210,7 @@ export async function exportAppAsync(
     }
 
     // Generate a `metadata.json` and the export is complete.
-    await writeMetadataJsonAsync({ outputDir: staticFolder, bundles, fileNames });
+    await writeMetadataJsonAsync({ outputDir: staticFolder, bundles, fileNames, embeddedHashSet });
   }
 }
 

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -12,26 +12,57 @@ import { uniqBy } from '../utils/array';
 
 const debug = require('debug')('expo:export:exportAssets') as typeof console.log;
 
+function mapAssetHashToAssetString(asset: Asset, hash: string) {
+  return 'asset_' + hash + ('type' in asset && asset.type ? '.' + asset.type : '');
+}
+
+export function assetPatternsToBeBundled(
+  exp: ExpoConfig & { extra?: { assetPatternsToBeBundled?: string[] } }
+): string[] | undefined {
+  return exp?.extra?.assetPatternsToBeBundled?.length
+    ? exp?.extra?.assetPatternsToBeBundled
+    : undefined;
+}
+
 /**
- * Resolves the assetBundlePatterns from the manifest and returns a list of assets to bundle.
- *
- * @modifies {exp}
+ * Given an asset and a set of strings representing the assets to be bundled, returns true if
+ * the asset is part of the set to be bundled.
+ * @param asset Asset object
+ * @param bundledAssetsSet Set of strings
+ * @returns true if the asset should be bundled
  */
-export async function resolveAssetBundlePatternsAsync<T extends ExpoConfig>(
-  projectRoot: string,
-  exp: T,
-  assets: Asset[]
-): Promise<Omit<T, 'assetBundlePatterns'> & { bundledAssets?: string[] }> {
-  if (!exp.assetBundlePatterns?.length || !assets.length) {
-    delete exp.assetBundlePatterns;
-    return exp;
+export function assetShouldBeIncludedInExport(
+  asset: Asset,
+  bundledAssetsSet: Set<string> | undefined
+) {
+  if (!bundledAssetsSet) {
+    return true;
   }
+  return (
+    asset.fileHashes.filter((hash) => bundledAssetsSet?.has(mapAssetHashToAssetString(asset, hash)))
+      .length > 0 ?? false
+  );
+}
+
+/**
+ * Computes a set of strings representing the assets to be bundled with an export, given an array of assets,
+ * and a set of patterns to match
+ * @param assets The asset array
+ * @param assetPatternsToBeBundled An array of strings with glob patterns to match
+ * @param projectRoot The project root
+ * @returns A set of asset strings
+ */
+export function setOfAssetsToBeBundled(
+  assets: Asset[],
+  assetPatternsToBeBundled: string[],
+  projectRoot: string
+): Set<string> {
   // Convert asset patterns to a list of asset strings that match them.
   // Assets strings are formatted as `asset_<hash>.<type>` and represent
   // the name that the file will have in the app bundle. The `asset_` prefix is
   // needed because android doesn't support assets that start with numbers.
 
-  const fullPatterns: string[] = exp.assetBundlePatterns.map((p: string) =>
+  const fullPatterns: string[] = assetPatternsToBeBundled.map((p: string) =>
     path.join(projectRoot, p)
   );
 
@@ -42,9 +73,7 @@ export async function resolveAssetBundlePatternsAsync<T extends ExpoConfig>(
       const shouldBundle = shouldBundleAsset(asset, fullPatterns);
       if (shouldBundle) {
         debug(`${shouldBundle ? 'Include' : 'Exclude'} asset ${asset.files?.[0]}`);
-        return asset.fileHashes.map(
-          (hash) => 'asset_' + hash + ('type' in asset && asset.type ? '.' + asset.type : '')
-        );
+        return asset.fileHashes.map((hash) => mapAssetHashToAssetString(asset, hash));
       }
       return [];
     })
@@ -52,7 +81,27 @@ export async function resolveAssetBundlePatternsAsync<T extends ExpoConfig>(
 
   // The assets returned by the RN packager has duplicates so make sure we
   // only bundle each once.
-  (exp as any).bundledAssets = [...new Set(allBundledAssets)];
+  return new Set(allBundledAssets);
+}
+
+/**
+ * Resolves the assetBundlePatterns from the manifest and returns a list of assets to bundle.
+ *
+ * @modifies {exp}
+ */
+export async function resolveAssetPatternsToBeBundledAsync<T extends ExpoConfig>(
+  projectRoot: string,
+  exp: T,
+  assets: Asset[]
+): Promise<T & { bundledAssets?: Set<string> }> {
+  if (!assetPatternsToBeBundled(exp)) {
+    return exp;
+  }
+  (exp as any).bundledAssets = setOfAssetsToBeBundled(
+    assets,
+    assetPatternsToBeBundled(exp) ?? ['**/*'],
+    projectRoot
+  );
   delete exp.assetBundlePatterns;
 
   return exp;
@@ -92,16 +141,39 @@ export async function exportAssetsAsync(
   );
 
   if (assets[0]?.fileHashes) {
+    debug(`Assets = ${JSON.stringify(assets, null, 2)}`);
+    // Updates the manifest to reflect additional asset bundling + configs
+    // Get only asset strings for assets we will save
+    await resolveAssetPatternsToBeBundledAsync(projectRoot, exp, assets);
+    const bundledAssetsSet = (exp as any).bundledAssets;
+    let filteredAssets = assets;
+    if (bundledAssetsSet) {
+      debug(`Bundled assets = ${JSON.stringify([...bundledAssetsSet], null, 2)}`);
+      // Filter asset objects to only ones that include assetBundlePatterns matches
+      filteredAssets = assets.filter((asset) =>
+        assetShouldBeIncludedInExport(asset, bundledAssetsSet)
+      );
+      debug(`Filtered assets count = ${filteredAssets.length}`);
+    }
     Log.log('Saving assets');
-    await saveAssetsAsync(projectRoot, { assets, outputDir });
+    await saveAssetsAsync(projectRoot, { assets: filteredAssets, outputDir });
   }
 
   // Add google services file if it exists
   await resolveGoogleServicesFile(projectRoot, exp);
 
-  // Updates the manifest to reflect additional asset bundling + configs
-  await resolveAssetBundlePatternsAsync(projectRoot, exp, assets);
-
+  bundles.ios?.assets.forEach((asset: any) => {
+    // Mark assets to be removed from metadata
+    if (!assetShouldBeIncludedInExport(asset, (exp as any).bundledAssets)) {
+      asset.embedded = true;
+    }
+  });
+  bundles.android?.assets.forEach((asset: any) => {
+    // Mark assets to be removed from metadata
+    if (!assetShouldBeIncludedInExport(asset, (exp as any).bundledAssets)) {
+      asset.embedded = true;
+    }
+  });
   return { exp, assets };
 }
 

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -17,10 +17,10 @@ function mapAssetHashToAssetString(asset: Asset, hash: string) {
 }
 
 export function assetPatternsToBeBundled(
-  exp: ExpoConfig & { extra?: { assetPatternsToBeBundled?: string[] } }
+  exp: ExpoConfig & { extra?: { updates?: { assetPatternsToBeBundled?: string[] } } }
 ): string[] | undefined {
-  return exp?.extra?.assetPatternsToBeBundled?.length
-    ? exp?.extra?.assetPatternsToBeBundled
+  return exp?.extra?.updates?.assetPatternsToBeBundled?.length
+    ? exp?.extra?.updates?.assetPatternsToBeBundled
     : undefined;
 }
 

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -36,8 +36,8 @@ function assetShouldBeIncludedInExport(asset: Asset, bundledAssetsSet: Set<strin
     return true;
   }
   return (
-    asset.fileHashes.filter((hash) => bundledAssetsSet?.has(mapAssetHashToAssetString(asset, hash)))
-      .length > 0 ?? false
+    asset.fileHashes.filter((hash) => bundledAssetsSet.has(mapAssetHashToAssetString(asset, hash)))
+      .length > 0
   );
 }
 
@@ -51,7 +51,7 @@ function assetShouldBeIncludedInExport(asset: Asset, bundledAssetsSet: Set<strin
  */
 function setOfAssetsToBeBundled(
   assets: Asset[],
-  assetPatternsToBeBundled: string[] | undefined,
+  assetPatternsToBeBundled: string[],
   projectRoot: string
 ): Set<string> | undefined {
   // Convert asset patterns to a list of asset strings that match them.
@@ -59,11 +59,7 @@ function setOfAssetsToBeBundled(
   // the name that the file will have in the app bundle. The `asset_` prefix is
   // needed because android doesn't support assets that start with numbers.
 
-  if (!assetPatternsToBeBundled) {
-    return undefined;
-  }
-
-  const fullPatterns: string[] = (assetPatternsToBeBundled ?? ['**/*']).map((p: string) =>
+  const fullPatterns: string[] = assetPatternsToBeBundled.map((p: string) =>
     path.join(projectRoot, p)
   );
 

--- a/packages/@expo/cli/src/export/exportAssets.ts
+++ b/packages/@expo/cli/src/export/exportAssets.ts
@@ -158,13 +158,13 @@ export async function exportAssetsAsync(
   // Add google services file if it exists
   await resolveGoogleServicesFile(projectRoot, exp);
 
-  bundles.ios?.assets.forEach((asset: Asset & { embedded?: true }) => {
+  bundles.ios?.assets.forEach((asset: Asset) => {
     // Mark assets to be removed from metadata
     if (!assetShouldBeIncludedInExport(asset, bundledAssetsSet)) {
       asset.embedded = true;
     }
   });
-  bundles.android?.assets.forEach((asset: Asset & { embedded?: true }) => {
+  bundles.android?.assets.forEach((asset: Asset) => {
     // Mark assets to be removed from metadata
     if (!assetShouldBeIncludedInExport(asset, bundledAssetsSet)) {
       asset.embedded = true;

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -32,7 +32,6 @@ export type BundleOptions = {
 };
 export type BundleAssetWithFileHashes = Metro.AssetData & {
   fileHashes: string[]; // added by the hashAssets asset plugin
-  embedded?: boolean; // added by exportAssets to allow assets to be excluded from metadata
 };
 export type BundleOutput = {
   code: string;

--- a/packages/@expo/cli/src/export/fork-bundleAsync.ts
+++ b/packages/@expo/cli/src/export/fork-bundleAsync.ts
@@ -32,6 +32,7 @@ export type BundleOptions = {
 };
 export type BundleAssetWithFileHashes = Metro.AssetData & {
   fileHashes: string[]; // added by the hashAssets asset plugin
+  embedded?: boolean; // added by exportAssets to allow assets to be excluded from metadata
 };
 export type BundleOutput = {
   code: string;

--- a/packages/@expo/cli/src/export/writeContents.ts
+++ b/packages/@expo/cli/src/export/writeContents.ts
@@ -135,14 +135,17 @@ export async function writeMetadataJsonAsync({
   outputDir,
   bundles,
   fileNames,
+  embeddedHashSet,
 }: {
   outputDir: string;
   bundles: Record<string, Pick<BundleOutput, 'assets'> | undefined>;
   fileNames: Record<string, string | undefined>;
+  embeddedHashSet?: Set<string>;
 }) {
   const contents = createMetadataJson({
     bundles,
     fileNames,
+    embeddedHashSet,
   });
   const metadataPath = path.join(outputDir, 'metadata.json');
   debug(`Writing metadata.json to ${metadataPath}`);

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -208,6 +208,7 @@ export interface LinkComponent {
  * @param props.replace Should replace the current route without adding to the history.
  * @param props.asChild Forward props to child component. Useful for custom buttons.
  * @param props.children Child elements to render the content.
+ * @param props.className On web, this sets the HTML `class` directly. On native, this can be used with CSS interop tools like Nativewind.
  */
 export declare const Link: LinkComponent;
 


### PR DESCRIPTION
# Why

To support asset exclusion for `expo-updates`, the CLI needs to be able to only export certain assets, and not all assets found by Metro bundling.

Future PRs will contain code to make it safe for Android and iOS clients to use this new feature, and E2E tests to verify correct behavior.

# How

- Remove code that uses the old `assetBundlePatterns` Expo config property (no longer used).
- Assets are now matched against `extra.updates.assetPatternsToBeBundled`, an optional Expo config property containing an array of glob patterns.
- Assets that match any of the patterns in the array will be included in the export (and therefore included in EAS updates).
- If the above property is not present, the default behavior will be to include all assets in the export (so existing apps will not see any change in behavior)

> The property is currently in the `extra` object (which can have arbitrary properties) until the feature is stable, and a final decision is made on the new property name and location in the Expo config

Example of the new property:

```json
  "extra": {
    "updates": {
      "assetPatternsToBeBundled": [
        "assets/*",
        "node_modules/@expo-google-fonts/**/*"
      ]
    }
  }
```
# Test Plan

- Unit tests should continue to pass
- Tested with Updates E2E projects

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
