### PR TITLE
[expo-font] Remove `unimodule.json` in favour of `expo-module.config.json`

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Remove `unimodule.json` in favour of `expo-module.config.json`. ([#25099](https://github.com/expo/expo/pull/25099) by [@reichhartd](https://github.com/reichhartd))
+
 ## 11.7.0 — 2023-09-15
 
 ### 🎉 New features

--- a/packages/expo-font/unimodule.json
+++ b/packages/expo-font/unimodule.json
@@ -1,4 +1,0 @@
-{
-  "name": "expo-font",
-  "platforms": ["ios", "android"]
-}


### PR DESCRIPTION
# Why

After the Android migration, both `unimodule.json` and `expo-module.config.json` existed in `expo-font`.

# How

I removed the `unimodule.json` in favour of the `expo-module.config.json`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

-   [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
-   [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
-   [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
****