### PR TITLE
Update project-structure.mdx

### DIFF
--- a/docs/pages/develop/project-structure.mdx
+++ b/docs/pages/develop/project-structure.mdx
@@ -11,7 +11,7 @@ When you create a new Expo project, a few files and folders are provided by defa
 
 The **App.js** file is the default screen of your project. It is the root file that you'll load after running the development server with `npx expo start`. You can edit this file to see the project update instantly. Generally, this file will contain root-level React Contexts and navigation.
 
-> [Expo Router](https://expo.github.io/router/docs) is now available and supports file-based navigation in projects. With Expo Router, the route file will become **index.js** and all the screens in the project will be in the **app** folder.
+> [Expo Router](https://docs.expo.dev/routing/introduction/) is now available and supports file-based navigation in projects. With Expo Router, the route file will become **index.js** and all the screens in the project will be in the **app** folder.
 
 ## app.json
 


### PR DESCRIPTION
Update the link for `Expo Router`

# Why

In expo docs, `Expo Router` points to the old documentation.

# How

Updated the link to latest docs

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
