### PR TITLE
[ci] fix ios unit test errors

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -36,15 +36,15 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 75
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 14.3
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.app
+      - name: 🔨 Switch to Xcode 14.2
+        run: sudo xcode-select --switch /Applications/Xcode_14.2.app
       - name: 🔓 Decrypt secrets if possible
         uses: ./.github/actions/expo-git-decrypt
         with:


### PR DESCRIPTION
# Why

try to improve the unstable ios unit test ci situation

# How

downgrade to macos-12 which likely to be more performant. the spending time would reduce 1/2 as well (60mins -> 30mins)

# Test Plan

ios unit test ci passed