### PR TITLE
docs: update stack docs

### DIFF
--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -114,7 +114,7 @@ export default function Details() {
 
 As an alternative to the `<Stack.Screen>` component, you can use [`navigation.setOptions()`](https://reactnavigation.org/docs/navigation-prop/#setoptions) to configure screen options from within the component.
 
-```jsx app/home.js
+```jsx app/index.js
 import { Stack, useNavigation } from 'expo-router';
 import { Text, View } from 'react-native';
 

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -47,7 +47,7 @@ export default function Layout() {
 
 You can use a layout's Screen component to configure the header bar dynamically from within the route. This is good for interactions that change the UI.
 
-```jsx app/home.js
+```jsx app/index.js
 import { Link, Stack } from 'expo-router';
 import { Image, Text, View } from 'react-native';
 


### PR DESCRIPTION
# Why
I think here index.js is referenced and not home.js, following the pattern from the initial explanation: 
![image](https://github.com/expo/expo/assets/11761170/2a017109-26e0-48c4-b5e5-ba3cc5895119)

![image](https://github.com/expo/expo/assets/11761170/0226763b-3769-4cf6-996d-901cb4e87ea8)

# How
Updating title of code block example

# Test Plan
Try to create all files from example and run project

# Checklist
- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
