### PR TITLE
[docs] Allow referrer in Discord links

### DIFF
--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -188,4 +188,4 @@ If you don't set up your **metro.config.js** file properly, your assets could fa
 
 For more information, see [troubleshooting runtime and build errors, and crashes](/build-reference/troubleshooting).
 
-> **info** Having trouble migrating? Join us in the #eas channel on the <A href="https://chat.expo.dev/">Discord and Forums</A> and let us know.
+> **info** Having trouble migrating? Join us in the #eas channel on the <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord and Forums</A> and let us know.

--- a/docs/pages/build-reference/migrating.mdx
+++ b/docs/pages/build-reference/migrating.mdx
@@ -4,6 +4,7 @@ description: A reference for migrating from "expo build" (classic builds) to EAS
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { A } from '~/ui/components/Text';
 
 This page covers practical differences you should know when migrating your Expo [managed app](/archive/managed-vs-bare/#managed-workflow) from `expo build` (also known as **classic builds**) to EAS Build. If this is your first time using EAS Build, you can use this page as a companion to [Create your first build](/build/setup).
 
@@ -187,4 +188,4 @@ If you don't set up your **metro.config.js** file properly, your assets could fa
 
 For more information, see [troubleshooting runtime and build errors, and crashes](/build-reference/troubleshooting).
 
-> **info** Having trouble migrating? [Join us in the #eas channel on the Expo Discord](https://discord.com/invite/4gtbPAdpaE) and let us know, we'll do our best to help.
+> **info** Having trouble migrating? Join us in the #eas channel on the <A href="https://chat.expo.dev/">Discord and Forums</A> and let us know.

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -5,6 +5,7 @@ description: A reference for troubleshooting build errors and crashes when using
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
+import { A } from '~/ui/components/Text';
 
 > This document is under active development; the topic it covers is expansive and finding the right way to explain how to troubleshoot issues will take some trial and error. Your suggestions for improvements are welcome as pull requests.
 
@@ -154,7 +155,7 @@ If you have followed the advice here, you're now in a good position to describe 
 
 ### How to ask a good question
 
-Join us on [Discord and Forums](https://chat.expo.dev) to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/support-terms#target-response-time-guidelines-for-subscriptions). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
+Join us on <A href="https://chat.expo.dev/">Discord and Forums</A> to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/support-terms#target-response-time-guidelines-for-subscriptions). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
 
 When you ask for troubleshooting help, be sure to share the following information:
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -155,7 +155,7 @@ If you have followed the advice here, you're now in a good position to describe 
 
 ### How to ask a good question
 
-Join us on <A href="https://chat.expo.dev/">Discord and Forums</A> to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/support-terms#target-response-time-guidelines-for-subscriptions). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
+Join us on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord and Forums</A> to ask for help from the community and the Expo team. The Expo team does our best to respond to high quality and well-articulated questions and issues, but responses are not guaranteed unless you are signed up for a [support plan](https://expo.dev/support-terms#target-response-time-guidelines-for-subscriptions). To ensure that an Expo team member sees your question, you can file a ticket at [expo.dev/contact](https://expo.dev/contact).
 
 When you ask for troubleshooting help, be sure to share the following information:
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -7,12 +7,13 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { A } from '~/ui/components/Text';
 
 EAS Build allows you to build a ready-to-submit binary of your app for the Google Play Store or Apple App Store. In this guide, let's learn how to do that.
 
 Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you toward resources that explain how to do that.
 
-For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on [Discord and Forums](https://chat.expo.dev/).
+For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on <A href="https://chat.expo.dev/">Discord and Forums</A>.
 
 ## Prerequisites
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -13,7 +13,7 @@ EAS Build allows you to build a ready-to-submit binary of your app for the Googl
 
 Alternatively, if you prefer to install the app directly to your Android device/emulator or install it in the iOS Simulator, we will point you toward resources that explain how to do that.
 
-For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on <A href="https://chat.expo.dev/">Discord and Forums</A>.
+For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord and Forums</A>.
 
 ## Prerequisites
 

--- a/docs/pages/eas-update/known-issues.mdx
+++ b/docs/pages/eas-update/known-issues.mdx
@@ -13,4 +13,4 @@ With EAS Update, there are some known issues you may encounter. As we continue t
 - When using the new manifest format with Expo Go, the project's name will appear as "Untitled experience" in the dev menu.
 - After publishing an update, it's impossible to revert back to the build's embedded update.
 
-Are you experiencing issues not listed above? [Contact us](https://expo.dev/contact) or join us on <A href="https://chat.expo.dev/">Discord</A> in the #eas channel.
+Are you experiencing issues not listed above? [Contact us](https://expo.dev/contact) or join us on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord</A> in the #eas channel.

--- a/docs/pages/eas-update/known-issues.mdx
+++ b/docs/pages/eas-update/known-issues.mdx
@@ -4,6 +4,8 @@ sidebar_title: Known issues
 description: Known issues and limitations of EAS Update service.
 ---
 
+import { A } from '~/ui/components/Text';
+
 With EAS Update, there are some known issues you may encounter. As we continue to iterate on it, we will address these issues.
 
 ### Known issues
@@ -11,4 +13,4 @@ With EAS Update, there are some known issues you may encounter. As we continue t
 - When using the new manifest format with Expo Go, the project's name will appear as "Untitled experience" in the dev menu.
 - After publishing an update, it's impossible to revert back to the build's embedded update.
 
-Are you experiencing issues not listed above? [Contact us](https://expo.dev/contact) or join us on [Discord](https://chat.expo.dev/) in the #eas channel.
+Are you experiencing issues not listed above? [Contact us](https://expo.dev/contact) or join us on <A href="https://chat.expo.dev/">Discord</A> in the #eas channel.

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -116,4 +116,4 @@ Once published, you can see the update in the [Expo dashboard](https://expo.dev/
 
 The steps described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features. It can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-it-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) for your project and your team.
 
-If you experience issues with migrating, check out our [debugging guide](/eas-update/debug). If you have feedback, join us on <A href="https://chat.expo.dev/">Discord</A> in the #update channel.
+If you experience issues with migrating, check out our [debugging guide](/eas-update/debug). If you have feedback, join us on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord</A> in the #update channel.

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -5,6 +5,7 @@ description: A guide to help migrate from Classic Updates to EAS Update.
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { A } from '~/ui/components/Text';
 
 > SDK 49 will be the last version to support Classic Updates. To continue using the deprecated `expo publish` command, set [`updates.useClassicUpdates`](/versions/latest/config/app/#useclassicupdates) in your app config.
 
@@ -115,4 +116,4 @@ Once published, you can see the update in the [Expo dashboard](https://expo.dev/
 
 The steps described above allow you to use a similar flow to Classic Updates. However, EAS Update is more flexible and has more features. It can be used to create more stable release flows. Learn [how EAS Update works](/eas-update/how-it-works) and how you can craft a more stable [deployment process](/eas-update/deployment-patterns) for your project and your team.
 
-If you experience issues with migrating, check out our [debugging guide](/eas-update/debug). If you have feedback, join us on [Discord](https://chat.expo.dev/) in the #update channel.
+If you experience issues with migrating, check out our [debugging guide](/eas-update/debug). If you have feedback, join us on <A href="https://chat.expo.dev/">Discord</A> in the #update channel.

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -279,6 +279,7 @@ export function JoinTheCommunity() {
             link="https://chat.expo.dev"
             icon={<DiscordIcon className="icon-lg text-palette-white" />}
             iconBackground="#3131E8"
+            shouldLeakReferrer
           />
         </Row>
         <Row>

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -54,4 +54,4 @@ To learn more about implementing different types of gestures and animations, we 
 
 ## Join the community
 
-Join our community on <A href="https://chat.expo.dev/">Discord</A> to chat with other Expo users or to ask questions.
+Join our community on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord</A> to chat with other Expo users or to ask questions.

--- a/docs/pages/tutorial/follow-up.mdx
+++ b/docs/pages/tutorial/follow-up.mdx
@@ -3,6 +3,8 @@ title: Learn more
 description: A list of resources to learn more about Expo and React Native.
 ---
 
+import { A } from '~/ui/components/Text';
+
 Now that the doing is done, let's fill in the gaps on the concepts that we applied.
 
 ## JavaScript features such as async/await, import, and others
@@ -52,4 +54,4 @@ To learn more about implementing different types of gestures and animations, we 
 
 ## Join the community
 
-Join our community on [Discord](https://chat.expo.dev/) to chat with other Expo users or to ask questions.
+Join our community on <A href="https://chat.expo.dev/">Discord</A> to chat with other Expo users or to ask questions.

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -31,7 +31,12 @@ export const ForumsLink = ({ isAPIPage, title }: { isAPIPage: boolean; title: st
     </LI>
   ) : (
     <LI>
-      <A isStyled openInNewTab href="https://chat.expo.dev/" className={LINK_CLASSES}>
+      <A
+        isStyled
+        openInNewTab
+        href="https://chat.expo.dev/"
+        className={LINK_CLASSES}
+        shouldLeakReferrer>
         <MessageDotsSquareIcon className={ICON_CLASSES} />
         <CALLOUT theme="secondary">Ask a question on the forums</CALLOUT>
       </A>

--- a/docs/ui/components/Home/Cells.tsx
+++ b/docs/ui/components/Home/Cells.tsx
@@ -111,6 +111,7 @@ export const TalkGridCell = ({
 type CommunityGridCellProps = APIGridCellProps & {
   description?: string;
   iconBackground?: string;
+  shouldLeakReferrer?: boolean;
 };
 
 export const CommunityGridCell = ({
@@ -121,12 +122,14 @@ export const CommunityGridCell = ({
   description,
   className,
   md = 6,
+  shouldLeakReferrer,
 }: CommunityGridCellProps) => (
   <CustomCol css={cellWrapperStyle} md={md}>
     <A
       href={link}
       css={[cellStyle, cellCommunityStyle, cellCommunityHoverStyle]}
       className={className}
+      shouldLeakReferrer={shouldLeakReferrer}
       isStyled>
       <div css={[cellCommunityIconWrapperStyle, css({ backgroundColor: iconBackground })]}>
         {icon}

--- a/docs/ui/components/Sidebar/SidebarFooter.tsx
+++ b/docs/ui/components/Sidebar/SidebarFooter.tsx
@@ -32,6 +32,7 @@ export const SidebarFooter = () => {
         title="Discord and Forums"
         Icon={DiscordIcon}
         isExternal
+        shouldLeakReferrer
       />
       <SidebarSingleEntry
         secondary

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -11,6 +11,7 @@ type SidebarSingleEntryProps = {
   isActive?: boolean;
   isExternal?: boolean;
   secondary?: boolean;
+  shouldLeakReferrer?: boolean;
 };
 
 export const SidebarSingleEntry = ({
@@ -20,6 +21,7 @@ export const SidebarSingleEntry = ({
   isActive = false,
   isExternal = false,
   secondary = false,
+  shouldLeakReferrer,
 }: SidebarSingleEntryProps) => {
   return (
     <A
@@ -31,6 +33,7 @@ export const SidebarSingleEntry = ({
         secondary && 'text-xs',
         isActive && 'bg-palette-blue3 text-link font-medium hocus:text-link hocus:bg-palette-blue4'
       )}
+      shouldLeakReferrer={shouldLeakReferrer}
       isStyled>
       <Icon
         className={mergeClasses(

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -233,12 +233,14 @@ export const MONOSPACE = createTextComponent(TextElement.CODE);
 
 const isExternalLink = (href?: string) => href?.includes('://');
 
-export const A = (props: LinkBaseProps & { isStyled?: boolean }) => {
-  const { isStyled, openInNewTab, ...rest } = props;
+export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferrer?: boolean }) => {
+  const { isStyled, openInNewTab, shouldLeakReferrer, ...rest } = props;
+
   return (
     <LinkBase
       css={[link, !isStyled && linkStyled]}
-      openInNewTab={openInNewTab ?? isExternalLink(props.href)}
+      {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
+      openInNewTab={(!shouldLeakReferrer && openInNewTab) ?? isExternalLink(props.href)}
       {...rest}
     />
   );

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -239,7 +239,7 @@ export const A = (props: LinkBaseProps & { isStyled?: boolean; shouldLeakReferre
   return (
     <LinkBase
       css={[link, !isStyled && linkStyled]}
-      {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
+      {...(shouldLeakReferrer && { target: '_blank', referrerpolicy: 'origin' })}
       openInNewTab={(!shouldLeakReferrer && openInNewTab) ?? isExternalLink(props.href)}
       {...rest}
     />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Context [Slack](https://exponent-internal.slack.com/archives/CRM0Y8JLU/p1698167156183209), to help us to track when users click on the discord link from the docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

It follows the same pattern and work done by @tchayen in https://github.com/expo/universe/pull/13714 (thank you!)

- By adding a new prop called `shouldLeakReferrer`  to `A` component wraps the fundamental component `LinkBase` from the `@expo/styleguide` library. This helps us to drop the `rel` attribute and add `target` and `referrerPolicy` attributes. 
- Also, replaced all Discord links to use `A` with the prop.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs either locally or use Preview
- Click on a Discord link, open Dev tools in your browser and inspect the link element
- You should see `target` set to `_blank` and `referpolicy` to `origin` on the `a` element

![CleanShot 2023-10-30 at 15 33 16@2x](https://github.com/expo/expo/assets/10234615/26ffec8a-b527-4817-935b-ed7cdc086a77)



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
