### PR TITLE
[image][android] Fix `contentFit` not working for SVG images

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `contentFit` not forking for `SVG` images. ([#25187](https://github.com/expo/expo/pull/25187) by [@behenate](https://github.com/behenate))
+- [Android] Fix `contentFit` not working for `SVG` images. ([#25187](https://github.com/expo/expo/pull/25187) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `contentFit` not forking for `SVG` images.
+- [Android] Fix `contentFit` not forking for `SVG` images. ([#25187](https://github.com/expo/expo/pull/25187) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `contentFit` not forking for `SVG` images.
+
 ### 💡 Others
 
 ## 1.7.0 — 2023-11-01


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/25069

# How

The svg was always rendered into a bitmap with the dimensions of the view, which meant that content fit wasn't applied correctly (the image was filling the entire view with padding, so every contentFit was giving the same result). Now the image is rendered while keeping it's aspect ratio, which means that later the content fit is applied correctly

# Test Plan

Tested in BareExpo on Android 13 emulator


<img width="160" alt="Screenshot 2023-11-02 at 15 58 23" src="https://github.com/expo/expo/assets/31368152/5554129b-be66-4a8a-87b8-144f9b867081">
<img width="160" alt="Screenshot 2023-11-02 at 15 58 32" src="https://github.com/expo/expo/assets/31368152/97172620-3fac-4696-a138-ee47a5626a94">
<img width="160" alt="Screenshot 2023-11-02 at 15 58 13" src="https://github.com/expo/expo/assets/31368152/f00113a6-a0db-4b31-9c3c-0206be6a6d14">

