### PR TITLE
[docs] Fix TypeScript errors in Expo Router docs example code

### DIFF
--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -96,7 +96,7 @@ function useAsyncState<T>(
   initialValue: [boolean, T | null] = [true, undefined],
 ): UseStateHook<T> {
   return React.useReducer(
-    (state: [boolean, T | null], action: T | null = null) => [false, action],
+    (state: [boolean, T | null], action: T | null = null): [boolean, T | null] => [false, action],
     initialValue
   ) as UseStateHook<T>;
 }

--- a/docs/pages/router/reference/authentication.mdx
+++ b/docs/pages/router/reference/authentication.mdx
@@ -90,10 +90,10 @@ import * as SecureStore from 'expo-secure-store';
 import * as React from 'react';
 import { Platform } from 'react-native';
 
-type UseStateHook<T> = [[boolean, T | null], (value?: T | null) => void];
+type UseStateHook<T> = [[boolean, T | null], (value: T | null) => void];
 
 function useAsyncState<T>(
-  initialValue: [boolean, T | null] = [true, undefined],
+  initialValue: [boolean, T | null] = [true, null],
 ): UseStateHook<T> {
   return React.useReducer(
     (state: [boolean, T | null], action: T | null = null): [boolean, T | null] => [false, action],


### PR DESCRIPTION
# Why

I attempted to use the example authentication context provided in the docs to scaffold the logic for the protected routes in my app.

# How

I noticed a few typescript errors in the example provided.

1. Typescript could not infer the type of the useReducer action correctly and so it was giving me the following type error:

```
No overload matches this call.
  Overload 1 of 5, '(reducer: (state: [boolean, T | null], action?: T | null) => (boolean | T | null)[], initializerArg: never, initializer?: undefined): [never, DispatchWithoutAction]', gave the following error.
    Argument of type '[boolean, T | null]' is not assignable to parameter of type 'never'.
  Overload 2 of 5, '(reducer: (state: [boolean, T | null], action?: T | null) => (boolean | T | null)[], initialState: never, initializer?: undefined): [never, Dispatch<T | null | undefined>]', gave the following error.
    Argument of type '[boolean, T | null]' is not assignable to parameter of type 'never'.
```

The issue is resolved by explicitly declaring the return type of the action.

2. The initial value for the `initialValue` parameter of the useAsyncState function was incorrectly set to `[true, undefined]`. This was resolved by setting it to `[true, null]` to match the types declared.
3. The type declared for the callback function passed to the useCallback hook was incompatible because value was set as optional. This was resolved by making it a required argument.
