### PR TITLE
[dev-launcher][android] Update DevLauncherDevSupportManager to make the controller nullable

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix dev server not using query params from manifest when loading the JS bundle. ([#25061](https://github.com/expo/expo/pull/25061) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fix dev server not using query params from manifest when loading the JS bundle. ([#25061](https://github.com/expo/expo/pull/25061), [#25147](https://github.com/expo/expo/pull/25147) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
+++ b/packages/expo-dev-launcher/android/src/react-native-72/expo/modules/devlauncher/rncompatibility/DevLauncherDevSupportManager.kt
@@ -29,11 +29,11 @@ import com.facebook.react.devsupport.interfaces.RedBoxHandler
 import com.facebook.react.packagerconnection.RequestHandler
 import expo.modules.devlauncher.DevLauncherController
 import expo.modules.devlauncher.koin.DevLauncherKoinComponent
+import expo.modules.devlauncher.koin.optInject
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
 
-import org.koin.core.component.inject
 import java.io.File
 import java.io.IOException
 import java.util.concurrent.ExecutionException
@@ -62,7 +62,7 @@ class DevLauncherDevSupportManager(
   null
 ),
   DevLauncherKoinComponent {
-  private val controller: DevLauncherControllerInterface by inject()
+  private val controller: DevLauncherControllerInterface? by optInject()
   // copied from https://github.com/facebook/react-native/blob/aa4da248c12e3ba41ecc9f1c547b21c208d9a15f/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java#L65
   private var mIsSamplingProfilerEnabled = false
   private val devSettings: DevLauncherInternalSettingsWrapper = DevLauncherInternalSettingsWrapper(getDevSettings())
@@ -104,7 +104,7 @@ class DevLauncherDevSupportManager(
       return
     }
 
-    controller.onAppLoadedWithError()
+    controller?.onAppLoadedWithError()
     DevLauncherErrorActivity.showError(activity, DevLauncherAppError(message, e))
   }
 
@@ -121,7 +121,7 @@ class DevLauncherDevSupportManager(
       object : CallbackWithBundleLoader {
         override fun onSuccess(bundleLoader: JSBundleLoader) {
           bundleLoader.loadScript(currentContext!!.catalystInstance)
-          var bundleURL = controller.manifest?.getBundleURL() ?: devServerHelper.getDevServerSplitBundleURL(bundlePath)
+          var bundleURL = controller?.manifest?.getBundleURL() ?: devServerHelper.getDevServerSplitBundleURL(bundlePath)
           currentContext!!
             .getJSModule(HMRClient::class.java)
             .registerBundle(bundleURL)
@@ -214,7 +214,7 @@ class DevLauncherDevSupportManager(
     } else {
       PrinterHolder.getPrinter()
         .logMessage(ReactDebugOverlayTags.RN_CORE, "RNCore: load from Server")
-      val bundleURL = controller.manifest?.getBundleURL() ?: devServerHelper
+      val bundleURL = controller?.manifest?.getBundleURL() ?: devServerHelper
         .getDevServerBundleURL(Assertions.assertNotNull(jsAppBundleName))
       reloadJSFromServer(bundleURL)
     }


### PR DESCRIPTION
# Why

When running BareExpo with `USE_DEV_CLIENT = false` the app instacrashes with an error regarding `No definition found for class:'expo.modules.devlauncher.launcher.DevLauncherControllerInterface'`

![image](https://github.com/expo/expo/assets/11707729/fec3a936-b616-4cc6-9720-eac9e9c85e4b)



Follow up of https://github.com/expo/expo/pull/25061

# How

Update `DevLauncherControllerInterface controller` inside `DevLauncherDevSupportManager` to use `optInject`, making the controller nullable and preventing the app from crashing if the variable is not accessible, which may occur if `dev-client` is installed but not used.

# Test Plan

Run bare-expo locally with and without dev-client 

# Checklist
 

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
