### PR TITLE
feat (cli) Added Brave Browser debugger support

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Include static routes from `generateStaticParams` in server manifest. ([#25003](https://github.com/expo/expo/pull/25003) by [@EvanBacon](https://github.com/EvanBacon))
 - Added Expo CLI devtools plugins support. ([#24650](https://github.com/expo/expo/pull/24650) by [@kudo](https://github.com/kudo))
 - Optionally export only selected assets. ([#25065](https://github.com/expo/expo/pull/25065) by [@douglowder](https://github.com/douglowder))
+- Added Brave Browser debugger support. ([#25109](https://github.com/expo/expo/pull/25109) by [@kapobajza](https://github.com/kapobajza))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -1,7 +1,6 @@
 import fetch from 'node-fetch';
 
-import { launchBrowserAsync, type LaunchBrowserInstance } from './LaunchBrowser';
-
+import { launchInspectorBrowserAsync, type LaunchBrowserInstance } from './LaunchBrowser';
 export interface MetroInspectorProxyApp {
   description: string;
   devtoolsFrontendUrl: string;
@@ -28,7 +27,7 @@ export async function openJsInspector(app: MetroInspectorProxyApp) {
   const ws = app.webSocketDebuggerUrl.replace(/^ws:\/\//, '');
   const url = `${urlBase}?panel=console&ws=${encodeURIComponent(ws)}`;
   await closeJsInspector();
-  openingBrowserInstance = await launchBrowserAsync(url);
+  openingBrowserInstance = await launchInspectorBrowserAsync(url);
 }
 
 export async function closeJsInspector() {

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import os from 'os';
 
 import { launchInspectorBrowserAsync, type LaunchBrowserInstance } from './LaunchBrowser';
 export interface MetroInspectorProxyApp {
@@ -13,6 +14,21 @@ export interface MetroInspectorProxyApp {
 }
 
 let openingBrowserInstance: LaunchBrowserInstance | null = null;
+
+const IS_WSL = require('is-wsl') && !require('is-docker')();
+
+function createBrowser() {
+  if (os.platform() === 'darwin') {
+    return new LaunchBrowserImplMacOS();
+  }
+  if (os.platform() === 'win32' || IS_WSL) {
+    return new LaunchBrowserImplWindows();
+  }
+  if (os.platform() === 'linux') {
+    return new LaunchBrowserImplLinux();
+  }
+  throw new Error('[LaunchBrowser] Unsupported host platform');
+}
 
 export async function openJsInspector(app: MetroInspectorProxyApp) {
   // To update devtoolsFrontendRev, find the full commit hash in the url:

--- a/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/JsInspector.ts
@@ -1,5 +1,4 @@
 import fetch from 'node-fetch';
-import os from 'os';
 
 import { launchInspectorBrowserAsync, type LaunchBrowserInstance } from './LaunchBrowser';
 export interface MetroInspectorProxyApp {
@@ -14,21 +13,6 @@ export interface MetroInspectorProxyApp {
 }
 
 let openingBrowserInstance: LaunchBrowserInstance | null = null;
-
-const IS_WSL = require('is-wsl') && !require('is-docker')();
-
-function createBrowser() {
-  if (os.platform() === 'darwin') {
-    return new LaunchBrowserImplMacOS();
-  }
-  if (os.platform() === 'win32' || IS_WSL) {
-    return new LaunchBrowserImplWindows();
-  }
-  if (os.platform() === 'linux') {
-    return new LaunchBrowserImplLinux();
-  }
-  throw new Error('[LaunchBrowser] Unsupported host platform');
-}
 
 export async function openJsInspector(app: MetroInspectorProxyApp) {
   // To update devtoolsFrontendRev, find the full commit hash in the url:

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
@@ -1,6 +1,11 @@
 import os from 'os';
 
-import { LaunchBrowserTypes, type LaunchBrowserInstance } from './LaunchBrowser.types';
+import {
+  LaunchBrowserTypesEnum,
+  type LaunchBrowser,
+  type LaunchBrowserInstance,
+  type LaunchBrowserTypes,
+} from './LaunchBrowser.types';
 import LaunchBrowserImplLinux from './LaunchBrowserImplLinux';
 import LaunchBrowserImplMacOS from './LaunchBrowserImplMacOS';
 import LaunchBrowserImplWindows from './LaunchBrowserImplWindows';
@@ -10,11 +15,54 @@ export type { LaunchBrowserInstance };
 const IS_WSL = require('is-wsl') && !require('is-docker')();
 
 /**
- * Launch a browser for JavaScript inspector
+ * A factory to create a LaunchBrowser instance based on the host platform
  */
-export async function launchBrowserAsync(url: string): Promise<LaunchBrowserInstance> {
-  const browser = createBrowser();
-  const tempBrowserDir = await browser.createTempBrowserDir('expo-inspector');
+export function createLaunchBrowser(): LaunchBrowser {
+  let launchBrowser: LaunchBrowser;
+  if (os.platform() === 'darwin') {
+    launchBrowser = new LaunchBrowserImplMacOS();
+  } else if (os.platform() === 'win32' || IS_WSL) {
+    launchBrowser = new LaunchBrowserImplWindows();
+  } else if (os.platform() === 'linux') {
+    launchBrowser = new LaunchBrowserImplLinux();
+  } else {
+    throw new Error('[createLaunchBrowser] Unsupported host platform');
+  }
+  return launchBrowser;
+}
+
+/**
+ * Find a supported browser type on the host
+ */
+export async function findSupportedBrowserTypeAsync(
+  launchBrowser: LaunchBrowser
+): Promise<LaunchBrowserTypes> {
+  const supportedBrowsers = Object.values(LaunchBrowserTypesEnum);
+  for (const browserType of supportedBrowsers) {
+    if (await launchBrowser.isSupportedBrowser(browserType)) {
+      return browserType;
+    }
+  }
+
+  throw new Error(
+    `[findSupportedBrowserTypeAsync] Unable to find a browser on the host to open the inspector. Supported browsers: ${supportedBrowsers.join(
+      ', '
+    )}`
+  );
+}
+
+/**
+ * Launch a browser for inspector
+ */
+export async function launchInspectorBrowserAsync(
+  url: string,
+  browser?: LaunchBrowser,
+  browserType?: LaunchBrowserTypes
+): Promise<LaunchBrowserInstance> {
+  const launchBrowser = browser ?? createLaunchBrowser();
+  const launchBrowserType = browserType ?? (await findSupportedBrowserTypeAsync(launchBrowser));
+
+  const tempBrowserDir = await launchBrowser.createTempBrowserDir('expo-inspector');
 
   // For dev-client connecting metro in LAN, the request to fetch sourcemaps may be blocked by Chromium
   // with insecure-content (https page send xhr for http resource).
@@ -30,27 +78,5 @@ export async function launchBrowserAsync(url: string): Promise<LaunchBrowserInst
     '--no-default-browser-check',
   ];
 
-  for (const browserType of [LaunchBrowserTypes.CHROME, LaunchBrowserTypes.EDGE]) {
-    const isSupported = await browser.isSupportedBrowser(browserType);
-    if (isSupported) {
-      return browser.launchAsync(browserType, launchArgs);
-    }
-  }
-
-  throw new Error(
-    '[LaunchBrowser] Unable to find a browser on the host to open the inspector. Supported browsers: Google Chrome, Microsoft Edge'
-  );
-}
-
-function createBrowser() {
-  if (os.platform() === 'darwin') {
-    return new LaunchBrowserImplMacOS();
-  }
-  if (os.platform() === 'win32' || IS_WSL) {
-    return new LaunchBrowserImplWindows();
-  }
-  if (os.platform() === 'linux') {
-    return new LaunchBrowserImplLinux();
-  }
-  throw new Error('[LaunchBrowser] Unsupported host platform');
+  return launchBrowser.launchAsync(launchBrowserType, launchArgs);
 }

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
@@ -12,6 +12,8 @@ import LaunchBrowserImplWindows from './LaunchBrowserImplWindows';
 
 export type { LaunchBrowserInstance };
 
+const IS_WSL = require('is-wsl') && !require('is-docker')();
+
 /**
  * A factory to create a LaunchBrowser instance based on the host platform
  */

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.ts
@@ -12,8 +12,6 @@ import LaunchBrowserImplWindows from './LaunchBrowserImplWindows';
 
 export type { LaunchBrowserInstance };
 
-const IS_WSL = require('is-wsl') && !require('is-docker')();
-
 /**
  * A factory to create a LaunchBrowser instance based on the host platform
  */

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.types.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.types.ts
@@ -3,17 +3,24 @@ export interface LaunchBrowserInstance {
 }
 
 /**
- * Supported browser types
+ * Supported browser types enum
  */
-export enum LaunchBrowserTypes {
-  CHROME,
-  EDGE,
-}
+export const LaunchBrowserTypesEnum = {
+  CHROME: 'Google Chrome',
+  EDGE: 'Microsoft Edge',
+  BRAVE: 'Brave Browser',
+} as const;
 
 /**
- * Internal browser implementation constraints
+ * Supported browser types
  */
-export interface LaunchBrowserImpl {
+export type LaunchBrowserTypes =
+  (typeof LaunchBrowserTypesEnum)[keyof typeof LaunchBrowserTypesEnum];
+
+/**
+ * A browser launcher
+ */
+export interface LaunchBrowser {
   /**
    * Return whether the given `browserType` is supported
    */

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.types.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowser.types.ts
@@ -8,7 +8,7 @@ export interface LaunchBrowserInstance {
 export const LaunchBrowserTypesEnum = {
   CHROME: 'Google Chrome',
   EDGE: 'Microsoft Edge',
-  BRAVE: 'Brave Browser',
+  BRAVE: 'Brave',
 } as const;
 
 /**

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplLinux.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplLinux.ts
@@ -5,20 +5,25 @@ import path from 'path';
 
 import {
   LaunchBrowserTypes,
-  type LaunchBrowserImpl,
+  type LaunchBrowser,
   type LaunchBrowserInstance,
+  LaunchBrowserTypesEnum,
 } from './LaunchBrowser.types';
 
 /**
  * Browser implementation for Linux
  */
-export default class LaunchBrowserImplLinux implements LaunchBrowserImpl, LaunchBrowserInstance {
+export default class LaunchBrowserImplLinux implements LaunchBrowser, LaunchBrowserInstance {
   private _appId: string | undefined;
   private _process: ChildProcess | undefined;
 
   MAP = {
-    [LaunchBrowserTypes.CHROME]: ['google-chrome', 'google-chrome-stable', 'chromium'],
-    [LaunchBrowserTypes.EDGE]: ['microsoft-edge', 'microsoft-edge-dev'],
+    [LaunchBrowserTypesEnum.CHROME]: ['google-chrome', 'google-chrome-stable', 'chromium'],
+    [LaunchBrowserTypesEnum.EDGE]: ['microsoft-edge', 'microsoft-edge-dev'],
+    [LaunchBrowserTypesEnum.BRAVE]: [
+      // I am not sure if this is the correct appId for brave, because I have only tested it on Mac
+      'brave-browser',
+    ],
   };
 
   /**

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplLinux.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplLinux.ts
@@ -20,10 +20,7 @@ export default class LaunchBrowserImplLinux implements LaunchBrowser, LaunchBrow
   MAP = {
     [LaunchBrowserTypesEnum.CHROME]: ['google-chrome', 'google-chrome-stable', 'chromium'],
     [LaunchBrowserTypesEnum.EDGE]: ['microsoft-edge', 'microsoft-edge-dev'],
-    [LaunchBrowserTypesEnum.BRAVE]: [
-      // I am not sure if this is the correct appId for brave, because I have only tested it on Mac
-      'brave-browser',
-    ],
+    [LaunchBrowserTypesEnum.BRAVE]: ['brave'],
   };
 
   /**

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplMacOS.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplMacOS.ts
@@ -5,19 +5,21 @@ import path from 'path';
 
 import {
   LaunchBrowserTypes,
-  type LaunchBrowserImpl,
+  type LaunchBrowser,
   type LaunchBrowserInstance,
+  LaunchBrowserTypesEnum,
 } from './LaunchBrowser.types';
 
 /**
  * Browser implementation for macOS
  */
-export default class LaunchBrowserImplMacOS implements LaunchBrowserImpl, LaunchBrowserInstance {
+export default class LaunchBrowserImplMacOS implements LaunchBrowser, LaunchBrowserInstance {
   private _process: ChildProcess | undefined;
 
   MAP = {
-    [LaunchBrowserTypes.CHROME]: 'google chrome',
-    [LaunchBrowserTypes.EDGE]: 'microsoft edge',
+    [LaunchBrowserTypesEnum.CHROME]: 'google chrome',
+    [LaunchBrowserTypesEnum.EDGE]: 'microsoft edge',
+    [LaunchBrowserTypesEnum.BRAVE]: 'brave browser',
   };
 
   async isSupportedBrowser(browserType: LaunchBrowserTypes): Promise<boolean> {

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplWindows.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplWindows.ts
@@ -4,8 +4,9 @@ import path from 'path';
 
 import {
   LaunchBrowserTypes,
-  type LaunchBrowserImpl,
+  type LaunchBrowser,
   type LaunchBrowserInstance,
+  LaunchBrowserTypesEnum,
 } from './LaunchBrowser.types';
 
 const IS_WSL = require('is-wsl') && !require('is-docker')();
@@ -15,18 +16,20 @@ const IS_WSL = require('is-wsl') && !require('is-docker')();
  *
  * To minimize the difference between Windows and WSL, the implementation wraps all spawn calls through powershell.
  */
-export default class LaunchBrowserImplWindows implements LaunchBrowserImpl, LaunchBrowserInstance {
+export default class LaunchBrowserImplWindows implements LaunchBrowser, LaunchBrowserInstance {
   private _appId: string | undefined;
   private _powershellEnv: { [key: string]: string } | undefined;
 
   MAP = {
-    [LaunchBrowserTypes.CHROME]: {
+    [LaunchBrowserTypesEnum.CHROME]: {
       appId: 'chrome',
-      fullName: 'Google Chrome',
     },
-    [LaunchBrowserTypes.EDGE]: {
+    [LaunchBrowserTypesEnum.EDGE]: {
       appId: 'msedge',
-      fullName: 'Microsoft Edge',
+    },
+    [LaunchBrowserTypesEnum.BRAVE]: {
+      // I am not sure if this is the correct appId for brave, because I have only tested it on Mac
+      appId: 'brave',
     },
   };
 
@@ -36,7 +39,7 @@ export default class LaunchBrowserImplWindows implements LaunchBrowserImpl, Laun
       const env = await this.getPowershellEnv();
       const { status } = await spawnAsync(
         'powershell.exe',
-        ['-c', `Get-Package -Name '${this.MAP[browserType].fullName}'`],
+        ['-c', `Get-Package -Name '${browserType}'`],
         {
           // @ts-expect-error: Missing NODE_ENV
           env,

--- a/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplWindows.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/LaunchBrowserImplWindows.ts
@@ -28,7 +28,6 @@ export default class LaunchBrowserImplWindows implements LaunchBrowser, LaunchBr
       appId: 'msedge',
     },
     [LaunchBrowserTypesEnum.BRAVE]: {
-      // I am not sure if this is the correct appId for brave, because I have only tested it on Mac
       appId: 'brave',
     },
   };

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/JsInspector-test.ts
@@ -6,7 +6,7 @@ import {
   queryAllInspectorAppsAsync,
   queryInspectorAppAsync,
 } from '../JsInspector';
-import { launchBrowserAsync } from '../LaunchBrowser';
+import { launchInspectorBrowserAsync } from '../LaunchBrowser';
 
 jest.mock('fs-extra');
 jest.mock('node-fetch');
@@ -18,8 +18,8 @@ const { Response } = jest.requireActual('node-fetch');
 
 describe(openJsInspector, () => {
   it('should open browser for PUT request with given app', async () => {
-    const mockLaunchBrowserAsync = launchBrowserAsync as jest.MockedFunction<
-      typeof launchBrowserAsync
+    const mockLaunchBrowserAsync = launchInspectorBrowserAsync as jest.MockedFunction<
+      typeof launchInspectorBrowserAsync
     >;
     const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0];
     await openJsInspector(app);

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/LaunchBrowser-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/LaunchBrowser-test.ts
@@ -1,0 +1,74 @@
+import os from 'os';
+
+import {
+  createLaunchBrowser,
+  findSupportedBrowserTypeAsync,
+  launchInspectorBrowserAsync,
+} from '../LaunchBrowser';
+import {
+  type LaunchBrowser,
+  type LaunchBrowserTypes,
+  LaunchBrowserTypesEnum,
+} from '../LaunchBrowser.types';
+import LaunchBrowserImplMacOS from '../LaunchBrowserImplMacOS';
+
+jest.mock('os', () => ({
+  ...jest.requireActual<typeof os>('os'),
+  platform: jest.fn().mockReturnValue('darwin'),
+}));
+jest.mock('../LaunchBrowserImplMacOS');
+
+describe(createLaunchBrowser, () => {
+  it('should return LaunchBrowser instance based on current host platform', () => {
+    expect(createLaunchBrowser()).toBeInstanceOf(LaunchBrowserImplMacOS);
+  });
+
+  it('should throw error if no host platform is supported', () => {
+    jest.spyOn(os, 'platform').mockReturnValueOnce('freebsd');
+    expect(() => createLaunchBrowser()).toThrowError(/Unsupported host platform/);
+  });
+});
+
+describe(findSupportedBrowserTypeAsync, () => {
+  const launchBrowser = createLaunchBrowser();
+  const supportedBrowsers = Object.values(LaunchBrowserTypesEnum);
+
+  afterEach(() => {
+    jest.spyOn(LaunchBrowserImplMacOS.prototype, 'isSupportedBrowser').mockReset();
+  });
+
+  it('should return supported browserType', async () => {
+    jest
+      .spyOn(LaunchBrowserImplMacOS.prototype, 'isSupportedBrowser')
+      .mockImplementation(async (type) => type === 'Microsoft Edge');
+
+    const browserType = await findSupportedBrowserTypeAsync(launchBrowser);
+    expect(browserType).toBe('Microsoft Edge');
+  });
+
+  it('should throw error if no supported browsers on current platform', async () => {
+    jest.spyOn(LaunchBrowserImplMacOS.prototype, 'isSupportedBrowser').mockResolvedValue(false);
+
+    await expect(findSupportedBrowserTypeAsync(launchBrowser)).rejects.toThrowError(
+      new RegExp(`${supportedBrowsers.join(', ')}`, 'i')
+    );
+  });
+});
+
+describe(launchInspectorBrowserAsync, () => {
+  const browserMock: LaunchBrowser = {
+    close: jest.fn(),
+    createTempBrowserDir: jest.fn(),
+    launchAsync: jest.fn(),
+    isSupportedBrowser: jest.fn(),
+  };
+
+  it('should launch browser if supported', async () => {
+    const browserType: LaunchBrowserTypes = 'Microsoft Edge';
+    browserMock.isSupportedBrowser = jest.fn((type) => Promise.resolve(type === browserType));
+
+    await launchInspectorBrowserAsync('url', browserMock, browserType);
+
+    expect(browserMock.launchAsync).toHaveBeenCalledWith(browserType, expect.any(Array));
+  });
+});

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -208,6 +208,7 @@ export interface LinkComponent {
  * @param props.replace Should replace the current route without adding to the history.
  * @param props.asChild Forward props to child component. Useful for custom buttons.
  * @param props.children Child elements to render the content.
+ * @param props.className On web, this sets the HTML `class` directly. On native, this can be used with CSS interop tools like Nativewind.
  */
 export declare const Link: LinkComponent;
 

--- a/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
+++ b/packages/@expo/cli/src/start/server/type-generation/__typetests__/fixtures/basic.ts
@@ -208,7 +208,6 @@ export interface LinkComponent {
  * @param props.replace Should replace the current route without adding to the history.
  * @param props.asChild Forward props to child component. Useful for custom buttons.
  * @param props.children Child elements to render the content.
- * @param props.className On web, this sets the HTML `class` directly. On native, this can be used with CSS interop tools like Nativewind.
  */
 export declare const Link: LinkComponent;
 


### PR DESCRIPTION
# Why

I wanted to debug my app using Brave Browser, but I couldn't. So I decided to add support for it.

# How

By extending the `LaunchBrowser` and `LaunchBrowserImpl` functionalities.

# Test Plan

- Wrote some tests. 
- Also built the CLI and tried it locally by starting a new metro bundler using my local build, and then starting the debugger from the metro bundler (by pressing "j")

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
