### PR TITLE
[font][plugin] handle no arguments

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Handle the case where no argument is passed to the plugin.
+- Handle the case where no argument is passed to the plugin. ([#25138](https://github.com/expo/expo/pull/25138) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Handle the case where no argument is passed to the plugin.
+
 ### 💡 Others
 
 ## 11.8.0 — 2023-10-17

--- a/packages/expo-font/plugin/build/withFonts.js
+++ b/packages/expo-font/plugin/build/withFonts.js
@@ -5,6 +5,9 @@ const withFontsAndroid_1 = require("./withFontsAndroid");
 const withFontsIos_1 = require("./withFontsIos");
 const pkg = require('expo-font/package.json');
 const withFonts = (config, props) => {
+    if (!props) {
+        return config;
+    }
     if (props.fonts && props.fonts.length === 0) {
         return config;
     }

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -10,6 +10,10 @@ export type FontProps = {
 };
 
 const withFonts: ConfigPlugin<FontProps> = (config, props) => {
+  if (!props) {
+    return config;
+  }
+
   if (props.fonts && props.fonts.length === 0) {
     return config;
   }


### PR DESCRIPTION
# Why
Closes ENG-10497
The plugin should handle the case where it is added but no options are passed.

# How
Check if the `props` are defined.

# Test Plan
Tested in `sandbox` app
