### PR TITLE
feat(babel): support all options in top-level object

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Support all options in top-level object and in `native` and `web` sub-objects.
 - Use the standard `@babel/preset-react` for all React transformations. ([#25125](https://github.com/expo/expo/pull/25125) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Support all options in top-level object and in `native` and `web` sub-objects.
+- Support all options in top-level object and in `native` and `web` sub-objects. ([#25172](https://github.com/expo/expo/pull/25172) by [@EvanBacon](https://github.com/EvanBacon))
 - Use the standard `@babel/preset-react` for all React transformations. ([#25125](https://github.com/expo/expo/pull/25125) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -62,7 +62,7 @@ If the `bundler` is not defined, it will default to checking if a `babel-loader`
 ];
 ```
 
-This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This flag does nothing when `native.useTransformReactJSXExperimental` is set to `true` because `@babel/plugin-transform-react-jsx` is omitted.
+This property is passed down to [`@babel/plugin-transform-react-jsx`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx). This flag does nothing when `useTransformReactJSXExperimental` is set to `true` because `@babel/plugin-transform-react-jsx` is omitted.
 
 ### [`jsxImportSource`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#importsource)
 
@@ -115,7 +115,7 @@ The value of `lazyImports` has a few possible effects:
 ],
 ```
 
-### `web.disableImportExportTransform`
+### `disableImportExportTransform`
 
 Enabling this option will allow your project to run with older JavaScript syntax (i.e. `module.exports`). This option will break tree shaking and increase your bundle size, but will eliminate the following error when `module.exports` is used:
 
@@ -127,7 +127,40 @@ Enabling this option will allow your project to run with older JavaScript syntax
 [
     'babel-preset-expo',
     {
-        web: { disableImportExportTransform: true }
+        disableImportExportTransform: true
     }
 ],
 ```
+
+### `unstable_transformProfile`
+
+Changes the engine preset in `metro-react-native-babel-preset` based on the JavaScript engine that is being targeted. In Expo SDK 50 and greater, this is automatically set based on the [`jsEngine`](https://docs.expo.dev/versions/latest/config/app/#jsengine) option in your `app.json`.
+
+### `enableBabelRuntime`
+
+Passed to `metro-react-native-babel-preset`.
+
+### `disableFlowStripTypesTransform`
+
+Passed to `metro-react-native-babel-preset`.
+
+## Platform-specific options
+
+All options can be passed in the platform-specific objects `native` and `web` to provide different settings on different platforms. For example, if you'd like to only apply `disableImportExportTransform` on web, use the following:
+
+```js
+[
+  'babel-preset-expo',
+  {
+    // Default value:
+    disableImportExportTransform: false,
+
+    web: {
+      // Web-specific value:
+      disableImportExportTransform: true,
+    },
+  },
+];
+```
+
+Platform-specific options have higher priority over top-level options.

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -1,18 +1,23 @@
 import { ConfigAPI, TransformOptions } from '@babel/core';
 type BabelPresetExpoPlatformOptions = {
+    /** Enable or disable adding the Reanimated plugin by default. @default `true` */
+    reanimated?: boolean;
     /** @deprecated Set `jsxRuntime: 'classic'` to disable automatic JSX handling.  */
     useTransformReactJSXExperimental?: boolean;
+    /** Change the policy for handling JSX in a file. Passed to `plugin-transform-react-jsx`. @default `'automatic'` */
+    jsxRuntime?: 'classic' | 'automatic';
+    /** Change the source module ID to use when importing an automatic JSX import. Only applied when `jsxRuntime` is `'automatic'` (default). Passed to `plugin-transform-react-jsx`. @default `'react'` */
+    jsxImportSource?: string;
+    lazyImports?: boolean;
     disableImportExportTransform?: boolean;
     disableFlowStripTypesTransform?: boolean;
     enableBabelRuntime?: boolean;
     unstable_transformProfile?: 'default' | 'hermes-stable' | 'hermes-canary';
 };
-export type BabelPresetExpoOptions = {
-    lazyImports?: boolean;
-    reanimated?: boolean;
-    jsxRuntime?: 'classic' | 'automatic';
-    jsxImportSource?: string;
+export type BabelPresetExpoOptions = BabelPresetExpoPlatformOptions & {
+    /** Web-specific settings. */
     web?: BabelPresetExpoPlatformOptions;
+    /** Native-specific settings. */
     native?: BabelPresetExpoPlatformOptions;
 };
 declare function babelPresetExpo(api: ConfigAPI, options?: BabelPresetExpoOptions): TransformOptions;


### PR DESCRIPTION
# Why

Based on feedback from @gaearon, we now normalize the babel options so you can use any value in the top-level object, and provide platform-specific overrides in the sub-objects `web` and `native`.

This PR also adds better documentation for the available options.

# Test Plan

Tests will continue to pass.