### PR TITLE
[core][iOS] Add missing conversion of concurrent function results

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed the object identifier for shared object types. ([#25060](https://github.com/expo/expo/pull/25060) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed the object identifier for shared object types. ([#25060](https://github.com/expo/expo/pull/25060) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects.
+- [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects. ([#25075](https://github.com/expo/expo/pull/25075) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Conversions.swift
+++ b/packages/expo-modules-core/ios/Conversions.swift
@@ -168,7 +168,7 @@ internal final class Conversions {
       }
 
       // If the returned value is a native shared object, create its JS representation and add the pair to the registry of shared objects.
-      if let value = value as? SharedObject, let dynamicType = dynamicType as? DynamicSharedObjectType {
+      if let value = value as? SharedObject, let dynamicType = asDynamicSharedObjectType(dynamicType) {
         guard let object = try? appContext.newObject(nativeClassId: dynamicType.typeIdentifier) else {
           log.warn("Unable to create a JS object for \(dynamicType.description)")
           return Optional<Any>.none
@@ -264,4 +264,14 @@ internal final class Conversions {
       "Provided hex color '\(param)' would result in an overflow"
     }
   }
+}
+
+/**
+ Unwraps the dynamic optional type and returns as a dynamic shared object type if possible.
+ */
+private func asDynamicSharedObjectType(_ dynamicType: AnyDynamicType?) -> DynamicSharedObjectType? {
+  if let dynamicType = dynamicType as? DynamicOptionalType {
+    return dynamicType.wrappedType as? DynamicSharedObjectType
+  }
+  return dynamicType as? DynamicSharedObjectType
 }


### PR DESCRIPTION
# Why

- Completion handler of concurrent (async/await) functions was not invoked on the JS thread
- Some complex types such as records and shared objects were not being converted to primitive types or JS values
- Optional shared object types are not recognized as shared object types (it results in the JS shared object not being created at all)

# How

Fixed the above

# Test Plan

Tested with things that I'm working on (where the concurrent function returns a shared object)