### PR TITLE
fix(router): fix NSUserActivityTypes duplication  after prebuild

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent duplicated `NSUserActivityTypes` strings in prebuild. ([#25114](https://github.com/expo/expo/pull/25114) by [@yjose](https://github.com/yjose))
 - Fix deep linking to Expo Go. ([#30283](https://github.com/expo/expo/pull/30283) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix server hosting root html in a group with a layout. ([#29948](https://github.com/expo/expo/pull/29948) by [@EvanBacon](https://github.com/EvanBacon))
 - Ensure initial route is created with params ([#27223](https://github.com/expo/expo/pull/27223) by [@marklawlor](https://github.com/marklawlor))

--- a/packages/expo-router/plugin/build/index.js
+++ b/packages/expo-router/plugin/build/index.js
@@ -14,7 +14,9 @@ const withExpoHeadIos = (config) => {
         // This ensures that stored `NSUserActivityType`s can be opened in-app.
         // This is important for moving between native devices or from opening a link that was saved
         // in a Quick Note or Siri Reminder.
-        config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+        if (!config.modResults.NSUserActivityTypes.includes('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route')) {
+            config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+        }
         return config;
     });
 };

--- a/packages/expo-router/plugin/build/index.js
+++ b/packages/expo-router/plugin/build/index.js
@@ -14,8 +14,9 @@ const withExpoHeadIos = (config) => {
         // This ensures that stored `NSUserActivityType`s can be opened in-app.
         // This is important for moving between native devices or from opening a link that was saved
         // in a Quick Note or Siri Reminder.
-        if (!config.modResults.NSUserActivityTypes.includes('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route')) {
-            config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+        const activityType = '$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route';
+        if (!config.modResults.NSUserActivityTypes.includes(activityType)) {
+            config.modResults.NSUserActivityTypes.push(activityType);
         }
         return config;
     });

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -15,12 +15,9 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
     // This ensures that stored `NSUserActivityType`s can be opened in-app.
     // This is important for moving between native devices or from opening a link that was saved
     // in a Quick Note or Siri Reminder.
-    if (
-      !config.modResults.NSUserActivityTypes.includes(
-        '$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route'
-      )
-    ) {
-      config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+    const activityType = '$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route';
+    if (!config.modResults.NSUserActivityTypes.includes(activityType)) {
+      config.modResults.NSUserActivityTypes.push(activityType);
     }
     return config;
   });

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -15,7 +15,11 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
     // This ensures that stored `NSUserActivityType`s can be opened in-app.
     // This is important for moving between native devices or from opening a link that was saved
     // in a Quick Note or Siri Reminder.
-    if (!config.modResults.NSUserActivityTypes.includes('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route')) {
+    if (
+      !config.modResults.NSUserActivityTypes.includes(
+        '$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route'
+      )
+    ) {
       config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
     }
     return config;

--- a/packages/expo-router/plugin/src/index.ts
+++ b/packages/expo-router/plugin/src/index.ts
@@ -15,7 +15,9 @@ const withExpoHeadIos: ConfigPlugin = (config) => {
     // This ensures that stored `NSUserActivityType`s can be opened in-app.
     // This is important for moving between native devices or from opening a link that was saved
     // in a Quick Note or Siri Reminder.
-    config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+    if (!config.modResults.NSUserActivityTypes.includes('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route')) {
+      config.modResults.NSUserActivityTypes.push('$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route');
+    }
     return config;
   });
 };


### PR DESCRIPTION
# Why

I am using Expo Router with a custom dev client and noticed that my `ios/info.plist` looks like the following:

```
    <key>NSUserActivityTypes</key>
    <array>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
      <string>$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route</string>
    </array>
```
Apparently, the `expo-router` plugin is adding a new string every time I run `prebuild.`

# How

To fix this issue, I just added a condition to check if `$(PRODUCT_BUNDLE_IDENTIFIER).expo.index_route` already exists. If it does, it will skip adding a new string.

# Test Plan

I tried it with my own project by updating expo-router dependency and seems to work correctly 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
