### PR TITLE
chore(repo): drop unused babel plugins

### DIFF
--- a/apps/bare-expo/babel.config.js
+++ b/apps/bare-expo/babel.config.js
@@ -14,12 +14,7 @@ module.exports = function (api) {
   }
 
   return {
-    // [Custom] Needed for decorators
     presets: ['babel-preset-expo'],
-    plugins: [
-      '@babel/plugin-proposal-export-namespace-from',
-      'react-native-reanimated/plugin',
-      ['babel-plugin-module-resolver', moduleResolverConfig],
-    ],
+    plugins: [['babel-plugin-module-resolver', moduleResolverConfig]],
   };
 };

--- a/apps/native-component-list/babel.config.js
+++ b/apps/native-component-list/babel.config.js
@@ -1,7 +1,6 @@
-module.exports = function(api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['@babel/plugin-proposal-export-namespace-from', 'react-native-reanimated/plugin'],
   };
 };

--- a/apps/router-e2e/babel.config.js
+++ b/apps/router-e2e/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin', 'expo-router/babel'],
   };
 };

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['expo-router/babel'],
   };
 };

--- a/apps/test-suite/babel.config.js
+++ b/apps/test-suite/babel.config.js
@@ -2,6 +2,5 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
# Why

babel-preset-expo can now do router and reanimated transforms automatically, this PR updates the apps in the repo to be simpler.
