### PR TITLE
[ci] fix pr-labeler errors for external contributors

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   test-suite-fingerprint:
     runs-on: ubuntu-22.04
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:


### PR DESCRIPTION
# Why

fix pr-labeler errors for external contributors

# How

only run pr-labeler on expo/expo repo, namely for prs from external contributors. the workflow will be skipped.

not considering `pull_request_target` because the pr-labeler workflow needs to run `yarn install` which is not ideal for security auditing.

# Test Plan

ci passed