### PR TITLE
[core][iOS] Fix concurrent functions not supporting an owner argument

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [iOS] Fixed the object identifier for shared object types. ([#25060](https://github.com/expo/expo/pull/25060) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed concurrent functions (async/await) not converting results such as records and shared objects. ([#25075](https://github.com/expo/expo/pull/25075) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed concurrent functions (async/await) not supporting an owner argument (view and class functions). ([#25141](https://github.com/expo/expo/pull/25141) by [@tsapeta](https://github.com/tsapeta))
 - Fixed UIView arguments not being resolved correctly when passed in with findNodeHandle ([#24703](https://github.com/expo/expo/pull/24703) by [@javache](https://github.com/javache))
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/Classes/ClassComponentElement.swift
+++ b/packages/expo-modules-core/ios/Classes/ClassComponentElement.swift
@@ -24,6 +24,10 @@ extension AsyncFunctionComponent: ClassComponentElement {
   public typealias OwnerType = FirstArgType
 }
 
+extension ConcurrentFunctionDefinition: ClassComponentElement {
+  public typealias OwnerType = FirstArgType
+}
+
 extension PropertyComponent: ClassComponentElement {
   // It already has the `OwnerType`
 }

--- a/packages/expo-modules-core/ios/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Functions/ConcurrentFunctionDefinition.swift
@@ -26,6 +26,10 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
 
   let dynamicArgumentTypes: [AnyDynamicType]
 
+  var argumentsCount: Int {
+    return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
+  }
+
   var takesOwner: Bool = false
 
   func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> Void) {
@@ -43,7 +47,7 @@ public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
       )
 
       // All `JavaScriptValue` args must be preliminarly converted on the JS thread, before we jump to the function's queue.
-      arguments = try cast(jsValues: args, forFunction: self, appContext: appContext)
+      arguments = try cast(jsValues: arguments, forFunction: self, appContext: appContext)
     } catch let error as Exception {
       callback(.failure(error))
       return


### PR DESCRIPTION
# Why

Currently concurrent functions in Swift cannot take an owner (additional first argument that represents `this`) in class functions

# How

- Made `ConcurrentFunctionDefinition` conform to `ClassComponentElement`
- Concurrent functions were throwing an exception when there was an additional owner argument because of the number of expected arguments. I had to provide an implementation for `argumentsCount` that allows an owner.

# Test Plan

Tested as part of #25079 