### PR TITLE
[tools] Use `npx pod-install` in `et pod-install`

### DIFF
--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -62,3 +62,22 @@ export async function podInstallAsync(
     stdio: options.stdio ?? 'pipe',
   });
 }
+
+/**
+ * An alternative version of `podInstallAsync` that uses `npx pod-install` command.
+ * See https://github.com/expo/expo-cli/tree/main/packages/pod-install
+ */
+export async function npxPodInstallAsync(
+  projectPath: string,
+  verbose: boolean = false
+): Promise<void> {
+  const args = ['pod-install'];
+
+  if (!verbose) {
+    args.push('--quiet');
+  }
+  await spawnAsync('npx', args, {
+    cwd: projectPath,
+    stdio: verbose ? 'inherit' : 'pipe',
+  });
+}

--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -71,7 +71,7 @@ export async function npxPodInstallAsync(
   projectPath: string,
   verbose: boolean = false
 ): Promise<void> {
-  const args = ['pod-install'];
+  const args = ['pod-install@latest'];
 
   if (!verbose) {
     args.push('--quiet');

--- a/tools/src/commands/PodInstallCommand.ts
+++ b/tools/src/commands/PodInstallCommand.ts
@@ -4,7 +4,7 @@ import { hashElement } from 'folder-hash';
 import path from 'path';
 import process from 'process';
 
-import { podInstallAsync } from '../CocoaPods';
+import { npxPodInstallAsync } from '../CocoaPods';
 import { EXPO_DIR } from '../Constants';
 import logger from '../Logger';
 
@@ -27,9 +27,7 @@ async function action(options: ActionOptions) {
       logger.info(`🥥 Installing pods in ${chalk.yellow(relativeProjectPath)} directory`);
 
       try {
-        await podInstallAsync(absoluteProjectPath, {
-          stdio: options.verbose ? 'inherit' : 'pipe',
-        });
+        await npxPodInstallAsync(absoluteProjectPath, !!options.verbose);
       } catch (e) {
         if (!options.verbose) {
           // In this case, the output has already been printed.


### PR DESCRIPTION
# Why

It's been annoying that `et pod-install` fails when a pod needs to be updated. For instance, it fails every time we upgrade React Native shipped with a new version of hermes-engine.

# How

As a solution we can run `npx pod-install` that handles this case and runs `pod update <pod_name>` when necessary.

# Test Plan

I tested that command after downgrading RN to 0.72.0 and then back to 0.72.5 – in both cases, hermes-engine was successfully updated
