### PR TITLE
[docs] Add Bun Support Documentation for Github Actions

### DIFF
--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -164,22 +164,15 @@ Your GitHub Action should be set up now. Whenever a developer creates a pull req
 
 ## Using Bun instead of Yarn
 
-If you're using Bun as your package manager instead of Yarn, you'll need to make some modifications to the provided workflow. Below are the updated steps for both publishing updates on push and previews on pull requests:
+To use [Bun](/guides/using-bun/) as your package manager instead of Yarn, follow the steps below for both publishing updates on push and previews on pull requests:
 
-Publish updates on push using Bun:
 
 <Step label="1">
 
-Replace the Node setup steps in update.yml:
+Replace the `Setup Node` step in **update.yml** with the following snippet:
 
-```- name: Setup Node
-  uses: actions/setup-node@v3
-  with:
-    node-version: 18.x
-    cache: yarn
-```
-with
-```- name: Setup Bun
+```yaml update.yml
+- name: Setup Bun
   uses: oven-sh/setup-bun@v1
   with:
     bun-version: latest
@@ -188,14 +181,9 @@ with
 
 <Step label="2">
 
-Install Dependencies with Bun:
+To install dependencies using Bun, replace the `Install dependencies` step with the following snippet:
 
-Replace the dependency installation step:
-
-```- name: Install dependencies
-  run: yarn install
-```
-with
-```- name: Install dependencies
+```yaml update.yml
+- name: Install dependencies
   run: bun install
 ```

--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -161,3 +161,41 @@ Your GitHub Action should be set up now. Whenever a developer creates a pull req
 > Some repositories or organizations might need to explicitly enable GitHub Workflows and allow third-party Actions.
 
 </Step>
+
+## Using Bun instead of Yarn
+
+If you're using Bun as your package manager instead of Yarn, you'll need to make some modifications to the provided workflow. Below are the updated steps for both publishing updates on push and previews on pull requests:
+
+Publish updates on push using Bun:
+
+<Step label="1">
+
+Replace the Node setup steps in update.yml:
+
+```- name: Setup Node
+  uses: actions/setup-node@v3
+  with:
+    node-version: 18.x
+    cache: yarn
+```
+with
+```- name: Setup Bun
+  uses: oven-sh/setup-bun@v1
+  with:
+    bun-version: latest
+```
+</Step>
+
+<Step label="2">
+
+Install Dependencies with Bun:
+
+Replace the dependency installation step:
+
+```- name: Install dependencies
+  run: yarn install
+```
+with
+```- name: Install dependencies
+  run: bun install
+```

--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -186,4 +186,5 @@ To install dependencies using Bun, replace the `Install dependencies` step with 
 ```yaml update.yml
 - name: Install dependencies
   run: bun install
+```
 </Step>

--- a/docs/pages/eas-update/github-actions.mdx
+++ b/docs/pages/eas-update/github-actions.mdx
@@ -186,4 +186,4 @@ To install dependencies using Bun, replace the `Install dependencies` step with 
 ```yaml update.yml
 - name: Install dependencies
   run: bun install
-```
+</Step>


### PR DESCRIPTION
# Why

Add documentation on how to setup github actions with bun

# How

documentation taken from https://github.com/oven-sh/setup-bun

# Test Plan

I followed the docs and github action ran successfully

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
