### PR TITLE
Fix tvOS breakage in expo-localization

### DIFF
--- a/.github/workflows/updates-e2e.yml
+++ b/.github/workflows/updates-e2e.yml
@@ -8,7 +8,10 @@ on:
       - packages/@expo/cli/**
       - packages/@expo/config-plugins/**
       - packages/@expo/config-types/**
+      - packages/expo-av/**
+      - packages/expo-image/**
       - packages/expo-json-utils/**
+      - packages/expo-localization/**
       - packages/expo-manifests/**
       - packages/expo-modules-core/**
       - packages/expo-structured-headers/**

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix expo-localization tvOS compile, add CI. ([#25082](https://github.com/expo/expo/pull/25082) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - [iOS] Use newer, non-deprecated platform APIs in `getLocales()`. ([#24884](https://github.com/expo/expo/pull/24884) by [@aleqsio](https://github.com/aleqsio))

--- a/packages/expo-localization/ios/LocalizationModule.swift
+++ b/packages/expo-localization/ios/LocalizationModule.swift
@@ -133,7 +133,7 @@ public class LocalizationModule: Module {
       .map { languageTag -> [String: Any?] in
         let languageLocale = Locale.init(identifier: languageTag)
 
-        if #available(iOS 16, *) {
+        if #available(iOS 16, tvOS 16, *) {
           return [
             "languageTag": languageTag,
             "languageCode": languageLocale.language.languageCode?.identifier,

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Fix the E2E tests. ([#24865](https://github.com/expo/expo/pull/24865) by [@douglowder](https://github.com/douglowder))
 - [Android] Simplify UpdatesUtils.parseDateString, fix UpdatesLoggingTest. ([#24951](https://github.com/expo/expo/pull/24951) by [@douglowder](https://github.com/douglowder))
+- [iOS] Fix expo-localization tvOS compile, add CI. ([#25082](https://github.com/expo/expo/pull/25082) by [@douglowder](https://github.com/douglowder))
 
 ### 💡 Others
 

--- a/packages/expo-updates/e2e/setup/project.js
+++ b/packages/expo-updates/e2e/setup/project.js
@@ -266,8 +266,8 @@ async function preparePackageJson(projectRoot, repoRoot, configureE2E, isTV) {
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.72.6-0',
-        '@react-native-tvos/config-tv': '0.0.1',
+        'react-native': 'npm:react-native-tvos@~0.72.6-0',
+        '@react-native-tvos/config-tv': '~0.0.2',
       },
       expo: {
         install: {


### PR DESCRIPTION
# Why

tvOS should compile

# How

- Fix the compile issue in expo-localization
- Add expo-localization and other modules to tvOS compilation CI

# Test Plan

- tvOS CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
