### PR TITLE
[docs] Add alpha to SDK list

### DIFF
--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -7,6 +7,10 @@ description: Learn how to incrementally upgrade the Expo SDK version in your pro
 
 Expo maintains ~6 months of backward compatibility. Once an SDK version has been deprecated, you will no longer be able to use the Expo Go app. However, you will still be able to publish updates via `eas update`, and build using `eas build`. Deprecations **will not** affect the standalone apps you have in production.
 
+## SDK 50 (alpha)
+
+[How to use pre-release versions](/versions/latest/#using-pre-release-versions)
+
 ## SDK 49
 
 [Blog Post](https://blog.expo.dev/expo-sdk-49-c6d398cdf740)


### PR DESCRIPTION
# Why

As suggested on slack, we may want to link to a list of SDK versions in error messages in EAS CLI for features that are only available after a certain SDK version.

For example, EAS Update roll-back-to-embedded command is only available with SDK 50, which is unreleased.

This PR adds the alpha release to this page so that we can link to it and there are instructions for those that wish to upgrade early to an alpha.

# How

Add item that links to https://docs.expo.dev/versions/latest/#using-pre-release-versions

# Test Plan
<img width="1235" alt="Screenshot 2023-10-31 at 1 57 49 PM" src="https://github.com/expo/expo/assets/189568/85af2d0e-4f5d-46e2-9dd5-61b298a7adcf">



# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
