### PR TITLE
[ci][expo] fix unstable ci testing

### DIFF
--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -110,11 +110,8 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Run iOS tests
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: cd apps/bare-expo && ./scripts/start-ios-e2e-test.ts --test
+        run: ./scripts/start-ios-e2e-test.ts --test
+        working-directory: apps/bare-expo
       - name: Store images of build failures
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -110,8 +110,11 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🍏 Run iOS tests
-        run: ./scripts/start-ios-e2e-test.ts --test
-        working-directory: apps/bare-expo
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd apps/bare-expo && ./scripts/start-ios-e2e-test.ts --test
       - name: Store images of build failures
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -132,7 +132,7 @@ jobs:
 
   ios-test:
     needs: ios-build
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -160,11 +160,9 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧪 Run tests
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 30
-          max_attempts: 3
-          command: cd apps/bare-expo && ./scripts/start-ios-e2e-test.ts --test
+        run: ./scripts/start-ios-e2e-test.ts --test
+        working-directory: apps/bare-expo
+        timeout-minutes: 30
       - name: Store testing artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -160,9 +160,11 @@ jobs:
         if: steps.expo-caches.outputs.yarn-workspace-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: 🧪 Run tests
-        run: ./scripts/start-ios-e2e-test.ts --test
-        working-directory: apps/bare-expo
-        timeout-minutes: 30
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          command: cd apps/bare-expo && ./scripts/start-ios-e2e-test.ts --test
       - name: Store testing artifacts
         if: always()
         uses: actions/upload-artifact@v3

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -152,7 +152,7 @@ appId: dev.expo.Payments
 - extendedWaitUntil:
     visible:
       id: "test_suite_container"
-    timeout: 5000
+    timeout: 30000
 - scrollUntilVisible:
     element:
       id: "test_suite_text_results"

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -5,7 +5,7 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs/promises';
 import path from 'path';
 
-const TARGET_DEVICE = 'iPhone 14 Pro';
+const TARGET_DEVICE = 'iPhone 14';
 const TARGET_DEVICE_IOS_VERSION = 16;
 const MAESTRO_GENERATED_FLOW = 'e2e/maestro-generated.yaml';
 const OUTPUT_APP_PATH = 'ios/build/Bare Expo.app';
@@ -34,7 +34,7 @@ enum StartMode {
       await fs.cp(binaryPath, appBinaryPath, { recursive: true });
     }
     if (startMode === StartMode.TEST || startMode === StartMode.BUILD_AND_TEST) {
-      await testAsync(projectRoot, deviceId, appBinaryPath);
+      await retryAsync(() => testAsync(projectRoot, deviceId, appBinaryPath), 3);
     }
   } catch (e) {
     console.error('Uncaught Error', e);
@@ -72,25 +72,50 @@ async function testAsync(
   deviceId: string,
   appBinaryPath: string
 ): Promise<void> {
-  console.log(`\n📱 Starting Device - name[${TARGET_DEVICE}] udid[${deviceId}]`);
-  await spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], { stdio: 'inherit' });
-  await spawnAsync('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', deviceId], {
-    stdio: 'inherit',
-  });
+  try {
+    console.log(`\n📱 Starting Device - name[${TARGET_DEVICE}] udid[${deviceId}]`);
+    await spawnAsync('xcrun', ['simctl', 'bootstatus', deviceId, '-b'], { stdio: 'inherit' });
+    await spawnAsync('open', ['-a', 'Simulator', '--args', '-CurrentDeviceUDID', deviceId], {
+      stdio: 'inherit',
+    });
 
-  console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
-  await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
+    console.log(`\n🔌 Installing App - appBinaryPath[${appBinaryPath}]`);
+    await spawnAsync('xcrun', ['simctl', 'install', deviceId, appBinaryPath], { stdio: 'inherit' });
 
-  const maestroFlowFilePath = path.join(projectRoot, MAESTRO_GENERATED_FLOW);
-  await createMaestroFlowAsync(projectRoot, maestroFlowFilePath);
-  console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
-  await spawnAsync('maestro', ['--device', deviceId, 'test', maestroFlowFilePath], {
-    stdio: 'inherit',
-    env: {
-      ...process.env,
-      MAESTRO_DRIVER_STARTUP_TIMEOUT,
-    },
-  });
+    const maestroFlowFilePath = path.join(projectRoot, MAESTRO_GENERATED_FLOW);
+    await createMaestroFlowAsync(projectRoot, maestroFlowFilePath);
+    console.log(`\n📷 Starting Maestro tests - maestroFlowFilePath[${maestroFlowFilePath}]`);
+    await spawnAsync('maestro', ['--device', deviceId, 'test', maestroFlowFilePath], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        MAESTRO_DRIVER_STARTUP_TIMEOUT,
+      },
+    });
+  } finally {
+    await spawnAsync('xcrun', ['simctl', 'shutdown', deviceId], { stdio: 'inherit' });
+  }
+}
+
+async function retryAsync<T>(
+  fn: () => Promise<T>,
+  retries: number,
+  delayAfterErrorMs: number = 5000
+): Promise<T> {
+  let lastError: Error | undefined;
+  for (let i = 0; i < retries; ++i) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastError = e;
+      await delayAsync(delayAfterErrorMs);
+    }
+  }
+  throw lastError;
+}
+
+async function delayAsync(timeMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, timeMs));
 }
 
 /**

--- a/packages/expo/src/devtools/__tests__/DevToolsPluginClient-test.ts
+++ b/packages/expo/src/devtools/__tests__/DevToolsPluginClient-test.ts
@@ -123,6 +123,8 @@ describe(`DevToolsPluginClient (browser <> app)`, () => {
     });
 
     browserClient = await createDevToolsPluginClient({ devServer, sender: 'browser', pluginName });
+
+    await delayAsync(100);
     const browserClient2 = await createDevToolsPluginClient({
       devServer,
       sender: 'browser',


### PR DESCRIPTION
# Why

1. try to fix flaky DevToolsPluginClient unit test on github actions like https://github.com/expo/expo/actions/runs/6727511919/job/18287525005
2. try to fix flaky test-suite ios tests

# How

1. [expo] try to wait 100ms for the browserClient1 for handshaking then start browserClient2
2. [test-suite] retry ios tests

# Test Plan

ci passed

# Checklist

- n/a Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
