### PR TITLE
[core][iOS] Allow CGFloat to be used as an argument type

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Add `preventModuleOverriding` to `ModuleRegistry.register` method. ([#24860](https://github.com/expo/expo/pull/24860) by [@wschurman](https://github.com/wschurman))
-- [iOS] `CGFloat` can now be used as an argument type.
+- [iOS] `CGFloat` can now be used as an argument type. ([#25140](https://github.com/expo/expo/pull/25140) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Add `preventModuleOverriding` to `ModuleRegistry.register` method. ([#24860](https://github.com/expo/expo/pull/24860) by [@wschurman](https://github.com/wschurman))
+- [iOS] `CGFloat` can now be used as an argument type.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
+++ b/packages/expo-modules-core/ios/Arguments/AnyArgument.swift
@@ -25,6 +25,7 @@ extension UInt64: AnyArgument {}
 
 extension Float32: AnyArgument {}
 extension Double: AnyArgument {}
+extension CGFloat: AnyArgument {}
 
 extension String: AnyArgument {}
 extension Array: AnyArgument {}

--- a/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionSpec.swift
@@ -269,6 +269,10 @@ class FunctionSpec: ExpoSpec {
           Function("withFunction") { (fn: JavaScriptFunction<String>) -> String in
             return try fn.call("foo", "bar")
           }
+
+          Function("withCGFloat") { (f: CGFloat) in
+            return "\(f)"
+          }
         })
       }
 
@@ -300,6 +304,10 @@ class FunctionSpec: ExpoSpec {
 
         expect(value.kind) == .string
         expect(value.getString()) == "foobar"
+      }
+
+      it("accepts CGFloat argument") {
+        expect(try runtime.eval("expo.modules.TestModule.withCGFloat(20.23)").asString()) == "20.23"
       }
     }
   }


### PR DESCRIPTION
# Why

It was not possible to use a common CGFloat type as an argument.

# How

Made `CGFloat` conform to `AnyArgument`

# Test Plan

Added a unit test
