### PR TITLE
[ios][av] Fix iOS fixed orientation in onReadyForDisplay for hls stream

### DIFF
--- a/apps/test-suite/tests/Video.js
+++ b/apps/test-suite/tests/Video.js
@@ -369,6 +369,15 @@ export function test(t, { setPortalChild, cleanupPortal }) {
         t.expect(status.naturalSize.height).toBeDefined();
         t.expect(status.naturalSize.orientation).toBe('portrait');
       });
+
+      t.it('correctly orientation for HLS streams', async () => {
+        const props = {
+          style,
+          source: { uri: hlsStreamUri },
+        };
+        const status = await mountAndWaitFor(<Video {...props} />, 'onReadyForDisplay');
+        t.expect(status.naturalSize.orientation).toBe('landscape');
+      });
     });
 
     t.describe('Video fullscreen player', () => {

--- a/packages/expo-av/CHANGELOG.md
+++ b/packages/expo-av/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix audio recording resetting when receiving a phone call. ([#25054](https://github.com/expo/expo/pull/25054) by [@behenate](https://github.com/behenate))
+- Fix iOS `naturalSize.orientation` in prop `onReadyForDisplay` for hls stream ([#25169](https://github.com/expo/expo/pull/25169) by [@souzaluiz](https://github.com/souzaluiz))
 
 ### 💡 Others
 

--- a/packages/expo-av/ios/EXAV/Video/EXVideoView.m
+++ b/packages/expo-av/ios/EXAV/Video/EXVideoView.m
@@ -257,7 +257,7 @@ static NSString *const EXAVFullScreenViewControllerClassName = @"AVFullScreenVie
         CGSize presentationSize = _data.player.currentItem.presentationSize;
         naturalSize = @{@"width": @(presentationSize.width),
                         @"height": @(presentationSize.height),
-                        @"orientation": @"landscape"};
+                        @"orientation": presentationSize.width < presentationSize.height ? @"portrait" : @"landscape"};
       }
       
       _onReadyForDisplay(@{@"naturalSize": naturalSize,


### PR DESCRIPTION
# Why

In our app, onReadyForDisplay prop always returns `landscape` in `naturalSize.orientation`, this happens because the orientation is always `landscape` for iOS and `.m3u8` files.

# How
- Change fixed return `landscape` for a condition.
- If the width is less than the height, the video is portrait, else is landscape.

# Test Plan

- Add a test for `correctly orientation for HLS streams`.
- Also check in the existing test that the expected video is landscape.
- Tested in Bare Expo on iOS 15 device