### PR TITLE
[docs] Add a link to local app dev in Firebase guide

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -226,13 +226,9 @@ For more information on creating a development build, see the section on [instal
 
 <Collapsible summary="Run project locally?">
 
-If you want to run the project locally:
+If you want to run the project locally, you need both Android Studio and Xcode installed and configured on your machine. See [Local app development](/guides/local-app-development/) guide for more information.
 
-- You need both Android Studio and Xcode installed and configured on your computer.
-- Then, you can run the project using `npx expo run:android` or `npx expo run:ios` command.
-
-If a particular React Native Firebase module requires custom native configuration steps, you must add it as a `plugin` to [app config file](/workflow/configuration/).
-Then, to run the project locally, you will have to run the `npx expo prebuild --clean` command to apply the native changes before the `npx expo run` commands.
+If a particular React Native Firebase module requires custom native configuration steps, you must add it as a `plugin` to [app config](/workflow/configuration/) file. Then, to run the project locally, run the `npx expo prebuild --clean` command to apply the native changes before the `npx expo run` commands.
 
 </Collapsible>
 </Step>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We now have a dedicated on local app development that goes through the entire process of installing required tools and how to use `npx expo run` commands. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the run project locally collapsible in React Native Firebase section by adding link to the Local app development guide and updating verbiage.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs locally and go to http://localhost:3002/guides/using-firebase/#run-project-locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
