### PR TITLE
[cli] change instruction when upgrade is used

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### 💡 Others
 
 - Memoize notice log about `src/app` directory to prevent spam. ([#25000](https://github.com/expo/expo/pull/25000) by [@EvanBacon](https://github.com/EvanBacon))
-- Link to [upgrading sdk docs](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) instead of `expo-cli` when the `upgrade` subcommand is used.
+- Link to [upgrading sdk docs](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) instead of `expo-cli` when the `upgrade` subcommand is used. ([#25168](https://github.com/expo/expo/pull/25168) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 0.10.14 — 2023-10-20
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### 💡 Others
 
 - Memoize notice log about `src/app` directory to prevent spam. ([#25000](https://github.com/expo/expo/pull/25000) by [@EvanBacon](https://github.com/EvanBacon))
+- Link to [upgrading sdk docs](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) instead of `expo-cli` when the `upgrade` subcommand is used.
 
 ## 0.10.14 — 2023-10-20
 

--- a/packages/@expo/cli/bin/cli.ts
+++ b/packages/@expo/cli/bin/cli.ts
@@ -127,7 +127,7 @@ if (!isSubcommand) {
     'client:install:ios': 'npx expo start --ios',
     'client:install:android': 'npx expo start --android',
     doctor: 'npx expo-doctor',
-    upgrade: 'expo-cli upgrade',
+    upgrade: 'https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/',
     'customize:web': 'npx expo customize',
 
     publish: 'eas update',
@@ -164,8 +164,9 @@ if (!isSubcommand) {
   if (subcommand in migrationMap) {
     const replacement = migrationMap[subcommand];
     console.log();
+    const instruction = subcommand === 'upgrade' ? 'follow this guide' : 'use'
     console.log(
-      chalk.yellow`  {gray $} {bold expo ${subcommand}} is not supported in the local CLI, please use {bold ${replacement}} instead`
+      chalk.yellow`  {gray $} {bold expo ${subcommand}} is not supported in the local CLI, please ${instruction} {bold ${replacement}} instead`
     );
     console.log();
     process.exit(1);


### PR DESCRIPTION
# Why
Closes ENG-10280

# How
Link to the [upgrade docs](https://docs.expo.dev/workflow/upgrading-expo-sdk-walkthrough/) instead of `expo-cli` when a user tries to use the `upgrade` subcommand.

# Test Plan
Tested locally.