### PR TITLE
[docs] Fix hydration issue for Video component

### DIFF
--- a/docs/components/plugins/Video.tsx
+++ b/docs/components/plugins/Video.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
 import { borderRadius, breakpoints } from '@expo/styleguide-base';
+import dynamic from 'next/dynamic';
 import { PropsWithChildren, useState } from 'react';
-import ReactPlayer from 'react-player';
 import VisibilitySensor from 'react-visibility-sensor';
+
+const ReactPlayer = dynamic(() => import('react-player/lazy'), { ssr: false });
 
 const PLAYER_WIDTH = '100%' as const;
 const PLAYER_HEIGHT = 400 as const;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

After upgrading `react-player` dependency to the latest, the following hydration issue started occurring where we use `Video` component.

![image](https://github.com/expo/expo/assets/10234615/62b3b8f9-7788-468a-a0a1-2a4793236060)


I found a similar open issue in React Player GitHub repo (https://github.com/cookpete/react-player/issues/1474) where it states that the library is not SSR friendly and this issue happens with React 18.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Apply the workaround suggested [here](https://github.com/cookpete/react-player/issues/1474#issuecomment-1184645105) which implies to lazy load the player using Next.js dynamic imports.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested this locally and there doesn't seem to be the hydration error on docs where we use the `Video` component.

To test it locally, run docs locally and go to: http://localhost:3002/develop/development-builds/introduction/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
