### PR TITLE
[docs] Add a section about React Navigation Elements library

### DIFF
--- a/docs/pages/routing/appearance.mdx
+++ b/docs/pages/routing/appearance.mdx
@@ -5,6 +5,8 @@ description: Learn how to use a splash screen, fonts and images in your app that
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { BookOpen02Icon } from '@expo/styleguide-icons';
+import { Tabs, Tab } from '~/ui/components/Tabs';
+import { Terminal } from '~/ui/components/Snippet';
 
 There are three major elements that you can use to customize the appearance of your app:
 
@@ -27,7 +29,6 @@ import {
   // This example uses a basic Layout component, but you can use any Layout.
   Slot,
 } from 'expo-router';
-
 import { useFonts, Inter_500Medium } from '@expo-google-fonts/inter';
 
 /* @info Prevent hiding the splash screen after the navigation has mounted. */
@@ -107,7 +108,6 @@ React Navigation navigators `<Stack>`, `<Drawer>`, and `<Tabs>` use a shared app
 /* @info Import theme APIs from React Navigation directly. */
 import { ThemeProvider, DarkTheme, DefaultTheme, useTheme } from '@react-navigation/native';
 /* @end */
-
 import { Slot } from 'expo-router';
 
 export default function RootLayout() {
@@ -123,6 +123,30 @@ export default function RootLayout() {
 
 You can use this technique at any layer of the app to set the theme for a specific layout. The current theme can be accessed with `useTheme` from `@react-navigation/native`.
 
+## React Navigation Elements
+
+The [`@react-navigation/elements`](https://reactnavigation.org/docs/elements/) library provides a set of UI elements and helpers that can be used to build a navigation UI. These components are designed to be composable and customizable. You can reuse the default functionality from the library or build your navigator's UI on top of it.
+
+To use it with Expo Router, you need to install the library:
+
+<Tabs>
+
+<Tab label="npm">
+
+<Terminal cmd={['$ npm install @react-navigation/elements']} />
+
+</Tab>
+
+<Tab label="Yarn">
+
+<Terminal cmd={['$ yarn add @react-navigation/elements']} />
+
+</Tab>
+
+</Tabs>
+
+To learn more about the components and utilities the library provides, see [Elements library](https://reactnavigation.org/docs/elements/) documentation.
+
 ## Next steps
 
 <BoxLink
@@ -131,3 +155,4 @@ You can use this technique at any layer of the app to set the theme for a specif
   href="/routing/error-handling/"
   Icon={BookOpen02Icon}
 />
+```


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This came up in last Expo Router to add a section about React Navigation Elements library and point it towards their docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- By adding a section in [Expo Router > Appearance page](https://docs.expo.dev/routing/appearance/).
- Remove extra newlines from code snippets from import statements.


# Test Plan

**Preview**

![CleanShot 2023-11-03 at 00 33 30](https://github.com/expo/expo/assets/10234615/d651bb07-2ee5-486a-8736-c6d03b0034f0)

Alternatively, run docs locally and visit: http://localhost:3002/routing/appearance/

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff. This is required for changes to Expo modules.
-->

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
