### PR TITLE
chore: remove deprecated REACT_NATIVE_OVERRIDE_VERSION

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -21,8 +21,6 @@ concurrency:
 jobs:
   ios-build:
     runs-on: macos-13
-    env:
-      REACT_NATIVE_OVERRIDE_VERSION: 9999.9999.9999
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
@@ -85,8 +83,6 @@ jobs:
   ios-test:
     needs: ios-build
     runs-on: macos-12
-    env:
-      REACT_NATIVE_OVERRIDE_VERSION: 9999.9999.9999
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
@@ -141,7 +137,6 @@ jobs:
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
       GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx4096m -XX:MaxMetaspaceSize=4096m"
-      REACT_NATIVE_OVERRIDE_VERSION: 9999.9999.9999
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Use `pointerEvent` style instead of prop for video component on web. ([#24931](https://github.com/expo/expo/pull/24931) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
 
 ## 13.8.0 — 2023-10-17
 

--- a/packages/expo-av/android/build.gradle
+++ b/packages/expo-av/android/build.gradle
@@ -18,7 +18,7 @@ def RN_SO_DIR = REACT_NATIVE_BUILD_FROM_SOURCE
 
 def reactProperties = new Properties()
 file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
-def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 def reactNativeArchitectures() {

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
+
 ## 3.3.0 — 2023-10-17
 
 ### 🛠 Breaking changes

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -192,17 +192,6 @@ def getNodeModulesPackageVersion(packageName, overridePropName) {
 }
 
 def getRNVersion() {
-  if (System.getenv("REACT_NATIVE_OVERRIDE_VERSION")) {
-    def version = System.getenv("REACT_NATIVE_OVERRIDE_VERSION")
-    def coreVersion = version.split("-")[0]
-    def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
-    return versionToNumber(
-        major,
-        minor,
-        patch
-    )
-  }
-
   return getNodeModulesPackageVersion("react-native", "reactNativeVersion")
 }
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
+
 ## 4.3.0 — 2023-10-17
 
 ### 🛠 Breaking changes

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -8,9 +8,6 @@ begin
 rescue
   reactNativeVersion = '0.0.0'
 end
-if ENV["REACT_NATIVE_OVERRIDE_VERSION"]
-  reactNativeVersion = ENV["REACT_NATIVE_OVERRIDE_VERSION"]
-end
 reactNativeTargetVersion = reactNativeVersion.split('.')[1].to_i
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Use `pointerEvent` style instead of prop for components on web. ([#24931](https://github.com/expo/expo/pull/24931) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
 
 ## 13.4.0 — 2023-10-17
 

--- a/packages/expo-gl/android/build.gradle
+++ b/packages/expo-gl/android/build.gradle
@@ -18,7 +18,7 @@ def RN_SO_DIR = REACT_NATIVE_BUILD_FROM_SOURCE
 
 def reactProperties = new Properties()
 file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
-def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 def reactNativeArchitectures() {

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 💡 Others
 
 - Remove `unimodule.json` in favour of `expo-module.config.json`. ([#25100](https://github.com/expo/expo/pull/25100) by [@reichhartd](https://github.com/reichhartd))
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
 
 ## 1.9.0 — 2023-10-17
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -8,9 +8,6 @@ begin
 rescue
   reactNativeVersion = '0.0.0'
 end
-if ENV["REACT_NATIVE_OVERRIDE_VERSION"]
-  reactNativeVersion = ENV["REACT_NATIVE_OVERRIDE_VERSION"]
-end
 
 reactNativeMinorVersion = reactNativeVersion.split('.')[1].to_i
 

--- a/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+++ b/packages/expo-modules-core/android/ExpoModulesCorePlugin.gradle
@@ -156,7 +156,7 @@ class LegacyReactNativeLibsExtractionPlugin implements Plugin<Project> {
     new File("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
     def FOLLY_VERSION = reactProperties.getProperty("FOLLY_VERSION")
     def DOUBLE_CONVERSION_VERSION = reactProperties.getProperty("DOUBLE_CONVERSION_VERSION")
-    def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+    def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
     def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
     def isNewArchitectureEnabled = project.findProperty("newArchEnabled") == "true"

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -71,7 +71,7 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
 
 // TODO: Remove react-native < 0.71 support
 def BOOST_VERSION = reactProperties.getProperty("BOOST_VERSION") ?: "1_76_0"
-def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 def reactNativeThirdParty = new File("$REACT_NATIVE_DIR/ReactAndroid/src/main/jni/third-party")

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Revert `URL` support. ([#25006](https://github.com/expo/expo/pull/25006) by [@EvanBacon](https://github.com/EvanBacon))
 - Encode Blob components in `URL.createObjectURL`. ([#25004](https://github.com/expo/expo/pull/25004) by [@EvanBacon](https://github.com/EvanBacon))
+- Remove deprecated `REACT_NATIVE_OVERRIDE_VERSION` for React Native nightly testing. ([#25151](https://github.com/expo/expo/pull/25151) by [@kudo](https://github.com/kudo))
 
 ## 49.0.16 — 2023-10-20
 

--- a/packages/expo/android/build.gradle
+++ b/packages/expo/android/build.gradle
@@ -30,7 +30,7 @@ def getRNVersion() {
       .text
       .trim()
 
-  def version = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: safeExtGet("reactNativeVersion", nodeModulesVersion)
+  def version = safeExtGet("reactNativeVersion", nodeModulesVersion)
   def coreVersion = version.split("-")[0]
   def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
 

--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -100,29 +100,6 @@ async function addPinnedPackagesAsync(packages: Record<string, string>) {
 async function updateReactNativePackageAsync() {
   const reactNativeRoot = path.join(EXPO_DIR, 'node_modules', 'react-native');
 
-  // Update native ReactNativeVersion
-  const versions = (process.env.REACT_NATIVE_OVERRIDE_VERSION ?? '9999.9999.9999').split('.');
-  await transformFileAsync(
-    path.join(
-      reactNativeRoot,
-      'ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java'
-    ),
-    [
-      {
-        find: /("major", )\d+,/g,
-        replaceWith: `$1${versions[0]},`,
-      },
-      {
-        find: /("minor", )\d+,/g,
-        replaceWith: `$1${versions[1]},`,
-      },
-      {
-        find: /("patch", )\d+,/g,
-        replaceWith: `$1${versions[2]},`,
-      },
-    ]
-  );
-
   // https://github.com/facebook/react-native/pull/38993
   await transformFileAsync(path.join(reactNativeRoot, 'React-Core.podspec'), [
     {

--- a/tools/src/versioning/android/versionCxx/patches/expo-av.patch
+++ b/tools/src/versioning/android/versionCxx/patches/expo-av.patch
@@ -3,7 +3,7 @@ index f2c50906e3..396012ffee 100644
 --- a/packages/expo-av/android/build.gradle
 +++ b/packages/expo-av/android/build.gradle
 @@ -21,6 +21,10 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
- def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
  def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 +REACT_NATIVE_DIR = "${rootDir}/versioned-react-native/packages/react-native"

--- a/tools/src/versioning/android/versionCxx/patches/expo-gl.patch
+++ b/tools/src/versioning/android/versionCxx/patches/expo-gl.patch
@@ -3,7 +3,7 @@ index 32784fe8a6..bbbea44599 100644
 --- a/packages/expo-gl/android/build.gradle
 +++ b/packages/expo-gl/android/build.gradle
 @@ -21,6 +21,10 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
- def REACT_NATIVE_VERSION = System.getenv("REACT_NATIVE_OVERRIDE_VERSION") ?: reactProperties.getProperty("VERSION_NAME")
+ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
  def REACT_NATIVE_TARGET_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 +REACT_NATIVE_DIR = "${rootDir}/versioned-react-native/packages/react-native"


### PR DESCRIPTION
# Why

Since react-native now has newer versions in nightlies (e.g. 0.74.0-nightly-20231031-572dd76ba in the mean time). we don't have to override it for version checks.

# How

remove all `REACT_NATIVE_OVERRIDE_VERSION` references

# Test Plan

- ci passed
- test nightlies ci is known to break

# Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
